### PR TITLE
fix(perf): Tag explorer cumulative time not upscaled with sampling

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -295,13 +295,19 @@ def query_facet_performance(
 
         tag_selected_columns = [
             [
-                "sum",
+                "divide",
                 [
-                    "minus",
                     [
-                        translated_aggregate_column,
-                        str(transaction_aggregate),
+                        "sum",
+                        [
+                            "minus",
+                            [
+                                translated_aggregate_column,
+                                str(transaction_aggregate),
+                            ],
+                        ],
                     ],
+                    frequency_sample_rate,
                 ],
                 "sumdelta",
             ],


### PR DESCRIPTION
### Summary
Looking at larger datasets, I've noticed that since the delta is sampled and then summed, it might not be giving an accurate impression of how much total time is involved. Adjusting it for the sample rate should be no less accurate (since it's still doing a delta of a specific set), but should improve sense of scale.