### PR TITLE
ref(ui) Remove legacy context from JsonForm

### DIFF
--- a/static/app/components/modals/sentryAppPublishRequestModal.tsx
+++ b/static/app/components/modals/sentryAppPublishRequestModal.tsx
@@ -86,7 +86,7 @@ export default class SentryAppPublishRequestModal extends Component<Props> {
     );
 
     //No translations since we need to be able to read this email :)
-    const baseFields: JsonForm['props']['fields'] = [
+    const baseFields: React.ComponentProps<typeof JsonForm>['fields'] = [
       {
         type: 'textarea',
         required: true,

--- a/static/app/views/settings/account/accountDetails.tsx
+++ b/static/app/views/settings/account/accountDetails.tsx
@@ -31,7 +31,6 @@ class AccountDetails extends AsyncView {
 
   renderBody() {
     const user = this.state.user as User;
-    const {location} = this.props;
 
     const formCommonProps: Partial<Form['props']> = {
       apiEndpoint: ENDPOINT,
@@ -45,18 +44,10 @@ class AccountDetails extends AsyncView {
       <div>
         <SettingsPageHeader title={t('Account Details')} />
         <Form initialData={user} {...formCommonProps}>
-          <JsonForm
-            location={location}
-            forms={accountDetailsFields}
-            additionalFieldProps={{user}}
-          />
+          <JsonForm forms={accountDetailsFields} additionalFieldProps={{user}} />
         </Form>
         <Form initialData={user.options} {...formCommonProps}>
-          <JsonForm
-            location={location}
-            forms={accountPreferencesFields}
-            additionalFieldProps={{user}}
-          />
+          <JsonForm forms={accountPreferencesFields} additionalFieldProps={{user}} />
         </Form>
         <AvatarChooser
           endpoint="/users/me/avatar/"

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -116,7 +116,7 @@ class AccountEmails extends AsyncView<Props, State> {
           allowUndo={false}
           onSubmitSuccess={this.handleSubmitSuccess}
         >
-          <JsonForm location={this.props.location} forms={accountEmailsFields} />
+          <JsonForm forms={accountEmailsFields} />
         </Form>
 
         <AlertLink to="/settings/account/notifications" icon={<IconStack />}>

--- a/static/app/views/settings/account/apiApplications/details.tsx
+++ b/static/app/views/settings/account/apiApplications/details.tsx
@@ -43,7 +43,7 @@ class ApiApplicationsDetails extends AsyncView<Props, State> {
           initialData={this.state.app}
           onSubmitError={() => addErrorMessage('Unable to save change')}
         >
-          <JsonForm location={this.props.location} forms={apiApplication} />
+          <JsonForm forms={apiApplication} />
 
           <Panel>
             <PanelHeader>{t('Credentials')}</PanelHeader>

--- a/static/app/views/settings/components/forms/formPanel.tsx
+++ b/static/app/views/settings/components/forms/formPanel.tsx
@@ -7,7 +7,11 @@ import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig
 
 import {FieldObject, JsonFormObject} from './type';
 
-type Props = {
+type DefaultProps = {
+  additionalFieldProps: {[key: string]: any};
+};
+
+type Props = DefaultProps & {
   /**
    * Panel title
    */
@@ -20,8 +24,6 @@ type Props = {
 
   access?: Set<Scope>;
   features?: Record<string, any>;
-
-  additionalFieldProps: {[key: string]: any};
 
   /**
    * The name of the field that should be highlighted
@@ -45,6 +47,10 @@ type Props = {
 };
 
 export default class FormPanel extends React.Component<Props> {
+  static defaultProps: DefaultProps = {
+    additionalFieldProps: {},
+  };
+
   render() {
     const {
       title,

--- a/static/app/views/settings/components/forms/jsonForm.tsx
+++ b/static/app/views/settings/components/forms/jsonForm.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
+import {withRouter, WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
-import {Location} from 'history';
-import PropTypes from 'prop-types';
 import scrollToElement from 'scroll-to-element';
 
 import {defined} from 'app/utils';
@@ -9,10 +8,6 @@ import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
 
 import FormPanel from './formPanel';
 import {Field, FieldObject, JsonFormObject} from './type';
-
-type DefaultProps = {
-  additionalFieldProps: {[key: string]: any};
-};
 
 type Props = {
   /**
@@ -25,16 +20,13 @@ type Props = {
    * Allows more fine grain control of title/fields
    */
   fields?: FieldObject[];
-  location?: Location;
-} & DefaultProps &
+
+  additionalFieldProps?: {[key: string]: any};
+} & WithRouterProps &
   Omit<
     React.ComponentProps<typeof FormPanel>,
     'highlighted' | 'fields' | 'additionalFieldProps'
   >;
-
-type Context = {
-  location?: Location;
-};
 
 type State = {
   // Field name that should be highlighted
@@ -42,16 +34,9 @@ type State = {
 };
 
 class JsonForm extends React.Component<Props, State> {
-  static contextTypes = {
-    location: PropTypes.object,
-  };
-
-  static defaultProps: DefaultProps = {
-    additionalFieldProps: {},
-  };
-
   state: State = {
-    highlighted: getLocation(this.props, this.context).hash,
+    // location.hash is optional because of tests.
+    highlighted: this.props.location?.hash,
   };
 
   componentDidMount() {
@@ -59,18 +44,16 @@ class JsonForm extends React.Component<Props, State> {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps: Props) {
-    if (
-      getLocation(this.props, this.context).hash !==
-      getLocation(nextProps, this.context).hash
-    ) {
-      const hash = getLocation(nextProps, this.context).hash;
+    if (this.props.location.hash !== nextProps.location.hash) {
+      const hash = nextProps.location.hash;
       this.scrollToHash(hash);
       this.setState({highlighted: hash});
     }
   }
 
   scrollToHash(toHash?: string): void {
-    const hash = toHash || getLocation(this.props, this.context).hash;
+    // location.hash is optional because of tests.
+    const hash = toHash || this.props.location?.hash;
 
     if (!hash) {
       return;
@@ -182,8 +165,4 @@ class JsonForm extends React.Component<Props, State> {
   }
 }
 
-export default JsonForm;
-
-function getLocation(props: Props, context: Context): Location | {hash?: string} {
-  return props.location || context.location || {};
-}
+export default withRouter(JsonForm);

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -323,11 +323,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
                 this.isInternal && !this.form.getValue('webhookUrl');
               return (
                 <React.Fragment>
-                  <JsonForm
-                    location={this.props.location}
-                    additionalFieldProps={{webhookDisabled}}
-                    forms={forms}
-                  />
+                  <JsonForm additionalFieldProps={{webhookDisabled}} forms={forms} />
 
                   <PermissionsObserver
                     webhookDisabled={webhookDisabled}

--- a/static/app/views/settings/organizationTeams/teamSettings/index.tsx
+++ b/static/app/views/settings/organizationTeams/teamSettings/index.tsx
@@ -54,7 +54,7 @@ class TeamSettings extends AsyncView<Props, State> {
   };
 
   renderBody() {
-    const {location, organization, team} = this.props;
+    const {organization, team} = this.props;
 
     const access = new Set<Scope>(organization.access);
 
@@ -72,7 +72,7 @@ class TeamSettings extends AsyncView<Props, State> {
             slug: team.slug,
           }}
         >
-          <JsonForm access={access} location={location} forms={teamSettingsFields} />
+          <JsonForm access={access} forms={teamSettingsFields} />
         </Form>
 
         <Panel>

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -139,13 +139,16 @@ describe('Organization Developer Settings', function () {
       await tick();
       wrapper.update();
 
-      wrapper.find('textarea').forEach((node, i) => {
+      const modal = await mountGlobalModal();
+
+      modal.find('textarea').forEach((node, i) => {
         node
           .simulate('change', {target: {value: `Answer ${i}`}})
           .simulate('keyDown', {keyCode: 13});
       });
-      expect(wrapper.find('button[aria-label="Request Publication"]')).toBeTruthy();
-      wrapper.find('form').simulate('submit');
+      expect(modal.find('button[aria-label="Request Publication"]')).toBeTruthy();
+
+      modal.find('form').simulate('submit');
       expect(mock).toHaveBeenCalledWith(
         `/sentry-apps/${sentryApp.slug}/publish-request/`,
         expect.objectContaining({


### PR DESCRIPTION
This required pushing defaultProps down to FormPanel (where they are actually used), and updating tests for sentry application publishing to query the modal.

Because JsonForm is getting `location` from `withRouter()` we don't need to pass it in as a prop anymore.