### PR TITLE
Fix initial sort on dashboards manage page

### DIFF
--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -46,13 +46,15 @@ type State = {
 class ManageDashboards extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, location} = this.props;
+
     return [
       [
         'dashboards',
         `/organizations/${organization.slug}/dashboards/`,
         {
           query: {
-            ...pick(location.query, ['cursor', 'query', 'sort']),
+            ...pick(location.query, ['cursor', 'query']),
+            sort: this.getActiveSort().value,
             per_page: '9',
           },
         },

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -46,7 +46,6 @@ type State = {
 class ManageDashboards extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {organization, location} = this.props;
-
     return [
       [
         'dashboards',


### PR DESCRIPTION
Fixing the default sort to be "My Dashboards".