### PR TITLE
fix(integration): Treat single label domains as valid in jira server and bitbucket server

### DIFF
--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -15,7 +15,7 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.repositories import RepositoryMixin
-from sentry.integrations.validators.url import URLValidatorWithoutDot
+from sentry.integrations.validators.url import SingleLevelDomainURLValidator
 from sentry.models.repository import Repository
 from sentry.pipeline import PipelineView
 from sentry.shared_integrations.exceptions import ApiError
@@ -76,7 +76,7 @@ class InstallationForm(forms.Form):
             "The base URL for your Bitbucket Server instance, including the host and protocol."
         ),
         widget=forms.TextInput(attrs={"placeholder": "https://bitbucket.example.com"}),
-        validators=[URLValidatorWithoutDot()],
+        validators=[SingleLevelDomainURLValidator()],
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from django import forms
-from django.core.validators import URLValidator
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
@@ -16,6 +15,7 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.repositories import RepositoryMixin
+from sentry.integrations.validators.url import URLValidatorWithoutDot
 from sentry.models.repository import Repository
 from sentry.pipeline import PipelineView
 from sentry.shared_integrations.exceptions import ApiError
@@ -76,7 +76,7 @@ class InstallationForm(forms.Form):
             "The base URL for your Bitbucket Server instance, including the host and protocol."
         ),
         widget=forms.TextInput(attrs={"placeholder": "https://bitbucket.example.com"}),
-        validators=[URLValidator()],
+        validators=[URLValidatorWithoutDot()],
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from django import forms
-from django.core.validators import URLValidator
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
@@ -16,6 +15,7 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.jira import JiraIntegration
+from sentry.integrations.validators.url import URLValidatorWithoutDot
 from sentry.pipeline import PipelineView
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.decorators import classproperty
@@ -83,7 +83,7 @@ class InstallationForm(forms.Form):
         label=_("Jira URL"),
         help_text=_("The base URL for your Jira Server instance, including the host and protocol."),
         widget=forms.TextInput(attrs={"placeholder": "https://jira.example.com"}),
-        validators=[URLValidator()],
+        validators=[URLValidatorWithoutDot()],
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -15,7 +15,7 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.jira import JiraIntegration
-from sentry.integrations.validators.url import URLValidatorWithoutDot
+from sentry.integrations.validators.url import SingleLevelDomainURLValidator
 from sentry.pipeline import PipelineView
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.utils.decorators import classproperty
@@ -83,7 +83,7 @@ class InstallationForm(forms.Form):
         label=_("Jira URL"),
         help_text=_("The base URL for your Jira Server instance, including the host and protocol."),
         widget=forms.TextInput(attrs={"placeholder": "https://jira.example.com"}),
-        validators=[URLValidatorWithoutDot()],
+        validators=[SingleLevelDomainURLValidator()],
     )
     verify_ssl = forms.BooleanField(
         label=_("Verify SSL"),

--- a/src/sentry/integrations/validators/url.py
+++ b/src/sentry/integrations/validators/url.py
@@ -1,0 +1,24 @@
+import re
+
+from django.core.validators import URLValidator, _lazy_re_compile
+
+
+class URLValidatorWithoutDot(URLValidator):
+    host_re = (
+        "("
+        + URLValidator.hostname_re
+        + URLValidator.domain_re
+        + URLValidator.tld_re
+        + "|"
+        + URLValidator.hostname_re
+        + ")"
+    )
+    regex = _lazy_re_compile(
+        r"^(?:[a-z0-9\.\-\+]*)://"  # scheme is validated separately
+        r"(?:\S+(?::\S*)?@)?"  # user:pass authentication
+        r"(?:" + URLValidator.ipv4_re + "|" + URLValidator.ipv6_re + "|" + host_re + ")"
+        r"(?::\d{2,5})?"  # port
+        r"(?:[/?#][^\s]*)?"  # resource path
+        r"\Z",
+        re.IGNORECASE,
+    )

--- a/src/sentry/integrations/validators/url.py
+++ b/src/sentry/integrations/validators/url.py
@@ -3,7 +3,7 @@ import re
 from django.core.validators import URLValidator, _lazy_re_compile
 
 
-class URLValidatorWithoutDot(URLValidator):
+class SingleLevelDomainURLValidator(URLValidator):
     host_re = (
         "("
         + URLValidator.hostname_re

--- a/tests/sentry/integrations/bitbucket_server/test_integration.py
+++ b/tests/sentry/integrations/bitbucket_server/test_integration.py
@@ -37,7 +37,7 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Enter a valid URL")
 
     @responses.activate
-    def test_validate_url_without_dot(self):
+    def test_validate_single_level_domain_url(self):
         # Start pipeline and go to setup page.
         self.client.get(self.setup_path)
 

--- a/tests/sentry/integrations/bitbucket_server/test_integration.py
+++ b/tests/sentry/integrations/bitbucket_server/test_integration.py
@@ -37,6 +37,22 @@ class BitbucketServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Enter a valid URL")
 
     @responses.activate
+    def test_validate_url_without_dot(self):
+        # Start pipeline and go to setup page.
+        self.client.get(self.setup_path)
+
+        # Submit credentials
+        data = {
+            "url": "http://bitbucket",
+            "verify_ssl": False,
+            "consumer_key": "sentry-bot",
+            "private_key": EXAMPLE_PRIVATE_KEY,
+        }
+        resp = self.client.post(self.setup_path, data=data)
+        assert resp.status_code == 200
+        self.assertNotContains(resp, "Enter a valid URL")
+
+    @responses.activate
     def test_validate_private_key(self):
         responses.add(
             responses.POST,

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -40,7 +40,7 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Enter a valid URL")
 
     @responses.activate
-    def test_validate_url_without_dot(self):
+    def test_validate_single_level_domain_url(self):
         # Start pipeline and go to setup page.
         self.client.get(self.setup_path)
 

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -40,6 +40,22 @@ class JiraServerIntegrationTest(IntegrationTestCase):
         self.assertContains(resp, "Enter a valid URL")
 
     @responses.activate
+    def test_validate_url_without_dot(self):
+        # Start pipeline and go to setup page.
+        self.client.get(self.setup_path)
+
+        # Submit credentials
+        data = {
+            "url": "https://jira",
+            "verify_ssl": False,
+            "consumer_key": "sentry-bot",
+            "private_key": EXAMPLE_PRIVATE_KEY,
+        }
+        resp = self.client.post(self.setup_path, data=data)
+        assert resp.status_code == 200
+        self.assertNotContains(resp, "Enter a valid URL")
+
+    @responses.activate
     def test_validate_private_key(self):
         responses.add(
             responses.POST,


### PR DESCRIPTION
The Jira and Bitbucket server integrations are using a built-in Django URL validator. This means Jira and Bitbucket server can't be used without using a FQDN. This PR proposes to add a custom validator that inherits from Django URLValidator and allows to use single label domains as the URL.

Fixes #17376