### PR TITLE
fix(test): Fix framer motion during acceptance

### DIFF
--- a/static/app/utils/testableTransition.tsx
+++ b/static/app/utils/testableTransition.tsx
@@ -18,9 +18,8 @@ import {IS_ACCEPTANCE_TEST} from 'app/constants';
  */
 const testableTransition = !IS_ACCEPTANCE_TEST
   ? (t?: Transition) => t
-  : function (transition?: Transition): Transition {
+  : function (): Transition {
       return {
-        ...transition,
         delay: 0,
         staggerChildren: 0,
         type: false,


### PR DESCRIPTION
### Summary
This stops props being passed to the transition which can override the 0
delay on the animation.