### PR TITLE
ref(webpack): Remove `webpackChunkName` from dynamic imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,9 @@ module.exports = {
     jest: true,
   },
 
-  rules: {},
+  rules: {
+    "import/dynamic-import-chunkname": ['off'],
+  },
 
   overrides: [
     {

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -45,9 +45,7 @@ type OpenSudoModalOptions = {
 };
 
 export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
-  const mod = await import(
-    /* webpackChunkName: "SudoModal" */ 'app/components/modals/sudoModal'
-  );
+  const mod = await import('app/components/modals/sudoModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...args} />, {onClose});
@@ -63,9 +61,7 @@ type OpenDiffModalOptions = {
 };
 
 export async function openDiffModal(options: OpenDiffModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "DiffModal" */ 'app/components/modals/diffModal'
-  );
+  const mod = await import('app/components/modals/diffModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
@@ -84,9 +80,7 @@ type CreateTeamModalOptions = {
 };
 
 export async function openCreateTeamModal(options: CreateTeamModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "CreateTeamModal" */ 'app/components/modals/createTeamModal'
-  );
+  const mod = await import('app/components/modals/createTeamModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />);
@@ -112,27 +106,21 @@ export type EditOwnershipRulesModalOptions = {
 };
 
 export async function openCreateOwnershipRule(options: CreateOwnershipRuleModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "CreateOwnershipRuleModal" */ 'app/components/modals/createOwnershipRuleModal'
-  );
+  const mod = await import('app/components/modals/createOwnershipRuleModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
 
 export async function openEditOwnershipRules(options: EditOwnershipRulesModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "EditOwnershipRulesModal" */ 'app/components/modals/editOwnershipRulesModal'
-  );
+  const mod = await import('app/components/modals/editOwnershipRulesModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {backdrop: 'static', modalCss});
 }
 
 export async function openCommandPalette(options: ModalOptions = {}) {
-  const mod = await import(
-    /* webpackChunkName: "CommandPalette" */ 'app/components/modals/commandPalette'
-  );
+  const mod = await import('app/components/modals/commandPalette');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
@@ -143,9 +131,7 @@ type RecoveryModalOptions = {
 };
 
 export async function openRecoveryOptions(options: RecoveryModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "RecoveryOptionsModal" */ 'app/components/modals/recoveryOptionsModal'
-  );
+  const mod = await import('app/components/modals/recoveryOptionsModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />);
@@ -158,18 +144,14 @@ export type TeamAccessRequestModalOptions = {
 };
 
 export async function openTeamAccessRequestModal(options: TeamAccessRequestModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "TeamAccessRequestModal" */ 'app/components/modals/teamAccessRequestModal'
-  );
+  const mod = await import('app/components/modals/teamAccessRequestModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
 
 export async function redirectToProject(newProjectSlug: string) {
-  const mod = await import(
-    /* webpackChunkName: "RedirectToProjectModal" */ 'app/components/modals/redirectToProject'
-  );
+  const mod = await import('app/components/modals/redirectToProject');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} slug={newProjectSlug} />, {});
@@ -181,9 +163,7 @@ type HelpSearchModalOptions = {
 };
 
 export async function openHelpSearchModal(options?: HelpSearchModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "HelpSearchModal" */ 'app/components/modals/helpSearchModal'
-  );
+  const mod = await import('app/components/modals/helpSearchModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
@@ -204,27 +184,21 @@ type DebugFileSourceModalOptions = {
 };
 
 export async function openDebugFileSourceModal(options: DebugFileSourceModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "DebugFileSourceModal" */ 'app/components/modals/debugFileSourceModal'
-  );
+  const mod = await import('app/components/modals/debugFileSourceModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />);
 }
 
 export async function openInviteMembersModal(options = {}) {
-  const mod = await import(
-    /* webpackChunkName: "InviteMembersModal" */ 'app/components/modals/inviteMembersModal'
-  );
+  const mod = await import('app/components/modals/inviteMembersModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
 
 export async function openAddDashboardWidgetModal(options: DashboardWidgetModalOptions) {
-  const mod = await import(
-    /* webpackChunkName: "AddDashboardWidgetModal" */ 'app/components/modals/addDashboardWidgetModal'
-  );
+  const mod = await import('app/components/modals/addDashboardWidgetModal');
   const {default: Modal, modalCss} = mod;
 
   openModal(deps => <Modal {...deps} {...options} />, {backdrop: 'static', modalCss});
@@ -234,9 +208,7 @@ export async function openReprocessEventModal({
   onClose,
   ...options
 }: ReprocessEventModalOptions & {onClose?: () => void}) {
-  const mod = await import(
-    /* webpackChunkName: "ReprocessEventModal" */ 'app/components/modals/reprocessEventModal'
-  );
+  const mod = await import('app/components/modals/reprocessEventModal');
 
   const {default: Modal} = mod;
 

--- a/static/app/bootstrap/commonInitialization.tsx
+++ b/static/app/bootstrap/commonInitialization.tsx
@@ -7,9 +7,7 @@ import {setupColorScheme} from 'app/utils/matchMedia';
 
 export function commonInitialization(config: Config) {
   if (NODE_ENV === 'development') {
-    import(
-      /* webpackChunkName: "SilenceReactUnsafeWarnings" */ /* webpackMode: "eager" */ 'app/utils/silence-react-unsafe-warnings'
-    );
+    import(/* webpackMode: "eager" */ 'app/utils/silence-react-unsafe-warnings');
   }
 
   ConfigStore.loadInitialData(config);

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -15,9 +15,7 @@ import plugins from 'app/plugins';
 // it on demand.
 async function loadPasswordStrength(callback: Function) {
   try {
-    const module = await import(
-      /* webpackChunkName: "passwordStrength" */ 'app/components/passwordStrength'
-    );
+    const module = await import('app/components/passwordStrength');
     callback(module);
   } catch (err) {
     // Ignore if client can't load this, it enhances UX a bit, but is optional

--- a/static/app/components/avatar/gravatar.tsx
+++ b/static/app/components/avatar/gravatar.tsx
@@ -27,7 +27,7 @@ class Gravatar extends Component<Props, State> {
   componentDidMount() {
     this._isMounted = true;
 
-    import(/* webpackChunkName: "MD5" */ 'crypto-js/md5')
+    import('crypto-js/md5')
       .then(mod => mod.default)
       .then(MD5 => {
         if (!this._isMounted) {

--- a/static/app/components/charts/worldMapChart.tsx
+++ b/static/app/components/charts/worldMapChart.tsx
@@ -45,8 +45,8 @@ class WorldMapChart extends React.Component<Props, State> {
 
   async componentDidMount() {
     const [countryToCodeMap, worldMap] = await Promise.all([
-      import(/* webpackChunkName: "countryCodesMap" */ 'app/data/countryCodesMap'),
-      import(/* webpackChunkName: "worldMapGeoJson" */ 'app/data/world.json'),
+      import('app/data/countryCodesMap'),
+      import('app/data/world.json'),
     ]);
 
     echarts.registerMap('sentryWorld', worldMap.default);

--- a/static/app/components/deviceName.tsx
+++ b/static/app/components/deviceName.tsx
@@ -10,7 +10,7 @@ export function deviceNameMapper(model: string, iOSDeviceList): string {
 }
 
 export async function loadDeviceListModule() {
-  return import(/* webpackChunkName: "iOSDeviceList" */ 'ios-device-list');
+  return import('ios-device-list');
 }
 
 type Props = {

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -232,7 +232,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
         : undefined;
 
     const mod = await import(
-      /* webpackChunkName: "DebugImageDetails" */ 'app/components/events/interfaces/debugMeta-v2/debugImageDetails'
+      'app/components/events/interfaces/debugMeta-v2/debugImageDetails'
     );
 
     const {default: Modal, modalCss} = mod;

--- a/static/app/components/events/rrwebIntegration.tsx
+++ b/static/app/components/events/rrwebIntegration.tsx
@@ -48,9 +48,7 @@ class RRWebIntegration extends AsyncComponent<Props, State> {
     return (
       <StyledEventDataSection type="context-replay" title={t('Replay')}>
         <LazyLoad
-          component={() =>
-            import(/* webpackChunkName: "rrwebReplayer" */ './rrwebReplayer')
-          }
+          component={() => import('./rrwebReplayer')}
           url={`/api/0/projects/${orgId}/${projectId}/events/${event.id}/attachments/${attachment.id}/?download`}
         />
       </StyledEventDataSection>

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -65,7 +65,7 @@ class IssueDiff extends Component<Props, State> {
 
     // Fetch component and event data
     Promise.all([
-      import(/* webpackChunkName: "splitDiff" */ '../splitDiff'),
+      import('../splitDiff'),
       this.fetchEventData(baseIssueId, baseEventId ?? 'latest'),
       this.fetchEventData(targetIssueId, targetEventId ?? 'latest'),
     ])

--- a/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
@@ -23,9 +23,7 @@ import {
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import {Theme} from 'app/utils/theme';
 
-const DateRangePicker = React.lazy(
-  () => import(/* webpackChunkName: "DateRangePicker" */ './dateRangeWrapper')
-);
+const DateRangePicker = React.lazy(() => import('./dateRangeWrapper'));
 
 const getTimeStringFromDate = (date: Date) => moment(date).local().format('HH:mm');
 

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -350,9 +350,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
   handleOpen = () => {
     this.setState({isOpen: true});
     // Start loading react-date-picker
-    import(
-      /* webpackChunkName: "DateRangePicker" */ '../timeRangeSelector/dateRange/index'
-    );
+    import('../timeRangeSelector/dateRange/index');
   };
 
   render() {

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -116,9 +116,7 @@ class Tooltip extends React.Component<Props, State> {
 
   async componentDidMount() {
     if (IS_ACCEPTANCE_TEST) {
-      const TooltipStore = (
-        await import(/* webpackChunkName: "TooltipStore" */ 'app/stores/tooltipStore')
-      ).default;
+      const TooltipStore = (await import('app/stores/tooltipStore')).default;
       TooltipStore.addTooltip(this);
     }
   }
@@ -127,9 +125,7 @@ class Tooltip extends React.Component<Props, State> {
     const {usesGlobalPortal} = this.state;
 
     if (IS_ACCEPTANCE_TEST) {
-      const TooltipStore = (
-        await import(/* webpackChunkName: "TooltipStore" */ 'app/stores/tooltipStore')
-      ).default;
+      const TooltipStore = (await import('app/stores/tooltipStore')).default;
       TooltipStore.removeTooltip(this);
     }
     if (!usesGlobalPortal) {

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -71,20 +71,14 @@ function routes() {
       <Route
         path="details/"
         name="Details"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AccountDetails" */ 'app/views/settings/account/accountDetails'
-          )
-        }
+        componentPromise={() => import('app/views/settings/account/accountDetails')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route path="notifications/" name="Notifications">
         <IndexRoute
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "AccountNotifications" */ 'app/views/settings/account/accountNotifications'
-            )
+            import('app/views/settings/account/accountNotifications')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -92,9 +86,7 @@ function routes() {
           path=":fineTuneType/"
           name="Fine Tune Alerts"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "AccountNotificationsFineTuning" */ 'app/views/settings/account/accountNotificationFineTuning'
-            )
+            import('app/views/settings/account/accountNotificationFineTuning')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -102,20 +94,14 @@ function routes() {
       <Route
         path="emails/"
         name="Emails"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AccountEmails" */ 'app/views/settings/account/accountEmails'
-          )
-        }
+        componentPromise={() => import('app/views/settings/account/accountEmails')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="authorizations/"
         componentPromise={() =>
-          import(
-            /* webpackChunkName: "AccountAuthorizations" */ 'app/views/settings/account/accountAuthorizations'
-          )
+          import('app/views/settings/account/accountAuthorizations')
         }
         component={errorHandler(LazyLoad)}
       />
@@ -123,27 +109,19 @@ function routes() {
       <Route name="Security" path="security/">
         <Route
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "AccountSecurityWrapper" */ 'app/views/settings/account/accountSecurity/accountSecurityWrapper'
-            )
+            import('app/views/settings/account/accountSecurity/accountSecurityWrapper')
           }
           component={errorHandler(LazyLoad)}
         >
           <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "AccountSecurity" */ 'app/views/settings/account/accountSecurity'
-              )
-            }
+            componentPromise={() => import('app/views/settings/account/accountSecurity')}
             component={errorHandler(LazyLoad)}
           />
           <Route
             path="session-history/"
             name="Session History"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "SessionHistory" */ 'app/views/settings/account/accountSecurity/sessionHistory'
-              )
+              import('app/views/settings/account/accountSecurity/sessionHistory')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -151,9 +129,7 @@ function routes() {
             path="mfa/:authId/"
             name="Details"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "AccountSecurityDetails" */ 'app/views/settings/account/accountSecurity/accountSecurityDetails'
-              )
+              import('app/views/settings/account/accountSecurity/accountSecurityDetails')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -163,9 +139,7 @@ function routes() {
           path="mfa/:authId/enroll/"
           name="Enroll"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "AccountSecurityEnroll" */ 'app/views/settings/account/accountSecurity/accountSecurityEnroll'
-            )
+            import('app/views/settings/account/accountSecurity/accountSecurityEnroll')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -174,22 +148,14 @@ function routes() {
       <Route
         path="subscriptions/"
         name="Subscriptions"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AccountSubscriptions" */ 'app/views/settings/account/accountSubscriptions'
-          )
-        }
+        componentPromise={() => import('app/views/settings/account/accountSubscriptions')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="identities/"
         name="Identities"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AccountSocialIdentities" */ 'app/views/settings/account/accountIdentities'
-          )
-        }
+        componentPromise={() => import('app/views/settings/account/accountIdentities')}
         component={errorHandler(LazyLoad)}
       />
 
@@ -198,41 +164,27 @@ function routes() {
 
         <Route path="auth-tokens/" name="Auth Tokens">
           <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ApiTokensIndex" */ 'app/views/settings/account/apiTokens'
-              )
-            }
+            componentPromise={() => import('app/views/settings/account/apiTokens')}
             component={errorHandler(LazyLoad)}
           />
           <Route
             path="new-token/"
             name="Create New Token"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ApiTokenCreate" */ 'app/views/settings/account/apiNewToken'
-              )
-            }
+            componentPromise={() => import('app/views/settings/account/apiNewToken')}
             component={errorHandler(LazyLoad)}
           />
         </Route>
 
         <Route path="applications/" name="Applications">
           <IndexRoute
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ApiApplications" */ 'app/views/settings/account/apiApplications'
-              )
-            }
+            componentPromise={() => import('app/views/settings/account/apiApplications')}
             component={errorHandler(LazyLoad)}
           />
           <Route
             path=":appId/"
             name="Details"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "ApiApplicationDetails" */ 'app/views/settings/account/apiApplications/details'
-              )
+              import('app/views/settings/account/apiApplications/details')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -244,11 +196,7 @@ function routes() {
       <Route
         path="close-account/"
         name="Close Account"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "AccountClose" */ 'app/views/settings/account/accountClose'
-          )
-        }
+        componentPromise={() => import('app/views/settings/account/accountClose')}
         component={errorHandler(LazyLoad)}
       />
     </React.Fragment>
@@ -258,21 +206,13 @@ function routes() {
     <React.Fragment>
       <IndexRoute
         name="General"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectGeneralSettings" */ 'app/views/settings/projectGeneralSettings'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectGeneralSettings')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="teams/"
         name="Teams"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectTeams" */ 'app/views/settings/project/projectTeams'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/projectTeams')}
         component={errorHandler(LazyLoad)}
       />
 
@@ -280,19 +220,11 @@ function routes() {
         name="Alerts"
         path="alerts/"
         component={errorHandler(LazyLoad)}
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectAlerts" */ 'app/views/settings/projectAlerts'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectAlerts')}
       >
         <IndexRoute
           component={errorHandler(LazyLoad)}
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectAlertsSettings" */ 'app/views/settings/projectAlerts/settings'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectAlerts/settings')}
         />
         <Redirect from="new/" to="/organizations/:orgId/alerts/:projectId/new/" />
         <Redirect from="rules/" to="/organizations/:orgId/alerts/rules/" />
@@ -314,11 +246,7 @@ function routes() {
       <Route
         name="Environments"
         path="environments/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectEnvironments" */ 'app/views/settings/project/projectEnvironments'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/projectEnvironments')}
         component={errorHandler(LazyLoad)}
       >
         <IndexRoute />
@@ -327,9 +255,7 @@ function routes() {
       <Route
         name="Tags"
         path="tags/"
-        componentPromise={() =>
-          import(/* webpackChunkName: "ProjectTags" */ 'app/views/settings/projectTags')
-        }
+        componentPromise={() => import('app/views/settings/projectTags')}
         component={errorHandler(LazyLoad)}
       />
       <Redirect from="issue-tracking/" to="/settings/:orgId/:projectId/plugins/" />
@@ -337,88 +263,54 @@ function routes() {
         path="release-tracking/"
         name="Release Tracking"
         componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectReleaseTracking" */ 'app/views/settings/project/projectReleaseTracking'
-          )
+          import('app/views/settings/project/projectReleaseTracking')
         }
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="ownership/"
         name="Issue Owners"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectOwnership" */ 'app/views/settings/project/projectOwnership'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/projectOwnership')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="data-forwarding/"
         name="Data Forwarding"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectDataForwarding" */ 'app/views/settings/projectDataForwarding'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectDataForwarding')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         name={t('Security & Privacy')}
         path="security-and-privacy/"
         component={errorHandler(LazyLoad)}
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectSecurityAndPrivacy" */ 'app/views/settings/projectSecurityAndPrivacy'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectSecurityAndPrivacy')}
       />
       <Route
         path="debug-symbols/"
         name="Debug Information Files"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectDebugFiles" */ 'app/views/settings/projectDebugFiles'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectDebugFiles')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="proguard/"
         name={t('ProGuard Mappings')}
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectProguard" */ 'app/views/settings/projectProguard'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectProguard')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="source-maps/"
         name={t('Source Maps')}
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectSourceMaps" */ 'app/views/settings/projectSourceMaps'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectSourceMaps')}
         component={errorHandler(LazyLoad)}
       >
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectSourceMapsList" */ 'app/views/settings/projectSourceMaps/list'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectSourceMaps/list')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path=":name/"
           name={t('Archive')}
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectSourceMapsDetail" */ 'app/views/settings/projectSourceMaps/detail'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectSourceMaps/detail')}
           component={errorHandler(LazyLoad)}
         />
       </Route>
@@ -426,20 +318,14 @@ function routes() {
         path="processing-issues/"
         name="Processing Issues"
         componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectProcessingIssues" */ 'app/views/settings/project/projectProcessingIssues'
-          )
+          import('app/views/settings/project/projectProcessingIssues')
         }
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="filters/"
         name="Inbound Filters"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectFilters" */ 'app/views/settings/project/projectFilters'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/projectFilters')}
         component={errorHandler(LazyLoad)}
       >
         <IndexRedirect to="data-filters/" />
@@ -448,40 +334,26 @@ function routes() {
       <Route
         name={t('Filters & Sampling')}
         path="filters-and-sampling/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectFiltersAndSampling" */ 'app/views/settings/project/filtersAndSampling'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/filtersAndSampling')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="issue-grouping/"
         name={t('Issue Grouping')}
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectIssueGrouping" */ 'app/views/settings/projectIssueGrouping'
-          )
-        }
+        componentPromise={() => import('app/views/settings/projectIssueGrouping')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="hooks/"
         name="Service Hooks"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectServiceHooks" */ 'app/views/settings/project/projectServiceHooks'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/projectServiceHooks')}
         component={errorHandler(LazyLoad)}
       />
       <Route
         path="hooks/new/"
         name="Create Service Hook"
         componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectCreateServiceHook" */ 'app/views/settings/project/projectCreateServiceHook'
-          )
+          import('app/views/settings/project/projectCreateServiceHook')
         }
         component={errorHandler(LazyLoad)}
       />
@@ -489,19 +361,13 @@ function routes() {
         path="hooks/:hookId/"
         name="Service Hook Details"
         componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectServiceHookDetails" */ 'app/views/settings/project/projectServiceHookDetails'
-          )
+          import('app/views/settings/project/projectServiceHookDetails')
         }
         component={errorHandler(LazyLoad)}
       />
       <Route path="keys/" name="Client Keys">
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectKeys" */ 'app/views/settings/project/projectKeys/list'
-            )
-          }
+          componentPromise={() => import('app/views/settings/project/projectKeys/list')}
           component={errorHandler(LazyLoad)}
         />
 
@@ -509,9 +375,7 @@ function routes() {
           path=":keyId/"
           name="Details"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectKeyDetails" */ 'app/views/settings/project/projectKeys/details'
-            )
+            import('app/views/settings/project/projectKeys/details')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -519,40 +383,26 @@ function routes() {
       <Route
         path="user-feedback/"
         name="User Feedback"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "ProjectUserFeedbackSettings" */ 'app/views/settings/project/projectUserFeedback'
-          )
-        }
+        componentPromise={() => import('app/views/settings/project/projectUserFeedback')}
         component={errorHandler(LazyLoad)}
       />
       <Redirect from="csp/" to="security-headers/" />
       <Route path="security-headers/" name="Security Headers">
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectSecurityHeaders" */ 'app/views/settings/projectSecurityHeaders'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectSecurityHeaders')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path="csp/"
           name="Content Security Policy"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectCspReports" */ 'app/views/settings/projectSecurityHeaders/csp'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectSecurityHeaders/csp')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path="expect-ct/"
           name="Certificate Transparency"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectExpectCtReports" */ 'app/views/settings/projectSecurityHeaders/expectCt'
-            )
+            import('app/views/settings/projectSecurityHeaders/expectCt')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -560,49 +410,33 @@ function routes() {
           path="hpkp/"
           name="HPKP"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectHpkpReports" */ 'app/views/settings/projectSecurityHeaders/hpkp'
-            )
+            import('app/views/settings/projectSecurityHeaders/hpkp')
           }
           component={errorHandler(LazyLoad)}
         />
       </Route>
       <Route path="plugins/" name="Legacy Integrations">
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectPlugins" */ 'app/views/settings/projectPlugins'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectPlugins')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path=":pluginId/"
           name="Integration Details"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectPluginDetails" */ 'app/views/settings/projectPlugins/details'
-            )
-          }
+          componentPromise={() => import('app/views/settings/projectPlugins/details')}
           component={errorHandler(LazyLoad)}
         />
       </Route>
       <Route path="install/" name="Configuration">
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "ProjectInstallOverview" */ 'app/views/projectInstall/overview'
-            )
-          }
+          componentPromise={() => import('app/views/projectInstall/overview')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path=":platform/"
           name="Docs"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "PlatformOrIntegration" */ 'app/views/projectInstall/platformOrIntegration'
-            )
+            import('app/views/projectInstall/platformOrIntegration')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -616,32 +450,20 @@ function routes() {
     <React.Fragment>
       <IndexRoute
         name="General"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationGeneralSettings" */ 'app/views/settings/organizationGeneralSettings'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationGeneralSettings')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="projects/"
         name="Projects"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationProjects" */ 'app/views/settings/organizationProjects'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationProjects')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route path="api-keys/" name="API Key">
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationApiKeys" */ 'app/views/settings/organizationApiKeys'
-            )
-          }
+          componentPromise={() => import('app/views/settings/organizationApiKeys')}
           component={errorHandler(LazyLoad)}
         />
 
@@ -649,9 +471,7 @@ function routes() {
           path=":apiKey/"
           name="Details"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationApiKeyDetails" */ 'app/views/settings/organizationApiKeys/organizationApiKeyDetails'
-            )
+            import('app/views/settings/organizationApiKeys/organizationApiKeyDetails')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -660,39 +480,27 @@ function routes() {
       <Route
         path="audit-log/"
         name="Audit Log"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationAuditLog" */ 'app/views/settings/organizationAuditLog'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationAuditLog')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="auth/"
         name="Auth Providers"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationAuth" */ 'app/views/settings/organizationAuth'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationAuth')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route path="members/" name="Members">
         <Route
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationMembersWrapper" */ 'app/views/settings/organizationMembers/organizationMembersWrapper'
-            )
+            import('app/views/settings/organizationMembers/organizationMembersWrapper')
           }
           component={errorHandler(LazyLoad)}
         >
           <IndexRoute
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationMembersList" */ 'app/views/settings/organizationMembers/organizationMembersList'
-              )
+              import('app/views/settings/organizationMembers/organizationMembersList')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -701,9 +509,7 @@ function routes() {
             path="requests/"
             name="Requests"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationRequestsView" */ 'app/views/settings/organizationMembers/organizationRequestsView'
-              )
+              import('app/views/settings/organizationMembers/organizationRequestsView')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -713,9 +519,7 @@ function routes() {
           path=":memberId/"
           name="Details"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationMemberDetail" */ 'app/views/settings/organizationMembers/organizationMemberDetail'
-            )
+            import('app/views/settings/organizationMembers/organizationMemberDetail')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -724,54 +528,34 @@ function routes() {
       <Route
         path="rate-limits/"
         name="Rate Limits"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationRateLimits" */ 'app/views/settings/organizationRateLimits'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationRateLimits')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         name={t('Relay')}
         path="relay/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "organizationRelay" */ 'app/views/settings/organizationRelay'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationRelay')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="repos/"
         name="Repositories"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationRepositories" */ 'app/views/settings/organizationRepositories'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationRepositories')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="performance/"
         name={t('Performance')}
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationPerformance" */ 'app/views/settings/organizationPerformance'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationPerformance')}
         component={errorHandler(LazyLoad)}
       />
 
       <Route
         path="settings/"
-        componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationGeneralSettings" */ 'app/views/settings/organizationGeneralSettings'
-          )
-        }
+        componentPromise={() => import('app/views/settings/organizationGeneralSettings')}
         component={errorHandler(LazyLoad)}
       />
 
@@ -779,20 +563,14 @@ function routes() {
         name={t('Security & Privacy')}
         path="security-and-privacy/"
         componentPromise={() =>
-          import(
-            /* webpackChunkName: "OrganizationSecurityAndPrivacy" */ 'app/views/settings/organizationSecurityAndPrivacy'
-          )
+          import('app/views/settings/organizationSecurityAndPrivacy')
         }
         component={errorHandler(LazyLoad)}
       />
 
       <Route name="Teams" path="teams/">
         <IndexRoute
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationTeams" */ 'app/views/settings/organizationTeams'
-            )
-          }
+          componentPromise={() => import('app/views/settings/organizationTeams')}
           component={errorHandler(LazyLoad)}
         />
 
@@ -800,9 +578,7 @@ function routes() {
           name="Team"
           path=":teamId/"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "TeamDetails" */ 'app/views/settings/organizationTeams/teamDetails'
-            )
+            import('app/views/settings/organizationTeams/teamDetails')
           }
           component={errorHandler(LazyLoad)}
         >
@@ -811,9 +587,7 @@ function routes() {
             path="members/"
             name="Members"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "TeamMembers" */ 'app/views/settings/organizationTeams/teamMembers'
-              )
+              import('app/views/settings/organizationTeams/teamMembers')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -821,9 +595,7 @@ function routes() {
             path="projects/"
             name="Projects"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "TeamProjects" */ 'app/views/settings/organizationTeams/teamProjects'
-              )
+              import('app/views/settings/organizationTeams/teamProjects')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -831,9 +603,7 @@ function routes() {
             path="settings/"
             name="settings"
             componentPromise={() =>
-              import(
-                /* webpackChunkName: "TeamSettings" */ 'app/views/settings/organizationTeams/teamSettings'
-              )
+              import('app/views/settings/organizationTeams/teamSettings')
             }
             component={errorHandler(LazyLoad)}
           />
@@ -846,9 +616,7 @@ function routes() {
           name="Integration Details"
           path=":integrationSlug/"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "PluginDetailedView" */ 'app/views/organizationIntegrations/pluginDetailedView'
-            )
+            import('app/views/organizationIntegrations/pluginDetailedView')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -860,9 +628,7 @@ function routes() {
           name="Details"
           path=":integrationSlug"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "SentryAppDetailedView" */ 'app/views/organizationIntegrations/sentryAppDetailedView'
-            )
+            import('app/views/organizationIntegrations/sentryAppDetailedView')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -874,9 +640,7 @@ function routes() {
           name="Details"
           path=":integrationSlug"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "DocIntegrationDetailedView" */ 'app/views/organizationIntegrations/docIntegrationDetailedView'
-            )
+            import('app/views/organizationIntegrations/docIntegrationDetailedView')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -884,9 +648,7 @@ function routes() {
       <Route name="Integrations" path="integrations/">
         <IndexRoute
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "IntegrationListDirectory" */ 'app/views/organizationIntegrations/integrationListDirectory'
-            )
+            import('app/views/organizationIntegrations/integrationListDirectory')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -894,9 +656,7 @@ function routes() {
           name="Integration Details"
           path=":integrationSlug"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "IntegrationDetailedView" */ 'app/views/organizationIntegrations/integrationDetailedView'
-            )
+            import('app/views/organizationIntegrations/integrationDetailedView')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -904,9 +664,7 @@ function routes() {
           name="Configure Integration"
           path=":providerKey/:integrationId/"
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "ConfigureIntegration" */ 'app/views/settings/organizationIntegrations/configureIntegration'
-            )
+            import('app/views/settings/organizationIntegrations/configureIntegration')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -915,9 +673,7 @@ function routes() {
       <Route name="Developer Settings" path="developer-settings/">
         <IndexRoute
           componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationDeveloperSettings" */ 'app/views/settings/organizationDeveloperSettings'
-            )
+            import('app/views/settings/organizationDeveloperSettings')
           }
           component={errorHandler(LazyLoad)}
         />
@@ -926,7 +682,7 @@ function routes() {
           path="new-public/"
           componentPromise={() =>
             import(
-              /* webpackChunkName: "sentryApplicationDetails" */ 'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
+              'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
             )
           }
           component={errorHandler(LazyLoad)}
@@ -936,7 +692,7 @@ function routes() {
           path="new-internal/"
           componentPromise={() =>
             import(
-              /* webpackChunkName: "sentryApplicationDetails" */ 'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
+              'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
             )
           }
           component={errorHandler(LazyLoad)}
@@ -946,7 +702,7 @@ function routes() {
           path=":appSlug/"
           componentPromise={() =>
             import(
-              /* webpackChunkName: "sentryApplicationDetails" */ 'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
+              'app/views/settings/organizationDeveloperSettings/sentryApplicationDetails'
             )
           }
           component={errorHandler(LazyLoad)}
@@ -956,7 +712,7 @@ function routes() {
           path=":appSlug/dashboard/"
           componentPromise={() =>
             import(
-              /* webpackChunkName: "SentryApplicationDashboard" */ 'app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard'
+              'app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard'
             )
           }
           component={errorHandler(LazyLoad)}
@@ -970,9 +726,7 @@ function routes() {
       {EXPERIMENTAL_SPA && (
         <Route path="/auth/login/" component={errorHandler(AuthLayout)}>
           <IndexRoute
-            componentPromise={() =>
-              import(/* webpackChunkName: "AuthLogin" */ 'app/views/auth/login')
-            }
+            componentPromise={() => import('app/views/auth/login')}
             component={errorHandler(LazyLoad)}
           />
         </Route>
@@ -980,56 +734,36 @@ function routes() {
 
       <Route path="/" component={errorHandler(App)}>
         <IndexRoute
-          componentPromise={() =>
-            import(/* webpackChunkName: "AppRoot" */ 'app/views/app/root')
-          }
+          componentPromise={() => import('app/views/app/root')}
           component={errorHandler(LazyLoad)}
         />
 
         <Route
           path="/accept/:memberId/:token/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AcceptOrganizationInvite" */ 'app/views/acceptOrganizationInvite'
-            )
-          }
+          componentPromise={() => import('app/views/acceptOrganizationInvite')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path="/accept-transfer/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "AcceptProjectTransfer" */ 'app/views/acceptProjectTransfer'
-            )
-          }
+          componentPromise={() => import('app/views/acceptProjectTransfer')}
           component={errorHandler(LazyLoad)}
         />
         <Route
           path="/extensions/external-install/:integrationSlug/:installationId"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "IntegrationOrganizationLink" */ 'app/views/integrationOrganizationLink'
-            )
-          }
+          componentPromise={() => import('app/views/integrationOrganizationLink')}
           component={errorHandler(LazyLoad)}
         />
 
         <Route
           path="/extensions/:integrationSlug/link/"
           getComponent={(_loc, cb) =>
-            import(
-              /* webpackChunkName: "IntegrationOrganizationLink" */ 'app/views/integrationOrganizationLink'
-            ).then(lazyLoad(cb))
+            import('app/views/integrationOrganizationLink').then(lazyLoad(cb))
           }
         />
 
         <Route
           path="/sentry-apps/:sentryAppSlug/external-install/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "SentryAppExternalInstallation" */ 'app/views/sentryAppExternalInstallation'
-            )
-          }
+          componentPromise={() => import('app/views/sentryAppExternalInstallation')}
           component={errorHandler(LazyLoad)}
         />
 
@@ -1038,41 +772,25 @@ function routes() {
         <Redirect from="/share/group/:shareId/" to="/share/issue/:shareId/" />
         <Route
           path="/share/issue/:shareId/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "SharedGroupDetails" */ 'app/views/sharedGroupDetails'
-            )
-          }
+          componentPromise={() => import('app/views/sharedGroupDetails')}
           component={errorHandler(LazyLoad)}
         />
 
         <Route
           path="/organizations/new/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationCreate" */ 'app/views/organizationCreate'
-            )
-          }
+          componentPromise={() => import('app/views/organizationCreate')}
           component={errorHandler(LazyLoad)}
         />
 
         <Route
           path="/organizations/:orgId/data-export/:dataExportId"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "DataDownloadView" */ 'app/views/dataExport/dataDownload'
-            )
-          }
+          componentPromise={() => import('app/views/dataExport/dataDownload')}
           component={errorHandler(LazyLoad)}
         />
 
         <Route
           path="/join-request/:orgId/"
-          componentPromise={() =>
-            import(
-              /* webpackChunkName: "OrganizationJoinRequest" */ 'app/views/organizationJoinRequest'
-            )
-          }
+          componentPromise={() => import('app/views/organizationJoinRequest')}
           component={errorHandler(LazyLoad)}
         />
 
@@ -1080,11 +798,7 @@ function routes() {
           <IndexRedirect to="welcome/" />
           <Route
             path=":step/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "Onboarding" */ 'app/views/onboarding/onboarding'
-              )
-            }
+            componentPromise={() => import('app/views/onboarding/onboarding')}
             component={errorHandler(LazyLoad)}
           />
         </Route>
@@ -1094,9 +808,7 @@ function routes() {
           <Route path="/settings/" name="Settings" component={SettingsWrapper}>
             <IndexRoute
               getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "SettingsIndex" */ 'app/views/settings/settingsIndex'
-                ).then(lazyLoad(cb))
+                import('app/views/settings/settingsIndex').then(lazyLoad(cb))
               }
             />
 
@@ -1104,9 +816,9 @@ function routes() {
               path="account/"
               name="Account"
               getComponent={(_loc, cb) =>
-                import(
-                  /* webpackChunkName: "AccountSettingsLayout" */ 'app/views/settings/account/accountSettingsLayout'
-                ).then(lazyLoad(cb))
+                import('app/views/settings/account/accountSettingsLayout').then(
+                  lazyLoad(cb)
+                )
               }
             >
               {accountSettingsRoutes}
@@ -1116,7 +828,7 @@ function routes() {
               <Route
                 getComponent={(_loc, cb) =>
                   import(
-                    /* webpackChunkName: "OrganizationSettingsLayout" */ 'app/views/settings/organization/organizationSettingsLayout'
+                    'app/views/settings/organization/organizationSettingsLayout'
                   ).then(lazyLoad(cb))
                 }
               >
@@ -1128,9 +840,9 @@ function routes() {
                 name="Project"
                 path="projects/:projectId/"
                 getComponent={(_loc, cb) =>
-                  import(
-                    /* webpackChunkName: "ProjectSettingsLayout" */ 'app/views/settings/project/projectSettingsLayout'
-                  ).then(lazyLoad(cb))
+                  import('app/views/settings/project/projectSettingsLayout').then(
+                    lazyLoad(cb)
+                  )
                 }
               >
                 <Route component={errorHandler(SettingsProjectProvider)}>
@@ -1159,37 +871,23 @@ function routes() {
         <Route component={errorHandler(LightWeightOrganizationDetails)}>
           <Route
             path="/organizations/:orgId/projects/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ProjectsDashboard" */ 'app/views/projectsDashboard'
-              )
-            }
+            componentPromise={() => import('app/views/projectsDashboard')}
             component={errorHandler(LazyLoad)}
           />
           <Route
             path="/organizations/:orgId/dashboards/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "DashboardsV2Container" */ 'app/views/dashboardsV2'
-              )
-            }
+            componentPromise={() => import('app/views/dashboardsV2')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ManageDashboards" */ 'app/views/dashboardsV2/manage'
-                )
-              }
+              componentPromise={() => import('app/views/dashboardsV2/manage')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
 
           <Route
             path="/organizations/:orgId/user-feedback/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "UserFeedback" */ 'app/views/userFeedback')
-            }
+            componentPromise={() => import('app/views/userFeedback')}
             component={errorHandler(LazyLoad)}
           />
 
@@ -1209,18 +907,12 @@ function routes() {
           /organizations/:orgId/issues */}
           <Route
             path="/organizations/:orgId/issues/:groupId/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "GroupDetails" */ 'app/views/organizationGroupDetails'
-              )
-            }
+            componentPromise={() => import('app/views/organizationGroupDetails')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupEventDetails" */ 'app/views/organizationGroupDetails/groupEventDetails'
-                )
+                import('app/views/organizationGroupDetails/groupEventDetails')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1231,9 +923,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/activity/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupActivity" */ 'app/views/organizationGroupDetails/groupActivity'
-                )
+                import('app/views/organizationGroupDetails/groupActivity')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1244,9 +934,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/events/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupEvents" */ 'app/views/organizationGroupDetails/groupEvents'
-                )
+                import('app/views/organizationGroupDetails/groupEvents')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1257,9 +945,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/tags/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupTags" */ 'app/views/organizationGroupDetails/groupTags'
-                )
+                import('app/views/organizationGroupDetails/groupTags')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1270,9 +956,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/tags/:tagKey/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupTagsValues" */ 'app/views/organizationGroupDetails/groupTagValues'
-                )
+                import('app/views/organizationGroupDetails/groupTagValues')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1283,9 +967,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/feedback/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupUserFeedback" */ 'app/views/organizationGroupDetails/groupUserFeedback'
-                )
+                import('app/views/organizationGroupDetails/groupUserFeedback')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1296,9 +978,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/attachments/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupEventAttachments" */ 'app/views/organizationGroupDetails/groupEventAttachments'
-                )
+                import('app/views/organizationGroupDetails/groupEventAttachments')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1309,9 +989,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/similar/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupSimilarIssues" */ 'app/views/organizationGroupDetails/groupSimilarIssues'
-                )
+                import('app/views/organizationGroupDetails/groupSimilarIssues')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1322,9 +1000,7 @@ function routes() {
             <Route
               path="/organizations/:orgId/issues/:groupId/merged/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "GroupMerged" */ 'app/views/organizationGroupDetails/groupMerged'
-                )
+                import('app/views/organizationGroupDetails/groupMerged')
               }
               component={errorHandler(LazyLoad)}
               props={{
@@ -1335,9 +1011,7 @@ function routes() {
             <Route path="/organizations/:orgId/issues/:groupId/events/:eventId/">
               <IndexRoute
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupEventDetails" */ 'app/views/organizationGroupDetails/groupEventDetails'
-                  )
+                  import('app/views/organizationGroupDetails/groupEventDetails')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1348,9 +1022,7 @@ function routes() {
               <Route
                 path="activity/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupActivity" */ 'app/views/organizationGroupDetails/groupActivity'
-                  )
+                  import('app/views/organizationGroupDetails/groupActivity')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1361,9 +1033,7 @@ function routes() {
               <Route
                 path="events/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupEvents" */ 'app/views/organizationGroupDetails/groupEvents'
-                  )
+                  import('app/views/organizationGroupDetails/groupEvents')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1374,9 +1044,7 @@ function routes() {
               <Route
                 path="similar/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupSimilarIssues" */ 'app/views/organizationGroupDetails/groupSimilarIssues'
-                  )
+                  import('app/views/organizationGroupDetails/groupSimilarIssues')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1387,9 +1055,7 @@ function routes() {
               <Route
                 path="tags/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupTags" */ 'app/views/organizationGroupDetails/groupTags'
-                  )
+                  import('app/views/organizationGroupDetails/groupTags')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1400,9 +1066,7 @@ function routes() {
               <Route
                 path="tags/:tagKey/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupTagsValues" */ 'app/views/organizationGroupDetails/groupTagValues'
-                  )
+                  import('app/views/organizationGroupDetails/groupTagValues')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1413,9 +1077,7 @@ function routes() {
               <Route
                 path="feedback/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupUserFeedback" */ 'app/views/organizationGroupDetails/groupUserFeedback'
-                  )
+                  import('app/views/organizationGroupDetails/groupUserFeedback')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1426,9 +1088,7 @@ function routes() {
               <Route
                 path="attachments/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupEventAttachments" */ 'app/views/organizationGroupDetails/groupEventAttachments'
-                  )
+                  import('app/views/organizationGroupDetails/groupEventAttachments')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1439,9 +1099,7 @@ function routes() {
               <Route
                 path="merged/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "GroupMerged" */ 'app/views/organizationGroupDetails/groupMerged'
-                  )
+                  import('app/views/organizationGroupDetails/groupMerged')
                 }
                 component={errorHandler(LazyLoad)}
                 props={{
@@ -1454,15 +1112,11 @@ function routes() {
 
           <Route
             path="/organizations/:orgId/alerts/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "AlertsContainer" */ 'app/views/alerts')
-            }
+            componentPromise={() => import('app/views/alerts')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "AlertsList" */ 'app/views/alerts/list')
-              }
+              componentPromise={() => import('app/views/alerts/list')}
               component={errorHandler(LazyLoad)}
             />
 
@@ -1470,26 +1124,18 @@ function routes() {
               path="rules/details/:ruleId/"
               name="Alert Rule Details"
               component={errorHandler(LazyLoad)}
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AlertRulesDetails" */ 'app/views/alerts/rules/details'
-                )
-              }
+              componentPromise={() => import('app/views/alerts/rules/details')}
             />
 
             <Route path="rules/">
               <IndexRoute
                 component={errorHandler(LazyLoad)}
-                componentPromise={() =>
-                  import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/rules')
-                }
+                componentPromise={() => import('app/views/alerts/rules')}
               />
               <Route
                 path=":projectId/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "AlertsProjectProvider" */ 'app/views/alerts/builder/projectProvider'
-                  )
+                  import('app/views/alerts/builder/projectProvider')
                 }
                 component={errorHandler(LazyLoad)}
               >
@@ -1497,11 +1143,7 @@ function routes() {
                 <Route
                   path=":ruleId/"
                   name="Edit Alert Rule"
-                  componentPromise={() =>
-                    import(
-                      /* webpackChunkName: "ProjectAlertsEdit" */ 'app/views/settings/projectAlerts/edit'
-                    )
-                  }
+                  componentPromise={() => import('app/views/settings/projectAlerts/edit')}
                   component={errorHandler(LazyLoad)}
                 />
               </Route>
@@ -1512,9 +1154,7 @@ function routes() {
               <Route
                 path=":projectId/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "AlertsProjectProvider" */ 'app/views/alerts/builder/projectProvider'
-                  )
+                  import('app/views/alerts/builder/projectProvider')
                 }
                 component={errorHandler(LazyLoad)}
               >
@@ -1522,11 +1162,7 @@ function routes() {
                 <Route
                   path=":ruleId/"
                   name="Edit Alert Rule"
-                  componentPromise={() =>
-                    import(
-                      /* webpackChunkName: "ProjectAlertsEdit" */ 'app/views/settings/projectAlerts/edit'
-                    )
-                  }
+                  componentPromise={() => import('app/views/settings/projectAlerts/edit')}
                   component={errorHandler(LazyLoad)}
                 />
               </Route>
@@ -1534,138 +1170,88 @@ function routes() {
 
             <Route
               path="rules/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/rules')
-              }
+              componentPromise={() => import('app/views/alerts/rules')}
               component={errorHandler(LazyLoad)}
             />
 
             <Route
               path=":alertId/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "AlertsDetails" */ 'app/views/alerts/details')
-              }
+              componentPromise={() => import('app/views/alerts/details')}
               component={errorHandler(LazyLoad)}
             />
 
             <Route
               path=":projectId/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AlertsProjectProvider" */ 'app/views/alerts/builder/projectProvider'
-                )
-              }
+              componentPromise={() => import('app/views/alerts/builder/projectProvider')}
               component={errorHandler(LazyLoad)}
             >
               <Route
                 path="new/"
                 name="New Alert Rule"
                 component={errorHandler(LazyLoad)}
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "ProjectAlertsCreate" */ 'app/views/settings/projectAlerts/create'
-                  )
-                }
+                componentPromise={() => import('app/views/settings/projectAlerts/create')}
               />
               <Route
                 path="wizard/"
                 name="Alert Creation Wizard"
                 component={errorHandler(LazyLoad)}
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "ProjectAlertsWizard" */ 'app/views/alerts/wizard'
-                  )
-                }
+                componentPromise={() => import('app/views/alerts/wizard')}
               />
             </Route>
           </Route>
 
           <Route
             path="/organizations/:orgId/monitors/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "MonitorsContainer" */ 'app/views/monitors')
-            }
+            componentPromise={() => import('app/views/monitors')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "Monitors" */ 'app/views/monitors/monitors')
-              }
+              componentPromise={() => import('app/views/monitors/monitors')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="/organizations/:orgId/monitors/create/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "MonitorCreate" */ 'app/views/monitors/create'
-                )
-              }
+              componentPromise={() => import('app/views/monitors/create')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="/organizations/:orgId/monitors/:monitorId/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "MonitorDetails" */ 'app/views/monitors/details'
-                )
-              }
+              componentPromise={() => import('app/views/monitors/details')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="/organizations/:orgId/monitors/:monitorId/edit/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "MonitorEdit" */ 'app/views/monitors/edit')
-              }
+              componentPromise={() => import('app/views/monitors/edit')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
 
           <Route
             path="/organizations/:orgId/releases/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "ReleasesContainer" */ 'app/views/releases')
-            }
+            componentPromise={() => import('app/views/releases')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(/* webpackChunkName: "ReleasesList" */ 'app/views/releases/list')
-              }
+              componentPromise={() => import('app/views/releases/list')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path=":release/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ReleasesDetail" */ 'app/views/releases/detail'
-                )
-              }
+              componentPromise={() => import('app/views/releases/detail')}
               component={errorHandler(LazyLoad)}
             >
               <IndexRoute
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "ReleasesDetailOverview" */ 'app/views/releases/detail/overview'
-                  )
-                }
+                componentPromise={() => import('app/views/releases/detail/overview')}
                 component={errorHandler(LazyLoad)}
               />
               <Route
                 path="commits/"
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "ReleasesDetailCommits" */ 'app/views/releases/detail/commits'
-                  )
-                }
+                componentPromise={() => import('app/views/releases/detail/commits')}
                 component={errorHandler(LazyLoad)}
               />
               <Route
                 path="files-changed/"
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "ReleasesDetailFilesChanged" */ 'app/views/releases/detail/filesChanged'
-                  )
-                }
+                componentPromise={() => import('app/views/releases/detail/filesChanged')}
                 component={errorHandler(LazyLoad)}
               />
               <Redirect
@@ -1681,21 +1267,13 @@ function routes() {
 
           <Route
             path="/organizations/:orgId/activity/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationActivity" */ 'app/views/organizationActivity'
-              )
-            }
+            componentPromise={() => import('app/views/organizationActivity')}
             component={errorHandler(LazyLoad)}
           />
 
           <Route
             path="/organizations/:orgId/stats/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "OrganizationStats" */ 'app/views/organizationStats'
-              )
-            }
+            componentPromise={() => import('app/views/organizationStats')}
             component={errorHandler(LazyLoad)}
           />
 
@@ -1715,181 +1293,103 @@ function routes() {
           />
           <Route
             path="/organizations/:orgId/discover/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "DiscoverV2Container" */ 'app/views/eventsV2')
-            }
+            componentPromise={() => import('app/views/eventsV2')}
             component={errorHandler(LazyLoad)}
           >
             <Route
               path="queries/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DiscoverV2Landing" */ 'app/views/eventsV2/landing'
-                )
-              }
+              componentPromise={() => import('app/views/eventsV2/landing')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="results/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DiscoverV2Results" */ 'app/views/eventsV2/results'
-                )
-              }
+              componentPromise={() => import('app/views/eventsV2/results')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path=":eventSlug/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DiscoverV2Details" */ 'app/views/eventsV2/eventDetails'
-                )
-              }
+              componentPromise={() => import('app/views/eventsV2/eventDetails')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/performance/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
+            componentPromise={() => import('app/views/performance')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceLanding" */ 'app/views/performance/landing'
-                )
-              }
+              componentPromise={() => import('app/views/performance/landing')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/performance/summary/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
+            componentPromise={() => import('app/views/performance')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceTransactionSummary" */ 'app/views/performance/transactionSummary'
-                )
-              }
+              componentPromise={() => import('app/views/performance/transactionSummary')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="/organizations/:orgId/performance/summary/vitals/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceTransactionVitals" */ 'app/views/performance/transactionVitals'
-                )
-              }
+              componentPromise={() => import('app/views/performance/transactionVitals')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/performance/vitaldetail/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
+            componentPromise={() => import('app/views/performance')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceVitalDetail" */ 'app/views/performance/vitalDetail'
-                )
-              }
+              componentPromise={() => import('app/views/performance/vitalDetail')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/performance/trace/:traceSlug/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
+            componentPromise={() => import('app/views/performance')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceTraceDetails" */ 'app/views/performance/traceDetails'
-                )
-              }
+              componentPromise={() => import('app/views/performance/traceDetails')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/performance/:eventSlug/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
+            componentPromise={() => import('app/views/performance')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceTransactionDetails" */ 'app/views/performance/transactionDetails'
-                )
-              }
+              componentPromise={() => import('app/views/performance/transactionDetails')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/performance/compare/:baselineEventSlug/:regressionEventSlug/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "PerformanceContainer" */ 'app/views/performance'
-              )
-            }
+            componentPromise={() => import('app/views/performance')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PerformanceCompareTransactions" */ 'app/views/performance/compare'
-                )
-              }
+              componentPromise={() => import('app/views/performance/compare')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path="/organizations/:orgId/dashboards/new/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "DashboardsCreate" */ 'app/views/dashboardsV2/create'
-              )
-            }
+            componentPromise={() => import('app/views/dashboardsV2/create')}
             component={errorHandler(LazyLoad)}
           >
             <Route
               path="widget/:widgetId/edit/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DashboardsCreateWidgetEdit" */ 'app/views/dashboardsV2/widget'
-                )
-              }
+              componentPromise={() => import('app/views/dashboardsV2/widget')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="widget/new/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DashboardsCreateWidgetNew" */ 'app/views/dashboardsV2/widget'
-                )
-              }
+              componentPromise={() => import('app/views/dashboardsV2/widget')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
@@ -1899,29 +1399,17 @@ function routes() {
           />
           <Route
             path="/organizations/:orgId/dashboard/:dashboardId/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "DashboardsView" */ 'app/views/dashboardsV2/view'
-              )
-            }
+            componentPromise={() => import('app/views/dashboardsV2/view')}
             component={errorHandler(LazyLoad)}
           >
             <Route
               path="widget/:widgetId/edit/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DashboardsViewWidgetEdit" */ 'app/views/dashboardsV2/widget'
-                )
-              }
+              componentPromise={() => import('app/views/dashboardsV2/widget')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path="widget/new/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "DashboardsViewWidgetNew" */ 'app/views/dashboardsV2/widget'
-                )
-              }
+              componentPromise={() => import('app/views/dashboardsV2/widget')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
@@ -1930,142 +1418,88 @@ function routes() {
           <Route
             name="Admin"
             path="/manage/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "AdminLayout" */ 'app/views/admin/adminLayout')
-            }
+            componentPromise={() => import('app/views/admin/adminLayout')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminOverview" */ 'app/views/admin/adminOverview'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminOverview')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Buffer"
               path="buffer/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminBuffer" */ 'app/views/admin/adminBuffer'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminBuffer')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Relays"
               path="relays/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminRelays" */ 'app/views/admin/adminRelays'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminRelays')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Organizations"
               path="organizations/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminOrganizations" */ 'app/views/admin/adminOrganizations'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminOrganizations')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Projects"
               path="projects/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminProjects" */ 'app/views/admin/adminProjects'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminProjects')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Queue"
               path="queue/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "AdminQueue" */ 'app/views/admin/adminQueue')
-              }
+              componentPromise={() => import('app/views/admin/adminQueue')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Quotas"
               path="quotas/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminQuotas" */ 'app/views/admin/adminQuotas'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminQuotas')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Settings"
               path="settings/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminSettings" */ 'app/views/admin/adminSettings'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminSettings')}
               component={errorHandler(LazyLoad)}
             />
             <Route name="Users" path="users/">
               <IndexRoute
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "AdminUsers" */ 'app/views/admin/adminUsers'
-                  )
-                }
+                componentPromise={() => import('app/views/admin/adminUsers')}
                 component={errorHandler(LazyLoad)}
               />
               <Route
                 path=":id"
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "AdminUserEdit" */ 'app/views/admin/adminUserEdit'
-                  )
-                }
+                componentPromise={() => import('app/views/admin/adminUserEdit')}
                 component={errorHandler(LazyLoad)}
               />
             </Route>
             <Route
               name="Mail"
               path="status/mail/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "AdminMail" */ 'app/views/admin/adminMail')
-              }
+              componentPromise={() => import('app/views/admin/adminMail')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Environment"
               path="status/environment/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminEnvironment" */ 'app/views/admin/adminEnvironment'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminEnvironment')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Packages"
               path="status/packages/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminPackages" */ 'app/views/admin/adminPackages'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminPackages')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               name="Warnings"
               path="status/warnings/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "AdminWarnings" */ 'app/views/admin/adminWarnings'
-                )
-              }
+              componentPromise={() => import('app/views/admin/adminWarnings')}
               component={errorHandler(LazyLoad)}
             />
             {hook('routes:admin')}
@@ -2079,27 +1513,17 @@ function routes() {
 
             <Route
               path="/organizations/:orgId/projects/:projectId/getting-started/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ProjectGettingStarted" */ 'app/views/projectInstall/gettingStarted'
-                )
-              }
+              componentPromise={() => import('app/views/projectInstall/gettingStarted')}
               component={errorHandler(LazyLoad)}
             >
               <IndexRoute
-                componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "ProjectInstallOverview" */ 'app/views/projectInstall/overview'
-                  )
-                }
+                componentPromise={() => import('app/views/projectInstall/overview')}
                 component={errorHandler(LazyLoad)}
               />
               <Route
                 path=":platform/"
                 componentPromise={() =>
-                  import(
-                    /* webpackChunkName: "PlatformOrIntegration" */ 'app/views/projectInstall/platformOrIntegration'
-                  )
+                  import('app/views/projectInstall/platformOrIntegration')
                 }
                 component={errorHandler(LazyLoad)}
               />
@@ -2107,9 +1531,7 @@ function routes() {
 
             <Route
               path="/organizations/:orgId/teams/new/"
-              componentPromise={() =>
-                import(/* webpackChunkName: "TeamCreate" */ 'app/views/teamCreate')
-              }
+              componentPromise={() => import('app/views/teamCreate')}
               component={errorHandler(LazyLoad)}
             />
 
@@ -2171,37 +1593,23 @@ function routes() {
             </Route>
             <Route
               path="/organizations/:orgId/projects/new/"
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "NewProject" */ 'app/views/projectInstall/newProject'
-                )
-              }
+              componentPromise={() => import('app/views/projectInstall/newProject')}
               component={errorHandler(LazyLoad)}
             />
           </Route>
           <Route
             path=":projectId/getting-started/"
-            componentPromise={() =>
-              import(
-                /* webpackChunkName: "ProjectGettingStarted" */ 'app/views/projectInstall/gettingStarted'
-              )
-            }
+            componentPromise={() => import('app/views/projectInstall/gettingStarted')}
             component={errorHandler(LazyLoad)}
           >
             <IndexRoute
-              componentPromise={() =>
-                import(
-                  /* webpackChunkName: "ProjectInstallOverview" */ 'app/views/projectInstall/overview'
-                )
-              }
+              componentPromise={() => import('app/views/projectInstall/overview')}
               component={errorHandler(LazyLoad)}
             />
             <Route
               path=":platform/"
               componentPromise={() =>
-                import(
-                  /* webpackChunkName: "PlatformOrIntegration" */ 'app/views/projectInstall/platformOrIntegration'
-                )
+                import('app/views/projectInstall/platformOrIntegration')
               }
               component={errorHandler(LazyLoad)}
             />
@@ -2214,9 +1622,7 @@ function routes() {
           {/* This is in the bottom lightweight group because "/organizations/:orgId/projects/new/" in heavyweight needs to be matched first */}
           <Route
             path="/organizations/:orgId/projects/:projectId/"
-            componentPromise={() =>
-              import(/* webpackChunkName: "ProjectDetail" */ 'app/views/projectDetail')
-            }
+            componentPromise={() => import('app/views/projectDetail')}
             component={errorHandler(LazyLoad)}
           />
 

--- a/static/app/utils/createFuzzySearch.tsx
+++ b/static/app/utils/createFuzzySearch.tsx
@@ -1,7 +1,7 @@
 import {DEFAULT_FUSE_OPTIONS} from 'app/constants';
 
 export function loadFuzzySearch() {
-  return import(/* webpackChunkName: "Fuse" */ 'fuse.js');
+  return import('fuse.js');
 }
 
 export async function createFuzzySearch<

--- a/static/app/views/alerts/list/sparkLine.tsx
+++ b/static/app/views/alerts/list/sparkLine.tsx
@@ -14,12 +14,8 @@ type Props = {
   error?: React.ReactNode;
 };
 
-const Sparklines = React.lazy(
-  () => import(/* webpackChunkName: "Sparklines" */ 'app/components/sparklines')
-);
-const SparklinesLine = React.lazy(
-  () => import(/* webpackChunkName: "SparklinesLine" */ 'app/components/sparklines/line')
-);
+const Sparklines = React.lazy(() => import('app/components/sparklines'));
+const SparklinesLine = React.lazy(() => import('app/components/sparklines/line'));
 
 class SparkLine extends React.Component<Props> {
   render() {

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -200,10 +200,7 @@ class App extends Component<Props, State> {
     const {needsUpgrade, newsletterConsentPrompt} = this.state;
 
     if (needsUpgrade) {
-      const InstallWizard = lazy(
-        () =>
-          import(/* webpackChunkName: "InstallWizard" */ 'app/views/admin/installWizard')
-      );
+      const InstallWizard = lazy(() => import('app/views/admin/installWizard'));
 
       return (
         <Suspense fallback={null}>

--- a/static/app/views/issueList/noGroupsHandler/index.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.tsx
@@ -116,9 +116,7 @@ class NoGroupsHandler extends React.Component<Props, State> {
     const project = projects && projects.length > 0 ? projects[0] : undefined;
     const sampleIssueId = groupIds.length > 0 ? groupIds[0] : undefined;
 
-    const ErrorRobot = React.lazy(
-      () => import(/* webpackChunkName: "ErrorRobot" */ 'app/components/errorRobot')
-    );
+    const ErrorRobot = React.lazy(() => import('app/components/errorRobot'));
 
     return (
       <React.Suspense fallback={<Placeholder height="260px" />}>

--- a/static/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
+++ b/static/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
@@ -22,9 +22,7 @@ const Message = () => (
   </React.Fragment>
 );
 
-const CongratsRobotsVideo = React.lazy(
-  () => import(/* webpackChunkName: "CongratsRobotsVideo" */ './congratsRobots')
-);
+const CongratsRobotsVideo = React.lazy(() => import('./congratsRobots'));
 
 type State = {hasError: boolean};
 

--- a/static/app/views/settings/components/forms/datePickerField.tsx
+++ b/static/app/views/settings/components/forms/datePickerField.tsx
@@ -27,9 +27,7 @@ function handleChangeDate(
   close();
 }
 
-const Calendar = lazy(
-  () => import(/* webpackChunkName: "CalendarField" */ './calendarField')
-);
+const Calendar = lazy(() => import('./calendarField'));
 
 export default function DatePickerField(props: Props) {
   return (


### PR DESCRIPTION
Lets use webpacks defaults instead of having the developer come up with a chunk name. This will blow up our cache for these chunks, but they are generally in less-used components anyway.