### PR TITLE
fix(ui): Restrict boolean in contextPickerModal

### DIFF
--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -392,7 +392,7 @@ class ContextPickerModal extends Component<Props> {
 
     const shouldShowProjectSelector = organization && needProject && !loading;
 
-    const shouldShowConfigSelector = integrationConfigs.length && isSuperuser;
+    const shouldShowConfigSelector = integrationConfigs.length > 0 && isSuperuser;
 
     const orgChoices = organizations
       .filter(({status}) => status.id !== 'pending_deletion')


### PR DESCRIPTION
Making sure shouldShowConfigSelector is a boolean to prevent a `0` from being rendered in the DOM

Before:
![image](https://user-images.githubusercontent.com/9372512/119564019-449f1900-bd76-11eb-9e5a-18c9c4f2ee4f.png)

After:
![image](https://user-images.githubusercontent.com/9372512/119563998-3e10a180-bd76-11eb-926a-6772ee797bb6.png)
