### PR TITLE
fix(ui) Handle globals beacon errors

### DIFF
--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -68,15 +68,19 @@ const makeBeaconRequest = throttle(
 
     const components = _beaconComponents;
     _beaconComponents = [];
-    await api.requestPromise('/api/0/internal/beacon/', {
-      method: 'POST',
-      data: {
-        batch_data: components.map(component => ({
-          description: 'SentryApp',
-          component,
-        })),
-      },
-    });
+    try {
+      await api.requestPromise('/api/0/internal/beacon/', {
+        method: 'POST',
+        data: {
+          batch_data: components.map(component => ({
+            description: 'SentryApp',
+            component,
+          })),
+        },
+      });
+    } catch (e) {
+      // Delicious failure.
+    }
   },
   5000,
   {trailing: true, leading: false}


### PR DESCRIPTION
When a globals usage beacon fails we shouldn't have an unhandled error. These errors can come up in local development when using getsentry and make using the app hard as the error overlay from webpack keeps popping up.