### PR TITLE
feat(async-csv): Retry exports with lower limit

### DIFF
--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -8,7 +8,9 @@ DEFAULT_EXPIRATION = timedelta(weeks=4)
 
 
 class ExportError(Exception):
-    pass
+    def __init__(self, message, recoverable=False):
+        super().__init__(message)
+        self.recoverable = recoverable
 
 
 class ExportStatus(str, Enum):

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.data_export.tasks.assemble_download",
     queue="data_export",
-    default_retry_delay=30,
+    default_retry_delay=60,
     max_retries=3,
     acks_late=True,
 )

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -34,6 +34,7 @@ def handle_snuba_errors(logger):
                 logger.warn("dataexport.error: %s", str(error))
                 capture_exception(error)
                 message = "Internal error. Please try again."
+                recoverable = False
                 if isinstance(
                     error,
                     (
@@ -44,6 +45,7 @@ def handle_snuba_errors(logger):
                     ),
                 ):
                     message = "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
+                    recoverable = True
                 elif isinstance(
                     error,
                     (
@@ -56,7 +58,7 @@ def handle_snuba_errors(logger):
                     ),
                 ):
                     message = "Internal error. Your query failed to run."
-                raise ExportError(message)
+                raise ExportError(message, recoverable=recoverable)
 
         return wrapped
 


### PR DESCRIPTION
Async CSV exports currently always query 10,000 rows at a time. Certain queries
error because they exceed the maximum time or memory allotted. This change
introduces a retry that halves the query limit up to 3 times to try to
circumvent this issue. After 3 attempts with smaller limits, if the query still
has errors, the export will fail.