### PR TITLE
fix(alert): Fix edit permissions for team alerts

### DIFF
--- a/static/app/views/settings/incidentRules/create.tsx
+++ b/static/app/views/settings/incidentRules/create.tsx
@@ -50,12 +50,11 @@ class IncidentRulesCreate extends Component<Props> {
       ? createRuleFromWizardTemplate(wizardTemplate)
       : createDefaultRule();
 
-    const userTeamIdArr = teams.filter(({isMember}) => isMember).map(({id}) => id);
-    const userTeamIds = new Set(userTeamIdArr);
+    const userTeamIds = teams.filter(({isMember}) => isMember).map(({id}) => id);
 
     if (props.organization.features.includes('team-alerts-ownership')) {
       const projectTeamIds = new Set(project.teams.map(({id}) => id));
-      const defaultOwnerId = userTeamIdArr.find(id => projectTeamIds.has(id)) ?? null;
+      const defaultOwnerId = userTeamIds.find(id => projectTeamIds.has(id)) ?? null;
       defaultRule.owner = defaultOwnerId && `team:${defaultOwnerId}`;
     }
 

--- a/static/app/views/settings/incidentRules/details.tsx
+++ b/static/app/views/settings/incidentRules/details.tsx
@@ -58,7 +58,7 @@ class IncidentRulesDetails extends AsyncView<Props, State> {
     const {ruleId} = this.props.params;
     const {rule} = this.state;
 
-    const userTeamIds = new Set(teams.filter(({isMember}) => isMember).map(({id}) => id));
+    const userTeamIds = teams.filter(({isMember}) => isMember).map(({id}) => id);
 
     return (
       <RuleForm

--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -61,7 +61,7 @@ type Props = {
   project: Project;
   routes: PlainRoute[];
   rule: IncidentRule;
-  userTeamIds: Set<string>;
+  userTeamIds: string[];
   ruleId?: string;
   sessionId?: string;
   isCustomMetric?: boolean;
@@ -635,7 +635,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const chart = <TriggersChart {...chartProps} />;
 
     const ownerId = rule.owner?.split(':')[1];
-    const canEdit = isActiveSuperuser() || (ownerId ? userTeamIds.has(ownerId) : true);
+    const canEdit =
+      isActiveSuperuser() || (ownerId ? userTeamIds.includes(ownerId) : true);
 
     const triggerForm = (hasAccess: boolean) => (
       <Triggers

--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -23,6 +23,7 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {metric, trackAnalyticsEvent} from 'app/utils/analytics';
+import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
 import {AlertWizardAlertNames} from 'app/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
 import Form from 'app/views/settings/components/forms/form';
@@ -634,7 +635,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const chart = <TriggersChart {...chartProps} />;
 
     const ownerId = rule.owner?.split(':')[1];
-    const canEdit = ownerId ? userTeamIds.has(ownerId) : true;
+    const canEdit = isActiveSuperuser() || (ownerId ? userTeamIds.has(ownerId) : true);
 
     const triggerForm = (hasAccess: boolean) => (
       <Triggers

--- a/static/app/views/settings/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/settings/incidentRules/ruleNameOwnerForm.tsx
@@ -12,7 +12,7 @@ type Props = {
   disabled: boolean;
   project: Project;
   organization: Organization;
-  userTeamIds: Set<string>;
+  userTeamIds: string[];
 };
 
 class RuleNameOwnerForm extends PureComponent<Props> {

--- a/static/app/views/settings/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/settings/incidentRules/ruleNameOwnerForm.tsx
@@ -18,7 +18,6 @@ type Props = {
 class RuleNameOwnerForm extends PureComponent<Props> {
   render() {
     const {disabled, project, organization, userTeamIds} = this.props;
-
     return (
       <Panel>
         <PanelBody>
@@ -35,10 +34,16 @@ class RuleNameOwnerForm extends PureComponent<Props> {
               name="owner"
               label={t('Team')}
               help={t('The team that can edit this alert.')}
+              disabled={disabled}
             >
               {({model}) => {
                 const owner = model.getValue('owner');
                 const ownerId = owner && owner.split(':')[1];
+                const filteredTeamIds = new Set(...userTeamIds);
+                // Add the current team that owns the alert
+                if (ownerId) {
+                  filteredTeamIds.add(ownerId);
+                }
                 return (
                   <SelectMembers
                     showTeam
@@ -49,8 +54,9 @@ class RuleNameOwnerForm extends PureComponent<Props> {
                       const ownerValue = value && `team:${value}`;
                       model.setValue('owner', ownerValue);
                     }}
-                    filteredTeamIds={userTeamIds}
+                    filteredTeamIds={filteredTeamIds}
                     includeUnassigned
+                    disabled={disabled}
                   />
                 );
               }}

--- a/static/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/static/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -517,10 +517,10 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const environment =
       !rule || !rule.environment ? ALL_ENVIRONMENTS_KEY : rule.environment;
 
-    const userTeams = new Set(teams.filter(({isMember}) => isMember).map(({id}) => id));
+    const userTeams = teams.filter(({isMember}) => isMember).map(({id}) => id);
     const ownerId = rule?.owner?.split(':')[1];
     // check if superuser or if user is on the alert's team
-    const canEdit = isActiveSuperuser() || (ownerId ? userTeams.has(ownerId) : true);
+    const canEdit = isActiveSuperuser() || (ownerId ? userTeams.includes(ownerId) : true);
 
     const filteredTeamIds = new Set(...userTeams);
     if (ownerId) {


### PR DESCRIPTION
- Disables the team dropdown if the user can not edit the alert.
- Fixes a bug where the current team wasn't shown (`Select...` was shown instead)
- Makes an exception for superusers
- Does this for issue alerts page and metric alerts page

**Before:**
![image](https://user-images.githubusercontent.com/9372512/119035338-76327180-b97d-11eb-8747-2a23a05747a4.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/119035368-7df21600-b97d-11eb-96ce-b905e73a7bfb.png)
