### PR TITLE
fix(ui): Fix background overflow on tags

### DIFF
--- a/static/app/views/organizationGroupDetails/groupTags.tsx
+++ b/static/app/views/organizationGroupDetails/groupTags.tsx
@@ -194,6 +194,7 @@ const TagBarGlobalSelectionLink = styled(GlobalSelectionLink)`
   padding: 0 ${space(1)};
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
+  overflow: hidden;
 
   &:hover {
     color: ${p => p.theme.textColor};


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/9060071/119650399-1710a900-be24-11eb-8195-0dce78f39615.png)


### After
![image](https://user-images.githubusercontent.com/9060071/119650378-0e1fd780-be24-11eb-9d48-b122f6c4b71f.png)

This is just a UI fix, we need to escalate the investigation why `totalValues` is lower than `count` of individual row.
![image](https://user-images.githubusercontent.com/9060071/119655787-3f9ba180-be2a-11eb-88a5-8e01486f8ffa.png)
