### PR TITLE
feat(ui): Collect metrics for globals usage

### DIFF
--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -102,6 +102,12 @@ Object.entries(SentryApp).forEach(([key, value]) =>
 );
 
 // Make globals available on the window object
-Object.entries(globals).forEach(([key, value]) => wrapObject(window, key, value));
+Object.entries(globals).forEach(([key, value]) => {
+  if (key === 'SentryApp') {
+    return;
+  }
+
+  wrapObject(window, key, value);
+});
 
 export default globals;

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -87,8 +87,11 @@ function wrapObject(parent, key, value) {
     configurable: true,
     enumerable: true,
     get: () => {
-      _beaconComponents.push(key);
-      makeBeaconRequest();
+      if (key !== 'SentryApp') {
+        _beaconComponents.push(key);
+        makeBeaconRequest();
+      }
+
       return value;
     },
   });
@@ -99,12 +102,6 @@ Object.entries(SentryApp).forEach(([key, value]) =>
 );
 
 // Make globals available on the window object
-Object.entries(globals).forEach(([key, value]) => {
-  if (key === 'SentryApp') {
-    return;
-  }
-
-  wrapObject(window, key, value);
-});
+Object.entries(globals).forEach(([key, value]) => wrapObject(window, key, value));
 
 export default globals;

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
+import {Client} from 'app/api';
 import plugins from 'app/plugins';
 
 const globals = {
@@ -63,22 +64,18 @@ const SentryApp = {
 let _beaconComponents: string[] = [];
 const makeBeaconRequest = throttle(
   async () => {
-    const headers = new Headers({
-      Accept: 'application/json; charset=utf-8',
-      'Content-Type': 'application/json',
-    });
+    const api = new Client();
 
     const components = _beaconComponents;
     _beaconComponents = [];
-    await fetch('/api/0/internal/beacon/', {
+    await api.requestPromise('/api/0/internal/beacon/', {
       method: 'POST',
-      headers,
-      body: JSON.stringify({
+      data: {
         batch_data: components.map(component => ({
           description: 'SentryApp',
           component,
         })),
-      }),
+      },
     });
   },
   5000,

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -4,6 +4,7 @@ import * as Router from 'react-router';
 import * as Sentry from '@sentry/react';
 import createReactClass from 'create-react-class';
 import jQuery from 'jquery';
+import throttle from 'lodash/throttle';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import Reflux from 'reflux';
@@ -36,7 +37,7 @@ const globals = {
 
 // The SentryApp global contains exported app modules for use in javascript
 // modules that are not compiled with the sentry bundle.
-globals.SentryApp = {
+const SentryApp = {
   // The following components are used in sentry-plugins.
   Form: require('app/components/forms/form').default,
   FormState: require('app/components/forms/index').FormState,
@@ -54,7 +55,53 @@ globals.SentryApp = {
   Modal: require('app/actionCreators/modal'),
 };
 
+/**
+ * Wrap export so that we can track usage of these globals to determine how we want to handle deprecatation.
+ * These are sent to Sentry install, which then checks to see if SENTRY_BEACON is enabled
+ * in order to make a request to the SaaS beacon.
+ */
+let _beaconComponents: string[] = [];
+const makeBeaconRequest = throttle(
+  async () => {
+    const headers = new Headers({
+      Accept: 'application/json; charset=utf-8',
+      'Content-Type': 'application/json',
+    });
+
+    const components = _beaconComponents;
+    _beaconComponents = [];
+    await fetch('/api/0/internal/beacon/', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        batch_data: components.map(component => ({
+          description: 'SentryApp',
+          component,
+        })),
+      }),
+    });
+  },
+  5000,
+  {trailing: true, leading: false}
+);
+
+function wrapObject(parent, key, value) {
+  Object.defineProperty(parent, key, {
+    configurable: true,
+    enumerable: true,
+    get: () => {
+      _beaconComponents.push(key);
+      makeBeaconRequest();
+      return value;
+    },
+  });
+}
+
+Object.entries(SentryApp).forEach(([key, value]) =>
+  wrapObject(globals.SentryApp, key, value)
+);
+
 // Make globals available on the window object
-Object.keys(globals).forEach(name => (window[name] = globals[name]));
+Object.entries(globals).forEach(([key, value]) => wrapObject(window, key, value));
 
 export default globals;


### PR DESCRIPTION
We export certain components and/or functionality to the global object (`window`) for use in frontend systems outside of the main SPA (e.g. plugins, getsentry). We will need to deprecate this functionality (see https://github.com/getsentry/sentry/pull/25821 for a migration path), but we would also like to know if this is used outside of sentry.

This PR requires the backend portion which is described more here: https://github.com/getsentry/sentry/pull/25866.