### PR TITLE
fix(ui): Fix no access on Project Details

### DIFF
--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -201,7 +201,7 @@ class ProjectDetail extends AsyncView<Props, State> {
       return this.renderProjectNotFound();
     }
 
-    if (!loadingProjects && project && !project?.hasAccess) {
+    if (!loadingProjects && project && !project.hasAccess) {
       return this.renderNoAccess(project);
     }
 

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -14,6 +14,7 @@ import IdBadge from 'app/components/idBadge';
 import * as Layout from 'app/components/layouts/thirds';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import MissingProjectMembership from 'app/components/projects/missingProjectMembership';
 import TextOverflow from 'app/components/textOverflow';
 import {IconSettings, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -88,21 +89,26 @@ class ProjectDetail extends AsyncView<Props, State> {
       hasSessions: null,
     });
 
-    const response: SessionApiResponse = await this.api.requestPromise(
-      `/organizations/${organization.slug}/sessions/`,
-      {
-        query: {
-          project: projectId,
-          field: 'sum(session)',
-          statsPeriod: '90d',
-          interval: '1d',
-        },
-      }
-    );
-
-    this.setState({
-      hasSessions: response.groups[0].totals['sum(session)'] > 0,
-    });
+    try {
+      const response: SessionApiResponse = await this.api.requestPromise(
+        `/organizations/${organization.slug}/sessions/`,
+        {
+          query: {
+            project: projectId,
+            field: 'sum(session)',
+            statsPeriod: '90d',
+            interval: '1d',
+          },
+        }
+      );
+      this.setState({
+        hasSessions: response.groups[0].totals['sum(session)'] > 0,
+      });
+    } catch {
+      this.setState({
+        hasSessions: false,
+      });
+    }
   }
 
   handleProjectChange = (selectedProjects: number[]) => {
@@ -148,6 +154,19 @@ class ProjectDetail extends AsyncView<Props, State> {
     return this.renderBody();
   }
 
+  renderNoAccess(project: Project) {
+    const {organization} = this.props;
+
+    return (
+      <PageContent>
+        <MissingProjectMembership
+          organization={organization}
+          projectSlug={project.slug}
+        />
+      </PageContent>
+    );
+  }
+
   renderProjectNotFound() {
     return (
       <PageContent>
@@ -180,6 +199,10 @@ class ProjectDetail extends AsyncView<Props, State> {
 
     if (!loadingProjects && !project) {
       return this.renderProjectNotFound();
+    }
+
+    if (!loadingProjects && project && !project?.hasAccess) {
+      return this.renderNoAccess(project);
     }
 
     return (


### PR DESCRIPTION
This could happen when the organization had their Open Membership setting disabled and Members visited the project details (either directly via URL or via Organization Stats) to which their team did not have access.

Fixes JAVASCRIPT-247Q

## Before
![image](https://user-images.githubusercontent.com/9060071/117273712-ab5aa200-ae5c-11eb-9c77-bfd4203b0575.png)

## After
![image](https://user-images.githubusercontent.com/9060071/117273521-7fd7b780-ae5c-11eb-8a5c-2fb145926e7c.png)