### PR TITLE
ref(custom-scm): Add CUSTOM provider to endpoint

### DIFF
--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -20,6 +20,7 @@ AVAILABLE_PROVIDERS = {
     ExternalProviders.GITHUB,
     ExternalProviders.GITLAB,
     ExternalProviders.SLACK,
+    ExternalProviders.CUSTOM,
 }
 
 


### PR DESCRIPTION
Maybe should have just been part of https://github.com/getsentry/sentry/pull/26043, but this just makes sure it's valid to create external user and teams for the Custom SCM integrations. 