### PR TITLE
fix(perf): Remove any explicit ops when switching between displays

### DIFF
--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -70,6 +70,11 @@ class LandingContent extends Component<Props, State> {
     const defaultDisplay = getDefaultDisplayFieldForPlatform(projects, eventView);
     const currentDisplay = decodeScalar(location.query.landingDisplay);
 
+    // Transaction op can affect the display and show no results if it is explicitly set.
+    const query = decodeScalar(location.query.query, '');
+    const searchConditions = tokenizeSearch(query);
+    searchConditions.removeTag('transaction.op');
+
     trackAnalyticsEvent({
       eventKey: 'performance_views.landingv2.display_change',
       eventName: 'Performance Views: Landing v2 Display Change',
@@ -84,6 +89,7 @@ class LandingContent extends Component<Props, State> {
       pathname: location.pathname,
       query: {
         ...newQuery,
+        query: stringifyQueryObject(searchConditions),
         landingDisplay: field,
       },
     });


### PR DESCRIPTION
### Summary

When navigating down into the summary view from landing, transaction.op's might be explicitly set to help inform the user about additional constraints on their view. When using the breadcrumb to get back to landing however, this explicit op might still be set. Since we don't want to remove all transaction ops since people might want certain displays for different ops, this instead simply removes the op when the display dropdown is used to change display.

Refs VIS-648