### PR TITLE
fix(visibility): Fix echart options bug

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -249,7 +249,6 @@ function BaseChartUnwrapped({
   previousPeriod,
   echartsTheme,
   devicePixelRatio,
-  visualMap,
 
   showTimeInTooltip,
   useShortDate,
@@ -384,8 +383,6 @@ function BaseChartUnwrapped({
     dataZoom,
     graphic,
   };
-
-  chartOption.visualMap = visualMap as EChartOption.VisualMap[]; // TODO(ts): EChart types only allow an array whereas echart options accepts a single visual map object.
 
   const chartStyles = {
     height: getDimensionValue(height),

--- a/static/app/components/charts/heatMapChart.tsx
+++ b/static/app/components/charts/heatMapChart.tsx
@@ -1,3 +1,5 @@
+import './components/visualMap';
+
 import * as React from 'react';
 import {EChartOption} from 'echarts';
 
@@ -16,14 +18,18 @@ export type LineChartSeries = Series &
 type Props = Omit<ChartProps, 'series'> & {
   series: LineChartSeries[];
   seriesOptions?: EChartOption.SeriesHeatmap;
+  visualMaps: EChartOption.VisualMap[];
 };
 
 export default class HeatMapChart extends React.Component<Props> {
   render() {
-    const {series, seriesOptions, ...props} = this.props;
+    const {series, seriesOptions, visualMaps, ...props} = this.props;
 
     return (
       <BaseChart
+        options={{
+          visualMap: visualMaps,
+        }}
         {...props}
         series={series.map(({seriesName, data, dataArray, ...options}) =>
           HeatMapSeries({

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -110,7 +110,17 @@ const TagsHeatMap = (
         alignWithLabel: true,
       },
     } as any, // TODO(k-fish): Expand typing to allow data option
-    visualMap: {
+
+    grid: {
+      left: space(3),
+      right: space(3),
+      top: space(3),
+      bottom: space(4),
+    },
+  };
+
+  const visualMaps = [
+    {
       min: 0,
       max: maxCount,
       show: false,
@@ -120,14 +130,7 @@ const TagsHeatMap = (
         color: purples,
       },
     } as EChartOption.VisualMap,
-
-    grid: {
-      left: space(3),
-      right: space(3),
-      top: space(3),
-      bottom: space(4),
-    },
-  };
+  ];
 
   const series: Series[] = [];
 
@@ -164,7 +167,7 @@ const TagsHeatMap = (
       <TransitionChart loading={loading} reloading={reloading}>
         <TransparentLoadingMask visible={reloading} />
 
-        <HeatMapChart series={series} {...chartOptions} />
+        <HeatMapChart visualMaps={visualMaps} series={series} {...chartOptions} />
       </TransitionChart>
     </StyledPanel>
   );


### PR DESCRIPTION
### Summary
WorldMapChart was previously using BaseChart's options to pass in VisualMap, but the changes to add HeatMap changed baseChart to accept visualMap as a prop. Unfortunately this had the side effect of declaring the visualMap as undefined for WorldMapChart.