### PR TITLE
ref(ui): Remove `propTypes` from `<Sparklines>`

### DIFF
--- a/static/app/components/sparklines/index.tsx
+++ b/static/app/components/sparklines/index.tsx
@@ -1,28 +1,6 @@
-import {Sparklines} from 'react-sparklines';
-import PropTypes from 'prop-types';
-
 /**
  * This is required because:
  *
  * - React.Suspense only works with default exports
- * - typescript complains that the library's `propTypes` does not
- * have `children defined.
- * - typescript also won't let us access `Sparklines.propTypes`
  */
-export default class SparklinesWithCustomPropTypes extends Sparklines {
-  static propTypes = {
-    children: PropTypes.node,
-    data: PropTypes.array,
-    limit: PropTypes.number,
-    width: PropTypes.number,
-    height: PropTypes.number,
-    svgWidth: PropTypes.number,
-    svgHeight: PropTypes.number,
-    preserveAspectRatio: PropTypes.string,
-    margin: PropTypes.number,
-    style: PropTypes.object,
-    min: PropTypes.number,
-    max: PropTypes.number,
-    onMouseMove: PropTypes.func,
-  };
-}
+export {Sparklines as default} from 'react-sparklines';


### PR DESCRIPTION
This removes the `propTypes` from `<Sparklines>` and instead of extending the component, re-export from the library. (It needs to be re-exported as default export so that it can be used with `React.lazy`)