### PR TITLE
fix(codeowners): Use user_id instead of member_id

### DIFF
--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -76,9 +76,9 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
 
   get sentryNames() {
     const {members} = this.state;
-    return members.map(({id, email, name, ...rest}) => {
+    return members.map(({user: {id}, email, name}) => {
       const label = email !== name ? `${name} - ${email}` : `${email}`;
-      return {...rest, id, name: label, email};
+      return {id, name: label};
     });
   }
 

--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -36,6 +36,25 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
         self.browser.wait_until_not(".loading-indicator")
 
     def test_external_user_mappings(self):
+        # create `auth_user` records to differentiate `user_id` and `organization_member_id`
+        self.create_sentry_app()
+        self.user2 = self.create_user("user2@example.com")
+        self.user3 = self.create_user("user3@example.com")
+
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+        self.team2 = self.create_team(
+            organization=self.organization, slug="tiger-team2", members=[self.user2]
+        )
+        self.team3 = self.create_team(
+            organization=self.organization, slug="tiger-team3", members=[self.user3]
+        )
+
+        self.project = self.create_project(
+            organization=self.organization, teams=[self.team, self.team2, self.team3], slug="bengal"
+        )
+
         with self.feature(
             {
                 "organizations:integrations-codeowners": True,
@@ -59,9 +78,9 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
 
             # Add Mapping Modal
             externalName = self.browser.find_element_by_name("externalName")
-            externalName.send_keys("@admin")
+            externalName.send_keys("user2")
             self.browser.click("#userId:first-child div")
-            self.browser.click('[id="react-select-2-option-0"]')
+            self.browser.click('[id="react-select-2-option-1"]')
             self.browser.snapshot("integrations - save new external user mapping")
 
             # List View


### PR DESCRIPTION
## Objective:
We are unable to add External User mappings bc the frontend is requesting with the wrong data.
We are sending in the organization_member_id as user_id for the request. This causes the request to fail the Serializer's validation.

This PR fixes the fronted for the modal to use the user_id for the user_id key in the POST request.