### PR TITLE
feat(alert): Allow custom metric to change dataset

### DIFF
--- a/static/app/views/settings/incidentRules/constants.tsx
+++ b/static/app/views/settings/incidentRules/constants.tsx
@@ -65,10 +65,10 @@ export function getWizardAlertFieldConfig(
   alertType: AlertType,
   dataset: Dataset
 ): OptionConfig {
-  // If user selected apdex we must include that in the OptionConfig as it has a user specified column
   if (alertType === 'custom' && dataset === Dataset.ERRORS) {
     return errorFieldConfig;
   }
+  // If user selected apdex we must include that in the OptionConfig as it has a user specified column
   const aggregations =
     alertType === 'apdex' || alertType === 'custom'
       ? allAggregations

--- a/static/app/views/settings/incidentRules/constants.tsx
+++ b/static/app/views/settings/incidentRules/constants.tsx
@@ -61,8 +61,14 @@ const allAggregations: AggregationKey[] = [
   'count',
 ];
 
-export function getWizardAlertFieldConfig(alertType: AlertType): OptionConfig {
+export function getWizardAlertFieldConfig(
+  alertType: AlertType,
+  dataset: Dataset
+): OptionConfig {
   // If user selected apdex we must include that in the OptionConfig as it has a user specified column
+  if (alertType === 'custom' && dataset === Dataset.ERRORS) {
+    return errorFieldConfig;
+  }
   const aggregations =
     alertType === 'apdex' || alertType === 'custom'
       ? allAggregations

--- a/static/app/views/settings/incidentRules/metricField.tsx
+++ b/static/app/views/settings/incidentRules/metricField.tsx
@@ -57,7 +57,7 @@ const getFieldOptionConfig = ({
   let hidePrimarySelector = false;
   let hideParameterSelector = false;
   if (organization.features.includes('alert-wizard') && alertType) {
-    config = getWizardAlertFieldConfig(alertType);
+    config = getWizardAlertFieldConfig(alertType, dataset);
     hidePrimarySelector = hidePrimarySelectorSet.has(alertType);
     hideParameterSelector = hideParameterSelectorSet.has(alertType);
   } else {

--- a/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -132,6 +132,18 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
       },
     ];
 
+    if (organization.features.includes('performance-view') && alertType === 'custom') {
+      dataSourceOptions.push({
+        label: t('Transactions'),
+        options: [
+          {
+            value: Datasource.TRANSACTION,
+            label: DATA_SOURCE_LABELS[Datasource.TRANSACTION],
+          },
+        ],
+      });
+    }
+
     const formElemBaseStyle = {
       padding: `${space(0.5)}`,
       border: 'none',

--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -717,7 +717,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       disabled={!hasAccess || !canEdit}
                       thresholdChart={wizardBuilderChart}
                       onFilterSearch={this.handleFilterUpdate}
-                      allowChangeEventTypes={dataset === Dataset.ERRORS}
+                      allowChangeEventTypes={isCustomMetric || dataset === Dataset.ERRORS}
                       alertType={isCustomMetric ? 'custom' : alertType}
                     />
                     <AlertListItem>{t('Set thresholds to trigger alert')}</AlertListItem>


### PR DESCRIPTION
Adds the data source dropdown to the alert builder for custom metric alerts. 
- Added in `transaction` as an option
- Added additional logic to the metric field config function to be able to get a list of options for when errors is selected as the dataset.

![Kapture 2021-05-14 at 14 23 50](https://user-images.githubusercontent.com/9372512/118312874-0aa15d80-b4c0-11eb-89a7-db68b7700638.gif)
