### PR TITLE
feat(api): Add CSRF for anonymous POST

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -2,7 +2,11 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.crypto import constant_time_compare
 from django.utils.encoding import force_text
-from rest_framework.authentication import BasicAuthentication, get_authorization_header
+from rest_framework.authentication import (
+    BasicAuthentication,
+    SessionAuthentication,
+    get_authorization_header,
+)
 from rest_framework.exceptions import AuthenticationFailed
 from sentry_relay import UnpackError
 
@@ -183,3 +187,18 @@ class DSNAuthentication(StandardAuthentication):
             scope.set_tag("api_project_key", key.id)
 
         return (AnonymousUser(), key)
+
+
+class ImprovedSessionAuthentication(SessionAuthentication):
+    """
+    Identical to SesssionAuthentication but it forces CSRF even on anonymous requests.
+    """
+
+    def authenticate(self, request):
+        rv = super().authenticate(request)
+        if rv:
+            return rv
+
+        # if we didnt return a user, it means we never ran CSRF checks, so force them now
+        self.enforce_csrf(request)
+        return None

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -9,7 +9,6 @@ from django.http import HttpResponse
 from django.utils.http import urlquote
 from django.views.decorators.csrf import csrf_exempt
 from pytz import utc
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -24,7 +23,7 @@ from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
 from sentry.utils.sdk import capture_exception
 
-from .authentication import ApiKeyAuthentication, TokenAuthentication
+from .authentication import ApiKeyAuthentication, ImprovedSessionAuthentication, TokenAuthentication
 from .paginator import BadPaginationError, Paginator
 from .permissions import NoPermission
 
@@ -36,7 +35,7 @@ ONE_DAY = ONE_HOUR * 24
 
 LINK_HEADER = '<{uri}&cursor={cursor}>; rel="{name}"; results="{has_results}"; cursor="{cursor}"'
 
-DEFAULT_AUTHENTICATION = (TokenAuthentication, ApiKeyAuthentication, SessionAuthentication)
+DEFAULT_AUTHENTICATION = (TokenAuthentication, ApiKeyAuthentication, ImprovedSessionAuthentication)
 
 logger = logging.getLogger(__name__)
 audit_logger = logging.getLogger("sentry.audit.api")

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -5,7 +5,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from sentry import roles
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import (
@@ -27,7 +28,7 @@ class InvalidPayload(Exception):
 
 
 class AcceptProjectTransferEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get_validated_data(self, data, user):

--- a/src/sentry/api/endpoints/api_application_details.py
+++ b/src/sentry/api/endpoints/api_application_details.py
@@ -5,7 +5,8 @@ from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import ListField
@@ -35,7 +36,7 @@ class ApiApplicationSerializer(serializers.Serializer):
 
 
 class ApiApplicationDetailsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, app_id):

--- a/src/sentry/api/endpoints/api_applications.py
+++ b/src/sentry/api/endpoints/api_applications.py
@@ -1,14 +1,15 @@
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ApiApplication, ApiApplicationStatus
 
 
 class ApiApplicationsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):

--- a/src/sentry/api/endpoints/api_authorizations.py
+++ b/src/sentry/api/endpoints/api_authorizations.py
@@ -2,14 +2,15 @@ from django.db import transaction
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ApiApplicationStatus, ApiAuthorization, ApiToken
 
 
 class ApiAuthorizationsEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -3,7 +3,8 @@ from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, SessionAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication
+from sentry.api.base import Endpoint
 from sentry.api.fields import MultipleChoiceField
 from sentry.api.serializers import serialize
 from sentry.models import ApiToken
@@ -15,7 +16,7 @@ class ApiTokenSerializer(serializers.Serializer):
 
 
 class ApiTokensEndpoint(Endpoint):
-    authentication_classes = (SessionAuthentication,)
+    authentication_classes = (ImprovedSessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -1,10 +1,9 @@
 from django.contrib.auth import logout
 from django.contrib.auth.models import AnonymousUser
 from rest_framework import status
-from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
-from sentry.api.authentication import QuietBasicAuthentication
+from sentry.api.authentication import ImprovedSessionAuthentication, QuietBasicAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.serializers import DetailedUserSerializer, serialize
 from sentry.api.validators import AuthVerifyValidator
@@ -22,7 +21,7 @@ class AuthIndexEndpoint(Endpoint):
     and simple HTTP authentication.
     """
 
-    authentication_classes = [QuietBasicAuthentication, SessionAuthentication]
+    authentication_classes = [QuietBasicAuthentication, ImprovedSessionAuthentication]
 
     permission_classes = ()
 


### PR DESCRIPTION
This updates API endpoints to require CSRF even for anonymous views when they're allowing a POST request. Its the same behavior that would have existed for an authenticated user, but its often assumed an anonymous request would be safe in this regard and that is not always true.

Refs #26054 