### PR TITLE
fix(perf): Fix tag explorer for navigation ops

### DIFF
--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -29,7 +29,7 @@ import {TableColumn} from 'app/views/eventsV2/table/types';
 
 import {
   PerformanceDuration,
-  platformToPerformanceType,
+  platformAndConditionsToPerformanceType,
   PROJECT_PERFORMANCE_TYPE,
 } from '../utils';
 
@@ -119,17 +119,17 @@ const filterToField = {
   [SpanOperationBreakdownFilter.Resource]: 'spans.resource',
 };
 
-const getTransactionField = (
+export const getTransactionField = (
   currentFilter: SpanOperationBreakdownFilter,
   projects: Project[],
-  projectIds: readonly number[]
+  eventView: EventView
 ) => {
   const fieldFromFilter = filterToField[currentFilter];
   if (fieldFromFilter) {
     return fieldFromFilter;
   }
 
-  const performanceType = platformToPerformanceType(projects, projectIds);
+  const performanceType = platformAndConditionsToPerformanceType(projects, eventView);
   if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
     return 'measurements.lcp';
   }
@@ -140,7 +140,7 @@ const getTransactionField = (
 const getColumnsWithReplacedDuration = (
   currentFilter: SpanOperationBreakdownFilter,
   projects: Project[],
-  projectIds: readonly number[]
+  eventView: EventView
 ) => {
   const columns = COLUMN_ORDER.map(c => ({...c}));
   const durationColumn = columns.find(c => c.key === 'aggregate');
@@ -155,7 +155,7 @@ const getColumnsWithReplacedDuration = (
     return columns;
   }
 
-  const performanceType = platformToPerformanceType(projects, projectIds);
+  const performanceType = platformAndConditionsToPerformanceType(projects, eventView);
   if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
     durationColumn.name = 'Avg LCP';
     return columns;
@@ -403,16 +403,12 @@ class _TagExplorer extends React.Component<Props> {
           ]
     );
 
-    const aggregateColumn = getTransactionField(
-      currentFilter,
-      projects,
-      sortedEventView.project
-    );
+    const aggregateColumn = getTransactionField(currentFilter, projects, sortedEventView);
 
     const adjustedColumns = getColumnsWithReplacedDuration(
       currentFilter,
       projects,
-      sortedEventView.project
+      sortedEventView
     );
     const columns = this.getColumnOrder(adjustedColumns);
 

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -6,8 +6,10 @@ import {backend, frontend} from 'app/data/platformCategories';
 import {GlobalSelection, OrganizationSummary, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {statsPeriodToDays} from 'app/utils/dates';
+import EventView from 'app/utils/discover/eventView';
 import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'app/utils/queryString';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 /**
  * Performance type can used to determine a default view or which specific field should be used by default on pages
@@ -17,6 +19,7 @@ export enum PROJECT_PERFORMANCE_TYPE {
   ANY = 'any', // Fallback to transaction duration
   FRONTEND = 'frontend',
   BACKEND = 'backend',
+  FRONTEND_OTHER = 'frontend_other',
 }
 
 const FRONTEND_PLATFORMS: string[] = [...frontend];
@@ -51,6 +54,24 @@ export function platformToPerformanceType(
   }
 
   return PROJECT_PERFORMANCE_TYPE.ANY;
+}
+
+/**
+ * Used for transaction summary to determine appropriate columns on a page, since there is no display field set for the page.
+ */
+export function platformAndConditionsToPerformanceType(
+  projects: Project[],
+  eventView: EventView
+) {
+  const performanceType = platformToPerformanceType(projects, eventView.project);
+  if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
+    const conditions = tokenizeSearch(eventView.query);
+    const ops = conditions.getTagValues('!transaction.op');
+    if (ops.some(op => op === 'pageload')) {
+      return PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER;
+    }
+  }
+  return performanceType;
 }
 
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {


### PR DESCRIPTION
### Summary
This fixes navigation transactions not having suspect tags, since LCP was previously being used still due to the previous function not taking into account the conditions in addition to the platform.