### PR TITLE
ref(snql) Remove str cast of number

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -297,16 +297,7 @@ def query_facet_performance(
             [
                 "divide",
                 [
-                    [
-                        "sum",
-                        [
-                            "minus",
-                            [
-                                translated_aggregate_column,
-                                str(transaction_aggregate),
-                            ],
-                        ],
-                    ],
+                    ["sum", ["minus", [translated_aggregate_column, transaction_aggregate]]],
                     frequency_sample_rate,
                 ],
                 "sumdelta",
@@ -314,13 +305,7 @@ def query_facet_performance(
             ["count", [], "count"],
             [
                 "divide",
-                [
-                    [
-                        "divide",
-                        [["count", []], frequency_sample_rate],
-                    ],
-                    transaction_count,
-                ],
+                [["divide", [["count", []], frequency_sample_rate]], transaction_count],
                 "frequency",
             ],
             ["divide", ["aggregate", transaction_aggregate], "comparison"],


### PR DESCRIPTION
I can't find a reason why `transaction_aggregate` was being cast into a string,
and casting a number to a string makes it really difficult for SnQL to figure
out what it's supposed to be sending. Remove the cast.