### PR TITLE
ref(dynamic-sampling): Add missing custom inbound filters

### DIFF
--- a/static/app/types/dynamicSampling.tsx
+++ b/static/app/types/dynamicSampling.tsx
@@ -56,7 +56,11 @@ export enum DynamicSamplingInnerName {
   EVENT_LOCALHOST = 'event.is_local_ip',
   EVENT_WEB_CRAWLERS = 'event.web_crawlers',
   EVENT_BROWSER_EXTENSIONS = 'event.has_bad_browser_extensions',
+  // Custom operators
+  EVENT_IP_ADDRESSES = 'event.client_ip',
   EVENT_LEGACY_BROWSER = 'event.legacy_browser',
+  EVENT_ERROR_MESSAGES = 'event.error_messages',
+  EVENT_CSP = 'event.csp',
 }
 
 export enum LegacyBrowser {
@@ -102,6 +106,15 @@ type DynamicSamplingConditionLogicalInnerEqBoolean = {
 
 type DynamicSamplingConditionLogicalInnerCustom = {
   op: DynamicSamplingInnerOperator.CUSTOM;
+  name:
+    | DynamicSamplingInnerName.EVENT_CSP
+    | DynamicSamplingInnerName.EVENT_ERROR_MESSAGES
+    | DynamicSamplingInnerName.EVENT_IP_ADDRESSES;
+  value: Array<string>;
+};
+
+type DynamicSamplingConditionLogicalInnerCustomLegacyBrowser = {
+  op: DynamicSamplingInnerOperator.CUSTOM;
   name: DynamicSamplingInnerName.EVENT_LEGACY_BROWSER;
   value: Array<LegacyBrowser>;
 };
@@ -110,7 +123,8 @@ export type DynamicSamplingConditionLogicalInner =
   | DynamicSamplingConditionLogicalInnerGlob
   | DynamicSamplingConditionLogicalInnerEq
   | DynamicSamplingConditionLogicalInnerEqBoolean
-  | DynamicSamplingConditionLogicalInnerCustom;
+  | DynamicSamplingConditionLogicalInnerCustom
+  | DynamicSamplingConditionLogicalInnerCustomLegacyBrowser;
 
 export type DynamicSamplingCondition = {
   op: DynamicSamplingConditionOperator.AND;

--- a/static/app/views/settings/project/filtersAndSampling/filtersAndSampling.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/filtersAndSampling.tsx
@@ -253,7 +253,7 @@ class FiltersAndSampling extends AsyncView<Props, State> {
         />
         <TextBlock>
           {t(
-            'The transaction order is limited. Traces must occur first and individual transactions must occur last. Any individual transaction rules before a trace rule will be disregarded. '
+            'Trace rules (Individual transactions) should precede transaction rules (transaction traces).'
           )}
         </TextBlock>
         <RulesPanel

--- a/static/app/views/settings/project/filtersAndSampling/modals/conditionFields.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modals/conditionFields.tsx
@@ -82,7 +82,7 @@ function ConditionFields({
                 // help={t('This is a description')} // TODO(PRISCILA): Add correct description
                 placeholder={getMatchFieldPlaceholder(category)}
                 name={`match-${index}`}
-                value={match}
+                value={isMatchesDisabled ? '' : match}
                 onChange={value => onChange(index, 'match', value)}
                 disabled={isMatchesDisabled}
                 inline={false}

--- a/static/app/views/settings/project/filtersAndSampling/modals/errorRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modals/errorRuleModal.tsx
@@ -49,6 +49,9 @@ class ErrorRuleModal extends Form<Props, State> {
       [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
       [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browsers')],
       [DynamicSamplingInnerName.EVENT_WEB_CRAWLERS, t('Web Crawlers')],
+      [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Addresses')],
+      [DynamicSamplingInnerName.EVENT_CSP, t('Content Security Policy')],
+      [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Messages')],
     ];
   }
 

--- a/static/app/views/settings/project/filtersAndSampling/modals/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modals/transactionRuleModal.tsx
@@ -101,6 +101,9 @@ class TransactionRuleModal extends Form<Props, State> {
       [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
       [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browsers')],
       [DynamicSamplingInnerName.EVENT_WEB_CRAWLERS, t('Web Crawlers')],
+      [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Addresses')],
+      [DynamicSamplingInnerName.EVENT_CSP, t('Content Security Policy')],
+      [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Messages')],
     ];
   }
 

--- a/static/app/views/settings/project/filtersAndSampling/modals/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modals/utils.tsx
@@ -98,6 +98,12 @@ export function getMatchFieldPlaceholder(category: DynamicSamplingInnerName) {
     case DynamicSamplingInnerName.TRACE_RELEASE:
     case DynamicSamplingInnerName.EVENT_RELEASE:
       return t('ex. 1* or [I3].[0-9].* (Multiline)');
+    case DynamicSamplingInnerName.EVENT_IP_ADDRESSES:
+      return t('ex. 127.0.0.1 or 10.0.0.0/8 (Multiline)');
+    case DynamicSamplingInnerName.EVENT_CSP:
+      return t('ex. file://* or example.com (Multiline)');
+    case DynamicSamplingInnerName.EVENT_ERROR_MESSAGES:
+      return t('ex. TypeError* (Multiline)');
     default:
       return '';
   }


### PR DESCRIPTION
Adds the following missing custom options:

![image](https://user-images.githubusercontent.com/29228205/119500546-36e29700-bd68-11eb-8f4d-34e12ee64302.png)

- Ip Addresses - `event.client_ip` 
- Error Messages - `event.error_messages` 
- Content Security Policy - `event.csp` 

closes: https://app.asana.com/0/1182975495223897/1200315225518971