### PR TITLE
ref(vercel): Assume one config per user/team

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -17,7 +17,6 @@ from sentry.integrations import (
 )
 from sentry.mediators.sentry_apps import InternalCreator
 from sentry.models import (
-    Integration,
     Organization,
     Project,
     ProjectKey,
@@ -116,9 +115,16 @@ class VercelIntegration(IntegrationInstallation):
 
         return VercelClient(access_token)
 
-    # note this could return a different integration if the user has multiple
-    # installations with the same organization
     def get_configuration_id(self):
+        # XXX(meredith): The "configurations" in the metadata is no longer
+        # needed since Vercel restricted installation on their end to be
+        # once per user/team. Eventually we should be able to just use
+        # `self.metadata["installation_id"]`
+        if not self.metadata.get("configurations"):
+            return self.metadata["installation_id"]
+
+        # note this could return a different integration if the user has multiple
+        # installations with the same organization
         for configuration_id, data in self.metadata["configurations"].items():
             if data["organization_id"] == self.organization_id:
                 return configuration_id
@@ -301,19 +307,6 @@ class VercelIntegrationProvider(IntegrationProvider):
 
         return [identity_pipeline_view]
 
-    def get_configuration_metadata(self, external_id):
-        # If a vercel team or user was already installed on another sentry org
-        # we want to make sure we don't overwrite the existing configurations. We
-        # keep all the configurations so that if one of them is deleted from vercel's
-        # side, the other sentry org will still have a working vercel integration.
-        try:
-            integration = Integration.objects.get(external_id=external_id, provider=self.key)
-        except Integration.DoesNotExist:
-            # first time setting up vercel team/user
-            return {}
-
-        return integration.metadata["configurations"]
-
     def build_integration(self, state):
         data = state["identity"]["data"]
         access_token = data["access_token"]
@@ -344,8 +337,6 @@ class VercelIntegrationProvider(IntegrationProvider):
             message = f"Could not create deployment webhook in Vercel: {details}"
             raise IntegrationError(message)
 
-        configurations = self.get_configuration_metadata(external_id)
-
         integration = {
             "name": name,
             "external_id": external_id,
@@ -354,7 +345,6 @@ class VercelIntegrationProvider(IntegrationProvider):
                 "installation_id": data["installation_id"],
                 "installation_type": installation_type,
                 "webhook_id": webhook["id"],
-                "configurations": configurations,
             },
             "post_install_data": {"user_id": state["user_id"]},
         }
@@ -362,17 +352,7 @@ class VercelIntegrationProvider(IntegrationProvider):
         return integration
 
     def post_install(self, integration, organization, extra=None):
-        # add new configuration information to metadata
-        configurations = integration.metadata.get("configurations") or {}
-        configurations[integration.metadata["installation_id"]] = {
-            "access_token": integration.metadata["access_token"],
-            "webhook_id": integration.metadata["webhook_id"],
-            "organization_id": organization.id,
-        }
-        integration.metadata["configurations"] = configurations
-        integration.save()
-
-        # check if we have an installation already
+        # check if we have an Vercel internal installation already
         if SentryAppInstallationForProvider.objects.filter(
             organization=organization, provider="vercel"
         ).exists():

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -90,25 +90,11 @@ class VercelIntegrationTest(IntegrationTestCase):
 
         assert integration.external_id == external_id
         assert integration.name == name
-        configurations = {
-            "my_config_id": {
-                "access_token": "my_access_token",
-                "webhook_id": "webhook-id",
-                "organization_id": self.organization.id,
-            }
-        }
-        if multi_config_org:
-            configurations["orig_config_id"] = {
-                "access_token": "orig_access_token",
-                "webhook_id": "orig-webhook-id",
-                "organization_id": multi_config_org.id,
-            }
         assert integration.metadata == {
             "access_token": "my_access_token",
             "installation_id": "my_config_id",
             "installation_type": installation_type,
             "webhook_id": "webhook-id",
-            "configurations": configurations,
         }
         assert OrganizationIntegration.objects.get(
             integration=integration, organization=self.organization
@@ -144,28 +130,6 @@ class VercelIntegrationTest(IntegrationTestCase):
         )
         self.assert_setup_flow(is_team=False)
         assert SentryAppInstallation.objects.count() == 1
-
-    @responses.activate
-    def test_install_on_multiple_orgs(self):
-        orig_org = self.create_organization()
-        metadata = {
-            "access_token": "orig_access_token",
-            "installation_id": "orig_config_id",
-            "installation_type": "team",
-            "webhook_id": "orig-webhook-id",
-            "configurations": {
-                "orig_config_id": {
-                    "access_token": "orig_access_token",
-                    "webhook_id": "orig-webhook-id",
-                    "organization_id": orig_org.id,
-                }
-            },
-        }
-        Integration.objects.create(
-            provider="vercel", name="My Team Name", external_id="my_team_id", metadata=metadata
-        )
-
-        self.assert_setup_flow(is_team=True, multi_config_org=orig_org)
 
     @responses.activate
     def test_update_organization_config(self):

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -25,6 +25,50 @@ USERID_UNINSTALL_RESPONSE = """{
 class VercelUninstallTest(APITestCase):
     def setUp(self):
         self.url = "/extensions/vercel/delete/"
+        metadata = {
+            "access_token": "my_access_token",
+            "installation_id": "my_config_id",
+            "installation_type": "team",
+            "webhook_id": "my_webhook_id",
+        }
+        self.integration = Integration.objects.create(
+            provider="vercel",
+            external_id="vercel_team_id",
+            name="My Vercel Team",
+            metadata=metadata,
+        )
+        self.integration.add_organization(self.organization)
+
+    def _get_delete_response(self):
+        # https://vercel.com/docs/integrations?query=event%20paylo#webhooks/events/integration-configuration-removed
+        return """{
+            "payload": {
+                "configuration": {
+                    "id": "my_config_id",
+                    "projects": ["project_id1"]
+                }
+            },
+            "teamId": "vercel_team_id",
+            "userId": "vercel_user_id"
+        }"""
+
+    def test_uninstall(self):
+        response = self.client.post(
+            path=self.url,
+            data=self._get_delete_response(),
+            content_type="application/json",
+        )
+
+        assert response.status_code == 204
+        assert not Integration.objects.filter(id=self.integration.id).exists()
+        assert not OrganizationIntegration.objects.filter(
+            integration_id=self.integration.id, organization_id=self.organization.id
+        ).exists()
+
+
+class VercelUninstallWithConfigurationsTest(APITestCase):
+    def setUp(self):
+        self.url = "/extensions/vercel/delete/"
         self.second_org = self.create_organization(name="Blah", owner=self.user)
         metadata = {
             "access_token": "my_access_token",


### PR DESCRIPTION
**Context**
Vercel has changed since we first built it out, and there are several things that we need to update:
- [x] Remove the UI Hook (done in https://github.com/getsentry/sentry/pull/25987)
- [x] **Assume Single install per user/team** - docs [here](https://vercel.com/docs/integrations#upgrading-your-integration/assume-single-installation-per-scope).
- [x] Remove creation of webhooks on install - use their generic webhook instead (done in https://github.com/getsentry/sentry/pull/26185)
- [x] Update the endpoints used to set env variables (done in https://github.com/getsentry/sentry/pull/26251)

**Assume Single Install**
When first building out Vercel we needed to handle multiple installs, for more context see https://github.com/getsentry/sentry/pull/19534. Now that Vercel enforces installing Sentry once per Vercel user/team, we no longer need much of the code that we had implemented. 

We used to keep track of all the `configurations` tied to an integration, and this was stored in the `integration.metadata`. We can get rid of this because the "primary" configuration data was already stored as top level attributes in the `metadata`.

Uninstallation still needs to account for integrations that have the `configurations` in the metadata because there still might be old configurations from before Vercel enforced the single install constraint. 