### PR TITLE
feat(api): Enforce CORS on all requests

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -200,8 +200,11 @@ class Endpoint(APIView):
 
         try:
             with sentry_sdk.start_span(op="base.dispatch.request", description=type(self).__name__):
-                if origin and request.auth:
-                    allowed_origins = request.auth.get_allowed_origins()
+                if origin:
+                    if request.auth:
+                        allowed_origins = request.auth.get_allowed_origins()
+                    else:
+                        allowed_origins = None
                     if not is_valid_origin(origin, allowed=allowed_origins):
                         response = Response(f"Invalid origin: {origin}", status=400)
                         self.response = self.finalize_response(request, response, *args, **kwargs)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1176,7 +1176,7 @@ SENTRY_ALLOW_PUBLIC_PROJECTS = True
 # Will an invite be sent when a member is added to an organization?
 SENTRY_ENABLE_INVITES = True
 
-# Default to not sending the Access-Control-Allow-Origin header on api/store
+# Origins allowed for session-based API access (via the Access-Control-Allow-Origin header)
 SENTRY_ALLOW_ORIGIN = None
 
 # Enable scraping of javascript context for source code

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -64,18 +64,19 @@ def is_same_domain(url1, url2):
 
 
 def get_origins(project=None):
-    if settings.SENTRY_ALLOW_ORIGIN == "*":
-        return frozenset(["*"])
-
-    if settings.SENTRY_ALLOW_ORIGIN:
-        result = settings.SENTRY_ALLOW_ORIGIN.split(" ")
+    if not project:
+        if settings.SENTRY_ALLOW_ORIGIN in ("*", None):
+            result = ["*"]
+        elif settings.SENTRY_ALLOW_ORIGIN:
+            result = settings.SENTRY_ALLOW_ORIGIN.split(" ")
+        else:
+            result = []
     else:
-        result = []
-
-    if project:
         optval = project.get_option("sentry:origins", ["*"])
         if optval:
-            result.extend(optval)
+            result = optval
+        else:
+            result = []
 
     # lowercase and strip the trailing slash from all origin values
     # filter out empty values

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -55,6 +55,42 @@ class EndpointTest(APITestCase):
 
         assert response["Access-Control-Allow-Origin"] == "http://example.com"
 
+    def test_invalid_cors_without_auth(self):
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["HTTP_ORIGIN"] = "http://example.com"
+
+        with self.settings(SENTRY_ALLOW_ORIGIN="https://sentry.io"):
+            response = _dummy_endpoint(request)
+            response.render()
+
+        assert response.status_code == 400, response.content
+
+    def test_valid_cors_without_auth(self):
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["HTTP_ORIGIN"] = "http://example.com"
+
+        with self.settings(SENTRY_ALLOW_ORIGIN="*"):
+            response = _dummy_endpoint(request)
+            response.render()
+
+        assert response.status_code == 200, response.content
+        assert response["Access-Control-Allow-Origin"] == "http://example.com"
+
+    # XXX(dcramer): The default setting needs to allow requests to work or it will be a regression
+    def test_cors_not_configured_is_valid(self):
+        request = HttpRequest()
+        request.method = "GET"
+        request.META["HTTP_ORIGIN"] = "http://example.com"
+
+        with self.settings(SENTRY_ALLOW_ORIGIN=None):
+            response = _dummy_endpoint(request)
+            response.render()
+
+        assert response.status_code == 200, response.content
+        assert response["Access-Control-Allow-Origin"] == "http://example.com"
+
 
 class PaginateTest(APITestCase):
     def setUp(self):

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -67,12 +67,12 @@ class GetOriginsTestCase(TestCase):
 
         with self.settings(SENTRY_ALLOW_ORIGIN="http://example.com"):
             result = get_origins(project)
-            self.assertEquals(result, frozenset(["http://foo.example", "http://example.com"]))
+            self.assertEquals(result, frozenset(["http://foo.example"]))
 
     def test_setting_empty(self):
         with self.settings(SENTRY_ALLOW_ORIGIN=None):
             result = get_origins(None)
-            self.assertEquals(result, frozenset([]))
+            self.assertEquals(result, frozenset(["*"]))
 
     def test_setting_all(self):
         with self.settings(SENTRY_ALLOW_ORIGIN="*"):

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -26,33 +26,29 @@ class ErrorPageEmbedTest(TestCase):
         )
 
     def test_invalid_referer(self):
-        with self.settings(SENTRY_ALLOW_ORIGIN=None):
-            resp = self.client.get(self.path_with_qs, HTTP_REFERER="http://foo.com")
+        resp = self.client.get(self.path_with_qs, HTTP_REFERER="http://foo.com")
         assert resp.status_code == 403, resp.content
         assert resp["Content-Type"] == "application/json"
 
     def test_invalid_origin(self):
-        with self.settings(SENTRY_ALLOW_ORIGIN=None):
-            resp = self.client.get(self.path_with_qs, HTTP_ORIGIN="http://foo.com")
+        resp = self.client.get(self.path_with_qs, HTTP_ORIGIN="http://foo.com")
         assert resp.status_code == 403, resp.content
         assert resp["Content-Type"] == "application/json"
 
     def test_invalid_origin_respects_accept(self):
-        with self.settings(SENTRY_ALLOW_ORIGIN=None):
-            resp = self.client.get(
-                self.path_with_qs,
-                HTTP_ORIGIN="http://foo.com",
-                HTTP_ACCEPT="text/html, text/javascript",
-            )
+        resp = self.client.get(
+            self.path_with_qs,
+            HTTP_ORIGIN="http://foo.com",
+            HTTP_ACCEPT="text/html, text/javascript",
+        )
         assert resp.status_code == 403, resp.content
         assert resp["Content-Type"] == "text/javascript"
 
     def test_missing_eventId(self):
         path = f"{self.path}?dsn={quote(self.key.dsn_public)}"
-        with self.settings(SENTRY_ALLOW_ORIGIN="*"):
-            resp = self.client.get(
-                path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
-            )
+        resp = self.client.get(
+            path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
+        )
         assert resp.status_code == 400, resp.content
         assert resp["Content-Type"] == "text/javascript"
         assert resp["X-Sentry-Context"] == '{"eventId":"Missing or invalid parameter."}'
@@ -60,10 +56,9 @@ class ErrorPageEmbedTest(TestCase):
 
     def test_missing_dsn(self):
         path = f"{self.path}?eventId={quote(self.event_id)}"
-        with self.settings(SENTRY_ALLOW_ORIGIN="*"):
-            resp = self.client.get(
-                path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
-            )
+        resp = self.client.get(
+            path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
+        )
         assert resp.status_code == 404, resp.content
         assert resp["Content-Type"] == "text/javascript"
         assert resp["X-Sentry-Context"] == '{"dsn":"Missing or invalid parameter."}'


### PR DESCRIPTION
This requires session-based API calls to follow CORS rules for the Sentry site, in the same way that we'd enforce them elsewhere.

Refs #26054