### PR TITLE
ref(search): Improve free_text token

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -43,7 +43,8 @@ boolean_operator = spaces (or_operator / and_operator) spaces
 paren_term       = spaces open_paren spaces (paren_term / boolean_operator / search_term)+ spaces closed_paren spaces
 search_term      = key_val_term / free_text_quoted / free_text
 
-free_text        = (!key_val_term ~r"\ *(?!(?i)OR(?![^\s]))(?!(?i)AND(?![^\s]))([^\ ^\n ()]+)\ *" )*
+free_text        = (spaces !key_val_term !or_operator !and_operator (free_parens / ~r"[^()\n ]+") spaces)+
+free_parens      = spaces open_paren spaces free_text? spaces closed_paren spaces
 free_text_quoted = spaces quoted_value spaces
 
 # All key:value filter types

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -45,6 +45,7 @@ def apply_dataset_query_conditions(dataset, query, event_types, discover=False):
     """
     if not discover and dataset == QueryDatasets.TRANSACTIONS:
         return query
+
     if event_types:
         event_type_conditions = " OR ".join(
             [f"event.type:{event_type.name.lower()}" for event_type in event_types]
@@ -54,7 +55,10 @@ def apply_dataset_query_conditions(dataset, query, event_types, discover=False):
     else:
         return query
 
-    return f"({event_type_conditions}) AND ({query})"
+    if query:
+        return f"({event_type_conditions}) AND ({query})"
+
+    return event_type_conditions
 
 
 @instrumented_task(

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -142,12 +142,9 @@ class ParseSearchQueryTest(TestCase):
             SearchFilter(
                 key=SearchKey(name="message"),
                 operator="=",
-                value=SearchValue(raw_value="TypeError Anonymous function"),
-            ),
-            SearchFilter(
-                key=SearchKey(name="message"),
-                operator="=",
-                value=SearchValue(raw_value="(app/javascript/utils/transform-object-keys)"),
+                value=SearchValue(
+                    raw_value="TypeError Anonymous function(app/javascript/utils/transform-object-keys)"
+                ),
             ),
         ]
 


### PR DESCRIPTION
It now correctly understands parenthesis when they just include more
free text, and are not paren_terms