### PR TITLE
fix: Remove shellcheck-py from pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,12 +51,6 @@ repos:
       # We can't change this mock to unittest.mock until Python 3.8,
       # refer to the comment in this file.
       exclude: 'src/sentry/utils/compat/mock.py'
-    - id: shellcheck
-      name: shellcheck
-      entry: shellcheck
-      language: system
-      exclude: 'src/sentry/templates/sentry/reprocessing-script.sh'
-      types: [shell]
 
 -   repo: https://github.com/sirosen/check-jsonschema
     rev: 0.3.0

--- a/requirements-pre-commit.txt
+++ b/requirements-pre-commit.txt
@@ -3,4 +3,3 @@ black==20.8b1
 sentry-flake8==1.0.0
 pyupgrade==2.10.0
 isort==5.8.0
-shellcheck-py==0.7.1.1


### PR DESCRIPTION
It's given me and @dcramer trouble in the past.
My VS Code comes with the shellcheck extension, thus, I get the benefits that way.