### PR TITLE
fix(workflow): Fixing group_details put error not being forwarded to user

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -269,9 +269,10 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             response = update_groups(
                 request, [group.id], [project], project.organization_id, search_fn, has_inbox
             )
-
             # if action was discard, there isn't a group to serialize anymore
-            if discard:
+            # if response isn't 200, return the response update_groups gave us (i.e. helpful error)
+            # instead of serializing the updated group
+            if discard or response.status_code != 200:
                 return response
 
             # we need to fetch the object against as the bulk mutation endpoint


### PR DESCRIPTION
This endpoint used to call another endpoint and it captured the error differently. Since that change was made, errors happening in `update_groups`  through `group_details.py` were getting overwritten by the serialized group and not passed to the frontend.

This PR changes it so that we return the response from `update_groups` for anything but a 200 (so that errors are returned), and serialize the entire group for successful updates.

Fixes WOR-920