### PR TITLE
fix(GithubEnterpriseIntegration): Adding Authorization-header for installations-request

### DIFF
--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -311,7 +311,6 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
 
         resp = session.get(
             "https://{}/api/v3/user/installations".format(installation_data["url"]),
-            params={"access_token": access_token},
             headers={
                 "Accept": "application/vnd.github.machine-man-preview+json",
                 "Authorization": "token {}".format(access_token)

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -313,7 +313,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             "https://{}/api/v3/user/installations".format(installation_data["url"]),
             headers={
                 "Accept": "application/vnd.github.machine-man-preview+json",
-                f"Authorization": "token {access_token}",
+                "Authorization": f"token {access_token}",
             },
             verify=installation_data["verify_ssl"],
         )

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -313,7 +313,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             "https://{}/api/v3/user/installations".format(installation_data["url"]),
             headers={
                 "Accept": "application/vnd.github.machine-man-preview+json",
-                "Authorization": "token {}".format(access_token)
+                "Authorization": "token {}".format(access_token),
             },
             verify=installation_data["verify_ssl"],
         )

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -312,7 +312,10 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         resp = session.get(
             "https://{}/api/v3/user/installations".format(installation_data["url"]),
             params={"access_token": access_token},
-            headers={"Accept": "application/vnd.github.machine-man-preview+json"},
+            headers={
+                "Accept": "application/vnd.github.machine-man-preview+json",
+                "Authorization": "token {}".format(access_token)
+            },
             verify=installation_data["verify_ssl"],
         )
         resp.raise_for_status()

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -313,7 +313,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             "https://{}/api/v3/user/installations".format(installation_data["url"]),
             headers={
                 "Accept": "application/vnd.github.machine-man-preview+json",
-                "Authorization": "token {}".format(access_token),
+                f"Authorization": "token {access_token}",
             },
             verify=installation_data["verify_ssl"],
         )

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -97,7 +97,8 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         responses.add(
             responses.GET,
             self.base_url + "/user/installations",
-            json={"installations": [{"id": installation_id}], match_querystring=True},
+            json={"installations": [{"id": installation_id}]},
+            match_querystring=True,
         )
 
         resp = self.client.get(

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -97,7 +97,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         responses.add(
             responses.GET,
             self.base_url + "/user/installations",
-            json={"installations": [{"id": installation_id}]},
+            json={"installations": [{"id": installation_id}], match_querystring=True},
         )
 
         resp = self.client.get(


### PR DESCRIPTION
GitHub Enterprise has deprecated using `access_token` only in querystring.

Response from newer versions:
```json
{
    "message": "Must specify access token via Authorization header",
    "documentation_url": "https://docs.github.com/enterprise/3.0/v3/#oauth2-token-sent-in-a-header"
}
```