### PR TITLE
fix(notifications): Notification Settings Toggle

### DIFF
--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -102,8 +102,15 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
 
         data = get_fallback_settings(types_to_serialize, project_ids, organization_ids, user)
 
-        # Forgive the variable name, I wanted the following line to be legible.
+        # Forgive the variable name, I wanted the following lines to be legible.
         for n in attrs["settings"]:
+            # Filter out invalid notification settings.
+            if (n.scope_str == "project" and n.scope_identifier not in project_ids) or (
+                n.scope_str == "organization" and n.scope_identifier not in organization_ids
+            ):
+                continue
+
+            # Override the notification settings.
             data[n.type_str][n.scope_str][n.scope_identifier][n.provider_str] = n.value_str
 
         return data

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -97,9 +97,10 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
         types_to_serialize = {type_option} if type_option else set(VALID_VALUES_FOR_KEY.keys())
         user = obj if type(obj) == User else None
 
-        data = get_fallback_settings(
-            types_to_serialize, attrs["projects"], attrs["organizations"], user
-        )
+        project_ids = {_.id for _ in attrs["projects"]}
+        organization_ids = {_.id for _ in attrs["organizations"]}
+
+        data = get_fallback_settings(types_to_serialize, project_ids, organization_ids, user)
 
         # Forgive the variable name, I wanted the following line to be legible.
         for n in attrs["settings"]:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -64,7 +64,7 @@ class ProjectManager(BaseManager):
         """ Returns the QuerySet of all organizations that a set of Teams have access to. """
         from sentry.models import ProjectStatus
 
-        return self.filter(status=ProjectStatus.VISIBLE, team_id__in=team_ids)
+        return self.filter(status=ProjectStatus.VISIBLE, teams__in=team_ids)
 
     # TODO(dcramer): we might want to cache this per user
     def get_for_user(self, team, user, scope=None, _skip_team_check=False):

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -53,27 +53,18 @@ class ProjectTeam(Model):
 class ProjectManager(BaseManager):
     def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
         """ Returns the QuerySet of all projects that a set of Users have access to. """
-        from sentry.models import OrganizationMemberTeam, ProjectStatus, ProjectTeam
+        from sentry.models import ProjectStatus
 
         return self.filter(
             status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(
-                team_id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user_id__in=user_ids
-                ).values_list("team_id", flat=True)
-            ).values_list("project_id", flat=True),
+            teams__organizationmember__user_id__in=user_ids,
         )
 
     def get_for_team_ids(self, team_ids: Sequence[int]) -> QuerySet:
         """ Returns the QuerySet of all organizations that a set of Teams have access to. """
-        from sentry.models import ProjectStatus, ProjectTeam
+        from sentry.models import ProjectStatus
 
-        return self.filter(
-            status=ProjectStatus.VISIBLE,
-            id__in=ProjectTeam.objects.filter(team_id__in=team_ids).values_list(
-                "project_id", flat=True
-            ),
-        )
+        return self.filter(status=ProjectStatus.VISIBLE, team_id__in=team_ids)
 
     # TODO(dcramer): we might want to cache this per user
     def get_for_user(self, team, user, scope=None, _skip_team_check=False):

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -349,8 +349,8 @@ def get_settings_by_provider(
 
 def get_fallback_settings(
     types_to_serialize: Iterable[NotificationSettingTypes],
-    projects: Iterable[Any],
-    organizations: Iterable[Any],
+    project_ids: Iterable[int],
+    organization_ids: Iterable[int],
     user: Optional[Any] = None,
 ) -> MutableMapping[str, MutableMapping[str, MutableMapping[int, MutableMapping[str, str]]]]:
     """
@@ -376,9 +376,11 @@ def get_fallback_settings(
         for provider in NOTIFICATION_SETTING_DEFAULTS.keys():
             provider_str = EXTERNAL_PROVIDERS[provider]
 
-            parents = projects if scope_type == NotificationScopeType.PROJECT else organizations
-            for parent in parents:
-                data[type_str][scope_str][parent.id][provider_str] = parent_independent_value_str
+            parent_ids = (
+                project_ids if scope_type == NotificationScopeType.PROJECT else organization_ids
+            )
+            for parent_id in parent_ids:
+                data[type_str][scope_str][parent_id][provider_str] = parent_independent_value_str
 
             # Only users (i.e. not teams) have parent-independent notification settings.
             if user:

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -15,8 +15,8 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
     type: 'select',
     label: t('Issue Alert Notifications'),
     choices: [
-      ['always', t('Always')],
-      ['never', t('Never')],
+      ['always', t('On')],
+      ['never', t('Off')],
     ],
   },
   deploy: {
@@ -24,9 +24,9 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
     type: 'select',
     label: t('Deploy Notifications'),
     choices: [
-      ['always', t('Always')],
+      ['always', t('On')],
       ['committed_only', t('Only Committed Issues')],
-      ['never', t('Never')],
+      ['never', t('Off')],
     ],
   },
   provider: {
@@ -44,9 +44,9 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
     type: 'select',
     label: t('Workflow Notifications'),
     choices: [
-      ['always', t('Always')],
+      ['always', t('On')],
       ['subscribe_only', t('Only Subscribed Issues')],
-      ['never', t('Never')],
+      ['never', t('Off')],
     ],
   },
 };

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -15,6 +15,8 @@ import {
   getFallBackValue,
   groupByOrganization,
   isGroupedByProject,
+  mergeNotificationSettings,
+  NotificationSettingsObject,
   providerListToString,
 } from 'app/views/settings/account/notifications/utils';
 import Form from 'app/views/settings/components/forms/form';
@@ -29,9 +31,7 @@ type Props = {
 } & AsyncComponent['props'];
 
 type State = {
-  notificationSettings: {
-    [key: string]: {[key: string]: {[key: string]: {[key: string]: string}}};
-  };
+  notificationSettings: NotificationSettingsObject;
   projects: Project[];
 } & AsyncComponent['state'];
 
@@ -174,7 +174,10 @@ class NotificationSettings extends AsyncComponent<Props, State> {
     }
 
     this.setState({
-      notificationSettings: {...notificationSettings, ...updatedNotificationSettings},
+      notificationSettings: mergeNotificationSettings(
+        notificationSettings,
+        updatedNotificationSettings
+      ),
     });
 
     return updatedNotificationSettings;
@@ -216,7 +219,10 @@ class NotificationSettings extends AsyncComponent<Props, State> {
     }
 
     this.setState({
-      notificationSettings: {...notificationSettings, ...updatedNotificationSettings},
+      notificationSettings: mergeNotificationSettings(
+        notificationSettings,
+        updatedNotificationSettings
+      ),
     });
 
     return updatedNotificationSettings;
@@ -240,7 +246,10 @@ class NotificationSettings extends AsyncComponent<Props, State> {
       },
     };
     this.setState({
-      notificationSettings: {...notificationSettings, ...updatedNotificationSettings},
+      notificationSettings: mergeNotificationSettings(
+        notificationSettings,
+        updatedNotificationSettings
+      ),
     });
     return updatedNotificationSettings;
   };

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -293,7 +293,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
       choices: defaultFields.choices?.concat([
         [
           'default',
-          `${getChoiceString(defaultFields.choices, currentDefault)} (${t('default')})`,
+          `${t('Default')} (${getChoiceString(defaultFields.choices, currentDefault)})`,
         ],
       ]),
       defaultValue: 'default',

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Avatar from 'app/components/avatar';
-import {t} from 'app/locale';
+import {IconInfo} from 'app/icons';
+import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import withOrganizations from 'app/utils/withOrganizations';
@@ -374,6 +376,11 @@ class NotificationSettings extends AsyncComponent<Props, State> {
       <React.Fragment>
         <SettingsPageHeader title={title} />
         {description && <TextBlock>{description}</TextBlock>}
+        <FeedbackAlert type="info" icon={<IconInfo />}>
+          {tct('Got feedback? Email [email:ecosystem-feedback@sentry.io].', {
+            email: <a href="mailto:ecosystem-feedback@sentry.io" />,
+          })}
+        </FeedbackAlert>
         <Form
           saveOnBlur
           apiMethod="PUT"
@@ -411,4 +418,9 @@ const FieldLabel = styled('div')`
   gap: ${space(0.5)};
   line-height: 16px;
 `;
+
+const FeedbackAlert = styled(Alert)`
+  margin: 20px 0px;
+`;
+
 export default withOrganizations(NotificationSettings);

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -1,5 +1,9 @@
 import {Organization, Project} from 'app/types';
 
+export type NotificationSettingsObject = {
+  [key: string]: {[key: string]: {[key: string]: {[key: string]: string}}};
+};
+
 // Which fine tuning parts are grouped by project
 export const isGroupedByProject = (type: string): boolean =>
   ['alerts', 'email', 'workflow'].includes(type);
@@ -89,4 +93,24 @@ export const backfillMissingProvidersWithFallback = (
     entries.push([provider, fallback]);
   }
   return Object.fromEntries(entries);
+};
+
+export const mergeNotificationSettings = (
+  ...objects: NotificationSettingsObject[]
+): NotificationSettingsObject => {
+  /** Deeply merge N notification settings objects (usually just 2). */
+  const output = {};
+  objects.map(settingsByType =>
+    Object.entries(settingsByType).map(([type, settingsByScopeType]) =>
+      Object.entries(settingsByScopeType).map(([scopeType, settingsByScopeId]) =>
+        Object.entries(settingsByScopeId).map(([scopeId, settingsByProvider]) =>
+          Object.entries(settingsByProvider).map(([provider, value]) => {
+            output[type][scopeType][scopeId][provider] = value;
+          })
+        )
+      )
+    )
+  );
+
+  return output;
 };

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -1,3 +1,5 @@
+import set from 'lodash/set';
+
 import {Organization, Project} from 'app/types';
 
 export type NotificationSettingsObject = {
@@ -105,7 +107,7 @@ export const mergeNotificationSettings = (
       Object.entries(settingsByScopeType).map(([scopeType, settingsByScopeId]) =>
         Object.entries(settingsByScopeId).map(([scopeId, settingsByProvider]) =>
           Object.entries(settingsByProvider).map(([provider, value]) => {
-            output[type][scopeType][scopeId][provider] = value;
+            set(output, [type, scopeType, scopeId, provider].join('.'), value);
           })
         )
       )

--- a/tests/sentry/api/endpoints/test_user_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings.py
@@ -85,6 +85,25 @@ class UserNotificationSettingsGetTest(UserNotificationSettingsTestBase):
         with self.feature(FEATURE_NAMES):
             self.get_error_response(other_user.id, status_code=403)
 
+    def test_invalid_notification_setting(self):
+        other_organization = self.create_organization(name="Rowdy Tiger", owner=None)
+        other_project = self.create_project(
+            organization=other_organization, teams=[], name="Bengal"
+        )
+
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            user=self.user,
+            project=other_project,
+        )
+
+        with self.feature(FEATURE_NAMES):
+            response = self.get_success_response("me")
+
+        assert other_project.id not in response.data["workflow"]["project"]
+
 
 class UserNotificationSettingsTest(UserNotificationSettingsTestBase):
     method = "put"

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -361,7 +361,7 @@ class NotificationHelpersTest(TestCase):
         }
 
     def test_get_fallback_settings_projects(self):
-        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {self.project}, {})
+        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {self.project.id}, {})
         assert data == {
             "alerts": {
                 "project": {


### PR DESCRIPTION
This PR solves two bugs:
- filter out projects from notification settings where the user doesn't have access
- hides notification setting fine-tuning when all preferences are "never".

![Screen Shot 2021-05-18 at 11 04 02 AM](https://user-images.githubusercontent.com/31750075/118701608-c4524400-b7c8-11eb-84f6-a05821ac6c6f.png)
