### PR TITLE
fix(grouping): Deduplicate hashes before using them

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -382,8 +382,17 @@ class Event:
     @staticmethod
     def _hashes_from_sorted_grouping_variants(variants):
         """ Create hashes from variants and filter out None values """
-        hashes = (variant.get_hash() for variant in variants)
-        return [hash_ for hash_ in hashes if hash_ is not None]
+        filtered_hashes = []
+        seen_hashes = set()
+        for variant in variants:
+            hash_ = variant.get_hash()
+            if hash_ is None or hash_ in seen_hashes:
+                continue
+
+            seen_hashes.add(hash_)
+            filtered_hashes.append(hash_)
+
+        return filtered_hashes
 
     def get_grouping_variants(self, force_config=None, normalize_stacktraces=False):
         """

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -381,7 +381,7 @@ class Event:
 
     @staticmethod
     def _hashes_from_sorted_grouping_variants(variants):
-        """ Create hashes from variants and filter out None values """
+        """ Create hashes from variants and filter out duplicates and None values """
         filtered_hashes = []
         seen_hashes = set()
         for variant in variants:

--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -59,13 +59,14 @@ def get_stacktrace_hierarchy(main_variant, components, frames, inverted_hierarch
         all_variants[key] = prev_variant = GroupingComponent(
             id="stacktrace", values=layer, tree_label=tree_label
         )
-    else:
-        all_variants["app-depth-max"] = main_variant
 
     if not all_variants:
         all_variants.update(
             _build_fallback_tree(main_variant, components, frames, inverted_hierarchy)
         )
+
+    all_variants["app-depth-max"] = main_variant
+
     return all_variants
 
 
@@ -129,9 +130,6 @@ def _build_fallback_tree(main_variant, components, frames, inverted_hierarchy):
             values=pre_frames,
             tree_label=tree_label,
         )
-
-    else:
-        all_variants["app-depth-max"] = main_variant
 
     return all_variants
 

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:36.876582Z'
+created: '2021-05-05T18:04:41.142702Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -35,8 +35,792 @@ app-depth-1:
           "ApplicationNotResponding"
         value (ignored because stacktrace takes precedence)
           "Application Not Responding for at least <int> ms."
-      threads (exception of app-depth-1/system takes precedence)
+      threads (exception of app-depth-1/app-depth-max/system takes precedence)
         stacktrace*
+          frame*
+            module*
+              "dalvik.system.VMStack"
+            filename (module takes precedence)
+              "vmstack.java"
+            function*
+              "getThreadStackTrace"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "81103d430ba24ccad51cdbf81de2297a"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            module*
+              "com.android.internal.os.ZygoteInit"
+            filename (module takes precedence)
+              "zygoteinit.java"
+            function*
+              "main"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            module*
+              "com.android.internal.os.ZygoteInit$MethodAndArgsCaller"
+            filename (module takes precedence)
+              "zygoteinit.java"
+            function*
+              "run"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            module*
+              "java.lang.reflect.Method"
+            filename (module takes precedence)
+              "method.java"
+            function*
+              "invoke"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            module*
+              "java.lang.reflect.Method"
+            filename (module takes precedence)
+              "method.java"
+            function*
+              "invoke"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            module*
+              "android.app.ActivityThread"
+            filename (module takes precedence)
+              "activitythread.java"
+            function*
+              "main"
+          frame*
+            module*
+              "android.os.Looper"
+            filename (module takes precedence)
+              "looper.java"
+            function*
+              "loop"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.os.Handler"
+            filename (module takes precedence)
+              "handler.java"
+            function*
+              "dispatchMessage"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.os.Handler"
+            filename (module takes precedence)
+              "handler.java"
+            function*
+              "handleCallback"
+          frame (ignored by stack trace rule (category:indirection -group))
+            module*
+              "android.view.Choreographer$FrameDisplayEventReceiver"
+            filename (module takes precedence)
+              "choreographer.java"
+            function*
+              "run"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            module*
+              "android.view.Choreographer"
+            filename (module takes precedence)
+              "choreographer.java"
+            function*
+              "doFrame"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.Choreographer"
+            filename (module takes precedence)
+              "choreographer.java"
+            function*
+              "doCallbacks"
+          frame (ignored by stack trace rule (category:indirection -group))
+            module*
+              "android.view.Choreographer$CallbackRecord"
+            filename (module takes precedence)
+              "choreographer.java"
+            function*
+              "run"
+          frame (ignored by stack trace rule (category:indirection -group))
+            module*
+              "android.view.ViewRootImpl$TraversalRunnable"
+            filename (module takes precedence)
+              "viewrootimpl.java"
+            function*
+              "run"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            module*
+              "android.view.ViewRootImpl"
+            filename (module takes precedence)
+              "viewrootimpl.java"
+            function*
+              "doTraversal"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewRootImpl"
+            filename (module takes precedence)
+              "viewrootimpl.java"
+            function*
+              "performTraversals"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewRootImpl"
+            filename (module takes precedence)
+              "viewrootimpl.java"
+            function*
+              "performLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "layoutVertical"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "setChildFrame"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "layoutVertical"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "setChildFrame"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "layoutVertical"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "setChildFrame"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "layoutVertical"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "setChildFrame"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "layoutVertical"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.LinearLayout"
+            filename (module takes precedence)
+              "linearlayout.java"
+            function*
+              "setChildFrame"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.widget.FrameLayout"
+            filename (module takes precedence)
+              "framelayout.java"
+            function*
+              "layoutChildren"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.ViewGroup"
+            filename (module takes precedence)
+              "viewgroup.java"
+            function*
+              "layout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "android.view.View"
+            filename (module takes precedence)
+              "view.java"
+            function*
+              "layout"
+          frame*
+            module*
+              "androidx.recyclerview.widget.RecyclerView"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "onLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.RecyclerView"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "dispatchLayout"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.RecyclerView"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "dispatchLayoutStep1"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.RecyclerView"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "processAdapterUpdatesAndSetAnimationFlags"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.AdapterHelper"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "consumeUpdatesInOnePass"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.RecyclerView$6"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "offsetPositionsForAdd"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.RecyclerView"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "offsetPositionRecordsForInsert"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.ChildHelper"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "getUnfilteredChildAt"
+          frame (ignored by stack trace rule (category:internals -group))
+            module*
+              "androidx.recyclerview.widget.RecyclerView$5"
+            filename (module takes precedence)
+              "sourcefile"
+            function*
+              "getChildAt"
+        type*
+          "ApplicationNotResponding"
+        value (ignored because stacktrace takes precedence)
+          "Application Not Responding for at least <int> ms."
+      threads (exception of app-depth-1/app-depth-max/system takes precedence)
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            module*
+              "java.lang.Thread"
+            filename (module takes precedence)
+              "thread.java"
+            function*
+              "getStackTrace"
           frame*
             module*
               "dalvik.system.VMStack"
@@ -812,7 +1596,7 @@ system:
           "ApplicationNotResponding"
         value (ignored because stacktrace takes precedence)
           "Application Not Responding for at least <int> ms."
-      threads (exception of app-depth-1/system takes precedence)
+      threads (exception of app-depth-1/app-depth-max/system takes precedence)
         stacktrace*
           frame (ignored by stack trace rule (category:threadbase -group v-group))
             module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-22T14:32:55.424993Z'
+created: '2021-05-05T18:04:39.852089Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -72,6 +72,82 @@ app-depth-3:
           frame*
             function*
               "main"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "UIApplicationMain"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "CFRunLoopRunSpecific"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopRun"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSources0"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSource0"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "__eventFetcherSourceCallback"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__processEventQueue"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"
 --------------------------------------------------------------------------
 system:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.862512Z'
+created: '2021-05-05T18:04:39.600300Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,21 @@ app-depth-1:
   hash: "9509e122c6175606d52862fa4f64853c"
   component:
     app-depth-1*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "baz.py"
+        type*
+          "ValueError"
+        value (ignored because stacktrace takes precedence)
+          "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "9509e122c6175606d52862fa4f64853c"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.621130Z'
+created: '2021-05-05T18:04:39.161561Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,21 @@ app-depth-1:
   hash: "9509e122c6175606d52862fa4f64853c"
   component:
     app-depth-1*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "baz.py"
+        type*
+          "ValueError"
+        value (ignored because stacktrace takes precedence)
+          "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "9509e122c6175606d52862fa4f64853c"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.357811Z'
+created: '2021-05-05T18:04:38.716500Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,31 @@ app-depth-1:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   component:
     app-depth-1*
+      chained-exception*
+        exception*
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"
+          type*
+            "ValueError"
+          value (ignored because stacktrace takes precedence)
+            "hello world"
+        exception*
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"
+          type*
+            "ValueError"
+          value (ignored because stacktrace takes precedence)
+            "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "669cb6664e0f5fed38665da04e464f7e"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       chained-exception*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.514797Z'
+created: '2021-05-05T18:04:39.059761Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -28,6 +28,34 @@ app-depth-2:
   tree_label: "..."
   component:
     app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            module*
+              "app/components/modals/createTeamModal"
+            filename (module takes precedence)
+              "createteammodal.jsx"
+            context-line*
+              "onError(err);"
+          frame*
+            module*
+              "app/views/settings/components/forms/form"
+            filename (module takes precedence)
+              "form.jsx"
+            function (ignored because sourcemap used and context line available)
+              "onError"
+            context-line*
+              "this.model.submitError(error);"
+        type*
+          "TypeError"
+        value (ignored because stacktrace takes precedence)
+          "Cannot read property 'submitError' of null"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "26552f86ca2368e708afa1df6effc1c5"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.795803Z'
+created: '2021-05-05T18:04:39.559305Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "invoke"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "sentry_clojure_example.core$_main$fn__<auto>"
+          function*
+            "invoke"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "526b64456c48836a46ec1a89544fd412"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.994609Z'
+created: '2021-05-05T18:04:40.027133Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "jipJipManagementApplication"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>"
+          function*
+            "jipJipManagementApplication"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "45c0b0a8c777e7a7040d7c39233a08a5"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.304957Z'
+created: '2021-05-05T18:04:40.151253Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "invoke"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "sentry_clojure_example.core$_main$fn__<auto>$fn__<auto>"
+          function*
+            "invoke"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "353e05904b48bd3ae4fa9623934a70d0"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.710238Z'
+created: '2021-05-05T18:04:39.242553Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "jipJipManagementApplication"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "invalid.gruml.talkytalkyhub.common.config.JipJipConfig$$EnhancerBySpringCGLIB$$<auto>$$EnhancerBySpringCGLIB$$<auto>$$FastClassBySpringCGLIB$$<auto>"
+          function*
+            "jipJipManagementApplication"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "be15ca3d511b96918e087c4f42503ca2"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:36.737386Z'
+created: '2021-05-05T18:04:40.832596Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -36,6 +36,32 @@ app-depth-2:
           function*
             "test"
           context-line*
+            "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "e04dce7550635e05dbd7f656102cf304"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      stacktrace*
+        frame*
+          filename (ignored because frame points to a URL)
+            "foo.js"
+          function*
+            "test"
+          context-line*
+            "hello world"
+        frame*
+          filename*
+            "foo.js"
+          function*
+            "test"
+          context-line*
+            "hello world"
+        frame
+          filename (ignored because frame points to a URL)
+            "foo.js"
+          context-line (discarded because from URL origin and no function)
             "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:36.704624Z'
+created: '2021-05-05T18:04:40.798794Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "test"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename (ignored because frame points to a URL)
+            "foo.py"
+          function*
+            "test"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "098f6bcd4621d373cade4e832627b4f6"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.320259Z'
+created: '2021-05-05T18:04:39.279368Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,15 @@ app-depth-1:
   hash: null
   component:
     app-depth-1
+      stacktrace
+        frame
+          filename (ignored because frame points to a URL)
+            "7f7aaadf-a006-4217-9ed5-5fbf8585c6c0"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max
       stacktrace
         frame
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.940813Z'
+created: '2021-05-05T18:04:39.759111Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,20 @@ app-depth-1:
   tree_label: "test"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename (ignored because frame points to a URL)
+            "foo.py"
+          function*
+            "test"
+          context-line*
+            "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.633605Z'
+created: '2021-05-05T18:04:39.094903Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,20 @@ app-depth-1:
   tree_label: "test"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename (ignored because frame points to a URL)
+            "foo.py"
+          function*
+            "test"
+          context-line*
+            "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.201173Z'
+created: '2021-05-05T18:04:39.937644Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,18 @@ app-depth-1:
   hash: "be7f1b8b4014de623c533a8218dba5bd"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module*
+            "foo.bar.Baz"
+          function (ignored lambda function)
+            "lambda$work$1"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "be7f1b8b4014de623c533a8218dba5bd"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.788673Z'
+created: '2021-05-05T18:04:40.059552Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "call"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module (ignored java lambda)
+            "foo.bar.Baz$$Lambda$40/1673859467"
+          function*
+            "call"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "53b9e9679a8ea25880376080b76f98ad"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module (ignored java lambda)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.004751Z'
+created: '2021-05-05T18:04:39.916596Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "fn"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "com.example.api.entry.EntriesResource_$$_javassist<auto>"
+          function*
+            "fn"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "538bdfd8d7bb2495d0d6429c3689a420"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.089998Z'
+created: '2021-05-05T18:04:38.865451Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "fn"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "com.example.api.entry.EntriesResource_$$_javassist<auto>"
+          function*
+            "fn"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "538bdfd8d7bb2495d0d6429c3689a420"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.481555Z'
+created: '2021-05-05T18:04:39.212878Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "fn"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename* (cleaned javassist parts)
+            "entriesresource_$$_javassist<auto>.java"
+          function*
+            "fn"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "dc3d511120ce04996b1eef3496516e5c"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename* (cleaned javassist parts)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.254880Z'
+created: '2021-05-05T18:04:39.079549Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,17 @@ app-depth-1:
   hash: null
   component:
     app-depth-1
+      stacktrace
+        frame (ignored single non-URL JavaScript frame)
+          module*
+            "foo/bar/baz"
+          filename (ignored because frame points to a URL)
+            "foo.py"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max
       stacktrace
         frame (ignored single non-URL JavaScript frame)
           module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.546613Z'
+created: '2021-05-05T18:04:39.118908Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,20 @@ app-depth-1:
   tree_label: "a"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module (ignored bad javascript module)
+            "foo/bar/baz"
+          filename (ignored because frame points to a URL)
+            "foo.py"
+          function*
+            "a"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "0cc175b9c0f1b6a831c399e269772661"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module (ignored bad javascript module)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.222895Z'
+created: '2021-05-05T18:04:39.021227Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "forEach"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename (native code indicated by filename)
+            "[native code]"
+          function*
+            "forEach"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "30eb5001914d29dd8461898b5b8094fe"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename (native code indicated by filename)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.021795Z'
+created: '2021-05-05T18:04:38.654164Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "invoke"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "sun.reflect.GeneratedSerializationConstructorAccessor<auto>"
+          function*
+            "invoke"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:40.067743Z'
+created: '2021-05-05T18:04:40.102179Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "invoke"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module* (removed codegen marker)
+            "sun.reflect.GeneratedConstructorAccessor<auto>"
+          function*
+            "invoke"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "09e0efcab18f545166318118ed4e0292"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed codegen marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.267934Z'
+created: '2021-05-05T18:04:40.093763Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,6 +20,23 @@ app-depth-2:
   tree_label: "invoke | ..."
   component:
     app-depth-2*
+      stacktrace*
+        frame*
+          module* (removed reflection marker)
+            "sun.reflect.GeneratedMethodAccessor"
+          function*
+            "invoke"
+        frame*
+          module* (removed reflection marker)
+            "jdk.internal.reflect.GeneratedMethodAccessor"
+          function*
+            "invoke"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "9bc326575875422d0d4ced3c35d9f916"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module* (removed reflection marker)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.319889Z'
+created: '2021-05-05T18:04:38.646744Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "block"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+          function* (ruby block)
+            "block"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "27eed4125fc13d42163ddb0b8f357b48"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:40.053964Z'
+created: '2021-05-05T18:04:40.069655Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "_foo_html_erb"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.html.erb"
+          function* (removed generated erb template suffix)
+            "_foo_html_erb"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "4067a71d7098866f87c746a57a77b2bb"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.810142Z'
+created: '2021-05-05T18:04:38.992202Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,16 @@ app-depth-1:
   hash: "2f908c015ad77a50595512fcf65d344c"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.html.erb"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "2f908c015ad77a50595512fcf65d344c"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.251399Z'
+created: '2021-05-05T18:04:40.057966Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,16 @@ app-depth-1:
   hash: "2f908c015ad77a50595512fcf65d344c"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.html.erb"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "2f908c015ad77a50595512fcf65d344c"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_skips_symbol_if_unknown.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_skips_symbol_if_unknown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.117932Z'
+created: '2021-05-05T18:04:38.890598Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "main"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module*
+            "libfoo"
+          function*
+            "main"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "a972f399399f5566f39b14a7afdd24ff"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:40.040220Z'
+created: '2021-05-05T18:04:40.040273Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "bar"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+          function*
+            "bar"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "fb73cb54ced59b1c0c60d9bb40b7336b"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_function_over_lineno.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_function_over_lineno.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.336585Z'
+created: '2021-05-05T18:04:38.678299Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "bar"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+          function*
+            "bar"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "fb73cb54ced59b1c0c60d9bb40b7336b"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.828498Z'
+created: '2021-05-05T18:04:39.659337Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,18 @@ app-depth-1:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module*
+            "foo"
+          filename (module takes precedence)
+            "foo.py"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "acbd18db4cc2f85cedef654fccc4a4d8"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_symbol_instead_of_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_symbol_instead_of_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.004411Z'
+created: '2021-05-05T18:04:38.617675Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,18 @@ app-depth-1:
   tree_label: "int main()"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module*
+            "libfoo"
+          function*
+            "int main()"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "23db4a9e73800923f345d2b868993345"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.898696Z'
+created: '2021-05-05T18:04:39.167806Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,16 @@ app-depth-1:
   hash: "1effb24729ae4c43efa36b460511136a"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "1effb24729ae4c43efa36b460511136a"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:28.875056Z'
+created: '2021-05-05T18:04:38.977894Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,168 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / 0x00000032"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "3da34e8c72dbcd4a490ac36eb7130638"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::function<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__value_func<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__func<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__alloc_func<T>::operator()"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__functional_base"
+            function*
+              "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "type_traits"
+            function*
+              "std::__1::__invoke<T>"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "initialize.cpp"
+            function*
+              "MZ::`anonymous namespace'::lambda::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "CFBundleGetFunctionPointerForName"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_CFBundleLoadExecutableAndReturnError"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_CFBundleDlfcnLoadBundle"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+            function*
+              "dlopen"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "dlopen_internal"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "dyld::link"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoader::link"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoader::recursiveRebase"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoaderMachOCompressed::rebase"
+            package (ignored because function takes precedence)
+              "dyld"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / 0x00000032"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:25.221976Z'
+created: '2021-05-05T18:04:39.120835Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -25,6 +25,138 @@ app-depth-1:
               "destructor'"
             package (ignored because function takes precedence)
               "winhttp.dll"
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "6b9106347534a0018fe5f3d9993b3bb5"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "RtlUserThreadStart"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "BaseThreadInitThunk"
+            package (ignored because function takes precedence)
+              "kernel32.dll"
+          frame*
+            function*
+              "TppWorkerThread"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "TppWorkpExecuteCallback"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "HTTP_THREAD_POOL::_StaticWorkItemCallback"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "HTTP_ASYNC_OVERLAPPED::OnWorkItem"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "WEBIO_REQUEST::OnIoComplete"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "HTTP_USER_REQUEST::OnSendRequest"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "HTTP_BASE_OBJECT::Dereference"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "HTTP_USER_REQUEST::~HTTP_USER_REQUEST"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+            function*
+              "RtlFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "memset"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpFreeUserBlock"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpFreeUserBlockToHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+            function*
+              "RtlFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpFreeHeapInternal"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlEnterCriticalSection"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpEnterCriticalSectionContended"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpWaitOnCriticalSection"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpWaitOnAddress"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpOptimizeWaitOnAddressWaitList"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_WRITE"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.793645Z'
+created: '2021-05-05T18:04:38.960145Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -52,6 +52,118 @@ app-depth-3:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "2c1bbd635b64d5adccdb64a620044075"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_root_queues_init_once"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start_wqthread"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_wqthread"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_worker_thread2"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_root_queue_drain"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_client_callout"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T>"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:27.921056Z'
+created: '2021-05-05T18:04:39.560386Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -25,6 +25,126 @@ app-depth-1:
               "glDeleteTextures_Exec"
             package (ignored because function takes precedence)
               "glengine"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "9c336f632f6764c0f082a6a66edbf22d"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "thread.cpp"
+            function*
+              "boost::thread::start_thread_noexcept"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "thread_start"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_start"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "thread.cpp"
+            function*
+              "boost::`anonymous namespace'::thread_proxy"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+            function*
+              "glDeleteTextures_Exec"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gleUnbindDeleteHashNamesAndObjects"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gleUnbindTextureObject"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gldUpdateDispatch"
+            package (ignored because function takes precedence)
+              "geforcegldriver"
+          frame (ignored due to recursion)
+            function*
+              "gldUpdateDispatch"
+            package (ignored because function takes precedence)
+              "geforcegldriver"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            function*
+              "gldCreateDevice"
+            package (ignored because function takes precedence)
+              "geforcegldriver"
+          frame (ignored by stack trace rule (category:telemetry -group))
+            function*
+              "gpusGenerateCrashLog"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "gpusGenerateCrashLog.cold.1"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:26.555310Z'
+created: '2021-05-05T18:04:39.252753Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,6 +46,175 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "a3681449b8f66e38697bba72bab32569"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            package* (used as fallback because function name is not available)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start_wqthread"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_wqthread"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "libdispatch.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "libdispatch.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "libdispatch.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "mac"
+            function*
+              "std::__1::map<T>::~map"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "map"
+            function*
+              "std::__1::map<T>::~map"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::~__tree"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::~__tree"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::destroy"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::destroy<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::__destroy<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "mac"
+            function*
+              "std::__1::pair<T>::~pair"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "utility"
+            function*
+              "std::__1::pair<T>::~pair"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "std::__1::thread::~thread"
+            package (ignored because function takes precedence)
+              "libc++.1.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "std::__terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "default_terminate_handler"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort_message"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            package* (used as fallback because function name is not available)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:26.225820Z'
+created: '2021-05-05T18:04:40.413019Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -46,6 +46,188 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "a3681449b8f66e38697bba72bab32569"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_root_queues_init_once"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start_wqthread"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_wqthread"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_worker_thread2"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_root_queue_drain"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_dispatch_client_callout"
+            package (ignored because function takes precedence)
+              "libdispatch.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "mac"
+            function*
+              "std::__1::map<T>::~map"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "map"
+            function*
+              "std::__1::map<T>::~map"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::~__tree"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::~__tree"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::destroy"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            filename (discarded native filename for grouping stability)
+              "__tree"
+            function*
+              "std::__1::__tree<T>::destroy"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::destroy<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::__destroy<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "mac"
+            function*
+              "std::__1::pair<T>::~pair"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "utility"
+            function*
+              "std::__1::pair<T>::~pair"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "std::__terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "demangling_terminate_handler"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort_message"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:36.681188Z'
+created: '2021-05-05T18:04:40.769663Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,6 +13,72 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "thread_start"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_start"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "__dynamic_cast"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / EXC_I386_GPFLT"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.906460Z'
+created: '2021-05-05T18:04:39.707918Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,6 +13,69 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / EXC_I386_GPFLT"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / EXC_I386_GPFLT"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            package* (used as fallback because function name is not available)
+              "libsystem_pthread.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "libsystem_pthread.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "libsystem_pthread.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "libc++abi.dylib"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / EXC_I386_GPFLT"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:29.826417Z'
+created: '2021-05-05T18:04:39.688558Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -23,6 +23,237 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "8be5979a334287a1b47457228f1d4612"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::function<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__value_func<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__func<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__alloc_func<T>::operator()"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__functional_base"
+            function*
+              "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "type_traits"
+            function*
+              "std::__1::__invoke<T>"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "initialize.cpp"
+            function*
+              "MZ::`anonymous namespace'::lambda::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_objc_msgSend_uncached"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "lookUpImpOrForward"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "initializeAndMaybeRelock"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "initializeNonMetaClass"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CALLING_SOME_+initialize_METHOD"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+            function*
+              "dlopen"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "dlopen_internal"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            package* (used as fallback because function name is not available)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__report_load"
+            package (ignored because function takes precedence)
+              "libcrypto.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "__report_load.cold.1"
+            package (ignored because function takes precedence)
+              "libcrypto.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:33.349387Z'
+created: '2021-05-05T18:04:40.027144Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -23,6 +23,236 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "8be5979a334287a1b47457228f1d4612"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::function<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__value_func<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__func<T>::operator()"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::__1::__function::__alloc_func<T>::operator()"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "__functional_base"
+            function*
+              "std::__1::__invoke_void_return_wrapper<T>::__call<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "type_traits"
+            function*
+              "std::__1::__invoke<T>"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "initialize.cpp"
+            function*
+              "MZ::`anonymous namespace'::lambda::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_objc_msgSend_uncached"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "lookUpImpOrForward"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "initializeAndMaybeRelock"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "initializeNonMetaClass"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CALLING_SOME_+initialize_METHOD"
+            package (ignored because function takes precedence)
+              "libobjc.a.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
+            function*
+              "dlopen"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "dlopen_internal"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "dyld::runInitializers"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoader::runInitializers"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoader::processInitializers"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoader::recursiveInitialization"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoaderMachO::doInitialization"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ImageLoaderMachO::doModInitFunctions"
+            package (ignored because function takes precedence)
+              "dyld"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__report_load"
+            package (ignored because function takes precedence)
+              "libcrypto.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:32.601619Z'
+created: '2021-05-05T18:04:40.092075Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -25,6 +25,290 @@ app-depth-1:
               "CGLFlushDrawable"
             package (ignored because function takes precedence)
               "opengl"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "7e64037e487c78ce0439f750a2ef503f"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "-[NSApplication run]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_DPSNextEvent"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_BlockUntilNextEventMatchingListInModeWithFilter"
+            package (ignored because function takes precedence)
+              "hitoolbox"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ReceiveNextEventCommon"
+            package (ignored because function takes precedence)
+              "hitoolbox"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RunCurrentEventLoopInMode"
+            package (ignored because function takes precedence)
+              "hitoolbox"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CFRunLoopRunSpecific"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopRun"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSources0"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSource0"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__NSThreadPerformPerform"
+            package (ignored because function takes precedence)
+              "foundation"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "-[NSView displayIfNeeded]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[_NSOpenGLViewBackingLayer display]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "-[NSOpenGLContext flushBuffer]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+            function*
+              "CGLFlushDrawable"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "glSwap_Exec"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gldPresentFramebufferData"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "SwapFlush"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "intelSubmitCommands"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "IntelCommandBuffer::getNew"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:telemetry -group))
+            function*
+              "gpusKillClientExt"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:telemetry -group))
+            function*
+              "gpusGenerateCrashLog"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "gpusGenerateCrashLog.cold.1"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "_sigtramp"
+            package (ignored because function takes precedence)
+              "libsystem_platform.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "NSRunAlertPanel"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "_NSTryRunModal"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CA::Transaction::commit"
+            package (ignored because function takes precedence)
+              "quartzcore"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CA::Context::commit_transaction"
+            package (ignored because function takes precedence)
+              "quartzcore"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CA::Layer::display_if_needed"
+            package (ignored because function takes precedence)
+              "quartzcore"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "-[_NSOpenGLViewBackingLayer display]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CGLTexImageIOSurface2D"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CGLDescribeRenderer"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gliSetInteger"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gldFlushObject"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "intelSubmitCommands"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "IntelCommandBuffer::getNew"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusKillClientExt"
+            package (ignored because function takes precedence)
+              "appleintelhd4000graphicsgldriver"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusGenerateCrashLog"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusGenerateCrashLog.cold.1"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.879168Z'
+created: '2021-05-05T18:04:39.140176Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,6 +13,56 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "thread_start"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_start"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_body"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_pthread_testcancel"
+            package (ignored because function takes precedence)
+              "libsystem_pthread.dylib"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:23.974905Z'
+created: '2021-05-05T18:04:39.274954Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,144 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "28f1b76e3bcdfa5e5e1671e6a919a506"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "RtlUserThreadStart"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "BaseThreadInitThunk"
+            package (ignored because function takes precedence)
+              "kernel32.dll"
+          frame*
+            function*
+              "TppWorkerThread"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpTpWorkCallback"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "raise"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            filename (discarded native filename for grouping stability)
+              "crashpad_client_win.cc"
+            function*
+              "crashpad::`anonymous namespace'::HandleAbortSignal"
         type (ignored because exception is synthetic)
           "0x40000015 / 0x00000001"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:29.147219Z'
+created: '2021-05-05T18:04:39.675908Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,144 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "8a62fbea1511325fb930366d547f0afa"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "RtlUserThreadStart"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "BaseThreadInitThunk"
+            package (ignored because function takes precedence)
+              "kernel32.dll"
+          frame*
+            function*
+              "TppWorkerThread"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RtlpTpWorkCallback"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "xtree"
+            function*
+              "std::_Tree<T>::insert<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "xtree"
+            function*
+              "std::_Tree<T>::_Emplace"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "raise"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            filename (discarded native filename for grouping stability)
+              "crashpad_client_win.cc"
+            function*
+              "crashpad::`anonymous namespace'::HandleAbortSignal"
         type (ignored because exception is synthetic)
           "0x40000015 / 0x00000001"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:26.206284Z'
+created: '2021-05-05T18:04:38.810135Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,167 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "e964d1e7cfec1ffbfe73559e02f9ac1b"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "RtlUserThreadStart"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "BaseThreadInitThunk"
+            package (ignored because function takes precedence)
+              "kernel32.dll"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "exe_common.inl"
+            function*
+              "invoke_main"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "winmain.cpp"
+            function*
+              "wWinMain"
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            filename (discarded native filename for grouping stability)
+              "xstring"
+            function*
+              "std::basic_string<T>::{ctor}"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "xstring"
+            function*
+              "std::basic_string<T>::assign"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            filename (discarded native filename for grouping stability)
+              "xstring"
+            function*
+              "std::basic_string<T>::assign"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "xstring"
+            function*
+              "std::basic_string<T>::_Reallocate_for"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "functional"
+            function*
+              "std::_Func_class<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "DispatchMessageWorker"
+            package (ignored because function takes precedence)
+              "user32.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "UserCallWinProcCheckWow"
+            package (ignored because function takes precedence)
+              "user32.dll"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "function_template.hpp"
+            function*
+              "boost::function0<T>::operator()"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:indirection -group))
+            filename (discarded native filename for grouping stability)
+              "purevirt.cpp"
+            function*
+              "_purecall"
+            package (ignored because function takes precedence)
+              "vcruntime140.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "raise"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            filename (discarded native filename for grouping stability)
+              "crashpad_client_win.cc"
+            function*
+              "crashpad::`anonymous namespace'::HandleAbortSignal"
         type (ignored because exception is synthetic)
           "0x40000015 / 0x00000001"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.567946Z'
+created: '2021-05-05T18:04:39.155617Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -48,6 +48,37 @@ app-depth-3:
   tree_label: "... | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure}"
   component:
     app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "server.php"
+            context-line*
+              "require_once __DIR__.'/public/index.php';"
+          frame*
+            filename*
+              "pipeline.php"
+            function* (anonymous class method)
+              "run"
+            context-line*
+              "return $callable($passable);"
+          frame*
+            filename*
+              "pipeline.php"
+            function*
+              "Illuminate\\Pipeline\\Pipeline::Illuminate\\Pipeline\\{closure}"
+            context-line*
+              "? $pipe->{$this->method}(...$parameters)"
+        type*
+          "Exception"
+        value (ignored because stacktrace takes precedence)
+          "LARAVEL TEST"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "63c67781779781d9b0a442a5b2bdb976"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:33.011193Z'
+created: '2021-05-05T18:04:41.414705Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -23,6 +23,195 @@ app-depth-1:
               "glTexSubImage2D"
             package (ignored because function takes precedence)
               "libgl.dylib"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "0a16eff3ac6acb7f1b7926d65019e155"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame*
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame*
+            function*
+              "-[NSRunLoop(NSRunLoop) runMode:beforeDate:]"
+            package (ignored because function takes precedence)
+              "foundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CFRunLoopRunSpecific"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopRun"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSources0"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSource0"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+            package (ignored because function takes precedence)
+              "corefoundation"
+          frame*
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+            function*
+              "glTexSubImage2D"
+            package (ignored because function takes precedence)
+              "libgl.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "glTexSubImage2D_Exec"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gleTextureImagePut"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "amdradeonx5000gldriver"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "amdradeonx5000gldriver"
+          frame (ignored by stack trace rule (category:telemetry -group))
+            function*
+              "gpusGenerateCrashLog"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "gpusGenerateCrashLog.cold.1"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:28.980239Z'
+created: '2021-05-05T18:04:39.935791Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -25,6 +25,283 @@ app-depth-1:
               "CGLTexImageIOSurface2D"
             package (ignored because function takes precedence)
               "opengl"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "36be6e0b6123ef6ecfbef62f5cb88406"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame (marked out of app by stack trace rule (family:native package:/usr/lib/** -app))
+            function*
+              "start"
+            package (ignored because function takes precedence)
+              "libdyld.dylib"
+          frame*
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame*
+            function*
+              "-[NSApplication run]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_DPSNextEvent"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "_BlockUntilNextEventMatchingListInModeWithFilter"
+            package (ignored because function takes precedence)
+              "hitoolbox"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "ReceiveNextEventCommon"
+            package (ignored because function takes precedence)
+              "hitoolbox"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "RunCurrentEventLoopInMode"
+            package (ignored because function takes precedence)
+              "hitoolbox"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "corefoundation"
+          frame (ignored due to recursion)
+            package* (used as fallback because function name is not available)
+              "corefoundation"
+          frame (ignored due to recursion)
+            package* (used as fallback because function name is not available)
+              "corefoundation"
+          frame (ignored due to recursion)
+            package* (used as fallback because function name is not available)
+              "corefoundation"
+          frame (ignored due to recursion)
+            package* (used as fallback because function name is not available)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__NSThreadPerformPerform"
+            package (ignored because function takes precedence)
+              "foundation"
+          frame*
+            function*
+              "code"
+          frame*
+            function*
+              "-[NSView displayIfNeeded]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[_NSOpenGLViewBackingLayer display]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame*
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
+            function*
+              "CGLTexImageIOSurface2D"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CGLDescribeRenderer"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gliSetInteger"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "gldFlushObject"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "intelSubmitCommands"
+            package (ignored because function takes precedence)
+              "appleinteliclgraphicsgldriver"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "IntelCommandBuffer::getNew"
+            package (ignored because function takes precedence)
+              "appleinteliclgraphicsgldriver"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:telemetry -group))
+            function*
+              "gpusKillClientExt"
+            package (ignored because function takes precedence)
+              "appleinteliclgraphicsgldriver"
+          frame (ignored by stack trace rule (category:telemetry -group))
+            function*
+              "gpusGenerateCrashLog"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "gpusGenerateCrashLog.cold.1"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            package* (used as fallback because function name is not available)
+              "corefoundation"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "_sigtramp"
+            package (ignored because function takes precedence)
+              "libsystem_platform.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "NSRunAlertPanel"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "_NSTryRunModal"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CA::Transaction::commit"
+            package (ignored because function takes precedence)
+              "quartzcore"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CA::Context::commit_transaction"
+            package (ignored because function takes precedence)
+              "quartzcore"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CA::Layer::display_if_needed"
+            package (ignored because function takes precedence)
+              "quartzcore"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "-[_NSOpenGLViewBackingLayer display]"
+            package (ignored because function takes precedence)
+              "appkit"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "code"
+          frame (ignored due to recursion)
+            function*
+              "code"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CGLTexImageIOSurface2D"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "CGLDescribeRenderer"
+            package (ignored because function takes precedence)
+              "opengl"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gliSetInteger"
+            package (ignored because function takes precedence)
+              "glengine"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gldFlushObject"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "intelSubmitCommands"
+            package (ignored because function takes precedence)
+              "appleinteliclgraphicsgldriver"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "IntelCommandBuffer::getNew"
+            package (ignored because function takes precedence)
+              "appleinteliclgraphicsgldriver"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusKillClientExt"
+            package (ignored because function takes precedence)
+              "appleinteliclgraphicsgldriver"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusGenerateCrashLog"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "gpusGenerateCrashLog.cold.1"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+            package (ignored because function takes precedence)
+              "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.988080Z'
+created: '2021-05-05T18:04:39.870856Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -31,6 +31,27 @@ app-depth-2:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
+          frame*
+            function*
+              "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "<lambda>::operator()"
         type (ignored because exception is synthetic)
           "log_demo"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:25.894570Z'
+created: '2021-05-05T18:04:40.027745Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,51 @@ app-depth-1:
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
             package (ignored because function takes precedence)
               "d3d11.dll"
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "dace415c7739d08199fdcba4a694e255"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "CUseCountedObject<T>::UCDestroy"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame*
+            function*
+              "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CContext::LUCBeginLayerDestruction"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "NDXGI::CDevice::DestroyDriverInstance"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "OpenAdapter10"
+            package (ignored because function takes precedence)
+              "nvwgf2umx.dll"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.101902Z'
+created: '2021-05-05T18:04:38.798417Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,6 +15,44 @@ app-depth-1:
               "CUseCountedObject<T>::UCDestroy"
             package (ignored because function takes precedence)
               "d3d11.dll"
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "c85e23e804b52ea4b9f290ba838e77a0"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "CUseCountedObject<T>::UCDestroy"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CContext::LUCBeginLayerDestruction"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "NDXGI::CDevice::DestroyDriverInstance"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "OpenAdapter10"
+            package (ignored because function takes precedence)
+              "nvwgf2umx.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
+          frame (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:23.929387Z'
+created: '2021-05-05T18:04:38.795406Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,54 @@ app-depth-1:
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
             package (ignored because function takes precedence)
               "d3d11.dll"
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_READ"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_READ"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "f7257ec144c61a9da89b30a65eaa616e"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "CUseCountedObject<T>::UCDestroy"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame*
+            function*
+              "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CContext::LUCBeginLayerDestruction"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "NDXGI::CDevice::DestroyDriverInstance"
+            package (ignored because function takes precedence)
+              "d3d11.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "OpenAdapter12"
+            package (ignored because function takes precedence)
+              "nvwgf2umx.dll"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
         type (ignored because exception is synthetic)
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.530645Z'
+created: '2021-05-05T18:04:38.861575Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,6 +13,27 @@ app-depth-1:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "8f4c7709e4af98d3c47ce3519690e6d9"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored because only 1 frame is considered by stack trace rule (family:native max-frames=1))
+            function*
+              "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
+          frame*
+            function*
+              "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "<lambda>::operator()"
         type (ignored because exception is synthetic)
           "log_demo"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:25.915681Z'
+created: '2021-05-05T18:04:39.327974Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,6 +18,46 @@ app-depth-1:
           frame*
             function*
               "application_frame"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "3ff01ce959249abecc6bc8a8f1432b0b"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "application_frame"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+            function*
+              "malloc_zone_malloc"
+            package (ignored because function takes precedence)
+              "libsystem_malloc.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "nanov2_malloc"
+            package (ignored because function takes precedence)
+              "libsystem_malloc.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "nanov2_allocate"
+            package (ignored because function takes precedence)
+              "libsystem_malloc.dylib"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "nanov2_allocate_from_block"
+            package (ignored because function takes precedence)
+              "libsystem_malloc.dylib"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "nanov2_allocate_from_block.cold.1"
+            package (ignored because function takes precedence)
+              "libsystem_malloc.dylib"
         type (ignored because exception is synthetic)
           "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:36.245371Z'
+created: '2021-05-05T18:04:40.139532Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -31,6 +31,27 @@ app-depth-2:
           frame*
             function*
               "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+        type (ignored because exception is synthetic)
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
+          frame*
+            function*
+              "Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "<lambda>::operator()"
         type (ignored because exception is synthetic)
           "log_demo"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.925209Z'
+created: '2021-05-05T18:04:39.788581Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -49,6 +49,43 @@ app-depth-3:
     app-depth-3*
       exception*
         stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "main"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "`anonymous namespace'::start"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "`anonymous namespace'::crash"
+        type (ignored because exception is synthetic)
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "3df8bc242dfdc7460b42fa529422630f"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "exe_common.inl"
+            function*
+              "__scrt_common_main_seh"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "exe_common.inl"
+            function*
+              "invoke_main"
           frame*
             filename (discarded native filename for grouping stability)
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2021-04-30T12:13:37.603108Z'
+created: '2021-05-05T18:04:39.132688Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
   hash: null
   component:
-    app (exception of app-depth-1/app-depth-2/app-depth-3/app-depth-4/system takes precedence)
+    app (exception of app-depth-1/app-depth-2/app-depth-3/app-depth-4/app-depth-max/system takes precedence)
       threads (thread has no stacktrace)
 --------------------------------------------------------------------------
 app-depth-1:
@@ -92,6 +92,46 @@ app-depth-4:
   tree_label: "main | ..."
   component:
     app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "main"
+            package (ignored because function takes precedence)
+              "crash"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "`anonymous namespace'::start"
+            package (ignored because function takes precedence)
+              "crash"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "`anonymous namespace'::crash"
+            package (ignored because function takes precedence)
+              "crash"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "main.cpp"
+            function*
+              "`anonymous namespace'::something::nested::Foo<T>::crash"
+            package (ignored because function takes precedence)
+              "crash"
+        type (ignored because exception is synthetic)
+          "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "a07df792479c5ba46fc056236749b796"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       exception*
         stacktrace*
           frame*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.551294Z'
+created: '2021-05-05T18:04:38.893782Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,31 @@ app-depth-1:
   hash: "669cb6664e0f5fed38665da04e464f7e"
   component:
     app-depth-1*
+      chained-exception*
+        exception*
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"
+          type*
+            "ValueError"
+          value (ignored because stacktrace takes precedence)
+            "hello world"
+        exception*
+          stacktrace*
+            frame*
+              filename*
+                "baz.py"
+          type*
+            "ValueError"
+          value (ignored because stacktrace takes precedence)
+            "hello world"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "669cb6664e0f5fed38665da04e464f7e"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       chained-exception*
         exception*
           stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.522578Z'
+created: '2021-05-05T18:04:39.289608Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -31,6 +31,108 @@ app-depth-2:
     app-depth-2*
       exception*
         stacktrace*
+          frame*
+            module*
+              "sentry.web.frontend.release_webhook"
+            filename (module takes precedence)
+              "release_webhook.py"
+            function*
+              "post"
+            context-line*
+              "hook.handle(request)"
+          frame*
+            module*
+              "sentry_plugins.heroku.plugin"
+            filename (module takes precedence)
+              "plugin.py"
+            function*
+              "handle"
+            context-line*
+              "email = request.POST['user']"
+          frame*
+            module*
+              "django.utils.datastructures"
+            filename (module takes precedence)
+              "datastructures.py"
+            function*
+              "__getitem__"
+            context-line*
+              "raise MultiValueDictKeyError(repr(key))"
+        type*
+          "MultiValueDictKeyError"
+        value (ignored because stacktrace takes precedence)
+          "\"'user'\""
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "a5af2577d4caca8f983657c5d1919e14"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "django.core.handlers.base"
+            filename (module takes precedence)
+              "base.py"
+            function*
+              "get_response"
+            context-line*
+              "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "django.views.generic.base"
+            filename (module takes precedence)
+              "base.py"
+            function*
+              "view"
+            context-line*
+              "return self.dispatch(request, *args, **kwargs)"
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "django.utils.decorators"
+            filename (module takes precedence)
+              "decorators.py"
+            function*
+              "_wrapper"
+            context-line*
+              "return bound_func(*args, **kwargs)"
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "django.views.decorators.csrf"
+            filename (module takes precedence)
+              "csrf.py"
+            function*
+              "wrapped_view"
+            context-line*
+              "return view_func(*args, **kwargs)"
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "django.utils.decorators"
+            filename (module takes precedence)
+              "decorators.py"
+            function*
+              "bound_func"
+            context-line*
+              "return func(self, *args2, **kwargs2)"
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "sentry.web.frontend.release_webhook"
+            filename (module takes precedence)
+              "release_webhook.py"
+            function*
+              "dispatch"
+            context-line*
+              "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
+          frame (ignored by stack trace rule (path:**/release_webhook.py v-group))
+            module*
+              "django.views.generic.base"
+            filename (module takes precedence)
+              "base.py"
+            function*
+              "dispatch"
+            context-line*
+              "return handler(request, *args, **kwargs)"
           frame*
             module*
               "sentry.web.frontend.release_webhook"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.757091Z'
+created: '2021-05-05T18:04:39.420078Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -88,6 +88,108 @@ app-depth-3:
               "_wrapper"
             context-line*
               "return bound_func(*args, **kwargs)"
+        type*
+          "MultiValueDictKeyError"
+        value (ignored because stacktrace takes precedence)
+          "\"'user'\""
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "90888e813b09fa25061af2883c0fb9bd"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            module*
+              "django.core.handlers.base"
+            filename (module takes precedence)
+              "base.py"
+            function*
+              "get_response"
+            context-line*
+              "response = wrapped_callback(request, *callback_args, **callback_kwargs)"
+          frame*
+            module*
+              "django.views.generic.base"
+            filename (module takes precedence)
+              "base.py"
+            function*
+              "view"
+            context-line*
+              "return self.dispatch(request, *args, **kwargs)"
+          frame*
+            module*
+              "django.utils.decorators"
+            filename (module takes precedence)
+              "decorators.py"
+            function*
+              "_wrapper"
+            context-line*
+              "return bound_func(*args, **kwargs)"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "django.views.decorators.csrf"
+            filename (module takes precedence)
+              "csrf.py"
+            function*
+              "wrapped_view"
+            context-line*
+              "return view_func(*args, **kwargs)"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "django.utils.decorators"
+            filename (module takes precedence)
+              "decorators.py"
+            function*
+              "bound_func"
+            context-line*
+              "return func(self, *args2, **kwargs2)"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "sentry.web.frontend.release_webhook"
+            filename (module takes precedence)
+              "release_webhook.py"
+            function*
+              "dispatch"
+            context-line*
+              "return super(ReleaseWebhookView, self).dispatch(*args, **kwargs)"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "django.views.generic.base"
+            filename (module takes precedence)
+              "base.py"
+            function*
+              "dispatch"
+            context-line*
+              "return handler(request, *args, **kwargs)"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "sentry.web.frontend.release_webhook"
+            filename (module takes precedence)
+              "release_webhook.py"
+            function*
+              "post"
+            context-line*
+              "hook.handle(request)"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "sentry_plugins.heroku.plugin"
+            filename (module takes precedence)
+              "plugin.py"
+            function*
+              "handle"
+            context-line*
+              "email = request.POST['user']"
+          frame (ignored by stack trace rule (function:wrapped_view ^-group -group))
+            module*
+              "django.utils.datastructures"
+            filename (module takes precedence)
+              "datastructures.py"
+            function*
+              "__getitem__"
+            context-line*
+              "raise MultiValueDictKeyError(repr(key))"
         type*
           "MultiValueDictKeyError"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:37.494546Z'
+created: '2021-05-05T18:04:39.019344Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -63,11 +63,50 @@ app-depth-2:
         value (ignored because stacktrace takes precedence)
           "<int> Client Error: Too Many Requests for url: <url>"
 --------------------------------------------------------------------------
+app-depth-max:
+  hash: "133db3f366b1327dab4e661f66dfb961"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            module*
+              "sentry.utils.safe"
+            filename (module takes precedence)
+              "safe.py"
+            function*
+              "safe_execute"
+            context-line*
+              "result = func(*args, **kwargs)"
+          frame*
+            module*
+              "sentry.integrations.slack.notify_action"
+            filename (module takes precedence)
+              "notify_action.py"
+            function*
+              "send_notification"
+            context-line*
+              "resp.raise_for_status()"
+          frame*
+            module*
+              "requests.models"
+            filename (module takes precedence)
+              "models.py"
+            function*
+              "raise_for_status"
+            context-line*
+              "raise HTTPError(http_error_msg, response=self)"
+        type*
+          "HTTPError"
+        value (ignored because stacktrace takes precedence)
+          "<int> Client Error: Too Many Requests for url: <url>"
+--------------------------------------------------------------------------
 default:
   hash: null
   component:
-    default (exception of app-depth-1/app-depth-2/system takes precedence)
-      message (exception of app-depth-1/app-depth-2/system takes precedence)
+    default (exception of app-depth-1/app-depth-2/app-depth-max/system takes precedence)
+      message (exception of app-depth-1/app-depth-2/app-depth-max/system takes precedence)
         "%s.process_error"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.436073Z'
+created: '2021-05-05T18:04:38.737352Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,6 +17,19 @@ app-depth-2:
   tree_label: "..."
   component:
     app-depth-2*
+      stacktrace*
+        frame*
+          filename*
+            "bar.m"
+        frame*
+          filename*
+            "baz.m"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "1df786c8c266506e1acb6669c8df5154"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.845739Z'
+created: '2021-05-05T18:04:39.560216Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,6 +17,19 @@ app-depth-2:
   tree_label: "..."
   component:
     app-depth-2*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+        frame*
+          filename*
+            "bar.py"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "659ad79e2e70c822d30a53d7d889529e"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.501837Z'
+created: '2021-05-05T18:04:39.725272Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,15 @@ app-depth-1:
   hash: null
   component:
     app-depth-1
+      stacktrace
+        frame
+          filename (ignored because frame points to a URL)
+            "foo"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max
       stacktrace
         frame
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:38.741610Z'
+created: '2021-05-05T18:04:39.389832Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,16 @@ app-depth-1:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          filename*
+            "foo"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "acbd18db4cc2f85cedef654fccc4a4d8"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.679883Z'
+created: '2021-05-05T18:04:39.169507Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,15 @@ app-depth-1:
   hash: null
   component:
     app-depth-1
+      stacktrace
+        frame
+          filename (ignored because frame points to a URL)
+            "index.js"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max
       stacktrace
         frame
           filename (ignored because frame points to a URL)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:36.263723Z'
+created: '2021-05-05T18:04:38.945592Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,6 +7,18 @@ app-depth-1:
   hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
   component:
     app-depth-1*
+      stacktrace*
+        frame*
+          module*
+            "<unknown module>"
+          filename (ignored because frame points to a URL)
+            ""
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           module*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.844612Z'
+created: '2021-05-05T18:04:40.150268Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,6 +17,19 @@ app-depth-2:
   tree_label: "..."
   component:
     app-depth-2*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+        frame*
+          filename*
+            "bar.py"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "659ad79e2e70c822d30a53d7d889529e"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       stacktrace*
         frame*
           filename*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:35.729213Z'
+created: '2021-05-05T18:04:38.773573Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -21,6 +21,26 @@ app-depth-2:
   component:
     app-depth-2*
       stacktrace*
+        frame*
+          filename*
+            "dojo.js"
+          function*
+            "c"
+        frame*
+          filename*
+            "dojo.js"
+          function* (trimmed javascript function)
+            "_createDocumentViewModel"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "c5da56c71b31f34c5880d734cbc8f5bb"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      stacktrace*
+        frame (ignored low quality javascript frame)
+          filename (anonymous filename discarded)
+            "<anonymous>"
         frame*
           filename*
             "dojo.js"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.987512Z'
+created: '2021-05-05T18:04:39.924824Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,6 +15,49 @@ app-depth-1:
               "log_demo::main"
             package (ignored because function takes precedence)
               "log_demo"
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "eb87c1031dba55b67df86fb9fff59dc6"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (function:log_demo::* -group))
+            function*
+              "_main"
+          frame (ignored by stack trace rule (function:log_demo::* -group))
+            function*
+              "std::rt::lang_start_internal"
+            package (ignored because function takes precedence)
+              "std"
+          frame (ignored by stack trace rule (function:log_demo::* -group))
+            function*
+              "___rust_maybe_catch_panic"
+          frame (ignored by stack trace rule (function:log_demo::* -group))
+            function*
+              "std::panicking::try::do_call"
+            package (ignored because function takes precedence)
+              "std"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "std::rt::lang_start::{{closure}}"
+            package (ignored because function takes precedence)
+              "std"
+          frame*
+            function*
+              "log_demo::main"
+            package (ignored because function takes precedence)
+              "log_demo"
+          frame (ignored by stack trace rule (function:log_demo::* -group))
+            function*
+              "log::__private_api_log"
+            package (ignored because function takes precedence)
+              "log"
         type*
           "log_demo"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.046994Z'
+created: '2021-05-05T18:04:40.020418Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -94,6 +94,49 @@ app-depth-4:
               "log_demo::main"
             package (ignored because function takes precedence)
               "log_demo"
+        type*
+          "log_demo"
+        value (ignored because stacktrace takes precedence)
+          "Holy shit everything is on fire!"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "0817e4e604fbe88c4534eff166df1db9"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "_main"
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            function*
+              "std::rt::lang_start_internal"
+            package (ignored because function takes precedence)
+              "std"
+          frame (ignored by stack trace rule (family:native function:__* -group))
+            function*
+              "___rust_maybe_catch_panic"
+          frame* (marked out of app by stack trace rule (family:native function:std::* -app))
+            function*
+              "std::panicking::try::do_call"
+            package (ignored because function takes precedence)
+              "std"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "std::rt::lang_start::{{closure}}"
+            package (ignored because function takes precedence)
+              "std"
+          frame* (marked in-app by stack trace rule (family:native function:log_demo::* +app))
+            function*
+              "log_demo::main"
+            package (ignored because function takes precedence)
+              "log_demo"
+          frame (ignored by stack trace rule (family:native function:*::__* -group))
+            function*
+              "log::__private_api_log"
+            package (ignored because function takes precedence)
+              "log"
         type*
           "log_demo"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.466342Z'
+created: '2021-05-05T18:04:40.482039Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,6 +22,49 @@ app-depth-2:
           filename*
             "foo.py"
         frame*
+          filename*
+            "bar.py"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "659ad79e2e70c822d30a53d7d889529e"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
+      stacktrace*
+        frame*
+          filename*
+            "foo.py"
+        frame*
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
+          filename*
+            "bar.py"
+        frame (ignored due to recursion)
           filename*
             "bar.py"
 --------------------------------------------------------------------------

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-30T12:13:39.187596Z'
+created: '2021-05-05T18:04:39.887775Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -8,6 +8,19 @@ app-depth-1:
   tree_label: "main"
   component:
     app-depth-1*
+      threads*
+        stacktrace*
+          frame*
+            filename*
+              "baz.c"
+            function*
+              "main"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "1a11687556cf74559f0ae90b1c87e2fd"
+  tree_label: "<entire stacktrace>"
+  component:
+    app-depth-max*
       threads*
         stacktrace*
           frame*


### PR DESCRIPTION
Previously we would try to deduplicate hashes from within the grouping
strategy. That turns out to be buggy and annoying to code. For example,
at some point I accidentally removed the final hierarchical hash that
used the entire stacktrace (app-depth-max).

Instead we now just deduplicate hashes after they have been computed and
don't worry about creating many variants from within grouping.