### PR TITLE
ref(flags): Remove unused symbolicator flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1027,8 +1027,6 @@ SENTRY_FEATURES = {
     "projects:servicehooks": False,
     # Use Kafka (instead of Celery) for ingestion pipeline.
     "projects:kafka-ingest": False,
-    # Enable stackwalking comparison
-    "symbolicator:compare-stackwalking-methods": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -156,9 +156,6 @@ default_manager.add("projects:similarity-view-v2", ProjectFeature)  # NOQA
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA
 
-# Globally scoped features
-default_manager.add("symbolicator:compare-stackwalking-methods", Feature, True)  # NOQA
-
 # This is a gross hardcoded list, but there's no
 # other sensible way to manage this right now without augmenting
 # features themselves in the manager with detections like this.


### PR DESCRIPTION
This feature flag has been superseeded by the
symbolicator.compare_stackwalking_methods_rate option instead and is
unused.