### PR TITLE
feat(workflow): Sending session count + adding metrics

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -949,11 +949,6 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             **query_params,
         )
 
-    def _get_session_percent(self, count, sessions):
-        if sessions != 0:
-            return round(int(count) / sessions, 4)
-        return None
-
     def get_attrs(self, item_list, user):
         if not self._collapse("base"):
             attrs = super().get_attrs(item_list, user)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -53,6 +53,7 @@ from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.types.integrations import ExternalProviders
+from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip
 from sentry.utils.db import attach_foreignkey
@@ -981,21 +982,21 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             if self._expand("sessions"):
                 uniq_project_ids = list({item.project_id for item in item_list})
                 cache_keys = {pid: self._build_session_cache_key(pid) for pid in uniq_project_ids}
-
                 cache_data = cache.get_many(cache_keys.values())
                 missed_items = []
                 for item in item_list:
                     num_sessions = cache_data.get(cache_keys[item.project_id])
                     if num_sessions is None:
+                        found = "miss"
                         missed_items.append(item)
                     else:
+                        found = "hit"
                         attrs[item].update(
                             {
-                                "sessionPercent": self._get_session_percent(
-                                    attrs[item]["times_seen"], num_sessions
-                                )
+                                "sessionCount": num_sessions,
                             }
                         )
+                    metrics.incr(f"group.get_session_counts.{found}")
 
                 if missed_items:
                     filters = {"project_id": list({item.project_id for item in missed_items})}
@@ -1021,13 +1022,11 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                         if item.project_id in results.keys():
                             attrs[item].update(
                                 {
-                                    "sessionPercent": self._get_session_percent(
-                                        attrs[item]["times_seen"], data["sessions"]
-                                    )
+                                    "sessionCount": results[item.project_id],
                                 }
                             )
                         else:
-                            attrs[item].update({"sessionPercent": None})
+                            attrs[item].update({"sessionCount": None})
 
         if self._expand("inbox"):
             inbox_stats = get_inbox_details(item_list)
@@ -1076,7 +1075,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                     result["filtered"] = None
 
             if self._expand("sessions"):
-                result["sessionPercent"] = attrs["sessionPercent"]
+                result["sessionCount"] = attrs["sessionCount"]
 
         if self._expand("inbox"):
             result["inbox"] = attrs["inbox"]

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -531,19 +531,19 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
             [group],
             serializer=StreamGroupSerializerSnuba(stats_period="14d"),
         )
-        assert "sessionPercent" not in result[0]
+        assert "sessionCount" not in result[0]
         result = serialize(
             [group],
             serializer=StreamGroupSerializerSnuba(stats_period="14d", expand=["sessions"]),
         )
-        assert result[0]["sessionPercent"] == 0.3333
+        assert result[0]["sessionCount"] == 3
         result = serialize(
             [group],
             serializer=StreamGroupSerializerSnuba(
                 environment_ids=[environment.id], stats_period="14d", expand=["sessions"]
             ),
         )
-        assert result[0]["sessionPercent"] == 0.5
+        assert result[0]["sessionCount"] == 2
 
         result = serialize(
             [group],
@@ -553,7 +553,7 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 expand=["sessions"],
             ),
         )
-        assert result[0]["sessionPercent"] is None
+        assert result[0]["sessionCount"] is None
 
         result = serialize(
             [group],
@@ -561,7 +561,7 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 environment_ids=[dev_environment.id], stats_period="14d", expand=["sessions"]
             ),
         )
-        assert result[0]["sessionPercent"] == 1
+        assert result[0]["sessionCount"] == 1
 
         self.store_session(
             {
@@ -591,7 +591,7 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 end=timezone.now() - timedelta(days=15),
             ),
         )
-        assert result[0]["sessionPercent"] == 0.0  # No events in that time period
+        assert result[0]["sessionCount"] == 1
 
         # Delete the cache from the query we did above, else this result comes back as 1 instead of 0.5
         cache.delete(f"w-s:{group.project.id}-{dev_environment.id}")
@@ -616,6 +616,6 @@ class StreamGroupSerializerTestCase(APITestCase, SnubaTestCase):
                 expand=["sessions"],
             ),
         )
-        assert result[0]["sessionPercent"] == 0.5
+        assert result[0]["sessionCount"] == 2
         # No sessions in project2
-        assert result[1]["sessionPercent"] is None
+        assert result[1]["sessionCount"] is None


### PR DESCRIPTION
Swapping out the session calculation for a session count and we'll do a calculation on the frontend. Also adding in metrics so that we can see how often this cache is used.