### PR TITLE
chore(trace-view): Trace view logs should use org slug

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -377,7 +377,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):  # 
                 return Response(status=404)
             self.record_analytics(transactions, trace_id, self.request.user.id, organization.id)
 
-        warning_extra: Dict[str, str] = {"trace": trace_id, "organization": organization}
+        warning_extra: Dict[str, str] = {"trace": trace_id, "organization": organization.slug}
 
         # Look for the roots
         roots: List[SnubaTransaction] = []


### PR DESCRIPTION
This was previously converting the organization object to string which isn't
helpful when searching through logs.