### PR TITLE
fix(notifications): Slack Notification Settings Fallbacks

### DIFF
--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -130,13 +130,6 @@ VALID_VALUES_FOR_KEY = {
 }
 
 
-NOTIFICATION_SETTING_DEFAULTS = {
-    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.COMMITTED_ONLY,
-    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-}
-
-
 class GroupSubscriptionReason:
     implicit = -1  # not for use as a persisted field value
     committed = -2  # not for use as a persisted field value

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -14,8 +14,8 @@ from sentry.models import (
     UserOption,
 )
 from sentry.notifications.helpers import (
-    get_deploy_values_by_provider,
     get_settings_by_provider,
+    get_values_by_provider_by_type,
     transform_to_notification_settings_by_user,
 )
 from sentry.notifications.notify import notification_providers
@@ -117,8 +117,10 @@ def get_participants_for_release(
     ] = defaultdict(dict)
     for user in users:
         notification_settings_by_scope = notification_settings_by_user.get(user, {})
-        values_by_provider = get_deploy_values_by_provider(
-            notification_settings_by_scope, notification_providers()
+        values_by_provider = get_values_by_provider_by_type(
+            notification_settings_by_scope,
+            notification_providers(),
+            NotificationSettingTypes.DEPLOY,
         )
         for provider, value in values_by_provider.items():
             reason_option = get_reason(user, value, user_ids)

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -2,7 +2,6 @@ from sentry.models import NotificationSetting
 from sentry.notifications.helpers import (
     _get_setting_mapping_from_mapping,
     collect_groups_by_project,
-    get_deploy_values_by_provider,
     get_groups_for_query,
     get_scope,
     get_scope_type,
@@ -10,6 +9,7 @@ from sentry.notifications.helpers import (
     get_subscription_from_attributes,
     get_target_id,
     get_user_subscriptions_for_groups,
+    get_values_by_provider_by_type,
     should_be_participating,
     transform_to_notification_settings_by_parent_id,
     transform_to_notification_settings_by_user,
@@ -147,20 +147,31 @@ class NotificationHelpersTest(TestCase):
             == [ExternalProviders.EMAIL]
         )
 
+    def test_get_deploy_values_by_provider_empty_settings(self):
+        values_by_provider = get_values_by_provider_by_type(
+            {}, notification_providers(), NotificationSettingTypes.DEPLOY
+        )
+        assert values_by_provider == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }
+
     def test_get_deploy_values_by_provider(self):
         notification_settings_by_scope = {
             NotificationScopeType.ORGANIZATION: {
-                ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY
+                ExternalProviders.SLACK: NotificationSettingOptionValues.COMMITTED_ONLY
             },
             NotificationScopeType.USER: {
                 ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
             },
         }
-        values_by_provider = get_deploy_values_by_provider(
-            notification_settings_by_scope, notification_providers()
+        values_by_provider = get_values_by_provider_by_type(
+            notification_settings_by_scope,
+            notification_providers(),
+            NotificationSettingTypes.DEPLOY,
         )
         assert values_by_provider == {
-            ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY,
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
             ExternalProviders.SLACK: NotificationSettingOptionValues.COMMITTED_ONLY,
         }
 


### PR DESCRIPTION
The fallback value for DEPLOY settings for Slack is "committed only". There shouldn't be any users with slack set up so this is causing a lot of failed slack channel lookups. This PR sets the defaults for all types for slack to "never".