### PR TITLE
ref(performance): Make team key transaction dropdown pure component

### DIFF
--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
@@ -1,6 +1,8 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
+import {toggleKeyTransaction} from 'app/actionCreators/performance';
+import {Client} from 'app/api';
 import Button from 'app/components/button';
 import TeamKeyTransaction, {
   TitleProps,
@@ -9,14 +11,8 @@ import {IconStar} from 'app/icons';
 import {t, tn} from 'app/locale';
 import {Organization, Team} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
+import withApi from 'app/utils/withApi';
 import withTeams from 'app/utils/withTeams';
-
-type Props = {
-  eventView: EventView;
-  organization: Organization;
-  teams: Team[];
-  transactionName: string;
-};
 
 /**
  * This can't be a function component because `TeamKeyTransaction` uses
@@ -38,17 +34,155 @@ class TitleButton extends Component<TitleProps> {
   }
 }
 
-function TeamKeyTransactionButton({eventView, teams, ...props}: Props) {
+type BaseProps = {
+  api: Client;
+  organization: Organization;
+  transactionName: string;
+  teams: Team[];
+};
+
+type Props = BaseProps & {
+  project: number;
+};
+
+type State = {
+  isLoading: boolean;
+  keyFetchID: symbol | undefined;
+  error: null | string;
+  keyedTeams: Set<string>;
+  counts: Map<string, number>;
+};
+
+class TeamKeyTransactionButton extends Component<Props, State> {
+  state: State = {
+    isLoading: true,
+    keyFetchID: undefined,
+    error: null,
+    keyedTeams: new Set(),
+    counts: new Map(),
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const orgSlugChanged = prevProps.organization.slug !== this.props.organization.slug;
+    const projectsChanged = prevProps.project !== this.props.project;
+    const transactionChanged = prevProps.transactionName !== this.props.transactionName;
+    if (orgSlugChanged || projectsChanged || transactionChanged) {
+      this.fetchData();
+    }
+  }
+
+  async fetchData() {
+    const keyFetchID = Symbol('keyFetchID');
+    this.setState({isLoading: true, keyFetchID});
+
+    try {
+      const [keyTransactions, counts] = await Promise.all([
+        this.fetchKeyTransactionsData(),
+        this.fetchCountData(),
+      ]);
+      this.setState({
+        isLoading: false,
+        keyFetchID: undefined,
+        error: null,
+        keyedTeams: new Set(keyTransactions.map(({team}) => team)),
+        counts: new Map(counts.map(({team, count}) => [team, count])),
+      });
+    } catch (err) {
+      this.setState({
+        isLoading: false,
+        keyFetchID: undefined,
+        error: err.responseJSON?.detail ?? null,
+      });
+    }
+  }
+
+  async fetchKeyTransactionsData() {
+    const {api, organization, project, transactionName} = this.props;
+
+    const url = `/organizations/${organization.slug}/key-transactions/`;
+    const [data] = await api.requestPromise(url, {
+      method: 'GET',
+      includeAllArgs: true,
+      query: {
+        project: String(project),
+        transaction: transactionName,
+      },
+    });
+    return data;
+  }
+
+  async fetchCountData() {
+    const {api, organization, teams} = this.props;
+
+    const url = `/organizations/${organization.slug}/key-transactions-count/`;
+    const [data] = await api.requestPromise(url, {
+      method: 'GET',
+      includeAllArgs: true,
+      query: {team: teams.map(({id}) => id)},
+    });
+    return data;
+  }
+
+  handleToggleKeyTransaction = async (
+    isKey: boolean,
+    teamIds: string[],
+    counts: Map<string, number>,
+    keyedTeams: Set<string>
+  ) => {
+    const {api, organization, project, transactionName} = this.props;
+    try {
+      await toggleKeyTransaction(
+        api,
+        isKey,
+        organization.slug,
+        [project],
+        transactionName,
+        teamIds
+      );
+      this.setState({
+        counts,
+        keyedTeams,
+      });
+    } catch (err) {
+      this.setState({
+        error: err.responseJSON?.detail ?? null,
+      });
+    }
+  };
+
+  render() {
+    const {isLoading, counts, keyedTeams} = this.state;
+    return (
+      <TeamKeyTransaction
+        isLoading={isLoading}
+        counts={counts}
+        keyedTeams={keyedTeams}
+        handleToggleKeyTransaction={this.handleToggleKeyTransaction}
+        title={TitleButton}
+        {...this.props}
+      />
+    );
+  }
+}
+
+type WrapperProps = BaseProps & {
+  eventView: EventView;
+};
+
+function TeamKeyTransactionButtonWrapper({eventView, teams, ...props}: WrapperProps) {
   if (eventView.project.length !== 1) {
     return <TitleButton disabled keyedTeamsCount={0} />;
   }
 
   const userTeams = teams.filter(({isMember}) => isMember);
   return (
-    <TeamKeyTransaction
+    <TeamKeyTransactionButton
       teams={userTeams}
       project={eventView.project[0]}
-      title={TitleButton}
       {...props}
     />
   );
@@ -58,4 +192,4 @@ const StyledButton = styled(Button)`
   width: 180px;
 `;
 
-export default withTeams(TeamKeyTransactionButton);
+export default withApi(withTeams(TeamKeyTransactionButtonWrapper));

--- a/tests/js/spec/views/performance/transactionSummary/teamKeyTransactionButton.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary/teamKeyTransactionButton.spec.jsx
@@ -2,8 +2,10 @@ import {Component} from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
-import TeamKeyTransaction from 'app/components/performance/teamKeyTransaction';
+import TeamStore from 'app/stores/teamStore';
+import EventView from 'app/utils/discover/eventView';
 import {MAX_TEAM_KEY_TRANSACTIONS} from 'app/utils/performance/constants';
+import TeamKeyTransactionButton from 'app/views/performance/transactionSummary/teamKeyTransactionButton';
 
 class TestButton extends Component {
   render() {
@@ -25,9 +27,22 @@ describe('TeamKeyTransaction', function () {
     TestStubs.Team({id: '1', slug: 'team1', name: 'Team 1'}),
     TestStubs.Team({id: '2', slug: 'team2', name: 'Team 2'}),
   ];
+  const eventView = new EventView({
+    id: '1',
+    name: 'my query',
+    fields: [{field: 'count()'}],
+    sorts: [{field: 'count', kind: 'desc'}],
+    query: '',
+    project: [project.id],
+    start: '2019-10-01T00:00:00',
+    end: '2019-10-02T00:00:00',
+    statsPeriod: '14d',
+    environment: [],
+  });
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
+    TeamStore.loadInitialData(teams);
   });
 
   describe('With no disabled', function () {
@@ -47,10 +62,9 @@ describe('TeamKeyTransaction', function () {
       });
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -85,10 +99,9 @@ describe('TeamKeyTransaction', function () {
       });
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -123,10 +136,9 @@ describe('TeamKeyTransaction', function () {
       });
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -176,10 +188,9 @@ describe('TeamKeyTransaction', function () {
       );
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -223,10 +234,9 @@ describe('TeamKeyTransaction', function () {
       );
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -271,10 +281,9 @@ describe('TeamKeyTransaction', function () {
       );
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -329,10 +338,9 @@ describe('TeamKeyTransaction', function () {
       );
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -378,10 +386,9 @@ describe('TeamKeyTransaction', function () {
       });
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />
@@ -413,10 +420,9 @@ describe('TeamKeyTransaction', function () {
       });
 
       const wrapper = mountWithTheme(
-        <TeamKeyTransaction
-          project={project.id}
+        <TeamKeyTransactionButton
+          eventView={eventView}
           organization={organization}
-          teams={teams}
           transactionName="transaction"
           title={TestButton}
         />


### PR DESCRIPTION
This lifts the stateful parts of the team key transaction dropdown to the parent
component so it can be reused on else where.