### PR TITLE
fix(spans): Fix incorrect span bar positions when zooming on the minimap

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -874,7 +874,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
               spanBarHatch={!!spanBarHatch}
               style={{
                 backgroundColor: spanBarColour,
-                left: `clamp(0%, ${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+                left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
                 width: toPercent(bounds.width || 0),
               }}
             >

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -349,7 +349,7 @@ class TransactionBar extends React.Component<Props, State> {
         spanBarHatch={false}
         style={{
           backgroundColor: barColour,
-          left: `clamp(0%, ${toPercent(startPercentage || 0)}, calc(100% - 1px))`,
+          left: `min(${toPercent(startPercentage || 0)}, calc(100% - 1px))`,
           width: toPercent(widthPercentage || 0),
         }}
       >


### PR DESCRIPTION
Fix a regression introduced in https://github.com/getsentry/sentry/pull/21336

When zooming on spans using the minimap, the spans are incorrectly positioned on the span view. Some span bars are always positioned as `left: 0%`, when they should be `left: -position%`.  This is due to the `clamp()` being used. I've changed this to use `min()` instead.

Their positions on the minimap are correct.

### Before

![Screen Shot 2021-05-18 at 3 09 17 PM](https://user-images.githubusercontent.com/139499/118711555-b82cad80-b7ed-11eb-9350-811859f4b9e6.png)

### After

![Screen Shot 2021-05-18 at 3 23 14 PM](https://user-images.githubusercontent.com/139499/118711550-b6fb8080-b7ed-11eb-9f97-e11f3bfae450.png)

