### PR TITLE
feat(performance): Add teams to filter params

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -258,7 +258,7 @@ class OrganizationEndpoint(Endpoint):
         return get_environments(request, organization)
 
     def get_teams(self, request, organization):
-        return list(get_teams(request, organization))
+        return get_teams(request, organization)
 
     def get_filter_params(
         self, request, organization, date_filter_optional=False, project_ids=None

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
+from sentry.api.helpers.teams import get_teams
 from sentry.api.permissions import SentryPermission
 from sentry.api.utils import (
     InvalidParams,
@@ -256,6 +257,9 @@ class OrganizationEndpoint(Endpoint):
     def get_environments(self, request, organization):
         return get_environments(request, organization)
 
+    def get_teams(self, request, organization):
+        return list(get_teams(request, organization))
+
     def get_filter_params(
         self, request, organization, date_filter_optional=False, project_ids=None
     ):
@@ -312,16 +316,21 @@ class OrganizationEndpoint(Endpoint):
             "<10" if len_projects < 10 else "<100" if len_projects < 100 else ">100",
         )
 
-        environments = self.get_environments(request, organization)
         params = {
             "start": start,
             "end": end,
             "project_id": [p.id for p in projects],
             "organization_id": organization.id,
         }
+
+        environments = self.get_environments(request, organization)
         if environments:
             params["environment"] = [env.name for env in environments]
             params["environment_objects"] = environments
+
+        teams = self.get_teams(request, organization)
+        if teams:
+            params["team_id"] = [team.id for team in teams]
 
         return params
 

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import MemberDisabledOverLimit, ResourceDoesNotExist, TwoFactorRequired
-from sentry.api.utils import MAX_STATS_PERIOD
+from sentry.api.utils import MAX_STATS_PERIOD, InvalidParams
 from sentry.auth.access import NoAccess, from_request
 from sentry.auth.authenticators import TotpInterface
 from sentry.models import ApiKey, Organization, OrganizationMember
@@ -326,9 +326,60 @@ class GetEnvironmentsTest(BaseOrganizationEndpointTest):
             self.run_test([self.env_1, self.env_2], ["fake", self.env_2.name])
 
 
+class GetTeamsTest(BaseOrganizationEndpointTest):
+    def setUp(self):
+        self.team_1 = self.create_team(organization=self.org)
+        self.team_2 = self.create_team(organization=self.org)
+        self.team_3 = self.create_team(organization=self.org)
+
+        self.create_team_membership(user=self.user, team=self.team_1)
+        self.create_team_membership(user=self.user, team=self.team_2)
+
+    def run_test(self, expected_teams, team_ids=None, active_superuser=False):
+        request_args = {}
+        if team_ids:
+            request_args["team"] = team_ids
+        request = self.build_request(active_superuser=active_superuser, **request_args)
+        result = self.endpoint.get_teams(request, self.org)
+        assert {t.name for t in expected_teams} == {t.name for t in result}
+
+    def test_no_params(self):
+        self.run_test([])
+
+    def test_my_teams(self):
+        self.run_test([self.team_1, self.team_2], "myteams")
+
+    def test_team_id(self):
+        self.run_test([self.team_1], [self.team_1.id])
+
+    def test_team_ids(self):
+        self.run_test([self.team_1, self.team_2], [self.team_1.id, self.team_2.id])
+
+    def test_my_teams_plus_an_id(self):
+        # need `allow_joinleave to access another team
+        self.org.flags.allow_joinleave = True
+        self.run_test([self.team_1, self.team_2, self.team_3], ["myteams", self.team_3.id])
+
+    def test_all_teams_as_superuser(self):
+        self.run_test(
+            [self.team_1, self.team_2, self.team_3],
+            [self.team_1.id, self.team_2.id, self.team_3.id],
+            active_superuser=True,
+        )
+
+    def test_invalid_negative_team(self):
+        with self.assertRaises(InvalidParams):
+            self.run_test([], [-1])
+
+    def test_invalid_string(self):
+        with self.assertRaises(InvalidParams):
+            self.run_test([], ["notateam"])
+
+
 class GetFilterParamsTest(BaseOrganizationEndpointTest):
     def setUp(self):
         self.team_1 = self.create_team(organization=self.org)
+        self.team_2 = self.create_team(organization=self.org)
         self.project_1 = self.create_project(organization=self.org, teams=[self.team_1])
         self.project_2 = self.create_project(organization=self.org, teams=[self.team_1])
         self.env_1 = self.create_environment(project=self.project_1)
@@ -338,9 +389,11 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
         self,
         expected_projects,
         expected_envs=None,
+        expected_teams=None,
         expected_start=None,
         expected_end=None,
         env_names=None,
+        team_ids=None,
         user=None,
         date_filter_optional=False,
         project_ids=None,
@@ -352,6 +405,8 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
         request_args = {}
         if env_names:
             request_args["environment"] = env_names
+        if team_ids:
+            request_args["team"] = team_ids
         if project_ids:
             request_args["project"] = project_ids
         if start and end:
@@ -373,20 +428,24 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
             assert {e.name for e in expected_envs} == set(result["environment"])
         else:
             assert "environment" not in result
+        if expected_teams:
+            assert {t.id for t in expected_teams} == set(result["team_id"])
+        else:
+            assert "team_id" not in result
 
     @freeze_time("2018-12-11 03:21:34")
     def test_no_params(self):
         with self.assertRaises(NoProjects):
             self.run_test([])
         self.run_test(
-            [self.project_1, self.project_2],
+            expected_projects=[self.project_1, self.project_2],
             expected_start=timezone.now() - MAX_STATS_PERIOD,
             expected_end=timezone.now(),
             user=self.user,
             active_superuser=True,
         )
         self.run_test(
-            [self.project_1, self.project_2],
+            expected_projects=[self.project_1, self.project_2],
             expected_start=None,
             expected_end=None,
             user=self.user,
@@ -403,6 +462,8 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
             project_ids=[self.project_1.id, self.project_2.id],
             expected_envs=[self.env_1, self.env_2],
             env_names=[self.env_1.name, self.env_2.name],
+            expected_teams=[self.team_1],
+            team_ids=["myteams"],
             expected_start=start,
             expected_end=end,
             start=start.replace(tzinfo=None).isoformat(),
@@ -415,6 +476,8 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
                 project_ids=[self.project_1.id, self.project_2.id],
                 expected_envs=[self.env_1, self.env_2],
                 env_names=[self.env_1.name, self.env_2.name],
+                expected_teams=[self.team_1],
+                team_ids=["myteams"],
                 expected_start=timezone.now() - timedelta(days=2),
                 expected_end=timezone.now(),
                 stats_period="2d",


### PR DESCRIPTION
This adds in support for a new param called `team` to the filter params. This
works the same way as the teams filter in alerts and soon team key transactions.

- The empty list represents no teams.
- `"myteams"` resolves to the teams the user is on.
- Team ids resolve to the corresponding team.

All while respecting permissions. Superusers are able to see all teams.