### PR TITLE
fix(services): Provide default empty object to executor configuration

### DIFF
--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -428,7 +428,7 @@ class ServiceDelegator(Delegator, Service):
                 name: (
                     build_instance_from_options(options),
                     build_instance_from_options(
-                        options.get("executor"), default_constructor=ThreadedExecutor
+                        options.get("executor", {}), default_constructor=ThreadedExecutor
                     ),
                 )
                 for name, options in backends.items()


### PR DESCRIPTION
Fixes this, introduced in #26000:

```
File "/usr/src/getsentry/src/sentry/src/sentry/reprocessing2.py", line 90, in <module> from sentry.eventstore.processing import event_processing_store
File "/usr/src/getsentry/src/sentry/src/sentry/eventstore/processing/__init__.py", line 6, in <module> **settings.SENTRY_EVENT_PROCESSING_STORE_OPTIONS
File "/usr/src/getsentry/src/sentry/src/sentry/utils/services.py", line 434, in __init__ for name, options in backends.items()
File "/usr/src/getsentry/src/sentry/src/sentry/utils/services.py", line 434, in <dictcomp> for name, options in backends.items()
File "/usr/src/getsentry/src/sentry/src/sentry/utils/services.py", line 380, in build_instance_from_options path = options["path"]

TypeError: 'NoneType' object is not subscriptable