### PR TITLE
feat(ui): use pink gradient for icon business

### DIFF
--- a/static/app/icons/iconBusiness.tsx
+++ b/static/app/icons/iconBusiness.tsx
@@ -1,19 +1,21 @@
 import * as React from 'react';
-import {keyframes} from '@emotion/react';
+import {keyframes, withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import theme from 'app/utils/theme';
+import {Theme} from 'app/utils/theme';
 
 import SvgIcon from './svgIcon';
 
 type WrappedProps = {
   forwardRef: React.Ref<SVGSVGElement>;
+  theme: Theme;
 } & Props;
 
-const IconBusinessComponent = function IconBusinessComponent({
+function IconBusinessComponent({
   gradient = false,
   withShine = false,
   forwardRef,
+  theme,
   ...props
 }: WrappedProps) {
   return (
@@ -26,7 +28,7 @@ const IconBusinessComponent = function IconBusinessComponent({
         />
       </mask>
       <linearGradient id="icon-power-features-gradient">
-        <stop offset="0%" stopColor={theme.pink200} />
+        <stop offset="0%" stopColor={theme.pink100} />
         <stop offset="100%" stopColor={theme.pink300} />
       </linearGradient>
       <linearGradient id="icon-power-features-shine" gradientTransform="rotate(35)">
@@ -48,7 +50,9 @@ const IconBusinessComponent = function IconBusinessComponent({
       )}
     </SvgIcon>
   );
-};
+}
+
+const ThemedIconBusiness = withTheme(IconBusinessComponent);
 
 type Props = {
   /**
@@ -63,7 +67,7 @@ type Props = {
 } & React.ComponentProps<typeof SvgIcon>;
 
 const IconBusiness = React.forwardRef((props: Props, ref: React.Ref<SVGSVGElement>) => (
-  <IconBusinessComponent {...props} forwardRef={ref} />
+  <ThemedIconBusiness {...props} forwardRef={ref} />
 ));
 
 IconBusiness.displayName = 'IconBusiness';

--- a/static/app/icons/iconBusiness.tsx
+++ b/static/app/icons/iconBusiness.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import theme from 'app/utils/theme';
+
 import SvgIcon from './svgIcon';
 
 type WrappedProps = {
@@ -24,8 +26,8 @@ const IconBusinessComponent = function IconBusinessComponent({
         />
       </mask>
       <linearGradient id="icon-power-features-gradient">
-        <stop offset="0%" stopColor="#EA5BC2" />
-        <stop offset="100%" stopColor="#6148CE" />
+        <stop offset="0%" stopColor={theme.pink200} />
+        <stop offset="100%" stopColor={theme.pink300} />
       </linearGradient>
       <linearGradient id="icon-power-features-shine" gradientTransform="rotate(35)">
         <stop offset="0%" stopColor="rgba(255, 255, 255, 0)" />


### PR DESCRIPTION
Changing the color of the gradient for `IconBusiness` from purple to pink to be more dark-mode friendly

Before:
![Screen Shot 2021-05-05 at 4 47 19 PM](https://user-images.githubusercontent.com/8533851/117223055-b3b1cf00-adc1-11eb-9749-badd2aee881f.png)
![Screen Shot 2021-05-05 at 4 47 39 PM](https://user-images.githubusercontent.com/8533851/117223060-b57b9280-adc1-11eb-8bba-1d93e5267aa7.png)

After:
![Screen Shot 2021-05-05 at 4 49 05 PM](https://user-images.githubusercontent.com/8533851/117223137-e22faa00-adc1-11eb-95f3-dc52a730f120.png)
![Screen Shot 2021-05-05 at 4 48 56 PM](https://user-images.githubusercontent.com/8533851/117223132-de9c2300-adc1-11eb-867e-42763058ff93.png)
