### PR TITLE
ref(notification platform): Replace ExternalActor with Identity

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -3,13 +3,13 @@ from typing import AbstractSet, Any, Mapping, Set, Tuple, Union
 
 from sentry.integrations.slack.client import SlackClient  # NOQA
 from sentry.integrations.slack.message_builder.notifications import build_notification_attachment
-from sentry.models import ExternalActor, Organization, Team, User
+from sentry.models import ExternalActor, Identity, Integration, Organization, Team, User
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.notifications.rules import AlertRuleNotification
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.types.integrations import ExternalProviders
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json, metrics
 
 logger = logging.getLogger("sentry.notifications")
@@ -31,28 +31,46 @@ def get_context(
 
 def get_integrations_by_recipient_id(
     organization: Organization, recipients: AbstractSet[Union[User, Team]]
-) -> Mapping[Union[User, Team], ExternalActor]:
-    actor_mapping = {recipient.actor_id: recipient for recipient in recipients}
+) -> Mapping[Union[User, Team], Union[ExternalActor, Identity]]:
 
-    external_actors = ExternalActor.objects.filter(
-        provider=ExternalProviders.SLACK.value,
-        actor_id__in=[recipient.actor_id for recipient in recipients],
-        organization=organization,
-    ).select_related("integration")
-
-    return {
-        actor_mapping.get(external_actor.actor_id): external_actor
-        for external_actor in external_actors
-    }
+    output = {}
+    for recipient in recipients:
+        if isinstance(recipient, User):
+            try:
+                identity = Identity.objects.get(
+                    idp__type=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],
+                    user=recipient.id,
+                )
+            except Identity.DoesNotExist:
+                # the user may not have linked their identity so just move on
+                # since there are likely other users or teams in the list of recipients
+                continue
+            output[recipient] = identity
+        else:
+            external_actor = ExternalActor.objects.filter(
+                provider=ExternalProviders.SLACK.value,
+                actor_id=recipient.actor_id,
+                organization=organization,
+            ).select_related("integration")[0]
+            output[recipient] = external_actor
+    return output
 
 
 def get_channel_and_token(
-    external_actors_by_recipient: Mapping[Union[User, Team], ExternalActor],
+    external_identity_by_recipient: Mapping[Union[User, Team], Union[ExternalActor, Identity]],
     recipient: Union[User, Team],
+    notification: BaseNotification,
 ) -> Tuple[str, str]:
-    external_actor = external_actors_by_recipient.get(recipient)
+    external_actor = external_identity_by_recipient.get(recipient)
     channel = external_actor.external_id
-    token = external_actor.integration.metadata["access_token"]
+    if isinstance(recipient, User):
+        integration = Integration.objects.get(
+            provider=external_actor.idp.type,
+            organizations=notification.organization,
+        )
+        token = integration.metadata["access_token"]
+    else:
+        token = external_actor.integration.metadata["access_token"]
     return channel, token
 
 
@@ -73,14 +91,17 @@ def send_notification_as_slack(
     extra_context_by_user_id: Mapping[str, Any],
 ) -> None:
     """ Send an "activity" or "alert rule" notification to a Slack user or team. """
-    external_actors_by_recipient = get_integrations_by_recipient_id(
+
+    external_identity_by_recipient = get_integrations_by_recipient_id(
         notification.organization, recipients
     )
     client = SlackClient()
     for recipient in recipients:
         extra_context = (extra_context_by_user_id or {}).get(recipient.id, {})
         try:
-            channel, token = get_channel_and_token(external_actors_by_recipient, recipient)
+            channel, token = get_channel_and_token(
+                external_identity_by_recipient, recipient, notification
+            )
         except AttributeError as e:
             logger.info(
                 "notification.fail.invalid_slack",

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -549,7 +549,6 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         assert attachments[0]["title"] == "Hello world"
         assert attachments[0]["text"] == ""
         assert attachments[0]["footer"] == event.group.qualified_short_id
-        # assert False
 
     @pytest.mark.skip(reason="will be needed soon but not yet")
     @responses.activate


### PR DESCRIPTION
We've decided to use the `Identity` table specifically for user notifications, and will continue using the `ExternalActor` table for team notifications. This PR updates the usages of `ExternalActor` for users to look them up by `Identity` record instead.