### PR TITLE
feat(demo): adds input to skip email and allows camel case post body

### DIFF
--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 ACCEPTED_TRACKING_COOKIE = "accepted_tracking"
 MEMBER_ID_COOKIE = "demo_member_id"
+SKIP_EMAIL_COOKIE = "skip_email"
 
 
 class DemoStartView(BaseView):
@@ -43,8 +44,9 @@ class DemoStartView(BaseView):
         logger.info("post.start", extra={"cookie_member_id": member_id})
         sentry_sdk.set_tag("member_id", member_id)
 
-        # TODO(steve): switch to camelCase for request field
-        skip_buffer = request.POST.get("skip_buffer") == "1"
+        # TODO: remove snake case
+        skip_buffer_input = request.POST.get("skipBuffer") or request.POST.get("skip_buffer")
+        skip_buffer = skip_buffer_input == "1"
         sentry_sdk.set_tag("skip_buffer", skip_buffer)
 
         scenario = request.POST.get("scenario")
@@ -81,10 +83,17 @@ class DemoStartView(BaseView):
         # whether to initialize analytics when accepted_tracking=1
         # 0 means don't show the footer to accept cookies (user already declined)
         # no value means we show the footer to accept cookies (user has neither accepted nor declined)
-        # TODO: switch to camelCase for request field
-        accepted_tracking = request.POST.get(ACCEPTED_TRACKING_COOKIE)
+        # TODO: remove snake case
+        accepted_tracking = request.POST.get("acceptedTracking") or request.POST.get(
+            ACCEPTED_TRACKING_COOKIE
+        )
         if accepted_tracking in ["0", "1"]:
             resp.set_cookie(ACCEPTED_TRACKING_COOKIE, accepted_tracking)
+
+        # if skip email is 1, set the cookie
+        skip_email = request.POST.get("skipEmail")
+        if skip_email == "1":
+            resp.set_cookie(SKIP_EMAIL_COOKIE, skip_email)
 
         # set the member id
         resp.set_signed_cookie(MEMBER_ID_COOKIE, member.id)

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -4,7 +4,7 @@ from django.core import signing
 from django.test.utils import override_settings
 from exam import fixture
 
-from sentry.demo.demo_start import MEMBER_ID_COOKIE
+from sentry.demo.demo_start import MEMBER_ID_COOKIE, SKIP_EMAIL_COOKIE
 from sentry.demo.models import DemoOrganization
 from sentry.demo.settings import DEMO_DATA_QUICK_GEN_PARAMS
 from sentry.models import Group, Organization, OrganizationStatus, Project, Release, User
@@ -137,5 +137,12 @@ class DemoStartTeset(TestCase):
     @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
     def test_skip_buffer(self, mock_assign_demo_org, mock_auth_login):
         mock_assign_demo_org.return_value = (self.org, self.user)
-        self.client.post(self.path, data={"skip_buffer": "1"})
+        self.client.post(self.path, data={"skipBuffer": "1"})
         mock_assign_demo_org.assert_called_once_with(skip_buffer=True)
+
+    @mock.patch("sentry.demo.demo_start.auth.login")
+    @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
+    def test_skip_email(self, mock_assign_demo_org, mock_auth_login):
+        mock_assign_demo_org.return_value = (self.org, self.user)
+        resp = self.client.post(self.path, data={"skipEmail": "1"})
+        assert resp.cookies[SKIP_EMAIL_COOKIE].value == "1"


### PR DESCRIPTION
This PR makes two changes with the demo start view:
1. Add a `skipEmail` input which will set the `skip_email` cookie on the response. When the browser detects the `skip_email` cookie, we will not show the modal which asks for the user's email. We will use this when deep linking from within Sentry for users that already have accounts.
2. Allow camel case inputs for the existing `skipBuffer` and `acceptedTracking` inputs. Snake case is still allowed for now. Once I have updated the client to send only camel case, I will remove the snake case options.

What the modal looks like:
![Screen Shot 2021-05-10 at 9 30 21 AM](https://user-images.githubusercontent.com/8533851/117692936-5d061580-b172-11eb-872e-7fd08c7f2bd0.png)
