### PR TITLE
ref(alert): Remove integration id from saveAlertRule transaction

### DIFF
--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -451,9 +451,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         for (const action of trigger.actions) {
           if (action.type === 'slack') {
             transaction.setTag(action.type, true);
-            if (action.integrationId) {
-              transaction.setTag(`integrationId:${action.integrationId}`, true);
-            }
           }
         }
       }


### PR DESCRIPTION
William and Tony notified me that a large number of these `integrationId` tags were still coming in to which I realized that this `integrationId` in an action is org specific so it isn't that helpful to have and just clutters discover with a bunch of these tags.