### PR TITLE
ref(sdk): Check if envelope has items and if it serializes

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -228,6 +228,18 @@ def patch_transport_for_instrumentation(transport, transport_name):
     if _send_envelope:
 
         def patched_send_envelope(*args, **kwargs):
+            envelope = args[0]
+            if envelope and len(envelope.items) > 0:
+                metrics.incr(f"internal.envelope_has_items.{transport_name}")
+
+                _serialize_into = envelope.serialize_into
+
+                def patched_envelope_serialize(*args, **kwargs):
+                    metrics.incr(f"internal.envelope_serialize_into.{transport}.count")
+                    return _serialize_into(*args, **kwargs)
+
+                envelope.serialize_into = patched_envelope_serialize
+
             metrics.incr(f"internal.send_envelope.{transport_name}.events")
             try:
                 result = _send_envelope(*args, **kwargs)
@@ -280,6 +292,7 @@ def patch_transport_for_instrumentation(transport, transport_name):
                 metrics.incr(f"internal.check_disabled.{transport_name}.bucket.{bucket}.disabled")
 
         def patched_check_disabled(*args, **kwargs):
+            metrics.incr(f"internal.pre_check_disabled.{transport_name}.events.count")
             result = _check_disabled(*args, **kwargs)
             metrics.incr(f"internal.check_disabled.{transport_name}.events.count")
             if result:


### PR DESCRIPTION
### Summary
These are the last two pieces of functionality between send_envelope being called and send request. It appears as though no errors are occurring, serialize_into being called would be a good indication that it's not check_disabled function or the items being empty. The pre-disabled metric should show if an error is occurring in the disabled function itself.

#### Reference
https://github.com/getsentry/sentry-python/blob/4b4ffc05795130c8a95577074a29462c2a512d66/sentry_sdk/transport.py#L251-L274