### PR TITLE
feat(perf): Add beta badge to tag explorer

### DIFF
--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Location, LocationDescriptorObject, Query} from 'history';
 
 import {GuideAnchor} from 'app/components/assistant/guideAnchor';
+import FeatureBadge from 'app/components/featureBadge';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumn,
@@ -475,7 +476,12 @@ function TagsHeader(props: HeaderProps) {
 
   return (
     <Header>
-      <SectionHeading>{t('Suspect Tags')}</SectionHeading>
+      <SectionHeading>
+        <div>
+          {t('Suspect Tags')}
+          <FeatureBadge type="beta" noTooltip />
+        </div>
+      </SectionHeading>
       <StyledPagination pageLinks={pageLinks} onCursor={handleCursor} size="small" />
     </Header>
   );


### PR DESCRIPTION
### Summary
Adds a beta badge to the tag explorer to point out that it's a new feature.

### Screenshots
![Screen Shot 2021-05-13 at 11 50 19 AM](https://user-images.githubusercontent.com/6111995/118172790-9d1eff80-b3e1-11eb-8b99-f8b2a6ade157.png)
