### PR TITLE
feat(auth): Enforce email verification on 2fa enrollment

### DIFF
--- a/src/sentry/api/decorators.py
+++ b/src/sentry/api/decorators.py
@@ -17,11 +17,6 @@ def is_considered_sudo(request):
     )
 
 
-def has_verified_email(request):
-    user = request.user
-    return request.user.get_verified_emails().filter(email=user.email).exists()
-
-
 def sudo_required(func):
     @wraps(func)
     def wrapped(self, request, *args, **kwargs):
@@ -39,7 +34,7 @@ def sudo_required(func):
 def email_verification_required(func):
     @wraps(func)
     def wrapped(self, request, *args, **kwargs):
-        if not has_verified_email(request):
+        if not request.user.get_verified_emails().exists():
             raise EmailVerificationRequired(request.user)
         return func(self, request, *args, **kwargs)
 

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -7,7 +7,7 @@ from rest_framework.fields import SkipField
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.api.decorators import sudo_required
+from sentry.api.decorators import email_verification_required, sudo_required
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
 from sentry.api.serializers import serialize
 from sentry.app import ratelimiter
@@ -140,6 +140,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         return Response(response)
 
     @sudo_required
+    @email_verification_required
     def post(self, request, user, interface_id):
         """
         Enroll in authenticator interface

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -4,7 +4,6 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.api.decorators import sudo_required
 from sentry.api.validators import AllowedEmailField
 from sentry.models import UserEmail
 
@@ -32,7 +31,6 @@ class EmailSerializer(serializers.Serializer):
 
 
 class UserEmailsConfirmEndpoint(UserEndpoint):
-    @sudo_required
     def post(self, request, user):
         """
         Sends a confirmation email to user

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -82,6 +82,15 @@ class SudoRequired(SentryAPIException):
         super().__init__(username=user.username)
 
 
+class EmailVerificationRequired(SentryAPIException):
+    status_code = status.HTTP_401_UNAUTHORIZED
+    code = "email-verification-required"
+    message = "Email verification required."
+
+    def __init__(self, user):
+        super().__init__(username=user.username)
+
+
 class TwoFactorRequired(SentryAPIException):
     status_code = status.HTTP_401_UNAUTHORIZED
     code = "2fa-required"

--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -44,8 +44,24 @@ type OpenSudoModalOptions = {
   retryRequest?: () => Promise<any>;
 };
 
+type emailVerificationModalOptions = {
+  onClose?: () => void;
+  emailVerified?: boolean;
+  actionMessage?: string;
+};
+
 export async function openSudo({onClose, ...args}: OpenSudoModalOptions = {}) {
   const mod = await import('app/components/modals/sudoModal');
+  const {default: Modal} = mod;
+
+  openModal(deps => <Modal {...deps} {...args} />, {onClose});
+}
+
+export async function openEmailVerification({
+  onClose,
+  ...args
+}: emailVerificationModalOptions = {}) {
+  const mod = await import('app/components/modals/emailVerificationModal');
   const {default: Modal} = mod;
 
   openModal(deps => <Modal {...deps} {...args} />, {onClose});

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -268,7 +268,6 @@ export class Client {
   ) {
     const code = response?.responseJSON?.detail?.code;
     const isSudoRequired = code === SUDO_REQUIRED || code === SUPERUSER_REQUIRED;
-
     let didSuccessfullyRetry = false;
 
     if (isSudoRequired) {

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -268,6 +268,7 @@ export class Client {
   ) {
     const code = response?.responseJSON?.detail?.code;
     const isSudoRequired = code === SUDO_REQUIRED || code === SUPERUSER_REQUIRED;
+
     let didSuccessfullyRetry = false;
 
     if (isSudoRequired) {

--- a/static/app/components/modals/emailVerificationModal.tsx
+++ b/static/app/components/modals/emailVerificationModal.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {withRouter} from 'react-router';
+import {WithRouterProps} from 'react-router/lib/withRouter';
+
+import {ModalRenderProps} from 'app/actionCreators/modal';
+import {Client} from 'app/api';
+import Link from 'app/components/links/link';
+import {t, tct} from 'app/locale';
+import withApi from 'app/utils/withApi';
+import {EmailAddresses} from 'app/views/settings/account/accountEmails';
+import TextBlock from 'app/views/settings/components/text/textBlock';
+
+type Props = WithRouterProps &
+  Pick<ModalRenderProps, 'Body' | 'Header'> & {
+    api: Client;
+    actionMessage?: string;
+  };
+
+type State = {};
+
+class EmailVerificationModal extends React.Component<Props, State> {
+  renderBodyContent() {
+    const {actionMessage = 'taking this action'} = this.props;
+    return (
+      <React.Fragment>
+        <TextBlock>
+          {tct('Please verify your email before [actionMessage], or [link].', {
+            actionMessage,
+            link: (
+              <Link to="/settings/account/emails/" data-test-id="email-settings-link">
+                {t('go to your email settings')}
+              </Link>
+            ),
+          })}
+        </TextBlock>
+        <EmailAddresses />
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    const {Header, Body} = this.props;
+    return (
+      <React.Fragment>
+        <Header closeButton>{t('Action Required')}</Header>
+        <Body>{this.renderBodyContent()}</Body>
+      </React.Fragment>
+    );
+  }
+}
+
+export default withRouter(withApi(EmailVerificationModal));
+export {EmailVerificationModal};

--- a/static/app/components/modals/emailVerificationModal.tsx
+++ b/static/app/components/modals/emailVerificationModal.tsx
@@ -16,13 +16,15 @@ type Props = WithRouterProps &
     actionMessage?: string;
   };
 
-type State = {};
-
-class EmailVerificationModal extends React.Component<Props, State> {
-  renderBodyContent() {
-    const {actionMessage = 'taking this action'} = this.props;
-    return (
-      <React.Fragment>
+function EmailVerificationModal({
+  Header,
+  Body,
+  actionMessage = 'taking this action',
+}: Props) {
+  return (
+    <React.Fragment>
+      <Header closeButton>{t('Action Required')}</Header>
+      <Body>
         <TextBlock>
           {tct('Please verify your email before [actionMessage], or [link].', {
             actionMessage,
@@ -34,19 +36,9 @@ class EmailVerificationModal extends React.Component<Props, State> {
           })}
         </TextBlock>
         <EmailAddresses />
-      </React.Fragment>
-    );
-  }
-
-  render() {
-    const {Header, Body} = this.props;
-    return (
-      <React.Fragment>
-        <Header closeButton>{t('Action Required')}</Header>
-        <Body>{this.renderBodyContent()}</Body>
-      </React.Fragment>
-    );
-  }
+      </Body>
+    </React.Fragment>
+  );
 }
 
 export default withRouter(withApi(EmailVerificationModal));

--- a/static/app/constants/apiErrorCodes.tsx
+++ b/static/app/constants/apiErrorCodes.tsx
@@ -1,3 +1,4 @@
 export const SUDO_REQUIRED = 'sudo-required';
+export const EMAIL_VERIFICATION_REQUIRED = 'email-verification-required';
 export const SUPERUSER_REQUIRED = 'superuser-required';
 export const PROJECT_MOVED = 'project-moved';

--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -43,7 +43,7 @@ class AccountEmails extends AsyncView<Props, State> {
 
   renderBody() {
     return (
-      <div>
+      <React.Fragment>
         <SettingsPageHeader title={t('Email Addresses')} />
         <EmailAddresses />
         <Form
@@ -59,7 +59,7 @@ class AccountEmails extends AsyncView<Props, State> {
         <AlertLink to="/settings/account/notifications" icon={<IconStack />}>
           {t('Want to change how many emails you get? Use the notifications panel.')}
         </AlertLink>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
@@ -4,7 +4,7 @@ import {RouteComponentProps} from 'react-router';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
 import {t} from 'app/locale';
-import {Authenticator, OrganizationSummary} from 'app/types';
+import {Authenticator, OrganizationSummary, UserEmail} from 'app/types';
 import {defined} from 'app/utils';
 
 const ENDPOINT = '/users/me/authenticators/';
@@ -17,6 +17,7 @@ type Props = {
 type State = {
   authenticators?: Authenticator[] | null;
   organizations?: OrganizationSummary[];
+  emails: UserEmail[];
 } & AsyncComponent['state'];
 
 class AccountSecurityWrapper extends AsyncComponent<Props, State> {
@@ -24,6 +25,7 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
     return [
       ['authenticators', ENDPOINT],
       ['organizations', '/organizations/'],
+      ['emails', '/users/me/emails/'],
     ];
   }
 
@@ -59,13 +61,15 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {children} = this.props;
-    const {authenticators, organizations} = this.state;
-
+    const {authenticators, organizations, emails} = this.state;
     const enrolled =
       authenticators?.filter(auth => auth.isEnrolled && !auth.isBackupInterface) || [];
     const countEnrolled = enrolled.length;
     const orgsRequire2fa = organizations?.filter(org => org.require2FA) || [];
     const deleteDisabled = orgsRequire2fa.length > 0 && countEnrolled === 1;
+    const primaryEmailVerified = !!emails?.find(
+      ({isPrimary, isVerified}) => isPrimary && isVerified
+    );
 
     // This happens when you switch between children views and the next child
     // view is lazy loaded, it can potentially be `null` while the code split
@@ -81,6 +85,7 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
       deleteDisabled,
       orgsRequire2fa,
       countEnrolled,
+      primaryEmailVerified,
     });
   }
 }

--- a/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
@@ -67,9 +67,7 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
     const countEnrolled = enrolled.length;
     const orgsRequire2fa = organizations?.filter(org => org.require2FA) || [];
     const deleteDisabled = orgsRequire2fa.length > 0 && countEnrolled === 1;
-    const primaryEmailVerified = !!emails?.find(
-      ({isPrimary, isVerified}) => isPrimary && isVerified
-    );
+    const hasVerifiedEmail = !!emails?.find(({isVerified}) => isVerified);
 
     // This happens when you switch between children views and the next child
     // view is lazy loaded, it can potentially be `null` while the code split
@@ -85,7 +83,7 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
       deleteDisabled,
       orgsRequire2fa,
       countEnrolled,
-      primaryEmailVerified,
+      hasVerifiedEmail,
     });
   }
 }

--- a/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityWrapper.tsx
@@ -58,6 +58,9 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
       addErrorMessage(t('Error regenerating backup codes'));
     }
   };
+  handleRefresh = () => {
+    this.fetchData();
+  };
 
   renderBody() {
     const {children} = this.props;
@@ -84,6 +87,7 @@ class AccountSecurityWrapper extends AsyncComponent<Props, State> {
       orgsRequire2fa,
       countEnrolled,
       hasVerifiedEmail,
+      handleRefresh: this.handleRefresh,
     });
   }
 }

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -28,7 +28,7 @@ type Props = {
   orgsRequire2fa: OrganizationSummary[];
   countEnrolled: number;
   deleteDisabled: boolean;
-  primaryEmailVerified: boolean;
+  hasVerifiedEmail: boolean;
   onDisable: (auth: Authenticator) => void;
 } & AsyncView['props'] &
   ReactRouter.WithRouterProps;
@@ -73,7 +73,7 @@ class AccountSecurity extends AsyncView<Props> {
       countEnrolled,
       deleteDisabled,
       onDisable,
-      primaryEmailVerified,
+      hasVerifiedEmail,
     } = this.props;
     const isEmpty = !authenticators?.length;
 
@@ -147,16 +147,16 @@ class AccountSecurity extends AsyncView<Props> {
                           <Tooltip
                             isHoverable
                             title={tct(
-                              'you must [link:verify your primary email] to enroll a 2FA device.',
+                              'you must [link:verify an email address] to enroll a 2FA device.',
                               {
                                 link: <Link to="/settings/account/emails/" />,
                               }
                             )}
-                            disabled={primaryEmailVerified}
+                            disabled={hasVerifiedEmail}
                           >
                             <RemoveConfirm
                               onConfirm={() => onDisable(auth)}
-                              disabled={!primaryEmailVerified}
+                              disabled={!hasVerifiedEmail}
                             >
                               <Button
                                 to={`/settings/account/security/mfa/${id}/enroll/`}

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -1,8 +1,8 @@
 import * as ReactRouter from 'react-router';
-import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
+import {openEmailVerification} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
 import ListLink from 'app/components/links/listLink';
@@ -10,7 +10,7 @@ import NavTabs from 'app/components/navTabs';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
 import {IconDelete} from 'app/icons';
-import {t, tct} from 'app/locale';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Authenticator, OrganizationSummary} from 'app/types';
 import recreateRoute from 'app/utils/recreateRoute';
@@ -29,6 +29,7 @@ type Props = {
   countEnrolled: number;
   deleteDisabled: boolean;
   hasVerifiedEmail: boolean;
+  handleRefresh: () => void;
   onDisable: (auth: Authenticator) => void;
 } & AsyncView['props'] &
   ReactRouter.WithRouterProps;
@@ -67,6 +68,15 @@ class AccountSecurity extends AsyncView<Props> {
     );
   };
 
+  handleAdd2FAClicked = () => {
+    const {handleRefresh} = this.props;
+    openEmailVerification({
+      onClose: () => {
+        handleRefresh();
+      },
+    });
+  };
+
   renderBody() {
     const {
       authenticators,
@@ -76,7 +86,6 @@ class AccountSecurity extends AsyncView<Props> {
       hasVerifiedEmail,
     } = this.props;
     const isEmpty = !authenticators?.length;
-
     return (
       <div>
         <SettingsPageHeader
@@ -143,31 +152,25 @@ class AccountSecurity extends AsyncView<Props> {
                       </AuthenticatorTitle>
 
                       <Actions>
-                        {!isBackupInterface && !isEnrolled && (
-                          <Tooltip
-                            isHoverable
-                            title={tct(
-                              'you must [link:verify an email address] to enroll a 2FA device.',
-                              {
-                                link: <Link to="/settings/account/emails/" />,
-                              }
-                            )}
-                            disabled={hasVerifiedEmail}
+                        {!isBackupInterface && !isEnrolled && hasVerifiedEmail && (
+                          <Button
+                            to={`/settings/account/security/mfa/${id}/enroll/`}
+                            size="small"
+                            priority="primary"
+                            className="enroll-button"
                           >
-                            <RemoveConfirm
-                              onConfirm={() => onDisable(auth)}
-                              disabled={!hasVerifiedEmail}
-                            >
-                              <Button
-                                to={`/settings/account/security/mfa/${id}/enroll/`}
-                                size="small"
-                                priority="primary"
-                                className="enroll-button"
-                              >
-                                {t('Add')}
-                              </Button>
-                            </RemoveConfirm>
-                          </Tooltip>
+                            {t('Add')}
+                          </Button>
+                        )}
+                        {!isBackupInterface && !isEnrolled && !hasVerifiedEmail && (
+                          <Button
+                            onClick={this.handleAdd2FAClicked}
+                            size="small"
+                            priority="primary"
+                            className="enroll-button"
+                          >
+                            {t('Add')}
+                          </Button>
                         )}
 
                         {isEnrolled && authId && (

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -1,4 +1,5 @@
 import * as ReactRouter from 'react-router';
+import {Link} from 'react-router';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -9,7 +10,7 @@ import NavTabs from 'app/components/navTabs';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
 import {IconDelete} from 'app/icons';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Authenticator, OrganizationSummary} from 'app/types';
 import recreateRoute from 'app/utils/recreateRoute';
@@ -27,6 +28,7 @@ type Props = {
   orgsRequire2fa: OrganizationSummary[];
   countEnrolled: number;
   deleteDisabled: boolean;
+  primaryEmailVerified: boolean;
   onDisable: (auth: Authenticator) => void;
 } & AsyncView['props'] &
   ReactRouter.WithRouterProps;
@@ -66,7 +68,13 @@ class AccountSecurity extends AsyncView<Props> {
   };
 
   renderBody() {
-    const {authenticators, countEnrolled, deleteDisabled, onDisable} = this.props;
+    const {
+      authenticators,
+      countEnrolled,
+      deleteDisabled,
+      onDisable,
+      primaryEmailVerified,
+    } = this.props;
     const isEmpty = !authenticators?.length;
 
     return (
@@ -136,14 +144,30 @@ class AccountSecurity extends AsyncView<Props> {
 
                       <Actions>
                         {!isBackupInterface && !isEnrolled && (
-                          <Button
-                            to={`/settings/account/security/mfa/${id}/enroll/`}
-                            size="small"
-                            priority="primary"
-                            className="enroll-button"
+                          <Tooltip
+                            isHoverable
+                            title={tct(
+                              'you must [link:verify your primary email] to enroll a 2FA device.',
+                              {
+                                link: <Link to="/settings/account/emails/" />,
+                              }
+                            )}
+                            disabled={primaryEmailVerified}
                           >
-                            {t('Add')}
-                          </Button>
+                            <RemoveConfirm
+                              onConfirm={() => onDisable(auth)}
+                              disabled={!primaryEmailVerified}
+                            >
+                              <Button
+                                to={`/settings/account/security/mfa/${id}/enroll/`}
+                                size="small"
+                                priority="primary"
+                                className="enroll-button"
+                              >
+                                {t('Add')}
+                              </Button>
+                            </RemoveConfirm>
+                          </Tooltip>
                         )}
 
                         {isEnrolled && authId && (

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -74,6 +74,7 @@ class AccountSecurity extends AsyncView<Props> {
       onClose: () => {
         handleRefresh();
       },
+      actionMessage: 'enrolling a 2FA device',
     });
   };
 

--- a/tests/js/spec/components/modals/emailVerificationModal.spec.js
+++ b/tests/js/spec/components/modals/emailVerificationModal.spec.js
@@ -1,0 +1,35 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import EmailVerificationModal from 'app/components/modals/emailVerificationModal.tsx';
+
+describe('Email Verification Modal', function () {
+  let wrapper;
+  beforeEach(function () {
+    wrapper = mountWithTheme(
+      <EmailVerificationModal Body={p => p.children} Header={p => p.children} />,
+      TestStubs.routerContext()
+    );
+  });
+  it('renders', async function () {
+    expect(wrapper.find('TextBlock').text()).toEqual(
+      'Please verify your email before taking this action, or go to your email settings.'
+    );
+    expect(
+      wrapper.find('Link[data-test-id="email-settings-link"]').first().props('to').to
+    ).toEqual('/settings/account/emails/');
+    expect(wrapper.find('EmailAddresses')).toHaveLength(1);
+  });
+  it('renders with action param', async function () {
+    wrapper = mountWithTheme(
+      <EmailVerificationModal
+        Body={p => p.children}
+        Header={p => p.children}
+        actionMessage="accepting the tenet"
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('TextBlock').text()).toEqual(
+      'Please verify your email before accepting the tenet, or go to your email settings.'
+    );
+  });
+});

--- a/tests/js/spec/components/modals/emailVerificationModal.spec.js
+++ b/tests/js/spec/components/modals/emailVerificationModal.spec.js
@@ -10,6 +10,7 @@ describe('Email Verification Modal', function () {
       TestStubs.routerContext()
     );
   });
+
   it('renders', async function () {
     expect(wrapper.find('TextBlock').text()).toEqual(
       'Please verify your email before taking this action, or go to your email settings.'
@@ -19,6 +20,7 @@ describe('Email Verification Modal', function () {
     ).toEqual('/settings/account/emails/');
     expect(wrapper.find('EmailAddresses')).toHaveLength(1);
   });
+
   it('renders with action param', async function () {
     wrapper = mountWithTheme(
       <EmailVerificationModal

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -400,7 +400,6 @@ describe('AccountSecurity', function () {
       url: ENDPOINT,
       body: [TestStubs.Authenticators().Recovery({isEnrolled: false})],
     });
-
     const mock = Client.addMockResponse({
       url: AUTH_ENDPOINT,
       body: {all: true},

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -249,7 +249,10 @@ describe('AccountSecurity', function () {
     expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
 
     expect(wrapper.find('Tooltip')).toHaveLength(1);
-    // expect(wrapper.find('Tooltip').prop('title').children()).toContain('to enable 2FA');
+    const tooltip = mountWithTheme(wrapper.find('Tooltip').prop('title'));
+    expect(tooltip.text()).toContain(
+      'you must verify an email address to enroll a 2FA device.'
+    );
     expect(wrapper.find('Tooltip').prop('disabled')).toBe(false);
   });
 

--- a/tests/js/spec/views/accountSecurityDetails.spec.jsx
+++ b/tests/js/spec/views/accountSecurityDetails.spec.jsx
@@ -7,6 +7,7 @@ import AccountSecurityDetails from 'app/views/settings/account/accountSecurity/a
 import AccountSecurityWrapper from 'app/views/settings/account/accountSecurity/accountSecurityWrapper';
 
 const ENDPOINT = '/users/me/authenticators/';
+const ACCOUNT_EMAILS_ENDPOINT = '/users/me/emails/';
 const ORG_ENDPOINT = '/organizations/';
 
 describe('AccountSecurityDetails', function () {
@@ -39,6 +40,10 @@ describe('AccountSecurityDetails', function () {
       Client.addMockResponse({
         url: `${ENDPOINT}15/`,
         body: TestStubs.Authenticators().Totp(),
+      });
+      Client.addMockResponse({
+        url: ACCOUNT_EMAILS_ENDPOINT,
+        body: TestStubs.AccountEmails(),
       });
       wrapper = mountWithTheme(
         <AccountSecurityWrapper router={router} params={params}>
@@ -144,6 +149,10 @@ describe('AccountSecurityDetails', function () {
       Client.addMockResponse({
         url: `${ENDPOINT}16/`,
         body: TestStubs.Authenticators().Recovery(),
+      });
+      Client.addMockResponse({
+        url: ACCOUNT_EMAILS_ENDPOINT,
+        body: TestStubs.AccountEmails(),
       });
 
       wrapper = mountWithTheme(

--- a/tests/js/spec/views/twoFactorRequired.spec.jsx
+++ b/tests/js/spec/views/twoFactorRequired.spec.jsx
@@ -8,6 +8,7 @@ import AccountSecurityWrapper from 'app/views/settings/account/accountSecurity/a
 const ENDPOINT = '/users/me/authenticators/';
 const ORG_ENDPOINT = '/organizations/';
 const INVITE_COOKIE = 'pending-invite';
+const ACCOUNT_EMAILS_ENDPOINT = '/users/me/emails/';
 
 describe('TwoFactorRequired', function () {
   beforeEach(function () {
@@ -20,6 +21,10 @@ describe('TwoFactorRequired', function () {
     MockApiClient.addMockResponse({
       url: ORG_ENDPOINT,
       body: TestStubs.Organizations(),
+    });
+    MockApiClient.addMockResponse({
+      url: ACCOUNT_EMAILS_ENDPOINT,
+      body: TestStubs.AccountEmails(),
     });
   });
 


### PR DESCRIPTION
- adds a new decorator that is used to check the users primary email is verified before allowing entering a route
- applies this decorator to 2fa enrollment POST
- separates out email verification component, uses new component to create a generic "verify your email" modal
- removes sudo_required on resend email verification route
<img width="992" alt="Screen Shot 2021-06-01 at 10 28 12 AM" src="https://user-images.githubusercontent.com/1976777/120368689-36e21a00-c2c7-11eb-863c-25383f82b894.png">


