### PR TITLE
ref(flag): Add flag for performance landing widgets

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -951,6 +951,8 @@ SENTRY_FEATURES = {
     "organizations:performance-ops-breakdown": False,
     # Enable views for tag explorer
     "organizations:performance-tag-explorer": False,
+    # Enable landing improvements for performance
+    "organizations:performance-landing-widgets": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -132,6 +132,8 @@ default_manager.add("organizations:team-key-transactions", OrganizationFeature, 
 default_manager.add(
     "organizations:project-transaction-threshold", OrganizationFeature, True  # NOQA
 )
+default_manager.add("organizations:performance-landing-widgets", OrganizationFeature, True)  # NOQA
+
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 


### PR DESCRIPTION
### Summary
A flag we can put potential improvements to the landing page behind.