### PR TITLE
 feat(releases): Release adoption chart for projects with releases

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -988,6 +988,8 @@ SENTRY_FEATURES = {
     "organizations:team-alerts-ownership": False,
     # Enable the new alert creation wizard
     "organizations:alert-wizard": True,
+    # Enable the adoption chart in the releases page
+    "organizations:release-adoption-chart": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -107,7 +107,7 @@ default_manager.add("organizations:performance-ops-breakdown", OrganizationFeatu
 default_manager.add("organizations:performance-tag-explorer", OrganizationFeature, True)  # NOQA
 default_manager.add("organizations:performance-view", OrganizationFeature)  # NOQA
 default_manager.add("organizations:related-events", OrganizationFeature)  # NOQA
-default_manager.add("organizations:release-adoption-chart", OrganizationFeature)  # NOQA
+default_manager.add("organizations:release-adoption-chart", OrganizationFeature, True)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -107,6 +107,7 @@ default_manager.add("organizations:performance-ops-breakdown", OrganizationFeatu
 default_manager.add("organizations:performance-tag-explorer", OrganizationFeature, True)  # NOQA
 default_manager.add("organizations:performance-view", OrganizationFeature)  # NOQA
 default_manager.add("organizations:related-events", OrganizationFeature)  # NOQA
+default_manager.add("organizations:release-adoption-chart", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -281,29 +281,29 @@ class ReleasesList extends AsyncView<Props, State> {
                 <Feature features={['organizations:release-adoption-chart']}>
                   <Projects orgId={organization.slug} slugs={[selectedProject.slug]}>
                     {({projects, initiallyLoaded, fetchError}) => {
-                      const project = projects && projects.length === 1 && projects[0];
-
-                      if (!initiallyLoaded || fetchError) {
-                        return null;
-                      }
+                      const project =
+                        projects && projects.length === 1 ? projects[0] : null;
 
                       if (
-                        project &&
-                        project.hasOwnProperty('features') &&
+                        fetchError ||
+                        !project ||
+                        !project.hasOwnProperty('features') ||
                         !(project as Project).features.includes('releases')
                       ) {
                         return null;
                       }
+
+                      const showPlaceholders = !initiallyLoaded || !isHealthLoading;
 
                       return (
                         <ReleaseAdoptionChart
                           organization={organization}
                           selection={selection}
                           releases={releases}
-                          project={project}
+                          project={project as Project}
                           getHealthData={getHealthData}
                           activeDisplay={activeDisplay}
-                          showHealthPlaceholders={isHealthLoading}
+                          showPlaceholders={showPlaceholders}
                         />
                       );
                     }}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -300,6 +300,7 @@ class ReleasesList extends AsyncView<Props, State> {
                           organization={organization}
                           selection={selection}
                           releases={releases}
+                          project={project}
                           getHealthData={getHealthData}
                           activeDisplay={activeDisplay}
                           showHealthPlaceholders={isHealthLoading}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -4,6 +4,7 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
+import Feature from 'app/components/acl/feature';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -17,8 +18,9 @@ import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
 import space from 'app/styles/space';
-import {GlobalSelection, Organization, Release, ReleaseStatus} from 'app/types';
+import {GlobalSelection, Organization, Project, Release, ReleaseStatus} from 'app/types';
 import {defined} from 'app/utils';
+import Projects from 'app/utils/projects';
 import routeTitleGen from 'app/utils/routeTitle';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -27,6 +29,7 @@ import AsyncView from 'app/views/asyncView';
 import ReleaseArchivedNotice from '../detail/overview/releaseArchivedNotice';
 import ReleaseHealthRequest from '../utils/releaseHealthRequest';
 
+import ReleaseAdoptionChart from './releaseAdoptionChart';
 import ReleaseCard from './releaseCard';
 import ReleaseDisplayOptions from './releaseDisplayOptions';
 import ReleaseLanding from './releaseLanding';
@@ -263,25 +266,68 @@ class ReleasesList extends AsyncView<Props, State> {
         releasesReloading={reloading}
         healthStatsPeriod={location.query.healthStatsPeriod}
       >
-        {({isHealthLoading, getHealthData}) => (
-          <Fragment>
-            {releases.map((release, index) => (
-              <ReleaseCard
-                key={`${release.version}-${release.projects[0].slug}`}
-                activeDisplay={activeDisplay}
-                release={release}
-                organization={organization}
-                location={location}
-                selection={selection}
-                reloading={reloading}
-                showHealthPlaceholders={isHealthLoading}
-                isTopRelease={index === 0}
-                getHealthData={getHealthData}
-              />
-            ))}
-            <Pagination pageLinks={releasesPageLinks} />
-          </Fragment>
-        )}
+        {({isHealthLoading, getHealthData}) => {
+          const selectedProjectId =
+            selection.projects &&
+            selection.projects.length === 1 &&
+            selection.projects[0];
+          const selectedProject = organization.projects.find(
+            p => p.id === `${selectedProjectId}`
+          );
+
+          return (
+            <Fragment>
+              {selectedProject && (
+                <Feature features={['organizations:release-adoption-chart']}>
+                  <Projects orgId={organization.slug} slugs={[selectedProject.slug]}>
+                    {({projects, initiallyLoaded, fetchError}) => {
+                      const project = projects && projects.length === 1 && projects[0];
+
+                      if (!initiallyLoaded || fetchError) {
+                        return null;
+                      }
+
+                      if (
+                        project &&
+                        project.hasOwnProperty('features') &&
+                        !(project as Project).features.includes('releases')
+                      ) {
+                        return null;
+                      }
+
+                      return (
+                        <ReleaseAdoptionChart
+                          organization={organization}
+                          selection={selection}
+                          releases={releases}
+                          getHealthData={getHealthData}
+                          activeDisplay={activeDisplay}
+                          showHealthPlaceholders={isHealthLoading}
+                        />
+                      );
+                    }}
+                  </Projects>
+                </Feature>
+              )}
+
+              {releases.map((release, index) => (
+                <ReleaseCard
+                  key={`${release.version}-${release.projects[0].slug}`}
+                  activeDisplay={activeDisplay}
+                  release={release}
+                  organization={organization}
+                  location={location}
+                  selection={selection}
+                  reloading={reloading}
+                  showHealthPlaceholders={isHealthLoading}
+                  isTopRelease={index === 0}
+                  getHealthData={getHealthData}
+                />
+              ))}
+              <Pagination pageLinks={releasesPageLinks} />
+            </Fragment>
+          );
+        }}
       </ReleaseHealthRequest>
     );
   }

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -27,7 +27,7 @@ type Props = WithRouterProps & {
   project: Project;
   getHealthData: ReleaseHealthRequestRenderProps['getHealthData'];
   activeDisplay: DisplayOption;
-  showHealthPlaceholders: boolean;
+  showPlaceholders: boolean;
 };
 
 type State = {
@@ -91,7 +91,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
 
   render() {
     const {
-      showHealthPlaceholders,
+      showPlaceholders,
       releases,
       project,
       activeDisplay,
@@ -101,7 +101,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
     } = this.props;
     const {start, end, period, utc} = selection.datetime;
 
-    if (showHealthPlaceholders) {
+    if (showPlaceholders) {
       return this.renderEmpty();
     }
 

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -119,12 +119,15 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
         activeDisplay
       );
 
+      const releaseData = timeSeries[0].data;
+      const totalData = timeSeries[1].data;
+
       return {
-        data: timeSeries[0].data.map((d, i) => ({
+        data: releaseData.map((d, i) => ({
           name: d.name,
           value:
-            d.value > 0 && timeSeries[1].data[i].value > 0
-              ? (100 * d.value) / timeSeries[1].data[i].value
+            d.value > 0 && totalData[i].value > 0
+              ? (100 * d.value) / totalData[i].value
               : 0,
         })),
         seriesName: releaseVersion,

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -13,7 +13,7 @@ import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {GlobalSelection, Organization, Release} from 'app/types';
+import {GlobalSelection, Organization, Project, Release} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
 import withApi from 'app/utils/withApi';
 import {DisplayOption} from 'app/views/releases/list/utils';
@@ -24,6 +24,7 @@ type Props = WithRouterProps & {
   organization: Organization;
   selection: GlobalSelection;
   releases: Release[];
+  project: Project;
   getHealthData: ReleaseHealthRequestRenderProps['getHealthData'];
   activeDisplay: DisplayOption;
   showHealthPlaceholders: boolean;
@@ -92,6 +93,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
     const {
       showHealthPlaceholders,
       releases,
+      project,
       activeDisplay,
       router,
       selection,
@@ -103,10 +105,8 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
       return this.renderEmpty();
     }
 
-    const projectId = 11276;
-
     const get24hCountByProject = getHealthData.get24hCountByProject(
-      projectId,
+      Number(project.id),
       activeDisplay
     );
 
@@ -115,7 +115,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
 
       const timeSeries = getHealthData.getTimeSeries(
         releaseVersion,
-        projectId,
+        Number(project.id),
         activeDisplay
       );
 

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -200,8 +200,9 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
         </ChartBody>
         {
           <ChartFooter>
-            {tct('Total Sessions [sessionCount]', {
-              sessionCount: <Count value={get24hCountByProject ?? 0} />,
+            {tct('Total [display] [count]', {
+              display: activeDisplay === DisplayOption.USERS ? 'Users' : 'Sessions',
+              count: <Count value={get24hCountByProject ?? 0} />,
             })}
           </ChartFooter>
         }

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -122,7 +122,10 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
       return {
         data: timeSeries[0].data.map((d, i) => ({
           name: d.name,
-          value: (100 * d.value) / timeSeries[1].data[i].value,
+          value:
+            d.value > 0 && timeSeries[1].data[i].value > 0
+              ? (100 * d.value) / timeSeries[1].data[i].value
+              : 0,
         })),
         seriesName: releaseVersion,
       };


### PR DESCRIPTION
This adds a release adoption chart, data is shown as a percentage. Adoption numbers by release for a project is divided by total numbers for a project, whether it's sessions or users. Tooltip shows top 3 releases at any point and the rest summed up.

[Design](https://www.figma.com/file/HZCnihbjP23L53k3r3TlpD/Handover%3A-Release-Adoption-Chart?node-id=0%3A1)

Display: Sessions
![Screen Shot 2021-05-11 at 11 07 36 AM](https://user-images.githubusercontent.com/15015880/118201540-8b9f1d00-b40c-11eb-8fc8-152028ee9afa.png)

Display: Users
![Screen Shot 2021-05-13 at 4 52 14 PM](https://user-images.githubusercontent.com/15015880/118201534-8510a580-b40c-11eb-8cc0-079e7b171512.png)
