### PR TITLE
feat(group-breakdown): Splitting moves events

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -83,7 +83,9 @@ class EventStream(Service):
     def end_merge(self, state):
         pass
 
-    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
+    def start_unmerge(
+        self, project_id, hashes, hierarchical_hashes, previous_group_id, new_group_id
+    ):
         pass
 
     def end_unmerge(self, state):

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -169,8 +169,10 @@ class SnubaProtocolEventStream(EventStream):
         state["datetime"] = datetime.now(tz=pytz.utc)
         self._send(state["project_id"], "end_merge", extra_data=(state,), asynchronous=False)
 
-    def start_unmerge(self, project_id, hashes, previous_group_id, new_group_id):
-        if not hashes:
+    def start_unmerge(
+        self, project_id, hashes, hierarchical_hashes, previous_group_id, new_group_id
+    ):
+        if not hashes and not hierarchical_hashes:
             return
 
         state = {
@@ -179,6 +181,7 @@ class SnubaProtocolEventStream(EventStream):
             "previous_group_id": previous_group_id,
             "new_group_id": new_group_id,
             "hashes": list(hashes),
+            "hierarchical_hashes": dict(hierarchical_hashes),
             "datetime": datetime.now(tz=pytz.utc),
         }
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -279,7 +279,11 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
         with self.tasks():
             eventstream_state = eventstream.start_unmerge(
-                project.id, [list(events.keys())[0]], source.id, destination.id
+                project.id,
+                [list(events.keys())[0]],
+                {},
+                source.id,
+                destination.id,
             )
             unmerge.delay(
                 project.id, source.id, destination.id, [list(events.keys())[0]], None, batch_size=5


### PR DESCRIPTION
When https://github.com/getsentry/snuba/pull/1876 lands, Sentry will be able to move existing events into subgroups instead of just applying the split to future events.

Marked as draft as long as Snuba API is not finalized.