### PR TITLE
fix(invite-members): Let tab do it's default thing

### DIFF
--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -61,7 +61,6 @@ class InviteRowControl extends React.Component<Props, State> {
     const {inputValue} = this.state;
     switch (event.key) {
       case 'Enter':
-      case 'Tab':
       case ',':
       case ' ':
         onChangeEmails([...mapToOptions(emails), {label: inputValue, value: inputValue}]);


### PR DESCRIPTION
When tabbing away, we will by default create an entry in the multi-select box. It's likely the user _also_ wants to go to the next input.