### PR TITLE
ref(integrations): Pass noOptionsMessage text

### DIFF
--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -281,6 +281,7 @@ export default class AbstractExternalIssueForm<
               <Form initialData={initialData} {...this.getFormProps()}>
                 {(formFields || [])
                   .filter((field: FormField) => field.hasOwnProperty('name'))
+                  .map(fields => ({...fields, noOptionsMessage: () => 'Type to search'}))
                   .map(field => (
                     <FieldFromConfig
                       disabled={this.state.reloading}

--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -281,7 +281,10 @@ export default class AbstractExternalIssueForm<
               <Form initialData={initialData} {...this.getFormProps()}>
                 {(formFields || [])
                   .filter((field: FormField) => field.hasOwnProperty('name'))
-                  .map(fields => ({...fields, noOptionsMessage: () => 'Type to search'}))
+                  .map(fields => ({
+                    ...fields,
+                    noOptionsMessage: () => 'No options. Type to search.',
+                  }))
                   .map(field => (
                     <FieldFromConfig
                       disabled={this.state.reloading}


### PR DESCRIPTION
When initially creating a ticket for an integration (e.g. a Jira ticket), values in the dropdown fields aren't populated and you must type a letter or some letters to begin the search, but this is unclear to the user as we simply display "No options". We do store and show the last used value so it's less confusing after the first time. This PR updates the `noOptionsText` to indicate you must type to search, as we do in [sentryAppExternalIssueForm](https://github.com/getsentry/sentry/blob/master/static/app/components/group/sentryAppExternalIssueForm.tsx#L274). 

A user recently created a GitHub issue about this, thinking the integration wasn't working:
https://github.com/getsentry/sentry/issues/25882

This is what it looks like now:
<img width="622" alt="Screen Shot 2021-05-07 at 12 15 29 PM" src="https://user-images.githubusercontent.com/29959063/117498232-61da8780-af2e-11eb-953d-548ae1f58b2e.png">
Updated to indicate that you may need to type something:
<img width="622" alt="Screen Shot 2021-05-07 at 12 27 50 PM" src="https://user-images.githubusercontent.com/29959063/117499163-afa3bf80-af2f-11eb-9f80-6300df4dba1b.png">
