### PR TITLE
feat(codeowners): Detailed error message on delete failure

### DIFF
--- a/src/sentry/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_details.py
@@ -70,6 +70,6 @@ class OrganizationCodeMappingDetailsEndpoint(
             return self.respond(status=status.HTTP_204_NO_CONTENT)
         except ProtectedError:
             return self.respond(
-                "Cannot delete Code Mapping. There is a Code Owners that depends on it.",
+                "Cannot delete Code Mapping. Must delete Code Owner that uses this mapping first.",
                 status=status.HTTP_409_CONFLICT,
             )

--- a/src/sentry/api/endpoints/organization_code_mapping_details.py
+++ b/src/sentry/api/endpoints/organization_code_mapping_details.py
@@ -1,3 +1,4 @@
+from django.db.models.deletion import ProtectedError
 from django.http import Http404
 from rest_framework import status
 
@@ -64,5 +65,11 @@ class OrganizationCodeMappingDetailsEndpoint(
 
         :auth: required
         """
-        config.delete()
-        return self.respond(status=status.HTTP_204_NO_CONTENT)
+        try:
+            config.delete()
+            return self.respond(status=status.HTTP_204_NO_CONTENT)
+        except ProtectedError:
+            return self.respond(
+                "Cannot delete Code Mapping. There is a Code Owners that depends on it.",
+                status=status.HTTP_409_CONFLICT,
+            )

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -117,9 +117,13 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
       pathConfigs = pathConfigs.filter(config => config.id !== pathConfig.id);
       this.setState({pathConfigs});
       addSuccessMessage(t('Deletion successful'));
-    } catch {
-      //no 4xx errors should happen on delete
-      addErrorMessage(t('An error occurred'));
+    } catch (err) {
+      addErrorMessage(
+        tct('[status]: [text]', {
+          status: err.statusText,
+          text: err.responseText,
+        })
+      );
     }
   };
 

--- a/tests/sentry/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mapping_details.py
@@ -52,3 +52,13 @@ class OrganizationCodeMappingDetailsTest(APITestCase):
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.config.id)
         assert resp.data["sourceRoot"] == "newRoot"
+
+    def test_delete_with_existing_codeowners(self):
+        self.create_codeowners(project=self.project, code_mapping=self.config)
+        resp = self.client.delete(self.url)
+        assert resp.status_code == 409
+        assert (
+            resp.data
+            == "Cannot delete Code Mapping. Must delete Code Owner that uses this mapping first."
+        )
+        assert RepositoryProjectPathConfig.objects.filter(id=str(self.config.id)).exists()


### PR DESCRIPTION
## Objective:
When deleting file code mapping, if we can't delete it cause there's an associated codeowners. We should tell the user in the error message.

## UI:
![Screen Shot 2021-05-21 at 10 50 29 AM](https://user-images.githubusercontent.com/10491193/119178816-0e366680-ba23-11eb-88a1-1cd5f1f23a36.png)
