### PR TITLE
ref(acls): try deferring to access logic for proj permissions

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -1,17 +1,13 @@
 from rest_framework.response import Response
 
-from sentry import roles
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ProjectMoved, ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
 from sentry.api.utils import InvalidParams, get_date_range_from_params
-from sentry.auth.superuser import is_active_superuser
-from sentry.auth.system import is_system_auth
-from sentry.models import OrganizationMember, Project, ProjectRedirect, ProjectStatus, SentryApp
+from sentry.models import Project, ProjectRedirect, ProjectStatus
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 from .organization import OrganizationPermission
-from .team import has_team_permission
 
 
 class ProjectEventsError(Exception):
@@ -28,38 +24,12 @@ class ProjectPermission(OrganizationPermission):
 
     def has_object_permission(self, request, view, project):
         result = super().has_object_permission(request, view, project.organization)
-
         if not result:
             return result
-        if project.teams.exists():
-            return any(
-                has_team_permission(request, team, self.scope_map) for team in project.teams.all()
-            )
-        elif is_system_auth(request.auth):
-            return True
-        elif request.user and request.user.is_authenticated:
-            # this is only for team-less projects
-            if is_active_superuser(request):
-                return True
-            elif request.user.is_sentry_app:
-                return SentryApp.check_project_permission_for_sentry_app_user(request.user, project)
-            try:
-                role = (
-                    OrganizationMember.objects.filter(
-                        organization=project.organization, user=request.user
-                    )
-                    .values_list("role", flat=True)
-                    .get()
-                )
-            except OrganizationMember.DoesNotExist:
-                # this should probably never happen?
-                return False
 
-            return roles.get(role).is_global
-        elif hasattr(request.auth, "project_id") and project.id == request.auth.project_id:
-            return True
+        allowed_scopes = set(self.scope_map.get(request.method, []))
 
-        return False
+        return any(request.access.has_project_scope(project, s) for s in allowed_scopes)
 
 
 class StrictProjectPermission(ProjectPermission):

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -321,9 +321,9 @@ def _from_sentry_app(user, organization=None):
 
     team_list = list(Team.objects.filter(organization=organization))
     project_list = list(
-        Project.objects.filter(status=ProjectStatus.VISIBLE, teams__in=team_list).distinct()
+        Project.objects.filter(status=ProjectStatus.VISIBLE, organization=organization).distinct()
     )
-
+    # TODO: set has_global_access to true instead of grabbing all projects above?
     return Access(
         scopes=sentry_app.scope_list,
         is_active=True,

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -135,15 +135,6 @@ class SentryApp(ParanoidModel, HasApiScopes):
 
         return cls.objects.filter(status=SentryAppStatus.PUBLISHED)
 
-    # this method checks if a user from a sentry app has permission to a specific project
-    # for now, only checks if app is installed on the org of the project
-    @classmethod
-    def check_project_permission_for_sentry_app_user(cls, user, project):
-        assert user.is_sentry_app
-        # if the user exists, so should the sentry_app
-        sentry_app = cls.objects.get(proxy_user=user)
-        return sentry_app.is_installed_on(project.organization)
-
     @property
     def is_published(self):
         return self.status == SentryAppStatus.PUBLISHED

--- a/tests/sentry/api/bases/test_project.py
+++ b/tests/sentry/api/bases/test_project.py
@@ -47,6 +47,15 @@ class ProjectPermissionTest(ProjectPermissionBase):
         self.create_member(user=user, organization=self.org, role="member", teams=[self.team])
         assert self.has_object_perm("GET", self.project, user=user)
 
+    def test_member_project_no_teams(self):
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=self.org, role="member", teams=[])
+        project = self.create_project(teams=[self.team])
+        self.team.delete()
+        # if `allow_joinleave` is True, members should be able to GET a project even if
+        # it has no teams
+        assert self.has_object_perm("GET", project, user=user)
+
     def test_api_key_with_org_access(self):
         key = ApiKey.objects.create(organization=self.org, scope_list=["project:read"])
         assert self.has_object_perm("GET", self.project, auth=key)
@@ -178,6 +187,19 @@ class ProjectPermissionNoJoinLeaveTest(ProjectPermissionBase):
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=self.org, role="member", teams=[self.team])
         assert self.has_object_perm("GET", self.project, user=user)
+
+    def test_member_without_team_access(self):
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=self.org, role="member", teams=[])
+        assert not self.has_object_perm("GET", self.project, user=user)
+
+    def test_member_project_no_teams(self):
+        user = self.create_user(is_superuser=False)
+        self.create_member(user=user, organization=self.org, role="member", teams=[])
+        project = self.create_project(teams=[self.team])
+        self.team.delete()
+        # if `allow_joinleave` is False, members cannot GET a project with no teams
+        assert not self.has_object_perm("GET", project, user=user)
 
     def test_api_key_with_org_access(self):
         key = ApiKey.objects.create(organization=self.org, scope_list=["project:read"])

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -303,7 +303,8 @@ class FromSentryAppTest(TestCase):
         result = access.from_request(request, self.org)
         assert result.has_project_access(project) is False
         assert result.has_project_membership(project) is False
-        assert len(result.projects) == 1
+        # the create_app fixture creates a project that has no teams assigned
+        assert len(result.projects) == 2
         assert list(result.projects)[0].id == self.project.id
 
 

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -303,9 +303,8 @@ class FromSentryAppTest(TestCase):
         result = access.from_request(request, self.org)
         assert result.has_project_access(project) is False
         assert result.has_project_membership(project) is False
-        # the create_app fixture creates a project that has no teams assigned
         assert len(result.projects) == 2
-        assert list(result.projects)[0].id == self.project.id
+        assert self.project.id in [p.id for p in result.projects]
 
 
 class DefaultAccessTest(TestCase):

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -111,4 +111,4 @@ class BuiltinReleaseWebhookTest(ReleaseWebhookTestBase):
     def test_no_teams_and_no_user(self):
         self.project.remove_team(self.team)
         resp = self.client.post(self.path, user=None, content_type="application/json")
-        assert resp.status_code == 403
+        assert resp.status_code == 403  # TODO: confirm this is actually not expected behavior


### PR DESCRIPTION
Refactors ProjectPermissions to rely on the access object `has_project_scope` method for scope checking instead of checking team relations and other various logic. the noted behavior changes are:

- if a project does not belong to any teams, if a user has member permissions and their org is open membership, they will be able to see the project now
- the behavior of SentryApp's project permissions and handling global_access seemed inconsistent. was this on purpose?
    - in the project endpoint permission we call `check_project_permission_for_sentry_app_user` which just makes sure the app is installed on that org, and if yes returns true. this means regardless of global_access an app has access to all projects here
    - in `_from_sentry_app` in access we set global access to False. This meant that even if allow_joinleave were true for the org, sentryapps that relied on this permission would not have global access.
    - we'll now grab all projects in the `_from_sentry_app` function instead of only projects with teams so behavior is now consistent.
- there is an instance of us creating a ["god" api key (lol)](https://github.com/getsentry/sentry/blob/af33225197507a01c925f6d551dd786abe9fcaed/src/sentry/web/frontend/release_webhook.py#L51) that in theory it should have global org access, but the previous project logic had it 403 if there were no teams. I'm assuming this change is innocuous, but it broke a test.