### PR TITLE
fix: Preserve sign when formatting durations

### DIFF
--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -323,7 +323,7 @@ export function ngettext(singular: string, plural: string, ...args: FormatArg[])
   let countArg = 0;
 
   if (args.length > 0) {
-    countArg = (args[0] as number) || 0;
+    countArg = Math.abs(args[0] as number) || 0;
 
     // `toLocaleString` will render `999` as `"999"` but `9999` as `"9,999"`. This means that any call with `tn` or `ngettext` cannot use `%d` in the codebase but has to use `%s`.
     // This means a string is always being passed in as an argument, but `sprintf-js` implicitly coerces strings that can be parsed as integers into an integer.

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -60,16 +60,18 @@ export function getDuration(
   abbreviation: boolean = false,
   extraShort: boolean = false
 ): string {
-  const value = Math.abs(seconds * 1000);
+  // value in milliseconds
+  const msValue = seconds * 1000;
+  const value = Math.abs(msValue);
 
   if (value >= MONTH && !extraShort) {
-    const {label, result} = roundWithFixed(value / MONTH, fixedDigits);
+    const {label, result} = roundWithFixed(msValue / MONTH, fixedDigits);
     return `${label}${
       abbreviation ? tn('mo', 'mos', result) : ` ${tn('month', 'months', result)}`
     }`;
   }
   if (value >= WEEK) {
-    const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
+    const {label, result} = roundWithFixed(msValue / WEEK, fixedDigits);
     if (extraShort) {
       return `${label}${t('w')}`;
     }
@@ -79,13 +81,13 @@ export function getDuration(
     return `${label} ${tn('week', 'weeks', result)}`;
   }
   if (value >= 172800000) {
-    const {label, result} = roundWithFixed(value / DAY, fixedDigits);
+    const {label, result} = roundWithFixed(msValue / DAY, fixedDigits);
     return `${label}${
       abbreviation || extraShort ? t('d') : ` ${tn('day', 'days', result)}`
     }`;
   }
   if (value >= 7200000) {
-    const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
+    const {label, result} = roundWithFixed(msValue / HOUR, fixedDigits);
     if (extraShort) {
       return `${label}${t('h')}`;
     }
@@ -95,7 +97,7 @@ export function getDuration(
     return `${label} ${tn('hour', 'hours', result)}`;
   }
   if (value >= 120000) {
-    const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
+    const {label, result} = roundWithFixed(msValue / MINUTE, fixedDigits);
     if (extraShort) {
       return `${label}${t('m')}`;
     }
@@ -105,24 +107,29 @@ export function getDuration(
     return `${label} ${tn('minute', 'minutes', result)}`;
   }
   if (value >= SECOND) {
-    const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
+    const {label, result} = roundWithFixed(msValue / SECOND, fixedDigits);
     if (extraShort || abbreviation) {
       return `${label}${t('s')}`;
     }
     return `${label} ${tn('second', 'seconds', result)}`;
   }
 
-  const {label} = roundWithFixed(value, fixedDigits);
+  const {label} = roundWithFixed(msValue, fixedDigits);
 
   return label + t('ms');
 }
 
 export function getExactDuration(seconds: number, abbreviation: boolean = false) {
   const convertDuration = (secs: number, abbr: boolean) => {
+    // value in milliseconds
+    const msValue = round(secs * 1000);
     const value = round(Math.abs(secs * 1000));
 
     const divideBy = (time: number) => {
-      return {quotient: Math.floor(value / time), remainder: value % time};
+      return {
+        quotient: msValue < 0 ? Math.ceil(msValue / time) : Math.floor(msValue / time),
+        remainder: msValue % time,
+      };
     };
 
     if (value >= WEEK) {
@@ -165,7 +172,7 @@ export function getExactDuration(seconds: number, abbreviation: boolean = false)
       return '';
     }
 
-    return `${value}${abbr ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`}`;
+    return `${msValue}${abbr ? t('ms') : ` ${tn('millisecond', 'milliseconds', value)}`}`;
   };
 
   const result = convertDuration(seconds, abbreviation).trim();

--- a/tests/js/spec/helpers/formatters.spec.jsx
+++ b/tests/js/spec/helpers/formatters.spec.jsx
@@ -66,6 +66,17 @@ describe('formatters', function () {
       );
     });
 
+    it('should format negative durations', () => {
+      expect(getExactDuration(-2.030043848568126)).toEqual('-2 seconds -30 milliseconds');
+      expect(getExactDuration(-0.2)).toEqual('-200 milliseconds');
+      expect(getExactDuration(-13)).toEqual('-13 seconds');
+      expect(getExactDuration(-60)).toEqual('-1 minute');
+      expect(getExactDuration(-121)).toEqual('-2 minutes -1 second');
+      expect(getExactDuration(-234235435)).toEqual(
+        '-387 weeks -2 days -1 hour -23 minutes -55 seconds'
+      );
+    });
+
     it('should abbreviate label', () => {
       expect(getExactDuration(234235435, true)).toEqual('387wk 2d 1hr 23min 55s');
     });

--- a/tests/js/spec/utils/formatters.spec.jsx
+++ b/tests/js/spec/utils/formatters.spec.jsx
@@ -24,6 +24,24 @@ describe('getDuration()', function () {
     expect(getDuration(604800 * 12)).toBe('3 months');
   });
 
+  it('should format negative durations', function () {
+    expect(getDuration(-0, 2)).toBe('0.00ms');
+    expect(getDuration(-0.1)).toBe('-100ms');
+    expect(getDuration(-0.1, 2)).toBe('-100.00ms');
+    expect(getDuration(-1)).toBe('-1 second');
+    expect(getDuration(-2)).toBe('-2 seconds');
+    expect(getDuration(-65)).toBe('-65 seconds');
+    expect(getDuration(-122)).toBe('-2 minutes');
+    expect(getDuration(-3720)).toBe('-62 minutes');
+    expect(getDuration(-36000)).toBe('-10 hours');
+    expect(getDuration(-86400)).toBe('-24 hours');
+    expect(getDuration(-86400 * 2)).toBe('-2 days');
+    expect(getDuration(-604800)).toBe('-1 week');
+    expect(getDuration(-604800 * 4)).toBe('-4 weeks');
+    expect(getDuration(-2629800)).toBe('-1 month');
+    expect(getDuration(-604800 * 12)).toBe('-3 months');
+  });
+
   it('should format numbers and abbreviate units', function () {
     expect(getDuration(0, 2, true)).toBe('0.00ms');
     expect(getDuration(0, 0, true)).toBe('0ms');


### PR DESCRIPTION
We're not preserving signs when formatting duration values. Negative duration values may be propagated by the SDK as in https://github.com/GoogleChrome/web-vitals/issues/137 . While these values are invalid, knowing that duration values are negative would surface bugs sooner; and help us ensure duration values are not negative in the product.

In the future, we'll provide enhanced UI features to communicate that negative duration values are invalid.

### Before 
<img width="445" alt="Screen Shot 2021-05-05 at 2 01 14 PM" src="https://user-images.githubusercontent.com/139499/117188657-4bf08980-adab-11eb-9b59-f9bf4e0964ba.png">

### After

<img width="454" alt="Screen Shot 2021-05-05 at 2 01 07 PM" src="https://user-images.githubusercontent.com/139499/117188662-4c892000-adab-11eb-9eb2-9155e0cfad76.png">
