### PR TITLE
fix(deps): Bump relay to 0.8.6

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ requests==2.25.1
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay==0.8.5
+sentry-relay==0.8.6
 sentry-sdk>=1.0.0,<1.2.0
 snuba-sdk>=0.0.14,<1.0.0
 simplejson==3.17.2


### PR DESCRIPTION
Notable changes:

* Fix a bug where PII scrubbing selectors did not roundtrip correctly. Fix SENTRY-PS0
* Fix a bug where Snuba would crash because of reprocessing. Fix SNUBA-2C8

https://github.com/getsentry/relay/pull/1009
https://github.com/getsentry/relay/pull/982
