### PR TITLE
feat(quick-trace): Add disabled behaviour on discover

### DIFF
--- a/static/app/utils/docs.tsx
+++ b/static/app/utils/docs.tsx
@@ -58,3 +58,10 @@ export function getDocsPlatform(
   // can't find a matching docs platform
   return null;
 }
+
+export function getConfigureTracingDocsLink(platform: string | null): string | null {
+  const docsPlatform = platform ? getDocsPlatform(platform, true) : null;
+  return docsPlatform === null
+    ? null // this platform does not support performance
+    : `https://docs.sentry.io/platforms/${docsPlatform}/performance/`;
+}

--- a/static/app/utils/docs.tsx
+++ b/static/app/utils/docs.tsx
@@ -1,3 +1,5 @@
+import {AvatarProject} from 'app/types';
+
 const platforms = [
   'dotnet',
   'android',
@@ -59,7 +61,10 @@ export function getDocsPlatform(
   return null;
 }
 
-export function getConfigureTracingDocsLink(platform: string | null): string | null {
+export function getConfigureTracingDocsLink(
+  project: AvatarProject | undefined
+): string | null {
+  const platform = project?.platform ?? null;
   const docsPlatform = platform ? getDocsPlatform(platform, true) : null;
   return docsPlatform === null
     ? null // this platform does not support performance

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -11,11 +11,8 @@ import NotFound from 'app/components/errors/notFound';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import {BorderlessEventEntries} from 'app/components/events/eventEntries';
 import EventMessage from 'app/components/events/eventMessage';
-import EventMetadata from 'app/components/events/eventMetadata';
 import EventVitals from 'app/components/events/eventVitals';
 import * as SpanEntryContext from 'app/components/events/interfaces/spans/context';
-import OpsBreakdown from 'app/components/events/opsBreakdown';
-import RootSpanStatus from 'app/components/events/rootSpanStatus';
 import FileSize from 'app/components/fileSize';
 import * as Layout from 'app/components/layouts/thirds';
 import LoadingError from 'app/components/loadingError';
@@ -178,11 +175,9 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
               <Button onClick={this.toggleSidebar}>
                 {isSidebarVisible ? 'Hide Details' : 'Show Details'}
               </Button>
-              {results && (
-                <Button icon={<IconOpen />} href={eventJsonUrl} external>
-                  {t('JSON')} (<FileSize bytes={event.size} />)
-                </Button>
-              )}
+              <Button icon={<IconOpen />} href={eventJsonUrl} external>
+                {t('JSON')} (<FileSize bytes={event.size} />)
+              </Button>
               {transactionSummaryTarget && (
                 <Feature organization={organization} features={['performance-view']}>
                   {({hasFeature}) => (
@@ -200,20 +195,18 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
           </Layout.HeaderActions>
         </Layout.Header>
         <Layout.Body>
-          {results && (
-            <Layout.Main fullWidth>
-              <EventMetas
-                quickTrace={results}
-                meta={metaResults?.meta ?? null}
-                event={event}
-                organization={organization}
-                projectId={this.projectId}
-                location={location}
-                errorDest="discover"
-                transactionDest="discover"
-              />
-            </Layout.Main>
-          )}
+          <Layout.Main fullWidth>
+            <EventMetas
+              quickTrace={results ?? null}
+              meta={metaResults?.meta ?? null}
+              event={event}
+              organization={organization}
+              projectId={this.projectId}
+              location={location}
+              errorDest="discover"
+              transactionDest="discover"
+            />
+          </Layout.Main>
           <Layout.Main fullWidth={!isSidebarVisible}>
             <Projects orgId={organization.slug} slugs={[this.projectId]}>
               {({projects, initiallyLoaded}) =>
@@ -253,17 +246,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
           </Layout.Main>
           {isSidebarVisible && (
             <Layout.Side>
-              {results === undefined && (
-                <Fragment>
-                  <EventMetadata
-                    event={event}
-                    organization={organization}
-                    projectId={this.projectId}
-                  />
-                  <RootSpanStatus event={event} />
-                  <OpsBreakdown event={event} />
-                </Fragment>
-              )}
               <EventVitals event={event} />
               {event.groupID && (
                 <LinkedIssue groupId={event.groupID} eventId={event.eventID} />

--- a/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
@@ -134,7 +134,7 @@ class ConfigureDistributedTracing extends Component<Props, State> {
       return null;
     }
 
-    const docsLink = getConfigureTracingDocsLink(project.platform ?? null);
+    const docsLink = getConfigureTracingDocsLink(project);
     // if the platform does not support performance, do not show this prompt
     if (docsLink === null) {
       return null;

--- a/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
@@ -16,7 +16,7 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {Event} from 'app/types/event';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import {getDocsPlatform} from 'app/utils/docs';
+import {getConfigureTracingDocsLink} from 'app/utils/docs';
 import {promptCanShow, promptIsDismissed} from 'app/utils/promptIsDismissed';
 import withApi from 'app/utils/withApi';
 
@@ -83,14 +83,6 @@ class ConfigureDistributedTracing extends Component<Props, State> {
     this.trackAnalytics({eventKey, eventName});
   }
 
-  createDocsLink() {
-    const platform = this.props.project.platform ?? null;
-    const docsPlatform = platform ? getDocsPlatform(platform, true) : null;
-    return docsPlatform === null
-      ? null // this platform does not support performance
-      : `https://docs.sentry.io/platforms/${docsPlatform}/performance/`;
-  }
-
   renderActionButton(docsLink: string) {
     const features = ['organizations:performance-view'];
     const noFeatureMessage = t('Requires performance monitoring.');
@@ -136,12 +128,13 @@ class ConfigureDistributedTracing extends Component<Props, State> {
   }
 
   render() {
+    const {project} = this.props;
     const {shouldShow} = this.state;
     if (!shouldShow) {
       return null;
     }
 
-    const docsLink = this.createDocsLink();
+    const docsLink = getConfigureTracingDocsLink(project.platform ?? null);
     // if the platform does not support performance, do not show this prompt
     if (docsLink === null) {
       return null;

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -34,7 +34,7 @@ type Props = Pick<
   organization: OrganizationSummary;
   projectId: string;
   location: Location;
-  quickTrace: QuickTraceQueryChildrenProps;
+  quickTrace: QuickTraceQueryChildrenProps | null;
   meta: TraceMeta | null;
 };
 
@@ -87,20 +87,6 @@ class EventMetas extends React.Component<Props, State> {
 
     const type = isTransaction(event) ? 'transaction' : 'event';
 
-    const projectBadge = (
-      <Projects orgId={organization.slug} slugs={[projectId]}>
-        {({projects}) => {
-          const project = projects.find(p => p.slug === projectId);
-          return (
-            <ProjectBadge
-              project={project ? project : {slug: projectId}}
-              avatarSize={16}
-            />
-          );
-        }}
-      </Projects>
-    );
-
     const timestamp = (
       <TimeSince date={event.dateCreated || (event.endTimestamp || 0) * 1000} />
     );
@@ -108,56 +94,73 @@ class EventMetas extends React.Component<Props, State> {
     const httpStatus = <HttpStatus event={event} />;
 
     return (
-      <EventDetailHeader type={type}>
-        <MetaData
-          headingText={t('Event ID')}
-          tooltipText={t('The unique ID assigned to this %s.', type)}
-          bodyText={<EventID event={event} />}
-          subtext={projectBadge}
-        />
-        {isTransaction(event) ? (
-          <MetaData
-            headingText={t('Event Duration')}
-            tooltipText={t(
-              'The time elapsed between the start and end of this transaction.'
-            )}
-            bodyText={getDuration(event.endTimestamp - event.startTimestamp, 2, true)}
-            subtext={timestamp}
-          />
-        ) : (
-          <MetaData
-            headingText={t('Created')}
-            tooltipText={t('The time at which this event was created.')}
-            bodyText={timestamp}
-            subtext={getDynamicText({
-              value: <DateTime date={event.dateCreated} />,
-              fixed: 'May 6, 2021 3:27:01 UTC',
-            })}
-          />
-        )}
-        {isTransaction(event) && (
-          <MetaData
-            headingText={t('Status')}
-            tooltipText={t(
-              'The status of this transaction indicating if it succeeded or otherwise.'
-            )}
-            bodyText={event.contexts?.trace?.status ?? '\u2014'}
-            subtext={httpStatus}
-          />
-        )}
-        <QuickTraceContainer>
-          <QuickTraceMeta
-            event={event}
-            organization={organization}
-            location={location}
-            quickTrace={quickTrace}
-            traceMeta={meta}
-            anchor={isLargeScreen ? 'right' : 'left'}
-            errorDest={errorDest}
-            transactionDest={transactionDest}
-          />
-        </QuickTraceContainer>
-      </EventDetailHeader>
+      <Projects orgId={organization.slug} slugs={[projectId]}>
+        {({projects}) => {
+          const project = projects.find(p => p.slug === projectId);
+          return (
+            <EventDetailHeader type={type}>
+              <MetaData
+                headingText={t('Event ID')}
+                tooltipText={t('The unique ID assigned to this %s.', type)}
+                bodyText={<EventID event={event} />}
+                subtext={
+                  <ProjectBadge
+                    project={project ? project : {slug: projectId}}
+                    avatarSize={16}
+                  />
+                }
+              />
+              {isTransaction(event) ? (
+                <MetaData
+                  headingText={t('Event Duration')}
+                  tooltipText={t(
+                    'The time elapsed between the start and end of this transaction.'
+                  )}
+                  bodyText={getDuration(
+                    event.endTimestamp - event.startTimestamp,
+                    2,
+                    true
+                  )}
+                  subtext={timestamp}
+                />
+              ) : (
+                <MetaData
+                  headingText={t('Created')}
+                  tooltipText={t('The time at which this event was created.')}
+                  bodyText={timestamp}
+                  subtext={getDynamicText({
+                    value: <DateTime date={event.dateCreated} />,
+                    fixed: 'May 6, 2021 3:27:01 UTC',
+                  })}
+                />
+              )}
+              {isTransaction(event) && (
+                <MetaData
+                  headingText={t('Status')}
+                  tooltipText={t(
+                    'The status of this transaction indicating if it succeeded or otherwise.'
+                  )}
+                  bodyText={event.contexts?.trace?.status ?? '\u2014'}
+                  subtext={httpStatus}
+                />
+              )}
+              <QuickTraceContainer>
+                <QuickTraceMeta
+                  event={event}
+                  project={project}
+                  organization={organization}
+                  location={location}
+                  quickTrace={quickTrace}
+                  traceMeta={meta}
+                  anchor={isLargeScreen ? 'right' : 'left'}
+                  errorDest={errorDest}
+                  transactionDest={transactionDest}
+                />
+              </QuickTraceContainer>
+            </EventDetailHeader>
+          );
+        }}
+      </Projects>
     );
   }
 }

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -1,15 +1,20 @@
-import * as React from 'react';
+import {ComponentProps, ReactNode} from 'react';
 import {Location} from 'history';
 
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 import ErrorBoundary from 'app/components/errorBoundary';
+import Hovercard from 'app/components/hovercard';
+import ExternalLink from 'app/components/links/externalLink';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import QuickTrace from 'app/components/quickTrace';
 import {generateTraceTarget} from 'app/components/quickTrace/utils';
-import {t} from 'app/locale';
-import {OrganizationSummary} from 'app/types';
+import {t, tct, tn} from 'app/locale';
+import {AvatarProject, OrganizationSummary} from 'app/types';
 import {Event} from 'app/types/event';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {getConfigureTracingDocsLink} from 'app/utils/docs';
 import {getShortEventId} from 'app/utils/events';
 import {
   QuickTraceQueryChildrenProps,
@@ -18,16 +23,14 @@ import {
 
 import {MetaData} from './styles';
 
-type Props = Pick<
-  React.ComponentProps<typeof QuickTrace>,
-  'errorDest' | 'transactionDest'
-> & {
+type Props = Pick<ComponentProps<typeof QuickTrace>, 'errorDest' | 'transactionDest'> & {
   event: Event;
   location: Location;
   organization: OrganizationSummary;
-  quickTrace: QuickTraceQueryChildrenProps;
+  quickTrace: QuickTraceQueryChildrenProps | null;
   traceMeta: TraceMeta | null;
   anchor: 'left' | 'right';
+  project?: AvatarProject;
 };
 
 function handleTraceLink(organization: OrganizationSummary) {
@@ -43,41 +46,99 @@ export default function QuickTraceMeta({
   event,
   location,
   organization,
-  quickTrace: {isLoading, error, trace, type},
+  quickTrace,
   traceMeta,
   anchor,
   errorDest,
   transactionDest,
+  project,
 }: Props) {
+  const features = ['performance-view'];
+
+  const noFeatureMessage = t('Requires performance monitoring.');
+
+  const docsLink = getConfigureTracingDocsLink(project?.platform ?? null);
+
   const traceId = event.contexts?.trace?.trace_id ?? null;
   const traceTarget = generateTraceTarget(event, organization);
-  const linkText =
-    traceId === null
-      ? null
-      : t(
-          'Trace ID: %s (%s events)',
-          getShortEventId(traceId),
-          traceMeta ? traceMeta.transactions + traceMeta.errors : '?'
-        );
 
-  const body = isLoading ? (
-    <Placeholder height="24px" />
-  ) : error || trace === null ? (
-    '\u2014'
-  ) : (
-    <ErrorBoundary mini>
-      <QuickTrace
-        event={event}
-        quickTrace={{type, trace}}
-        location={location}
-        organization={organization}
-        anchor={anchor}
-        errorDest={errorDest}
-        transactionDest={transactionDest}
-      />
-    </ErrorBoundary>
+  let body: ReactNode;
+  let footer: ReactNode;
+
+  if (!traceId || !quickTrace || quickTrace.trace === null) {
+    // this platform doesn't support performance don't show anything here
+    if (docsLink === null) {
+      return null;
+    }
+
+    body = t('Missing Trace');
+
+    // need to configure tracing
+    footer = <ExternalLink href={docsLink}>{t('Read the docs')}</ExternalLink>;
+  } else {
+    if (quickTrace.isLoading) {
+      body = <Placeholder height="24px" />;
+    } else if (quickTrace.error) {
+      body = '\u2014';
+    } else {
+      body = (
+        <ErrorBoundary mini>
+          <QuickTrace
+            event={event}
+            quickTrace={{
+              type: quickTrace.type,
+              trace: quickTrace.trace,
+            }}
+            location={location}
+            organization={organization}
+            anchor={anchor}
+            errorDest={errorDest}
+            transactionDest={transactionDest}
+          />
+        </ErrorBoundary>
+      );
+    }
+
+    footer = (
+      <Link to={traceTarget} onClick={() => handleTraceLink(organization)}>
+        {tct('Trace ID: [id][events]', {
+          id: getShortEventId(traceId ?? ''),
+          events: traceMeta
+            ? tn(' (%s event)', ' (%s events)', traceMeta.transactions + traceMeta.errors)
+            : '',
+        })}
+      </Link>
+    );
+  }
+
+  return (
+    <Feature hookName="feature-disabled:performance-quick-trace" features={features}>
+      {({hasFeature}) => {
+        // also need to enable the performance feature
+        if (!hasFeature) {
+          footer = (
+            <Hovercard
+              body={
+                <FeatureDisabled
+                  features={features}
+                  hideHelpToggle
+                  message={noFeatureMessage}
+                  featureName={noFeatureMessage}
+                />
+              }
+            >
+              {footer}
+            </Hovercard>
+          );
+        }
+
+        return <QuickTraceMetaBase body={body} footer={footer} />;
+      }}
+    </Feature>
   );
+}
 
+export function QuickTraceMetaBase({body, footer}: {body: ReactNode; footer: ReactNode}) {
   return (
     <MetaData
       headingText={t('Quick Trace')}
@@ -85,16 +146,8 @@ export default function QuickTraceMeta({
       tooltipText={t(
         'A minified version of the full trace. Related frontend and backend services can be added to provide further visibility.'
       )}
-      bodyText={body}
-      subtext={
-        traceId === null ? (
-          '\u2014'
-        ) : (
-          <Link to={traceTarget} onClick={() => handleTraceLink(organization)}>
-            {linkText}
-          </Link>
-        )
-      }
+      bodyText={<div data-test-id="quick-trace-body">{body}</div>}
+      subtext={<div data-test-id="quick-trace-footer">{footer}</div>}
     />
   );
 }

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -57,7 +57,7 @@ export default function QuickTraceMeta({
 
   const noFeatureMessage = t('Requires performance monitoring.');
 
-  const docsLink = getConfigureTracingDocsLink(project?.platform ?? null);
+  const docsLink = getConfigureTracingDocsLink(project);
 
   const traceId = event.contexts?.trace?.trace_id ?? null;
   const traceTarget = generateTraceTarget(event, organization);

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -311,6 +311,13 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
             }
         )
+        if "contexts" not in event_data:
+            event_data["contexts"] = {}
+        event_data["contexts"]["trace"] = {
+            "type": "trace",
+            "trace_id": "a" * 32,
+            "span_id": "b" * 16,
+        }
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=False)
 
         with self.feature(FEATURE_NAMES):
@@ -339,6 +346,11 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
                 "fingerprint": ["group-1"],
             }
         )
+        event_data["contexts"]["trace"] = {
+            "type": "trace",
+            "trace_id": "a" * 32,
+            "span_id": "b" * 16,
+        }
         self.store_event(data=event_data, project_id=self.project.id)
         self.wait_for_event_count(self.project.id, 1)
 

--- a/tests/js/spec/views/performance/transactionDetails/quickTraceMeta.spec.jsx
+++ b/tests/js/spec/views/performance/transactionDetails/quickTraceMeta.spec.jsx
@@ -1,0 +1,197 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import QuickTraceMeta from 'app/views/performance/transactionDetails/quickTraceMeta';
+
+describe('QuickTraceMeta', function () {
+  const routerContext = TestStubs.routerContext();
+  const location = routerContext.context.location;
+  const organization = TestStubs.Organization({features: ['performance-view']});
+  const project = TestStubs.Project({platform: 'javascript'});
+  const event = TestStubs.Event({contexts: {trace: {trace_id: 'a'.repeat(32)}}});
+  const emptyQuickTrace = {
+    isLoading: false,
+    error: null,
+    trace: [],
+    type: 'empty',
+    currentEvent: null,
+  };
+  const emptyTraceMeta = {
+    projects: 0,
+    transactions: 0,
+    errors: 0,
+  };
+
+  it('renders basic UI', async function () {
+    const wrapper = mountWithTheme(
+      <QuickTraceMeta
+        event={event}
+        project={project}
+        organization={organization}
+        location={location}
+        quickTrace={emptyQuickTrace}
+        traceMeta={emptyTraceMeta}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MetaData').exists()).toBe(true);
+    expect(wrapper.find('div[data-test-id="quick-trace-body"] QuickTrace').exists()).toBe(
+      true
+    );
+    expect(wrapper.find('div[data-test-id="quick-trace-footer"]').text()).toEqual(
+      `Trace ID: ${'a'.repeat(8)} (0 events)`
+    );
+  });
+
+  it('renders placeholder while loading', async function () {
+    const wrapper = mountWithTheme(
+      <QuickTraceMeta
+        event={event}
+        project={project}
+        organization={organization}
+        location={location}
+        quickTrace={{
+          ...emptyQuickTrace,
+          isLoading: true,
+        }}
+        traceMeta={emptyTraceMeta}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MetaData').exists()).toBe(true);
+    expect(
+      wrapper.find('div[data-test-id="quick-trace-body"] Placeholder').exists()
+    ).toBe(true);
+    expect(wrapper.find('div[data-test-id="quick-trace-footer"]').text()).toEqual(
+      `Trace ID: ${'a'.repeat(8)} (0 events)`
+    );
+  });
+
+  it('renders errors', async function () {
+    const wrapper = mountWithTheme(
+      <QuickTraceMeta
+        event={event}
+        project={project}
+        organization={organization}
+        location={location}
+        quickTrace={{
+          ...emptyQuickTrace,
+          error: 'something bad',
+        }}
+        traceMeta={emptyTraceMeta}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MetaData').exists()).toBe(true);
+    expect(wrapper.find('div[data-test-id="quick-trace-body"]').text()).toEqual('\u2014');
+    expect(wrapper.find('div[data-test-id="quick-trace-footer"]').text()).toEqual(
+      `Trace ID: ${'a'.repeat(8)} (0 events)`
+    );
+  });
+
+  it('renders missing trace when trace id is not present', async function () {
+    const newEvent = TestStubs.Event();
+    const wrapper = mountWithTheme(
+      <QuickTraceMeta
+        event={newEvent}
+        project={project}
+        organization={organization}
+        location={location}
+        quickTrace={emptyQuickTrace}
+        traceMeta={emptyTraceMeta}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MetaData').exists()).toBe(true);
+    expect(wrapper.find('div[data-test-id="quick-trace-body"]').text()).toEqual(
+      'Missing Trace'
+    );
+    expect(wrapper.find('div[data-test-id="quick-trace-footer"]').text()).toEqual(
+      'Read the docs'
+    );
+  });
+
+  it('renders missing trace with hover card when feature disabled', async function () {
+    const newEvent = TestStubs.Event();
+    const newOrg = TestStubs.Organization();
+    const wrapper = mountWithTheme(
+      <QuickTraceMeta
+        event={newEvent}
+        project={project}
+        organization={newOrg}
+        location={location}
+        quickTrace={emptyQuickTrace}
+        traceMeta={emptyTraceMeta}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MetaData').exists()).toBe(true);
+    expect(wrapper.find('div[data-test-id="quick-trace-body"]').text()).toEqual(
+      'Missing Trace'
+    );
+    expect(wrapper.find('div[data-test-id="quick-trace-footer"]').text()).toEqual(
+      'Read the docs'
+    );
+    expect(
+      wrapper.find('div[data-test-id="quick-trace-footer"] Hovercard').exists()
+    ).toEqual(true);
+  });
+
+  it('does not render when platform does not support tracing', async function () {
+    const newProject = TestStubs.Project();
+    const newEvent = TestStubs.Event();
+    const wrapper = mountWithTheme(
+      <QuickTraceMeta
+        event={newEvent}
+        project={newProject}
+        organization={organization}
+        location={location}
+        quickTrace={emptyQuickTrace}
+        traceMeta={emptyTraceMeta}
+        anchor="left"
+        errorDest="issue"
+        transactionDest="performance"
+      />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.isEmptyRender()).toBe(true);
+  });
+});


### PR DESCRIPTION
This adds in the disabled behaviour for quick trace when its disabled on
discover. It can be disabled either because the feature is turned off, or event
doesn't have a trace id. In these cases, prompt the user to turn on the feature
or configure the sdk by linking to the docs. There is also the case where the
project platform does not support tracing yet. In this situation, quick trace
should not show.

Depends on # #25939

# Screenshots

![image](https://user-images.githubusercontent.com/10239353/117484057-92bdbb00-af34-11eb-9027-0c51d674ac43.png)
![Screen Shot 2021-05-07 at 1 09 17 PM](https://user-images.githubusercontent.com/10239353/117484726-7ec68900-af35-11eb-9971-6cbbed6293ff.png)
