### PR TITLE
feat(codeowners): Show transformed Code Owners rules syntax

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -234,7 +234,14 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectC
                 codeowners_id=project_codeowners.id,
             )
             return Response(
-                serialize(project_codeowners, request.user), status=status.HTTP_201_CREATED
+                serialize(
+                    project_codeowners,
+                    request.user,
+                    serializer=projectcodeowners_serializers.ProjectCodeOwnersSerializer(
+                        expand=["ownershipSyntax"]
+                    ),
+                ),
+                status=status.HTTP_201_CREATED,
             )
 
         self.track_response_code("create", status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -3,6 +3,7 @@ from sentry.api.serializers.models.repository_project_path_config import (
     RepositoryProjectPathConfigSerializer,
 )
 from sentry.models import ProjectCodeOwners
+from sentry.ownership.grammar import convert_schema_to_rules_text
 from sentry.utils.db import attach_foreignkey
 
 
@@ -48,5 +49,7 @@ class ProjectCodeOwnersSerializer(Serializer):
             data["codeMapping"] = serialize(
                 config, user=user, serializer=RepositoryProjectPathConfigSerializer()
             )
+        if "ownershipSyntax" in self.expand:
+            data["ownershipSyntax"] = convert_schema_to_rules_text(obj.schema)
 
         return data

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -237,6 +237,21 @@ def load_schema(schema):
     return [Rule.load(r) for r in schema["rules"]]
 
 
+def convert_schema_to_rules_text(schema):
+    rules = load_schema(schema)
+    text = ""
+
+    def owner_prefix(type):
+        if type == "team":
+            return "#"
+        return ""
+
+    for rule in rules:
+        text += f"{rule.matcher.type}:{rule.matcher.pattern} {' '.join([f'{owner_prefix(owner.type)}{owner.identifier}' for owner in rule.owners])}\n"
+
+    return text
+
+
 def parse_code_owners(data: str) -> Tuple[List[str], List[str], List[str]]:
     """Parse a CODEOWNERS text and returns the list of team names, list of usernames"""
     teams = []

--- a/static/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -38,17 +38,17 @@ class CodeOwnersPanel extends Component<Props> {
     const {codeowners} = this.props;
     return (codeowners || []).map(codeowner => {
       const {
-        raw,
         dateUpdated,
         provider,
         codeMapping: {repoName},
+        ownershipSyntax,
       } = codeowner;
       return (
         <Fragment key={codeowner.id}>
           <RulesPanel
             data-test-id="codeowners-panel"
             type="codeowners"
-            raw={raw}
+            raw={ownershipSyntax}
             dateUpdated={dateUpdated}
             provider={provider}
             repoName={repoName}

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -62,7 +62,7 @@ class ProjectOwnership extends AsyncView<Props, State> {
       endpoints.push([
         'codeowners',
         `/projects/${organization.slug}/${project.slug}/codeowners/`,
-        {query: {expand: ['codeMapping']}},
+        {query: {expand: ['codeMapping', 'ownershipSyntax']}},
       ]);
     }
     return endpoints;


### PR DESCRIPTION
## Objective:
We should show the transformed Code Owner rules rather than the raw CODEOWNERS file.

## UI:
Before:
<img width="959" alt="Screen Shot 2021-05-21 at 1 29 11 AM" src="https://user-images.githubusercontent.com/10491193/119419101-55845780-bcae-11eb-865f-6ca9801b190b.png">

After:
![Screen Shot 2021-05-24 at 4 37 02 PM](https://user-images.githubusercontent.com/10491193/119419092-51583a00-bcae-11eb-9bd1-6c0333fb65b2.png)
