### PR TITLE
ref(spans): Refactor span waterfall graph to <table />

### DIFF
--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -157,10 +157,6 @@ export class Provider extends React.Component<PropType, StateType> {
 
     const dividerHandlePositionString = toPercent(this.dividerHandlePosition);
 
-    document.body.style.setProperty(
-      '--ghost-divider-handle-position',
-      dividerHandlePositionString
-    );
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       const {parentNode} = dividerDOM;
 

--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -125,8 +125,6 @@ export class Provider extends React.Component<PropType, StateType> {
       dividerDOM.style.cursor = 'col-resize';
     });
 
-    document.body.style.setProperty('--ghost-divider-display', 'block');
-
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.cursor = 'col-resize';
 
@@ -202,9 +200,6 @@ export class Provider extends React.Component<PropType, StateType> {
       dividerDOM.style.backgroundColor = '';
       dividerDOM.style.cursor = '';
     });
-
-    document.body.style.removeProperty('--ghost-divider-handle-position');
-    document.body.style.removeProperty('--ghost-divider-display');
 
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.cursor = '';

--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -125,6 +125,8 @@ export class Provider extends React.Component<PropType, StateType> {
       dividerDOM.style.cursor = 'col-resize';
     });
 
+    document.body.style.setProperty('--ghost-divider-display', 'block');
+
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.cursor = 'col-resize';
 
@@ -157,6 +159,10 @@ export class Provider extends React.Component<PropType, StateType> {
 
     const dividerHandlePositionString = toPercent(this.dividerHandlePosition);
 
+    document.body.style.setProperty(
+      '--ghost-divider-handle-position',
+      dividerHandlePositionString
+    );
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       const {parentNode} = dividerDOM;
 
@@ -196,6 +202,9 @@ export class Provider extends React.Component<PropType, StateType> {
       dividerDOM.style.backgroundColor = '';
       dividerDOM.style.cursor = '';
     });
+
+    document.body.style.removeProperty('--ghost-divider-handle-position');
+    document.body.style.removeProperty('--ghost-divider-display');
 
     selectRefs(this.ghostDividerLineRefs, (dividerDOM: HTMLDivElement) => {
       dividerDOM.style.cursor = '';

--- a/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
+++ b/static/app/components/events/interfaces/spans/dividerHandlerManager.tsx
@@ -46,7 +46,7 @@ type PropType = {
 
   // this is the DOM element where the drag events occur. it's also the reference point
   // for calculating the relative mouse x coordinate.
-  interactiveLayerRef: React.RefObject<HTMLDivElement>;
+  interactiveLayerRef: React.RefObject<HTMLTableElement>;
 };
 
 export class Provider extends React.Component<PropType, StateType> {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -903,15 +903,13 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             {this.renderCursorGuide()}
           </RowCell>
         </td>
-        <td>
+        <td style={{all: 'unset'}}>
           {!this.state.showDetail && (
             <DividerLineGhostContainer
               style={{
                 width: toPercent(dividerPosition),
                 display: 'none',
                 left: 0,
-                marginTop: `-${ROW_HEIGHT / 2}px`,
-                // top: 0,
                 height: `${ROW_HEIGHT}px`,
                 outline: '1px solid red',
               }}

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -820,6 +820,30 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     );
   }
 
+  renderNewHeader({
+    scrollbarManagerChildrenProps,
+    dividerHandlerChildrenProps,
+    errors,
+  }: {
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps;
+    scrollbarManagerChildrenProps: ScrollbarManager.ScrollbarManagerChildrenProps;
+    errors: TraceError[] | null;
+  }) {
+    return (
+      <React.Fragment>
+        <td style={{outline: '1px solid red', position: 'relative'}}>
+          title
+          <div
+            style={{position: 'absolute', top: 0, right: 0, width: '1px', height: '100%'}}
+          >
+            {this.renderDivider(dividerHandlerChildrenProps)}
+          </div>
+        </td>
+        <td>spanbar</td>
+      </React.Fragment>
+    );
+  }
+
   renderHeader({
     scrollbarManagerChildrenProps,
     dividerHandlerChildrenProps,
@@ -943,7 +967,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
                       {(
                         dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
                       ) =>
-                        this.renderHeader({
+                        this.renderNewHeader({
                           dividerHandlerChildrenProps,
                           scrollbarManagerChildrenProps,
                           errors,

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -861,7 +861,13 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             {this.renderTitle(scrollbarManagerChildrenProps, errors)}
           </RowCell>
           <div
-            style={{position: 'absolute', top: 0, right: 0, width: '1px', height: '100%'}}
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: `-1px`,
+              width: '1px',
+              height: '100%',
+            }}
           >
             {this.renderDivider(dividerHandlerChildrenProps)}
           </div>
@@ -907,17 +913,17 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           {!this.state.showDetail && (
             <DividerLineGhostContainer
               style={{
-                width: toPercent(dividerPosition),
-                display: 'none',
+                width: `var(--ghost-divider-handle-position, ${toPercent(
+                  dividerPosition
+                )})`,
+                display: 'var(--ghost-divider-display, none)',
                 left: 0,
                 height: `${ROW_HEIGHT}px`,
-                outline: '1px solid red',
               }}
             >
               <DividerLine
-                ref={addGhostDividerLineRef()}
                 style={{
-                  right: 0,
+                  right: '-1px',
                 }}
                 className="hovering"
                 onClick={event => {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -870,6 +870,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             }}
           >
             {this.renderDivider(dividerHandlerChildrenProps)}
+            {this.renderErrorBadge(errors)}
           </div>
         </td>
         <td style={{position: 'relative'}}>

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -866,7 +866,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             {this.renderDivider(dividerHandlerChildrenProps)}
           </div>
         </td>
-        <td>
+        <td style={{position: 'relative'}}>
           <RowCell
             data-type="span-row-cell"
             showDetail={this.state.showDetail}
@@ -902,6 +902,35 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             {this.renderMeasurements()}
             {this.renderCursorGuide()}
           </RowCell>
+        </td>
+        <td>
+          {!this.state.showDetail && (
+            <DividerLineGhostContainer
+              style={{
+                width: toPercent(dividerPosition),
+                display: 'none',
+                left: 0,
+                marginTop: `-${ROW_HEIGHT / 2}px`,
+                // top: 0,
+                height: `${ROW_HEIGHT}px`,
+                outline: '1px solid red',
+              }}
+            >
+              <DividerLine
+                ref={addGhostDividerLineRef()}
+                style={{
+                  right: 0,
+                }}
+                className="hovering"
+                onClick={event => {
+                  // the ghost divider line should not be interactive.
+                  // we prevent the propagation of the clicks from this component to prevent
+                  // the span detail from being opened.
+                  event.stopPropagation();
+                }}
+              />
+            </DividerLineGhostContainer>
+          )}
         </td>
       </React.Fragment>
     );

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -913,15 +913,14 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           {!this.state.showDetail && (
             <DividerLineGhostContainer
               style={{
-                width: `var(--ghost-divider-handle-position, ${toPercent(
-                  dividerPosition
-                )})`,
-                display: 'var(--ghost-divider-display, none)',
+                width: toPercent(dividerPosition),
+                display: 'none',
                 left: 0,
                 height: `${ROW_HEIGHT}px`,
               }}
             >
               <DividerLine
+                ref={addGhostDividerLineRef()}
                 style={{
                   right: '-1px',
                 }}

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -829,17 +829,76 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     scrollbarManagerChildrenProps: ScrollbarManager.ScrollbarManagerChildrenProps;
     errors: TraceError[] | null;
   }) {
+    const {span, spanBarColour, spanBarHatch, spanNumber} = this.props;
+    const startTimestamp: number = span.start_timestamp;
+    const endTimestamp: number = span.timestamp;
+    const duration = Math.abs(endTimestamp - startTimestamp);
+    const durationString = getHumanDuration(duration);
+    const bounds = this.getBounds();
+    const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
+    const displaySpanBar = defined(bounds.left) && defined(bounds.width);
+    const durationDisplay = getDurationDisplay(bounds);
+
     return (
       <React.Fragment>
-        <td style={{outline: '1px solid red', position: 'relative'}}>
-          title
+        <td style={{position: 'relative'}}>
+          <RowCell
+            data-type="span-row-cell"
+            showDetail={this.state.showDetail}
+            style={{
+              height: `${ROW_HEIGHT}px`,
+              top: 0,
+              left: 0,
+            }}
+            onClick={() => {
+              this.toggleDisplayDetail();
+            }}
+          >
+            {this.renderTitle(scrollbarManagerChildrenProps, errors)}
+          </RowCell>
           <div
             style={{position: 'absolute', top: 0, right: 0, width: '1px', height: '100%'}}
           >
             {this.renderDivider(dividerHandlerChildrenProps)}
           </div>
         </td>
-        <td>spanbar</td>
+        <td>
+          <RowCell
+            data-type="span-row-cell"
+            showDetail={this.state.showDetail}
+            showStriping={spanNumber % 2 !== 0}
+            style={{
+              height: `${ROW_HEIGHT}px`,
+              top: 0,
+              left: 0,
+            }}
+            onClick={() => {
+              this.toggleDisplayDetail();
+            }}
+          >
+            {displaySpanBar && (
+              <RowRectangle
+                spanBarHatch={!!spanBarHatch}
+                style={{
+                  backgroundColor: spanBarColour,
+                  left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+                  width: toPercent(bounds.width || 0),
+                }}
+              >
+                <DurationPill
+                  durationDisplay={durationDisplay}
+                  showDetail={this.state.showDetail}
+                  spanBarHatch={!!spanBarHatch}
+                >
+                  {durationString}
+                  {this.renderWarningText({warningText: bounds.warning})}
+                </DurationPill>
+              </RowRectangle>
+            )}
+            {this.renderMeasurements()}
+            {this.renderCursorGuide()}
+          </RowCell>
+        </td>
       </React.Fragment>
     );
   }

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -264,16 +264,20 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           }
 
           return (
-            <SpanDetail
-              span={span}
-              organization={organization}
-              event={event}
-              isRoot={!!isRoot}
-              trace={trace}
-              childTransactions={transactions}
-              relatedErrors={errors}
-              scrollToHash={scrollToHash}
-            />
+            <tr>
+              <td colSpan={2}>
+                <SpanDetail
+                  span={span}
+                  organization={organization}
+                  event={event}
+                  isRoot={!!isRoot}
+                  trace={trace}
+                  childTransactions={transactions}
+                  relatedErrors={errors}
+                  scrollToHash={scrollToHash}
+                />
+              </td>
+            </tr>
           );
         }}
       </AnchorLinkManager.Consumer>
@@ -1008,18 +1012,18 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     const isSpanVisible = isSpanVisibleInView && !isCurrentSpanFilteredOut;
 
     return (
-      <Row
-        ref={this.spanRowDOMRef}
-        visible={isSpanVisible}
-        showBorder={this.state.showDetail}
-        data-test-id="span-row"
-      >
-        <QuickTraceContext.Consumer>
-          {quickTrace => {
-            const errors = this.getRelatedErrors(quickTrace);
-            const transactions = this.getChildTransactions(quickTrace);
-            return (
-              <React.Fragment>
+      <QuickTraceContext.Consumer>
+        {quickTrace => {
+          const errors = this.getRelatedErrors(quickTrace);
+          const transactions = this.getChildTransactions(quickTrace);
+          return (
+            <React.Fragment>
+              <Row
+                ref={this.spanRowDOMRef}
+                visible={isSpanVisible}
+                showBorder={this.state.showDetail}
+                data-test-id="span-row"
+              >
                 <ScrollbarManager.Consumer>
                   {scrollbarManagerChildrenProps => (
                     <DividerHandlerManager.Consumer>
@@ -1035,12 +1039,12 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
                     </DividerHandlerManager.Consumer>
                   )}
                 </ScrollbarManager.Consumer>
-                {this.renderDetail({isVisible: isSpanVisible, transactions, errors})}
-              </React.Fragment>
-            );
-          }}
-        </QuickTraceContext.Consumer>
-      </Row>
+              </Row>
+              {this.renderDetail({isVisible: isSpanVisible, transactions, errors})}
+            </React.Fragment>
+          );
+        }}
+      </QuickTraceContext.Consumer>
     );
   }
 }

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -220,7 +220,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     this.disconnectObservers();
   }
 
-  spanRowDOMRef = React.createRef<HTMLDivElement>();
+  spanRowDOMRef = React.createRef<HTMLTableRowElement>();
   intersectionObserver?: IntersectionObserver = void 0;
   zoomLevel: number = 1; // assume initial zoomLevel is 100%
   _mounted: boolean = false;

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -436,6 +436,7 @@ const TraceViewContainer = styled('table')`
   table-layout: fixed;
   width: 100%;
   display: table;
+  margin: 0;
 `;
 
 /**

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 
 import {MessageRow} from 'app/components/performance/waterfall/messageRow';
-import {pickBarColour} from 'app/components/performance/waterfall/utils';
+import {pickBarColour, toPercent} from 'app/components/performance/waterfall/utils';
 import {t, tct} from 'app/locale';
 import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 
+import * as DividerHandlerManager from './dividerHandlerManager';
 import {DragManagerChildrenProps} from './dragManager';
 import {ActiveOperationFilter} from './filter';
 import SpanGroup from './spanGroup';
@@ -390,7 +391,20 @@ class SpanTree extends React.Component<PropType> {
 
     return (
       <TraceViewContainer ref={this.props.traceViewRef}>
-        {spanTree}
+        <DividerHandlerManager.Consumer>
+          {({
+            dividerPosition,
+          }: DividerHandlerManager.DividerHandlerManagerChildrenProps) => {
+            return (
+              <colgroup>
+                <col span={1} style={{width: toPercent(dividerPosition)}} />
+                <col span={1} style={{width: toPercent(1 - dividerPosition)}} />
+              </colgroup>
+            );
+          }}
+        </DividerHandlerManager.Consumer>
+
+        <tbody>{spanTree}</tbody>
         {infoMessage}
         {limitExceededMessage}
       </TraceViewContainer>

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -77,11 +77,21 @@ class SpanTree extends React.Component<PropType> {
 
     const showHiddenSpansMessage = !isCurrentSpanHidden && numOfSpansOutOfViewAbove > 0;
 
+    const Wrapper = ({children}) => {
+      return (
+        <MessageRow>
+          <td colSpan={2}>{children}</td>
+        </MessageRow>
+      );
+    };
+
     if (showHiddenSpansMessage) {
       messages.push(
-        <span key="spans-out-of-view">
-          <strong>{numOfSpansOutOfViewAbove}</strong> {t('spans out of view')}
-        </span>
+        <Wrapper key="spans-out-of-view">
+          <span>
+            <strong>{numOfSpansOutOfViewAbove}</strong> {t('spans out of view')}
+          </span>
+        </Wrapper>
       );
     }
 
@@ -92,19 +102,23 @@ class SpanTree extends React.Component<PropType> {
       if (!isCurrentSpanHidden) {
         if (numOfFilteredSpansAbove === 1) {
           messages.push(
-            <span key="spans-filtered">
-              {tct('[numOfSpans] hidden span', {
-                numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
-              })}
-            </span>
+            <Wrapper key="spans-out-of-view">
+              <span>
+                {tct('[numOfSpans] hidden span', {
+                  numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
+                })}
+              </span>
+            </Wrapper>
           );
         } else {
           messages.push(
-            <span key="spans-filtered">
-              {tct('[numOfSpans] hidden spans', {
-                numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
-              })}
-            </span>
+            <Wrapper key="spans-filtered">
+              <span>
+                {tct('[numOfSpans] hidden spans', {
+                  numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
+                })}
+              </span>
+            </Wrapper>
           );
         }
       }
@@ -114,7 +128,7 @@ class SpanTree extends React.Component<PropType> {
       return null;
     }
 
-    return <MessageRow>{messages}</MessageRow>;
+    return <React.Fragment>{messages}</React.Fragment>;
   }
 
   generateLimitExceededMessage() {
@@ -404,9 +418,11 @@ class SpanTree extends React.Component<PropType> {
           }}
         </DividerHandlerManager.Consumer>
 
-        <tbody>{spanTree}</tbody>
-        {infoMessage}
-        {limitExceededMessage}
+        <tbody>
+          {spanTree}
+          {infoMessage}
+          {limitExceededMessage}
+        </tbody>
       </TraceViewContainer>
     );
   }

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -48,7 +48,7 @@ type PropType = {
   filterSpans: FilterSpans | undefined;
   event: EventTransaction;
   operationNameFilters: ActiveOperationFilter;
-  traceViewRef: React.RefObject<HTMLDivElement>;
+  traceViewRef: React.RefObject<HTMLTableElement>;
 };
 
 class SpanTree extends React.Component<PropType> {

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -398,10 +398,14 @@ class SpanTree extends React.Component<PropType> {
   }
 }
 
-const TraceViewContainer = styled('div')`
+const TraceViewContainer = styled('table')`
   overflow-x: hidden;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
+
+  table-layout: fixed;
+  width: 100%;
+  display: table;
 `;
 
 /**

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -65,7 +65,7 @@ class TraceView extends PureComponent<Props, State> {
     }
   }
 
-  traceViewRef = createRef<HTMLDivElement>();
+  traceViewRef = createRef<HTMLTableElement>();
   virtualScrollBarContainerRef = createRef<HTMLDivElement>();
   minimapInteractiveRef = createRef<HTMLDivElement>();
 

--- a/static/app/components/performance/waterfall/messageRow.tsx
+++ b/static/app/components/performance/waterfall/messageRow.tsx
@@ -5,17 +5,21 @@ import {Row} from 'app/components/performance/waterfall/row';
 import space from 'app/styles/space';
 
 export const MessageRow = styled(Row)`
-  display: block;
+  display: table-row;
   cursor: auto;
   line-height: ${ROW_HEIGHT}px;
-  padding-left: ${space(1)};
-  padding-right: ${space(1)};
   color: ${p => p.theme.gray300};
   background-color: ${p => p.theme.backgroundSecondary};
-  outline: 1px solid ${p => p.theme.border};
+  border-top: 1px solid ${p => p.theme.border};
+  border-bottom: 1px solid ${p => p.theme.border};
   font-size: ${p => p.theme.fontSizeSmall};
 
   z-index: ${p => p.theme.zIndex.traceView.rowInfoMessage};
+
+  > td {
+    padding-left: ${space(1)};
+    padding-right: ${space(1)};
+  }
 
   > * + * {
     margin-left: ${space(2)};

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -10,10 +10,11 @@ type RowProps = {
   showBorder?: boolean;
 };
 
-type RowAndDivProps = Omit<React.HTMLProps<HTMLDivElement>, keyof RowProps> & RowProps;
+type RowAndElementProps = Omit<React.HTMLProps<HTMLTableRowElement>, keyof RowProps> &
+  RowProps;
 
-export const Row = styled('div')<RowAndDivProps>`
-  display: ${p => (p.visible ? 'block' : 'none')};
+export const Row = styled('tr')<RowAndElementProps>`
+  display: ${p => (p.visible ? 'table-row' : 'none')};
   border-top: ${p => (p.showBorder ? `1px solid ${p.theme.border}` : null)};
   margin-top: ${p => (p.showBorder ? '-1px' : null)}; /* to prevent offset on toggle */
   position: relative;

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -547,6 +547,10 @@ class TraceDetailsContent extends React.Component<Props, State> {
                     <DividerSpacer />
                   </TraceViewHeaderContainer>
                   <TraceViewContainer ref={this.traceViewRef}>
+                    <colgroup>
+                      <col span={1} style={{width: toPercent(dividerPosition)}} />
+                      <col span={1} style={{width: toPercent(1 - dividerPosition)}} />
+                    </colgroup>
                     <AnchorLinkManager.Provider>
                       <TransactionGroup
                         location={location}

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -86,7 +86,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
     filteredTransactionIds: undefined,
   };
 
-  traceViewRef = React.createRef<HTMLDivElement>();
+  traceViewRef = React.createRef<HTMLTableElement>();
   virtualScrollbarContainerRef = React.createRef<HTMLDivElement>();
 
   renderTraceLoading() {

--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -60,6 +60,7 @@ export const TraceViewContainer = styled('table')`
   table-layout: fixed;
   width: 100%;
   display: table;
+  margin: 0;
 `;
 
 export const StyledPanel = styled(Panel)`

--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -52,10 +52,14 @@ export const TraceDetailBody = styled('div')`
   margin-top: ${space(2)};
 `;
 
-export const TraceViewContainer = styled('div')`
+export const TraceViewContainer = styled('table')`
   overflow-x: hidden;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
+
+  table-layout: fixed;
+  width: 100%;
+  display: table;
 `;
 
 export const StyledPanel = styled(Panel)`

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -298,26 +298,32 @@ class TransactionBar extends React.Component<Props, State> {
     const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
 
     return (
-      <DividerLineGhostContainer
-        style={{
-          width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
-          display: 'none',
-        }}
-      >
-        <DividerLine
-          ref={addGhostDividerLineRef()}
-          style={{
-            right: 0,
-          }}
-          className="hovering"
-          onClick={event => {
-            // the ghost divider line should not be interactive.
-            // we prevent the propagation of the clicks from this component to prevent
-            // the span detail from being opened.
-            event.stopPropagation();
-          }}
-        />
-      </DividerLineGhostContainer>
+      <td style={{all: 'unset'}}>
+        {!this.state.showDetail && (
+          <DividerLineGhostContainer
+            style={{
+              width: toPercent(dividerPosition),
+              display: 'none',
+              left: 0,
+              height: `${ROW_HEIGHT}px`,
+            }}
+          >
+            <DividerLine
+              ref={addGhostDividerLineRef()}
+              style={{
+                right: '-1px',
+              }}
+              className="hovering"
+              onClick={event => {
+                // the ghost divider line should not be interactive.
+                // we prevent the propagation of the clicks from this component to prevent
+                // the span detail from being opened.
+                event.stopPropagation();
+              }}
+            />
+          </DividerLineGhostContainer>
+        )}
+      </td>
     );
   }
 
@@ -379,42 +385,56 @@ class TransactionBar extends React.Component<Props, State> {
     const {dividerPosition} = dividerHandlerChildrenProps;
 
     return (
-      <RowCellContainer showDetail={showDetail}>
-        <RowCell
-          data-test-id="transaction-row-title"
-          data-type="span-row-cell"
-          style={{
-            width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
-            paddingTop: 0,
-          }}
-          showDetail={showDetail}
-          onClick={this.toggleDisplayDetail}
-        >
-          <GuideAnchor target="trace_view_guide_row" disabled={!hasGuideAnchor}>
-            {this.renderTitle(scrollbarManagerChildrenProps)}
-          </GuideAnchor>
-        </RowCell>
-        <DividerContainer>
-          {this.renderDivider(dividerHandlerChildrenProps)}
-          {this.renderErrorBadge()}
-        </DividerContainer>
-        <RowCell
-          data-test-id="transaction-row-duration"
-          data-type="span-row-cell"
-          showStriping={index % 2 !== 0}
-          style={{
-            width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
-            paddingTop: 0,
-          }}
-          showDetail={showDetail}
-          onClick={this.toggleDisplayDetail}
-        >
-          <GuideAnchor target="trace_view_guide_row_details" disabled={!hasGuideAnchor}>
-            {this.renderRectangle()}
-          </GuideAnchor>
-        </RowCell>
-        {!showDetail && this.renderGhostDivider(dividerHandlerChildrenProps)}
-      </RowCellContainer>
+      <React.Fragment>
+        <td style={{position: 'relative'}}>
+          <RowCell
+            data-test-id="transaction-row-title"
+            data-type="span-row-cell"
+            style={{
+              height: `${ROW_HEIGHT}px`,
+              top: 0,
+              left: 0,
+            }}
+            showDetail={showDetail}
+            onClick={this.toggleDisplayDetail}
+          >
+            <GuideAnchor target="trace_view_guide_row" disabled={!hasGuideAnchor}>
+              {this.renderTitle(scrollbarManagerChildrenProps)}
+            </GuideAnchor>
+          </RowCell>
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: `-1px`,
+              width: '1px',
+              height: '100%',
+            }}
+          >
+            {this.renderDivider(dividerHandlerChildrenProps)}
+            {this.renderErrorBadge()}
+          </div>
+        </td>
+        <td style={{position: 'relative'}}>
+          <RowCell
+            data-test-id="transaction-row-duration"
+            data-type="span-row-cell"
+            showStriping={index % 2 !== 0}
+            style={{
+              height: `${ROW_HEIGHT}px`,
+              top: 0,
+              left: 0,
+            }}
+            showDetail={showDetail}
+            onClick={this.toggleDisplayDetail}
+          >
+            <GuideAnchor target="trace_view_guide_row_details" disabled={!hasGuideAnchor}>
+              {this.renderRectangle()}
+            </GuideAnchor>
+          </RowCell>
+        </td>
+        {this.renderGhostDivider(dividerHandlerChildrenProps)}
+      </React.Fragment>
     );
   }
 
@@ -446,12 +466,16 @@ class TransactionBar extends React.Component<Props, State> {
           }
 
           return (
-            <TransactionDetail
-              location={location}
-              organization={organization}
-              transaction={transaction}
-              scrollToHash={scrollToHash}
-            />
+            <tr>
+              <td colSpan={2}>
+                <TransactionDetail
+                  location={location}
+                  organization={organization}
+                  transaction={transaction}
+                  scrollToHash={scrollToHash}
+                />
+              </td>
+            </tr>
           );
         }}
       </AnchorLinkManager.Consumer>
@@ -463,26 +487,28 @@ class TransactionBar extends React.Component<Props, State> {
     const {showDetail} = this.state;
 
     return (
-      <Row
-        ref={this.transactionRowDOMRef}
-        visible={isVisible}
-        showBorder={showDetail}
-        cursor={isTraceFullDetailed(transaction) ? 'pointer' : 'default'}
-      >
-        <ScrollbarManager.Consumer>
-          {scrollbarManagerChildrenProps => (
-            <DividerHandlerManager.Consumer>
-              {dividerHandlerChildrenProps =>
-                this.renderHeader({
-                  dividerHandlerChildrenProps,
-                  scrollbarManagerChildrenProps,
-                })
-              }
-            </DividerHandlerManager.Consumer>
-          )}
-        </ScrollbarManager.Consumer>
+      <React.Fragment>
+        <Row
+          ref={this.transactionRowDOMRef}
+          visible={isVisible}
+          showBorder={showDetail}
+          cursor={isTraceFullDetailed(transaction) ? 'pointer' : 'default'}
+        >
+          <ScrollbarManager.Consumer>
+            {scrollbarManagerChildrenProps => (
+              <DividerHandlerManager.Consumer>
+                {dividerHandlerChildrenProps =>
+                  this.renderHeader({
+                    dividerHandlerChildrenProps,
+                    scrollbarManagerChildrenProps,
+                  })
+                }
+              </DividerHandlerManager.Consumer>
+            )}
+          </ScrollbarManager.Consumer>
+        </Row>
         {this.renderDetail()}
-      </Row>
+      </React.Fragment>
     );
   }
 }

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -70,7 +70,7 @@ class TransactionBar extends React.Component<Props, State> {
     showDetail: false,
   };
 
-  transactionRowDOMRef = React.createRef<HTMLDivElement>();
+  transactionRowDOMRef = React.createRef<HTMLTableRowElement>();
 
   toggleDisplayDetail = () => {
     const {transaction} = this.props;


### PR DESCRIPTION
WIP.

Refactor span waterfall graph to `<table />`, which permits us to control the width and placement of the vertical divider in only one place by making use of `<colgroup />` and `<col />` elements as follows:


```
<table>
    <colgroup>
        <col span="1" style="width: 40%;">
        <col span="1" style="width: 60%;">
    </colgroup>
    <tbody>
        <SpanContent />
        <SpanContent />
        ...
    </tbody>
<table>
```

The widths were previously set via `<RowCell />` for each row.

Refactor work on the `<DividerHandlerManager />` component will be in follow up PRs. 

Ref:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col