### PR TITLE
feat(api): Add query filtering to OrganizationReleaseDetail Endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -124,7 +124,7 @@ class OrganizationReleaseDetailsPaginationMixin:
 
         # Required re-ordering because django filter does not guarantee order of snuba primary order
         release_dict = {release.version: release for release in queryset}
-   
+
         return list(filter(None, [release_dict.get(version) for version in version_list]))
 
     @staticmethod


### PR DESCRIPTION
This PR:-
- Uses the results from the previous Snuba primary query in `OrganizationDetailsEndpoint` when sorting on things like `sessions`, `users`, `crash_free_users` and `crash_free_sessions` to execute another query on `Release` model that applies query filters to that queryset
- Uses `query_filter` to also filter `versions` for releases sorted on date

Builds on #26224 

~~ToDo: Figure out how to make query quicker interms of indexing~~
We have decided after a conversation with @wedamija to not do anything in regards for to this for the time being because 
1- We ran a version `LIKE` query on one of the biggest orgs and it was quite okay 
2- This is what we currently have for the `OrganizationReleasesEndpoint`

And so we have decided to not do anything here for the time being but if we get complaints of slow performance, we will investigate using `text_pattern_ops` index or some other index on the `version` field