### PR TITLE
fix(api): Sort organization_releases by only date_added

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -1,7 +1,7 @@
 import re
 
 from django.db import IntegrityError
-from django.db.models import Q
+from django.db.models import F, Q
 from django.db.models.functions import Coalesce
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
@@ -185,9 +185,7 @@ class OrganizationReleasesEndpoint(
             else:
                 queryset = queryset.filter(status=status_int)
 
-        queryset = queryset.select_related("owner").annotate(
-            date=Coalesce("date_released", "date_added"),
-        )
+        queryset = queryset.select_related("owner").annotate(date=F("date_added"))
 
         queryset = add_environment_to_queryset(queryset, filter_params)
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -78,9 +78,61 @@ class OrganizationReleaseListTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 3
-        assert response.data[0]["version"] == release3.version
-        assert response.data[1]["version"] == release4.version
-        assert response.data[2]["version"] == release1.version
+        assert response.data[0]["version"] == release4.version
+        assert response.data[1]["version"] == release1.version
+        assert response.data[2]["version"] == release3.version
+
+    def test_release_list_order_by_date_added(self):
+        """
+        Test that ensures that by relying on the default date sorting, releases
+        will only be sorted according to `Release.date_added`, and
+        `Release.date_released` should have no effect whatsoever on that order
+        """
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+
+        project = self.create_project(teams=[team], organization=org)
+
+        self.create_member(teams=[team], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        release6 = Release.objects.create(
+            organization_id=org.id,
+            version="6",
+            date_added=datetime(2013, 8, 10, 3, 8, 24, 880386),
+            date_released=datetime(2013, 8, 20, 3, 8, 24, 880386),
+        )
+        release6.add_project(project)
+
+        release7 = Release.objects.create(
+            organization_id=org.id,
+            version="7",
+            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386),
+            date_released=datetime(2013, 8, 18, 3, 8, 24, 880386),
+        )
+        release7.add_project(project)
+
+        release8 = Release.objects.create(
+            organization_id=org.id,
+            version="8",
+            date_added=datetime(2013, 8, 14, 3, 8, 24, 880386),
+            date_released=datetime(2013, 8, 16, 3, 8, 24, 880386),
+        )
+        release8.add_project(project)
+
+        url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+        assert response.data[0]["version"] == release8.version
+        assert response.data[1]["version"] == release7.version
+        assert response.data[2]["version"] == release6.version
 
     def test_query_filter(self):
         user = self.create_user(is_staff=False, is_superuser=False)
@@ -195,8 +247,8 @@ class OrganizationReleaseListTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert response.data[0]["version"] == release3.version
-        assert response.data[1]["version"] == release1.version
+        assert response.data[0]["version"] == release1.version
+        assert response.data[1]["version"] == release3.version
 
     def test_all_projects_parameter(self):
         user = self.create_user(is_staff=False, is_superuser=False)


### PR DESCRIPTION
This PR:- 
- Change the default date sorting behaviour of organization releases in Releases list endpoint from being sorted by `Coalesce("date_released", "date_added")`  to being sorted by just `date_added` to reduce confusion