### PR TITLE
ref(difs): Rename plist to uuidmap

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -24,7 +24,7 @@ CHUNK_UPLOAD_ACCEPT = (
     "release_files",  # Release files assemble
     "pdbs",  # PDB upload and debug id override
     "sources",  # Source artifact bundle upload
-    "bcsymbolmaps",  # BCSymbolMaps and associated PLists
+    "bcsymbolmaps",  # BCSymbolMaps and associated PLists/UuidMaps
 )
 
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -276,7 +276,7 @@ KNOWN_DIF_FORMATS = {
     "text/x-proguard+plain": "proguard",
     "application/x-sentry-bundle+zip": "sourcebundle",
     "application/x-bcsymbolmap": "bcsymbolmap",
-    "application/x-debugid-map": "plist",
+    "application/x-debugid-map": "uuidmap",
 }
 
 NATIVE_UNKNOWN_STRING = "<unknown>"

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -68,7 +68,7 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
               'sourcebundle',
               'wasm',
               'bcsymbolmap',
-              'plist',
+              'uuidmap',
             ],
           },
         },


### PR DESCRIPTION
In sentry-cli we also changed these names because plist is too generic
to expose to the user.  To not change stored data the "header" is still
kep the same, but the "name" now matches the other parts of the product.

This name is shown on the debug files page, which is how a user gets to
see this.  Otherwise this affects queries, which are done by the UI
(update included in this PR) and symbolicator.

In either case, this feature isn't yet exposed to people.