### PR TITLE
feat(dashboards): adds new icon for dashboards

### DIFF
--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -44,7 +44,7 @@ const FeaturedBadge = ({
       <React.Fragment>
         {variant === 'badge' && <StyledTag priority={type}>{labels[type]}</StyledTag>}
         {variant === 'indicator' && (
-          <CircleIndicator color={theme.badge[type].indicatorColor} size={8} />
+          <CircleIndicator color={theme?.badge[type].indicatorColor} size={8} />
         )}
       </React.Fragment>
     </Tooltip>

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -376,6 +376,7 @@ class Sidebar extends React.Component<Props, State> {
           label={t('Dashboards')}
           to={`/organizations/${organization.slug}/dashboards/`}
           id="customizable-dashboards"
+          isNew
         />
       </Feature>
     );


### PR DESCRIPTION
We want to show the Dashboard feature as being new.

Before:
![Screen Shot 2021-05-21 at 10 46 54 AM](https://user-images.githubusercontent.com/8533851/119178133-278ae300-ba22-11eb-8962-2fd39a2ea7ac.png)

After:
![Screen Shot 2021-05-21 at 10 46 42 AM](https://user-images.githubusercontent.com/8533851/119178120-25c11f80-ba22-11eb-8a95-859d919ebe48.png)

