### PR TITLE
feat(search): Remove optional colon date grammar

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -52,7 +52,7 @@ quoted_raw_search = spaces quoted_value spaces
 text_filter = negation? text_key sep ((open_bracket text_value (comma spaces text_value)* closed_bracket) / search_value)
 
 # filter for dates
-time_filter = search_key sep? operator iso_8601_date_format
+time_filter = search_key sep operator iso_8601_date_format
 
 # filter for relative dates
 rel_time_filter = search_key sep rel_date_format

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -275,7 +275,7 @@ class ParseSearchQueryTest(unittest.TestCase):
 
     def test_timestamp(self):
         # test date format
-        assert parse_search_query("timestamp>2015-05-18") == [
+        assert parse_search_query("timestamp:>2015-05-18") == [
             SearchFilter(
                 key=SearchKey(name="timestamp"),
                 operator=">",
@@ -285,7 +285,7 @@ class ParseSearchQueryTest(unittest.TestCase):
             )
         ]
         # test date time format
-        assert parse_search_query("timestamp>2015-05-18T10:15:01") == [
+        assert parse_search_query("timestamp:>2015-05-18T10:15:01") == [
             SearchFilter(
                 key=SearchKey(name="timestamp"),
                 operator=">",
@@ -296,7 +296,7 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
         # test date time format w microseconds
-        assert parse_search_query("timestamp>2015-05-18T10:15:01.103") == [
+        assert parse_search_query("timestamp:>2015-05-18T10:15:01.103") == [
             SearchFilter(
                 key=SearchKey(name="timestamp"),
                 operator=">",
@@ -319,17 +319,6 @@ class ParseSearchQueryTest(unittest.TestCase):
 
     def test_other_dates(self):
         # test date format with other name
-        assert parse_search_query("first_seen>2015-05-18") == [
-            SearchFilter(
-                key=SearchKey(name="first_seen"),
-                operator=">",
-                value=SearchValue(
-                    raw_value=datetime.datetime(2015, 5, 18, 0, 0, tzinfo=timezone.utc)
-                ),
-            )
-        ]
-
-        # test colon format
         assert parse_search_query("first_seen:>2015-05-18") == [
             SearchFilter(
                 key=SearchKey(name="first_seen"),


### PR DESCRIPTION
This removes the ability to search with `timestamp>2015-05-18` type
searches. You MUST include the `:` before the operator.

This keeps the search syntax totally consistent

![image](https://user-images.githubusercontent.com/1421724/118943288-557c0480-b908-11eb-9c0c-ce62c5c14f64.png)
