### PR TITLE
ref(jwt): Put JWT usage behind our own abstraction plus upgrade it

### DIFF
--- a/src/sentry/integrations/atlassian_connect.py
+++ b/src/sentry/integrations/atlassian_connect.py
@@ -56,7 +56,7 @@ def get_integration_from_jwt(token, path, provider, query_params, method="GET"):
     # alg field.  We only need the token + shared secret and do not want to provide an
     # audience to the JWT validation that is require to match.  Bitbucket does give us an
     # audience claim however, so disable verification of this.
-    decoded_verified = jwt.decode(token, integration.metadata["shared_secret"], verify_aud=False)
+    decoded_verified = jwt.decode(token, integration.metadata["shared_secret"], audience=False)
     # Verify the query has not been tampered by Creating a Query Hash
     # and comparing it against the qsh claim on the verified token.
 

--- a/src/sentry/integrations/atlassian_connect.py
+++ b/src/sentry/integrations/atlassian_connect.py
@@ -1,8 +1,7 @@
 import hashlib
 
-import jwt
-
 from sentry.models import Integration
+from sentry.utils import jwt
 from sentry.utils.http import percent_encode
 
 __all__ = ["AtlassianConnectValidationError", "get_query_hash", "get_integration_from_request"]
@@ -42,7 +41,7 @@ def get_integration_from_jwt(token, path, provider, query_params, method="GET"):
         raise AtlassianConnectValidationError("No token parameter")
     # Decode the JWT token, without verification. This gives
     # you a header JSON object, a claims JSON object, and a signature.
-    decoded = jwt.decode(token, verify=False)
+    decoded = jwt.peek_claims(token)
     # Extract the issuer ('iss') claim from the decoded, unverified
     # claims object. This is the clientKey for the tenant - an identifier
     # for the Atlassian application making the call
@@ -53,16 +52,11 @@ def get_integration_from_jwt(token, path, provider, query_params, method="GET"):
         integration = Integration.objects.get(provider=provider, external_id=issuer)
     except Integration.DoesNotExist:
         raise AtlassianConnectValidationError("No integration found")
-    # Verify the signature with the sharedSecret and
-    # the algorithm specified in the header's alg field.
-    options = {}
-    # If it's BitBucket, we only need the token + shared secret
-    # it will fail on this: https://github.com/jpadilla/pyjwt/blob/d25c92ca5e9980ca7bc8b31420bf36e3f4a9e3f0/jwt/api_jwt.py#L190
-    # if we try to verify the audience
-    if provider == "bitbucket":
-        options = {"verify_aud": False}
-
-    decoded_verified = jwt.decode(token, integration.metadata["shared_secret"], options=options)
+    # Verify the signature with the sharedSecret and the algorithm specified in the header's
+    # alg field.  We only need the token + shared secret and do not want to provide an
+    # audience to the JWT validation that is require to match.  Bitbucket does give us an
+    # audience claim however, so disable verification of this.
+    decoded_verified = jwt.decode(token, integration.metadata["shared_secret"], verify_aud=False)
     # Verify the query has not been tampered by Creating a Query Hash
     # and comparing it against the qsh claim on the verified token.
 

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -57,7 +57,7 @@ class BitbucketApiClient(ApiClient):
             "qsh": get_query_hash(path, method.upper(), params),
             "sub": self.subject,
         }
-        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret.encode("UTF-8"))
+        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret)
         headers = jwt.authorization_header(encoded_jwt, scheme="JWT")
         return self._request(method, path, data=data, params=params, headers=headers, **kwargs)
 

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -57,7 +57,7 @@ class BitbucketApiClient(ApiClient):
             "qsh": get_query_hash(path, method.upper(), params),
             "sub": self.subject,
         }
-        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret)
+        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret.encode("UTF-8"))
         headers = jwt.authorization_header(encoded_jwt, scheme="JWT")
         return self._request(method, path, data=data, params=params, headers=headers, **kwargs)
 

--- a/src/sentry/integrations/bitbucket/client.py
+++ b/src/sentry/integrations/bitbucket/client.py
@@ -1,11 +1,11 @@
 import datetime
 from urllib.parse import urlparse
 
-import jwt
 from unidiff import PatchSet
 
 from sentry.integrations.atlassian_connect import get_query_hash
 from sentry.integrations.client import ApiClient
+from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
 
 BITBUCKET_KEY = "%s.bitbucket" % urlparse(absolute_uri()).hostname
@@ -58,7 +58,7 @@ class BitbucketApiClient(ApiClient):
             "sub": self.subject,
         }
         encoded_jwt = jwt.encode(jwt_payload, self.shared_secret)
-        headers = {"Authorization": b"JWT %s" % encoded_jwt}
+        headers = jwt.authorization_header(encoded_jwt, scheme="JWT")
         return self._request(method, path, data=data, params=params, headers=headers, **kwargs)
 
     def get_issue(self, repo, issue_id):

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -4,6 +4,7 @@ import sentry_sdk
 
 from sentry.integrations.client import ApiClient
 from sentry.integrations.github.utils import get_jwt
+from sentry.utils import jwt
 
 
 class GitHubClientMixin(ApiClient):
@@ -149,13 +150,14 @@ class GitHubClientMixin(ApiClient):
         return token
 
     def create_token(self):
+        headers = {
+            # TODO(jess): remove this whenever it's out of preview
+            "Accept": "application/vnd.github.machine-man-preview+json",
+        }
+        headers.update(jwt.authorization_header(self.get_jwt()))
         return self.post(
             f"/app/installations/{self.integration.external_id}/access_tokens",
-            headers={
-                "Authorization": b"Bearer %s" % self.get_jwt(),
-                # TODO(jess): remove this whenever it's out of preview
-                "Accept": "application/vnd.github.machine-man-preview+json",
-            },
+            headers=headers,
         )
 
     def check_file(self, repo, path, version):

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -17,6 +17,7 @@ from sentry.pipeline import PipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.integrations import migrate_repo
+from sentry.utils import jwt
 
 from .client import GitHubAppsClient
 from .issues import GitHubIssueBasic
@@ -199,12 +200,13 @@ class GitHubIntegrationProvider(IntegrationProvider):
 
     def get_installation_info(self, installation_id):
         session = http.build_session()
+        headers = {
+            # TODO(jess): remove this whenever it's out of preview
+            "Accept": "application/vnd.github.machine-man-preview+json",
+        }
+        headers.update(jwt.authorization_header(get_jwt()))
         resp = session.get(
-            "https://api.github.com/app/installations/%s" % installation_id,
-            headers={
-                "Authorization": b"Bearer %s" % get_jwt(),
-                "Accept": "application/vnd.github.machine-man-preview+json",
-            },
+            "https://api.github.com/app/installations/%s" % installation_id, headers=headers
         )
         resp.raise_for_status()
         installation_resp = resp.json()

--- a/src/sentry/integrations/github/utils.py
+++ b/src/sentry/integrations/github/utils.py
@@ -2,9 +2,8 @@ import calendar
 import datetime
 import time
 
-import jwt
-
 from sentry import options
+from sentry.utils import jwt
 
 
 def get_jwt(github_id=None, github_private_key=None):

--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -1,5 +1,6 @@
 from sentry.integrations.github.client import GitHubClientMixin
 from sentry.integrations.github.utils import get_jwt
+from sentry.utils import jwt
 
 
 class GitHubEnterpriseAppsClient(GitHubClientMixin):
@@ -17,13 +18,14 @@ class GitHubEnterpriseAppsClient(GitHubClientMixin):
         return get_jwt(github_id=self.app_id, github_private_key=self.private_key)
 
     def create_token(self):
+        headers = {
+            # TODO(jess): remove this whenever it's out of preview
+            "Accept": "application/vnd.github.machine-man-preview+json",
+        }
+        headers.update(jwt.authorization_header(self.get_jwt()))
         return self.post(
             "/app/installations/{}/access_tokens".format(
                 self.integration.metadata["installation_id"]
             ),
-            headers={
-                "Authorization": b"Bearer %s" % self.get_jwt(),
-                # TODO(jess): remove this whenever it's out of preview
-                "Accept": "application/vnd.github.machine-man-preview+json",
-            },
+            headers=headers,
         )

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -44,7 +44,7 @@ class JiraCloud:
             "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=5 * 60),
             "qsh": get_query_hash(path, method.upper(), url_params),
         }
-        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret.encode("UTF-8"))
+        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret)
         params = dict(jwt=encoded_jwt, **(url_params or {}))
         request_spec = kwargs.copy()
         request_spec.update(dict(method=method, path=path, data=data, params=params))

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -44,7 +44,7 @@ class JiraCloud:
             "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=5 * 60),
             "qsh": get_query_hash(path, method.upper(), url_params),
         }
-        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret)
+        encoded_jwt = jwt.encode(jwt_payload, self.shared_secret.encode("UTF-8"))
         params = dict(jwt=encoded_jwt, **(url_params or {}))
         request_spec = kwargs.copy()
         request_spec.update(dict(method=method, path=path, data=data, params=params))

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -3,11 +3,10 @@ import logging
 import re
 from urllib.parse import parse_qs, urlparse, urlsplit
 
-import jwt
-
 from sentry.integrations.atlassian_connect import get_query_hash
 from sentry.integrations.client import ApiClient
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.integrations.jira")

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -1,6 +1,5 @@
 from urllib.parse import parse_qsl
 
-import jwt
 from django.urls import reverse
 from oauthlib.oauth1 import SIGNATURE_RSA
 from requests_oauthlib import OAuth1
@@ -8,6 +7,7 @@ from requests_oauthlib import OAuth1
 from sentry.integrations.client import ApiClient
 from sentry.integrations.jira.client import JiraApiClient
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
 
 

--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -1,12 +1,12 @@
 import logging
 
-import jwt
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.base import Endpoint
 from sentry.integrations.jira.webhooks import handle_assignee_change, handle_status_change
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import jwt
 
 logger = logging.getLogger("sentry.integrations.jira_server.webhooks")
 
@@ -21,7 +21,7 @@ def get_integration_from_token(token):
         raise ValueError("Token was empty")
 
     try:
-        unvalidated = jwt.decode(token, verify=False)
+        unvalidated = jwt.peek_claims(token)
     except jwt.DecodeError:
         raise ValueError("Could not decode JWT token")
     if "id" not in unvalidated:

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -99,7 +99,7 @@ def verify_signature(request):
         kid = jwk["kid"]
         public_keys[kid] = jwt.rsa_key_from_jwk(json.dumps(jwk))
 
-    kid = jwt.get_unverified_header(token)["kid"]
+    kid = jwt.peek_header(token)["kid"]
     key = public_keys[kid]
 
     try:

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -63,7 +63,7 @@ def decode(
     options = dict()
     kwargs = dict()
     if audience is False:
-        options["audience"] = False
+        options["verify_aud"] = False
     elif audience is True:
         raise ValueError("audience can not be True")
     elif audience is not None:

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -63,7 +63,7 @@ def decode(
     options = dict()
     kwargs = dict()
     if audience is False:
-        options["verify_aud"] = False
+        options["audience"] = False
     elif audience is True:
         raise ValueError("audience can not be True")
     elif audience is not None:

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -1,0 +1,64 @@
+"""Common handling of JWT tokens.
+
+This is an attempt to have all the interactions with JWT in once place, so that we have once
+central place which handles JWT in a uniform way.
+"""
+
+from typing import Mapping, Union
+
+import jwt
+from jwt import DecodeError
+
+__all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]
+
+
+def peek_claims(token: str) -> Mapping[str, str]:
+    """Returns the claims (payload) in the JWT token without validation.
+
+    These claims can be used to look up the correct key to use in :func:`decode`.
+    """
+    return jwt.decode(token, verify=False)
+
+
+def decode(token: str, key: bytes, verify_aud: bool = True) -> Mapping[str, str]:
+    """Returns the claims (payload) in the JWT token.
+
+    This will raise an exception if the claims can not be validated with the provided key.
+
+    :param verify_aud: By default if the claims in the token contain an audience ("aud")
+       then we would have to provide the audience at decode time to verify it matches.  If
+       your claims include an audience claim you can use this to ignore it.
+    """
+    options = dict()
+    if not verify_aud:
+        options["verify_aud"] = False
+    return jwt.decode(token, key, options=options)
+
+
+def encode(
+    payload: Mapping[str, str],
+    key: bytes,
+    *,
+    algorithm: str = "HS256",
+    headers: Union[Mapping[str, str], None] = None,
+) -> str:
+    """Encode a JWT token containing the provided payload/claims.
+
+    The encoded claims are signed with the provided key using the HS256 algorithm.
+    """
+    if headers is None:
+        headers = {}
+    return jwt.encode(payload, key, algorithm=algorithm, headers=headers).decode("UTF-8")
+
+
+def authorization_header(token: str, *, scheme: str = "Bearer") -> Mapping[str, str]:
+    """Returns an authorization header for the given token.
+
+    The returned header can be used with ``requests``, if you already have any headers in a
+    dictionary you can use ``headers.update(authorization_header(...))`` to add the
+    authorization header.
+
+    Typically JWT uses the token in the "Bearer" scheme for the authorisation header.  If
+    you need to use a differnt scheme use the `scheme` argument to change this.
+    """
+    return {"Authorization": f"{scheme} {token}"}

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -8,6 +8,7 @@ from typing import List, Mapping, Optional, Union
 
 import jwt as pyjwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+from jwt import get_unverified_header  # NOQA
 from jwt import DecodeError
 
 __all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -7,23 +7,29 @@ central place which handles JWT in a uniform way.
 from typing import List, Mapping, Optional, Union
 
 import jwt as pyjwt
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from jwt import DecodeError
 
 __all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]
 
 
-def get_unverified_header(token):
+def peek_header(token: str) -> Mapping[str, str]:
+    """Returns the headers in the JWT token without validation.
+
+    Headers are not signed and can thus be spoofed.  You can use these to decide on what
+    parameters to use to decode the token, but afterwards have to check that all information
+    you used was indeed correct using the claims in the token payload.
+
+    :param token: The JWT token to extract the headers from.
     """
-    Just delegating to jwt
-    """
-    return pyjwt.get_unverified_header(token)
+    return pyjwt.get_unverified_header(token)  # type: ignore
 
 
 def peek_claims(token: str) -> Mapping[str, str]:
     """Returns the claims (payload) in the JWT token without validation.
 
     These claims can be used to look up the correct key to use in :func:`decode`.
+
+    :param token: The JWT token to extract the payload from.
     """
     return pyjwt.decode(token, verify=False)
 
@@ -31,16 +37,21 @@ def peek_claims(token: str) -> Mapping[str, str]:
 def decode(
     token: str,
     key: bytes,
-    *,
-    audience: Union[None, str, bool] = None,
+    *,  # Force passing optional arguments by keyword
+    audience: Optional[Union[str, bool]] = None,
     algorithms: Optional[List[str]] = None,
 ) -> Mapping[str, str]:
     """Returns the claims (payload) in the JWT token.
 
     This will raise an exception if the claims can not be validated with the provided key.
 
+    :param token: The JWT token to decode.
+    :param key: The key as bytes.  Depending on the algorithm this can have several formats,
+       e.g. for HS256 it can be any string of characters, for RS256 it must be PEM formatted
+       RSA PRIVATE_KEY.
     :param audience: Set this to the audience you expect to be present in the claims.  Set
        this to ``False`` to disable verifying the audience.
+    :param algorithms: The algorithms which should be tried to verify the payload.
     """
     options = dict()
     kwargs = dict()
@@ -50,19 +61,26 @@ def decode(
         raise ValueError("audience can not be True")
     elif audience is not None:
         kwargs["audience"] = audience
-    return pyjwt.decode(token, key, options=options, algorithms=algorithms, **kwargs)
+    return pyjwt.decode(token, key, verify=True, options=options, algorithms=algorithms, **kwargs)
 
 
 def encode(
     payload: Mapping[str, str],
     key: bytes,
-    *,
+    *,  # Force passing optional arguments by keyword
     algorithm: str = "HS256",
     headers: Optional[Mapping[str, str]] = None,
 ) -> str:
     """Encode a JWT token containing the provided payload/claims.
 
-    The encoded claims are signed with the provided key using the HS256 algorithm.
+    :param payload: The JSON payload to create a token for, not yet encoded to JSON.
+    :param key: The key as bytes.  The exactly required shape of the bytes depends on the
+       algorithm chosen, see :func:decode:.
+    :param algorithm: The algorithm used to sign the payload.
+    :param headers: Any headers to encode into the token.  Headers are not part of the
+       signed payload and can be tampered with.  They can however help identify the key that
+       needs to be used to verify the payload, as long as the payload contains enough
+       information to also validate the key used was correct.
     """
     if headers is None:
         headers = {}
@@ -78,14 +96,20 @@ def authorization_header(token: str, *, scheme: str = "Bearer") -> Mapping[str, 
 
     Typically JWT uses the token in the "Bearer" scheme for the authorisation header.  If
     you need to use a differnt scheme use the `scheme` argument to change this.
+
+    :param token: The JWT token to use in the authorization header.
+    :param scheme: The authorisation scheme to use.
     """
     return {"Authorization": f"{scheme} {token}"}
 
 
-def rsa_key_from_jwk(jwk: str) -> Union[RSAPrivateKey, RSAPublicKey]:
+def rsa_key_from_jwk(jwk: str) -> bytes:
     """Returns an RSA key from a serialised JWK.
 
     This constructs an RSA key from a JSON Web Key, the result can be used as key to
-    :func:`encode`.
+    :func:`encode` and should be directly passed to it.
+
+    :param jwk: The JSON Web Key as encoded JSON.
     """
-    return pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)
+    key = pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)
+    return bytes(str(key), encoding="UTF-8")

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -7,6 +7,13 @@ central place which handles JWT in a uniform way.
 from typing import List, Mapping, Optional, Union
 
 import jwt as pyjwt
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
 from jwt import DecodeError
 
 __all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]
@@ -112,4 +119,9 @@ def rsa_key_from_jwk(jwk: str) -> bytes:
     :param jwk: The JSON Web Key as encoded JSON.
     """
     key = pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)
-    return bytes(str(key), encoding="UTF-8")
+    if isinstance(key, RSAPrivateKey):
+        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+    elif isinstance(key, RSAPublicKey):
+        return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+    else:
+        raise ValueError("Unknown RSA JWK key")

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -43,7 +43,7 @@ def peek_claims(token: str) -> Mapping[str, str]:
 
 def decode(
     token: str,
-    key: bytes,
+    key: str,
     *,  # Force passing optional arguments by keyword
     audience: Optional[Union[str, bool]] = None,
     algorithms: List[str] = ["HS256"],
@@ -73,7 +73,7 @@ def decode(
 
 def encode(
     payload: Mapping[str, str],
-    key: bytes,
+    key: str,
     *,  # Force passing optional arguments by keyword
     algorithm: str = "HS256",
     headers: Optional[Mapping[str, str]] = None,
@@ -110,7 +110,7 @@ def authorization_header(token: str, *, scheme: str = "Bearer") -> Mapping[str, 
     return {"Authorization": f"{scheme} {token}"}
 
 
-def rsa_key_from_jwk(jwk: str) -> bytes:
+def rsa_key_from_jwk(jwk: str) -> str:
     """Returns an RSA key from a serialised JWK.
 
     This constructs an RSA key from a JSON Web Key, the result can be used as key to
@@ -121,8 +121,8 @@ def rsa_key_from_jwk(jwk: str) -> bytes:
     key = pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)
     if isinstance(key, RSAPrivateKey):
         # The return type is verified in our own tests, this is fine.
-        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())  # type: ignore
+        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode("UTF-8")  # type: ignore
     elif isinstance(key, RSAPublicKey):
-        return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+        return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode("UTF-8")
     else:
         raise ValueError("Unknown RSA JWK key")

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -28,7 +28,7 @@ def peek_header(token: str) -> Mapping[str, str]:
 
     :param token: The JWT token to extract the headers from.
     """
-    return pyjwt.get_unverified_header(token)  # type: ignore
+    return pyjwt.get_unverified_header(token.encode("UTF-8"))  # type: ignore
 
 
 def peek_claims(token: str) -> Mapping[str, str]:
@@ -120,7 +120,8 @@ def rsa_key_from_jwk(jwk: str) -> bytes:
     """
     key = pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)
     if isinstance(key, RSAPrivateKey):
-        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+        # The return type is verified in our own tests, this is fine.
+        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())  # type: ignore
     elif isinstance(key, RSAPublicKey):
         return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
     else:

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -7,7 +7,7 @@ central place which handles JWT in a uniform way.
 from typing import List, Mapping, Optional, Union
 
 import jwt as pyjwt
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from jwt import DecodeError
 
 __all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]
@@ -51,7 +51,7 @@ def encode(
     key: bytes,
     *,
     algorithm: str = "HS256",
-    headers: Union[Mapping[str, str], None] = None,
+    headers: Optional[Mapping[str, str]] = None,
 ) -> str:
     """Encode a JWT token containing the provided payload/claims.
 
@@ -75,7 +75,7 @@ def authorization_header(token: str, *, scheme: str = "Bearer") -> Mapping[str, 
     return {"Authorization": f"{scheme} {token}"}
 
 
-def rsa_key_from_jwk(jwk: str) -> RSAPrivateKey:
+def rsa_key_from_jwk(jwk: str) -> Union[RSAPrivateKey, RSAPublicKey]:
     """Returns an RSA key from a serialised JWK.
 
     This constructs an RSA key from a JSON Web Key, the result can be used as key to

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -8,10 +8,16 @@ from typing import List, Mapping, Optional, Union
 
 import jwt as pyjwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
-from jwt import get_unverified_header  # NOQA
 from jwt import DecodeError
 
 __all__ = ["peek_claims", "decode", "encode", "authorization_header", "DecodeError"]
+
+
+def get_unverified_header(token):
+    """
+    Just delegating to jwt
+    """
+    return pyjwt.get_unverified_header(token)
 
 
 def peek_claims(token: str) -> Mapping[str, str]:

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -46,7 +46,7 @@ def decode(
     key: bytes,
     *,  # Force passing optional arguments by keyword
     audience: Optional[Union[str, bool]] = None,
-    algorithms: Optional[List[str]] = None,
+    algorithms: List[str] = ["HS256"],
 ) -> Mapping[str, str]:
     """Returns the claims (payload) in the JWT token.
 

--- a/src/sentry_plugins/github/client.py
+++ b/src/sentry_plugins/github/client.py
@@ -2,9 +2,8 @@ import calendar
 import datetime
 import time
 
-import jwt
-
 from sentry import options
+from sentry.utils import jwt
 from sentry_plugins.client import ApiClient, AuthApiClient
 
 
@@ -117,13 +116,14 @@ class GitHubAppsClient(GitHubClientMixin, ApiClient):
         return self._request(method, path, headers=headers, data=data, params=params)
 
     def create_token(self):
+        headers = {
+            # TODO(jess): remove this whenever it's out of preview
+            "Accept": "application/vnd.github.machine-man-preview+json",
+        }
+        headers.update(jwt.authorization_header(self.get_jwt()))
         return self.post(
             f"/app/installations/{self.integration.external_id}/access_tokens",
-            headers={
-                "Authorization": b"Bearer %s" % self.get_jwt(),
-                # TODO(jess): remove this whenever it's out of preview
-                "Accept": "application/vnd.github.machine-man-preview+json",
-            },
+            headers=headers,
         )
 
     def get_repositories(self):

--- a/src/sentry_plugins/jira_ac/models.py
+++ b/src/sentry_plugins/jira_ac/models.py
@@ -1,9 +1,9 @@
 from time import time
 
-import jwt
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey, Model
+from sentry.utils import jwt
 from sentry_plugins.jira_ac.utils import get_query_hash
 
 

--- a/src/sentry_plugins/jira_ac/utils.py
+++ b/src/sentry_plugins/jira_ac/utils.py
@@ -1,9 +1,8 @@
 import hashlib
 from urllib.parse import quote
 
-import jwt
-
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils import jwt
 
 
 def percent_encode(val):
@@ -42,7 +41,7 @@ def get_jira_auth_from_request(request):
         raise ApiError("No token parameter")
     # Decode the JWT token, without verification. This gives
     # you a header JSON object, a claims JSON object, and a signature.
-    decoded = jwt.decode(token, verify=False)
+    decoded = jwt.peek_claims(token)
     # Extract the issuer ('iss') claim from the decoded, unverified
     # claims object. This is the clientKey for the tenant - an identifier
     # for the Atlassian application making the call

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -36,8 +36,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def _stub_github(self):
         responses.reset()
 
-        sentry.integrations.github.integration.get_jwt = MagicMock(return_value=b"jwt_token_1")
-        sentry.integrations.github.client.get_jwt = MagicMock(return_value=b"jwt_token_1")
+        sentry.integrations.github.integration.get_jwt = MagicMock(return_value="jwt_token_1")
+        sentry.integrations.github.client.get_jwt = MagicMock(return_value="jwt_token_1")
 
         responses.add(
             responses.POST,
@@ -87,7 +87,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         auth_header = responses.calls[0].request.headers["Authorization"]
-        assert auth_header == b"Bearer jwt_token_1"
+        assert auth_header == "Bearer jwt_token_1"
 
         self.assertDialogSuccess(resp)
         return resp
@@ -177,7 +177,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert resp.status_code == 200
 
         auth_header = responses.calls[0].request.headers["Authorization"]
-        assert auth_header == b"Bearer jwt_token_1"
+        assert auth_header == "Bearer jwt_token_1"
 
         integration = Integration.objects.get(provider=self.provider.key)
         assert integration.status == ObjectStatus.VISIBLE

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -26,7 +26,7 @@ class GitHubIssueBasicTest(TestCase):
         self.min_ago = iso_format(before_now(minutes=1))
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -47,13 +47,13 @@ class GitHubIssueBasicTest(TestCase):
         )
 
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -86,7 +86,7 @@ class GitHubIssueBasicTest(TestCase):
             "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
@@ -94,7 +94,7 @@ class GitHubIssueBasicTest(TestCase):
         assert payload == {"body": "This is the description", "assignee": None, "title": "hello"}
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -111,13 +111,13 @@ class GitHubIssueBasicTest(TestCase):
         assert self.integration.get_repo_issues(repo) == ((321, "#321 hello"),)
 
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_link_issue(self, mock_get_jwt):
         issue_id = 321
         responses.add(
@@ -147,13 +147,13 @@ class GitHubIssueBasicTest(TestCase):
             "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_repo_dropdown_choices(self, mock_get_jwt):
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
@@ -207,7 +207,7 @@ class GitHubIssueBasicTest(TestCase):
         ]
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def after_link_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -238,7 +238,7 @@ class GitHubIssueBasicTest(TestCase):
 
     @responses.activate
     @patch(
-        "sentry.integrations.github.client.GitHubClientMixin.get_token", return_value=b"jwt_token_1"
+        "sentry.integrations.github.client.GitHubClientMixin.get_token", return_value="jwt_token_1"
     )
     def test_default_repo_link_fields(self, mock_get_jwt):
         responses.add(
@@ -264,7 +264,7 @@ class GitHubIssueBasicTest(TestCase):
         assert repo_field["default"] == "getsentry/sentry"
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_default_repo_create_fields(self, mock_get_jwt):
         responses.add(
             responses.GET,
@@ -299,7 +299,7 @@ class GitHubIssueBasicTest(TestCase):
 
     @responses.activate
     @patch(
-        "sentry.integrations.github.client.GitHubClientMixin.get_token", return_value=b"jwt_token_1"
+        "sentry.integrations.github.client.GitHubClientMixin.get_token", return_value="jwt_token_1"
     )
     def test_default_repo_link_fields_no_repos(self, mock_get_jwt):
         responses.add(
@@ -316,7 +316,7 @@ class GitHubIssueBasicTest(TestCase):
         assert repo_field["choices"] == []
 
     @responses.activate
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def test_default_repo_create_fields_no_repos(self, mock_get_jwt):
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -28,8 +28,8 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
     }
     base_url = "https://github.example.org/api/v3"
 
-    @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value=b"jwt_token_1")
-    @patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token_1")
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     def assert_setup_flow(
         self, get_jwt, _, installation_id="install_id_1", app_id="app_1", user_id="user_id_1"
     ):
@@ -121,7 +121,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         assert resp.status_code == 200
 
         auth_header = responses.calls[2].request.headers["Authorization"]
-        assert auth_header == b"Bearer jwt_token_1"
+        assert auth_header == "Bearer jwt_token_1"
 
         self.assertDialogSuccess(resp)
 
@@ -161,8 +161,8 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         assert identity.status == IdentityStatus.VALID
         assert identity.data == {"access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"}
 
-    @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value=b"jwt_token_1")
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_get_repositories_search_param(self, mock_jwtm, _):
         with self.tasks():

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -31,7 +31,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         self.integration = GitHubEnterpriseIntegration(self.model, self.organization.id)
 
     @responses.activate
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_get_allowed_assignees(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -52,13 +52,13 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         )
 
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_create_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -91,7 +91,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
             "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
@@ -99,7 +99,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         assert payload == {"body": "This is the description", "assignee": None, "title": "hello"}
 
     @responses.activate
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_get_repo_issues(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -116,13 +116,13 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         assert self.integration.get_repo_issues(repo) == ((321, "#321 hello"),)
 
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_link_issue(self, mock_get_jwt):
         issue_id = 321
         responses.add(
@@ -152,13 +152,13 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
             "repo": "getsentry/sentry",
         }
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"
 
     @responses.activate
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value=b"jwt_token_1")
+    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def after_link_issue(self, mock_get_jwt):
         responses.add(
             responses.POST,
@@ -180,7 +180,7 @@ class GitHubEnterpriseIssueBasicTest(TestCase):
         self.integration.after_link_issue(external_issue, data=data)
 
         request = responses.calls[0].request
-        assert request.headers["Authorization"] == b"Bearer jwt_token_1"
+        assert request.headers["Authorization"] == "Bearer jwt_token_1"
 
         request = responses.calls[1].request
         assert request.headers["Authorization"] == "token token_1"

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -1,4 +1,3 @@
-import jwt
 import responses
 from django.test.utils import override_settings
 from requests.exceptions import ReadTimeout
@@ -6,7 +5,7 @@ from requests.exceptions import ReadTimeout
 from sentry.integrations.jira_server import JiraServerIntegrationProvider
 from sentry.models import Identity, IdentityProvider, Integration, OrganizationIntegration
 from sentry.testutils import IntegrationTestCase
-from sentry.utils import json
+from sentry.utils import json, jwt
 
 from .testutils import EXAMPLE_PRIVATE_KEY
 
@@ -305,7 +304,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
             data = json.loads(request.body)
             url = data["url"]
             token = url.split("/")[-2]
-            token_data = jwt.decode(token, verify=False)
+            token_data = jwt.peek_claims(token)
             assert "id" in token_data
             assert token_data["id"] == expected_id
 

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -57,7 +57,7 @@ class MsTeamsWebhookTest(APITestCase):
         assert resp.status_code == 204
 
         mock_decode.assert_called_with(
-            TOKEN, mock.ANY, audience="msteams-client-id", algorithms=["RS256"]
+            TOKEN, mock.ANY, audience="msteams-client-id", algorithms=["RS256"], options={}
         )
         assert (
             responses.calls[0].request.url

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -1,11 +1,11 @@
 from copy import deepcopy
 from urllib.parse import urlencode
 
-import jwt
 import responses
 
 from sentry.models import Identity, IdentityProvider, Integration
 from sentry.testutils import APITestCase
+from sentry.utils import jwt
 from sentry.utils.compat import mock
 
 from .test_helpers import (

--- a/tests/sentry/utils/jwt.py
+++ b/tests/sentry/utils/jwt.py
@@ -1,0 +1,147 @@
+import jwt
+import pytest
+
+from sentry.utils import jwt as jwt_utils
+
+RS256_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIJKAIBAAKCAgEAwcYWTDju/+S7dgFLMp6VQHbCMHTQD7RxoaTWKY8/NizzW7QX
+82QZWGyc2+1EpYgza82Joy3IQ78FRV5NHjZONgeot+ZsnznFRokXvzdrshFCv4i+
+4Jeo9RJW/32T53dM3f7kYJ+n6cDouExHIg03TpQKiB/SiAR8f6K+qa9xOCbFRv5M
+cKvLWxHsSMOx034MQKseSokX+BtPrBrCNzPeor92jljKlamIBvgtJQj/Vi4WvaFl
+oXAZ+4BOZwe51ojujYWuLUHxo4khe5Yd/auV5tKtOIBPFQRgcOOFfVc9J2BiwAk1
+KkraO4zd+s7GYvQeTd2pVLXUIQO9lLzoCtI/f4e0NAUKNo1CY6UePsxs3Q+Rdvxm
+O09mvq7E8BzqM5rKmpGc7xxuk9R1lZ6aHGe3PIVKfYgPUBn8IIspoZjLhxxhk9BC
+mwKDRofHqtmVBOk7wWgwebDqEed99pPO63vsctlci1MwUo5OvUDQtd3ULCZr+5TK
+GPtM33rmDIrGgCOJvhp2jM54KvZpt9IyC2jvwrrcnJV7/9Sipy1Ns+jKvGntcPJb
+UThjMQGqREFi8G4L8sYMYC5vJz4R1vHcysY3k0hLqyfokkW5eNveba31yzprhUFl
+ikfxHWIZipMb2CFxYN1bukMWnkRJU4ZhUoRWNYg4Kl5rg3/rE+CVfboSGvcCAwEA
+AQKCAgAeFmPf8fcqRJnW+Nx0P6ttFwOQApNL3PjH4JBgY52tC829r3kIkcJduH+i
+pnTCPyO82W1FqRYvbrmiy8Gtr0D1orrP0zeKga3gBelqB3DxdTyoANOii+nwI6je
+guE0T5Hf5nQPjLrF0O5Rr4ZcAzFTQilgeZB3DjtGlj6Emnk5/ssi+tljpUkuGtpV
+cg1qiWfdorRRXngaTiNQ1dbSO3uWSaRe9ep+0pQMgPyBg6Qh/YYKa8UcDAv8wS9r
+UAfLB/gCgX9KB7M9cU2Bow2FFd9wt8WtwD6HROa0oJ9ZlvIn6w9qQgO/TWAVXwoY
+p4KmWsFZ1dE1FgaaGbqWHb7p7ztsjLRiwiKyrkWU62LcTAoiRMaUhVUfAfJpnwPS
+Puw73v04y7hVbzDlSbaFmVy3QfhpVZ3NpG4ILftJ8oEWhTptQQamki+7JduZ6rBa
+VoKyhsHrQMJZmJM8ZtbcOMwTwjp5+bCn1nTu8mg4DwR29pMDpGMuXzy1FeSPfa1q
+w/fYOD5FoPi0GcXJEkxiZt9rj41neuSKEP6POuLDR7yiuKasKtjP9/zh+bfJ9SIO
+z75IXUFMEL5ZWEVQZCp2uXf4kLMMpDBbs/5qWfB/mV0LNoYgRJ+6pJWcEsm3MPX3
+XGf8iEjxDSDAdskJTk9wWrd6pD1PEalE3rT3L+fvaPdYr4A6AQKCAQEA5PHbJWX2
+TflCgRediVZSVehKW7iW5KjjOUUe85rvGlOqQD66vOMjJfEJU83srhpI6tfJ3roi
+b2NK9XCEuXhQmeC74kZiLxVQFF8wY6j5mGAGMz6j/EGcoxZNhatLIbKNUtyKhFSo
+9+buVM5SZNG69WP5jIvGYR586EQv8/OlBB3ubcLYOT49oB7Z+onkIaeeYboXv+Tr
+XJ/JY7DAx0ZKIL8Dvg4kdJtRqFVi5jKfOENnV8Rj90wRcMbBAV7dDDvZhFju0uBm
+3O1y8sSIw8xBWkA4zgZl+Voscrruepp3MSceOczAtbwFcUwKymWucZ69FSr20iyG
+3ym6oMR2X4ZBcwKCAQEA2Kw46Soq47TsYwZvx8GnVM8t8CJDO5yPWPwppVKeYgwT
+g6du84Lf6WP2KB992J144rioVbfhSefuMZ8f7v/UaQvsPFE4SGRO2JVvBHy49vxI
+0zGTBAiIvKzQ6bQ3VqXdxdR+NsnQ2XICqhWPEbbqKZ1FmBC6ydaATXoz5nTDX0IA
+zPH3vaG0YQXrCyIN8iAdsv75BazPZqcjj6cm7CYi87kFvNVghfNAbsPgGnTxhgsg
+tnjWnWjnrTiy0lYHRPYoRnBSw3gcTlxJSPv+LvVxdEuEscFW0A3VsqlEsKw5FS8O
+j8o0iEjiTLtOHTHYggN2dnbmEG0gu1foHqPnyQOPbQKCAQEAzDG6V3y9VYY/fovl
+ghxvixeHWo8kZgULxISVuogxQbXlXy+TteyP6MM2onxD4HSpHGwiLHivRdG1hXs5
+pYJdwSDj8kj8QSotJj5QFlMbaoAah5ITCGYsoni9476HYCK0UXdKRASOP6zEXPc4
+HZvBuCPW6zevU+exWCeY7WgdgbKAeX0TBNsyc6GQoRhjVHD/ngIwNIKkORR6tmNr
+TVCvxM0ZNWW/thDhn9WoQ9Bamf/kKC+NSX+a/o8GjYZieQrYUmZPe92RYPKXV1da
+8+c1Up19DKRAR0nZ4uo+0TL7o+dT2hF4v55W7Fn6NdLC56vA0SRkx8fW8ytwvPr8
+6O4BaQKCAQASakDEAGN4yu20VN23OoxANwOOfzr7nAjK5VOcy3LOnnwiGl7hr2Pc
+cDSBoHuPp4KYsl0MO/6Xy3CBIycRpwikjPDdB4IjFPNmkPzIgtktlK+T04jNNPR6
+JK30zu5NHPfGUpMPkQOBF6GGVyK7vLIWK1m43OMjOGnbK+GxWocoV3G9+Wq24UF1
+ZY1eetx4kaY0ilsb0l4mOVpaYTh7pZoe4MDOFcyIVe5J+7fWR84nOFbla0vCQSI/
+pKv+GHWxtMIjinReTJ0LQ+iunUwzLYUg/zId8XKxaBubfatq4JhRZph0PBlO4/Ln
+1puC+7ONCUJOOzi+eKfphEUkJYYTnYvZAoIBABtykB17voNo1KVAQz2pMyg0Q2bu
+LWUdk1qKXF1VA4GlTAoylvX33N3f3rT176TRrSAfD3pjuRiWECWQ3ZayubTmEMAm
+Zvpv90jEn1HfRdT9Ymic4506ctv074/nfQJWX7TR5gfN87VlxH+ISqkaqjhUcXHk
+buBQ93oz/nENi+wWkTOtouQ6QzR6LIqmR/EofMDHi/vgCMFkg4+1kSSqOeDvWLGE
+WG5J/FJm/YY9c1G0kY7CMwq1WGyGUgpd0Xtqze0v7qqI3pwilRo7R/3+9OfAS58s
+Rt4IpcVVl+gvmjsV4PWILGI3EbCP6WOCbJPGjdVmRxl/8Ng4HYwU8DCveiQ=
+-----END RSA PRIVATE KEY-----
+"""
+
+
+@pytest.fixture
+def token():
+    headers = {
+        "alg": "HS256",
+        "typ": "JWT",
+    }
+    claims = {
+        "iss": "me",
+    }
+    key = "secret"
+    encoded = jwt.encode(claims, key, algorithm="HS256", headers=headers)
+
+    # PyJWT < 2.0 returns bytes, not strings
+    token = encoded.decode("UTF-8")
+    assert isinstance(token, str)
+
+    return token
+
+
+def test_peek_claims(token):
+    claims = jwt_utils.peek_claims(token)
+    assert claims == {"iss": "me"}
+
+    for key, value in claims.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+
+
+def test_decode(token):
+    claims = jwt_utils.decode(token, "secret")
+    assert claims == {"iss": "me"}
+
+    for key, value in claims.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+
+    claims["aud"] = "you"
+    token = jwt_utils.encode(claims, "secret")
+
+    with pytest.raises(jwt.InvalidAudience):
+        jwt_utils.decode(token, "secret")
+
+    claims = jwt_utils.decode(token, "secret", verify_aud=False)
+    assert claims == {"iss": "me", "aud": "you"}
+
+
+def test_encode(token):
+    headers = {
+        "alg": "HS256",
+        "typ": "JWT",
+    }
+    claims = {
+        "iss": "me",
+    }
+    key = b"secret"
+
+    encoded = jwt_utils.encode(claims, key, headers=headers)
+    assert isinstance(encoded, str)
+
+    assert encoded.count(".") == 2
+    assert encoded == token
+
+    decoded_claims = jwt_utils.decode(encoded, key)
+    assert decoded_claims == claims
+
+
+def test_encode_rs256():
+    headers = {
+        "alg": "RS256",
+        "typ": "JWT",
+    }
+    claims = {
+        "iss": "me",
+    }
+    encoded_hs256 = jwt_utils.encode(claims, "secret", headers=headers)
+    encoded_rs256 = jwt_utils.encode(claims, RS256_KEY, headers=headers, algorithm="RS256")
+
+    assert encoded_rs256.count(".") == 2
+    assert encoded_rs256 != encoded_hs256
+
+
+def test_authorization_header(token):
+    header = jwt_utils.authorization_header(token)
+    assert header == {"Authorization": f"Bearer {token}"}
+
+    header = jwt_utils.authorization_header(token, scheme="JWT")
+    assert header == {"Authorization": f"JWT {token}"}

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -193,7 +193,17 @@ def test_rsa_key_from_jwk() -> None:
     assert key
     assert isinstance(key, bytes)
 
+    # assert key == RS256_KEY.lstrip()
+
     # Ensure we can use the key to create a token
     claims = {"iss": "me"}
     token = jwt_utils.encode(claims, key)
     assert token
+
+    token2 = jwt_utils.encode(claims, RS256_KEY)
+    assert token == token2
+
+
+# TODO: add tests which only have a public key and verify we can decode with that.  We do
+# not currently have type-safety of the keys to distinguish between keys suitable for
+# encoding and decoding or those only suitable for decoding.

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -123,10 +123,10 @@ def rsa_token() -> str:
     claims = {
         "iss": "me",
     }
-    token = pyjwt.encode(claims, RS256_KEY, algorithm="RS256", headers=headers)
+    encoded = pyjwt.encode(claims, RS256_KEY, algorithm="RS256", headers=headers)
 
     # PyJWT < 2.0 returns bytes, not strings
-    token = token.decode("UTF-8")
+    token = encoded.decode("UTF-8")
     assert isinstance(token, str)
     return token
 

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -1,6 +1,5 @@
 import jwt as pyjwt
 import pytest
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 
 from sentry.utils import json
 from sentry.utils import jwt as jwt_utils
@@ -181,7 +180,7 @@ def test_authorization_header(token):
 def test_rsa_key_from_jwk():
     key = jwt_utils.rsa_key_from_jwk(json.dumps(RSA_JWK))
     assert key
-    assert isinstance(key, RSAPrivateKey)
+    assert isinstance(key, bytes)
 
     # Ensure we can use the key to create a token
     claims = {"iss": "me"}

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -193,15 +193,16 @@ def test_rsa_key_from_jwk() -> None:
     assert key
     assert isinstance(key, bytes)
 
+    # The PEM keys are not equal, and by more than just the header and footer ("BEGIN RSA
+    # PRIVATE KEY" vs "BEGIN PRIVATE KEY").  There might be some more metadata in there that
+    # is not relevant.  However below we assert the generated tokens are identical.
     # assert key == RS256_KEY.lstrip()
 
     # Ensure we can use the key to create a token
     claims = {"iss": "me"}
-    token = jwt_utils.encode(claims, key)
-    assert token
-
-    token2 = jwt_utils.encode(claims, RS256_KEY)
-    assert token == token2
+    token_from_jwk = jwt_utils.encode(claims, key, algorithm="RS256")
+    token = jwt_utils.encode(claims, RS256_KEY, algorithm="RS256")
+    assert token_from_jwk == token
 
 
 # TODO: add tests which only have a public key and verify we can decode with that.  We do

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -58,6 +58,23 @@ Rt4IpcVVl+gvmjsV4PWILGI3EbCP6WOCbJPGjdVmRxl/8Ng4HYwU8DCveiQ=
 -----END RSA PRIVATE KEY-----
 """
 
+RS256_PUB_KEY = b"""
+-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwcYWTDju/+S7dgFLMp6V
+QHbCMHTQD7RxoaTWKY8/NizzW7QX82QZWGyc2+1EpYgza82Joy3IQ78FRV5NHjZO
+Ngeot+ZsnznFRokXvzdrshFCv4i+4Jeo9RJW/32T53dM3f7kYJ+n6cDouExHIg03
+TpQKiB/SiAR8f6K+qa9xOCbFRv5McKvLWxHsSMOx034MQKseSokX+BtPrBrCNzPe
+or92jljKlamIBvgtJQj/Vi4WvaFloXAZ+4BOZwe51ojujYWuLUHxo4khe5Yd/auV
+5tKtOIBPFQRgcOOFfVc9J2BiwAk1KkraO4zd+s7GYvQeTd2pVLXUIQO9lLzoCtI/
+f4e0NAUKNo1CY6UePsxs3Q+RdvxmO09mvq7E8BzqM5rKmpGc7xxuk9R1lZ6aHGe3
+PIVKfYgPUBn8IIspoZjLhxxhk9BCmwKDRofHqtmVBOk7wWgwebDqEed99pPO63vs
+ctlci1MwUo5OvUDQtd3ULCZr+5TKGPtM33rmDIrGgCOJvhp2jM54KvZpt9IyC2jv
+wrrcnJV7/9Sipy1Ns+jKvGntcPJbUThjMQGqREFi8G4L8sYMYC5vJz4R1vHcysY3
+k0hLqyfokkW5eNveba31yzprhUFlikfxHWIZipMb2CFxYN1bukMWnkRJU4ZhUoRW
+NYg4Kl5rg3/rE+CVfboSGvcCAwEAAQ==
+-----END PUBLIC KEY-----
+"""
+
 RSA_JWK = {
     "n": "wcYWTDju_-S7dgFLMp6VQHbCMHTQD7RxoaTWKY8_NizzW7QX82QZWGyc2-1EpYgza82Joy3IQ78FRV5NHjZONgeot-ZsnznFRokXvzdrshFCv4i-4Jeo9RJW_32T53dM3f7kYJ-n6cDouExHIg03TpQKiB_SiAR8f6K-qa9xOCbFRv5McKvLWxHsSMOx034MQKseSokX-BtPrBrCNzPeor92jljKlamIBvgtJQj_Vi4WvaFloXAZ-4BOZwe51ojujYWuLUHxo4khe5Yd_auV5tKtOIBPFQRgcOOFfVc9J2BiwAk1KkraO4zd-s7GYvQeTd2pVLXUIQO9lLzoCtI_f4e0NAUKNo1CY6UePsxs3Q-RdvxmO09mvq7E8BzqM5rKmpGc7xxuk9R1lZ6aHGe3PIVKfYgPUBn8IIspoZjLhxxhk9BCmwKDRofHqtmVBOk7wWgwebDqEed99pPO63vsctlci1MwUo5OvUDQtd3ULCZr-5TKGPtM33rmDIrGgCOJvhp2jM54KvZpt9IyC2jvwrrcnJV7_9Sipy1Ns-jKvGntcPJbUThjMQGqREFi8G4L8sYMYC5vJz4R1vHcysY3k0hLqyfokkW5eNveba31yzprhUFlikfxHWIZipMb2CFxYN1bukMWnkRJU4ZhUoRWNYg4Kl5rg3_rE-CVfboSGvc",
     "e": "AQAB",
@@ -70,9 +87,16 @@ RSA_JWK = {
     "kty": "RSA",
 }
 
+RSA_PUB_JWK = {
+    "n": "wcYWTDju_-S7dgFLMp6VQHbCMHTQD7RxoaTWKY8_NizzW7QX82QZWGyc2-1EpYgza82Joy3IQ78FRV5NHjZONgeot-ZsnznFRokXvzdrshFCv4i-4Jeo9RJW_32T53dM3f7kYJ-n6cDouExHIg03TpQKiB_SiAR8f6K-qa9xOCbFRv5McKvLWxHsSMOx034MQKseSokX-BtPrBrCNzPeor92jljKlamIBvgtJQj_Vi4WvaFloXAZ-4BOZwe51ojujYWuLUHxo4khe5Yd_auV5tKtOIBPFQRgcOOFfVc9J2BiwAk1KkraO4zd-s7GYvQeTd2pVLXUIQO9lLzoCtI_f4e0NAUKNo1CY6UePsxs3Q-RdvxmO09mvq7E8BzqM5rKmpGc7xxuk9R1lZ6aHGe3PIVKfYgPUBn8IIspoZjLhxxhk9BCmwKDRofHqtmVBOk7wWgwebDqEed99pPO63vsctlci1MwUo5OvUDQtd3ULCZr-5TKGPtM33rmDIrGgCOJvhp2jM54KvZpt9IyC2jvwrrcnJV7_9Sipy1Ns-jKvGntcPJbUThjMQGqREFi8G4L8sYMYC5vJz4R1vHcysY3k0hLqyfokkW5eNveba31yzprhUFlikfxHWIZipMb2CFxYN1bukMWnkRJU4ZhUoRWNYg4Kl5rg3_rE-CVfboSGvc",
+    "e": "AQAB",
+    "kty": "RSA",
+}
+
 
 @pytest.fixture  # type: ignore
 def token() -> str:
+    """A JWT token, signed with symmetric key."""
     headers = {
         "alg": "HS256",
         "typ": "JWT",
@@ -86,7 +110,24 @@ def token() -> str:
     # PyJWT < 2.0 returns bytes, not strings
     token = encoded.decode("UTF-8")
     assert isinstance(token, str)
+    return token
 
+
+@pytest.fixture  # type: ignore
+def rsa_token() -> str:
+    """A JWT token, signed with RSA key."""
+    headers = {
+        "alg": "RS256",
+        "typ": "JWT",
+    }
+    claims = {
+        "iss": "me",
+    }
+    token = pyjwt.encode(claims, RS256_KEY, algorithm="RS256", headers=headers)
+
+    # PyJWT < 2.0 returns bytes, not strings
+    token = token.decode("UTF-8")
+    assert isinstance(token, str)
     return token
 
 
@@ -123,6 +164,11 @@ def test_decode(token: str) -> None:
 
     with pytest.raises(pyjwt.InvalidAudience):
         jwt_utils.decode(token, b"secret")
+
+
+def test_decode_pub(rsa_token: str) -> None:
+    claims = jwt_utils.decode(rsa_token, RS256_PUB_KEY, algorithms=["RS256"])
+    assert claims == {"iss": "me"}
 
 
 def test_decode_audience() -> None:
@@ -205,6 +251,10 @@ def test_rsa_key_from_jwk() -> None:
     assert token_from_jwk == token
 
 
-# TODO: add tests which only have a public key and verify we can decode with that.  We do
-# not currently have type-safety of the keys to distinguish between keys suitable for
-# encoding and decoding or those only suitable for decoding.
+def test_rsa_key_from_jwk_pubkey(rsa_token: str) -> None:
+    key = jwt_utils.rsa_key_from_jwk(json.dumps(RSA_PUB_JWK))
+    assert key
+    assert isinstance(key, bytes)
+
+    claims = jwt_utils.decode(rsa_token, key, algorithms=["RS256"])
+    assert claims == {"iss": "me"}

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -1,7 +1,7 @@
 import jwt as pyjwt
 import pytest
 
-from sentry.utils import json
+from sentry.utils import json  # type: ignore
 from sentry.utils import jwt as jwt_utils
 
 RS256_KEY = b"""
@@ -71,8 +71,8 @@ RSA_JWK = {
 }
 
 
-@pytest.fixture
-def token():
+@pytest.fixture  # type: ignore
+def token() -> str:
     headers = {
         "alg": "HS256",
         "typ": "JWT",
@@ -90,7 +90,7 @@ def token():
     return token
 
 
-def test_peek_header(token):
+def test_peek_header(token: str) -> None:
     header = jwt_utils.peek_header(token)
 
     assert isinstance(header, dict)
@@ -101,7 +101,7 @@ def test_peek_header(token):
     assert header == {"alg": "HS256", "typ": "JWT"}
 
 
-def test_peek_claims(token):
+def test_peek_claims(token: str) -> None:
     claims = jwt_utils.peek_claims(token)
     assert claims == {"iss": "me"}
 
@@ -110,7 +110,7 @@ def test_peek_claims(token):
         assert isinstance(value, str)
 
 
-def test_decode(token):
+def test_decode(token: str) -> None:
     claims = jwt_utils.decode(token, "secret")
     assert claims == {"iss": "me"}
 
@@ -125,7 +125,7 @@ def test_decode(token):
         jwt_utils.decode(token, b"secret")
 
 
-def test_decode_audience():
+def test_decode_audience() -> None:
     payload = {
         "iss": "me",
         "aud": "you",
@@ -145,7 +145,7 @@ def test_decode_audience():
     assert claims == payload
 
 
-def test_encode(token):
+def test_encode(token: str) -> None:
     headers = {
         "alg": "HS256",
         "typ": "JWT",
@@ -165,7 +165,7 @@ def test_encode(token):
     assert decoded_claims == claims
 
 
-def test_encode_rs256():
+def test_encode_rs256() -> None:
     headers = {
         "alg": "RS256",
         "typ": "JWT",
@@ -180,7 +180,7 @@ def test_encode_rs256():
     assert encoded_rs256 != encoded_hs256
 
 
-def test_authorization_header(token):
+def test_authorization_header(token: str) -> None:
     header = jwt_utils.authorization_header(token)
     assert header == {"Authorization": f"Bearer {token}"}
 
@@ -188,7 +188,7 @@ def test_authorization_header(token):
     assert header == {"Authorization": f"JWT {token}"}
 
 
-def test_rsa_key_from_jwk():
+def test_rsa_key_from_jwk() -> None:
     key = jwt_utils.rsa_key_from_jwk(json.dumps(RSA_JWK))
     assert key
     assert isinstance(key, bytes)

--- a/tests/sentry/utils/test_jwt.py
+++ b/tests/sentry/utils/test_jwt.py
@@ -4,7 +4,7 @@ import pytest
 from sentry.utils import json  # type: ignore
 from sentry.utils import jwt as jwt_utils
 
-RS256_KEY = b"""
+RS256_KEY = """
 -----BEGIN RSA PRIVATE KEY-----
 MIIJKAIBAAKCAgEAwcYWTDju/+S7dgFLMp6VQHbCMHTQD7RxoaTWKY8/NizzW7QX
 82QZWGyc2+1EpYgza82Joy3IQ78FRV5NHjZONgeot+ZsnznFRokXvzdrshFCv4i+
@@ -58,7 +58,7 @@ Rt4IpcVVl+gvmjsV4PWILGI3EbCP6WOCbJPGjdVmRxl/8Ng4HYwU8DCveiQ=
 -----END RSA PRIVATE KEY-----
 """
 
-RS256_PUB_KEY = b"""
+RS256_PUB_KEY = """
 -----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwcYWTDju/+S7dgFLMp6V
 QHbCMHTQD7RxoaTWKY8/NizzW7QX82QZWGyc2+1EpYgza82Joy3IQ78FRV5NHjZO
@@ -160,10 +160,10 @@ def test_decode(token: str) -> None:
         assert isinstance(value, str)
 
     claims["aud"] = "you"
-    token = jwt_utils.encode(claims, b"secret")
+    token = jwt_utils.encode(claims, "secret")
 
     with pytest.raises(pyjwt.InvalidAudience):
-        jwt_utils.decode(token, b"secret")
+        jwt_utils.decode(token, "secret")
 
 
 def test_decode_pub(rsa_token: str) -> None:
@@ -176,18 +176,18 @@ def test_decode_audience() -> None:
         "iss": "me",
         "aud": "you",
     }
-    token = jwt_utils.encode(payload, b"secret")
+    token = jwt_utils.encode(payload, "secret")
 
     with pytest.raises(pyjwt.InvalidAudience):
-        jwt_utils.decode(token, b"secret")
+        jwt_utils.decode(token, "secret")
 
-    claims = jwt_utils.decode(token, b"secret", audience="you")
+    claims = jwt_utils.decode(token, "secret", audience="you")
     assert claims == payload
 
     with pytest.raises(pyjwt.InvalidAudience):
-        jwt_utils.decode(token, b"secret", audience="wrong")
+        jwt_utils.decode(token, "secret", audience="wrong")
 
-    claims = jwt_utils.decode(token, b"secret", audience=False)
+    claims = jwt_utils.decode(token, "secret", audience=False)
     assert claims == payload
 
 
@@ -199,7 +199,7 @@ def test_encode(token: str) -> None:
     claims = {
         "iss": "me",
     }
-    key = b"secret"
+    key = "secret"
 
     encoded = jwt_utils.encode(claims, key, headers=headers)
     assert isinstance(encoded, str)
@@ -219,7 +219,7 @@ def test_encode_rs256() -> None:
     claims = {
         "iss": "me",
     }
-    encoded_hs256 = jwt_utils.encode(claims, b"secret", headers=headers)
+    encoded_hs256 = jwt_utils.encode(claims, "secret", headers=headers)
     encoded_rs256 = jwt_utils.encode(claims, RS256_KEY, headers=headers, algorithm="RS256")
 
     assert encoded_rs256.count(".") == 2
@@ -237,7 +237,7 @@ def test_authorization_header(token: str) -> None:
 def test_rsa_key_from_jwk() -> None:
     key = jwt_utils.rsa_key_from_jwk(json.dumps(RSA_JWK))
     assert key
-    assert isinstance(key, bytes)
+    assert isinstance(key, str)
 
     # The PEM keys are not equal, and by more than just the header and footer ("BEGIN RSA
     # PRIVATE KEY" vs "BEGIN PRIVATE KEY").  There might be some more metadata in there that
@@ -254,7 +254,7 @@ def test_rsa_key_from_jwk() -> None:
 def test_rsa_key_from_jwk_pubkey(rsa_token: str) -> None:
     key = jwt_utils.rsa_key_from_jwk(json.dumps(RSA_PUB_JWK))
     assert key
-    assert isinstance(key, bytes)
+    assert isinstance(key, str)
 
     claims = jwt_utils.decode(rsa_token, key, algorithms=["RS256"])
     assert claims == {"iss": "me"}


### PR DESCRIPTION
This achieves tight control of the types involved and centralises
all interactions with PyJWT.  Additionally a common method to
construct the authorization header is added as string type
subtleties here have been proven cumbersome.

This does not attempt to upgrade PyJWT yet, though it does adopt the token to be string type already.

Overall I'm not widely enthusiastic about this, it's a custom wrapper around the API that only does what we use but will get more complex as we need more.  Eventually it will end up the same at best, or more complex at worst.  I think the main interesting parts are `peek_claims()` and `authorisation_header()` as they probably solve some common operations.  So it could perhaps be better to keep those but remove the `encode()` and `decode()` calls, leaving users to use them directly from PyJWT.