### PR TITLE
fix: Prevent 'AbortError: Fetch is aborted' error from polluting our sessions data

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -84,18 +84,21 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
        * In Chrome and other browsers, it is handled gracefully, where in Safari on iOS, it produces additional error, that is jumping
        * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
        * Can be safely removed once the bug is fixed upstream.
-       * 
+       *
        * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
        */
       try {
-        if (window.navigator.userAgent.includes('iPhone') && hint.originalException.message === 'AbortError: Fetch is aborted') {
+        if (
+          window.navigator.userAgent.includes('iPhone') &&
+          hint.originalException.message === 'AbortError: Fetch is aborted'
+        ) {
           return null;
         }
       } catch {
         // Not every hint has `originalException` available.
       }
       return event;
-    }
+    },
   });
 
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -78,6 +78,24 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       : sentryConfig?.whitelistUrls,
     integrations: getSentryIntegrations(hasReplays, routes),
     tracesSampleRate,
+    beforeSend(event, hint) {
+      /**
+       * There is a bug in iOS, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
+       * In Chrome and other browsers, it is handled gracefully, where in Safari on iOS, it produces additional error, that is jumping
+       * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
+       * Can be safely removed once the bug is fixed upstream.
+       * 
+       * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
+       */
+      try {
+        if (window.navigator.userAgent.includes('iPhone') && hint.originalException.message === 'AbortError: Fetch is aborted') {
+          return null;
+        }
+      } catch {
+        // Not every hint has `originalException` available.
+      }
+      return event;
+    }
   });
 
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -90,6 +90,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       try {
         if (
           window.navigator.userAgent.includes('iPhone') &&
+          hint?.originalException instanceof Error &&
           hint.originalException.message === 'AbortError: Fetch is aborted'
         ) {
           return null;


### PR DESCRIPTION
There is a bug in iOS, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
In Chrome and other browsers, it is handled gracefully, where in Safari on iOS, it produces additional error, that is jumping
outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
Can be safely removed once the bug is fixed upstream.

Ref: https://bugs.webkit.org/show_bug.cgi?id=215771