### PR TITLE
fix(ui): Avoid level indicators peeking around sticky header

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -358,9 +358,10 @@ const StyledFlex = styled('div')`
   padding-bottom: ${space(1)};
   align-items: center;
   background: ${p => p.theme.backgroundSecondary};
-  border-bottom: 1px solid ${p => p.theme.border};
+  border: 1px solid ${p => p.theme.border};
+  border-top: none;
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
-  margin-bottom: -1px;
+  margin: 0 -1px -1px;
 `;
 
 const ActionsCheckbox = styled('div')`


### PR DESCRIPTION
Small subtle change

Before
![image](https://user-images.githubusercontent.com/1421724/118174869-37804280-b3e4-11eb-92f6-ab3dea340f27.png)

After
![image](https://user-images.githubusercontent.com/1421724/118175178-9d6cca00-b3e4-11eb-89df-84f11095f1ce.png)
