### PR TITLE
feat(alert): Add wizard analytics on component mount

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -42,10 +42,24 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 type State = {
   alertOption: AlertType;
 };
+
+const DEFAULT_ALERT_OPTION = 'issues';
+
 class AlertWizard extends Component<Props, State> {
   state: State = {
-    alertOption: 'issues',
+    alertOption: DEFAULT_ALERT_OPTION,
   };
+
+  componentDidMount() {
+    // capture landing on the alert wizard page and viewing the issue alert by default
+    const {organization} = this.props;
+    trackAnalyticsEvent({
+      eventKey: 'alert_wizard.option_viewed',
+      eventName: 'Alert Wizard: Option Viewed',
+      organization_id: organization.id,
+      alert_type: DEFAULT_ALERT_OPTION,
+    });
+  }
 
   handleChangeAlertOption = (alertOption: AlertType) => {
     const {organization} = this.props;


### PR DESCRIPTION
Right now we capture wizard analytics for when a user explicitly clicks a new alert type or when an alert type is selected for the user to move on to the builder. 
However we don't capture metrics for when the user lands on the wizard page and is presented with the default option (currently the issue alert). 

This PR:
- Tracks landing on the wizard page in the `componentDidMount` 