### PR TITLE
fix(ui): Remove selected incident from chart ui on unselect

### DIFF
--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -133,6 +133,8 @@ class AlertRuleDetails extends Component<Props, State> {
       await fetchIncident(api, orgId, location.query.alert)
         .then(incident => this.setState({selectedIncident: incident}))
         .catch(() => this.setState({selectedIncident: null}));
+    } else {
+      this.setState({selectedIncident: null});
     }
 
     const timePeriod = this.getTimePeriod();


### PR DESCRIPTION
This sets the selected incident in the alert details chart after it is removed from the url query parameters. It used to stay active when user zoomed into a different section and caused confusion.

[WOR-924](https://getsentry.atlassian.net/browse/WOR-924)