### PR TITLE
feat(alert): Add project breadcrumb to wizard and alert builder

### DIFF
--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -49,12 +49,12 @@ export type CrumbDropdown = {
   /**
    * Items of the crumb dropdown
    */
-  items: BreadcrumbDropdown['props']['items'];
+  items: React.ComponentProps<typeof BreadcrumbDropdown>['items'];
 
   /**
    * Callback function for when an item is selected
    */
-  onSelect: BreadcrumbDropdown['props']['onSelect'];
+  onSelect: React.ComponentProps<typeof BreadcrumbDropdown>['onSelect'];
 };
 
 type Props = React.ComponentPropsWithoutRef<typeof BreadcrumbList> & {

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -7,6 +7,7 @@ import IdBadge from 'app/components/idBadge';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Project} from 'app/types';
+import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
 import recreateRoute from 'app/utils/recreateRoute';
 import withProjects from 'app/utils/withProjects';
 import MenuItem from 'app/views/settings/components/settingsBreadcrumb/menuItem';
@@ -36,6 +37,7 @@ function BuilderBreadCrumbs(props: Props) {
     location,
   } = props;
   const project = projects.find(({slug}) => projectSlug === slug);
+  const isSuperuser = isActiveSuperuser();
 
   const projectCrumbLink = {
     to: `/settings/${orgSlug}/projects/${projectSlug}/`,
@@ -53,21 +55,23 @@ function BuilderBreadCrumbs(props: Props) {
       );
     },
     label: <IdBadge project={project} avatarSize={18} disableLink />,
-    items: projects.map((proj, index) => ({
-      index,
-      value: proj.slug,
-      label: (
-        <MenuItem>
-          <IdBadge
-            project={proj}
-            avatarProps={{consistentWidth: true}}
-            avatarSize={18}
-            disableLink
-          />
-        </MenuItem>
-      ),
-      searchKey: proj.slug,
-    })),
+    items: projects
+      .filter(proj => proj.isMember || isSuperuser)
+      .map((proj, index) => ({
+        index,
+        value: proj.slug,
+        label: (
+          <MenuItem>
+            <IdBadge
+              project={proj}
+              avatarProps={{consistentWidth: true}}
+              avatarSize={18}
+              disableLink
+            />
+          </MenuItem>
+        ),
+        searchKey: proj.slug,
+      })),
   };
   const projectCrumb = canChangeProject ? projectCrumbDropdown : projectCrumbLink;
 

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -1,27 +1,83 @@
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 
-import Breadcrumbs, {Crumb} from 'app/components/breadcrumbs';
+import Breadcrumbs, {Crumb, CrumbDropdown} from 'app/components/breadcrumbs';
+import IdBadge from 'app/components/idBadge';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
+import {Project} from 'app/types';
+import recreateRoute from 'app/utils/recreateRoute';
+import withProjects from 'app/utils/withProjects';
+import MenuItem from 'app/views/settings/components/settingsBreadcrumb/menuItem';
+import {RouteWithName} from 'app/views/settings/components/settingsBreadcrumb/types';
 
 type Props = {
   hasMetricAlerts: boolean;
   orgSlug: string;
   title: string;
   projectSlug: string;
+  projects: Project[];
+  routes: RouteWithName[];
+  location: Location;
   alertName?: string;
+  canChangeProject?: boolean;
 };
 
 function BuilderBreadCrumbs(props: Props) {
-  const {hasMetricAlerts, orgSlug, title, alertName, projectSlug} = props;
-  const crumbs: Crumb[] = [
+  const {
+    orgSlug,
+    title,
+    alertName,
+    projectSlug,
+    projects,
+    routes,
+    canChangeProject,
+    location,
+  } = props;
+  const project = projects.find(({slug}) => projectSlug === slug);
+
+  const projectCrumbLink = {
+    to: `/settings/${orgSlug}/projects/${projectSlug}/`,
+    label: <IdBadge project={project} avatarSize={18} disableLink />,
+    preserveGlobalSelection: true,
+  };
+  const projectCrumbDropdown = {
+    onSelect: ({value}) => {
+      browserHistory.push(
+        recreateRoute('', {
+          routes,
+          params: {orgId: orgSlug, projectId: value},
+          location,
+        })
+      );
+    },
+    label: <IdBadge project={project} avatarSize={18} disableLink />,
+    items: projects.map((proj, index) => ({
+      index,
+      value: proj.slug,
+      label: (
+        <MenuItem>
+          <IdBadge
+            project={proj}
+            avatarProps={{consistentWidth: true}}
+            avatarSize={18}
+            disableLink
+          />
+        </MenuItem>
+      ),
+      searchKey: proj.slug,
+    })),
+  };
+  const projectCrumb = canChangeProject ? projectCrumbDropdown : projectCrumbLink;
+
+  const crumbs: (Crumb | CrumbDropdown)[] = [
     {
-      to: hasMetricAlerts
-        ? `/organizations/${orgSlug}/alerts/`
-        : `/organizations/${orgSlug}/alerts/rules/`,
+      to: `/organizations/${orgSlug}/alerts/rules/`,
       label: t('Alerts'),
       preserveGlobalSelection: true,
     },
+    projectCrumb,
     {
       label: title,
       ...(alertName
@@ -44,4 +100,4 @@ const StyledBreadcrumbs = styled(Breadcrumbs)`
   margin-bottom: ${space(3)};
 `;
 
-export default BuilderBreadCrumbs;
+export default withProjects(BuilderBreadCrumbs);

--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -25,21 +25,20 @@ function AlertBuilderProjectProvider(props: Props) {
   const {children, params, organization, api, ...other} = props;
   const {projectId} = params;
   return (
-    <Projects orgId={organization.slug} slugs={[projectId]}>
+    <Projects orgId={organization.slug} allProjects>
       {({projects, initiallyLoaded, isIncomplete}) => {
         if (!initiallyLoaded) {
           return <LoadingIndicator />;
         }
-        // if loaded, but project fetching states incomplete, project doesn't exist
-        if (isIncomplete) {
+        const project = (projects as Project[]).find(({slug}) => slug === projectId);
+        // if loaded, but project fetching states incomplete or project can't be found, project doesn't exist
+        if (isIncomplete || !project) {
           return (
             <Alert type="warning">
               {t('The project you were looking for was not found.')}
             </Alert>
           );
         }
-        const project = projects[0] as Project;
-
         // fetch members list for mail action fields
         fetchOrgMembers(api, organization.slug, [project.id]);
 

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -73,14 +73,18 @@ class AlertWizard extends Component<Props, State> {
   };
 
   renderCreateAlertButton() {
-    const {organization, project, location} = this.props;
+    const {
+      organization,
+      location,
+      params: {projectId},
+    } = this.props;
     const {alertOption} = this.state;
     const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
     const isMetricAlert = !!metricRuleTemplate;
     const isTransactionDataset = metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
 
     const to = {
-      pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
+      pathname: `/organizations/${organization.slug}/alerts/${projectId}/new/`,
       query: {
         ...(metricRuleTemplate && metricRuleTemplate),
         createFromWizard: true,
@@ -131,7 +135,7 @@ class AlertWizard extends Component<Props, State> {
           >
             <CreateAlertButton
               organization={organization}
-              projectSlug={project.slug}
+              projectSlug={projectId}
               disabled={!hasFeature}
               priority="primary"
               to={to}
@@ -150,6 +154,8 @@ class AlertWizard extends Component<Props, State> {
       hasMetricAlerts,
       organization,
       params: {projectId},
+      routes,
+      location,
     } = this.props;
     const {alertOption} = this.state;
     const title = t('Alert Creation Wizard');
@@ -160,15 +166,18 @@ class AlertWizard extends Component<Props, State> {
 
         <Feature features={['organizations:alert-wizard']}>
           <Layout.Header>
-            <Layout.HeaderContent>
+            <StyledHeaderContent>
               <BuilderBreadCrumbs
                 hasMetricAlerts={hasMetricAlerts}
                 orgSlug={organization.slug}
                 projectSlug={projectId}
                 title={t('Select Alert')}
+                routes={routes}
+                location={location}
+                canChangeProject
               />
               <Layout.Title>{t('Select Alert')}</Layout.Title>
-            </Layout.HeaderContent>
+            </StyledHeaderContent>
           </Layout.Header>
           <StyledLayoutBody>
             <Layout.Main fullWidth>
@@ -225,6 +234,10 @@ class AlertWizard extends Component<Props, State> {
 
 const StyledLayoutBody = styled(Layout.Body)`
   margin-bottom: -${space(3)};
+`;
+
+const StyledHeaderContent = styled(Layout.HeaderContent)`
+  overflow: visible;
 `;
 
 const Styledh2 = styled('h2')`

--- a/static/app/views/settings/projectAlerts/create.tsx
+++ b/static/app/views/settings/projectAlerts/create.tsx
@@ -107,6 +107,7 @@ class Create extends Component<Props, State> {
       project,
       params: {projectId},
       location,
+      routes,
     } = this.props;
     const {alertType, eventView, wizardTemplate} = this.state;
 
@@ -126,21 +127,23 @@ class Create extends Component<Props, State> {
         <SentryDocumentTitle title={title} projectSlug={projectId} />
 
         <Layout.Header>
-          <Layout.HeaderContent>
+          <StyledHeaderContent>
             <BuilderBreadCrumbs
               hasMetricAlerts={hasMetricAlerts}
               orgSlug={organization.slug}
               alertName={t('Set Conditions')}
               title={wizardAlertType ? t('Select Alert') : title}
               projectSlug={projectId}
+              routes={routes}
+              location={location}
+              canChangeProject
             />
-
             <Layout.Title>
               {wizardAlertType
                 ? `${t('Set Conditions for')} ${AlertWizardAlertNames[wizardAlertType]}`
                 : title}
             </Layout.Title>
-          </Layout.HeaderContent>
+          </StyledHeaderContent>
         </Layout.Header>
         <AlertConditionsBody>
           <Layout.Main fullWidth>
@@ -179,6 +182,10 @@ const AlertConditionsBody = styled(Layout.Body)`
   *:not(img) {
     max-width: 1000px;
   }
+`;
+
+const StyledHeaderContent = styled(Layout.HeaderContent)`
+  overflow: visible;
 `;
 
 export default Create;

--- a/static/app/views/settings/projectAlerts/edit.tsx
+++ b/static/app/views/settings/projectAlerts/edit.tsx
@@ -44,7 +44,7 @@ class ProjectAlertsEditor extends Component<Props, State> {
   }
 
   render() {
-    const {hasMetricAlerts, location, organization, project} = this.props;
+    const {hasMetricAlerts, location, organization, project, routes} = this.props;
 
     const alertType = location.pathname.includes('/alerts/metric-rules/')
       ? 'metric'
@@ -64,6 +64,8 @@ class ProjectAlertsEditor extends Component<Props, State> {
               orgSlug={organization.slug}
               title={t('Edit Alert Rule')}
               projectSlug={project.slug}
+              routes={routes}
+              location={location}
             />
             <Layout.Title>{this.getTitle()}</Layout.Title>
           </Layout.HeaderContent>

--- a/tests/js/spec/components/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/breadcrumbs.spec.jsx
@@ -22,6 +22,26 @@ describe('Breadcrumbs', () => {
     />
   );
 
+  const wrapperWithDropdown = shallow(
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: 'dropdown crumb',
+          onSelect: () => {},
+          items: ['item1', 'item2', 'item3'],
+        },
+        {
+          label: 'Test 2',
+          to: '/test2',
+        },
+        {
+          label: 'Test 3',
+          to: null,
+        },
+      ]}
+    />
+  );
+
   it('returns null when 0 crumbs', () => {
     const empty = shallow(<Breadcrumbs crumbs={[]} />);
 
@@ -58,5 +78,14 @@ describe('Breadcrumbs', () => {
     expect(allElements.at(1).is('BreadcrumbDividerIcon')).toBeTruthy();
     expect(allElements.at(3).is('BreadcrumbDividerIcon')).toBeTruthy();
     expect(allElements.at(5).exists()).toBeFalsy();
+  });
+
+  it('renders a crumb dropdown', () => {
+    const allElements = wrapperWithDropdown.find('BreadcrumbList').children();
+    const dropdown = wrapperWithDropdown.find('BreadcrumbDropdown');
+    expect(allElements.at(0).is('BreadcrumbDropdown')).toBeTruthy();
+    expect(allElements.at(1).is('BreadcrumbLink')).toBeTruthy();
+    expect(allElements.at(3).is('BreadcrumbItem')).toBeTruthy();
+    expect(dropdown.exists()).toBeTruthy();
   });
 });

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -168,6 +168,8 @@ describe('ProjectAlertsCreate', function () {
         const {wrapper} = createWrapper({
           organization: {features: ['incidents']},
         });
+        await tick();
+        wrapper.update();
         expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
         expect(wrapper.find('IssueEditor')).toHaveLength(0);
         expect(wrapper.find('IncidentRulesCreate')).toHaveLength(0);
@@ -190,8 +192,10 @@ describe('ProjectAlertsCreate', function () {
     });
 
     describe('Without Metric Alerts', function () {
-      it('loads default values', function () {
+      it('loads default values', async function () {
         const {wrapper} = createWrapper();
+        await tick();
+        wrapper.update();
         expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
         expect(wrapper.find('SelectControl[name="environment"]').prop('value')).toBe(
           '__all_environments__'
@@ -213,6 +217,8 @@ describe('ProjectAlertsCreate', function () {
           method: 'POST',
           body: TestStubs.ProjectAlertRule(),
         });
+        await tick();
+        wrapper.update();
 
         expect(memberActionCreators.fetchOrgMembers).toHaveBeenCalled();
         // Change target environment


### PR DESCRIPTION
Adds a project breadcrumb dropdown to the wizard and alert builder page:

![Kapture 2021-05-13 at 15 34 49](https://user-images.githubusercontent.com/9372512/118177505-c56a2680-b400-11eb-8fc0-f5513287f95e.gif)

![Kapture 2021-05-13 at 15 35 54](https://user-images.githubusercontent.com/9372512/118177628-ef234d80-b400-11eb-8ab0-7d0c1962cb4f.gif)

- Added a new type of crumb (crumbdropdown) to our breadcrumbs component
- Utilizes this new type of crumb in the `BuilderBreadcrumbs` to present the user with a list of projects
- Changes `projectProvider.tsx` to get all projects since the user can switch between projects on the fly now
