### PR TITLE
fix(sdk): Fixing syntax in utils/sdk.py

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -394,7 +394,7 @@ def configure_sdk():
                     envelope = args_list[0]
                     relay_envelope = copy.copy(envelope)
                     relay_envelope.items = envelope.items.copy()
-                    args = tuple([relay_envelope, args_list[1:]])
+                    args = [relay_envelope, *args_list[1:]]
 
                 if is_current_event_safe():
                     metrics.incr("internal.captured.events.relay")


### PR DESCRIPTION
- the way we were constructing args was incorrect, creating something like `tuple([arg1, []])`