### PR TITLE
fix(alert): Redirect away from blank alert rule builder

### DIFF
--- a/static/app/views/organizationIntegrations/integrationAlertRules.tsx
+++ b/static/app/views/organizationIntegrations/integrationAlertRules.tsx
@@ -27,7 +27,11 @@ const IntegrationAlertRules = ({projects, organization}: Props) => (
         <ProjectItem key={project.slug}>
           <ProjectBadge project={project} avatarSize={16} />
           <Button
-            to={`/organizations/${organization.slug}/alerts/${project.slug}/new/`}
+            to={
+              organization.features.includes('alert-wizard')
+                ? `/organizations/${organization.slug}/alerts/${project.slug}/wizard/`
+                : `/organizations/${organization.slug}/alerts/${project.slug}/new`
+            }
             size="xsmall"
           >
             {t('Add Alert Rule')}

--- a/static/app/views/settings/projectAlerts/create.tsx
+++ b/static/app/views/settings/projectAlerts/create.tsx
@@ -1,5 +1,5 @@
 import {Component, Fragment} from 'react';
-import {RouteComponentProps} from 'react-router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import * as Layout from 'app/components/layouts/thirds';
@@ -53,6 +53,7 @@ class Create extends Component<Props, State> {
 
   componentDidMount() {
     const {organization, location, project} = this.props;
+    const hasWizard = organization.features.includes('alert-wizard');
 
     trackAnalyticsEvent({
       eventKey: 'new_alert_rule.viewed',
@@ -83,6 +84,10 @@ class Create extends Component<Props, State> {
             alertType: 'issue',
           });
         }
+      } else if (hasWizard) {
+        browserHistory.replace(
+          `/organizations/${organization.slug}/alerts/${project.id}/wizard`
+        );
       }
     }
   }


### PR DESCRIPTION
Because of the new wizard changes, if we direct to the `/new` alerts route with no `createFromDiscover` or `createFromWizard` query args, nothing will be shown. 
**Example:**
![image](https://user-images.githubusercontent.com/9372512/117210419-a3035800-adc5-11eb-865d-caf4520041a6.png)

The solution is to fix some links to go to the wizard page if the org has the feature, and also to redirect to the wizard from the `/new` alerts route if the org has the wizard, but no query args were found.