### PR TITLE
feat(codeowners): Async query for teams/users

### DIFF
--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -149,7 +149,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                         ).distinct()
                     else:
                         queryset = queryset.filter(user__authenticator__isnull=True)
-                elif key == "hasExternalTeams" and "true" in value:
+                elif key == "hasExternalUsers" and "true" in value:
                     queryset = queryset.filter(
                         user__actor_id__in=ExternalActor.objects.filter(
                             organization=organization

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -149,12 +149,20 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                         ).distinct()
                     else:
                         queryset = queryset.filter(user__authenticator__isnull=True)
-                elif key == "hasExternalUsers" and "true" in value:
-                    queryset = queryset.filter(
-                        user__actor_id__in=ExternalActor.objects.filter(
-                            organization=organization
-                        ).values_list("actor_id")
-                    )
+                elif key == "hasExternalUsers":
+                    hasExternalUsers = "true" in value
+                    if hasExternalUsers:
+                        queryset = queryset.filter(
+                            user__actor_id__in=ExternalActor.objects.filter(
+                                organization=organization
+                            ).values_list("actor_id")
+                        )
+                    else:
+                        queryset = queryset.exclude(
+                            user__actor_id__in=ExternalActor.objects.filter(
+                                organization=organization
+                            ).values_list("actor_id")
+                        )
 
                 elif key == "query":
                     value = " ".join(value)

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -14,6 +14,7 @@ from sentry.api.validators import AllowedEmailField
 from sentry.app import locks
 from sentry.models import (
     AuditLogEntryEvent,
+    ExternalActor,
     InviteStatus,
     OrganizationMember,
     OrganizationMemberTeam,
@@ -148,6 +149,12 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                         ).distinct()
                     else:
                         queryset = queryset.filter(user__authenticator__isnull=True)
+                elif key == "hasExternalTeams" and "true" in value:
+                    queryset = queryset.filter(
+                        user__actor_id__in=ExternalActor.objects.filter(
+                            organization=organization
+                        ).values_list("actor_id")
+                    )
 
                 elif key == "query":
                     value = " ".join(value)

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -87,12 +87,21 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         if query:
             tokens = tokenize_query(query)
             for key, value in tokens.items():
-                if key == "hasExternalTeams" and "true" in value:
-                    queryset = queryset.filter(
-                        actor_id__in=ExternalActor.objects.filter(
-                            organization=organization
-                        ).values_list("actor_id")
-                    )
+                if key == "hasExternalTeams":
+                    hasExternalTeams = "true" in value
+                    if hasExternalTeams:
+                        queryset = queryset.filter(
+                            actor_id__in=ExternalActor.objects.filter(
+                                organization=organization
+                            ).values_list("actor_id")
+                        )
+                    else:
+                        queryset = queryset.exclude(
+                            actor_id__in=ExternalActor.objects.filter(
+                                organization=organization
+                            ).values_list("actor_id")
+                        )
+
                 elif key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(Q(name__icontains=value) | Q(slug__icontains=value))

--- a/static/app/components/forms/selectAsyncControl.tsx
+++ b/static/app/components/forms/selectAsyncControl.tsx
@@ -99,9 +99,11 @@ class SelectAsyncControl extends React.Component<Props> {
 
   render() {
     const {value, forwardedRef, ...props} = this.props;
-
     return (
       <SelectControl
+        // The key is used as a way to force a reload of the options:
+        // https://github.com/JedWatson/react-select/issues/1879#issuecomment-316871520
+        key={value}
         ref={forwardedRef}
         value={value}
         defaultOptions

--- a/static/app/components/forms/selectAsyncControl.tsx
+++ b/static/app/components/forms/selectAsyncControl.tsx
@@ -13,7 +13,7 @@ type Result = {
   label: string;
 };
 
-export type Props = {
+type Props = {
   url: string;
   onResults: (data: any) => Result[]; //TODO(ts): Improve data type
   onQuery: (query: string | undefined) => {};

--- a/static/app/components/forms/selectAsyncControl.tsx
+++ b/static/app/components/forms/selectAsyncControl.tsx
@@ -13,7 +13,7 @@ type Result = {
   label: string;
 };
 
-type Props = {
+export type Props = {
   url: string;
   onResults: (data: any) => Result[]; //TODO(ts): Improve data type
   onQuery: (query: string | undefined) => {};

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -58,7 +58,9 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         placeholder: t(`Choose your Sentry User`),
         url,
         onResults: result => {
-          // check if mapping is in result, else add it
+          // For organizations with >100 users, we want to make sure their
+          // saved mapping gets populated in the results if it wouldn't have
+          // been in the inital 100 API results, which is why we add it here
           if (mapping && !result.find(({id}) => id === mapping.userId)) {
             result = [{id: mapping.userId, name: mapping.sentryName}, ...result];
           }
@@ -76,10 +78,15 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         placeholder: t(`Choose your Sentry Team`),
         url,
         onResults: result => {
-          // check if mapping is in result, else add it
+          // For organizations with >100 teams, we want to make sure their
+          // saved mapping gets populated in the results if it wouldn't have
+          // been in the inital 100 API results, which is why we add it here
           if (mapping && !result.find(({id}) => id === mapping.teamId)) {
             result = [{id: mapping.teamId, name: mapping.sentryName}, ...result];
           }
+          // The team needs `this.props.onResults` so that we have team slug
+          // when a user submits a team mapping, the endpoint needs the slug
+          // as a path param: /teams/${organization.slug}/${team.slug}/external-teams/
           this.props.onResults?.(result);
           return optionMapper(sentryNamesMapper(result));
         },

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -36,7 +36,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
   }
 
   get formFields(): Field[] {
-    const {type, sentryNamesMapper, url} = this.props;
+    const {type, sentryNamesMapper, url, mapping} = this.props;
     const optionMapper = sentryNames =>
       sentryNames.map(({name, id}) => ({value: id, label: name}));
 
@@ -58,6 +58,10 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         placeholder: t(`Choose your Sentry User`),
         url,
         onResults: result => {
+          // check if mapping is in result, else add it
+          if (mapping && !result.find(({id}) => id === mapping.userId)) {
+            result = [{id: mapping.userId, name: mapping.sentryName}, ...result];
+          }
           this.props.onResults?.(result);
           return optionMapper(sentryNamesMapper(result));
         },
@@ -72,6 +76,10 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         placeholder: t(`Choose your Sentry Team`),
         url,
         onResults: result => {
+          // check if mapping is in result, else add it
+          if (mapping && !result.find(({id}) => id === mapping.teamId)) {
+            result = [{id: mapping.teamId, name: mapping.sentryName}, ...result];
+          }
           this.props.onResults?.(result);
           return optionMapper(sentryNamesMapper(result));
         },

--- a/static/app/data/forms/sentryApplication.tsx
+++ b/static/app/data/forms/sentryApplication.tsx
@@ -3,7 +3,7 @@ import {tct} from 'app/locale';
 import {extractMultilineFields} from 'app/utils';
 import {Field} from 'app/views/settings/components/forms/type';
 
-let getPublicFormFields = (): Field[] => [
+const getPublicFormFields = (): Field[] => [
   {
     name: 'name',
     type: 'string',

--- a/static/app/data/forms/sentryApplication.tsx
+++ b/static/app/data/forms/sentryApplication.tsx
@@ -3,7 +3,7 @@ import {tct} from 'app/locale';
 import {extractMultilineFields} from 'app/utils';
 import {Field} from 'app/views/settings/components/forms/type';
 
-const getPublicFormFields = (): Field[] => [
+let getPublicFormFields = (): Field[] => [
   {
     name: 'name',
     type: 'string',

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2086,7 +2086,7 @@ export type KeyValueListData = {
 export type ExternalActorMapping = {
   id: string;
   externalName: string;
-  memberId?: string;
+  userId?: string;
   teamId?: string;
   sentryName: string;
 };

--- a/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -81,10 +81,6 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
     return externalTeamMappings.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
   }
 
-  get sentryNames() {
-    const {teams} = this.state;
-    return this.sentryNamesMapper(teams);
-  }
   sentryNamesMapper(teams: Team[]) {
     return teams.map(({id, name}) => ({id, name}));
   }

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -31,7 +31,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
       [
         'members',
         `/organizations/${organization.slug}/members/`,
-        {query: {query: 'hasExternalTeams:true', expand: 'externalUsers'}},
+        {query: {query: 'hasExternalUsers:true', expand: 'externalUsers'}},
       ],
     ];
   }

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -31,7 +31,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
       [
         'members',
         `/organizations/${organization.slug}/members/`,
-        {query: {expand: 'externalUsers'}},
+        {query: {query: 'hasExternalTeams:true', expand: 'externalUsers'}},
       ],
     ];
   }
@@ -74,12 +74,13 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
     return externalUserMappings.sort((a, b) => parseInt(a.id, 10) - parseInt(b.id, 10));
   }
 
-  get sentryNames() {
-    const {members} = this.state;
-    return members.map(({user: {id}, email, name}) => {
-      const label = email !== name ? `${name} - ${email}` : `${email}`;
-      return {id, name: label};
-    });
+  sentryNamesMapper(members: Member[]) {
+    return members
+      .filter(member => member.user)
+      .map(({user: {id}, email, name}) => {
+        const label = email !== name ? `${name} - ${email}` : `${email}`;
+        return {id, name: label};
+      });
   }
 
   openModal = (mapping?: ExternalActorMapping) => {
@@ -96,8 +97,9 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
               closeModal();
             }}
             mapping={mapping}
-            sentryNames={this.sentryNames}
+            sentryNamesMapper={this.sentryNamesMapper}
             type="user"
+            url={`/organizations/${organization.slug}/members/`}
             onCancel={closeModal}
             baseEndpoint={`/organizations/${organization.slug}/external-users/`}
           />

--- a/static/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/static/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -14,6 +14,7 @@ import ProjectMapperField from './projectMapperField';
 import RadioField from './radioField';
 import RangeField from './rangeField';
 import RichListField from './richListField';
+import SelectAsyncField from './selectAsyncField';
 import SelectField from './selectField';
 import SentryProjectSelectorField from './sentryProjectSelectorField';
 import TableField from './tableField';
@@ -98,6 +99,8 @@ export default class FieldFromConfig extends Component<Props> {
         return <ProjectMapperField {...props} />;
       case 'sentry_project_selector':
         return <SentryProjectSelectorField {...props} />;
+      case 'select_async':
+        return <SelectAsyncField {...(props as any)} />;
       case 'custom':
         return field.Component(props);
       default:

--- a/static/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/static/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -100,7 +100,7 @@ export default class FieldFromConfig extends Component<Props> {
       case 'sentry_project_selector':
         return <SentryProjectSelectorField {...props} />;
       case 'select_async':
-        return <SelectAsyncField {...(props as any)} />;
+        return <SelectAsyncField {...props} />;
       case 'custom':
         return field.Component(props);
       default:

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import SelectAsyncControl, {
+  Props as SelectAsyncControlProps,
+} from 'app/components/forms/selectAsyncControl';
+import InputField from 'app/views/settings/components/forms/inputField';
+
+//projects can be passed as a direct prop as well
+type Props = InputField['props'];
+
+type SelectAsyncFieldProps = SelectAsyncControlProps & Props;
+
+class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
+  state = {
+    results: [],
+    value: {},
+  };
+  //need to map the option object to the value
+  handleChange = (
+    onBlur: Props['onBlur'],
+    onChange: Props['onChange'],
+    optionObj: {value: any},
+    event: React.MouseEvent
+  ) => {
+    let {value} = optionObj;
+    if (!optionObj) {
+      value = optionObj;
+    } else if (this.props.multiple && Array.isArray(optionObj)) {
+      // List of optionObjs
+      value = optionObj.map(({value: val}) => val);
+    } else if (!Array.isArray(optionObj)) {
+      value = optionObj.value;
+    }
+    onChange?.(value, event);
+    onBlur?.(value, event);
+  };
+
+  findValue(propsValue) {
+    return this.state.results.find(({value}) => value === propsValue) || propsValue;
+  }
+
+  render() {
+    const {...otherProps} = this.props;
+    return (
+      <InputField
+        {...otherProps}
+        field={({onChange, onBlur, required: _required, onResults, value, ...props}) => (
+          <SelectAsyncControl
+            {...props}
+            onChange={this.handleChange.bind(this, onBlur, onChange)}
+            onResults={data => {
+              const results = onResults(data);
+              this.setState({results});
+              return results;
+            }}
+            value={this.findValue(value)}
+          />
+        )}
+      />
+    );
+  }
+}
+
+export default SelectAsyncField;

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -4,7 +4,7 @@ import SelectAsyncControl from 'app/components/forms/selectAsyncControl';
 import InputField from 'app/views/settings/components/forms/inputField';
 
 //projects can be passed as a direct prop as well
-type Props = Omit<InputField['props'], 'highlighted'| 'visible' | 'fields'>;
+type Props = Omit<InputField['props'], 'highlighted' | 'visible' | 'required'>;
 
 export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<
   typeof SelectAsyncControl

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -4,7 +4,7 @@ import SelectAsyncControl from 'app/components/forms/selectAsyncControl';
 import InputField from 'app/views/settings/components/forms/inputField';
 
 //projects can be passed as a direct prop as well
-type Props = InputField['props'];
+type Props = Omit<InputField['props'], 'highlighted'>;
 
 export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<
   typeof SelectAsyncControl

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -8,18 +8,17 @@ import InputField from 'app/views/settings/components/forms/inputField';
 //projects can be passed as a direct prop as well
 type Props = InputField['props'];
 
-type SelectAsyncFieldProps = SelectAsyncControlProps & Props;
+export type SelectAsyncFieldProps = SelectAsyncControlProps & Props;
 
 class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
   state = {
     results: [],
-    value: {},
   };
   //need to map the option object to the value
   handleChange = (
     onBlur: Props['onBlur'],
     onChange: Props['onChange'],
-    optionObj: {value: any},
+    optionObj: {value: string | any[]},
     event: React.MouseEvent
   ) => {
     let {value} = optionObj;
@@ -36,7 +35,20 @@ class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
   };
 
   findValue(propsValue) {
-    return this.state.results.find(({value}) => value === propsValue) || propsValue;
+    /**
+     * When this component first loads, this.state.results will get set to the
+     * first 100 results from the API.
+     *
+     * The propsValue is the `id` of the object (user, team, etc), and so if that
+     * `id` doesn't match the first 100 results, react-select won't be able to
+     *  return the full value object: {value: "id", label: "name"}
+     *
+     * We return {} here instead of the propsValue (the `id`) because react-select
+     * expects there to be an object and there seems to be weirdness if it isn't.
+     * This will affect large orgs who are editing form fields that may have saved
+     * data outside of the first 100 results. :(
+     **/
+    return this.state.results.find(({value}) => value === propsValue) || {};
   }
 
   render() {
@@ -53,6 +65,9 @@ class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
               this.setState({results});
               return results;
             }}
+            onSelectResetsInput
+            onCloseResetsInput={false}
+            onBlurResetsInput={false}
             value={this.findValue(value)}
           />
         )}

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -38,17 +38,10 @@ class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
 
   findValue(propsValue) {
     /**
-     * When this component first loads, this.state.results will get set to the
-     * first 100 results from the API.
+     * The propsValue is the `id` of the object (user, team, etc), and
+     * react-select expects a full value object: {value: "id", label: "name"}
      *
-     * The propsValue is the `id` of the object (user, team, etc), and so if that
-     * `id` doesn't match the first 100 results, react-select won't be able to
-     *  return the full value object: {value: "id", label: "name"}
-     *
-     * We return {} here instead of the propsValue (the `id`) because react-select
-     * expects there to be an object and there seems to be weirdness if it isn't.
-     * This will affect large orgs who are editing form fields that may have saved
-     * data outside of the first 100 results. :(
+     * Returning {} here will show the user a dropdown with "No options".
      **/
     return this.state.results.find(({value}) => value === propsValue) || {};
   }

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -15,7 +15,8 @@ class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
   state = {
     results: [],
   };
-  //need to map the option object to the value
+  // need to map the option object to the value
+  // this is essentially the same code from ./selectField handleChange()
   handleChange = (
     onBlur: Props['onBlur'],
     onChange: Props['onChange'],

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -4,7 +4,7 @@ import SelectAsyncControl from 'app/components/forms/selectAsyncControl';
 import InputField from 'app/views/settings/components/forms/inputField';
 
 //projects can be passed as a direct prop as well
-type Props = Omit<InputField['props'], 'highlighted'>;
+type Props = Omit<InputField['props'], 'highlighted'| 'visible' | 'fields'>;
 
 export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<
   typeof SelectAsyncControl

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -6,7 +6,10 @@ import InputField from 'app/views/settings/components/forms/inputField';
 //projects can be passed as a direct prop as well
 type Props = InputField['props'];
 
-export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<typeof SelectAsyncControl> & Props;
+export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<
+  typeof SelectAsyncControl
+> &
+  Props;
 
 class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
   state = {

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
 
-import SelectAsyncControl, {
-  Props as SelectAsyncControlProps,
-} from 'app/components/forms/selectAsyncControl';
+import SelectAsyncControl from 'app/components/forms/selectAsyncControl';
 import InputField from 'app/views/settings/components/forms/inputField';
 
 //projects can be passed as a direct prop as well
 type Props = InputField['props'];
 
-export type SelectAsyncFieldProps = SelectAsyncControlProps & Props;
+export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<typeof SelectAsyncControl> & Props;
 
 class SelectAsyncField extends React.Component<SelectAsyncFieldProps> {
   state = {

--- a/static/app/views/settings/components/forms/type.tsx
+++ b/static/app/views/settings/components/forms/type.tsx
@@ -27,6 +27,7 @@ export const FieldType = [
   'table',
   'project_mapper',
   'sentry_project_selector',
+  'select_async',
 ] as const;
 
 export type FieldValue = any;

--- a/static/app/views/settings/components/forms/type.tsx
+++ b/static/app/views/settings/components/forms/type.tsx
@@ -6,6 +6,7 @@ import {AvatarProject, Project} from 'app/types';
 import {ChoiceMapperProps} from 'app/views/settings/components/forms/choiceMapperField';
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 import {RichListProps} from 'app/views/settings/components/forms/richListField';
+import {SelectAsyncFieldProps} from 'app/views/settings/components/forms/selectAsyncField';
 
 export const FieldType = [
   'array',
@@ -174,6 +175,9 @@ export type SentryProjectSelectorType = {
   avatarSize?: number;
 };
 
+export type SelectAsyncType = {
+  type: 'select_async';
+} & SelectAsyncFieldProps;
 /**
  * Json field configuration makes using generics hard.
  * This isn't the ideal type to use, but it will cover
@@ -201,6 +205,7 @@ export type Field = (
   | TableType
   | ProjectMapperType
   | SentryProjectSelectorType
+  | SelectAsyncType
   | RichListType
   | ChoiceMapperType
   | {type: typeof FieldType[number]}

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -219,6 +219,17 @@ class OrganizationMemberListTest(APITestCase):
         assert response.status_code == 200
         assert len(response.data) == 2
 
+    def test_has_external_users_query(self):
+        response = self.client.get(self.url + "?query=hasExternalUsers:true")
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["email"] == self.user_2.email
+
+        response = self.client.get(self.url + "?query=hasExternalUsers:false")
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["email"] == self.owner_user.email
+
     def test_cannot_get_unapproved_invites(self):
         join_request = "test@email.com"
         invite_request = "test@gmail.com"

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -111,6 +111,27 @@ class OrganizationTeamsListTest(APITestCase):
             "teamId": str(self.team.id),
         }
 
+    def test_has_external_teams_query(self):
+        team = self.create_team(organization=self.organization, name="foo")
+        self.login_as(user=self.user)
+        path = f"/api/0/organizations/{self.organization.slug}/teams/?query=hasExternalTeams:true"
+
+        response = self.client.get(path)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
+        self.create_external_team(team, external_name="@getsentry/ecosystem")
+
+        response = self.client.get(path)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(team.id)
+
+        path = f"/api/0/organizations/{self.organization.slug}/teams/?query=hasExternalTeams:false"
+        response = self.client.get(path)
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 0
+
 
 class OrganizationTeamsCreateTest(APITestCase):
     endpoint = "sentry-api-0-organization-teams"


### PR DESCRIPTION
## Objective:
In the External User/Team Mapping Modals, we are currently only fetching a subset of all the Sentry Users/Teams.
In this PR, there is now a SelectAsyncField which we can use to query the API for teams/users.
Fixes [JAVASCRIPT-24M3](https://sentry.io/organizations/sentry/issues/2419028488/?referrer=jira_integration)

**notes:**
It's worth noting that this current solution may be a bit wonky for organizations with >100 users or teams. This is because when we first populate the select field, we are populating the results with the first 100 results we get back from our API. Consider the following scenario:

1. User opens modal to create a new team mapping
2. User opens the sentry team dropdown to see a list of their teams, but doesn't see the one they want
3. User types to search for their team (we fetch results based on their query and we return the result, let's say id = `101`)
4. User saves mapping 
5. User goes back later to edit their mapping
    * at this point the initial list from the API isn't going to include their saved team (with id = `101`), so what we do is we manually append their saved result to the list so that it's the first 100 results + our saved mapping. 
    * this works well but means that if someone typed gibberish or we didn't find the team they were looking for, we are still appending result + our saved mapping, so the results will always include the initial mapping. 