### PR TITLE
feat(ui): adds businessIconColors to theme

### DIFF
--- a/static/app/icons/iconBusiness.tsx
+++ b/static/app/icons/iconBusiness.tsx
@@ -28,8 +28,8 @@ function IconBusinessComponent({
         />
       </mask>
       <linearGradient id="icon-power-features-gradient">
-        <stop offset="0%" stopColor={theme.pink100} />
-        <stop offset="100%" stopColor={theme.pink300} />
+        <stop offset="0%" stopColor={theme.businessIconColors[0]} />
+        <stop offset="100%" stopColor={theme.businessIconColors[1]} />
       </linearGradient>
       <linearGradient id="icon-power-features-shine" gradientTransform="rotate(35)">
         <stop offset="0%" stopColor="rgba(255, 255, 255, 0)" />

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -545,7 +545,7 @@ const commonTheme = {
   space: [0, 8, 16, 20, 30],
 
   // used as a gradient,
-  businessIconColors: ['#EA5BC2', '#6148CE'],
+  businessIconColors: [colors.purple100, colors.purple300],
 
   demo: {
     headerSize: '70px',

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -544,6 +544,9 @@ const commonTheme = {
 
   space: [0, 8, 16, 20, 30],
 
+  // used as a gradient,
+  businessIconColors: ['#EA5BC2', '#6148CE'],
+
   demo: {
     headerSize: '70px',
   },
@@ -585,6 +588,7 @@ const darkAliases = {
   overlayBackgroundAlpha: 'rgba(18, 9, 23, 0.7)',
   tagBarHover: colors.purple300,
   tagBar: colors.gray400,
+  businessIconColors: [colors.pink100, colors.pink300],
 };
 
 export const lightTheme = {


### PR DESCRIPTION
This is a follow up to: https://github.com/getsentry/sentry/pull/25906

Making the icon color gradient dark mode dependent:

![Screen Shot 2021-05-06 at 2 55 11 PM](https://user-images.githubusercontent.com/8533851/117370588-74e04f80-ae7b-11eb-90de-6dccfa80521a.png)
![Screen Shot 2021-05-06 at 2 55 19 PM](https://user-images.githubusercontent.com/8533851/117370589-7578e600-ae7b-11eb-8f47-74909f89a7f9.png)
