### PR TITLE
ui(performance): Make team transactions dropdown scrollable

### DIFF
--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
@@ -1,3 +1,4 @@
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
@@ -17,6 +18,26 @@ type Props = {
   transactionName: string;
 };
 
+/**
+ * This can't be a function component because `TeamKeyTransaction` uses
+ * `DropdownControl` which in turn uses passes a ref to this component.
+ */
+class TitleButton extends Component<TitleProps> {
+  render() {
+    const {keyedTeamsCount, ...props} = this.props;
+    return (
+      <StyledButton
+        {...props}
+        icon={keyedTeamsCount ? <IconStar color="yellow300" isSolid /> : <IconStar />}
+      >
+        {keyedTeamsCount
+          ? tn('Starred for Team', 'Starred for Teams', keyedTeamsCount)
+          : t('Star for Team')}
+      </StyledButton>
+    );
+  }
+}
+
 function TeamKeyTransactionButton({eventView, teams, ...props}: Props) {
   if (eventView.project.length !== 1) {
     return <TitleButton disabled keyedTeamsCount={0} />;
@@ -30,19 +51,6 @@ function TeamKeyTransactionButton({eventView, teams, ...props}: Props) {
       title={TitleButton}
       {...props}
     />
-  );
-}
-
-function TitleButton({disabled, keyedTeamsCount}: TitleProps) {
-  return (
-    <StyledButton
-      disabled={disabled}
-      icon={keyedTeamsCount ? <IconStar color="yellow300" isSolid /> : <IconStar />}
-    >
-      {keyedTeamsCount
-        ? tn('Starred for Team', 'Starred for Teams', keyedTeamsCount)
-        : t('Star for Team')}
-    </StyledButton>
   );
 }
 

--- a/tests/js/spec/components/performance/teamKeyTransaction.spec.jsx
+++ b/tests/js/spec/components/performance/teamKeyTransaction.spec.jsx
@@ -1,9 +1,20 @@
+import {Component} from 'react';
+
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import TeamKeyTransaction from 'app/components/performance/teamKeyTransaction';
 
-function TestTitle({disabled, keyedTeamsCount}) {
-  return <p>{disabled ? 'disabled' : `count: ${keyedTeamsCount}`}</p>;
+class TestButton extends Component {
+  render() {
+    const {keyedTeamsCount, ...props} = this.props;
+    return <button {...props}>{`count: ${keyedTeamsCount}`}</button>;
+  }
+}
+
+async function openTeamKeyTransactionDropdown(wrapper) {
+  wrapper.find('TestButton').simulate('click');
+  await tick();
+  wrapper.update();
 }
 
 describe('TeamKeyTransaction', function () {
@@ -15,7 +26,6 @@ describe('TeamKeyTransaction', function () {
   ];
 
   beforeEach(function () {
-    jest.clearAllMocks();
     MockApiClient.clearMockResponses();
   });
 
@@ -32,16 +42,17 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
-
     await tick();
     wrapper.update();
 
+    openTeamKeyTransactionDropdown(wrapper);
+
     // header should show the checked state
     expect(getTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('TestTitle').exists()).toBeTruthy();
+    expect(wrapper.find('TestButton').exists()).toBeTruthy();
     const header = wrapper.find('DropdownMenuHeader');
     expect(header.exists()).toBeTruthy();
     expect(header.find('StyledCheckbox').props().isChecked).toBeTruthy();
@@ -69,12 +80,14 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
 
     await tick();
     wrapper.update();
+
+    openTeamKeyTransactionDropdown(wrapper);
 
     // header should show the indeterminate state
     const header = wrapper.find('DropdownMenuHeader');
@@ -105,12 +118,13 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
-
     await tick();
     wrapper.update();
+
+    openTeamKeyTransactionDropdown(wrapper);
 
     // header should show the unchecked state
     const header = wrapper.find('DropdownMenuHeader');
@@ -157,15 +171,15 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
-
     await tick();
     wrapper.update();
 
-    wrapper.find('DropdownMenuItem').first().simulate('click');
+    openTeamKeyTransactionDropdown(wrapper);
 
+    wrapper.find('DropdownMenuItem').first().simulate('click');
     await tick();
     wrapper.update();
 
@@ -204,15 +218,15 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
-
     await tick();
     wrapper.update();
 
-    wrapper.find('DropdownMenuItem').first().simulate('click');
+    openTeamKeyTransactionDropdown(wrapper);
 
+    wrapper.find('DropdownMenuItem').first().simulate('click');
     await tick();
     wrapper.update();
 
@@ -252,22 +266,22 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
-
     await tick();
     wrapper.update();
 
-    wrapper.find('DropdownMenuHeader').simulate('click');
+    openTeamKeyTransactionDropdown(wrapper);
 
+    wrapper.find('DropdownMenuHeader StyledCheckbox').simulate('click');
     await tick();
     wrapper.update();
 
     // header should be checked now
-    const header = wrapper.find('DropdownMenuHeader');
-    expect(header.find('StyledCheckbox').props().isChecked).toBeTruthy();
-    expect(header.find('StyledCheckbox').props().isIndeterminate).toBeFalsy();
+    const headerCheckbox = wrapper.find('DropdownMenuHeader StyledCheckbox');
+    expect(headerCheckbox.props().isChecked).toBeTruthy();
+    expect(headerCheckbox.props().isIndeterminate).toBeFalsy();
 
     // all teams should be checked now
     const entries = wrapper.find('DropdownMenuItem');
@@ -308,22 +322,22 @@ describe('TeamKeyTransaction', function () {
         organization={organization}
         teams={teams}
         transactionName="transaction"
-        title={TestTitle}
+        title={TestButton}
       />
     );
-
     await tick();
     wrapper.update();
 
-    wrapper.find('DropdownMenuHeader').simulate('click');
+    openTeamKeyTransactionDropdown(wrapper);
 
+    wrapper.find('DropdownMenuHeader StyledCheckbox').simulate('click');
     await tick();
     wrapper.update();
 
     // header should be unchecked now
-    const header = wrapper.find('DropdownMenuHeader');
-    expect(header.find('StyledCheckbox').props().isChecked).toBeFalsy();
-    expect(header.find('StyledCheckbox').props().isIndeterminate).toBeFalsy();
+    const headerCheckbox = wrapper.find('DropdownMenuHeader StyledCheckbox');
+    expect(headerCheckbox.props().isChecked).toBeFalsy();
+    expect(headerCheckbox.props().isIndeterminate).toBeFalsy();
 
     // all teams should be unchecked now
     const entries = wrapper.find('DropdownMenuItem');


### PR DESCRIPTION
This makes the list of teams scrollable so it does not expand vertically
indefinitely.

https://user-images.githubusercontent.com/10239353/119035196-4be0b400-b97d-11eb-98fb-de46d1a3c43b.mp4