### PR TITLE
build(ci): Fix eslint for backend changes

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -80,7 +80,7 @@ jobs:
       # Otherwise... only lint modified files
       # Note `eslint --fix` will not fail when it auto fixes files
       - name: eslint (changed files only)
-        if: steps.eslint.outputs.all-files != 'true'
+        if: steps.changes.outputs.frontend == 'true' && steps.eslint.outputs.all-files != 'true'
         run: |
           yarn eslint --fix ${{ steps.changes.outputs.frontend_modified_lintable_files }}
 


### PR DESCRIPTION
Regressed due to https://github.com/getsentry/sentry/pull/25973 - fixes eslint being run when no frontend files were changed.