### PR TITLE
feat(workflow): Adding check on alert rule edit to ensure user is part of team

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
+from sentry.auth.superuser import is_active_superuser
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.logic import AlreadyDeletedError, delete_alert_rule
@@ -28,6 +29,27 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
         )
 
         if serializer.is_valid():
+            if not is_active_superuser(request):
+                if alert_rule.owner and alert_rule.owner.type == ACTOR_TYPES["team"]:
+                    team = alert_rule.owner.resolve()
+                    if not OrganizationMemberTeam.objects.filter(
+                        organizationmember__user=request.user, team=team, is_active=True
+                    ).exists():
+                        return Response(
+                            {
+                                "detail": [
+                                    "You do not have permission to edit this alert rule because you are not a member of the assigned team."
+                                ]
+                            },
+                            status=403,
+                        )
+            alert_rule = serializer.save()
+            return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, organization, alert_rule):
+        if not is_active_superuser(request):
             if alert_rule.owner and alert_rule.owner.type == ACTOR_TYPES["team"]:
                 team = alert_rule.owner.resolve()
                 if not OrganizationMemberTeam.objects.filter(
@@ -36,17 +58,12 @@ class OrganizationAlertRuleDetailsEndpoint(OrganizationAlertRuleEndpoint):
                     return Response(
                         {
                             "detail": [
-                                "You do not have permission to edit this alert rule because you are not a member of the assigned team."
+                                "You do not have permission to delete this alert rule because you are not a member of the assigned team."
                             ]
                         },
                         status=403,
                     )
-            alert_rule = serializer.save()
-            return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
 
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-    def delete(self, request, organization, alert_rule):
         try:
             delete_alert_rule(alert_rule)
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -7,6 +7,7 @@ from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer
 from sentry.auth.access import OrganizationGlobalAccess
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 from sentry.incidents.models import AlertRule, AlertRuleStatus, Incident, IncidentStatus
+from sentry.models import OrganizationMemberTeam
 from sentry.testutils import APITestCase
 from tests.sentry.incidents.endpoints.test_organization_alert_rule_index import AlertRuleBase
 
@@ -389,6 +390,32 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert (
             resp.data["owner"] == self.user.actor.get_actor_identifier()
         )  # Doesn't unassign yet - TDB in future though
+
+    def test_team_permission(self):
+        # Test ensures you can only edit alerts owned by your team or no one.
+
+        om = self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        alert_rule = self.alert_rule
+        alert_rule.owner = self.team.actor
+        alert_rule.save()
+        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        OrganizationMemberTeam.objects.filter(
+            organizationmember__user=self.user,
+            team=self.team,
+        ).delete()
+        with self.feature("organizations:incidents"):
+            resp = self.get_response(self.organization.slug, alert_rule.id, **serialized_alert_rule)
+        assert resp.status_code == 403
+        self.create_team_membership(team=self.team, member=om)
+        with self.feature("organizations:incidents"):
+            resp = self.get_valid_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+        assert resp.data == serialize(alert_rule, self.user)
 
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):


### PR DESCRIPTION
Adding an additional check when editing an alert rule. If the rule has an owner, and that owner is a team, we make sure the user is on that team. If not, we send them a 403.