### PR TITLE
ref(ui): make event parameter for handleAbsoluteClick and handleSelectRelative optional

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/dateRange/relativeSelector.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/relativeSelector.tsx
@@ -5,7 +5,7 @@ import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import SelectorItem from './selectorItem';
 
 type Props = {
-  onClick: (value: string, e: React.MouseEvent) => void;
+  onClick: (value: string, e?: React.MouseEvent) => void;
   selected: string;
   relativePeriods?: Record<string, string>;
 };

--- a/static/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import space from 'app/styles/space';
 
 type Props = {
-  onClick: (value: string, e: React.MouseEvent) => void;
+  onClick: (value: string, e?: React.MouseEvent) => void;
   value: string;
   label: React.ReactNode;
   selected: boolean;

--- a/static/app/components/organizations/timeRangeSelector/dateRange/selectorItems.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/selectorItems.tsx
@@ -5,8 +5,8 @@ import SelectorItem from 'app/components/organizations/timeRangeSelector/dateRan
 import {t} from 'app/locale';
 
 type Props = {
-  handleSelectRelative: (value: string, e: React.MouseEvent) => void;
-  handleAbsoluteClick: (value: string, e: React.MouseEvent) => void;
+  handleSelectRelative: (value: string, e?: React.MouseEvent) => void;
+  handleAbsoluteClick: (value: string, e?: React.MouseEvent) => void;
   isAbsoluteSelected: boolean;
   relativeSelected: string;
   relativePeriods?: Record<string, string>; // Override DEFAULT_RELATIVE_PERIODS

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -259,7 +259,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
     this.callCallback(onChange, newDateTime);
   };
 
-  handleSelectRelative = value => {
+  handleSelectRelative = (value: string) => {
     const {onChange} = this.props;
     const newDateTime: ChangeData = {
       relative: value,


### PR DESCRIPTION
The event parameter for `handleAbsoluteClick` and `handleSelectRelative` for `SelectorItems` should be optional since as far as I can tell, we aren't even using the event in any of the current instances of the component. This will impact a change I am making in getsentry where we will need to call `handleSelectRelative` but we won't have the event available.