### PR TITLE
fix(discover): Update Discover chart whenever its URL parameters change

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -113,7 +113,10 @@ class Results extends React.Component<Props, State> {
     this.checkEventView();
     const currentQuery = eventView.getEventsAPIPayload(location);
     const prevQuery = prevState.eventView.getEventsAPIPayload(prevProps.location);
-    if (!isAPIPayloadSimilar(currentQuery, prevQuery)) {
+    if (
+      !isAPIPayloadSimilar(currentQuery, prevQuery) ||
+      this.hasChartParametersChanged(prevState.eventView, eventView)
+    ) {
       api.clear();
       this.canLoadEvents();
     }
@@ -126,6 +129,20 @@ class Results extends React.Component<Props, State> {
     }
 
     if (prevState.confirmedQuery !== confirmedQuery) this.fetchTotalCount();
+  }
+
+  hasChartParametersChanged(prevEventView: EventView, eventView: EventView) {
+    const prevYAxisValue = prevEventView.getYAxis();
+    const yAxisValue = eventView.getYAxis();
+
+    if (prevYAxisValue !== yAxisValue) {
+      return true;
+    }
+
+    const prevDisplay = prevEventView.getDisplayMode();
+    const display = eventView.getDisplayMode();
+
+    return prevDisplay !== display;
   }
 
   canLoadEvents = async () => {

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -649,6 +649,7 @@ describe('EventsV2 > Results', function () {
     wrapper.update();
 
     // Should load events again
+    expect(eventsStatsMock).toHaveBeenCalledTimes(2);
     expect(eventsStatsMock).toHaveBeenNthCalledWith(
       2,
       '/organizations/org-slug/events-stats/',

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -711,6 +711,7 @@ describe('EventsV2 > Results', function () {
     wrapper.update();
 
     // Should load events again
+    expect(eventsStatsMock).toHaveBeenCalledTimes(2);
     expect(eventsStatsMock).toHaveBeenNthCalledWith(
       2,
       '/organizations/org-slug/events-stats/',
@@ -772,6 +773,7 @@ describe('EventsV2 > Results', function () {
     wrapper.update();
 
     // Should load events again
+    expect(eventsStatsMock).toHaveBeenCalledTimes(2);
     expect(eventsStatsMock).toHaveBeenNthCalledWith(
       2,
       '/organizations/org-slug/events-stats/',


### PR DESCRIPTION
Updating the Discover chart parameters (Y-axis and/or Display mode) will update the event chart. But pressing the browser's back button will not induce the chart to update (since React components are not re-mounted)

This PR introduces checks to ensure events are reloaded.