### PR TITLE
ref(ui) Remove an unused context type

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -90,7 +90,6 @@ type State = {
 
 export default class PermissionSelection extends Component<Props, State> {
   static contextTypes = {
-    router: PropTypes.object.isRequired,
     form: PropTypes.object,
   };
 


### PR DESCRIPTION
This component and its children don't use router.