### PR TITLE
ref(sdk): Stop transports from leaking items and destroying traces

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -392,7 +392,7 @@ def configure_sdk():
                 if method_name == "capture_envelope":
                     envelope = args[0]
                     relay_envelope = copy.copy(envelope)
-                    relay_envelope.items = envelope.items[:]
+                    relay_envelope.items = envelope.items.copy()
                     args[0] = relay_envelope
 
                 if is_current_event_safe():

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -374,6 +374,7 @@ def configure_sdk():
             self._capture_anything("capture_event", event)
 
         def _capture_anything(self, method_name, *args, **kwargs):
+
             # Upstream should get the event first because it is most isolated from
             # the this sentry installation.
             if upstream_transport:
@@ -386,6 +387,13 @@ def configure_sdk():
                 getattr(upstream_transport, method_name)(*args, **kwargs)
 
             if relay_transport and options.get("store.use-relay-dsn-sample-rate") == 1:
+                # If this is a envelope ensure envelope and it's items are distinct references
+                if method_name == "capture_envelope":
+                    envelope = args[0]
+                    relay_envelope = envelope.copy()
+                    relay_envelope.items = envelope.items[:]
+                    args[0] = relay_envelope
+
                 if is_current_event_safe():
                     metrics.incr("internal.captured.events.relay")
                     getattr(relay_transport, method_name)(*args, **kwargs)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -390,10 +390,11 @@ def configure_sdk():
             if relay_transport and options.get("store.use-relay-dsn-sample-rate") == 1:
                 # If this is a envelope ensure envelope and it's items are distinct references
                 if method_name == "capture_envelope":
-                    envelope = args[0]
+                    args_list = list(args)
+                    envelope = args_list[0]
                     relay_envelope = copy.copy(envelope)
                     relay_envelope.items = envelope.items.copy()
-                    args[0] = relay_envelope
+                    args = tuple([relay_envelope, args_list[1:]])
 
                 if is_current_event_safe():
                     metrics.incr("internal.captured.events.relay")

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import random
 from datetime import datetime
@@ -390,7 +391,7 @@ def configure_sdk():
                 # If this is a envelope ensure envelope and it's items are distinct references
                 if method_name == "capture_envelope":
                     envelope = args[0]
-                    relay_envelope = envelope.copy()
+                    relay_envelope = copy.copy(envelope)
                     relay_envelope.items = envelope.items[:]
                     args[0] = relay_envelope
 


### PR DESCRIPTION
### Summary
When sending envelopes, this will ensure that the items are their own references, so that we can be sure the has_items metric is accurate.