### PR TITLE
fix(discover): Ensure org tags are loaded in Discover

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -84,6 +84,8 @@ class Results extends React.Component<Props, State> {
     return prevState;
   }
 
+  tagsApi: Client = new Client();
+
   state: State = {
     eventView: EventView.fromSavedQueryOrLocation(
       this.props.savedQuery,
@@ -99,8 +101,8 @@ class Results extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    const {api, organization, selection} = this.props;
-    loadOrganizationTags(api, organization.slug, selection);
+    const {organization, selection} = this.props;
+    loadOrganizationTags(this.tagsApi, organization.slug, selection);
     addRoutePerformanceContext(selection);
     this.checkEventView();
     this.canLoadEvents();
@@ -124,7 +126,7 @@ class Results extends React.Component<Props, State> {
       !isEqual(prevProps.selection.datetime, selection.datetime) ||
       !isEqual(prevProps.selection.projects, selection.projects)
     ) {
-      loadOrganizationTags(api, organization.slug, selection);
+      loadOrganizationTags(this.tagsApi, organization.slug, selection);
       addRoutePerformanceContext(selection);
     }
 

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -118,7 +118,6 @@ class Results extends React.Component<Props, State> {
       this.hasChartParametersChanged(prevState.eventView, eventView)
     ) {
       api.clear();
-      loadOrganizationTags(api, organization.slug, selection);
       this.canLoadEvents();
     }
     if (

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -84,8 +84,6 @@ class Results extends React.Component<Props, State> {
     return prevState;
   }
 
-  tagsApi: Client = new Client();
-
   state: State = {
     eventView: EventView.fromSavedQueryOrLocation(
       this.props.savedQuery,
@@ -132,6 +130,8 @@ class Results extends React.Component<Props, State> {
 
     if (prevState.confirmedQuery !== confirmedQuery) this.fetchTotalCount();
   }
+
+  tagsApi: Client = new Client();
 
   hasChartParametersChanged(prevEventView: EventView, eventView: EventView) {
     const prevYAxisValue = prevEventView.getYAxis();

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -118,6 +118,7 @@ class Results extends React.Component<Props, State> {
       this.hasChartParametersChanged(prevState.eventView, eventView)
     ) {
       api.clear();
+      loadOrganizationTags(api, organization.slug, selection);
       this.canLoadEvents();
     }
     if (


### PR DESCRIPTION
Sometimes the org tag endpoint request may be cancelled before it's completed. We need to ensure we load org tags for whenever we can load events in Discover.