### PR TITLE
ref(ingest): Enable concurrent execution of event processing store insertion

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -217,7 +217,7 @@ def _do_process_event(message, projects):
 
 
 @trace_func(name="ingest_consumer.process_event")
-def process_event(message, projects):
+def process_event(message, projects) -> None:
     return _do_process_event(message, projects)
 
 
@@ -237,7 +237,7 @@ def process_attachment_chunk(message, projects):
 
 @trace_func(name="ingest_consumer.process_individual_attachment")
 @metrics.wraps("ingest_consumer.process_individual_attachment")
-def process_individual_attachment(message, projects):
+def process_individual_attachment(message, projects) -> None:
     event_id = message["event_id"]
     project_id = int(message["project_id"])
     cache_key = cache_key_for_event({"event_id": event_id, "project": project_id})
@@ -284,7 +284,7 @@ def process_individual_attachment(message, projects):
 
 @trace_func(name="ingest_consumer.process_userreport")
 @metrics.wraps("ingest_consumer.process_userreport")
-def process_userreport(message, projects):
+def process_userreport(message, projects) -> None:
     project_id = int(message["project_id"])
     start_time = to_datetime(message["start_time"])
     feedback = json.loads(message["payload"])

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -78,10 +78,10 @@ class IngestConsumerWorker(AbstractBatchWorker):
         attachment_chunks = []
 
         # Processing functions may be either synchronous or asynchronous.
-        # Functions that return a ``AsyncResult`` may perform a combination of
+        # Functions that return an ``AsyncResult`` may perform a combination of
         # synchronous and asynchronous work, and need to be explicitly waited on
         # to ensure they have completed and callbacks have been invoked before
-        # returning.  Functions that return anything else are assumed to have
+        # returning. Functions that return anything else are assumed to have
         # completed successfully after they have returned.
         other_messages: MutableSequence[
             Tuple[

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -384,7 +384,9 @@ def process_userreport(message, projects) -> None:
         return False
 
 
-def get_ingest_consumer(consumer_types, once=False, **options):
+def get_ingest_consumer(
+    consumer_types, once=False, executor: Optional[ThreadPoolExecutor] = None, **options
+):
     """
     Handles events coming via a kafka queue.
 
@@ -392,5 +394,5 @@ def get_ingest_consumer(consumer_types, once=False, **options):
     """
     topic_names = {ConsumerType.get_topic_name(consumer_type) for consumer_type in consumer_types}
     return create_batching_kafka_consumer(
-        topic_names=topic_names, worker=IngestConsumerWorker(), **options
+        topic_names=topic_names, worker=IngestConsumerWorker(executor), **options
     )

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -48,7 +48,7 @@ Message = Any
 
 class AsyncResult(NamedTuple):  # TODO: Use Generic[T] with 3.7+
     future: "Future[T]"
-    callback: Optional[Callable[["Future[T]"], None]] = None
+    callback: Optional[Callable[["Future[T]"], Any]] = None
 
 
 class IngestConsumerWorker(AbstractBatchWorker):

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -1,5 +1,6 @@
 import signal
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import cpu_count
 
 import click
@@ -469,7 +470,7 @@ def batching_kafka_options(group):
     "--concurrency",
     type=int,
     default=None,
-    help="(Deprecated) Ingest consumers no longer use multiple processing threads.",
+    help="Thread pool size (only utilitized for message types that support concurrent processing)",
 )
 @configuration
 def ingest_consumer(consumer_types, all_consumer_types, **options):
@@ -494,10 +495,12 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
         raise click.ClickException("Need to specify --all-consumer-types or --consumer-type")
 
     concurrency = options.pop("concurrency", None)
-    if concurrency is not None:
-        click.echo("Warning: `concurrency` argument is deprecated and will be removed.", err=True)
+    if concurrency is None:
+        executor = ThreadPoolExecutor()
+    else:
+        executor = None
 
     with metrics.global_tags(
         ingest_consumer_types=",".join(sorted(consumer_types)), _all_threads=True
     ):
-        get_ingest_consumer(consumer_types=consumer_types, **options).run()
+        get_ingest_consumer(consumer_types=consumer_types, executor=executor, **options).run()

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import random
 import time
+from concurrent.futures.thread import ThreadPoolExecutor
 
 import msgpack
 import pytest
@@ -78,7 +79,12 @@ def random_group_id():
 
 
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    "executor",
+    [pytest.param(None, id="synchronous"), pytest.param(ThreadPoolExecutor(), id="asynchronous")],
+)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
+    executor,
     task_runner,
     kafka_producer,
     kafka_admin,


### PR DESCRIPTION
This change enables portions of the ingest consumer to be run concurrently. In particular, this allows saving the event to the processing store to be performed concurrently, while other operations remain on the main thread, avoiding thread safety concerns or introducing new connections to shared resources (i.e. Postgres.)

The motivation for this change is due to the move to Bigtable, as set operations against the Bigtable storage are marginally slower than the Redis storage by roughly 25%. Since this is such a frequently hit path, those serially executed blocking operations back up, limiting overall throughput without increasing the consumer count. Testing shadow operations with a small thread pool (4 threads per consumer) enabled the Bigtable storage to maintain similar quality of service to the existing Redis backend.

Other details of note:

- Individual messages are no longer guaranteed to be processed in FIFO order. Batches as a whole are still guaranteed to be processed in FIFO order, and the committed offset still moves monotonically.
- The ThreadPoolExecutor is not backed by a bounded queue, but the queue is implicitly bounded by the batch size and/or time by virtue of being used with the batching consumer. Even though the queue has _some_ upper bound, it is still possible that this could lead to the memory required to hold all of the in-flight messages leading to an OOM condition (these objects were previously eligible for garbage collection much more frequently since only one message was processed at a time), particularly since the callback itself contains references to large objects. (This backlog should not accumulate to the extent of what we were previously seeing with consumer OOMs due to the secondary backend backing up prior to getsentry/getsentry#5545.)