### PR TITLE
feat(grouping): Run additional grouping config in background

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -25,7 +25,9 @@ from sentry.constants import (
 from sentry.culprit import generate_culprit
 from sentry.eventstore.processing import event_processing_store
 from sentry.grouping.api import (
+    BackgroundGroupingConfigLoader,
     GroupingConfigNotFound,
+    SecondaryGroupingConfigLoader,
     apply_server_fingerprinting,
     get_fingerprinting_config_for_project,
     get_grouping_config_dict_for_event_data,
@@ -345,32 +347,20 @@ class EventManager:
         _derive_plugin_tags_many(jobs, projects)
         _derive_interface_tags_many(jobs)
 
+        do_background_grouping_before = options.get("store.background-grouping-before")
+        if do_background_grouping_before:
+            _run_background_grouping(project, job)
+
         secondary_flat_hashes = []
 
         try:
             if (project.get_option("sentry:secondary_grouping_expiry") or 0) >= time.time():
                 with metrics.timer("event_manager.secondary_grouping"):
                     secondary_event = copy.deepcopy(job["event"])
-                    secondary_grouping_config = get_grouping_config_dict_for_project(
-                        project, secondary=True
-                    )
+                    loader = SecondaryGroupingConfigLoader()
+                    secondary_grouping_config = loader.get_config_dict(project)
                     _calculate_event_grouping(project, secondary_event, secondary_grouping_config)
                     secondary_flat_hashes.extend(secondary_event.data["hashes"])
-        except Exception:
-            sentry_sdk.capture_exception()
-
-        # Optionally run a fraction of events with a third grouping
-        # configuration to measure its performance impact.
-        # This does not affect actual grouping.
-        try:
-            sample_rate = options.get("store.background-grouping-sample-rate")
-            if sample_rate and random.random() <= sample_rate:
-                with metrics.timer("event_manager.background_grouping"):
-                    copied_event = copy.deepcopy(job["event"])
-                    secondary_grouping_config = get_grouping_config_dict_for_project(
-                        project, secondary=True
-                    )
-                    _calculate_event_grouping(project, copied_event, secondary_grouping_config)
         except Exception:
             sentry_sdk.capture_exception()
 
@@ -388,6 +378,9 @@ class EventManager:
 
         flat_hashes = job["event"].data["hashes"] + secondary_flat_hashes
         hierarchical_hashes = job["event"].data.get("hierarchical_hashes") or []
+
+        if not do_background_grouping_before:
+            _run_background_grouping(project, job)
 
         _materialize_metadata_many(jobs)
 
@@ -537,6 +530,27 @@ class EventManager:
 
         self._data = job["event"].data.data
         return job["event"]
+
+
+@metrics.wraps("event_manager.background_grouping")
+def _calculate_background_grouping(project, event, config):
+    _calculate_event_grouping(project, event, config)
+
+
+def _run_background_grouping(project, job):
+    """Optionally run a fraction of events with a third grouping config
+    This can be helpful to measure its performance impact.
+    This does not affect actual grouping.
+    """
+    try:
+        sample_rate = options.get("store.background-grouping-sample-rate")
+        if sample_rate and random.random() <= sample_rate:
+            config = BackgroundGroupingConfigLoader().get_config_dict(project)
+            if config["id"]:
+                copied_event = copy.deepcopy(job["event"])
+                _calculate_background_grouping(project, copied_event, config)
+    except Exception:
+        sentry_sdk.capture_exception()
 
 
 @metrics.wraps("save_event.pull_out_data")

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -315,3 +315,12 @@ register("store.load-shed-pipeline-projects", type=Sequence, default=[])
 
 # Switch for more performant project counter incr
 register("store.projectcounter-modern-upsert-sample-rate", default=0.0)
+
+# Run an experimental grouping config in background for performance analysis
+register("store.background-grouping-config-id", default=None)
+
+# Fraction of events that will pass through background grouping
+register("store.background-grouping-sample-rate", default=0.0)
+
+# True if background grouping should run before secondary and primary grouping
+register("store.background-grouping-before", default=False)


### PR DESCRIPTION
In order to estimate the performance impact of a new grouping strategy, optionally run the strategy for a fraction of events without influencing the actual event grouping. Events are sampled at random from all projects.

Configurable sentry options are
* `store.background-grouping-config-id`, e.g. `mobile:2021-02-12`,
* `store.background-grouping-sample-rate`, e.g. 0.01,
* `store.background-grouping-before`, whether the background grouping should run before or after regular grouping. This flag can be switched to verify if global caching influences the run time. Defaults to `False`.