### PR TITLE
feat(integrations): email alert link to slack

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -20,6 +20,7 @@ from sentry.utils import json, metrics
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
+from sentry.notifications.utils import get_integration_link, has_integration_installed
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +198,7 @@ class MailAdapter:
                 "user_ids": user_ids,
             },
         )
+        org = project.organization
         for user_id, digest in get_personalized_digests(target_type, project.id, digest, user_ids):
             start, end, counts = get_digest_metadata(digest)
 
@@ -221,6 +223,8 @@ class MailAdapter:
                 "project": project,
                 "digest": digest,
                 "counts": counts,
+                "slack_link": get_integration_link(org, "slack"),
+                "has_slack": has_integration_installed(org, "slack"),
             }
 
             headers = {

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -20,7 +20,7 @@ from sentry.utils import json, metrics
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
-from sentry.notifications.utils import get_integration_link, has_integration_installed
+from sentry.notifications.utils import get_integration_link, has_alert_integration
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +224,7 @@ class MailAdapter:
                 "digest": digest,
                 "counts": counts,
                 "slack_link": get_integration_link(org, "slack"),
-                "has_slack": has_integration_installed(org, "slack"),
+                "has_alert_integration": has_alert_integration(project),
             }
 
             headers = {

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -13,6 +13,7 @@ from sentry.models import Group, GroupSubscription, NotificationSetting, Project
 from sentry.notifications.activity import EMAIL_CLASSES_BY_TYPE
 from sentry.notifications.rules import AlertRuleNotification, get_send_to
 from sentry.notifications.types import ActionTargetType, GroupSubscriptionReason
+from sentry.notifications.utils import get_integration_link, has_integration_installed
 from sentry.plugins.base.structs import Notification
 from sentry.tasks.digests import deliver_digest
 from sentry.types.integrations import ExternalProviders
@@ -20,7 +21,6 @@ from sentry.utils import json, metrics
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 from sentry.utils.linksign import generate_signed_link
-from sentry.notifications.utils import get_integration_link, has_integration_installed
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -10,9 +10,8 @@ from sentry.notifications.utils import (
     get_interface_list,
     get_link,
     get_rules,
-    get_integration_link,
-    has_integrations,
     has_alert_integration,
+    has_integrations,
 )
 from sentry.notifications.utils.participants import get_send_to
 from sentry.plugins.base.structs import Notification

--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -9,7 +9,9 @@ from sentry.notifications.utils import (
     get_interface_list,
     get_link,
     get_rules,
+    get_integration_link,
     has_integrations,
+    has_integration_installed,
 )
 from sentry.notifications.utils.participants import get_send_to
 from sentry.plugins.base.structs import Notification
@@ -68,6 +70,8 @@ class AlertRuleNotification(BaseNotification):
             "enhanced_privacy": enhanced_privacy,
             "commits": get_commits(self.project, self.event),
             "environment": environment,
+            "slack_link": get_integration_link(self.organization, "slack"),
+            "has_slack": has_integration_installed(self.organization, "slack"),
         }
 
         # if the organization has enabled enhanced privacy controls we dont send

--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -11,7 +11,7 @@ from sentry.notifications.utils import (
     get_rules,
     get_integration_link,
     has_integrations,
-    has_integration_installed,
+    has_alert_integration,
 )
 from sentry.notifications.utils.participants import get_send_to
 from sentry.plugins.base.structs import Notification
@@ -71,7 +71,7 @@ class AlertRuleNotification(BaseNotification):
             "commits": get_commits(self.project, self.event),
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack"),
-            "has_slack": has_integration_installed(self.organization, "slack"),
+            "has_alert_integration": has_alert_integration(self.project),
         }
 
         # if the organization has enabled enhanced privacy controls we dont send

--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -6,12 +6,12 @@ from sentry.notifications.base import BaseNotification
 from sentry.notifications.types import ActionTargetType
 from sentry.notifications.utils import (
     get_commits,
+    get_integration_link,
     get_interface_list,
     get_link,
     get_rules,
-    get_integration_link,
-    has_integrations,
     has_integration_installed,
+    has_integrations,
 )
 from sentry.notifications.utils.participants import get_send_to
 from sentry.plugins.base.structs import Notification

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -1,6 +1,17 @@
 import logging
 from collections import defaultdict
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple
+from typing import (
+    cast,
+    Any,
+    Iterable,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 from django.db.models import Count
 from django.utils.safestring import mark_safe
@@ -225,7 +236,7 @@ def has_alert_integration(project: Project) -> bool:
 
     # check integrations
     providers = filter(is_alert_rule_integration, list(integrations.all()))
-    provider_keys = list(map(lambda x: x.key, providers))
+    provider_keys = map(lambda x: cast(str, x.key), providers)
     if Integration.objects.filter(organizations=org, provider__in=provider_keys).exists():
         return True
 

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -228,7 +228,6 @@ def has_integrations(organization: Organization, project: Project) -> bool:
 
 def is_alert_rule_integration(provider: IntegrationProvider) -> bool:
     return any(feature == IntegrationFeatures.ALERT_RULE for feature in provider.features)
-    # return any(lambda x: x == IntegrationFeatures.ALERT_RULE, provider.features)
 
 
 def has_alert_integration(project: Project) -> bool:

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -26,8 +26,8 @@ from sentry.models import (
     User,
     UserEmail,
 )
-from sentry.utils.http import absolute_uri
 from sentry.utils.committers import get_serialized_event_file_committers
+from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -4,10 +4,10 @@ from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Seque
 
 from django.db.models import Count
 from django.utils.safestring import mark_safe
-from sentry import integrations
-from sentry.integrations import IntegrationProvider, IntegrationFeatures
 
+from sentry import integrations
 from sentry.db.models.query import in_iexact
+from sentry.integrations import IntegrationFeatures, IntegrationProvider
 from sentry.models import (
     Activity,
     Commit,

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -1,7 +1,6 @@
 import logging
 from collections import defaultdict
 from typing import (
-    cast,
     Any,
     Iterable,
     List,
@@ -11,6 +10,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    cast,
 )
 
 from django.db.models import Count

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -1,8 +1,21 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load sentry_helpers %}
+{% load sentry_assets %}
 
 {% block bodyclass %}digest{% endblock %}
+
+
+{% block header %}
+  {% if not has_slack %}
+    <a href="{{ slack_link }}" class="btn btn-default integration-link">
+      <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" alt="Slack"/>
+      Setup in Slack
+    </a>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}
+
 
 {% block content %}
 

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -9,8 +9,8 @@
 {% block header %}
   {% if not has_alert_integration %}
     <a href="{{ slack_link }}" class="btn btn-default integration-link">
-      <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" alt="Slack"/>
-      Setup in Slack
+      <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small"/>
+      Set up in Slack
     </a>
   {% endif %}
   {{ block.super }}

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -7,13 +7,15 @@
 
 
 {% block header %}
-  {% if not has_alert_integration %}
-    <a href="{{ slack_link }}" class="btn btn-default integration-link">
-      <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small"/>
-      Set up in Slack
-    </a>
-  {% endif %}
-  {{ block.super }}
+  <div class="header-with-buttons">
+    {{ block.super }}
+    {% if not has_alert_integration %}
+      <a href="{{ slack_link }}" class="btn btn-default integration-link">
+        <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small"/>
+        Set up in Slack
+      </a>
+    {% endif %}
+  </div>
 {% endblock %}
 
 

--- a/src/sentry/templates/sentry/emails/digests/body.html
+++ b/src/sentry/templates/sentry/emails/digests/body.html
@@ -7,7 +7,7 @@
 
 
 {% block header %}
-  {% if not has_slack %}
+  {% if not has_alert_integration %}
     <a href="{{ slack_link }}" class="btn btn-default integration-link">
       <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" alt="Slack"/>
       Setup in Slack

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -949,7 +949,7 @@
   }
 
   .header-buttons .integration-link {
-    margin-right: 4px;
+    margin-right: 8px;
   }
 
   @media only screen and (max-device-width: 480px) {

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -156,6 +156,12 @@
     border-bottom: 1px solid #dee7eb;
   }
 
+  .header-with-buttons {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+  }
+
   .header table {
     margin-bottom: 0;
   }
@@ -941,6 +947,7 @@
     display: flex;
     width: 100%;
     justify-content: flex-end;
+    height: fit-content;
   }
 
   .integration-link {

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -934,7 +934,7 @@
   .logo-small {
     width: 16px;
     height: 16px;
-    margin-right: 2px;
+    margin-right: 4px;
   }
 
   .header-buttons {

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -160,6 +160,7 @@
     display: flex;
     width: 100%;
     justify-content: space-between;
+    align-items: center;
   }
 
   .header table {
@@ -961,6 +962,11 @@
 
   @media only screen and (max-device-width: 480px) {
     /* mobile-specific CSS styles */
+
+    /* Hide CTA in header on mobile */
+    .header-buttons .integration-link {
+      display: none;
+    }
 
     .event-id {
       float: none;

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -934,7 +934,7 @@
   .logo-small {
     width: 16px;
     height: 16px;
-    margin-right: 4px;
+    margin-right: 8px;
   }
 
   .header-buttons {

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -943,12 +943,14 @@
     justify-content: flex-end;
   }
 
-  .header-buttons .integration-link {
+  .integration-link {
     display: flex;
     align-items: center;
-    margin-right: 4px;
   }
 
+  .header-buttons .integration-link {
+    margin-right: 4px;
+  }
 
   @media only screen and (max-device-width: 480px) {
     /* mobile-specific CSS styles */

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -963,11 +963,6 @@
   @media only screen and (max-device-width: 480px) {
     /* mobile-specific CSS styles */
 
-    /* Hide CTA in header on mobile */
-    .header-buttons .integration-link {
-      display: none;
-    }
-
     .event-id {
       float: none;
       margin-bottom: 10px;

--- a/src/sentry/templates/sentry/emails/email-styles.html
+++ b/src/sentry/templates/sentry/emails/email-styles.html
@@ -878,6 +878,7 @@
       height:29px;
   }
 
+
   /* Commit list */
 
   .inner table.table.commit-list h4 {
@@ -929,6 +930,25 @@
   .well p {
     margin-bottom: 20px;
   }
+
+  .logo-small {
+    width: 16px;
+    height: 16px;
+    margin-right: 2px;
+  }
+
+  .header-buttons {
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .header-buttons .integration-link {
+    display: flex;
+    align-items: center;
+    margin-right: 4px;
+  }
+
 
   @media only screen and (max-device-width: 480px) {
     /* mobile-specific CSS styles */

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -14,8 +14,8 @@
   <div class="header-buttons">
     {% if not has_alert_integration %}
       <a href="{{ slack_link }}" class="btn btn-default integration-link">
-        <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" alt="Slack"/>
-        Setup in Slack
+        <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" />
+        Set up in Slack
       </a>
     {% endif %}
     <a href="{{ link }}" class="btn">View on Sentry</a>

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -12,7 +12,7 @@
 
 {% block header %}
   <div class="header-buttons">
-    {% if not has_slack %}
+    {% if not has_alert_integration %}
       <a href="{{ slack_link }}" class="btn btn-default integration-link">
         <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" alt="Slack"/>
         Setup in Slack

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -6,6 +6,18 @@
 {% load sentry_assets %}
 {% load i18n static %}
 
+{% block head %}
+  {{ block.super }}
+  <style type="text/css" inline="false">
+    @media only screen and (max-device-width: 480px) {
+      /* Hide CTA in header on mobile */
+      .header-buttons .integration-link {
+        display: none !important;
+      }
+    }
+  </style>
+{% endblock %}
+
 {% block preheader %}
   New alert from {{ project_label }}.
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -3,6 +3,7 @@
 {% load sentry_avatars %}
 {% load sentry_helpers %}
 {% load sentry_features %}
+{% load sentry_assets %}
 {% load i18n static %}
 
 {% block preheader %}
@@ -10,8 +11,16 @@
 {% endblock %}
 
 {% block header %}
+  <div class="header-buttons">
+    {% if not has_slack %}
+      <a href="{{ slack_link }}" class="btn btn-default integration-link">
+        <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" alt="Slack"/>
+        Setup in Slack
+      </a>
+    {% endif %}
     <a href="{{ link }}" class="btn">View on Sentry</a>
-    {{ block.super }}
+  </div>
+  {{ block.super }}
 {% endblock %}
 
 {% block main %}

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -11,16 +11,18 @@
 {% endblock %}
 
 {% block header %}
-  <div class="header-buttons">
-    {% if not has_alert_integration %}
-      <a href="{{ slack_link }}" class="btn btn-default integration-link">
-        <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" />
-        Set up in Slack
-      </a>
-    {% endif %}
-    <a href="{{ link }}" class="btn">View on Sentry</a>
+  <div class="header-with-buttons">
+    {{ block.super }}
+    <div class="header-buttons">
+      {% if not has_alert_integration %}
+        <a href="{{ slack_link }}" class="btn btn-default integration-link">
+          <img src="{% absolute_asset_url 'sentry' 'images/logos/logo-slack.svg' %}" class="logo-small" />
+          Set up in Slack
+        </a>
+      {% endif %}
+      <a href="{{ link }}" class="btn">View on Sentry</a>
+    </div>
   </div>
-  {{ block.super }}
 {% endblock %}
 
 {% block main %}

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -15,8 +15,8 @@ from sentry.mail import mail_adapter, send_notification_as_email
 from sentry.mail.adapter import ActionTargetType
 from sentry.models import (
     Activity,
-    NotificationSetting,
     Integration,
+    NotificationSetting,
     Organization,
     OrganizationMember,
     OrganizationMemberTeam,
@@ -27,7 +27,6 @@ from sentry.models import (
     User,
     UserReport,
 )
-from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 from sentry.notifications.rules import AlertRuleNotification
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.notifications.utils.participants import (
@@ -45,6 +44,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import mock
 from sentry.utils.email import MessageBuilder
+from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 
 
 def send_notification(*args):

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -398,6 +398,24 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
 
         assert "Suspect Commits" in msg.body
 
+    def test_slack_link(self):
+        project = self.project
+        organization = project.organization
+        event = self.store_event(data=self.make_event_data("foo.jx"), project_id=project.id)
+
+        with self.tasks():
+            notification = Notification(event=event)
+
+            self.adapter.notify(notification, ActionTargetType.ISSUE_OWNERS)
+
+        assert len(mail.outbox) >= 1
+
+        msg = mail.outbox[-1]
+        assert (
+            f"/settings/{organization.slug}/integrations/slack/?referrer=alert_email"
+            in msg.alternatives[0][0]
+        )
+
     def assert_notify(
         self,
         event,


### PR DESCRIPTION
This PR adds a link to slack in the issue alert emails and digests if the org does not have any alert integrations (or plugins) installed for that org/project.

Single issue:
![Screen Shot 2021-05-14 at 9 53 17 AM](https://user-images.githubusercontent.com/8533851/118303383-3c9fc900-b49a-11eb-90ce-903909b9ae0d.png)


Digest:
![Screen Shot 2021-05-14 at 9 55 52 AM](https://user-images.githubusercontent.com/8533851/118303690-96a08e80-b49a-11eb-8ceb-3396e5eafc46.png)



The `Setup in Slack` button brings you to the integration detail page for slack with the `alert_email` referrer.