### PR TITLE
feat(ui): min width selector

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -478,7 +478,7 @@ const SelectorList = styled('div')<MenuProps>`
   flex: 1;
   flex-direction: column;
   flex-shrink: 0;
-  width: ${p => (p.isAbsoluteSelected ? '160px' : '220px')};
+  min-width: ${p => (p.isAbsoluteSelected ? '160px' : '220px')};
   min-height: 305px;
 `;
 


### PR DESCRIPTION
Adding an upsell in getsentry which needs more room in the selector for the time:
![Screen Shot 2021-05-07 at 1 48 23 PM](https://user-images.githubusercontent.com/8533851/117507116-8557ff00-af3b-11eb-86a3-87de058e9b85.png)

Changing width to min-with so it expands with the upsell:

![Screen Shot 2021-05-07 at 1 51 38 PM](https://user-images.githubusercontent.com/8533851/117507153-90129400-af3b-11eb-8ce1-3d04f7538df0.png)
