### PR TITLE
ref(search): Correct questionable regex for in_value

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -120,7 +120,7 @@ aggregate_key    = key open_paren function_arg* closed_paren
 search_key       = key / quoted_key
 search_value     = quoted_value / value
 value            = ~r"[^()\s]*"
-in_value         = ~r"[^(),\s]*(?:[^],\s)]|](?=]))"
+in_value         = ~r"[^(),\s]*(?:[^\],\s)]|](?=]))"
 numeric_value    = ~r"([-]?[0-9\.]+)([kmb])?(?=\s|\)|$|,|])"
 boolean_value    = ~r"(true|1|false|0)(?=\s|\)|$)"i
 quoted_value     = ~r"\"((?:[^\"]|(?<=\\)[\"])*)?\""s


### PR DESCRIPTION
Pretty sure however parsamonious was generating the regex, this was... somehow valid.. not sure how else this would have worked 😬 