### PR TITLE
fix(orgstats): Allow full totals on queries even if user doesn't have proj access

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -208,7 +208,6 @@ class OrganizationEndpoint(Endpoint):
     ):
         qs = Project.objects.filter(organization=organization, status=ProjectStatus.VISIBLE)
         user = getattr(request, "user", None)
-
         # A project_id of -1 means 'all projects I have access to'
         # While no project_ids means 'all projects I am a member of'.
         if project_ids == ALL_ACCESS_PROJECTS:

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.search.utils import InvalidQuery
 from sentry.snuba.outcomes import QueryDefinition, massage_outcomes_result, run_outcomes_query
 from sentry.snuba.sessions_v2 import InvalidField, InvalidParams
@@ -50,7 +51,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
         req_proj_ids = self.get_requested_project_ids(request)
         return all(
             [
-                not req_proj_ids or req_proj_ids == {-1},
+                not req_proj_ids or req_proj_ids == ALL_ACCESS_PROJECTS,
                 "project" not in request.GET.get("groupBy", []),
             ]
         )

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -203,8 +203,8 @@ def get_filter(
 
     if "project_id" in params:
         filter_keys["project_id"] = params["project_id"]
-    if "organization" in params:
-        filter_keys["organization_id"] = params["organization_id"]
+    if "organization_id" in params:
+        filter_keys["org_id"] = [params["organization_id"]]
 
     return conditions, filter_keys
 

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -327,6 +327,24 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
             "detail": "You do not have permission to perform this action."
         }
 
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "groupBy": ["project"],
+                "statsPeriod": "1d",
+                "interval": "1d",
+                "category": ["error", "transaction"],
+                "field": ["sum(quantity)"],
+            },
+            org=self.organization,
+            user=user,
+        )
+
+        assert response.status_code == 403, response.content
+        assert result_sorted(response.data) == {
+            "detail": "You do not have permission to perform this action."
+        }
+
     @freeze_time("2021-03-14T12:27:28.303Z")
     def test_open_membership_semantics(self):
         self.org.flags.allow_joinleave = True

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -352,8 +352,6 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
                 },
             ],
         }
-        self.org.flags.allow_joinleave = False
-        self.org.save()
 
     @freeze_time("2021-03-14T12:27:28.303Z")
     def test_org_simple(self):


### PR DESCRIPTION
On orgstats queries we want to show total org summations even if the user doesn't have access to all projects. to do this, we check to see if the query is filtering on any projects or grouping by project. If not, delete the project id parameter that gets passed to query definition.

TODO:

- [x] some manual testing to confirm intended behaviors and to confirm no combo of permissions / params can break