### PR TITLE
feat(integrations): Unhide published sentry apps from metric alerts

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -8,12 +8,9 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.constants import SentryAppStatus
 from sentry.incidents.endpoints.bases import OrganizationEndpoint
 from sentry.incidents.endpoints.serializers import action_target_type_to_string
-from sentry.incidents.logic import (
-    get_alertable_sentry_apps,
-    get_available_action_integrations_for_org,
-    get_pagerduty_services,
-)
+from sentry.incidents.logic import get_available_action_integrations_for_org, get_pagerduty_services
 from sentry.incidents.models import AlertRuleTriggerAction
+from sentry.models import SentryApp
 
 
 def build_action_response(registered_type, integration=None, organization=None, sentry_app=None):
@@ -82,7 +79,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
             elif registered_type.type == AlertRuleTriggerAction.Type.SENTRY_APP:
                 actions += [
                     build_action_response(registered_type, sentry_app=app)
-                    for app in get_alertable_sentry_apps(organization.id, with_metric_alerts=True)
+                    for app in SentryApp.objects.get_alertable_sentry_apps(organization.id)
                 ]
 
             else:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from sentry import analytics, quotas
 from sentry.auth.access import SystemAccess
-from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
+from sentry.constants import SentryAppInstallationStatus
 from sentry.incidents import tasks
 from sentry.incidents.models import (
     AlertRule,
@@ -1385,19 +1385,6 @@ def get_available_action_integrations_for_org(organization):
         if registration.integration_provider is not None
     ]
     return Integration.objects.filter(organizations=organization, provider__in=providers)
-
-
-def get_alertable_sentry_apps(organization_id, with_metric_alerts=False):
-    query = SentryApp.objects.filter(
-        installations__organization_id=organization_id,
-        is_alertable=True,
-        installations__status=SentryAppInstallationStatus.INSTALLED,
-        installations__date_deleted=None,
-    )
-
-    if with_metric_alerts:
-        query = query.exclude(status=SentryAppStatus.PUBLISHED)
-    return query.distinct()
 
 
 def get_pagerduty_services(organization, integration_id):

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -15,10 +15,10 @@ from sentry.constants import (
 )
 from sentry.db.models import (
     ArrayField,
-    BaseManager,
     BoundedPositiveIntegerField,
     EncryptedJsonField,
     FlexibleForeignKey,
+    ParanoidManager,
     ParanoidModel,
 )
 from sentry.models.apiscopes import HasApiScopes
@@ -78,7 +78,7 @@ def track_response_code(status, integration_slug, webhook_event):
     )
 
 
-class SentryAppManager(BaseManager):
+class SentryAppManager(ParanoidManager):
     def get_alertable_sentry_apps(self, organization_id: int) -> QuerySet:
         return self.filter(
             installations__organization_id=organization_id,

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -10,7 +10,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.app_platform_event import AppPlatformEvent
 from sentry.api.serializers.models.incident import IncidentSerializer
 from sentry.constants import SentryAppInstallationStatus
-from sentry.incidents.logic import get_alertable_sentry_apps
 from sentry.incidents.models import INCIDENT_STATUS
 from sentry.integrations.metric_alerts import incident_attachment_info, incident_status_info
 from sentry.models import SentryApp, SentryAppInstallation
@@ -159,7 +158,8 @@ class NotifyEventServiceAction(EventAction):
 
     def get_sentry_app_services(self):
         return [
-            SentryAppService(app) for app in get_alertable_sentry_apps(self.project.organization_id)
+            SentryAppService(app)
+            for app in SentryApp.objects.get_alertable_sentry_apps(self.project.organization_id)
         ]
 
     def get_plugins(self):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -87,24 +87,24 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
 
     def test_no_integrations(self):
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            response = self.get_success_response(self.organization.slug)
 
-        assert resp.data == [build_action_response(self.email)]
+        assert response.data == [build_action_response(self.email)]
 
     def test_simple(self):
         integration = Integration.objects.create(external_id="1", provider="slack")
         integration.add_organization(self.organization)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            response = self.get_success_response(self.organization.slug)
 
-        assert len(resp.data) == 2
-        assert build_action_response(self.email) in resp.data
+        assert len(response.data) == 2
+        assert build_action_response(self.email) in response.data
         assert (
             build_action_response(
                 self.slack, integration=integration, organization=self.organization
             )
-            in resp.data
+            in response.data
         )
 
     def test_duplicate_integrations(self):
@@ -116,37 +116,36 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         other_integration.add_organization(self.organization)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            response = self.get_success_response(self.organization.slug)
 
-        assert len(resp.data) == 3
-        assert build_action_response(self.email) in resp.data
+        assert len(response.data) == 3
+        assert build_action_response(self.email) in response.data
         assert (
             build_action_response(
                 self.slack, integration=integration, organization=self.organization
             )
-            in resp.data
+            in response.data
         )
         assert (
             build_action_response(
                 self.slack, integration=other_integration, organization=self.organization
             )
-            in resp.data
+            in response.data
         )
 
     def test_no_feature(self):
         self.create_team(organization=self.organization, members=[self.user])
-        resp = self.get_response(self.organization.slug)
-        assert resp.status_code == 404
+        self.get_error_response(self.organization.slug, status_code=404)
 
     def test_sentry_apps(self):
         sentry_app = self.install_new_sentry_app("foo")
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            response = self.get_success_response(self.organization.slug)
 
-        assert len(resp.data) == 2
-        assert build_action_response(self.email) in resp.data
-        assert build_action_response(self.sentry_app, sentry_app=sentry_app) in resp.data
+        assert len(response.data) == 2
+        assert build_action_response(self.email) in response.data
+        assert build_action_response(self.sentry_app, sentry_app=sentry_app) in response.data
 
     def test_blocked_sentry_apps(self):
         internal_sentry_app = self.install_new_sentry_app("internal")
@@ -154,7 +153,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         self.install_new_sentry_app("published", published=True)
 
         with self.feature("organizations:incidents"):
-            resp = self.get_valid_response(self.organization.slug)
+            response = self.get_success_response(self.organization.slug)
 
         assert len(resp.data) == 2
         assert build_action_response(self.email) in resp.data
@@ -165,8 +164,8 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         integration.add_organization(self.organization)
 
         with self.feature(["organizations:incidents", "organizations:integrations-ticket-rules"]):
-            resp = self.get_valid_response(self.organization.slug)
+            response = self.get_success_response(self.organization.slug)
 
         # There should be no ticket actions for Metric Alerts.
-        assert len(resp.data) == 1
-        assert build_action_response(self.email) in resp.data
+        assert len(response.data) == 1
+        assert build_action_response(self.email) in response.data

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -147,17 +147,15 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
         assert build_action_response(self.email) in response.data
         assert build_action_response(self.sentry_app, sentry_app=sentry_app) in response.data
 
-    def test_blocked_sentry_apps(self):
-        internal_sentry_app = self.install_new_sentry_app("internal")
-        # Should not show up in available actions.
-        self.install_new_sentry_app("published", published=True)
+    def test_published_sentry_apps(self):
+        # Should show up in available actions.
+        published_app = self.install_new_sentry_app("published", published=True)
 
         with self.feature("organizations:incidents"):
             response = self.get_success_response(self.organization.slug)
 
-        assert len(resp.data) == 2
-        assert build_action_response(self.email) in resp.data
-        assert build_action_response(self.sentry_app, sentry_app=internal_sentry_app) in resp.data
+        assert len(response.data) == 2
+        assert build_action_response(self.sentry_app, sentry_app=published_app) in response.data
 
     def test_no_ticket_actions(self):
         integration = Integration.objects.create(external_id="1", provider="jira")


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/20506 we intentionally hid published integrations from the available actions list to give the apps time to handle metric alerts. One of the two apps is ready to go so this PR unhides the apps.