### PR TITLE
ref(search): Avoid double negative for operator lookahead

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -141,8 +141,8 @@ percentage_format    = ~r"([0-9\.]+)%"
 # NOTE: the order in which these operators are listed matters because for
 # example, if < comes before <= it will match that even if the operator is <=
 operator             = ">=" / "<=" / ">" / "<" / "=" / "!="
-or_operator          = ~r"OR(?![^\s])"i
-and_operator         = ~r"AND(?![^\s])"i
+or_operator          = ~r"OR(?=\s|$)"i
+and_operator         = ~r"AND(?=\s|$)"i
 open_paren           = "("
 closed_paren         = ")"
 open_bracket         = "["


### PR DESCRIPTION
Just more minor cleanup on this grammer. Getting a good understanding of it
because I'm porting it over to javascript