### PR TITLE
feat(alerts): Turn on alert details for all self hosted

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -984,7 +984,7 @@ SENTRY_FEATURES = {
     # Enable inbox support in the issue stream
     "organizations:inbox": True,
     # Enable the new alert details ux design
-    "organizations:alert-details-redesign": False,
+    "organizations:alert-details-redesign": True,
     # Enable the new images loaded design and features
     "organizations:images-loaded-v2": True,
     # Enable teams to have ownership of alert rules

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -18,6 +18,7 @@ class OrganizationSerializerTest(TestCase):
         assert result["id"] == str(organization.id)
         assert result["features"] == {
             "advanced-search",
+            "alert-details-redesign",
             "alert-wizard",
             "custom-event-title",
             "custom-symbol-sources",


### PR DESCRIPTION
This turns on the alert details redesign feature for all self-hosted orgs.