### PR TITLE
ref(killswitches): Remove usage of $EDITOR, fix bugs

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -27,14 +27,14 @@ class KillswitchInfo:
 
 
 ALL_KILLSWITCH_OPTIONS = {
-    "store.load-shed-group-creation-projects": KillswitchInfo(  # type: ignore
+    "store.load-shed-group-creation-projects": KillswitchInfo(
         description="Drop event in save_event before entering transaction to create group",
         fields={
             "project_id": "A project ID to filter events by.",
             "platform": "The event platform as defined in the event payload's platform field.",
         },
     ),
-    "store.load-shed-pipeline-projects": KillswitchInfo(  # type: ignore
+    "store.load-shed-pipeline-projects": KillswitchInfo(
         description="Drop event in ingest consumer. Available fields are severely restricted because nothing is parsed yet.",
         fields={
             "project_id": "A project ID to filter events by.",
@@ -42,7 +42,7 @@ ALL_KILLSWITCH_OPTIONS = {
             "has_attachments": "Filter events by whether they have been sent together with attachments or not. Note that attachments can be sent completely separately as well.",
         },
     ),
-    "store.load-shed-parsed-pipeline-projects": KillswitchInfo(  # type: ignore
+    "store.load-shed-parsed-pipeline-projects": KillswitchInfo(
         description="Drop events in ingest consumer after parsing them. Available fields are more but a bunch of stuff can go wrong before that.",
         fields={
             "organization_id": "Numeric organization ID to filter events by.",
@@ -52,7 +52,7 @@ ALL_KILLSWITCH_OPTIONS = {
             "event_id": "An event ID as given in the event payload.",
         },
     ),
-    "store.load-shed-process-event-projects": KillswitchInfo(  # type: ignore
+    "store.load-shed-process-event-projects": KillswitchInfo(
         description="Drop events in process_event.",
         fields={
             "project_id": "A project ID to filter events by.",
@@ -60,7 +60,7 @@ ALL_KILLSWITCH_OPTIONS = {
             "platform": "The event platform as defined in the event payload's platform field.",
         },
     ),
-    "store.load-shed-symbolicate-event-projects": KillswitchInfo(  # type: ignore
+    "store.load-shed-symbolicate-event-projects": KillswitchInfo(
         description="Drop events in symbolicate_event.",
         fields={
             "project_id": "A project ID to filter events by.",

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -109,7 +109,7 @@ def killswitch_matches_context(killswitch_name: str, context: Context) -> bool:
     option_value = options.get(killswitch_name)
     rv = _value_matches(killswitch_name, option_value, context)
     metrics.incr(
-        "sentry.killswitches.run",
+        "killswitches.run",
         tags={"killswitch_name": killswitch_name, "decision": "matched" if rv else "passed"},
     )
 

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -8,7 +8,7 @@ features and more performant.
 """
 
 import copy
-from collections import namedtuple
+from dataclasses import dataclass
 from typing import Any, Dict, List, Union
 
 from sentry import options
@@ -19,75 +19,107 @@ KillswitchConfig = List[Condition]
 LegacyKillswitchConfig = Union[KillswitchConfig, List[int]]
 Context = Dict[str, Any]
 
-KillswitchInfo = namedtuple("KillswitchInfo", ["description", "fields"])
+
+@dataclass
+class KillswitchInfo:
+    description: str
+    fields: Dict[str, str]
+
 
 ALL_KILLSWITCH_OPTIONS = {
-    "store.load-shed-group-creation-projects": KillswitchInfo(
+    "store.load-shed-group-creation-projects": KillswitchInfo(  # type: ignore
         description="Drop event in save_event before entering transaction to create group",
-        fields=("project_id", "platform"),
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "platform": "The event platform as defined in the event payload's platform field.",
+        },
     ),
-    "store.load-shed-pipeline-projects": KillswitchInfo(
+    "store.load-shed-pipeline-projects": KillswitchInfo(  # type: ignore
         description="Drop event in ingest consumer. Available fields are severely restricted because nothing is parsed yet.",
-        fields=("project_id", "event_id", "has_attachments"),
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "event_id": "An event ID as given in the event payload.",
+            "has_attachments": "Filter events by whether they have been sent together with attachments or not. Note that attachments can be sent completely separately as well.",
+        },
     ),
-    "store.load-shed-parsed-pipeline-projects": KillswitchInfo(
+    "store.load-shed-parsed-pipeline-projects": KillswitchInfo(  # type: ignore
         description="Drop events in ingest consumer after parsing them. Available fields are more but a bunch of stuff can go wrong before that.",
-        fields=("organization_id", "project_id", "event_type", "has_attachments", "event_id"),
+        fields={
+            "organization_id": "Numeric organization ID to filter events by.",
+            "project_id": "A project ID to filter events by.",
+            "event_type": "transaction, csp, hpkp, expectct, expectstaple, transaction, default or null",
+            "has_attachments": "Filter events by whether they have been sent together with attachments or not. Note that attachments can be sent completely separately as well.",
+            "event_id": "An event ID as given in the event payload.",
+        },
     ),
-    "store.load-shed-process-event-projects": KillswitchInfo(
+    "store.load-shed-process-event-projects": KillswitchInfo(  # type: ignore
         description="Drop events in process_event.",
-        fields=("project_id", "event_id", "platform"),
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "event_id": "An event ID as given in the event payload.",
+            "platform": "The event platform as defined in the event payload's platform field.",
+        },
     ),
-    "store.load-shed-symbolicate-event-projects": KillswitchInfo(
+    "store.load-shed-symbolicate-event-projects": KillswitchInfo(  # type: ignore
         description="Drop events in symbolicate_event.",
-        fields=("project_id", "event_id", "platform"),
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "event_id": "An event ID as given in the event payload.",
+            "platform": "The event platform as defined in the event payload's platform field.",
+        },
     ),
 }
 
 
 def validate_user_input(killswitch_name: str, option_value: Any) -> KillswitchConfig:
-    for condition in option_value:
-        valid_options = set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields)
-        used_options = set(condition)
-        if valid_options - used_options:
-            raise ValueError(f"Missing fields: {valid_options - used_options}")
-
-        if used_options - valid_options:
-            raise ValueError(f"Unknown fields: {used_options - valid_options}")
-
-    return normalize_value(option_value)
+    return normalize_value(killswitch_name, option_value, strict=True)
 
 
-def normalize_value(option_value: Any) -> KillswitchConfig:
+def normalize_value(
+    killswitch_name: str, option_value: Any, strict: bool = False
+) -> KillswitchConfig:
     rv = []
-    for condition in option_value:
+    for condition in option_value or ():
         if not condition:
             continue
         elif isinstance(condition, int):
             rv.append({"project_id": str(condition)})
         elif isinstance(condition, dict):
-            condition = {k: str(v) for k, v in condition.items() if v is not None}
-            if condition:
+            for k in ALL_KILLSWITCH_OPTIONS[killswitch_name].fields:
+                if k not in condition:
+                    if strict:
+                        raise ValueError(f"Missing field {k}")
+                    else:
+                        condition[k] = None
+
+            if strict:
+                for k in list(condition):
+                    if k not in ALL_KILLSWITCH_OPTIONS[killswitch_name].fields:
+                        raise ValueError(f"Unknown field: {k}")
+
+            if any(v is not None for v in condition.values()):
                 rv.append(condition)
 
     return rv
 
 
-def killswitch_matches_context(option_key: str, context: Context) -> bool:
-    assert option_key in ALL_KILLSWITCH_OPTIONS
-    assert set(ALL_KILLSWITCH_OPTIONS[option_key].fields) == set(context)
-    option_value = options.get(option_key)
-    rv = _value_matches(option_value, context)
+def killswitch_matches_context(killswitch_name: str, context: Context) -> bool:
+    assert killswitch_name in ALL_KILLSWITCH_OPTIONS
+    assert set(ALL_KILLSWITCH_OPTIONS[killswitch_name].fields) == set(context)
+    option_value = options.get(killswitch_name)
+    rv = _value_matches(killswitch_name, option_value, context)
     metrics.incr(
         "sentry.killswitches.run",
-        tags={"option_key": option_key, "decision": "matched" if rv else "passed"},
+        tags={"killswitch_name": killswitch_name, "decision": "matched" if rv else "passed"},
     )
 
     return rv
 
 
-def _value_matches(raw_option_value: LegacyKillswitchConfig, context: Context) -> bool:
-    option_value = normalize_value(raw_option_value)
+def _value_matches(
+    killswitch_name: str, raw_option_value: LegacyKillswitchConfig, context: Context
+) -> bool:
+    option_value = normalize_value(killswitch_name, raw_option_value)
 
     for condition in option_value:
         for field, matching_value in condition.items():
@@ -103,31 +135,35 @@ def _value_matches(raw_option_value: LegacyKillswitchConfig, context: Context) -
     return False
 
 
-def print_conditions(raw_option_value: LegacyKillswitchConfig) -> str:
-    option_value = normalize_value(raw_option_value)
+def print_conditions(killswitch_name: str, raw_option_value: LegacyKillswitchConfig) -> str:
+    option_value = normalize_value(killswitch_name, raw_option_value)
 
     if not option_value:
         return "<disabled entirely>"
 
     return "DROP DATA WHERE\n  " + " OR\n  ".join(
         "("
-        + " AND ".join(f"{field} = {matching_value}" for field, matching_value in condition.items())
+        + " AND ".join(
+            f"{field} = {matching_value}"
+            for field, matching_value in condition.items()
+            if matching_value is not None
+        )
         + ")"
         for condition in option_value
     )
 
 
 def add_condition(
-    raw_option_value: LegacyKillswitchConfig, condition: Condition
+    killswitch_name: str, raw_option_value: LegacyKillswitchConfig, condition: Condition
 ) -> KillswitchConfig:
-    option_value = copy.deepcopy(normalize_value(raw_option_value))
+    option_value = copy.deepcopy(normalize_value(killswitch_name, raw_option_value))
     option_value.append(condition)
-    return normalize_value(option_value)
+    return normalize_value(killswitch_name, option_value)
 
 
 def remove_condition(
-    raw_option_value: LegacyKillswitchConfig, condition: Condition
+    killswitch_name: str, raw_option_value: LegacyKillswitchConfig, condition: Condition
 ) -> KillswitchConfig:
-    option_value = copy.deepcopy(normalize_value(raw_option_value))
+    option_value = copy.deepcopy(normalize_value(killswitch_name, raw_option_value))
     option_value = [m for m in option_value if m != condition]
-    return normalize_value(option_value)
+    return normalize_value(killswitch_name, option_value)

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -123,6 +123,9 @@ def _value_matches(
 
     for condition in option_value:
         for field, matching_value in condition.items():
+            if matching_value is None:
+                continue
+
             value = context.get(field)
             if value is None:
                 break

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -9,12 +9,12 @@ features and more performant.
 
 import copy
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from sentry import options
 from sentry.utils import metrics
 
-Condition = Dict[str, str]
+Condition = Dict[str, Optional[str]]
 KillswitchConfig = List[Condition]
 LegacyKillswitchConfig = Union[KillswitchConfig, List[int]]
 Context = Dict[str, Any]
@@ -78,7 +78,7 @@ def validate_user_input(killswitch_name: str, option_value: Any) -> KillswitchCo
 def normalize_value(
     killswitch_name: str, option_value: Any, strict: bool = False
 ) -> KillswitchConfig:
-    rv = []
+    rv: KillswitchConfig = []
     for i, condition in enumerate(option_value or ()):
         if not condition:
             continue

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -79,7 +79,7 @@ def normalize_value(
     killswitch_name: str, option_value: Any, strict: bool = False
 ) -> KillswitchConfig:
     rv = []
-    for condition in option_value or ():
+    for i, condition in enumerate(option_value or ()):
         if not condition:
             continue
         elif isinstance(condition, int):
@@ -88,14 +88,14 @@ def normalize_value(
             for k in ALL_KILLSWITCH_OPTIONS[killswitch_name].fields:
                 if k not in condition:
                     if strict:
-                        raise ValueError(f"Missing field {k}")
+                        raise ValueError(f"Condition {i}: Missing field {k}")
                     else:
                         condition[k] = None
 
             if strict:
                 for k in list(condition):
                     if k not in ALL_KILLSWITCH_OPTIONS[killswitch_name].fields:
-                        raise ValueError(f"Unknown field: {k}")
+                        raise ValueError(f"Condition {i}: Unknown field: {k}")
 
             if any(v is not None for v in condition.values()):
                 rv.append(condition)

--- a/src/sentry/runner/commands/killswitches.py
+++ b/src/sentry/runner/commands/killswitches.py
@@ -31,7 +31,7 @@ def _get_edit_template(killswitch_name: str, option_value) -> str:
     ):
         for j, line in enumerate(textwrap.wrap(description)):
             comments.append(f"{' ' if i or j else '-'} # {line}")
-        comments.append(f"  {field}: ~")
+        comments.append(f"  {field}: null")
 
     edit_text = "\n".join(f"# {line}" for line in comments)
 

--- a/src/sentry/runner/commands/killswitches.py
+++ b/src/sentry/runner/commands/killswitches.py
@@ -19,8 +19,8 @@ def _get_edit_template(killswitch_name: str, option_value) -> str:
         f"{killswitch_name}: {killswitches.ALL_KILLSWITCH_OPTIONS[killswitch_name].description}",
         "After saving and exiting, your killswitch conditions will be printed in faux-SQL "
         "for you to confirm.",
-        "Below a template is given for a single block. The block's fields "
-        "will be joined with AND, while all blocks will be joined with OR. "
+        "Below a template is given for a single condition. The condition's fields "
+        "will be joined with AND, while all conditions will be joined with OR. "
         "All fields need to be set, but can be set to null/~, which is a wildcard.",
     ]
 
@@ -88,12 +88,16 @@ def _push(killswitch_name, infile, yes):
     option_value = options.get(killswitch_name)
 
     edited_text = infile.read()
-    new_option_value = killswitches.validate_user_input(
-        killswitch_name, yaml.safe_load(edited_text)
-    )
+    try:
+        new_option_value = killswitches.validate_user_input(
+            killswitch_name, yaml.safe_load(edited_text)
+        )
+    except ValueError as e:
+        click.echo(f"Invalid data: {e}")
+        raise click.Abort()
 
     if option_value == new_option_value:
-        click.echo("No changes!")
+        click.echo("No changes!", err=True)
         raise click.Abort()
 
     click.echo("Before:")

--- a/tests/sentry/runner/commands/test_killswitches.py
+++ b/tests/sentry/runner/commands/test_killswitches.py
@@ -22,21 +22,24 @@ class KillswitchesTest(CliTestCase):
             "\n" "store.load-shed-group-creation-projects\n" "  # hey\n" "<disabled entirely>\n"
         )
 
-        assert self.invoke("pull", OPTION, "-").output == (
+        PREAMBLE = (
             "# store.load-shed-group-creation-projects: hey\n"
             "# \n"
             "# After saving and exiting, your killswitch conditions will be printed\n"
             "# in faux-SQL for you to confirm.\n"
             "# \n"
-            "# Below a template is given for a single block. The block's fields will\n"
-            "# be joined with AND, while all blocks will be joined with OR. All\n"
-            "# fields need to be set, but can be set to null/~, which is a wildcard.\n"
+            "# Below a template is given for a single condition. The condition's\n"
+            "# fields will be joined with AND, while all conditions will be joined\n"
+            "# with OR. All fields need to be set, but can be set to null/~, which is\n"
+            "# a wildcard.\n"
             "# \n"
             "# - # ho\n"
-            "#   event_type: ~\n"
+            "#   event_type: null\n"
             "#   # hey\n"
-            "#   project_id: ~"
+            "#   project_id: null"
         )
+
+        assert self.invoke("pull", OPTION, "-").output == PREAMBLE
 
         rv = self.invoke(
             "push", "--yes", OPTION, "-", input=("- project_id: 42\n  event_type: transaction\n")
@@ -50,23 +53,8 @@ class KillswitchesTest(CliTestCase):
             "  (project_id = 42 AND event_type = transaction)\n"
         )
 
-        assert self.invoke("pull", OPTION, "-").output == (
-            "# store.load-shed-group-creation-projects: hey\n"
-            "# \n"
-            "# After saving and exiting, your killswitch conditions will be printed\n"
-            "# in faux-SQL for you to confirm.\n"
-            "# \n"
-            "# Below a template is given for a single block. The block's fields will\n"
-            "# be joined with AND, while all blocks will be joined with OR. All\n"
-            "# fields need to be set, but can be set to null/~, which is a wildcard.\n"
-            "# \n"
-            "# - # ho\n"
-            "#   event_type: ~\n"
-            "#   # hey\n"
-            "#   project_id: ~\n"
-            "\n"
-            "- event_type: transaction\n"
-            "  project_id: 42\n"
+        assert self.invoke("pull", OPTION, "-").output == PREAMBLE + (
+            "\n" "\n" "- event_type: transaction\n" "  project_id: 42\n"
         )
 
         rv = self.invoke(
@@ -91,20 +79,8 @@ class KillswitchesTest(CliTestCase):
             "  (project_id = 43)\n"
         )
 
-        assert self.invoke("pull", OPTION, "-").output == (
-            "# store.load-shed-group-creation-projects: hey\n"
-            "# \n"
-            "# After saving and exiting, your killswitch conditions will be printed\n"
-            "# in faux-SQL for you to confirm.\n"
-            "# \n"
-            "# Below a template is given for a single block. The block's fields will\n"
-            "# be joined with AND, while all blocks will be joined with OR. All\n"
-            "# fields need to be set, but can be set to null/~, which is a wildcard.\n"
-            "# \n"
-            "# - # ho\n"
-            "#   event_type: ~\n"
-            "#   # hey\n"
-            "#   project_id: ~\n"
+        assert self.invoke("pull", OPTION, "-").output == PREAMBLE + (
+            "\n"
             "\n"
             "- event_type: transaction\n"
             "  project_id: 42\n"
@@ -123,3 +99,5 @@ class KillswitchesTest(CliTestCase):
         assert self.invoke("list").output == (
             "\n" "store.load-shed-group-creation-projects\n" "  # hey\n" "<disabled entirely>\n"
         )
+
+        assert self.invoke("pull", OPTION, "-").output == PREAMBLE

--- a/tests/sentry/runner/commands/test_killswitches.py
+++ b/tests/sentry/runner/commands/test_killswitches.py
@@ -11,17 +11,36 @@ class KillswitchesTest(CliTestCase):
 
     @mock.patch(
         "sentry.killswitches.ALL_KILLSWITCH_OPTIONS",
-        {OPTION: KillswitchInfo(description="hey", fields=("project_id", "event_type"))},
+        {
+            OPTION: KillswitchInfo(
+                description="hey", fields={"project_id": "hey", "event_type": "ho"}
+            )
+        },
     )
-    @mock.patch("click.edit")
-    def test_basic(self, mock_edit):
+    def test_basic(self):
         assert self.invoke("list").output == (
             "\n" "store.load-shed-group-creation-projects\n" "  # hey\n" "<disabled entirely>\n"
         )
 
-        mock_edit.return_value = "- project_id: 42\n" "  event_type: transaction\n"
+        assert self.invoke("pull", OPTION, "-").output == (
+            "# store.load-shed-group-creation-projects: hey\n"
+            "# \n"
+            "# After saving and exiting, your killswitch conditions will be printed\n"
+            "# in faux-SQL for you to confirm.\n"
+            "# \n"
+            "# Below a template is given for a single block. The block's fields will\n"
+            "# be joined with AND, while all blocks will be joined with OR. All\n"
+            "# fields need to be set, but can be set to null/~, which is a wildcard.\n"
+            "# \n"
+            "# - # ho\n"
+            "#   event_type: ~\n"
+            "#   # hey\n"
+            "#   project_id: ~"
+        )
 
-        rv = self.invoke("edit", OPTION, input="y\n")
+        rv = self.invoke(
+            "push", "--yes", OPTION, "-", input=("- project_id: 42\n  event_type: transaction\n")
+        )
         assert rv.exit_code == 0
         assert self.invoke("list").output == (
             "\n"
@@ -31,17 +50,36 @@ class KillswitchesTest(CliTestCase):
             "  (project_id = 42 AND event_type = transaction)\n"
         )
 
-        mock_edit.return_value = (
-            "- project_id: 42\n"
-            "  event_type: transaction\n"
-            "- project_id: 43\n"
-            "  event_type: ~\n"
+        assert self.invoke("pull", OPTION, "-").output == (
+            "# store.load-shed-group-creation-projects: hey\n"
+            "# \n"
+            "# After saving and exiting, your killswitch conditions will be printed\n"
+            "# in faux-SQL for you to confirm.\n"
+            "# \n"
+            "# Below a template is given for a single block. The block's fields will\n"
+            "# be joined with AND, while all blocks will be joined with OR. All\n"
+            "# fields need to be set, but can be set to null/~, which is a wildcard.\n"
+            "# \n"
+            "# - # ho\n"
+            "#   event_type: ~\n"
+            "#   # hey\n"
+            "#   project_id: ~\n"
+            "\n"
+            "- event_type: transaction\n"
+            "  project_id: 42\n"
         )
 
         rv = self.invoke(
-            "edit",
+            "push",
+            "--yes",
             OPTION,
-            input="y\n",
+            "-",
+            input=(
+                "- project_id: 42\n"
+                "  event_type: transaction\n"
+                "- project_id: 43\n"
+                "  event_type: ~\n"
+            ),
         )
         assert rv.exit_code == 0
         assert self.invoke("list").output == (
@@ -51,4 +89,37 @@ class KillswitchesTest(CliTestCase):
             "DROP DATA WHERE\n"
             "  (project_id = 42 AND event_type = transaction) OR\n"
             "  (project_id = 43)\n"
+        )
+
+        assert self.invoke("pull", OPTION, "-").output == (
+            "# store.load-shed-group-creation-projects: hey\n"
+            "# \n"
+            "# After saving and exiting, your killswitch conditions will be printed\n"
+            "# in faux-SQL for you to confirm.\n"
+            "# \n"
+            "# Below a template is given for a single block. The block's fields will\n"
+            "# be joined with AND, while all blocks will be joined with OR. All\n"
+            "# fields need to be set, but can be set to null/~, which is a wildcard.\n"
+            "# \n"
+            "# - # ho\n"
+            "#   event_type: ~\n"
+            "#   # hey\n"
+            "#   project_id: ~\n"
+            "\n"
+            "- event_type: transaction\n"
+            "  project_id: 42\n"
+            "- event_type: null\n"
+            "  project_id: 43\n"
+        )
+
+        rv = self.invoke(
+            "push",
+            "--yes",
+            OPTION,
+            "-",
+            input="\n",
+        )
+        assert rv.exit_code == 0
+        assert self.invoke("list").output == (
+            "\n" "store.load-shed-group-creation-projects\n" "  # hey\n" "<disabled entirely>\n"
         )

--- a/tests/sentry/runner/commands/test_killswitches.py
+++ b/tests/sentry/runner/commands/test_killswitches.py
@@ -13,17 +13,20 @@ class KillswitchesTest(CliTestCase):
         "sentry.killswitches.ALL_KILLSWITCH_OPTIONS",
         {
             OPTION: KillswitchInfo(
-                description="hey", fields={"project_id": "hey", "event_type": "ho"}
+                description="the description", fields={"project_id": "hey", "event_type": "ho"}
             )
         },
     )
     def test_basic(self):
         assert self.invoke("list").output == (
-            "\n" "store.load-shed-group-creation-projects\n" "  # hey\n" "<disabled entirely>\n"
+            "\n"
+            "store.load-shed-group-creation-projects\n"
+            "  # the description\n"
+            "<disabled entirely>\n"
         )
 
         PREAMBLE = (
-            "# store.load-shed-group-creation-projects: hey\n"
+            "# store.load-shed-group-creation-projects: the description\n"
             "# \n"
             "# After saving and exiting, your killswitch conditions will be printed\n"
             "# in faux-SQL for you to confirm.\n"
@@ -48,7 +51,7 @@ class KillswitchesTest(CliTestCase):
         assert self.invoke("list").output == (
             "\n"
             "store.load-shed-group-creation-projects\n"
-            "  # hey\n"
+            "  # the description\n"
             "DROP DATA WHERE\n"
             "  (project_id = 42 AND event_type = transaction)\n"
         )
@@ -73,7 +76,7 @@ class KillswitchesTest(CliTestCase):
         assert self.invoke("list").output == (
             "\n"
             "store.load-shed-group-creation-projects\n"
-            "  # hey\n"
+            "  # the description\n"
             "DROP DATA WHERE\n"
             "  (project_id = 42 AND event_type = transaction) OR\n"
             "  (project_id = 43)\n"
@@ -97,7 +100,10 @@ class KillswitchesTest(CliTestCase):
         )
         assert rv.exit_code == 0
         assert self.invoke("list").output == (
-            "\n" "store.load-shed-group-creation-projects\n" "  # hey\n" "<disabled entirely>\n"
+            "\n"
+            "store.load-shed-group-creation-projects\n"
+            "  # the description\n"
+            "<disabled entirely>\n"
         )
 
         assert self.invoke("pull", OPTION, "-").output == PREAMBLE

--- a/tests/sentry/test_killswitches.py
+++ b/tests/sentry/test_killswitches.py
@@ -2,7 +2,7 @@ from sentry.killswitches import _value_matches, normalize_value
 
 
 def test_normalize_value():
-    assert normalize_value([1, 2, 3]) == [
+    assert normalize_value("store.load-shed-group-creation-projects", [1, 2, 3]) == [
         {"project_id": "1"},
         {"project_id": "2"},
         {"project_id": "3"},
@@ -11,6 +11,7 @@ def test_normalize_value():
 
 def test_value_matches():
     assert _value_matches(
+        "store.load-shed-group-creation-projects",
         [
             {"project_id": "1"},
             {"project_id": "2"},
@@ -20,6 +21,7 @@ def test_value_matches():
     )
 
     assert not _value_matches(
+        "store.load-shed-group-creation-projects",
         [
             {"project_id": "1"},
             {"project_id": "2"},
@@ -28,11 +30,12 @@ def test_value_matches():
         {"project_id": 4},
     )
 
-    assert not _value_matches([], {"project_id": 3})
+    assert not _value_matches("store.load-shed-group-creation-projects", [], {"project_id": 3})
 
-    assert not _value_matches([{}], {"project_id": 3})
+    assert not _value_matches("store.load-shed-group-creation-projects", [{}], {"project_id": 3})
 
     assert not _value_matches(
+        "store.load-shed-group-creation-projects",
         [
             {"project_id": "1"},
             {"project_id": "2"},
@@ -41,8 +44,12 @@ def test_value_matches():
         {},
     )
 
-    assert not _value_matches([{"project_id": None}], {"project_id": 3})  # type: ignore
+    assert not _value_matches(
+        "store.load-shed-group-creation-projects", [{"project_id": None}], {"project_id": 3}
+    )  # type: ignore
 
     assert _value_matches(
-        [{"event_type": "transaction"}], {"project_id": 3, "event_type": "transaction"}
+        "store.load-shed-group-creation-projects",
+        [{"event_type": "transaction"}],
+        {"project_id": 3, "event_type": "transaction"},
     )


### PR DESCRIPTION
We found it was inergonomic to use vim or any editor from within Docker.
Instead, have two separate commands for getting and setting the file
contents.

Instead of running `sentry killswitches edit foo`, one runs:

```
sentry killswitches pull foo foo.txt
nano foo.txt
sentry killswitches push foo foo.txt
```

Also fix a couple of bugs:

* null-fields didn't roundtrip correctly.
* better examples