### PR TITLE
fix: Filter "AbortError: Fetch is aborted" for all browsers

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -79,12 +79,12 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     integrations: getSentryIntegrations(hasReplays, routes),
     tracesSampleRate,
     /**
-    * There is a bug in Safari, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
-    * In Chrome and other browsers, it is handled gracefully, where in Safari, it produces additional error, that is jumping
-    * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
-    * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
-    */
-    ignoreErrors: ['AbortError: Fetch is aborted']
+     * There is a bug in Safari, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
+     * In Chrome and other browsers, it is handled gracefully, where in Safari, it produces additional error, that is jumping
+     * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
+     * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
+     */
+    ignoreErrors: ['AbortError: Fetch is aborted'],
   });
 
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -80,16 +80,13 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     tracesSampleRate,
     beforeSend(event, hint) {
       /**
-       * There is a bug in iOS, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
-       * In Chrome and other browsers, it is handled gracefully, where in Safari on iOS, it produces additional error, that is jumping
+       * There is a bug in Safari, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
+       * In Chrome and other browsers, it is handled gracefully, where in Safari, it produces additional error, that is jumping
        * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
-       * Can be safely removed once the bug is fixed upstream.
-       *
        * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
        */
       try {
         if (
-          window.navigator.userAgent.includes('iPhone') &&
           hint?.originalException instanceof Error &&
           hint.originalException.message === 'AbortError: Fetch is aborted'
         ) {

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -78,25 +78,13 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       : sentryConfig?.whitelistUrls,
     integrations: getSentryIntegrations(hasReplays, routes),
     tracesSampleRate,
-    beforeSend(event, hint) {
-      /**
-       * There is a bug in Safari, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
-       * In Chrome and other browsers, it is handled gracefully, where in Safari, it produces additional error, that is jumping
-       * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
-       * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
-       */
-      try {
-        if (
-          hint?.originalException instanceof Error &&
-          hint.originalException.message === 'AbortError: Fetch is aborted'
-        ) {
-          return null;
-        }
-      } catch {
-        // Not every hint has `originalException` available.
-      }
-      return event;
-    },
+    /**
+    * There is a bug in Safari, that causes `AbortError` when fetch is aborted, and you are in the middle of reading the response.
+    * In Chrome and other browsers, it is handled gracefully, where in Safari, it produces additional error, that is jumping
+    * outside of the original Promise chain and bubbles up to the `unhandledRejection` handler, that we then captures as error.
+    * Ref: https://bugs.webkit.org/show_bug.cgi?id=215771
+    */
+    ignoreErrors: ['AbortError: Fetch is aborted']
   });
 
   // Track timeOrigin Selection by the SDK to see if it improves transaction durations


### PR DESCRIPTION
Original fix: https://github.com/getsentry/sentry/pull/26216

Eh, it's apparently not only on iOS, but rather all webkit browsers. We could use https://www.npmjs.com/package/ua-parser-js (which sounds like an overkill), or ignore it for all browsers.