### PR TITLE
ref(search): More clarity cleanup in grammar

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -174,7 +174,7 @@ class ParseSearchQueryTest(unittest.TestCase):
             ),
         ]
 
-    def test_raw_search_anywhere(self):
+    def test_free_text_search_anywhere(self):
         assert parse_search_query(
             "hello what user.email:foo@example.com where release:1.2.1 when"
         ) == [
@@ -228,7 +228,7 @@ class ParseSearchQueryTest(unittest.TestCase):
             ),
         ]
 
-    def test_quoted_raw_search_anywhere(self):
+    def test_quoted_free_text_search_anywhere(self):
         assert parse_search_query('"hello there" user.email:foo@example.com "general kenobi"') == [
             SearchFilter(
                 key=SearchKey(name="message"),


### PR DESCRIPTION
- Many of the spaces tokens were not required. It should be much more clear now where spaces are needed.

- free text now has been more consistently broken into `free_text_unquoted` and `free_text_quoted`, which makes up the `free_text` token.

- Consistent naming for date / time filters

- Match ordering of time filters