### PR TITLE
ref(grouping): Refactor matchers such that extracted frame comes from indiv. matchers

### DIFF
--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -158,10 +158,6 @@ class VarAction(Action):
         except KeyError:
             raise InvalidEnhancerConfig(f"Unknown variable '{var}'")
 
-        self._encoded_value = (
-            self.value.encode("utf-8") if isinstance(self.value, str) else self.value
-        )
-
     def __str__(self):
         return f"{self.var}={self.value}"
 
@@ -176,4 +172,3 @@ class VarAction(Action):
         if self.var == "category":
             frame = frames[idx]
             set_path(frame, "data", "category", value=self.value)
-            match_frames[idx]["category"] = self._encoded_value

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -400,3 +400,42 @@ def test_range_matching_direct():
         ],
         "python",
     )
+
+
+def test_range_matching_negative():
+    enhancement = Enhancements.from_config_string(
+        """
+        [ !function:foo ] | function:foo | [ !function:foo ] category=foo
+    """
+    )
+
+    (rule,) = enhancement.rules
+
+    assert not bool(
+        _get_matching_frame_actions(
+            rule,
+            [
+                {"function": "foo"},
+                {"function": "bar"},
+                {"function": "foo"},
+            ],
+            "python",
+        )
+    )
+
+    assert (
+        sorted(
+            dict(
+                _get_matching_frame_actions(
+                    rule,
+                    [
+                        {"function": "bar"},
+                        {"function": "foo"},
+                        {"function": "baz"},
+                    ],
+                    "python",
+                )
+            )
+        )
+        == [1]
+    )


### PR DESCRIPTION
Significantly refactor interface such that globbing happens in one place (exactly one impl of `matches_frame`) and can be ported to Rust as one unit. Before we do that we need to invoke matches_frame in batches though