### PR TITLE
feat(growth): adds two new hooks for dashboards

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -358,6 +358,7 @@ class Sidebar extends React.Component<Props, State> {
 
     const dashboards = hasOrganization && (
       <Feature
+        hookName="feature-disabled:dashboards-sidebar-item"
         features={['discover', 'discover-query', 'dashboards-basic', 'dashboards-edit']}
         organization={organization}
         requireAll={false}

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -34,6 +34,8 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:grid-editable-actions',
   'feature-disabled:open-discover',
   'feature-disabled:dashboards-edit',
+  'feature-disabled:dashboards-page',
+  'feature-disabled:dashboards-sidebar-item',
   'feature-disabled:incidents-sidebar-item',
   'feature-disabled:performance-new-project',
   'feature-disabled:performance-page',

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -106,6 +106,8 @@ export type FeatureDisabledHooks = {
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
   'feature-disabled:open-discover': FeatureDisabledHook;
   'feature-disabled:dashboards-edit': FeatureDisabledHook;
+  'feature-disabled:dashboards-page': FeatureDisabledHook;
+  'feature-disabled:dashboards-sidebar-item': FeatureDisabledHook;
   'feature-disabled:incidents-sidebar-item': FeatureDisabledHook;
   'feature-disabled:performance-new-project': FeatureDisabledHook;
   'feature-disabled:performance-page': FeatureDisabledHook;

--- a/static/app/views/dashboardsV2/view.tsx
+++ b/static/app/views/dashboardsV2/view.tsx
@@ -68,6 +68,7 @@ export const DashboardBasicFeature = ({organization, children}: FeatureProps) =>
 
   return (
     <Feature
+      hookName="feature-disabled:dashboards-page"
       features={['organizations:dashboards-basic']}
       organization={organization}
       renderDisabled={renderDisabled}


### PR DESCRIPTION
This PR adds two new hooks for dasbhoards: `feature-disabled:dashboards-page` (controls view of the page) and `feature-disabled:dashboards-sidebar-item` (controls view of the sidebar item). An upcoming getsentry PR will start consuming these hooks to upsell the Dashboard feature.