### PR TITLE
feat(notifications): Calculate Fallback Settings

### DIFF
--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -58,17 +58,17 @@ class UserEndpoint(Endpoint):
     permission_classes = (UserPermission,)
 
     def convert_args(self, request, user_id, *args, **kwargs):
-        try:
-            if user_id == "me":
-                if not request.user.is_authenticated:
-                    raise ResourceDoesNotExist
-                user_id = request.user.id
+        if user_id == "me":
+            if not request.user.is_authenticated:
+                raise ResourceDoesNotExist
+            user_id = request.user.id
 
+        try:
             user = User.objects.get(id=user_id)
-        except User.DoesNotExist:
+        except (User.DoesNotExist, ValueError):
             raise ResourceDoesNotExist
 
         self.check_object_permissions(request, user)
 
         kwargs["user"] = user
-        return (args, kwargs)
+        return args, kwargs

--- a/src/sentry/api/endpoints/team_notification_settings_details.py
+++ b/src/sentry/api/endpoints/team_notification_settings_details.py
@@ -34,7 +34,7 @@ class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
 
         return Response(
             serialize(
-                team.actor,
+                team,
                 request.user,
                 NotificationSettingsSerializer(),
                 type=type_option,

--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -45,7 +45,7 @@ class UserNotificationSettingsDetailsEndpoint(UserEndpoint):
 
         return Response(
             serialize(
-                user.actor,
+                user,
                 request.user,
                 NotificationSettingsSerializer(),
                 type=type_option,

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -3,8 +3,8 @@ from typing import Any, Iterable, Mapping, MutableMapping, Optional, Set, Union
 
 from sentry.api.serializers import Serializer
 from sentry.models import NotificationSetting, Team, User
-from sentry.notifications.helpers import NOTIFICATION_SETTING_DEFAULTS, get_fallback_settings
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.helpers import get_fallback_settings
+from sentry.notifications.types import VALID_VALUES_FOR_KEY, NotificationSettingTypes
 
 
 class NotificationSettingsSerializer(Serializer):  # type: ignore
@@ -94,9 +94,7 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
         :returns A mapping. See example.
         """
         type_option: Optional[NotificationSettingTypes] = kwargs.get("type")
-        types_to_serialize = (
-            {type_option} if type_option else set(NOTIFICATION_SETTING_DEFAULTS.keys())
-        )
+        types_to_serialize = {type_option} if type_option else set(VALID_VALUES_FOR_KEY.keys())
         user = obj if type(obj) == User else None
 
         data = get_fallback_settings(

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -3,8 +3,8 @@ from typing import Any, Iterable, Mapping, MutableMapping, Optional, Set, Union
 
 from sentry.api.serializers import Serializer
 from sentry.models import NotificationSetting, Team, User
-from sentry.notifications.helpers import get_fallback_settings
-from sentry.notifications.types import NOTIFICATION_SETTING_DEFAULTS, NotificationSettingTypes
+from sentry.notifications.helpers import NOTIFICATION_SETTING_DEFAULTS, get_fallback_settings
+from sentry.notifications.types import NotificationSettingTypes
 
 
 class NotificationSettingsSerializer(Serializer):  # type: ignore

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1366,7 +1366,7 @@ urlpatterns = [
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/notification-settings/$",
                     TeamNotificationSettingsDetailsEndpoint.as_view(),
-                    name="sentry-api-0-user-notification-settings",
+                    name="sentry-api-0-team-notification-settings",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/members/$",

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -1,9 +1,11 @@
 import logging
 from datetime import timedelta
 from enum import IntEnum
+from typing import Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, transaction
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -55,8 +57,23 @@ OrganizationStatus._labels = {
 
 
 class OrganizationManager(BaseManager):
-    # def get_by_natural_key(self, slug):
-    #     return self.get(slug=slug)
+    def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
+        """ Returns the QuerySet of all organizations that a set of Users have access to. """
+        from sentry.models import OrganizationMember
+
+        return self.filter(
+            status=OrganizationStatus.VISIBLE,
+            id__in=OrganizationMember.objects.filter(user_id__in=user_ids).values("organization"),
+        )
+
+    def get_for_team_ids(self, team_ids: Sequence[int]) -> QuerySet:
+        """ Returns the QuerySet of all organizations that a set of Teams have access to. """
+        from sentry.models import Team
+
+        return self.filter(
+            status=OrganizationStatus.VISIBLE,
+            id__in=Team.objects.filter(id__in=team_ids).values("organization"),
+        )
 
     def get_for_user(self, user, scope=None, only_visible=True):
         """

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -247,11 +247,6 @@ class Team(Model):
         return {"id": self.id, "slug": self.slug, "name": self.name, "status": self.status}
 
     def get_projects(self):
-        from sentry.models import Project, ProjectStatus, ProjectTeam
+        from sentry.models import Project
 
-        return Project.objects.filter(
-            status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(
-                team_id=self.id,
-            ).values_list("project_id", flat=True),
-        )
+        return Project.objects.get_for_team_ids({self.id})

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -338,24 +338,14 @@ class User(BaseModel, AbstractBaseUser):
             request.session["_nonce"] = self.session_nonce
 
     def get_orgs(self):
-        from sentry.models import Organization, OrganizationMember, OrganizationStatus
+        from sentry.models import Organization
 
-        return Organization.objects.filter(
-            status=OrganizationStatus.VISIBLE,
-            id__in=OrganizationMember.objects.filter(user=self).values("organization"),
-        )
+        return Organization.objects.get_for_user_ids({self.id})
 
     def get_projects(self):
-        from sentry.models import OrganizationMemberTeam, Project, ProjectStatus, ProjectTeam
+        from sentry.models import Project
 
-        return Project.objects.filter(
-            status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(
-                team_id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user=self
-                ).values_list("team_id", flat=True)
-            ).values_list("project_id", flat=True),
-        )
+        return Project.objects.get_for_user_ids({self.id})
 
     def get_orgs_require_2fa(self):
         from sentry.models import Organization, OrganizationStatus

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -216,7 +216,7 @@ def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
     if type in [NotificationSettingTypes.WORKFLOW, NotificationSettingTypes.ISSUE_ALERTS]:
         return NotificationScopeType.PROJECT
 
-    raise Exception("type must be issue_alert, deploy, or workflow")
+    raise Exception(f"type {type}, must be alerts, deploy, or workflow")
 
 
 def get_scope(

--- a/tests/sentry/api/endpoints/test_team_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_team_notification_settings.py
@@ -1,0 +1,98 @@
+from sentry.models import NotificationSetting
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders
+
+FEATURE_NAMES = [
+    "organizations:notification-platform",
+]
+
+
+class TeamNotificationSettingsTestBase(APITestCase):
+    endpoint = "sentry-api-0-team-notification-settings"
+
+    def setUp(self):
+        self.login_as(self.user)
+        self.org = self.organization  # Force creation.
+        _ = self.project  # Force creation.
+
+
+class UserNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
+    def test_simple(self):
+        with self.feature(FEATURE_NAMES):
+            response = self.get_success_response(self.org.slug, self.team.slug)
+
+        # Spot check.
+        assert response.data["alerts"]["project"][self.project.id]["email"] == "default"
+        assert response.data["deploy"]["organization"][self.org.id]["email"] == "default"
+        assert response.data["workflow"]["project"][self.project.id]["slack"] == "never"
+
+    def test_type_querystring(self):
+        with self.feature(FEATURE_NAMES):
+            response = self.get_success_response(
+                self.org.slug, self.team.slug, qs_params={"type": "workflow"}
+            )
+
+        assert "alerts" not in response.data
+        assert "workflow" in response.data
+
+    def test_invalid_querystring(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response(
+                self.org.slug, self.team.slug, qs_params={"type": "invalid"}, status_code=400
+            )
+
+    def test_invalid_team_slug(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response(self.org.slug, "invalid", status_code=404)
+
+    def test_wrong_team_slug(self):
+        other_org = self.create_organization()
+        other_team = self.create_team(organization=other_org, name="Tesla Motors")
+
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response(other_org.slug, other_team.slug, status_code=403)
+
+
+class UserNotificationSettingsTest(TeamNotificationSettingsTestBase):
+    method = "put"
+
+    def test_simple(self):
+        assert (
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.SLACK,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                team=self.team,
+                project=self.project,
+            )
+            == NotificationSettingOptionValues.DEFAULT
+        )
+
+        with self.feature(FEATURE_NAMES):
+            self.get_success_response(
+                self.org.slug,
+                self.team.slug,
+                **{
+                    "alerts": {"project": {self.project.id: {"email": "always", "slack": "always"}}}
+                },
+            )
+
+        assert (
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.SLACK,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                team=self.team,
+                project=self.project,
+            )
+            == NotificationSettingOptionValues.ALWAYS
+        )
+
+    def test_empty_payload(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response(self.org.slug, self.team.slug, **{}, status_code=400)
+
+    def test_invalid_payload(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response(
+                self.org.slug, self.team.slug, **{"invalid": 1}, status_code=400
+            )

--- a/tests/sentry/api/endpoints/test_team_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_team_notification_settings.py
@@ -17,7 +17,7 @@ class TeamNotificationSettingsTestBase(APITestCase):
         _ = self.project  # Force creation.
 
 
-class UserNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
+class TeamNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
     def test_simple(self):
         with self.feature(FEATURE_NAMES):
             response = self.get_success_response(self.org.slug, self.team.slug)
@@ -25,7 +25,7 @@ class UserNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
         # Spot check.
         assert response.data["alerts"]["project"][self.project.id]["email"] == "default"
         assert response.data["deploy"]["organization"][self.org.id]["email"] == "default"
-        assert response.data["workflow"]["project"][self.project.id]["slack"] == "never"
+        assert response.data["workflow"]["project"][self.project.id]["slack"] == "default"
 
     def test_type_querystring(self):
         with self.feature(FEATURE_NAMES):
@@ -54,7 +54,7 @@ class UserNotificationSettingsGetTest(TeamNotificationSettingsTestBase):
             self.get_error_response(other_org.slug, other_team.slug, status_code=403)
 
 
-class UserNotificationSettingsTest(TeamNotificationSettingsTestBase):
+class TeamNotificationSettingsTest(TeamNotificationSettingsTestBase):
     method = "put"
 
     def test_simple(self):

--- a/tests/sentry/api/endpoints/test_user_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings.py
@@ -1,0 +1,84 @@
+from sentry.models import NotificationSetting
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders
+
+FEATURE_NAMES = [
+    "organizations:notification-platform",
+]
+
+
+class UserNotificationSettingsTestBase(APITestCase):
+    endpoint = "sentry-api-0-user-notification-settings"
+
+    def setUp(self):
+        self.login_as(self.user)
+        self.org = self.organization  # Force creation.
+
+
+class UserNotificationSettingsGetTest(UserNotificationSettingsTestBase):
+    def test_simple(self):
+        with self.feature(FEATURE_NAMES):
+            response = self.get_success_response("me")
+
+        # Spot check.
+        assert response.data["alerts"]["user"][self.user.id]["email"] == "always"
+        assert response.data["deploy"]["organization"][self.org.id]["email"] == "default"
+        assert response.data["workflow"]["user"][self.user.id]["slack"] == "never"
+
+    def test_type_querystring(self):
+        with self.feature(FEATURE_NAMES):
+            response = self.get_success_response("me", qs_params={"type": "workflow"})
+
+        assert "alerts" not in response.data
+        assert "workflow" in response.data
+
+    def test_invalid_querystring(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response("me", qs_params={"type": "invalid"}, status_code=400)
+
+    def test_invalid_user_id(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response("invalid", status_code=404)
+
+    def test_wrong_user_id(self):
+        other_user = self.create_user("bizbaz@example.com")
+
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response(other_user.id, status_code=403)
+
+
+class UserNotificationSettingsTest(UserNotificationSettingsTestBase):
+    method = "put"
+
+    def test_simple(self):
+        assert (
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.SLACK,
+                type=NotificationSettingTypes.DEPLOY,
+                user=self.user,
+            )
+            == NotificationSettingOptionValues.DEFAULT
+        )
+
+        with self.feature(FEATURE_NAMES):
+            self.get_success_response(
+                "me", **{"deploy": {"user": {"me": {"email": "always", "slack": "always"}}}}
+            )
+
+        assert (
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.SLACK,
+                type=NotificationSettingTypes.DEPLOY,
+                user=self.user,
+            )
+            == NotificationSettingOptionValues.ALWAYS
+        )
+
+    def test_empty_payload(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response("me", **{}, status_code=400)
+
+    def test_invalid_payload(self):
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response("me", **{"invalid": 1}, status_code=400)

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -46,6 +46,15 @@ class TeamTest(TestCase):
 
         assert member not in team.member_set.all()
 
+    def test_get_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        project = self.create_project(teams=[team], name="name")
+
+        projects = team.get_projects()
+        assert {_.id for _ in projects} == {project.id}
+
 
 class TransferTest(TestCase):
     def test_simple(self):

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -1,5 +1,28 @@
-from sentry.models import Authenticator, OrganizationMember, User, UserEmail
+from sentry.models import Authenticator, OrganizationMember, OrganizationMemberTeam, User, UserEmail
 from sentry.testutils import TestCase
+
+
+class UserTest(TestCase):
+    def test_get_orgs(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        member = OrganizationMember.objects.get(user=user, organization=org)
+        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
+
+        organizations = user.get_orgs()
+        assert {_.id for _ in organizations} == {org.id}
+
+    def test_get_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        member = OrganizationMember.objects.get(user=user, organization=org)
+        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
+        project = self.create_project(teams=[team], name="name")
+
+        projects = user.get_projects()
+        assert {_.id for _ in projects} == {project.id}
 
 
 class UserDetailsTest(TestCase):

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -2,6 +2,7 @@ from sentry.models import NotificationSetting
 from sentry.notifications.helpers import (
     _get_setting_mapping_from_mapping,
     collect_groups_by_project,
+    get_fallback_settings,
     get_groups_for_query,
     get_scope,
     get_scope_type,
@@ -340,5 +341,34 @@ class NotificationHelpersTest(TestCase):
         assert get_settings_by_provider(settings) == {
             ExternalProviders.EMAIL: {
                 NotificationScopeType.USER: NotificationSettingOptionValues.NEVER
+            }
+        }
+
+    def test_get_fallback_settings_minimal(self):
+        assert get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {}, {}) == {}
+
+    def test_get_fallback_settings_user(self):
+        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {}, {}, self.user)
+        assert data == {
+            "alerts": {
+                "user": {
+                    self.user.id: {
+                        "email": "always",
+                        "slack": "never",
+                    }
+                }
+            }
+        }
+
+    def test_get_fallback_settings_projects(self):
+        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {self.project}, {})
+        assert data == {
+            "alerts": {
+                "project": {
+                    self.project.id: {
+                        "email": "default",
+                        "slack": "never",
+                    }
+                }
             }
         }

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -367,7 +367,7 @@ class NotificationHelpersTest(TestCase):
                 "project": {
                     self.project.id: {
                         "email": "default",
-                        "slack": "never",
+                        "slack": "default",
                     }
                 }
             }


### PR DESCRIPTION
Currently the serializer that the GET APIs use dumbly forwards the DB Rows and a nested object. The DB only stores the project/organizations that differ from the user's default setting to save space. We need to update the serializer to take all of the user's projects and/or organizations and calculate their implied values (which will be a lot of "default"s and "never"s). This takes some pressure off the frontend to pull down these lists and recalculate but also greatly simplifies the javascript we have to write and test.

