### PR TITLE
fix(notifications): Check user ID in validator

### DIFF
--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -91,8 +91,11 @@ def validate_scope(
     context: Optional[List[str]] = None,
 ) -> int:
     if user and scope_type == NotificationScopeType.USER:
-        # Overwrite every user ID with the current user's ID.
-        scope_id = user.id
+        if scope_id == "me":
+            # Overwrite "me" with the current user's ID.
+            scope_id = user.id
+        elif scope_id != user.id:
+            raise ParameterValidationError(f"Incorrect user ID: {scope_id}", context)
 
     try:
         return int(scope_id)

--- a/tests/sentry/api/endpoints/test_user_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings.py
@@ -118,10 +118,9 @@ class UserNotificationSettingsTest(UserNotificationSettingsTestBase):
             == NotificationSettingOptionValues.DEFAULT
         )
 
+        data = {"deploy": {"user": {"me": {"email": "always", "slack": "always"}}}}
         with self.feature(FEATURE_NAMES):
-            self.get_success_response(
-                "me", **{"deploy": {"user": {"me": {"email": "always", "slack": "always"}}}}
-            )
+            self.get_success_response("me", **data)
 
         assert (
             NotificationSetting.objects.get_settings(
@@ -139,3 +138,9 @@ class UserNotificationSettingsTest(UserNotificationSettingsTestBase):
     def test_invalid_payload(self):
         with self.feature(FEATURE_NAMES):
             self.get_error_response("me", **{"invalid": 1}, status_code=400)
+
+    def test_wrong_user_id(self):
+        user2 = self.create_user()
+        data = {"deploy": {"user": {user2.id: {"email": "always", "slack": "always"}}}}
+        with self.feature(FEATURE_NAMES):
+            self.get_error_response("me", **data, status_code=400)


### PR DESCRIPTION
The API validates the notification settings payload when it receives a PUT request. Previously we ignored the `scope_id` when the `scope_type` is `"user"` because we assumed that users would not try to update other users' settings. This PR reads the ID and checks it against the currently logged in user's ID.