### PR TITLE
fix(eventstore): Ability to pass group_id to get_event_by_id

### DIFF
--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -26,7 +26,7 @@ class GroupEventsLatestEndpoint(GroupEndpoint):
             return client.get(
                 f"/projects/{event.organization.slug}/{event.project.slug}/events/{event.event_id}/",
                 request=request,
-                data={"environment": environments},
+                data={"environment": environments, "group_id": event.group_id},
             )
         except client.ApiError as e:
             return Response(e.body, status=e.status_code)

--- a/src/sentry/api/endpoints/group_events_oldest.py
+++ b/src/sentry/api/endpoints/group_events_oldest.py
@@ -27,7 +27,7 @@ class GroupEventsOldestEndpoint(GroupEndpoint):
             return client.get(
                 f"/projects/{event.organization.slug}/{event.project.slug}/events/{event.event_id}/",
                 request=request,
-                data={"environment": environments},
+                data={"environment": environments, "group_id": event.group_id},
             )
         except client.ApiError as e:
             return Response(e.body, status=e.status_code)

--- a/src/sentry/api/endpoints/group_hashes_split.py
+++ b/src/sentry/api/endpoints/group_hashes_split.py
@@ -220,7 +220,7 @@ def _get_group_filters(group: Group):
 
 def _add_hash(
     trees: List[Dict[str, Any]],
-    project_id: int,
+    group: Group,
     user,
     parent_hash: Optional[str],
     hash: str,
@@ -229,7 +229,7 @@ def _add_hash(
     last_seen,
     latest_event_id,
 ):
-    event = eventstore.get_event_by_id(project_id, latest_event_id)
+    event = eventstore.get_event_by_id(group.project_id, latest_event_id, group_id=group.id)
 
     tree = {
         "parentId": parent_hash,
@@ -397,7 +397,7 @@ def _render_trees(group: Group, user):
 
         _add_hash(
             rv,
-            group.project_id,
+            group,
             user,
             parent_hash,
             hash,

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -26,7 +26,10 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         :auth: required
         """
 
-        event = eventstore.get_event_by_id(project.id, event_id)
+        group_id = request.GET.get("group_id")
+        group_id = int(group_id) if group_id else None
+
+        event = eventstore.get_event_by_id(project.id, event_id, group_id=group_id)
 
         if event is None:
             return Response({"detail": "Event not found"}, status=404)

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -178,10 +178,13 @@ class EventStorage(Service):
     def get_event_by_id(self, project_id, event_id):
         """
         Gets a single event given a project_id and event_id.
+        Returns None if an event cannot be found.
 
         Arguments:
         project_id (int): Project ID
         event_id (str): Event ID
+        group_id (int): If the group ID for this event is already known, pass
+            it here to save one Snuba query.
         """
         raise NotImplementedError
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -175,7 +175,7 @@ class EventStorage(Service):
         """
         raise NotImplementedError
 
-    def get_event_by_id(self, project_id, event_id):
+    def get_event_by_id(self, project_id, event_id, group_id=None):
         """
         Gets a single event given a project_id and event_id.
         Returns None if an event cannot be found.

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -183,7 +183,7 @@ class EventStorage(Service):
         Arguments:
         project_id (int): Project ID
         event_id (str): Event ID
-        group_id (int): If the group ID for this event is already known, pass
+        group_id (Optional[int]): If the group ID for this event is already known, pass
             it here to save one Snuba query.
         """
         raise NotImplementedError


### PR DESCRIPTION
The main problem we're trying to fix here is that `/events/latest/` sends two Snuba queries concerning a particular event in quick succession, which can cause the endpoint to return a 404 if the two queries hit two different clickhouse replicas. An (apparent) replication lag of 1-2 *minutes* actually has been observed for project 1317436 on sentry.io which caused this exact problem and caused "event not found" when just browsing to the latest event of an issue.

Also pass group ID to `get_event_by_id` in one other unrelated piece of code where I know I already have it.