### PR TITLE
ref(sdk): Add another check to find rest of events

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -231,6 +231,18 @@ def patch_transport_for_instrumentation(transport, transport_name):
             return _update_rate_limits(*args, **kwargs)
 
         transport._update_rate_limits = patched_update_rate_limits
+
+    _check_disabled = transport._check_disabled
+    if _check_disabled:
+
+        def patched_check_disabled(*args, **kwargs):
+            result = _check_disabled(*args, **kwargs)
+            if result:
+                metrics.incr(f"internal.check_disabled.{transport_name}.events.is_disabled")
+            return result
+
+        transport._check_disabled = patched_check_disabled
+
     return transport
 
 


### PR DESCRIPTION
### Summary
This is likely the check (due to occasional 429s or the returned header causing rate limited periods) that should be the cause of the missing transactions, adding another metric here to see if it adds up.