### PR TITLE
feat(api): Add user registration endpoint

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -2,7 +2,11 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_text
-from rest_framework.authentication import BasicAuthentication, get_authorization_header
+from rest_framework.authentication import (
+    BasicAuthentication,
+    SessionAuthentication,
+    get_authorization_header,
+)
 from rest_framework.exceptions import AuthenticationFailed
 from sentry_relay import UnpackError
 
@@ -183,3 +187,18 @@ class DSNAuthentication(StandardAuthentication):
             scope.set_tag("api_project_key", key.id)
 
         return (AnonymousUser(), key)
+
+
+class ImprovedSessionAuthentication(SessionAuthentication):
+    """
+    Identical to SesssionAuthentication but it forces CSRF even on anonymous requests.
+    """
+
+    def authenticate(self, request):
+        rv = super().authenticate(request)
+        if rv:
+            return rv
+
+        # if we didnt return a user, it means we never ran CSRF checks, so force them now
+        self.enforce_csrf(request)
+        return None

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -9,7 +9,6 @@ from django.http import HttpResponse
 from django.utils.http import urlquote
 from django.views.decorators.csrf import csrf_exempt
 from pytz import utc
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -24,7 +23,7 @@ from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
 from sentry.utils.sdk import capture_exception
 
-from .authentication import ApiKeyAuthentication, TokenAuthentication
+from .authentication import ApiKeyAuthentication, ImprovedSessionAuthentication, TokenAuthentication
 from .paginator import BadPaginationError, Paginator
 from .permissions import NoPermission
 
@@ -36,7 +35,7 @@ ONE_DAY = ONE_HOUR * 24
 
 LINK_HEADER = '<{uri}&cursor={cursor}>; rel="{name}"; results="{has_results}"; cursor="{cursor}"'
 
-DEFAULT_AUTHENTICATION = (TokenAuthentication, ApiKeyAuthentication, SessionAuthentication)
+DEFAULT_AUTHENTICATION = (TokenAuthentication, ApiKeyAuthentication, ImprovedSessionAuthentication)
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.api")

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -5,7 +5,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from sentry import roles
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
@@ -27,7 +28,7 @@ class InvalidPayload(Exception):
 
 
 class AcceptProjectTransferEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get_validated_data(self, data, user):

--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -5,7 +5,8 @@ from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ListField
@@ -35,7 +36,7 @@ class ApiApplicationSerializer(serializers.Serializer):
 
 
 class ApiApplicationDetailsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, app_id):

--- a/src/sentry/api/endpoints/api_applications.py
+++ b/src/sentry/api/endpoints/api_applications.py
@@ -1,14 +1,15 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ApiApplication, ApiApplicationStatus
 
 
 class ApiApplicationsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -2,14 +2,15 @@ from django.db import transaction
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ApiApplicationStatus, ApiAuthorization, ApiToken
 
 
 class ApiAuthorizationsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -3,7 +3,8 @@ from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.fields import MultipleChoiceField
 from sentry.api.serializers import serialize
 from sentry.models import ApiToken
@@ -15,7 +16,7 @@ class ApiTokenSerializer(serializers.Serializer):
 
 
 class ApiTokensEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -1,10 +1,9 @@
 from django.contrib.auth import logout
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import status
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
-from sentry.api.authentication import QuietBasicAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication, QuietBasicAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.serializers import DetailedUserSerializer, serialize
 from sentry.api.validators import AuthVerifyValidator
@@ -22,7 +21,7 @@ class AuthIndexEndpoint(Endpoint):
     and simple HTTP authentication.
     """
 
-    authentication_classes = [QuietBasicAuthentication, SessionAuthentication]
+    authentication_classes = [QuietBasicAuthentication, ImprovedSessionAuthentication]
 
     permission_classes = ()
 

--- a/src/sentry/api/endpoints/auth_register.py
+++ b/src/sentry/api/endpoints/auth_register.py
@@ -1,0 +1,135 @@
+import logging
+
+from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.db import transaction
+from rest_framework import serializers
+
+from sentry import newsletter, options
+from sentry.api.base import Endpoint
+from sentry.api.serializers.base import serialize
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.app import ratelimiter
+from sentry.auth import password_validation
+from sentry.models import User
+from sentry.signals import user_signup
+from sentry.utils import auth, metrics
+
+logger = logging.getLogger("sentry.auth")
+audit_logger = logging.getLogger("sentry.audit.ui")
+
+ERR_UNKNOWN = "An unknown error occurred while creating the account."
+
+
+class AuthRegisterSerializer(CamelSnakeSerializer):
+    name = serializers.CharField(max_length=30, required=True)
+    email = serializers.EmailField(required=True)
+    password = serializers.CharField(required=True)
+    subscribe = serializers.BooleanField(required=False)
+    referrer = serializers.CharField(required=False)
+
+    def is_rate_limited(self):
+        limit = options.get("auth.ip-rate-limit")
+        if not limit:
+            return False
+
+        ip_address = self.context["request"].META["REMOTE_ADDR"]
+        return ratelimiter.is_limited(f"auth:ip:{ip_address}", limit)
+
+    def validate_email(self, value):
+        value = value.strip()
+        if not value:
+            return
+        if User.objects.filter(username__iexact=value).exists():
+            raise serializers.ValidationError(
+                "An account is already registered with that email address."
+            )
+        return value.lower()
+
+    def validate_password(self, value):
+        try:
+            password_validation.validate_password(value)
+        except DjangoValidationError as error:
+            raise serializers.ValidationError(error.messages[0])
+        return value
+
+    def validate(self, data):
+        if self.is_rate_limited():
+            raise serializers.ValidationError("Rate limit exceeded")
+
+        return data
+
+    def create(self, data) -> User:
+        request = self.context["request"]
+
+        user = User(username=data["email"], email=data["email"], name=data["name"])
+        user.set_password(data["password"])
+        user.save()
+
+        # Authenticate user into the current request context
+        #
+        # XXX: This is a side-effect, which is maybe a little confusing as
+        #      creation of an account using this serializer will also
+        #      authenticate the created user.
+        user.backend = settings.AUTHENTICATION_BACKENDS[0]
+        assert auth.login(request, user)
+
+        if newsletter.is_enabled() and data.get("subscribe"):
+            newsletter.create_or_update_subscriptions(
+                user, list_ids=newsletter.get_default_list_ids()
+            )
+
+        for email in user.emails.filter(is_verified=False):
+            user.send_confirm_email_singular(email=email, is_new_user=True)
+
+        user_signup.send_robust(sender=self, user=user, source="api", referrer=data.get("referrer"))
+
+        # can_register should only allow a single registration
+        request.session.pop("can_register", None)
+
+        return user
+
+
+class AuthRegisterEndpoint(Endpoint):
+    # Disable permission requirements.
+    permission_classes = []
+
+    def can_register(self, request):
+        return bool(auth.has_user_registration() or request.session.get("can_register"))
+
+    def post(self, request):
+        if not self.can_register(request):
+            return self.respond({"details": "Registration is not allowed"}, status=400)
+
+        if request.user.is_authenticated():
+            # Authentication not allowed when a user is currently signed in
+            # 409 Conflict
+            metrics.incr("auth-register.failure", tags={"response_code": 409}, skip_internal=False)
+            return self.respond({"details": "Cannot register while authenticated"}, status=409)
+
+        serializer = AuthRegisterSerializer(data=request.data, context={"request": request})
+
+        if not serializer.is_valid():
+            # collect more specific error message
+            for field in serializer.errors:
+                metrics.incr(
+                    "auth-register.failure",
+                    tags={"response_code": 400, "type": "serializer-error", "subtype": field},
+                    skip_internal=False,
+                )
+
+            return self.respond(serializer.errors, status=400)
+
+        try:
+            with transaction.atomic():
+                user = serializer.save()
+        except Exception as e:
+            logger.error(repr(e), extra={"request": request}, exc_info=True)
+            metrics.incr(
+                "auth-register.failure",
+                tags={"response_code": 400, "type": "unknown-billing-error"},
+                skip_internal=False,
+            )
+            return self.respond({"details": ERR_UNKNOWN}, status=400)
+
+        return self.respond(serialize(user))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -56,6 +56,7 @@ from .endpoints.assistant import AssistantEndpoint
 from .endpoints.auth_config import AuthConfigEndpoint
 from .endpoints.auth_index import AuthIndexEndpoint
 from .endpoints.auth_login import AuthLoginEndpoint
+from .endpoints.auth_register import AuthRegisterEndpoint
 from .endpoints.authenticator_index import AuthenticatorIndexEndpoint
 from .endpoints.broadcast_details import BroadcastDetailsEndpoint
 from .endpoints.broadcast_index import BroadcastIndexEndpoint
@@ -522,6 +523,11 @@ urlpatterns = [
                 url(r"^$", AuthIndexEndpoint.as_view(), name="sentry-api-0-auth"),
                 url(r"^config/$", AuthConfigEndpoint.as_view(), name="sentry-api-0-auth-config"),
                 url(r"^login/$", AuthLoginEndpoint.as_view(), name="sentry-api-0-auth-login"),
+                url(
+                    r"^register/$",
+                    AuthRegisterEndpoint.as_view(),
+                    name="sentry-api-0-auth-register",
+                ),
             ]
         ),
     ),

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -12,7 +12,9 @@ from sentry import newsletter, options
 from sentry.app import ratelimiter
 from sentry.auth import password_validation
 from sentry.models import User
+from sentry.utils import metrics
 from sentry.utils.auth import find_users, logger
+from sentry.utils.hashlib import md5_text
 from sentry.web.forms.fields import AllowedEmailField, CustomTypedChoiceField
 
 
@@ -83,6 +85,8 @@ class AuthenticationForm(forms.Form):
             return
         return value.lower()
 
+    # TODO(dcramer): this logic needs updated to match the api-based validation in auth_login.py
+    # (and ideally moved entirely into the API)
     def is_rate_limited(self):
         if self._is_ip_rate_limited():
             return True
@@ -107,7 +111,7 @@ class AuthenticationForm(forms.Form):
         if not username:
             return False
 
-        return ratelimiter.is_limited(f"auth:username:{username}", limit)
+        return ratelimiter.is_limited(f"auth:username:{md5_text(username)}", limit)
 
     def clean(self):
         username = self.cleaned_data.get("username")
@@ -120,6 +124,9 @@ class AuthenticationForm(forms.Form):
             )
 
         if self.is_rate_limited():
+            metrics.incr(
+                "login.attempt", instance="rate_limited", skip_internal=True, sample_rate=1.0
+            )
             logger.info(
                 "user.auth.rate-limited",
                 extra={"ip_address": self.request.META["REMOTE_ADDR"], "username": username},

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -1,18 +1,12 @@
-from django.urls import reverse
-from exam import fixture
-
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class AuthLoginEndpointTest(APITestCase):
-    @fixture
-    def path(self):
-        return reverse("sentry-api-0-auth-login")
+    path = "/api/0/auth/login/"
 
     def setUp(self):
         # Requests to set the test cookie
-        self.client.get(reverse("sentry-api-0-auth-config"))
+        self.client.get("/api/0/auth/config/")
 
     def test_login_invalid_password(self):
         resp = self.client.post(self.path, {"username": self.user.username, "password": "bizbar"})
@@ -34,14 +28,3 @@ class AuthLoginEndpointTest(APITestCase):
 
         assert resp.status_code == 200
         assert resp.data["nextUri"] == "/auth/reactivate/"
-
-    @patch(
-        "sentry.api.endpoints.auth_login.ratelimiter.is_limited", autospec=True, return_value=True
-    )
-    def test_login_ratelimit(self, is_limited):
-        resp = self.client.post(self.path, {"username": self.user.username, "password": "admin"})
-
-        assert resp.status_code == 400
-        assert [str(s) for s in resp.data["errors"]["__all__"]] == [
-            "You have made too many failed authentication attempts. Please try again later."
-        ]

--- a/tests/sentry/api/endpoints/test_auth_register.py
+++ b/tests/sentry/api/endpoints/test_auth_register.py
@@ -1,0 +1,91 @@
+from unittest import mock
+
+from sentry import options
+from sentry.models import User
+from sentry.testutils import APITestCase
+
+
+class AuthRegisterEndpointTest(APITestCase):
+    path = "/api/0/auth/register/"
+
+    def setUp(self):
+        super().setUp()
+        options.set("auth.allow-registration", True)
+
+    def test_duplicate_username(self):
+        self.create_user(email="foo@example.com")
+        form_data = {
+            "email": "foo@example.com",
+            "password": "foo",
+            "name": "Foo Bar",
+        }
+        response = self.client.post(self.path, form_data)
+
+        assert response.status_code == 400, response.data
+
+    @mock.patch(
+        "sentry.api.endpoints.auth_register.AuthRegisterSerializer.is_rate_limited",
+        autospec=True,
+        return_value=True,
+    )
+    def test_ratelimit(self, mock_is_rate_limited):
+        form_data = {
+            "email": "foo@example.com",
+            "password": "foo",
+            "name": "Foo Bar",
+        }
+        response = self.client.post(self.path, form_data)
+
+        assert response.status_code == 400, response.data
+
+    def test_missing_email(self):
+        form_data = {
+            "password": "foo",
+            "name": "Foo Bar",
+        }
+        response = self.client.post(self.path, form_data)
+
+        assert response.status_code == 400, response.data
+
+    def test_missing_password(self):
+        form_data = {
+            "email": "foo@example.com",
+            "name": "Foo Bar",
+        }
+        response = self.client.post(self.path, form_data)
+
+        assert response.status_code == 400, response.data
+
+    def test_missing_name(self):
+        form_data = {
+            "email": "foo@example.com",
+            "password": "foo",
+        }
+        response = self.client.post(self.path, form_data)
+
+        assert response.status_code == 400, response.data
+
+    @mock.patch("sentry.analytics.record")
+    def test_user_register(self, mock_record):
+        form_data = {
+            "email": "foo@example.com",
+            "password": "foo",
+            "name": "Foo Bar",
+        }
+        response = self.client.post(self.path, form_data)
+
+        assert response.status_code == 200, response.data
+
+        data = response.data
+        assert data["email"] == form_data["email"]
+
+        user = User.objects.get(username=form_data["email"])
+        assert user.email == form_data["email"]
+        assert user.username == form_data["email"]
+        assert user.name == form_data["name"]
+        assert user.check_password(form_data["password"])
+
+        signup_record = [r for r in mock_record.call_args_list if r[0][0] == "user.signup"]
+        assert signup_record == [
+            mock.call("user.signup", user_id=user.id, source="api", provider=None, referrer=None)
+        ]


### PR DESCRIPTION
Thie exposes /api/0/auth/register/ which mirrors the logic in user registration.

It also reconciles some duplicate behavior with rate limiting and metrics reporting throughout both registration and login flows.

Note: This duplicates the code in the RegistrationForm to leverage a DRF serializer, so that it can be extended and reused in getsentry. This should be fine as long as our intent is to move away from server-generated forms for the registration view in a near future.