### PR TITLE
fix(ui): Alert details chart header item alignments

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -165,28 +165,28 @@ export default class DetailsBody extends React.Component<Props> {
     return (
       <React.Fragment>
         <SidebarGroup>
-          <SidebarHeading>{t('Metric')}</SidebarHeading>
+          <Heading>{t('Metric')}</Heading>
           <RuleText>{this.getMetricText()}</RuleText>
         </SidebarGroup>
 
         <SidebarGroup>
-          <SidebarHeading>{t('Environment')}</SidebarHeading>
+          <Heading>{t('Environment')}</Heading>
           <RuleText>{rule.environment ?? 'All'}</RuleText>
         </SidebarGroup>
 
         <SidebarGroup>
-          <SidebarHeading>{t('Filters')}</SidebarHeading>
+          <Heading>{t('Filters')}</Heading>
           {this.getFilter()}
         </SidebarGroup>
 
         <SidebarGroup>
-          <SidebarHeading>{t('Conditions')}</SidebarHeading>
+          <Heading>{t('Conditions')}</Heading>
           {criticalTrigger && this.renderTrigger(criticalTrigger)}
           {warningTrigger && this.renderTrigger(warningTrigger)}
         </SidebarGroup>
 
         <SidebarGroup>
-          <SidebarHeading>{t('Other Details')}</SidebarHeading>
+          <Heading>{t('Other Details')}</Heading>
           <KeyValueTable>
             <Feature features={['organizations:team-alerts-ownership']}>
               <KeyValueTableRow
@@ -234,15 +234,15 @@ export default class DetailsBody extends React.Component<Props> {
     return (
       <StatusContainer>
         <div>
-          <SidebarHeading noMargin>{t('Status')}</SidebarHeading>
+          <Heading noMargin>{t('Status')}</Heading>
           <ItemValue>
             <AlertBadge status={status} />
           </ItemValue>
         </div>
         <div>
-          <SidebarHeading noMargin>
+          <Heading noMargin>
             {activeIncident ? t('Last Triggered') : t('Last Resolved')}
-          </SidebarHeading>
+          </Heading>
           <ItemValue>{activityDate ? <TimeSince date={activityDate} /> : '-'}</ItemValue>
         </div>
       </StatusContainer>
@@ -307,8 +307,8 @@ export default class DetailsBody extends React.Component<Props> {
                 <Layout.Main>
                   <HeaderContainer>
                     <HeaderGrid>
-                      <div>
-                        <SidebarHeading noMargin>{t('Display')}</SidebarHeading>
+                      <HeaderItem>
+                        <Heading noMargin>{t('Display')}</Heading>
                         <ChartControls>
                           <DropdownControl label={timePeriod.display}>
                             {TIME_OPTIONS.map(({label, value}) => (
@@ -322,16 +322,16 @@ export default class DetailsBody extends React.Component<Props> {
                             ))}
                           </DropdownControl>
                         </ChartControls>
-                      </div>
+                      </HeaderItem>
                       {projects && projects.length && (
-                        <div>
-                          <SidebarHeading noMargin>{t('Project')}</SidebarHeading>
+                        <HeaderItem>
+                          <Heading noMargin>{t('Project')}</Heading>
 
                           <IdBadge avatarSize={16} project={projects[0]} />
-                        </div>
+                        </HeaderItem>
                       )}
-                      <div>
-                        <SidebarHeading noMargin>
+                      <HeaderItem>
+                        <Heading noMargin>
                           {t('Time Interval')}
                           <Tooltip
                             title={t(
@@ -340,10 +340,10 @@ export default class DetailsBody extends React.Component<Props> {
                           >
                             <IconInfo size="xs" color="gray200" />
                           </Tooltip>
-                        </SidebarHeading>
+                        </Heading>
 
                         <RuleText>{this.getTimeWindow()}</RuleText>
-                      </div>
+                      </HeaderItem>
                     </HeaderGrid>
                   </HeaderContainer>
 
@@ -435,8 +435,20 @@ const HeaderContainer = styled('div')`
 const HeaderGrid = styled('div')`
   display: grid;
   grid-template-columns: auto auto auto;
-  align-items: flex-start;
-  gap: ${space(4)};
+  align-items: stretch;
+  grid-gap: 60px;
+`;
+
+const HeaderItem = styled('div')`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  > *:nth-child(2) {
+    flex: 1;
+    display: flex;
+    align-items: center;
+  }
 `;
 
 const StyledLayoutBody = styled(Layout.Body)`
@@ -477,7 +489,7 @@ const StatusContainer = styled('div')`
   margin-bottom: 20px;
 `;
 
-const SidebarHeading = styled(SectionHeading)<{noMargin?: boolean}>`
+const Heading = styled(SectionHeading)<{noMargin?: boolean}>`
   display: grid;
   grid-template-columns: auto auto;
   justify-content: flex-start;

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -235,15 +235,11 @@ export default class DetailsBody extends React.Component<Props> {
       <StatusContainer>
         <HeaderItem>
           <Heading noMargin>{t('Status')}</Heading>
-          <ItemValue>
-            <AlertBadge status={status} />
-          </ItemValue>
-        </HeaderItem>
-        <HeaderItem>
-          <Heading noMargin>
-            {activeIncident ? t('Last Triggered') : t('Last Resolved')}
-          </Heading>
-          <ItemValue>{activityDate ? <TimeSince date={activityDate} /> : '-'}</ItemValue>
+          <Status>
+            <AlertBadge status={status} hideText />
+            {activeIncident ? t('Triggered') : t('Resolved')}
+            {activityDate ? <TimeSince date={activityDate} /> : '-'}
+          </Status>
         </HeaderItem>
       </StatusContainer>
     );
@@ -475,19 +471,17 @@ const ActivityWrapper = styled('div')`
   width: 100%;
 `;
 
-const ItemValue = styled('div')`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
+const Status = styled('div')`
   position: relative;
-  font-size: ${p => p.theme.fontSizeExtraLarge};
+  display: grid;
+  grid-template-columns: auto auto auto;
+  grid-gap: ${space(0.5)};
+  font-size: ${p => p.theme.fontSizeLarge};
 `;
 
 const StatusContainer = styled('div')`
   height: 60px;
-  display: grid;
-  grid-template-columns: 50% 50%;
-  grid-gap: ${space(2)};
+  display: flex;
   margin-bottom: ${space(1.5)};
 `;
 

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -233,18 +233,18 @@ export default class DetailsBody extends React.Component<Props> {
 
     return (
       <StatusContainer>
-        <div>
+        <HeaderItem>
           <Heading noMargin>{t('Status')}</Heading>
           <ItemValue>
             <AlertBadge status={status} />
           </ItemValue>
-        </div>
-        <div>
+        </HeaderItem>
+        <HeaderItem>
           <Heading noMargin>
             {activeIncident ? t('Last Triggered') : t('Last Resolved')}
           </Heading>
           <ItemValue>{activityDate ? <TimeSince date={activityDate} /> : '-'}</ItemValue>
-        </div>
+        </HeaderItem>
       </StatusContainer>
     );
   }
@@ -427,6 +427,7 @@ const StatusWrapper = styled('div')`
 `;
 
 const HeaderContainer = styled('div')`
+  height: 60px;
   display: flex;
   flex-direction: row;
   align-content: flex-start;
@@ -483,10 +484,11 @@ const ItemValue = styled('div')`
 `;
 
 const StatusContainer = styled('div')`
+  height: 60px;
   display: grid;
   grid-template-columns: 50% 50%;
-  grid-row-gap: 16px;
-  margin-bottom: 20px;
+  grid-gap: ${space(2)};
+  margin-bottom: ${space(1.5)};
 `;
 
 const Heading = styled(SectionHeading)<{noMargin?: boolean}>`

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -234,7 +234,7 @@ export default class DetailsBody extends React.Component<Props> {
     return (
       <StatusContainer>
         <HeaderItem>
-          <Heading noMargin>{t('Status')}</Heading>
+          <Heading noMargin>{t('Current Status')}</Heading>
           <Status>
             <AlertBadge status={status} hideText />
             {activeIncident ? t('Triggered') : t('Resolved')}

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -15,6 +15,7 @@ import MarkArea from 'app/components/charts/components/markArea';
 import MarkLine from 'app/components/charts/components/markLine';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart, {LineChartSeries} from 'app/components/charts/lineChart';
+import {SectionHeading} from 'app/components/charts/styles';
 import {
   parseStatsPeriod,
   StatsPeriodType,
@@ -672,10 +673,14 @@ const ChartSummary = styled('div')`
   margin-right: auto;
 `;
 
-const SummaryText = styled('span')`
-  margin-top: ${space(0.25)};
+const SummaryText = styled(SectionHeading)`
+  flex: 1;
+  display: flex;
+  align-items: center;
+  margin: 0;
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1;
 `;
 
 const SummaryStats = styled('div')`


### PR DESCRIPTION
This fixes the vertical alignment of the header items, makes them centered and increases the gap between items.
Changed the status headers to a single item and adjusted the margins according to the new designs.

Before:
![Screen Shot 2021-05-19 at 9 22 39 PM](https://user-images.githubusercontent.com/15015880/118918905-5f8e0b00-b8e8-11eb-9e95-a194dfc0c930.png)

After:
![Screen Shot 2021-05-19 at 10 01 04 PM](https://user-images.githubusercontent.com/15015880/118921848-c235d580-b8ed-11eb-8801-ef254c505b06.png)
