### PR TITLE
feat(notifications platform): Send notification to team's Slack channel

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -939,7 +939,7 @@ SENTRY_FEATURES = {
     # Enable experimental performance improvements.
     "organizations:enterprise-perf": False,
     # Enable the API to importing CODEOWNERS for a project
-    "organizations:integrations-codeowners": True,
+    "organizations:integrations-codeowners": False,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     "organizations:internal-catchall": False,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -967,7 +967,7 @@ SENTRY_FEATURES = {
     "organizations:minute-resolution-sessions": False,
     # Enable option to send alert, workflow, and deploy notifications
     # to 3rd parties (e.g. Slack) in addition to email
-    "organizations:notification-platform": True,
+    "organizations:notification-platform": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable basic SSO functionality, providing configurable single sign on

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -939,7 +939,7 @@ SENTRY_FEATURES = {
     # Enable experimental performance improvements.
     "organizations:enterprise-perf": False,
     # Enable the API to importing CODEOWNERS for a project
-    "organizations:integrations-codeowners": False,
+    "organizations:integrations-codeowners": True,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     "organizations:internal-catchall": False,
@@ -967,7 +967,7 @@ SENTRY_FEATURES = {
     "organizations:minute-resolution-sessions": False,
     # Enable option to send alert, workflow, and deploy notifications
     # to 3rd parties (e.g. Slack) in addition to email
-    "organizations:notification-platform": False,
+    "organizations:notification-platform": True,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable basic SSO functionality, providing configurable single sign on

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -1,9 +1,9 @@
 import logging
-from typing import AbstractSet, Any, Mapping, Set, Tuple
+from typing import AbstractSet, Any, Mapping, Set, Tuple, Union
 
 from sentry.integrations.slack.client import SlackClient  # NOQA
 from sentry.integrations.slack.message_builder.notifications import build_notification_attachment
-from sentry.models import ExternalActor, Organization, User
+from sentry.models import ExternalActor, Organization, Team, User
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
@@ -18,25 +18,25 @@ SLACK_TIMEOUT = 5
 
 def get_context(
     notification: BaseNotification,
-    user: User,
+    recipient: Union[User, Team],
     shared_context: Mapping[str, Any],
     extra_context: Mapping[str, Any],
 ) -> Mapping[str, Any]:
     """ Compose the various levels of context and add slack-specific fields. """
     return {
         **shared_context,
-        **notification.get_user_context(user, extra_context),
+        **notification.get_user_context(recipient, extra_context),
     }
 
 
-def get_integrations_by_user_id(
-    organization: Organization, users: AbstractSet[User]
-) -> Mapping[User, ExternalActor]:
-    actor_mapping = {user.actor_id: user for user in users}
+def get_integrations_by_recipient_id(
+    organization: Organization, recipients: AbstractSet[Union[User, Team]]
+) -> Mapping[Union[User, Team], ExternalActor]:
+    actor_mapping = {recipient.actor_id: recipient for recipient in recipients}
 
     external_actors = ExternalActor.objects.filter(
         provider=ExternalProviders.SLACK.value,
-        actor_id__in=[user.actor_id for user in users],
+        actor_id__in=[recipient.actor_id for recipient in recipients],
         organization=organization,
     ).select_related("integration")
 
@@ -47,9 +47,10 @@ def get_integrations_by_user_id(
 
 
 def get_channel_and_token(
-    external_actors_by_user: Mapping[User, ExternalActor], user: User
+    external_actors_by_recipient: Mapping[Union[User, Team], ExternalActor],
+    recipient: Union[User, Team],
 ) -> Tuple[str, str]:
-    external_actor = external_actors_by_user.get(user)
+    external_actor = external_actors_by_recipient.get(recipient)
     channel = external_actor.external_id
     token = external_actor.integration.metadata["access_token"]
     return channel, token
@@ -67,31 +68,31 @@ def get_key(notification: BaseNotification) -> str:
 @register_notification_provider(ExternalProviders.SLACK)
 def send_notification_as_slack(
     notification: BaseNotification,
-    users: Set[User],
+    recipients: Union[Set[User], Set[Team]],
     shared_context: Mapping[str, Any],
     extra_context_by_user_id: Mapping[str, Any],
 ) -> None:
-    """ Send an "activity" or "alert rule" notification to a Slack user. """
-
-    external_actors_by_user = get_integrations_by_user_id(notification.organization, users)
-
+    """ Send an "activity" or "alert rule" notification to a Slack user or team. """
+    external_actors_by_recipient = get_integrations_by_recipient_id(
+        notification.organization, recipients
+    )
     client = SlackClient()
-    for user in users:
-        extra_context = (extra_context_by_user_id or {}).get(user.id, {})
+    for recipient in recipients:
+        extra_context = (extra_context_by_user_id or {}).get(recipient.id, {})
         try:
-            channel, token = get_channel_and_token(external_actors_by_user, user)
+            channel, token = get_channel_and_token(external_actors_by_recipient, recipient)
         except AttributeError as e:
             logger.info(
                 "notification.fail.invalid_slack",
                 extra={
                     "error": str(e),
                     "notification": notification,
-                    "user": user.id,
+                    "recipient": recipient.id,
                 },
             )
             continue
 
-        context = get_context(notification, user, shared_context, extra_context)
+        context = get_context(notification, recipient, shared_context, extra_context)
         attachment = [build_notification_attachment(notification, context)]
         payload = {
             "token": token,
@@ -107,7 +108,7 @@ def send_notification_as_slack(
                 extra={
                     "error": str(e),
                     "notification": notification,
-                    "user": user.id,
+                    "recipient": recipient.id,
                     "channel_id": channel,
                 },
             )

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -235,6 +235,26 @@ class NotificationsManager(BaseManager):  # type: ignore
             target__in=[user.actor.id for user in users],
         )
 
+    def get_for_team(
+        self,
+        type: NotificationSettingTypes,
+        parent: Any,
+        team: Any,
+    ) -> QuerySet:
+        """
+        Find all of a project/organization's notification settings for a team.
+        This will include each team's project/organization-independent settings.
+        """
+        scope_type = get_scope_type(type)
+        return self.filter(
+            Q(
+                scope_type=scope_type.value,
+                scope_identifier=parent.id,
+            ),
+            type=type.value,
+            target=team.actor.id,
+        )
+
     def filter_to_subscribed_users(
         self,
         project: Any,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -235,24 +235,22 @@ class NotificationsManager(BaseManager):  # type: ignore
             target__in=[user.actor.id for user in users],
         )
 
-    def get_for_team(
+    def get_for_recipient_by_parent(
         self,
         type: NotificationSettingTypes,
         parent: Any,
-        team: Any,
+        recipient: Any,
     ) -> QuerySet:
         """
-        Find all of a project/organization's notification settings for a team.
-        This will include each team's project/organization-independent settings.
+        Find all of a project/organization's notification settings for a recipient.
+        This will include each recipient's project/organization-independent settings.
         """
         scope_type = get_scope_type(type)
         return self.filter(
-            Q(
-                scope_type=scope_type.value,
-                scope_identifier=parent.id,
-            ),
+            scope_type=scope_type.value,
+            scope_identifier=parent.id,
             type=type.value,
-            target=team.actor.id,
+            target=recipient.actor_id,
         )
 
     def filter_to_subscribed_users(

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,11 +1,17 @@
-from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Set
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Set, Union
 
-from sentry.models import User
+from sentry.models import Team, User
 from sentry.types.integrations import ExternalProviders
 
 # Shortcut so that types don't explode.
 Notifiable = Callable[
-    [Any, Set[User], Mapping[str, Any], Optional[Mapping[int, Mapping[str, Any]]]], None
+    [
+        Any,
+        Union[Set[User], Set[Team]],
+        Mapping[str, Any],
+        Optional[Mapping[int, Mapping[str, Any]]],
+    ],
+    None,
 ]
 
 # Global notifier registry.
@@ -35,9 +41,9 @@ def register_notification_provider(
 def notify(
     provider: ExternalProviders,
     notification: Any,
-    users: Set[User],
+    recipients: Union[Set[User], Set[Team]],
     shared_context: Mapping[str, Any],
     extra_context_by_user_id: Optional[Mapping[int, Mapping[str, Any]]] = None,
 ) -> None:
-    """ Send notifications to these users. """
-    registry[provider](notification, users, shared_context, extra_context_by_user_id)
+    """ Send notifications to these users or team. """
+    registry[provider](notification, recipients, shared_context, extra_context_by_user_id)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -264,8 +264,8 @@ def get_send_to_team(
     except Team.DoesNotExist:
         return {}
 
-    team_notification_settings = NotificationSetting.objects.get_for_team(
-        NotificationSettingTypes.ISSUE_ALERTS, parent=project, team=team
+    team_notification_settings = NotificationSetting.objects.get_for_recipient_by_parent(
+        NotificationSettingTypes.ISSUE_ALERTS, parent=project, recipient=team
     )
 
     if team_notification_settings:

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -269,11 +269,11 @@ def get_send_to_team(
     )
 
     if team_notification_settings:
-        mapping = {
+        team_mapping = {
             ExternalProviders(notification_setting.provider): {team}
             for notification_setting in team_notification_settings
         }
-        return mapping
+        return team_mapping
 
     # fallback to notifying each subscribed user if there aren't team notification settings
     member_list = team.member_set.values_list("user_id", flat=True)

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -452,8 +452,7 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         )
         action_data = {
             "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "Team",  # TODO CEO make another test where this is issue owners
-            # and the issue owners includes both users and teams
+            "targetType": "Team",
             "targetIdentifier": str(self.team.id),
         }
         rule = Rule.objects.create(

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -408,6 +408,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
         mail.outbox = []
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
             self.adapter.notify(Notification(event=event), target_type, target_identifier)
+
         assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
 
     def test_notify_users_with_owners(self):
@@ -470,7 +471,9 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
         )
         self.assert_notify(event_all_users, [user.email])
 
-    def test_notify_team(self):
+    def test_notify_team_members(self):
+        """Test that each member of a team is notified"""
+
         user = self.create_user(email="foo@example.com", is_active=True)
         user2 = self.create_user(email="baz@example.com", is_active=True)
         team = self.create_team(organization=self.organization, members=[user, user2])

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -408,7 +408,6 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
         mail.outbox = []
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
             self.adapter.notify(Notification(event=event), target_type, target_identifier)
-
         assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
 
     def test_notify_users_with_owners(self):


### PR DESCRIPTION
If a team has provided a Slack channel to send a notification to, we'll now send the notification there instead of notifying each individual team member. 

**Note**: This does _not_ support providing a team email address. We'll address this separately as it requires more changes. It's only possible to set this up via the API anyway, so it's low risk. This will be handled before we release a UI.