### PR TITLE
ref(webpack): Only use SENTRY_SPA_DSN in experimental mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,11 @@ const DEPLOY_PREVIEW_CONFIG = IS_DEPLOY_PREVIEW && {
 const SENTRY_EXPERIMENTAL_SPA =
   !DEPLOY_PREVIEW_CONFIG && !IS_UI_DEV_ONLY ? env.SENTRY_EXPERIMENTAL_SPA : true;
 
+// We should only read from the SENTRY_SPA_DSN env variable if SENTRY_EXPERIMENTAL_SPA
+// is true. This is to make sure we can validate that the experimental SPA mode is
+// working properly.
+const SENTRY_SPA_DSN = SENTRY_EXPERIMENTAL_SPA ? env.SENTRY_SPA_DSN : undefined;
+
 // this is the path to the django "sentry" app, we output the webpack build here to `dist`
 // so that `django collectstatic` and so that we can serve the post-webpack bundles
 const sentryDjangoAppPath = path.join(__dirname, 'src/sentry/static/sentry');
@@ -337,7 +342,7 @@ let appConfig = {
         IS_ACCEPTANCE_TEST: JSON.stringify(IS_ACCEPTANCE_TEST),
         DEPLOY_PREVIEW_CONFIG: JSON.stringify(DEPLOY_PREVIEW_CONFIG),
         EXPERIMENTAL_SPA: JSON.stringify(SENTRY_EXPERIMENTAL_SPA),
-        SPA_DSN: JSON.stringify(env.SENTRY_SPA_DSN),
+        SPA_DSN: JSON.stringify(SENTRY_SPA_DSN),
       },
     }),
 


### PR DESCRIPTION
Currently we always rely on the SENTRY_SPA_DSN env variable as the
default Sentry DSN for locally developed apps if it has been set. This
is not ideal for those looking to get errors and transactions from
Sentry into their local internal project, especially as the
bootstrap-sentry script now sets SENTRY_SPA_DSN by default. This patch
makes sure that SENTRY_SPA_DSN is only used if Sentry was started with
the experimental SPA mode activated.