### PR TITLE
feat(command-palette): Select integration config from palette

### DIFF
--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -7,7 +7,11 @@ import ContextPickerModal from 'app/components/contextPickerModal';
 import ProjectsStore from 'app/stores/projectsStore';
 
 // TODO(ts): figure out better typing for react-router here
-export function navigateTo(to: string, router: InjectedRouter & {location?: Location}) {
+export function navigateTo(
+  to: string,
+  router: InjectedRouter & {location?: Location},
+  configUrl?: string
+) {
   // Check for placeholder params
   const needOrg = to.indexOf(':orgId') > -1;
   const needProject = to.indexOf(':projectId') > -1;
@@ -16,7 +20,7 @@ export function navigateTo(to: string, router: InjectedRouter & {location?: Loca
 
   const projectById = ProjectsStore.getById(comingFromProjectId);
 
-  if (needOrg || (needProject && (needProjectId || !projectById))) {
+  if (needOrg || (needProject && (needProjectId || !projectById)) || configUrl) {
     openModal(
       modalProps => (
         <ContextPickerModal
@@ -24,6 +28,7 @@ export function navigateTo(to: string, router: InjectedRouter & {location?: Loca
           nextPath={to}
           needOrg={needOrg}
           needProject={needProject}
+          configUrl={configUrl}
           comingFromProjectId={
             Array.isArray(comingFromProjectId) ? '' : comingFromProjectId || ''
           }

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -553,6 +553,7 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
 `;
 
 const StyledIntegrationItem = styled('div')`
-  display: flex;
-  gap: ${space(0.5)};
+  display: grid;
+  grid-template-columns: ${space(4)} auto;
+  grid-template-rows: 1fr;
 `;

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -130,7 +130,7 @@ class Search extends React.Component<Props> {
       organization_id: null,
     });
 
-    const {to, action} = item;
+    const {to, action, configUrl} = item;
 
     // `action` refers to a callback function while
     // `to` is a react-router route
@@ -160,7 +160,7 @@ class Search extends React.Component<Props> {
     const {params, router} = this.props;
     const nextPath = replaceRouterParams(to, params);
 
-    navigateTo(nextPath, router);
+    navigateTo(nextPath, router, configUrl);
   };
 
   saveQueryMetrics = debounce(query => {

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -183,6 +183,7 @@ async function createIntegrationResults(
         sourceType: 'integration',
         resultType: 'integration',
         to: `/settings/${orgId}/integrations/${provider.slug}/`,
+        configUrl: `/api/0/organizations/${orgId}/integrations/?provider_key=${provider.slug}&includeConfig=0`,
       }))) ||
     []
   );

--- a/static/app/components/search/sources/types.tsx
+++ b/static/app/components/search/sources/types.tsx
@@ -63,6 +63,7 @@ export type ResultItem = {
   empty?: boolean;
   // Used to store groups and events
   model?: any;
+  configUrl?: string;
 };
 
 /**

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -2,6 +2,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
 
 import ContextPickerModal from 'app/components/contextPickerModal';
+import ConfigStore from 'app/stores/configStore';
 import OrganizationsStore from 'app/stores/organizationsStore';
 import OrganizationStore from 'app/stores/organizationStore';
 import ProjectsStore from 'app/stores/projectsStore';
@@ -244,6 +245,181 @@ describe('ContextPickerModal', function () {
     selectByValue(wrapper, 'project3', {control: true, name: 'project'});
 
     expect(onFinish).toHaveBeenCalledWith('/test/org2/path/project3/');
+
+    await tick();
+    wrapper.unmount();
+  });
+
+  it('isSuperUser and selects an integrationConfig and calls `onFinish` with URL to that configuration', async function () {
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    ConfigStore.config = {
+      user: {isSuperuser: true},
+    };
+
+    const provider = {slug: 'github'};
+    const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
+    const githubConfigs = [
+      {
+        accountType: 'User',
+        configData: null,
+        domainName: 'github.com/NisanthanNanthakumar',
+        icon: 'https://avatars.githubusercontent.com/u/10494',
+        id: '1',
+        name: 'NisanthanNanthakumar',
+        provider: {
+          aspects: {},
+          canAdd: true,
+          canDisable: false,
+          features: ['codeowners', 'commits', 'issue-basic', 'stacktrace-link'],
+          key: 'github',
+          name: 'GitHub',
+          slug: 'github',
+        },
+        status: 'active',
+      },
+      {
+        accountType: 'Organization',
+        configData: null,
+        domainName: 'github.com/santrysantrysantry',
+        icon: 'https://avatars.githubusercontent.com/u/83424',
+        id: '2',
+        name: 'santrysantrysantry',
+        provider: {
+          aspects: {},
+          canAdd: true,
+          canDisable: false,
+          features: ['codeowners', 'commits', 'issue-basic', 'stacktrace-link'],
+          key: 'github',
+          name: 'GitHub',
+          slug: 'github',
+        },
+        status: 'active',
+      },
+    ];
+    const fetchGithubConfigs = MockApiClient.addMockResponse({
+      url: configUrl,
+      body: githubConfigs,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    const wrapper = mountWithTheme(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
+        configUrl,
+      }),
+      TestStubs.routerContext()
+    );
+
+    expect(fetchGithubConfigs).toHaveBeenCalled();
+    expect(wrapper.find('StyledSelectControl').prop('name')).toEqual('configurations');
+    selectByValue(wrapper, githubConfigs[0].id, {control: true, name: 'configurations'});
+    expect(onFinish).toHaveBeenCalledWith(
+      `/settings/${org.slug}/integrations/github/${githubConfigs[0].id}/`
+    );
+
+    await tick();
+    wrapper.unmount();
+  });
+
+  it('not superUser and cannot select an integrationConfig and calls `onFinish` with URL to integration overview page', async function () {
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    ConfigStore.config = {
+      user: {isSuperuser: false},
+    };
+
+    const provider = {slug: 'github'};
+    const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
+    const githubConfigs = [
+      {
+        accountType: 'User',
+        configData: null,
+        domainName: 'github.com/NisanthanNanthakumar',
+        icon: 'https://avatars.githubusercontent.com/u/10494',
+        id: '1',
+        name: 'NisanthanNanthakumar',
+        provider: {
+          aspects: {},
+          canAdd: true,
+          canDisable: false,
+          features: ['codeowners', 'commits', 'issue-basic', 'stacktrace-link'],
+          key: 'github',
+          name: 'GitHub',
+          slug: 'github',
+        },
+        status: 'active',
+      },
+    ];
+
+    const fetchGithubConfigs = MockApiClient.addMockResponse({
+      url: configUrl,
+      body: githubConfigs,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    const wrapper = mountWithTheme(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
+        configUrl,
+      }),
+      TestStubs.routerContext()
+    );
+
+    expect(fetchGithubConfigs).toHaveBeenCalled();
+    expect(wrapper.find('StyledSelectControl').exists()).toBeFalsy();
+    expect(onFinish).toHaveBeenCalledWith(`/settings/${org.slug}/integrations/github/`);
+
+    await tick();
+    wrapper.unmount();
+  });
+
+  it('is superUser and no integration configurations and calls `onFinish` with URL to integration overview page', async function () {
+    OrganizationsStore.load([org]);
+    OrganizationStore.onUpdate(org);
+    ConfigStore.config = {
+      user: {isSuperuser: true},
+    };
+
+    const provider = {slug: 'github'};
+    const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
+    const githubConfigs = [];
+
+    const fetchGithubConfigs = MockApiClient.addMockResponse({
+      url: configUrl,
+      body: githubConfigs,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [],
+    });
+
+    const wrapper = mountWithTheme(
+      getComponent({
+        needOrg: false,
+        needProject: false,
+        nextPath: `/settings/${org.slug}/integrations/${provider.slug}/`,
+        configUrl,
+      }),
+      TestStubs.routerContext()
+    );
+
+    expect(fetchGithubConfigs).toHaveBeenCalled();
+    expect(wrapper.find('StyledSelectControl').exists()).toBeFalsy();
+    expect(onFinish).toHaveBeenCalledWith(`/settings/${org.slug}/integrations/github/`);
 
     await tick();
     wrapper.unmount();

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -259,47 +259,10 @@ describe('ContextPickerModal', function () {
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
-    const githubConfigs = [
-      {
-        accountType: 'User',
-        configData: null,
-        domainName: 'github.com/NisanthanNanthakumar',
-        icon: 'https://avatars.githubusercontent.com/u/10494',
-        id: '1',
-        name: 'NisanthanNanthakumar',
-        provider: {
-          aspects: {},
-          canAdd: true,
-          canDisable: false,
-          features: ['codeowners', 'commits', 'issue-basic', 'stacktrace-link'],
-          key: 'github',
-          name: 'GitHub',
-          slug: 'github',
-        },
-        status: 'active',
-      },
-      {
-        accountType: 'Organization',
-        configData: null,
-        domainName: 'github.com/santrysantrysantry',
-        icon: 'https://avatars.githubusercontent.com/u/83424',
-        id: '2',
-        name: 'santrysantrysantry',
-        provider: {
-          aspects: {},
-          canAdd: true,
-          canDisable: false,
-          features: ['codeowners', 'commits', 'issue-basic', 'stacktrace-link'],
-          key: 'github',
-          name: 'GitHub',
-          slug: 'github',
-        },
-        status: 'active',
-      },
-    ];
+    const integration = TestStubs.GitHubIntegration();
     const fetchGithubConfigs = MockApiClient.addMockResponse({
       url: configUrl,
-      body: githubConfigs,
+      body: [integration],
     });
 
     MockApiClient.addMockResponse({
@@ -319,9 +282,9 @@ describe('ContextPickerModal', function () {
 
     expect(fetchGithubConfigs).toHaveBeenCalled();
     expect(wrapper.find('StyledSelectControl').prop('name')).toEqual('configurations');
-    selectByValue(wrapper, githubConfigs[0].id, {control: true, name: 'configurations'});
+    selectByValue(wrapper, integration.id, {control: true, name: 'configurations'});
     expect(onFinish).toHaveBeenCalledWith(
-      `/settings/${org.slug}/integrations/github/${githubConfigs[0].id}/`
+      `/settings/${org.slug}/integrations/github/${integration.id}/`
     );
 
     await tick();
@@ -337,30 +300,10 @@ describe('ContextPickerModal', function () {
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
-    const githubConfigs = [
-      {
-        accountType: 'User',
-        configData: null,
-        domainName: 'github.com/NisanthanNanthakumar',
-        icon: 'https://avatars.githubusercontent.com/u/10494',
-        id: '1',
-        name: 'NisanthanNanthakumar',
-        provider: {
-          aspects: {},
-          canAdd: true,
-          canDisable: false,
-          features: ['codeowners', 'commits', 'issue-basic', 'stacktrace-link'],
-          key: 'github',
-          name: 'GitHub',
-          slug: 'github',
-        },
-        status: 'active',
-      },
-    ];
 
     const fetchGithubConfigs = MockApiClient.addMockResponse({
       url: configUrl,
-      body: githubConfigs,
+      body: [TestStubs.GitHubIntegration()],
     });
 
     MockApiClient.addMockResponse({
@@ -395,11 +338,10 @@ describe('ContextPickerModal', function () {
 
     const provider = {slug: 'github'};
     const configUrl = `/api/0/organizations/${org.slug}/integrations/?provider_key=${provider.slug}&includeConfig=0`;
-    const githubConfigs = [];
 
     const fetchGithubConfigs = MockApiClient.addMockResponse({
       url: configUrl,
-      body: githubConfigs,
+      body: [],
     });
 
     MockApiClient.addMockResponse({

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -115,6 +115,6 @@ describe('Command Palette Modal', function () {
       .first()
       .simulate('click');
 
-    expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything());
+    expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything(), undefined);
   });
 });

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -135,6 +135,6 @@ describe('SettingsSearch', function () {
       .first()
       .simulate('click');
 
-    expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything());
+    expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything(), undefined);
   });
 });


### PR DESCRIPTION
## Objective:
For integrations with multiple configurations, we should be able to select into the specific config from the command palette.
This will be enabled only for superusers. For non-superusers, the default behaviour is maintained. If you do not have a configuration for the integration, it will go to the Overview page (current behaviour)

SuperUser:
https://user-images.githubusercontent.com/10491193/118704997-8c4d0000-b7cc-11eb-9436-c142b3745445.mov

Member:
https://user-images.githubusercontent.com/10491193/118705060-9e2ea300-b7cc-11eb-9c69-3f74e4bd9d36.mov

# Future:
We can add access for owners, admins, managers in a later PR