### PR TITLE
fix(notifications): Get all of a user's projects

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -1,9 +1,11 @@
 import logging
 from datetime import timedelta
 from enum import IntEnum
+from typing import Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, transaction
+from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -55,8 +57,23 @@ OrganizationStatus._labels = {
 
 
 class OrganizationManager(BaseManager):
-    # def get_by_natural_key(self, slug):
-    #     return self.get(slug=slug)
+    def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
+        """ Returns the QuerySet of all organizations that a set of Users have access to. """
+        from sentry.models import OrganizationMember
+
+        return self.filter(
+            status=OrganizationStatus.VISIBLE,
+            id__in=OrganizationMember.objects.filter(user_id__in=user_ids).values("organization"),
+        )
+
+    def get_for_team_ids(self, team_ids: Sequence[int]) -> QuerySet:
+        """ Returns the QuerySet of all organizations that a set of Teams have access to. """
+        from sentry.models import Team
+
+        return self.filter(
+            status=OrganizationStatus.VISIBLE,
+            id__in=Team.objects.filter(id__in=team_ids).values("organization"),
+        )
 
     def get_for_user(self, user, scope=None, only_visible=True):
         """

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -53,15 +53,11 @@ class ProjectTeam(Model):
 class ProjectManager(BaseManager):
     def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
         """ Returns the QuerySet of all projects that a set of Users have access to. """
-        from sentry.models import OrganizationMemberTeam, ProjectStatus, ProjectTeam
+        from sentry.models import ProjectStatus
 
         return self.filter(
             status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(
-                team_id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user_id__in=user_ids
-                ).values_list("team_id", flat=True)
-            ).values_list("project_id", flat=True),
+            teams__organizationmember__user_id__in=user_ids,
         )
 
     def get_for_team_ids(self, team_ids: Sequence[int]) -> QuerySet:

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -247,11 +247,6 @@ class Team(Model):
         return {"id": self.id, "slug": self.slug, "name": self.name, "status": self.status}
 
     def get_projects(self):
-        from sentry.models import Project, ProjectStatus, ProjectTeam
+        from sentry.models import Project
 
-        return Project.objects.filter(
-            status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(
-                team_id=self.id,
-            ).values_list("project_id", flat=True),
-        )
+        return Project.objects.get_for_team_ids({self.id})

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -338,24 +338,14 @@ class User(BaseModel, AbstractBaseUser):
             request.session["_nonce"] = self.session_nonce
 
     def get_orgs(self):
-        from sentry.models import Organization, OrganizationMember, OrganizationStatus
+        from sentry.models import Organization
 
-        return Organization.objects.filter(
-            status=OrganizationStatus.VISIBLE,
-            id__in=OrganizationMember.objects.filter(user=self).values("organization"),
-        )
+        return Organization.objects.get_for_user_ids({self.id})
 
     def get_projects(self):
-        from sentry.models import OrganizationMemberTeam, Project, ProjectStatus, ProjectTeam
+        from sentry.models import Project
 
-        return Project.objects.filter(
-            status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(
-                team_id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user=self
-                ).values_list("team_id", flat=True)
-            ).values_list("project_id", flat=True),
-        )
+        return Project.objects.get_for_user_ids({self.id})
 
     def get_orgs_require_2fa(self):
         from sentry.models import Organization, OrganizationStatus

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -46,6 +46,15 @@ class TeamTest(TestCase):
 
         assert member not in team.member_set.all()
 
+    def test_get_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        project = self.create_project(teams=[team], name="name")
+
+        projects = team.get_projects()
+        assert {_.id for _ in projects} == {project.id}
+
 
 class TransferTest(TestCase):
     def test_simple(self):

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -1,5 +1,28 @@
-from sentry.models import Authenticator, OrganizationMember, User, UserEmail
+from sentry.models import Authenticator, OrganizationMember, OrganizationMemberTeam, User, UserEmail
 from sentry.testutils import TestCase
+
+
+class UserTest(TestCase):
+    def test_get_orgs(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        member = OrganizationMember.objects.get(user=user, organization=org)
+        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
+
+        organizations = user.get_orgs()
+        assert {_.id for _ in organizations} == {org.id}
+
+    def test_get_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        team = self.create_team(organization=org)
+        member = OrganizationMember.objects.get(user=user, organization=org)
+        OrganizationMemberTeam.objects.create(organizationmember=member, team=team)
+        project = self.create_project(teams=[team], name="name")
+
+        projects = user.get_projects()
+        assert {_.id for _ in projects} == {project.id}
 
 
 class UserDetailsTest(TestCase):


### PR DESCRIPTION
The current implementation of `.get_projects` in the User model has pretty complicated logic. It gets all projects for all teams that the user is a member of. When the project has no teams, this breaks down.