### PR TITLE
fix(snql) SnQL expects the JSON to be lists

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -164,7 +164,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         selected_columns = []
         if get_sample:
             query_hash = md5(json.dumps(conditions).encode("utf-8")).hexdigest()[:8]
-            selected_columns.append(("cityHash64", (f"'{query_hash}'", "group_id"), "sample"))
+            selected_columns.append(["cityHash64", [f"'{query_hash}'", "group_id"], "sample"])
             sort_field = "sample"
             orderby = [sort_field]
             referrer = "search_sample"


### PR DESCRIPTION
The schema of the JSON sent to Snuba should be lists, not tuples. It's not
usually an issue because JSON correctly encodes the tuples but when SnQL tries
to convert this to a SnQL query it errors out.