### PR TITLE
fix(quick-trace): Quick trace in issues should render less

### DIFF
--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -16,102 +16,93 @@ type QueryProps = Omit<DiscoverQueryProps, 'api' | 'eventView'> & {
   children: (props: QuickTraceQueryChildrenProps) => React.ReactNode;
 };
 
-class QuickTraceQuery extends React.Component<QueryProps> {
-  shouldComponentUpdate(nextProps) {
-    return this.props.event !== nextProps.event;
-  }
+export default function QuickTraceQuery({children, event, ...props}: QueryProps) {
+  const traceId = event.contexts?.trace?.trace_id;
 
-  render() {
-    const {children, event, ...props} = this.props;
-    const traceId = event.contexts?.trace?.trace_id;
-
-    if (!traceId) {
-      return (
-        <React.Fragment>
-          {children({
-            isLoading: false,
-            error: null,
-            trace: [],
-            type: 'empty',
-            currentEvent: null,
-          })}
-        </React.Fragment>
-      );
-    }
-
-    const {start, end} = getTraceTimeRangeFromEvent(event);
-
+  if (!traceId) {
     return (
-      <TraceLiteQuery
-        eventId={event.id}
-        traceId={traceId}
-        start={start}
-        end={end}
-        {...props}
-      >
-        {traceLiteResults => (
-          <TraceFullQuery
-            eventId={event.id}
-            traceId={traceId}
-            start={start}
-            end={end}
-            {...props}
-          >
-            {traceFullResults => {
-              if (
-                !traceFullResults.isLoading &&
-                traceFullResults.error === null &&
-                traceFullResults.traces !== null
-              ) {
-                for (const subtrace of traceFullResults.traces) {
-                  try {
-                    const trace = flattenRelevantPaths(event, subtrace);
-                    return children({
-                      ...traceFullResults,
-                      trace,
-                      currentEvent: trace.find(e => isCurrentEvent(e, event)) ?? null,
-                    });
-                  } catch {
-                    // let this fall through and check the next subtrace
-                    // or use the trace lite results
-                  }
-                }
-              }
-
-              if (
-                !traceLiteResults.isLoading &&
-                traceLiteResults.error === null &&
-                traceLiteResults.trace !== null
-              ) {
-                const {trace} = traceLiteResults;
-                return children({
-                  ...traceLiteResults,
-                  currentEvent: trace.find(e => isCurrentEvent(e, event)) ?? null,
-                });
-              }
-
-              return children({
-                // only use the light results loading state if it didn't error
-                // if it did, we should rely on the full results
-                isLoading: traceLiteResults.error
-                  ? traceFullResults.isLoading
-                  : traceLiteResults.isLoading || traceFullResults.isLoading,
-                // swallow any errors from the light results because we
-                // should rely on the full results in this situations
-                error: traceFullResults.error,
-                trace: [],
-                // if we reach this point but there were some traces in the full results,
-                // that means there were other transactions in the trace, but the current
-                // event could not be found
-                type: traceFullResults.traces?.length ? 'missing' : 'empty',
-                currentEvent: null,
-              });
-            }}
-          </TraceFullQuery>
-        )}
-      </TraceLiteQuery>
+      <React.Fragment>
+        {children({
+          isLoading: false,
+          error: null,
+          trace: [],
+          type: 'empty',
+          currentEvent: null,
+        })}
+      </React.Fragment>
     );
   }
-}
 
-export default QuickTraceQuery;
+  const {start, end} = getTraceTimeRangeFromEvent(event);
+
+  return (
+    <TraceLiteQuery
+      eventId={event.id}
+      traceId={traceId}
+      start={start}
+      end={end}
+      {...props}
+    >
+      {traceLiteResults => (
+        <TraceFullQuery
+          eventId={event.id}
+          traceId={traceId}
+          start={start}
+          end={end}
+          {...props}
+        >
+          {traceFullResults => {
+            if (
+              !traceFullResults.isLoading &&
+              traceFullResults.error === null &&
+              traceFullResults.traces !== null
+            ) {
+              for (const subtrace of traceFullResults.traces) {
+                try {
+                  const trace = flattenRelevantPaths(event, subtrace);
+                  return children({
+                    ...traceFullResults,
+                    trace,
+                    currentEvent: trace.find(e => isCurrentEvent(e, event)) ?? null,
+                  });
+                } catch {
+                  // let this fall through and check the next subtrace
+                  // or use the trace lite results
+                }
+              }
+            }
+
+            if (
+              !traceLiteResults.isLoading &&
+              traceLiteResults.error === null &&
+              traceLiteResults.trace !== null
+            ) {
+              const {trace} = traceLiteResults;
+              return children({
+                ...traceLiteResults,
+                currentEvent: trace.find(e => isCurrentEvent(e, event)) ?? null,
+              });
+            }
+
+            return children({
+              // only use the light results loading state if it didn't error
+              // if it did, we should rely on the full results
+              isLoading: traceLiteResults.error
+                ? traceFullResults.isLoading
+                : traceLiteResults.isLoading || traceFullResults.isLoading,
+              // swallow any errors from the light results because we
+              // should rely on the full results in this situations
+              error: traceFullResults.error,
+              trace: [],
+              // if we reach this point but there were some traces in the full results,
+              // that means there were other transactions in the trace, but the current
+              // event could not be found
+              type: traceFullResults.traces?.length ? 'missing' : 'empty',
+              currentEvent: null,
+            });
+          }}
+        </TraceFullQuery>
+      )}
+    </TraceLiteQuery>
+  );
+}

--- a/static/app/views/organizationGroupDetails/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/issueQuickTrace.tsx
@@ -43,6 +43,10 @@ class IssueQuickTrace extends Component<Props, State> {
     this.promptsCheck();
   }
 
+  shouldComponentUpdate(nextProps) {
+    return this.props.event !== nextProps.event;
+  }
+
   async promptsCheck() {
     const {api, event, organization} = this.props;
 


### PR DESCRIPTION
Turns out #25867 was causing issues with the quick trace in event details where
the component wasn't updating as needed when the meta results loaded. This
change undoes it and instead, lifts the check into the parent component to
achieve the same result without breaking the meta results in event details.