### PR TITLE
fix(release): Add bad characters to release version check

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -31,7 +31,7 @@ def get_all_languages():
 MODULE_ROOT = os.path.dirname(__import__("sentry").__file__)
 DATA_ROOT = os.path.join(MODULE_ROOT, "data")
 
-BAD_RELEASE_CHARS = "\n\f\t/"
+BAD_RELEASE_CHARS = "\r\n\f\x0c\t/\\"
 MAX_VERSION_LENGTH = 200
 MAX_COMMIT_LENGTH = 64
 COMMIT_RANGE_DELIMITER = ".."

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -642,3 +642,29 @@ class SetRefsTest(SetRefsTestCase):
     def test_invalid_version(self):
         release = Release.objects.create(organization=self.org)
         assert not release.is_valid_version(None)
+
+    @staticmethod
+    def test_invalid_chars_in_version():
+        version = (
+            "\n> rfrontend@0.1.0 release:version\n> echo "
+            "'dev-19be1b7e-dirty'\n\ndev-19be1b7e-dirty"
+        )
+        assert not Release.is_valid_version(version)
+
+        version = "\t hello world"
+        assert not Release.is_valid_version(version)
+
+        version = "\f hello world again"
+        assert not Release.is_valid_version(version)
+
+        version = "/ helo"
+        assert not Release.is_valid_version(version)
+
+        version = "\r hello world again"
+        assert not Release.is_valid_version(version)
+
+        version = "\x0c dogs and rabbits"
+        assert not Release.is_valid_version(version)
+
+        version = "\\ hello world again"
+        assert not Release.is_valid_version(version)


### PR DESCRIPTION
This PR:
- Adds to the bad characters release version check so that it matches the bad characters checks we have on relay

Ref: https://github.com/getsentry/relay/blob/10f2c93efb8b5a200168a8fb961c3b136c1e5f18/relay-general/src/protocol/event.rs#L330-L342