### PR TITLE
refs(search): Add some typing to `event_search.py`, and refactor `convert_search_filter_to_snuba_query` to be less huge

### DIFF
--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Callable, Mapping, Optional, Sequence, Union
 
 from parsimonious.exceptions import ParseError
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
@@ -112,7 +113,209 @@ def convert_function_to_condition(func):
     return [func[1][0], operator, func[1][1]]
 
 
-def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
+def _environment_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    # conditions added to env_conditions are OR'd
+    env_conditions = []
+    value = search_filter.value.value
+    values = set(value if isinstance(value, (list, tuple)) else [value])
+    # the "no environment" environment is null in snuba
+    if "" in values:
+        values.remove("")
+        operator = "IS NULL" if search_filter.operator == "=" else "IS NOT NULL"
+        env_conditions.append(["environment", operator, None])
+    if len(values) == 1:
+        operator = "=" if search_filter.operator in EQUALITY_OPERATORS else "!="
+        env_conditions.append(["environment", operator, values.pop()])
+    elif values:
+        operator = "IN" if search_filter.operator in EQUALITY_OPERATORS else "NOT IN"
+        env_conditions.append(["environment", operator, values])
+    return env_conditions
+
+
+def _message_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    value = search_filter.value.value
+    if search_filter.value.is_wildcard():
+        # XXX: We don't want the '^$' values at the beginning and end of
+        # the regex since we want to find the pattern anywhere in the
+        # message. Strip off here
+        value = search_filter.value.value[1:-1]
+        return [["match", ["message", f"'(?i){value}'"]], search_filter.operator, 1]
+    elif value == "":
+        operator = "=" if search_filter.operator == "=" else "!="
+        return [["equals", ["message", f"{value}"]], operator, 1]
+    else:
+        # https://clickhouse.yandex/docs/en/query_language/functions/string_search_functions/#position-haystack-needle
+        # positionCaseInsensitive returns 0 if not found and an index of 1 or more if found
+        # so we should flip the operator here
+        operator = "!=" if search_filter.operator in EQUALITY_OPERATORS else "="
+        if search_filter.is_in_filter:
+            # XXX: This `toString` usage is unnecessary, but we need it in place to
+            # trick the legacy Snuba language into not treating `message` as a
+            # function. Once we switch over to snql it can be removed.
+            return [
+                [
+                    "multiSearchFirstPositionCaseInsensitive",
+                    [["toString", ["message"]], ["array", [f"'{v}'" for v in value]]],
+                ],
+                operator,
+                0,
+            ]
+
+        # make message search case insensitive
+        return [["positionCaseInsensitive", ["message", f"'{value}'"]], operator, 0]
+
+
+def _transaction_status_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    # Handle "has" queries
+    if search_filter.value.raw_value == "":
+        return [["isNull", [name]], search_filter.operator, 1]
+
+    if search_filter.is_in_filter:
+        internal_value = [
+            translate_transaction_status(val) for val in search_filter.value.raw_value
+        ]
+    else:
+        internal_value = translate_transaction_status(search_filter.value.raw_value)
+
+    return [name, search_filter.operator, internal_value]
+
+
+def _issue_id_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    value = search_filter.value.value
+    # Handle "has" queries
+    if (
+        search_filter.value.raw_value == ""
+        or search_filter.is_in_filter
+        and [v for v in value if not v]
+    ):
+        # The state of having no issues is represented differently on transactions vs
+        # other events. On the transactions table, it is represented by 0 whereas it is
+        # represented by NULL everywhere else. We use coalesce here so we can treat this
+        # consistently
+        name = ["coalesce", [name, 0]]
+        if search_filter.is_in_filter:
+            value = [v if v else 0 for v in value]
+        else:
+            value = 0
+
+    # Skip isNull check on group_id value as we want to
+    # allow snuba's prewhere optimizer to find this condition.
+    return [name, search_filter.operator, value]
+
+
+def _user_display_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    value = search_filter.value.value
+    user_display_expr = FIELD_ALIASES[USER_DISPLAY_ALIAS].get_expression(params)
+
+    # Handle 'has' condition
+    if search_filter.value.raw_value == "":
+        return [["isNull", [user_display_expr]], search_filter.operator, 1]
+    if search_filter.value.is_wildcard():
+        return [
+            ["match", [user_display_expr, f"'(?i){value}'"]],
+            search_filter.operator,
+            1,
+        ]
+    return [user_display_expr, search_filter.operator, value]
+
+
+def _error_unhandled_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    value = search_filter.value.value
+    # This field is the inversion of error.handled, otherwise the logic is the same.
+    if search_filter.value.raw_value == "":
+        output = 0 if search_filter.operator == "!=" else 1
+        return [["isHandled", []], "=", output]
+    if value in ("1", 1):
+        return [["notHandled", []], "=", 1]
+    if value in ("0", 0):
+        return [["isHandled", []], "=", 1]
+    raise InvalidSearchQuery(
+        "Invalid value for error.unhandled condition. Accepted values are 1, 0"
+    )
+
+
+def _error_handled_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    value = search_filter.value.value
+    # Treat has filter as equivalent to handled
+    if search_filter.value.raw_value == "":
+        output = 1 if search_filter.operator == "!=" else 0
+        return [["isHandled", []], "=", output]
+    # Null values and 1 are the same, and both indicate a handled error.
+    if value in ("1", 1):
+        return [["isHandled", []], "=", 1]
+    if value in ("0", 0):
+        return [["notHandled", []], "=", 1]
+    raise InvalidSearchQuery("Invalid value for error.handled condition. Accepted values are 1, 0")
+
+
+def _key_transaction_filter_converter(
+    search_filter: SearchFilter,
+    name: str,
+    params: Optional[Mapping[str, Union[int, str, datetime]]],
+):
+    value = search_filter.value.value
+    key_transaction_expr = FIELD_ALIASES[KEY_TRANSACTION_ALIAS].get_expression(params)
+
+    if search_filter.value.raw_value == "":
+        operator = "!=" if search_filter.operator == "!=" else "="
+        return [key_transaction_expr, operator, 0]
+    if value in ("1", 1):
+        return [key_transaction_expr, "=", 1]
+    if value in ("0", 0):
+        return [key_transaction_expr, "=", 0]
+    raise InvalidSearchQuery(
+        "Invalid value for key_transaction condition. Accepted values are 1, 0"
+    )
+
+
+key_conversion_map: Mapping[
+    str,
+    Callable[[SearchFilter, str, Mapping[str, Union[int, str, datetime]]], Optional[Sequence[any]]],
+] = {
+    "environment": _environment_filter_converter,
+    "message": _message_filter_converter,
+    "transaction.status": _transaction_status_filter_converter,
+    "issue.id": _issue_id_filter_converter,
+    USER_DISPLAY_ALIAS: _user_display_filter_converter,
+    ERROR_UNHANDLED_ALIAS: _error_unhandled_filter_converter,
+    "error.handled": _error_handled_filter_converter,
+    KEY_TRANSACTION_ALIAS: _key_transaction_filter_converter,
+}
+
+
+def convert_search_filter_to_snuba_query(
+    search_filter: SearchFilter,
+    key: Optional[str] = None,
+    params: Optional[Mapping[str, Union[int, str, datetime]]] = None,
+) -> Optional[Sequence[any]]:
     name = search_filter.key.name if key is None else key
     value = search_filter.value.value
 
@@ -123,53 +326,8 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
 
     if name in NO_CONVERSION_FIELDS:
         return
-    elif name == "environment":
-        # conditions added to env_conditions are OR'd
-        env_conditions = []
-
-        values = set(value if isinstance(value, (list, tuple)) else [value])
-        # the "no environment" environment is null in snuba
-        if "" in values:
-            values.remove("")
-            operator = "IS NULL" if search_filter.operator == "=" else "IS NOT NULL"
-            env_conditions.append(["environment", operator, None])
-        if len(values) == 1:
-            operator = "=" if search_filter.operator in EQUALITY_OPERATORS else "!="
-            env_conditions.append(["environment", operator, values.pop()])
-        elif values:
-            operator = "IN" if search_filter.operator in EQUALITY_OPERATORS else "NOT IN"
-            env_conditions.append(["environment", operator, values])
-        return env_conditions
-    elif name == "message":
-        if search_filter.value.is_wildcard():
-            # XXX: We don't want the '^$' values at the beginning and end of
-            # the regex since we want to find the pattern anywhere in the
-            # message. Strip off here
-            value = search_filter.value.value[1:-1]
-            return [["match", ["message", f"'(?i){value}'"]], search_filter.operator, 1]
-        elif value == "":
-            operator = "=" if search_filter.operator == "=" else "!="
-            return [["equals", ["message", f"{value}"]], operator, 1]
-        else:
-            # https://clickhouse.yandex/docs/en/query_language/functions/string_search_functions/#position-haystack-needle
-            # positionCaseInsensitive returns 0 if not found and an index of 1 or more if found
-            # so we should flip the operator here
-            operator = "!=" if search_filter.operator in EQUALITY_OPERATORS else "="
-            if search_filter.is_in_filter:
-                # XXX: This `toString` usage is unnecessary, but we need it in place to
-                # trick the legacy Snuba language into not treating `message` as a
-                # function. Once we switch over to snql it can be removed.
-                return [
-                    [
-                        "multiSearchFirstPositionCaseInsensitive",
-                        [["toString", ["message"]], ["array", [f"'{v}'" for v in value]]],
-                    ],
-                    operator,
-                    0,
-                ]
-
-            # make message search case insensitive
-            return [["positionCaseInsensitive", ["message", f"'{value}'"]], operator, 0]
+    elif name in key_conversion_map:
+        return key_conversion_map[name](search_filter, name, params)
     elif name in ARRAY_FIELDS and search_filter.value.is_wildcard():
         # Escape and convert meta characters for LIKE expressions.
         raw_value = search_filter.value.raw_value
@@ -186,93 +344,6 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
             operator,
             1,
         ]
-    elif name == "transaction.status":
-        # Handle "has" queries
-        if search_filter.value.raw_value == "":
-            return [["isNull", [name]], search_filter.operator, 1]
-
-        if search_filter.is_in_filter:
-            internal_value = [
-                translate_transaction_status(val) for val in search_filter.value.raw_value
-            ]
-        else:
-            internal_value = translate_transaction_status(search_filter.value.raw_value)
-
-        return [name, search_filter.operator, internal_value]
-    elif name == "issue.id":
-        # Handle "has" queries
-        if (
-            search_filter.value.raw_value == ""
-            or search_filter.is_in_filter
-            and [v for v in value if not v]
-        ):
-            # The state of having no issues is represented differently on transactions vs
-            # other events. On the transactions table, it is represented by 0 whereas it is
-            # represented by NULL everywhere else. We use coalesce here so we can treat this
-            # consistently
-            name = ["coalesce", [name, 0]]
-            if search_filter.is_in_filter:
-                value = [v if v else 0 for v in value]
-            else:
-                value = 0
-
-        # Skip isNull check on group_id value as we want to
-        # allow snuba's prewhere optimizer to find this condition.
-        return [name, search_filter.operator, value]
-    elif name == USER_DISPLAY_ALIAS:
-        user_display_expr = FIELD_ALIASES[USER_DISPLAY_ALIAS].get_expression(params)
-
-        # Handle 'has' condition
-        if search_filter.value.raw_value == "":
-            return [["isNull", [user_display_expr]], search_filter.operator, 1]
-        if search_filter.value.is_wildcard():
-            return [
-                ["match", [user_display_expr, f"'(?i){value}'"]],
-                search_filter.operator,
-                1,
-            ]
-        return [user_display_expr, search_filter.operator, value]
-    elif name == ERROR_UNHANDLED_ALIAS:
-        # This field is the inversion of error.handled, otherwise the logic is the same.
-        if search_filter.value.raw_value == "":
-            output = 0 if search_filter.operator == "!=" else 1
-            return [["isHandled", []], "=", output]
-        if value in ("1", 1):
-            return [["notHandled", []], "=", 1]
-        if value in ("0", 0):
-            return [["isHandled", []], "=", 1]
-        raise InvalidSearchQuery(
-            "Invalid value for error.unhandled condition. Accepted values are 1, 0"
-        )
-    elif name == "error.handled":
-        # Treat has filter as equivalent to handled
-        if search_filter.value.raw_value == "":
-            output = 1 if search_filter.operator == "!=" else 0
-            return [["isHandled", []], "=", output]
-        # Null values and 1 are the same, and both indicate a handled error.
-        if value in ("1", 1):
-            return [["isHandled", []], "=", 1]
-        if value in (
-            "0",
-            0,
-        ):
-            return [["notHandled", []], "=", 1]
-        raise InvalidSearchQuery(
-            "Invalid value for error.handled condition. Accepted values are 1, 0"
-        )
-    elif name == KEY_TRANSACTION_ALIAS:
-        key_transaction_expr = FIELD_ALIASES[KEY_TRANSACTION_ALIAS].get_expression(params)
-
-        if search_filter.value.raw_value == "":
-            operator = "!=" if search_filter.operator == "!=" else "="
-            return [key_transaction_expr, operator, 0]
-        if value in ("1", 1):
-            return [key_transaction_expr, "=", 1]
-        if value in ("0", 0):
-            return [key_transaction_expr, "=", 0]
-        raise InvalidSearchQuery(
-            "Invalid value for key_transaction condition. Accepted values are 1, 0"
-        )
     elif name in ARRAY_FIELDS and search_filter.value.raw_value == "":
         return [["notEmpty", [name]], "=", 1 if search_filter.operator == "!=" else 0]
     else:


### PR DESCRIPTION
This should be functionally the same as before, just breaking up `convert_search_filter_to_snuba_query` some. I think this is an improvement, lmk if you disagree.