### PR TITLE
ref(vercel): Upgrade env var endpoints to v7

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -18,7 +18,6 @@ class VercelClient(ApiClient):
     WEBHOOK_URL = "/v1/integrations/webhooks"
     ENV_VAR_URL = "/v7/projects/%s/env"
     GET_ENV_VAR_URL = "/v7/projects/%s/env"
-    SECRETS_URL = "/v2/now/secrets"
     UPDATE_ENV_VAR_URL = "/v7/projects/%s/env/%s"
     UNINSTALL = "/v1/integrations/configuration/%s"
 
@@ -74,11 +73,6 @@ class VercelClient(ApiClient):
 
     def get_env_vars(self, vercel_project_id):
         return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
-
-    def create_secret(self, name, value):
-        data = {"name": name, "value": value}
-        response = self.post(self.SECRETS_URL, data=data)["uid"]
-        return response
 
     def create_env_variable(self, vercel_project_id, data):
         return self.post(self.ENV_VAR_URL % vercel_project_id, data=data)

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -15,7 +15,6 @@ class VercelClient(ApiClient):
     USER_URL = "/www/user"
     PROJECT_URL = "/v1/projects/%s"
     PROJECTS_URL = "/v4/projects/"
-    WEBHOOK_URL = "/v1/integrations/webhooks"
     ENV_VAR_URL = "/v7/projects/%s/env"
     GET_ENV_VAR_URL = "/v7/projects/%s/env"
     UPDATE_ENV_VAR_URL = "/v7/projects/%s/env/%s"

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -15,10 +15,11 @@ class VercelClient(ApiClient):
     USER_URL = "/www/user"
     PROJECT_URL = "/v1/projects/%s"
     PROJECTS_URL = "/v4/projects/"
-    ENV_VAR_URL = "/v6/projects/%s/env"
-    GET_ENV_VAR_URL = "/v6/projects/%s/env"
+    WEBHOOK_URL = "/v1/integrations/webhooks"
+    ENV_VAR_URL = "/v7/projects/%s/env"
+    GET_ENV_VAR_URL = "/v7/projects/%s/env"
     SECRETS_URL = "/v2/now/secrets"
-    UPDATE_ENV_VAR_URL = "/v6/projects/%s/env/%s"
+    UPDATE_ENV_VAR_URL = "/v7/projects/%s/env/%s"
     UNINSTALL = "/v1/integrations/configuration/%s"
 
     def __init__(self, access_token, team_id=None):

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -15,7 +15,6 @@ from sentry.models import (
 )
 from sentry.testutils import IntegrationTestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class VercelIntegrationTest(IntegrationTestCase):
@@ -176,8 +175,8 @@ class VercelIntegrationTest(IntegrationTestCase):
         data = {
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
-        with patch("sentry.integrations.vercel.integration.uuid4", new=self.get_mock_uuid()):
-            installation.update_organization_config(data)
+
+        installation.update_organization_config(data)
         org_integration = OrganizationIntegration.objects.get(
             organization_id=org.id, integration_id=integration.id
         )
@@ -286,8 +285,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             organization_id=org.id, integration_id=integration.id
         )
         assert org_integration.config == {}
-        with patch("sentry.integrations.vercel.integration.uuid4", new=self.get_mock_uuid()):
-            installation.update_organization_config(data)
+        installation.update_organization_config(data)
         org_integration = OrganizationIntegration.objects.get(
             organization_id=org.id, integration_id=integration.id
         )

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -168,7 +168,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 )
             responses.add(
                 responses.POST,
-                "https://api.vercel.com/v6/projects/%s/env"
+                "https://api.vercel.com/v7/projects/%s/env"
                 % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
                 json={
                     "key": env_var,
@@ -197,24 +197,24 @@ class VercelIntegrationTest(IntegrationTestCase):
         }
 
         # assert the secret was created correctly
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[6].request.body)
         assert req_params["name"] == "SENTRY_AUTH_TOKEN_%s" % uuid
         assert req_params["value"] == sentry_auth_token
 
         # assert the env vars were created correctly
-        req_params = json.loads(responses.calls[5].request.body)
+        req_params = json.loads(responses.calls[7].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[6].request.body)
+        req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[7].request.body)
+        req_params = json.loads(responses.calls[9].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production"]
@@ -274,7 +274,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             # mock try to create env var
             responses.add(
                 responses.POST,
-                "https://api.vercel.com/v6/projects/%s/env"
+                "https://api.vercel.com/v7/projects/%s/env"
                 % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
                 json={"error": {"code": "ENV_ALREADY_EXISTS"}},
                 status=400,
@@ -282,14 +282,14 @@ class VercelIntegrationTest(IntegrationTestCase):
             # mock get env var
             responses.add(
                 responses.GET,
-                "https://api.vercel.com/v6/projects/%s/env"
+                "https://api.vercel.com/v7/projects/%s/env"
                 % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
                 json={"envs": [{"id": count, "key": env_var}]},
             )
             # mock update env var
             responses.add(
                 responses.PATCH,
-                "https://api.vercel.com/v6/projects/%s/env/%s"
+                "https://api.vercel.com/v7/projects/%s/env/%s"
                 % ("Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H", count),
                 json={
                     "key": env_var,
@@ -322,19 +322,19 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[7].request.body)
+        req_params = json.loads(responses.calls[9].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[10].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
         assert req_params["target"] == ["production"]
         assert req_params["type"] == "plain"
 
-        req_params = json.loads(responses.calls[13].request.body)
+        req_params = json.loads(responses.calls[15].request.body)
         assert req_params["key"] == "SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
         assert req_params["target"] == ["production"]


### PR DESCRIPTION
**Context:**
Last bullet point in https://github.com/getsentry/sentry/pull/26162. 

~I'm actually not totally sure what changed between `v6` and `v7` of their environment variable endpoints, but I updated them anyway.~

~The only real changes in here aside from updating to `v7` were moving some lines around and pulling out the code for getting the `SENTRY_AUTH_TOKEN` value into its own method, since that made sense to me. My aim was to make `update_organization_config` a little easier to read.~

**Edit:**
There is a change and that is you no longer need to create a `secret` which we were previous doing via [their API](https://vercel.com/docs/api#endpoints/secrets/create-a-new-secret). Instead of creating a `secret` and having the env var be of type `secret` we can use the type `encrypted`. 

This is what it'll look like for the Vercel user:
> ![Screen Shot 2021-05-27 at 1 37 51 PM](https://user-images.githubusercontent.com/15368179/119910149-5b2aa900-bf0b-11eb-8d1c-2002b9562b61.png)

So they will see be able to figure out what the value is that we sending, but it's now encrypted. I've updated all of our env vars to use the `encrypted` type (except for the `system` one)
