### PR TITLE
feat(spans): Dynamically recalculate ops breakdown based on current filters

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -28,6 +28,7 @@ import {
 import * as CursorGuideHandler from './cursorGuideHandler';
 import * as DividerHandlerManager from './dividerHandlerManager';
 import {DragManagerChildrenProps} from './dragManager';
+import {ActiveOperationFilter} from './filter';
 import MeasurementsPanel from './measurementsPanel';
 import * as ScrollbarManager from './scrollbarManager';
 import {
@@ -51,6 +52,7 @@ type PropType = {
   dragProps: DragManagerChildrenProps;
   trace: ParsedTraceType;
   event: EventTransaction;
+  operationNameFilters: ActiveOperationFilter;
 };
 
 type State = {
@@ -419,7 +421,12 @@ class TraceViewHeader extends React.Component<PropType, State> {
                   }}
                 >
                   {this.props.event && (
-                    <OpsBreakdown event={this.props.event} topN={3} hideHeader />
+                    <OpsBreakdown
+                      operationNameFilters={this.props.operationNameFilters}
+                      event={this.props.event}
+                      topN={3}
+                      hideHeader
+                    />
                   )}
                 </OperationsBreakdown>
                 <DividerSpacer

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -176,6 +176,7 @@ class TraceView extends PureComponent<Props, State> {
       trace={parsedTrace}
       event={this.props.event}
       virtualScrollBarContainerRef={this.virtualScrollBarContainerRef}
+      operationNameFilters={this.props.operationNameFilters}
     />
   );
 

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -88,23 +88,24 @@ class OpsBreakdown extends Component<Props> {
 
     let spans: RawSpanType[] = spanEntry?.data ?? [];
 
+    const rootSpan = {
+      op: traceContext.op,
+      timestamp: event.endTimestamp,
+      start_timestamp: event.startTimestamp,
+      trace_id: traceContext.trace_id || '',
+      span_id: traceContext.span_id || '',
+      data: {},
+    };
+
     spans =
       spans.length > 0
         ? spans
         : // if there are no descendent spans, then use the transaction root span
-          [
-            {
-              op: traceContext.op,
-              timestamp: event.endTimestamp,
-              start_timestamp: event.startTimestamp,
-              trace_id: traceContext.trace_id || '',
-              span_id: traceContext.span_id || '',
-              data: {},
-            },
-          ];
+          [rootSpan];
 
     // Filter spans by operation name
     if (operationNameFilters.type === 'active_filter') {
+      spans = [...spans, rootSpan];
       spans = spans.filter(span => {
         const operationName = getSpanOperation(span);
 

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -10,7 +10,6 @@ import {BorderlessEventEntries} from 'app/components/events/eventEntries';
 import EventMetadata from 'app/components/events/eventMetadata';
 import EventVitals from 'app/components/events/eventVitals';
 import * as SpanEntryContext from 'app/components/events/interfaces/spans/context';
-import OpsBreakdown from 'app/components/events/opsBreakdown';
 import RootSpanStatus from 'app/components/events/rootSpanStatus';
 import FileSize from 'app/components/fileSize';
 import * as Layout from 'app/components/layouts/thirds';
@@ -215,7 +214,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                             projectId={this.projectId}
                           />
                           <RootSpanStatus event={event} />
-                          <OpsBreakdown event={event} />
                         </Fragment>
                       )}
                       <EventVitals event={event} />


### PR DESCRIPTION
When viewing an individual transaction event, applying operation name filters should update the operations breakdown information embedded on the top-left corner of the span view:

https://user-images.githubusercontent.com/139499/118043675-ace80680-b343-11eb-8122-15a9b652fcae.mp4

