### PR TITLE
fix(trends): Chart title background overlapping panel border

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -545,6 +545,7 @@ const ChartContainer = styled('div')`
 `;
 
 const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
+  border-radius: ${p => p.theme.borderRadius};
   padding: ${space(2)} ${space(3)};
 `;
 


### PR DESCRIPTION
### Summary
This fixes a few pixels missing from the trends panel because of the title header overlapping it.

### Screenshots
#### Before
![Screen Shot 2021-05-19 at 1 56 19 PM](https://user-images.githubusercontent.com/6111995/118883615-48c8c380-b8aa-11eb-9ea7-8fbe7cdd7b87.png)

#### After
![Screen Shot 2021-05-19 at 1 56 26 PM](https://user-images.githubusercontent.com/6111995/118883627-4c5c4a80-b8aa-11eb-980f-d1d20fb60e6a.png)
