### PR TITLE
feat(quick-trace): Add the hook types for disabled on discover

### DIFF
--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -37,6 +37,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:incidents-sidebar-item',
   'feature-disabled:performance-new-project',
   'feature-disabled:performance-page',
+  'feature-disabled:performance-quick-trace',
   'feature-disabled:performance-sidebar-item',
   'feature-disabled:project-performance-score-card',
   'feature-disabled:project-selector-checkbox',

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -109,6 +109,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:incidents-sidebar-item': FeatureDisabledHook;
   'feature-disabled:performance-new-project': FeatureDisabledHook;
   'feature-disabled:performance-page': FeatureDisabledHook;
+  'feature-disabled:performance-quick-trace': FeatureDisabledHook;
   'feature-disabled:performance-sidebar-item': FeatureDisabledHook;
   'feature-disabled:project-performance-score-card': FeatureDisabledHook;
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;


### PR DESCRIPTION
This adds in the necessary hook types for when quick trace is disabled on
discover.