### PR TITLE
feat(workflow): Add session % to Issue Stream serializer

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1090,12 +1090,12 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         session_count_key = f"w-s:{project_id}"
 
         if self.start:
-            session_count_key = f"{session_count_key}-{self.start.replace(minutes=0, second=0, microsecond=0, tzinfo=None)}".replace(
+            session_count_key = f"{session_count_key}-{self.start.replace(minute=0, second=0, microsecond=0, tzinfo=None)}".replace(
                 " ", ""
             )
 
         if self.end:
-            session_count_key = f"{session_count_key}-{self.end.replace(minutes=0, second=0, microsecond=0, tzinfo=None)}".replace(
+            session_count_key = f"{session_count_key}-{self.end.replace(minute=0, second=0, microsecond=0, tzinfo=None)}".replace(
                 " ", ""
             )
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1038,6 +1038,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                     end=self.end,
                     aggregations=[
                         ["count()", None, "session_count"],
+                        ["sum()", "session", "session_sum"],
+                        ["sum(session)", None, "anerror"],
                     ],
                     filter_keys=filters,
                     referrer="sessions.group.totals",

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -979,13 +979,13 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 attrs[item].update({"stats": stats[item.id]})
 
             if self._expand("sessions"):
-                cache_keys = list(
-                    {self._build_session_cache_key(item.project_id) for item in item_list}
-                )
-                cache_data = cache.get_many(cache_keys)
+                uniq_project_ids = list({item.project_id for item in item_list})
+                cache_keys = {pid: self._build_session_cache_key(pid) for pid in uniq_project_ids}
+
+                cache_data = cache.get_many(cache_keys.values())
                 missed_items = []
-                for item, cache_key in zip(item_list, cache_keys):
-                    num_sessions = cache_data.get(cache_key)
+                for item in item_list:
+                    num_sessions = cache_data.get(cache_keys[item.project_id])
                     if num_sessions is None:
                         missed_items.append(item)
                     else:


### PR DESCRIPTION
This PR aims to add support for a new expand parameter (`sessions`) to the issue stream serializer. If `expand=sessions` is sent, the serializer will include a `sessionPercent` field which will be the count of events divided by the count of sessions in time period/environment/project. As a caveat, this expand parameter is only supported if `collapse=stats` is not passed.

To get the count of sessions, we're querying against the hourly rollups table and summing up the sessions field, filtered by project and environment, constrained by any start and/or end times if passed. We're caching the result of this query for 5 minutes.