### PR TITLE
feat(performance): Add endpoint for team key transaction counts

### DIFF
--- a/src/sentry/api/helpers/teams.py
+++ b/src/sentry/api/helpers/teams.py
@@ -1,0 +1,39 @@
+from sentry.api.utils import InvalidParams
+from sentry.auth.superuser import is_active_superuser
+from sentry.models import Team, TeamStatus
+
+
+def get_teams(request, organization, teams=None):
+    # do normal teams lookup based on request params
+    requested_teams = set(request.GET.getlist("team", [])) if teams is None else teams
+
+    verified_ids = set()
+
+    if "myteams" in requested_teams:
+        requested_teams.remove("myteams")
+        if is_active_superuser(request):
+            # retrieve all teams within the organization
+            myteams = Team.objects.filter(
+                organization=organization, status=TeamStatus.VISIBLE
+            ).values_list("id", flat=True)
+            verified_ids.update(myteams)
+        else:
+            myteams = [t.id for t in request.access.teams]
+            verified_ids.update(myteams)
+
+    for team_id in requested_teams:  # Verify each passed Team id is numeric
+        if type(team_id) is not int and not team_id.isdigit():
+            raise InvalidParams(f"Invalid Team ID: {team_id}")
+    requested_teams.update(verified_ids)
+
+    teams_query = Team.objects.filter(id__in=requested_teams)
+    for team in teams_query:
+        if team.id in verified_ids:
+            continue
+
+        if not request.access.has_team_access(team):
+            raise InvalidParams(
+                f"Error: You do not have permission to access {team.name}",
+            )
+
+    return teams_query

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -4,6 +4,7 @@ from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.discover.endpoints.discover_key_transactions import (
     IsKeyTransactionEndpoint,
+    KeyTransactionCountEndpoint,
     KeyTransactionEndpoint,
 )
 from sentry.discover.endpoints.discover_query import DiscoverQueryEndpoint
@@ -786,6 +787,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/key-transactions/$",
                     KeyTransactionEndpoint.as_view(),
                     name="sentry-api-0-organization-key-transactions",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/key-transactions-count/$",
+                    KeyTransactionCountEndpoint.as_view(),
+                    name="sentry-api-0-organization-key-transactions-count",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/is-key-transactions/$",

--- a/src/sentry/incidents/endpoints/utils.py
+++ b/src/sentry/incidents/endpoints/utils.py
@@ -1,42 +1,14 @@
-from sentry.api.utils import InvalidParams
-from sentry.auth.superuser import is_active_superuser
-from sentry.models import Team, TeamStatus
+from sentry.api.helpers.teams import get_teams
 
 
 def parse_team_params(request, organization, teams):
     teams_set = set(teams)
-    # do normal teams lookup based on request params
-    verified_ids = set()
+
     unassigned = False
     if "unassigned" in teams_set:
         teams_set.remove("unassigned")
         unassigned = True
 
-    if "myteams" in teams_set:
-        teams_set.remove("myteams")
-        if is_active_superuser(request):
-            # retrieve all teams within the organization
-            myteams = Team.objects.filter(
-                organization=organization, status=TeamStatus.VISIBLE
-            ).values_list("id", flat=True)
-            verified_ids.update(myteams)
-        else:
-            myteams = [t.id for t in request.access.teams]
-            verified_ids.update(myteams)
+    teams = get_teams(request, organization, teams=teams_set)
 
-    for team_id in teams_set:  # Verify each passed Team id is numeric
-        if type(team_id) is not int and not team_id.isdigit():
-            raise InvalidParams(f"Invalid Team ID: {team_id}")
-    teams_set.update(verified_ids)
-
-    teams_query = Team.objects.filter(id__in=teams_set)
-    for team in teams_query:
-        if team.id in verified_ids:
-            continue
-
-        if not request.access.has_team_access(team):
-            raise InvalidParams(
-                f"Error: You do not have permission to access {team.name}",
-            )
-
-    return (teams_query, unassigned)
+    return (teams, unassigned)


### PR DESCRIPTION
Team key transactions has a per team limit. This adds an endpoint to get the
counts so we can better enforce the limits on the frontend.