### PR TITLE
fix(transactions): Temporarily remove `query_subscription_consumer_process_message` transaction

### DIFF
--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -170,11 +170,7 @@ class QuerySubscriptionConsumer:
 
             i = i + 1
 
-            with sentry_sdk.start_transaction(
-                op="handle_message",
-                name="query_subscription_consumer_process_message",
-                sampled=True,
-            ), metrics.timer("snuba_query_subscriber.handle_message"):
+            with metrics.timer("snuba_query_subscriber.handle_message"):
                 self.handle_message(message)
 
             # Track latest completed message here, for use in `shutdown` handler.


### PR DESCRIPTION
We put a fix in place that is now causing this to blast at 125/s. Temporarily removing, and will add
back in with sampling. `sampled=True` does not in fact sample this transaction.