### PR TITLE
feat(issue): Adding secondary percent and filtered percent to issue stream

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {css} from '@emotion/react';
+import {css, Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
@@ -37,6 +37,7 @@ import {defined, percent, valueIsEqual} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import EventView from 'app/utils/discover/eventView';
+import {formatPercentage} from 'app/utils/formatters';
 import {queryToObj} from 'app/utils/stream';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -387,7 +388,12 @@ class StreamGroup extends React.Component<Props, State> {
     const primaryPercent =
       showSessions &&
       data.sessionCount &&
-      (Number(primaryCount) / Number(data.sessionCount)) * 100;
+      formatPercentage(Number(primaryCount) / Number(data.sessionCount));
+    const secondaryPercent =
+      showSessions &&
+      data.sessionCount &&
+      secondaryCount &&
+      formatPercentage(Number(secondaryCount) / Number(data.sessionCount));
 
     return (
       <Wrapper
@@ -459,11 +465,18 @@ class StreamGroup extends React.Component<Props, State> {
                         >
                           <span {...getActorProps({})}>
                             <div className="dropdown-actor-title">
-                              <PrimaryCount value={primaryPercent || primaryCount} />
-                              {primaryPercent && '%'}
-                              {secondaryCount !== undefined && useFilteredStats && (
-                                <SecondaryCount value={secondaryCount} />
+                              {primaryPercent ? (
+                                <PrimaryPercent>{primaryPercent}</PrimaryPercent>
+                              ) : (
+                                <PrimaryCount value={primaryCount} />
                               )}
+                              {secondaryCount !== undefined &&
+                                useFilteredStats &&
+                                (secondaryPercent ? (
+                                  <SecondaryPercent>{secondaryPercent}</SecondaryPercent>
+                                ) : (
+                                  <SecondaryCount value={secondaryCount} />
+                                ))}
                             </div>
                           </span>
                           {useFilteredStats && (
@@ -476,7 +489,11 @@ class StreamGroup extends React.Component<Props, State> {
                                     <MenuItemText>
                                       {t('Matching search filters')}
                                     </MenuItemText>
-                                    <MenuItemCount value={data.filtered.count} />
+                                    {primaryPercent ? (
+                                      <MenuItemPercent>{primaryPercent}</MenuItemPercent>
+                                    ) : (
+                                      <MenuItemCount value={data.filtered.count} />
+                                    )}
                                   </StyledMenuItem>
                                   <MenuItem divider />
                                 </React.Fragment>
@@ -484,7 +501,11 @@ class StreamGroup extends React.Component<Props, State> {
 
                               <StyledMenuItem to={this.getDiscoverUrl()}>
                                 <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
-                                <MenuItemCount value={data.count} />
+                                {secondaryPercent ? (
+                                  <MenuItemPercent>{secondaryPercent}</MenuItemPercent>
+                                ) : (
+                                  <MenuItemCount value={secondaryPercent || data.count} />
+                                )}
                               </StyledMenuItem>
 
                               {data.lifetime && (
@@ -658,19 +679,35 @@ const GroupCheckBoxWrapper = styled('div')`
   }
 `;
 
-const PrimaryCount = styled(Count)`
-  font-size: ${p => p.theme.fontSizeLarge};
+const primaryStatStyle = (theme: Theme) => css`
+  font-size: ${theme.fontSizeLarge};
 `;
 
-const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)`
-  font-size: ${p => p.theme.fontSizeLarge};
+const PrimaryCount = styled(Count)`
+  ${p => primaryStatStyle(p.theme)};
+`;
+
+const PrimaryPercent = styled('div')`
+  ${p => primaryStatStyle(p.theme)};
+`;
+
+const secondaryStatStyle = (theme: Theme) => css`
+  font-size: ${theme.fontSizeLarge};
 
   :before {
     content: '/';
     padding-left: ${space(0.25)};
     padding-right: 2px;
-    color: ${p => p.theme.gray300};
+    color: ${theme.gray300};
   }
+`;
+
+const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)`
+  ${p => secondaryStatStyle(p.theme)}
+`;
+
+const SecondaryPercent = styled('div')`
+  ${p => secondaryStatStyle(p.theme)}
 `;
 
 const StyledDropdownList = styled('ul')`
@@ -701,14 +738,22 @@ const StyledMenuItem = styled(({to, children, ...p}: MenuItemProps) => (
   justify-content: space-between;
 `;
 
+const menuItemStatStyles = css`
+  text-align: right;
+  font-weight: bold;
+  padding-left: ${space(1)};
+`;
+
 const MenuItemCount = styled(({value, ...p}) => (
   <div {...p}>
     <Count value={value} />
   </div>
 ))`
-  text-align: right;
-  font-weight: bold;
-  padding-left: ${space(1)};
+  ${menuItemStatStyles};
+`;
+
+const MenuItemPercent = styled('div')`
+  ${menuItemStatStyles};
 `;
 
 const MenuItemText = styled('div')`

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -229,6 +229,9 @@ class IssueListOverview extends React.Component<Props, State> {
     if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
       this.fetchMemberList();
       this.fetchTags();
+      if (this.getDisplay() !== DEFAULT_DISPLAY) {
+        this.transitionTo({display: DEFAULT_DISPLAY});
+      }
     }
 
     // Wait for saved searches to load before we attempt to fetch stream data
@@ -373,6 +376,11 @@ class IssueListOverview extends React.Component<Props, State> {
     const sort = this.getSort();
     if (sort !== DEFAULT_SORT) {
       params.sort = sort;
+    }
+
+    const display = this.getDisplay();
+    if (display !== DEFAULT_DISPLAY) {
+      params.display = display;
     }
 
     const groupStatsPeriod = this.getGroupStatsPeriod();


### PR DESCRIPTION
This PR:
- formats percentages according to `formatPercentage` in `utils/formatters`
- adds the secondary percent and filtered percent to the tooltip and issue display
- Fixes a bug where selecting a sort would not maintain the display option
- Switches the user back to `event count` when they switch projects as there is no guarantee the newly selected project(s) have session data

**Before:**
![image](https://user-images.githubusercontent.com/9372512/119899703-7993a300-bf11-11eb-93ff-7df152794b02.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/119899535-33d6da80-bf11-11eb-9943-498c572d604a.png)
