### PR TITLE
fix(jira): Fix toast failures on settings changes

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -140,6 +140,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     "on_unresolve": _("When unresolved"),
                 },
                 "mappedColumnLabel": _("Jira Project"),
+                "formatMessageValue": False,
             },
             {
                 "name": self.outbound_assignee_key,


### PR DESCRIPTION
## Objective:
Fixes [JAVASCRIPT-24FX](https://sentry.io/organizations/sentry/issues/2371627373/?project=11276)

Currently when a user updates the Sync Sentry Status to Jira fields, it causes the page to error out. This is caused by the toast component trying to render a Mobx Observable that contains integer values for the dropdown. So this PR sets `"formatMessageValue": False` to simplify the toast message.

In the future, we may want to refactor this component to get access to the `JsonForm` component's fields to convert the integers values from `FormModel` into readable display strings for the toast.

## UI
![Screen Shot 2021-05-05 at 4 50 36 PM](https://user-images.githubusercontent.com/10491193/117223232-160acf80-adc2-11eb-9709-de6422199f73.png)
