### PR TITLE
ref(sdk): Add metrics between capturing and sending the envelope

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -224,14 +224,14 @@ def patch_transport_for_instrumentation(transport, transport_name):
 
         transport._worker.submit = patched_worker_submit
 
-    _send_envelope = transport.send_envelope
+    _send_envelope = transport._send_envelope
     if _send_envelope:
 
         def patched_send_envelope(*args, **kwargs):
             metrics.incr(f"internal.send_envelope.{transport_name}.events")
             return _send_envelope(*args, **kwargs)
 
-        transport.send_envelope = patched_send_envelope
+        transport._send_envelope = patched_send_envelope
 
     _send_request = transport._send_request
     if _send_request:


### PR DESCRIPTION
### Summary
The sent requests for the relay transport are lower than the captured envelopes, which implies there is somewhere in between where the events are not making it out. This again bisects the space somewhat, between the existing capture_envelope check and the send_request, checking that events are being submitted to a worker and how many send_envelopes result out of that should give more insight.