### PR TITLE
fix(dashboards): Update Dashboards Landing Page Title

### DIFF
--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -166,7 +166,7 @@ class ManageDashboards extends AsyncView<Props, State> {
   }
 
   getTitle() {
-    return t('Manage Dashboards');
+    return t('Dashboards');
   }
 
   onCreate() {
@@ -196,7 +196,7 @@ class ManageDashboards extends AsyncView<Props, State> {
             <LightWeightNoProjectMessage organization={organization}>
               <PageContent>
                 <StyledPageHeader>
-                  {t('Manage Dashboards')}
+                  {t('Dashboards')}
                   <Button
                     data-test-id="dashboard-create"
                     onClick={event => {


### PR DESCRIPTION
Changed title from Manage Dashboards -> Dashboards.

Before:
![Screen Shot 2021-05-12 at 11 17 06 AM](https://user-images.githubusercontent.com/63818634/118000542-e56fec00-b313-11eb-99cc-c1ea5e53a5d3.png)

After:
![Screen Shot 2021-05-12 at 11 19 00 AM](https://user-images.githubusercontent.com/63818634/118000549-e9037300-b313-11eb-8140-1bddb15a4d3f.png)
