### PR TITLE
ui(trace-view): Break header into multiple rows

### DIFF
--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -38,7 +38,7 @@ export const TraceViewHeaderContainer = styled(SecondaryHeader)`
 
 export const TraceDetailHeader = styled('div')`
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr;
   grid-gap: ${space(2)};
   margin-bottom: ${space(2)};
 


### PR DESCRIPTION
This breaks the trace view header into multiple rows on smaller screens to make
it more legible.

# Screenshots

## Before

![Screen Shot 2021-05-20 at 16 24 55](https://user-images.githubusercontent.com/10239353/118879482-c5fe3380-b8be-11eb-8b20-477035c090dd.png)

## After

![Screen Shot 2021-05-20 at 16 22 49](https://user-images.githubusercontent.com/10239353/118879282-846d8880-b8be-11eb-9b59-27a27c531ddc.png)
