### PR TITLE
feat(api): Increase allowed payload size of internal beacon metrics

### DIFF
--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -18,7 +18,7 @@ class MetricsSerializer(serializers.Serializer):
         child=serializers.DictField(
             # This is intentionally a bit restrictive to limit the size of payloads (and abuse)
             # These metrics should not be sending complex payloads anyway
-            child=serializers.CharField(max_length=255),
+            child=serializers.CharField(max_length=1024),
             allow_empty=False,
         ),
         max_length=MAX_LENGTH,

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -108,10 +108,10 @@ const makeBeaconRequest = throttle(
               // The stacktrace doesn't show it being called outside of this block either.
               // And this works fine in Chrome...
               if (key !== 'SentryApp' && stackArr.length > 1) {
-                // Limit the number of frames to include
+                // Limit the number of frames to include, as well as the total size of the string
                 _beaconComponents.push({
                   component: key,
-                  stack: stackArr.slice(0, 5).join('\n'),
+                  stack: stackArr.slice(0, 5).join('\n').slice(0, 1024),
                 });
                 makeBeaconRequest();
               }


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/25866 - we added partial frontend stack traces to the payload, and this is causing some requests to be rejected. We only send the last 5 frames, so I think 1024 should be enough to give us context of where globals are used.

Additionally, limit this in the frontend as well