### PR TITLE
ref(kvstore): Add Redis backend, cache backend compatibility wrapper

### DIFF
--- a/src/sentry/cache/base.py
+++ b/src/sentry/cache/base.py
@@ -1,6 +1,18 @@
 from threading import local
+from typing import Any
 
 from django.conf import settings
+
+
+def wrap_key(prefix: str, version: Any, key: Any) -> str:
+    return f"{prefix}:{version}:{key}"
+
+
+def unwrap_key(prefix: str, version: Any, value: str) -> str:
+    header = f"{prefix}:{version}"
+    if value[: len(header)] != header:
+        raise ValueError("invalid key header")
+    return value[len(header) + 1 :]
 
 
 class BaseCache(local):
@@ -11,8 +23,8 @@ class BaseCache(local):
         if prefix is not None:
             self.prefix = prefix
 
-    def make_key(self, key, version=None):
-        return f"{self.prefix}:{version or self.version}:{key}"
+    def make_key(self, key, version=None) -> str:
+        return wrap_key(self.prefix, version or self.version, key)
 
     def set(self, key, value, timeout, version=None, raw=False):
         raise NotImplementedError

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -7,7 +7,7 @@ from sentry.utils.kvstore.abstract import KVStorage
 
 
 class RedisKVStorage(KVStorage[str, bytes]):
-    def __init__(self, client: Redis[bytes]) -> None:
+    def __init__(self, client: "Redis[bytes]") -> None:
         self.client = client
 
     def get(self, key: str) -> Optional[bytes]:

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+from typing import Optional
+
+from redis import Redis
+
+from sentry.utils.kvstore.abstract import KVStorage
+
+
+class RedisKVStorage(KVStorage[str, bytes]):
+    def __init__(self, client: Redis) -> None:
+        self.__client = client
+
+    def get(self, key: str) -> Optional[bytes]:
+        return self.__client.get(key.encode("utf8"))
+
+    def set(self, key: str, value: bytes, ttl: Optional[timedelta] = None) -> None:
+        self.__client.set(key.encode("utf8"), value, ex=ttl)
+
+    def delete(self, key: str) -> None:
+        self.__client.delete(key.encode("utf8"))
+
+    def bootstrap(self) -> None:
+        pass  # nothing to do
+
+    def destroy(self) -> None:
+        self.__client.flushdb()

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -7,6 +7,11 @@ from sentry.utils.kvstore.abstract import KVStorage
 
 
 class RedisKVStorage(KVStorage[str, bytes]):
+    """
+    This class provides a key/value store backed by Redis (either a single node
+    or cluster.)
+    """
+
     def __init__(self, client: "Redis[bytes]") -> None:
         self.client = client
 

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -7,7 +7,7 @@ from sentry.utils.kvstore.abstract import KVStorage
 
 
 class RedisKVStorage(KVStorage[str, bytes]):
-    def __init__(self, client: Redis) -> None:
+    def __init__(self, client: Redis[bytes]) -> None:
         self.__client = client
 
     def get(self, key: str) -> Optional[bytes]:

--- a/src/sentry/utils/kvstore/redis.py
+++ b/src/sentry/utils/kvstore/redis.py
@@ -8,19 +8,19 @@ from sentry.utils.kvstore.abstract import KVStorage
 
 class RedisKVStorage(KVStorage[str, bytes]):
     def __init__(self, client: Redis[bytes]) -> None:
-        self.__client = client
+        self.client = client
 
     def get(self, key: str) -> Optional[bytes]:
-        return self.__client.get(key.encode("utf8"))
+        return self.client.get(key.encode("utf8"))
 
     def set(self, key: str, value: bytes, ttl: Optional[timedelta] = None) -> None:
-        self.__client.set(key.encode("utf8"), value, ex=ttl)
+        self.client.set(key.encode("utf8"), value, ex=ttl)
 
     def delete(self, key: str) -> None:
-        self.__client.delete(key.encode("utf8"))
+        self.client.delete(key.encode("utf8"))
 
     def bootstrap(self) -> None:
         pass  # nothing to do
 
     def destroy(self) -> None:
-        self.__client.flushdb()
+        self.client.flushdb()

--- a/tests/sentry/utils/kvstore/test_common.py
+++ b/tests/sentry/utils/kvstore/test_common.py
@@ -1,5 +1,6 @@
 import itertools
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import Iterator, Tuple
 
 import pytest
@@ -78,6 +79,11 @@ def test_single_key_operations(properties: Properties) -> None:
     # Test overwriting a key with a prior value.
     new_value = next(properties.values)
     store.set(key, new_value)
+    assert store.get(key) == new_value
+
+    # Test overwriting a key with a new TTL.
+    new_value = next(properties.values)
+    store.set(key, new_value, ttl=timedelta(seconds=30))
     assert store.get(key) == new_value
 
     # Test deleting an existing key.

--- a/tests/sentry/utils/kvstore/test_common.py
+++ b/tests/sentry/utils/kvstore/test_common.py
@@ -18,7 +18,7 @@ class Properties:
         return zip(self.keys, self.values)
 
 
-@pytest.fixture(params=["bigtable", "cache/default", "memory"])
+@pytest.fixture(params=["bigtable", "cache/default", "memory", "redis"])
 def properties(request) -> Properties:
     if request.param == "bigtable":
         from tests.sentry.utils.kvstore.test_bigtable import create_store, get_credentials
@@ -52,6 +52,16 @@ def properties(request) -> Properties:
             MemoryKVStorage(),
             keys=itertools.count(),
             values=itertools.count(),
+        )
+    elif request.param == "redis":
+        from redis import Redis
+
+        from sentry.utils.kvstore.redis import RedisKVStorage
+
+        return Properties(
+            RedisKVStorage(Redis(db=6)),
+            keys=(f"kvstore/{i}" for i in itertools.count()),
+            values=(f"{i}".encode("utf8") for i in itertools.count()),
         )
     else:
         raise ValueError("unknown kvstore label")

--- a/tests/sentry/utils/kvstore/test_common.py
+++ b/tests/sentry/utils/kvstore/test_common.py
@@ -19,7 +19,7 @@ class Properties:
         return zip(self.keys, self.values)
 
 
-@pytest.fixture(params=["bigtable", "cache/default", "memory", "redis"])
+@pytest.fixture(params=["bigtable", "cache/default", "memory", "memory+cachewrapper", "redis"])
 def properties(request) -> Properties:
     if request.param == "bigtable":
         from tests.sentry.utils.kvstore.test_bigtable import create_store, get_credentials
@@ -63,6 +63,15 @@ def properties(request) -> Properties:
             RedisKVStorage(Redis(db=6)),
             keys=(f"kvstore/{i}" for i in itertools.count()),
             values=(f"{i}".encode("utf8") for i in itertools.count()),
+        )
+    elif request.param == "memory+cachewrapper":
+        from sentry.utils.kvstore.cache import CacheKeyWrapper
+        from sentry.utils.kvstore.memory import MemoryKVStorage
+
+        return Properties(
+            CacheKeyWrapper(MemoryKVStorage()),
+            keys=map(str, itertools.count()),
+            values=itertools.count(),
         )
     else:
         raise ValueError("unknown kvstore label")

--- a/tests/sentry/utils/kvstore/test_compat.py
+++ b/tests/sentry/utils/kvstore/test_compat.py
@@ -1,0 +1,35 @@
+from redis import Redis
+
+from sentry.cache.redis import CommonRedisCache
+from sentry.utils.codecs import BytesCodec, JSONCodec
+from sentry.utils.kvstore.cache import CacheKeyWrapper, CacheKVStorage
+from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
+from sentry.utils.kvstore.redis import RedisKVStorage
+
+
+def test_redis_cache_compat() -> None:
+    redis = Redis(db=6)
+    version = 5
+    prefix = "test"
+
+    cache_backend = CacheKVStorage(CommonRedisCache(redis, version=version, prefix=prefix))
+    redis_backend = KVStorageCodecWrapper(
+        CacheKeyWrapper(RedisKVStorage(redis), version=version, prefix=prefix),
+        JSONCodec() | BytesCodec(),
+    )
+
+    key = "key"
+
+    value = [1, 2, 3]
+    cache_backend.set(key, value)
+    assert cache_backend.get(key) == value
+    assert redis_backend.get(key) == value
+
+    value = [4, 5, 6]
+    redis_backend.set("key", value)
+    assert cache_backend.get(key) == value
+    assert redis_backend.get(key) == value
+
+    cache_backend.delete("key")
+    assert cache_backend.get("key") is None
+    assert redis_backend.get("key") is None


### PR DESCRIPTION
This adds:

1. a `KVStore[str, bytes]` that is backed by Redis (either single node or cluster),
2. a cache key compatibility wrapper so that `RedisKVStorage` can be used to interact with data previously written by a `CacheKVStorage` instance

This allows decoupling storage responsibilities from serialization responsibilities (see https://github.com/getsentry/sentry/pull/26000#issuecomment-839285718 for details about what this means in practice.)