### PR TITLE
fix(api) Don't fail to handle requests when rate limits cannot be set

### DIFF
--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -40,5 +40,7 @@ class RedisRateLimiter(RateLimiter):
                 client.expire(key, window)
             return result.value > limit
         except RedisError as e:
+            # We don't want rate limited endpoints to fail when ratelimits
+            # can't be updated. We do want to know when that happens.
             capture_exception(e)
             return False

--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -1,5 +1,8 @@
 from time import time
 
+from redis.exceptions import RedisError
+from sentry_sdk import capture_exception
+
 from sentry.exceptions import InvalidConfiguration
 from sentry.ratelimits.base import RateLimiter
 from sentry.utils.hashlib import md5_text
@@ -31,8 +34,11 @@ class RedisRateLimiter(RateLimiter):
         else:
             key = f"rl:{key_hex}:{bucket}"
 
-        with self.cluster.map() as client:
-            result = client.incr(key)
-            client.expire(key, window)
-
-        return result.value > limit
+        try:
+            with self.cluster.map() as client:
+                result = client.incr(key)
+                client.expire(key, window)
+            return result.value > limit
+        except RedisError as e:
+            capture_exception(e)
+            return False


### PR DESCRIPTION
If we have a redis failure that impacts setting rate limits we should not fail the request. Instead we can assume that the rate limit is ok.

Fixes SENTRY-Q71