### PR TITLE
ref(splunk): Stop sending most 4xxs

### DIFF
--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -252,8 +252,8 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 # Just log and return.
                 return False
 
-            if isinstance(exc, ApiError) and exc.code == 403:
-                # 403s are not errors or actionable for us do not re-raise
+            if isinstance(exc, ApiError) and 401 <= exc.code <= 404:
+                # Most 4xxs are not errors or actionable for us do not re-raise
                 return False
 
             raise


### PR DESCRIPTION
We have a TON of un-actionable errors sent to Sentry that we are getting alerted on. Many of these are 404's from people putting ngrok.io urls in their Splunk configurations. 

We already log lots of information and realistically there is nothing we can do, so we don't need these errors in Sentry. 

One day it would be nice to let users know their configurations are effed, but for now this reduces the noise for ecosystem.