### PR TITLE
fix(aws-lambda): Rename function handler name

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -228,7 +228,7 @@ def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_le
             env_variables.update(
                 {"SENTRY_INITIAL_HANDLER": function["Handler"], **sentry_env_variables}
             )
-        updated_handler = "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler"
+        updated_handler = "init_serverless_sdk.sentry_lambda_handler"
 
     # Check if the sentry layer exists and update it or insert new layer to end
     if sentry_layer_index > -1:

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -251,7 +251,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
             },
-            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+            Handler="init_serverless_sdk.sentry_lambda_handler",
         )
 
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
@@ -313,7 +313,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
                     "FunctionName": "lambdaF",
                     "Runtime": "python3.6",
                     "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaF",
-                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                    "Handler": "init_serverless_sdk.sentry_lambda_handler",
                     "Layers": [
                         {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
                         {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34"},
@@ -410,7 +410,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
                 "Configuration": {
                     "FunctionName": "lambdaG",
                     "Runtime": "python3.6",
-                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                    "Handler": "init_serverless_sdk.sentry_lambda_handler",
                     "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaG",
                     "Layers": [
                         {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
@@ -458,8 +458,8 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
         Test that ensures that if sentry-sdk is already enabled, then
         re-enabling it should not override the env variables since it could be
         problematic since the SENTRY_INITIAL_HANDLER env variable could be overriden
-        the second time with "sentry_sdk.integrations.init_serverless_sdk.
-        sentry_lambda_handler" and then disabling the sentry-sdk, would break
+        the second time with "init_serverless_sdk.sentry_lambda_handler" and
+        then disabling the sentry-sdk, would break
         the function because the Handler will be updated with an incorrect
         SENTRY_INITIAL_HANDLER value
         """
@@ -471,7 +471,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
                 "Configuration": {
                     "FunctionName": "lambdaZ",
                     "Runtime": "python3.8",
-                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                    "Handler": "init_serverless_sdk.sentry_lambda_handler",
                     "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaZ",
                     "Layers": [
                         "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
@@ -514,5 +514,5 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
             },
-            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+            Handler="init_serverless_sdk.sentry_lambda_handler",
         )

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -261,7 +261,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
             },
-            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+            Handler="init_serverless_sdk.sentry_lambda_handler",
         )
 
         integration = Integration.objects.get(provider=self.provider.key)


### PR DESCRIPTION
This PR:
- Changes the lambda function handler name to the name of our sentry lambda handler to match the format of `x.y`

Related to: 
https://github.com/getsentry/sentry-python/pull/1107