### PR TITLE
fix(ui): Show release health setup banner if release health isn't setup for adoption chart feature

### DIFF
--- a/static/app/components/charts/stackedAreaChart.tsx
+++ b/static/app/components/charts/stackedAreaChart.tsx
@@ -4,7 +4,7 @@ import AreaChart from 'app/components/charts/areaChart';
 
 type AreaChartProps = React.ComponentProps<typeof AreaChart>;
 
-type Props = Omit<AreaChartProps, 'stacked' | 'tooltip' | 'ref'>;
+type Props = Omit<AreaChartProps, 'stacked' | 'ref'>;
 
 class StackedAreaChart extends React.Component<Props> {
   render() {

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -282,7 +282,7 @@ class ReleasesList extends AsyncView<Props, State> {
                       'Setup Release Health for this project to view user adoption, usage of the application, percentage of crashes, and session data.'
                     )}
                   </div>
-                  <ExternalLink href="https://docs.sentry.io/product/releases/health/setup/">
+                  <ExternalLink href="https://docs.sentry.io/product/releases/health/">
                     {t('Learn more')}
                   </ExternalLink>
                 </AlertText>

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -17,6 +17,7 @@ import Pagination from 'app/components/pagination';
 import SearchBar from 'app/components/searchBar';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
+import {releaseHealth} from 'app/data/platformCategories';
 import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
@@ -269,8 +270,16 @@ class ReleasesList extends AsyncView<Props, State> {
               project &&
               project.hasOwnProperty('features') &&
               (project as Project).features.includes('releases');
+            const projectCanHaveReleases =
+              project && project.platform && releaseHealth.includes(project.platform);
 
-            if (!initiallyLoaded || fetchError || !project || projectHasReleases) {
+            if (
+              !initiallyLoaded ||
+              fetchError ||
+              !project ||
+              projectHasReleases ||
+              !projectCanHaveReleases
+            ) {
               return null;
             }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -307,7 +307,7 @@ class ReleasesList extends AsyncView<Props, State> {
       p => p.id === `${selectedProjectId}`
     );
 
-    if (!selectedProject) {
+    if (!selectedProject || hasSessions !== false) {
       return null;
     }
 
@@ -319,12 +319,7 @@ class ReleasesList extends AsyncView<Props, State> {
             const projectCanHaveReleases =
               project && project.platform && releaseHealth.includes(project.platform);
 
-            if (
-              !initiallyLoaded ||
-              fetchError ||
-              !projectCanHaveReleases ||
-              hasSessions
-            ) {
+            if (!initiallyLoaded || fetchError || !projectCanHaveReleases) {
               return null;
             }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -473,8 +473,16 @@ class ReleasesList extends AsyncView<Props, State> {
 
 const AlertText = styled('div')`
   display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: ${space(2)};
+
   > *:nth-child(1) {
     flex: 1;
+  }
+  flex-direction: column;
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    flex-direction: row;
   }
 `;
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -303,7 +303,7 @@ class ReleasesList extends AsyncView<Props, State> {
 
     const selectedProjectId =
       selection.projects && selection.projects.length === 1 && selection.projects[0];
-    const selectedProject = organization.projects.find(
+    const selectedProject = organization.projects?.find(
       p => p.id === `${selectedProjectId}`
     );
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -350,7 +350,7 @@ class ReleasesList extends AsyncView<Props, State> {
 
   renderInnerBody(activeDisplay: DisplayOption) {
     const {location, selection, organization} = this.props;
-    const {releases, reloading, releasesPageLinks} = this.state;
+    const {hasSessions, releases, reloading, releasesPageLinks} = this.state;
 
     if (this.shouldShowLoadingIndicator()) {
       return <LoadingIndicator />;
@@ -388,7 +388,7 @@ class ReleasesList extends AsyncView<Props, State> {
                     {({projects, initiallyLoaded, fetchError}) => {
                       const project = projects && projects.length === 1 && projects[0];
 
-                      if (!initiallyLoaded || fetchError || !project) {
+                      if (!initiallyLoaded || fetchError || !project || !hasSessions) {
                         return null;
                       }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -296,6 +296,27 @@ class ReleasesList extends AsyncView<Props, State> {
 
                       const showPlaceholders = !initiallyLoaded || isHealthLoading;
 
+                      let totalCount = 0;
+
+                      if (releases && releases.length) {
+                        const timeSeries = getHealthData.getTimeSeries(
+                          releases[0].version,
+                          Number(project.id),
+                          activeDisplay
+                        );
+
+                        const totalData = timeSeries[1].data;
+
+                        totalCount = totalData
+                          .map(point => point.value)
+                          .reduce((acc, value) => acc + value);
+                      }
+
+                      // Hide the chart if the release has no total sessions
+                      if (totalCount === 0) {
+                        return null;
+                      }
+
                       return (
                         <ReleaseAdoptionChart
                           organization={organization}
@@ -305,6 +326,7 @@ class ReleasesList extends AsyncView<Props, State> {
                           getHealthData={getHealthData}
                           activeDisplay={activeDisplay}
                           showPlaceholders={showPlaceholders}
+                          totalCount={totalCount}
                         />
                       );
                     }}

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -5,8 +5,14 @@ import styled from '@emotion/styled';
 import moment from 'moment';
 
 import {Client} from 'app/api';
-import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
+import StackedAreaChart from 'app/components/charts/stackedAreaChart';
+import {
+  HeaderTitleLegend,
+  InlineContainer,
+  SectionHeading,
+  SectionValue,
+} from 'app/components/charts/styles';
 import {truncationFormatter} from 'app/components/charts/utils';
 import Count from 'app/components/count';
 import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
@@ -76,12 +82,12 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
   renderEmpty() {
     return (
       <Panel>
-        <ChartBody withPadding>
+        <PanelBody withPadding>
           <ChartHeader>
             <Placeholder height="24px" />
           </ChartHeader>
           <Placeholder height="200px" />
-        </ChartBody>
+        </PanelBody>
         <ChartFooter>
           <Placeholder height="24px" />
         </ChartFooter>
@@ -134,25 +140,26 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
       };
     });
 
-    const legend = {
-      right: 10,
-      top: 5,
-    };
-
     return (
       <Panel>
-        <ChartBody withPadding>
+        <PanelBody withPadding>
           <ChartHeader>
             <ChartTitle>
               {activeDisplay === DisplayOption.USERS
-                ? t('Releases Adopted by Users')
-                : t('Releases Adopted by Sessions')}
+                ? t('Users Adopted')
+                : t('Sessions Adopted')}
             </ChartTitle>
           </ChartHeader>
           <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
             {zoomRenderProps => (
-              <AreaChart
+              <StackedAreaChart
                 {...zoomRenderProps}
+                grid={{
+                  left: '10px',
+                  right: '10px',
+                  top: '40px',
+                  bottom: '0px',
+                }}
                 series={releasesSeries}
                 yAxis={{
                   min: 0,
@@ -202,19 +209,22 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
                     ].join('');
                   },
                 }}
-                legend={legend}
               />
             )}
           </ChartZoom>
-        </ChartBody>
-        {
-          <ChartFooter>
-            {tct('Total [display] [count]', {
-              display: activeDisplay === DisplayOption.USERS ? 'Users' : 'Sessions',
-              count: <Count value={get24hCountByProject ?? 0} />,
-            })}
-          </ChartFooter>
-        }
+        </PanelBody>
+        <ChartFooter>
+          <InlineContainer>
+            <SectionHeading>
+              {tct('Total [display]', {
+                display: activeDisplay === DisplayOption.USERS ? 'Users' : 'Sessions',
+              })}
+            </SectionHeading>
+            <SectionValue>
+              <Count value={get24hCountByProject ?? 0} />
+            </SectionValue>
+          </InlineContainer>
+        </ChartFooter>
       </Panel>
     );
   }
@@ -222,17 +232,13 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
 
 export default withApi(withRouter(ReleaseAdoptionChart));
 
-const ChartHeader = styled('div')`
+const ChartHeader = styled(HeaderTitleLegend)`
   margin-bottom: ${space(1)};
 `;
 
 const ChartTitle = styled('header')`
   display: flex;
   flex-direction: row;
-`;
-
-const ChartBody = styled(PanelBody)`
-  padding-bottom: 0;
 `;
 
 const ChartFooter = styled(PanelFooter)`

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -151,12 +151,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
             {zoomRenderProps => (
               <StackedAreaChart
                 {...zoomRenderProps}
-                grid={{
-                  left: '10px',
-                  right: '10px',
-                  top: '40px',
-                  bottom: '0px',
-                }}
+                grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
                 series={releasesSeries}
                 yAxis={{
                   min: 0,

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -134,6 +134,11 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
       };
     });
 
+    const legend = {
+      right: 10,
+      top: 5,
+    };
+
     return (
       <Panel>
         <ChartBody withPadding>
@@ -197,6 +202,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
                     ].join('');
                   },
                 }}
+                legend={legend}
               />
             )}
           </ChartZoom>

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -34,6 +34,7 @@ type Props = WithRouterProps & {
   getHealthData: ReleaseHealthRequestRenderProps['getHealthData'];
   activeDisplay: DisplayOption;
   showPlaceholders: boolean;
+  totalCount: number;
 };
 
 type State = {
@@ -104,17 +105,13 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
       router,
       selection,
       getHealthData,
+      totalCount,
     } = this.props;
     const {start, end, period, utc} = selection.datetime;
 
     if (showPlaceholders) {
       return this.renderEmpty();
     }
-
-    const get24hCountByProject = getHealthData.get24hCountByProject(
-      Number(project.id),
-      activeDisplay
-    );
 
     const releasesSeries = releases.map(release => {
       const releaseVersion = release.version;
@@ -221,7 +218,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
               })}
             </SectionHeading>
             <SectionValue>
-              <Count value={get24hCountByProject ?? 0} />
+              <Count value={totalCount ?? 0} />
             </SectionValue>
           </InlineContainer>
         </ChartFooter>

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -90,7 +90,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
           <Placeholder height="200px" />
         </PanelBody>
         <ChartFooter>
-          <Placeholder height="24px" />
+          <Placeholder height="34px" />
         </ChartFooter>
       </Panel>
     );


### PR DESCRIPTION
This converts session adoption chart to a stacked area chart, adds an alert banner with release health setup docs link if it isn't setup for the adoption chart feature. Added total counts to the bottom of the chart and fixed the styling to look more like other charts.

Before:
![Screen Shot 2021-05-27 at 11 28 09 AM](https://user-images.githubusercontent.com/15015880/119878142-aaa6b000-bede-11eb-88f6-48b568ba7488.png)

After:
![Screen Shot 2021-05-27 at 11 27 49 AM](https://user-images.githubusercontent.com/15015880/119878170-b09c9100-bede-11eb-9ef2-fb457c028c64.png)

