### PR TITLE
ref(demo): Move span tree demo guide

### DIFF
--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -3,6 +3,7 @@ import * as ReactRouter from 'react-router';
 import styled from '@emotion/styled';
 
 import Alert from 'app/components/alert';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import List from 'app/components/list';
 import ListItem from 'app/components/list/listItem';
 import {Panel} from 'app/components/panels';
@@ -199,6 +200,9 @@ class SpansInterface extends Component<Props, State> {
                   parsedTrace={parsedTrace}
                   operationNameFilters={this.state.operationNameFilters}
                 />
+                <GuideAnchorWrapper>
+                  <GuideAnchor target="span_tree" position="bottom" />
+                </GuideAnchorWrapper>
               </Panel>
             </AnchorLinkManager.Provider>
           )}
@@ -207,6 +211,12 @@ class SpansInterface extends Component<Props, State> {
     );
   }
 }
+
+const GuideAnchorWrapper = styled('div')`
+  height: 0;
+  width: 0;
+  margin-left: 50%;
+`;
 
 const Container = styled('div')<{hasErrors: boolean}>`
   ${p =>

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 
-import GuideAnchor from 'app/components/assistant/guideAnchor';
 import {MessageRow} from 'app/components/performance/waterfall/messageRow';
 import {pickBarColour} from 'app/components/performance/waterfall/utils';
 import {t, tct} from 'app/locale';
@@ -392,9 +391,6 @@ class SpanTree extends React.Component<PropType> {
     return (
       <TraceViewContainer ref={this.props.traceViewRef}>
         {spanTree}
-        <GuideAnchorWrapper>
-          <GuideAnchor target="span_tree" position="bottom" />
-        </GuideAnchorWrapper>
         {infoMessage}
         {limitExceededMessage}
       </TraceViewContainer>
@@ -406,12 +402,6 @@ const TraceViewContainer = styled('div')`
   overflow-x: hidden;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
-`;
-
-const GuideAnchorWrapper = styled('div')`
-  height: 0;
-  width: 0;
-  margin-left: 50%;
 `;
 
 /**


### PR DESCRIPTION
Moving the span tree assistant guide that would be shown in demo mode to a more suitable place. 

Need to do this as part of a larger refactor work on the span tree.

<img width="1309" alt="Screen Shot 2021-05-18 at 5 19 46 PM" src="https://user-images.githubusercontent.com/139499/118725020-5ffda780-b7fd-11eb-9dc6-12019f2b54a7.png">
