### PR TITLE
chore(platformicons): updated to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "moment": "2.29.1",
     "moment-timezone": "0.5.33",
     "papaparse": "^5.2.0",
-    "platformicons": "^4.1.5",
+    "platformicons": "^4.2.0",
     "po-catalog-loader": "2.0.0",
     "prism-sentry": "^1.0.2",
     "process": "^0.11.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11526,10 +11526,10 @@ pkg-up@3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-platformicons@^4.1.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.1.5.tgz#dd9b4f3f3e1dd8ea2abb85590dc6def27a5b7933"
-  integrity sha512-f3mfKCTtEqqLzauRwE0MWwqK+s9dRjYI0mUQeYrJC88bMF3CLuvYppPP2MRYxNt0kizqaCl21/1AXAHiypOJGA==
+platformicons@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-4.2.0.tgz#021d3fe576ff688e03352e1dbcc6edba4be05ef5"
+  integrity sha512-Sw87CXTWtILfzHEebziuvl4V7Oe604o+Xw2ueOR4XbHnRbyso0c1SxNy5VxasWEXtTQlc2r1NpAX59SvFwOlkA==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
![Screen Shot 2021-05-25 at 8 36 41 AM](https://user-images.githubusercontent.com/4830259/119526561-595abd00-bd34-11eb-9cce-776e105c33fa.png)
