### PR TITLE
fix(perf): Allow limit on tags page histogram query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -174,6 +174,8 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
                 on_results=lambda results: self.handle_results_with_meta(
                     request, organization, params["project_id"], results
                 ),
+                default_per_page=5,
+                max_per_page=10,
             )
 
 
@@ -350,6 +352,7 @@ def query_facet_performance_key_histogram(
     filter_query: Optional[str] = None,
     orderby: Optional[str] = None,
     referrer: Optional[str] = None,
+    limit: Optional[int] = None,
 ) -> Dict:
     precision = 0
     num_buckets = 100
@@ -365,6 +368,7 @@ def query_facet_performance_key_histogram(
         min_value=min_value,
         max_value=max_value,
         referrer="api.organization-events-facets-performance-histogram",
+        limit_by=[limit, "tags_key"] if limit else None,
         group_by=["tags_value", "tags_key"],
         extra_conditions=[["tags_key", "IN", [tag_key]]],
         normalize_results=False,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -781,6 +781,7 @@ def histogram_query(
     data_filter=None,
     referrer=None,
     group_by=None,
+    limit_by=None,
     extra_conditions=None,
     normalize_results=True,
 ):
@@ -803,6 +804,7 @@ def histogram_query(
         If left unspecified, it is queried using `user_query` and `params`.
     :param str data_filter: Indicate the filter strategy to be applied to the data.
     :param [str] group_by: Experimental. Allows additional grouping to serve multifacet histograms.
+    :param [str] limit_by: Experimental. Allows limiting within a group when serving multifacet histograms.
     :param [str] extra_conditions: Adds any additional conditions to the histogram query that aren't received from params.
     :param bool normalize_results: Indicate whether to normalize the results by column into bins.
     """
@@ -884,6 +886,7 @@ def histogram_query(
         having=snuba_filter.having,
         orderby=snuba_filter.orderby,
         dataset=Dataset.Discover,
+        limitby=limit_by,
         limit=limit,
         referrer=referrer,
     )


### PR DESCRIPTION
### Summary
Previously it was returning a histogram for all the tag values, which is excessive. This will allow also passing a limit through the endpoint to histogram_query, and set the default to reasonable amount.