### PR TITLE
ref(vercel): Remove webhook creation

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -2,7 +2,6 @@ import logging
 
 from sentry.integrations.client import ApiClient
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.integrations.vercel.api")
 
@@ -16,7 +15,6 @@ class VercelClient(ApiClient):
     USER_URL = "/www/user"
     PROJECT_URL = "/v1/projects/%s"
     PROJECTS_URL = "/v4/projects/"
-    WEBHOOK_URL = "/v1/integrations/webhooks"
     ENV_VAR_URL = "/v6/projects/%s/env"
     GET_ENV_VAR_URL = "/v6/projects/%s/env"
     SECRETS_URL = "/v2/now/secrets"
@@ -72,15 +70,6 @@ class VercelClient(ApiClient):
 
     def get_project(self, vercel_project_id):
         return self.get(self.PROJECT_URL % vercel_project_id)
-
-    def create_deploy_webhook(self):
-        data = {
-            "name": "Sentry webhook",
-            "url": absolute_uri("/extensions/vercel/webhook/"),
-            "events": ["deployment"],
-        }
-        response = self.post(self.WEBHOOK_URL, data=data)
-        return response
 
     def get_env_vars(self, vercel_project_id):
         return self.get(self.GET_ENV_VAR_URL % vercel_project_id)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -323,19 +323,6 @@ class VercelIntegrationProvider(IntegrationProvider):
             installation_type = "user"
             user = client.get_user()
             name = user.get("name") or user["username"]
-        try:
-            webhook = client.create_deploy_webhook()
-        except ApiError as err:
-            logger.info(
-                "vercel.create_webhook.failed",
-                extra={"error": str(err), "external_id": external_id},
-            )
-            try:
-                details = list(err.json["messages"][0].values()).pop()
-            except Exception:
-                details = "Unknown Error"
-            message = f"Could not create deployment webhook in Vercel: {details}"
-            raise IntegrationError(message)
 
         integration = {
             "name": name,
@@ -344,7 +331,6 @@ class VercelIntegrationProvider(IntegrationProvider):
                 "access_token": access_token,
                 "installation_id": data["installation_id"],
                 "installation_type": installation_type,
-                "webhook_id": webhook["id"],
             },
             "post_install_data": {"user_id": state["user_id"]},
         }

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -56,12 +56,6 @@ class VercelIntegrationTest(IntegrationTestCase):
             json={"projects": [], "pagination": {"count": 0}},
         )
 
-        responses.add(
-            responses.POST,
-            f"https://api.vercel.com/v1/integrations/webhooks?{team_query}",
-            json={"id": "webhook-id"},
-        )
-
         params = {
             "configurationId": "config_id",
             "code": "oauth-code",
@@ -94,7 +88,6 @@ class VercelIntegrationTest(IntegrationTestCase):
             "access_token": "my_access_token",
             "installation_id": "my_config_id",
             "installation_type": installation_type,
-            "webhook_id": "webhook-id",
         }
         assert OrganizationIntegration.objects.get(
             integration=integration, organization=self.organization

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -197,36 +197,36 @@ class VercelIntegrationTest(IntegrationTestCase):
         }
 
         # assert the secret was created correctly
-        req_params = json.loads(responses.calls[9].request.body)
+        req_params = json.loads(responses.calls[8].request.body)
         assert req_params["name"] == "SENTRY_AUTH_TOKEN_%s" % uuid
         assert req_params["value"] == sentry_auth_token
 
         # assert the env vars were created correctly
-        req_params = json.loads(responses.calls[6].request.body)
+        req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[7].request.body)
+        req_params = json.loads(responses.calls[6].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[7].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[10].request.body)
+        req_params = json.loads(responses.calls[9].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "secret"
 
-        req_params = json.loads(responses.calls[11].request.body)
+        req_params = json.loads(responses.calls[10].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["target"] == ["production"]
@@ -322,31 +322,31 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[7].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[9].request.body)
+        req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[14].request.body)
+        req_params = json.loads(responses.calls[13].request.body)
         assert req_params["key"] == "SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[18].request.body)
+        req_params = json.loads(responses.calls[17].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "secret"
 
-        req_params = json.loads(responses.calls[19].request.body)
+        req_params = json.loads(responses.calls[18].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["target"] == ["production"]


### PR DESCRIPTION
This is step 3. from the plan outlined in https://github.com/getsentry/sentry/pull/26185.

Users who installed Vercel prior to the merging of this PR will get two webhook events, and users who install Vercel after this is merged will only get the webhook event send to the `/delete/` route. 

To distinguish between the two, you can tell by looking at the integration metadata and seeing whether the integration has a `webhook_id` or not. 