### PR TITLE
feat(growth): modify hook for disabled member and add prop to hide items in the sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -558,7 +558,7 @@ const responsiveFlex = css`
   }
 `;
 
-const StyledSidebar = styled('div')<{collapsed: boolean}>`
+export const StyledSidebar = styled('div')<{collapsed: boolean}>`
   background: ${p => p.theme.sidebar.background};
   background: ${p => p.theme.sidebarGradient};
   color: ${p => p.theme.sidebar.color};

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -31,9 +31,19 @@ type Props = Pick<CommonSidebarProps, 'orientation' | 'collapsed'> & {
   org: Organization;
   user: User;
   config: Config;
+  //set to true for deactivated members so we can hide links they cannot access
+  hideInternalLinks?: boolean;
 };
 
-const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props) => {
+const SidebarDropdown = ({
+  api,
+  org,
+  orientation,
+  collapsed,
+  config,
+  user,
+  hideInternalLinks,
+}: Props) => {
   const handleLogout = async () => {
     await logout(api);
     window.location.assign('/auth/login/');
@@ -93,24 +103,26 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
               {hasOrganization && (
                 <Fragment>
                   <SidebarOrgSummary organization={org} />
-                  {hasOrgRead && (
+                  {hasOrgRead && !hideInternalLinks && (
                     <SidebarMenuItem to={`/settings/${org.slug}/`}>
                       {t('Organization settings')}
                     </SidebarMenuItem>
                   )}
-                  {hasMemberRead && (
+                  {hasMemberRead && !hideInternalLinks && (
                     <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
                       {t('Members')}
                     </SidebarMenuItem>
                   )}
 
-                  {hasTeamRead && (
+                  {hasTeamRead && !hideInternalLinks && (
                     <SidebarMenuItem to={`/settings/${org.slug}/teams/`}>
                       {t('Teams')}
                     </SidebarMenuItem>
                   )}
 
-                  <Hook name="sidebar:organization-dropdown-menu" organization={org} />
+                  {!hideInternalLinks && (
+                    <Hook name="sidebar:organization-dropdown-menu" organization={org} />
+                  )}
 
                   {!config.singleOrganization && (
                     <SidebarMenuItem>
@@ -130,18 +142,22 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
                     </UserSummary>
 
                     <div>
-                      <SidebarMenuItem to="/settings/account/">
-                        {t('User settings')}
-                      </SidebarMenuItem>
-                      <SidebarMenuItem to="/settings/account/api/">
-                        {t('API keys')}
-                      </SidebarMenuItem>
-                      <Hook
-                        name="sidebar:organization-dropdown-menu-bottom"
-                        organization={org}
-                      />
-                      {user.isSuperuser && (
-                        <SidebarMenuItem to="/manage/">{t('Admin')}</SidebarMenuItem>
+                      {!hideInternalLinks && (
+                        <Fragment>
+                          <SidebarMenuItem to="/settings/account/">
+                            {t('User settings')}
+                          </SidebarMenuItem>
+                          <SidebarMenuItem to="/settings/account/api/">
+                            {t('API keys')}
+                          </SidebarMenuItem>
+                          <Hook
+                            name="sidebar:organization-dropdown-menu-bottom"
+                            organization={org}
+                          />
+                          {user.isSuperuser && (
+                            <SidebarMenuItem to="/manage/">{t('Admin')}</SidebarMenuItem>
+                          )}
+                        </Fragment>
                       )}
                       <SidebarMenuItem
                         data-test-id="sidebarSignout"

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -26,13 +26,16 @@ import {CommonSidebarProps} from '../types';
 import Divider from './divider.styled';
 import SwitchOrganization from './switchOrganization';
 
+//TODO: make org and user optional props
 type Props = Pick<CommonSidebarProps, 'orientation' | 'collapsed'> & {
   api: Client;
   org: Organization;
   user: User;
   config: Config;
-  //set to true for deactivated members so we can hide links they cannot access
-  hideInternalLinks?: boolean;
+  /**
+   * Set to true to hide links within the organization
+   */
+  hideOrgLinks?: boolean;
 };
 
 const SidebarDropdown = ({
@@ -42,7 +45,7 @@ const SidebarDropdown = ({
   collapsed,
   config,
   user,
-  hideInternalLinks,
+  hideOrgLinks,
 }: Props) => {
   const handleLogout = async () => {
     await logout(api);
@@ -103,25 +106,30 @@ const SidebarDropdown = ({
               {hasOrganization && (
                 <Fragment>
                   <SidebarOrgSummary organization={org} />
-                  {hasOrgRead && !hideInternalLinks && (
-                    <SidebarMenuItem to={`/settings/${org.slug}/`}>
-                      {t('Organization settings')}
-                    </SidebarMenuItem>
-                  )}
-                  {hasMemberRead && !hideInternalLinks && (
-                    <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
-                      {t('Members')}
-                    </SidebarMenuItem>
-                  )}
+                  {!hideOrgLinks && (
+                    <Fragment>
+                      {hasOrgRead && (
+                        <SidebarMenuItem to={`/settings/${org.slug}/`}>
+                          {t('Organization settings')}
+                        </SidebarMenuItem>
+                      )}
+                      {hasMemberRead && (
+                        <SidebarMenuItem to={`/settings/${org.slug}/members/`}>
+                          {t('Members')}
+                        </SidebarMenuItem>
+                      )}
 
-                  {hasTeamRead && !hideInternalLinks && (
-                    <SidebarMenuItem to={`/settings/${org.slug}/teams/`}>
-                      {t('Teams')}
-                    </SidebarMenuItem>
-                  )}
+                      {hasTeamRead && (
+                        <SidebarMenuItem to={`/settings/${org.slug}/teams/`}>
+                          {t('Teams')}
+                        </SidebarMenuItem>
+                      )}
 
-                  {!hideInternalLinks && (
-                    <Hook name="sidebar:organization-dropdown-menu" organization={org} />
+                      <Hook
+                        name="sidebar:organization-dropdown-menu"
+                        organization={org}
+                      />
+                    </Fragment>
                   )}
 
                   {!config.singleOrganization && (
@@ -142,23 +150,21 @@ const SidebarDropdown = ({
                     </UserSummary>
 
                     <div>
-                      {!hideInternalLinks && (
-                        <Fragment>
-                          <SidebarMenuItem to="/settings/account/">
-                            {t('User settings')}
-                          </SidebarMenuItem>
-                          <SidebarMenuItem to="/settings/account/api/">
-                            {t('API keys')}
-                          </SidebarMenuItem>
-                          <Hook
-                            name="sidebar:organization-dropdown-menu-bottom"
-                            organization={org}
-                          />
-                          {user.isSuperuser && (
-                            <SidebarMenuItem to="/manage/">{t('Admin')}</SidebarMenuItem>
-                          )}
-                        </Fragment>
-                      )}
+                      <Fragment>
+                        <SidebarMenuItem to="/settings/account/">
+                          {t('User settings')}
+                        </SidebarMenuItem>
+                        <SidebarMenuItem to="/settings/account/api/">
+                          {t('API keys')}
+                        </SidebarMenuItem>
+                        <Hook
+                          name="sidebar:organization-dropdown-menu-bottom"
+                          organization={org}
+                        />
+                        {user.isSuperuser && (
+                          <SidebarMenuItem to="/manage/">{t('Admin')}</SidebarMenuItem>
+                        )}
+                      </Fragment>
                       <SidebarMenuItem
                         data-test-id="sidebarSignout"
                         onClick={handleLogout}

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -150,21 +150,19 @@ const SidebarDropdown = ({
                     </UserSummary>
 
                     <div>
-                      <Fragment>
-                        <SidebarMenuItem to="/settings/account/">
-                          {t('User settings')}
-                        </SidebarMenuItem>
-                        <SidebarMenuItem to="/settings/account/api/">
-                          {t('API keys')}
-                        </SidebarMenuItem>
-                        <Hook
-                          name="sidebar:organization-dropdown-menu-bottom"
-                          organization={org}
-                        />
-                        {user.isSuperuser && (
-                          <SidebarMenuItem to="/manage/">{t('Admin')}</SidebarMenuItem>
-                        )}
-                      </Fragment>
+                      <SidebarMenuItem to="/settings/account/">
+                        {t('User settings')}
+                      </SidebarMenuItem>
+                      <SidebarMenuItem to="/settings/account/api/">
+                        {t('API keys')}
+                      </SidebarMenuItem>
+                      <Hook
+                        name="sidebar:organization-dropdown-menu-bottom"
+                        organization={org}
+                      />
+                      {user.isSuperuser && (
+                        <SidebarMenuItem to="/manage/">{t('Admin')}</SidebarMenuItem>
+                      )}
                       <SidebarMenuItem
                         data-test-id="sidebarSignout"
                         onClick={handleLogout}

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -1,17 +1,10 @@
-import {Route} from 'react-router';
+import {Route, RouteComponentProps} from 'react-router';
 
 import {ChildrenRenderFn} from 'app/components/acl/feature';
 import DateRange from 'app/components/organizations/timeRangeSelector/dateRange';
 import SelectorItems from 'app/components/organizations/timeRangeSelector/dateRange/selectorItems';
 import SidebarItem from 'app/components/sidebar/sidebarItem';
-import {
-  IntegrationProvider,
-  Member,
-  Organization,
-  OrganizationSummary,
-  Project,
-  User,
-} from 'app/types';
+import {IntegrationProvider, Member, Organization, Project, User} from 'app/types';
 import {ExperimentKey} from 'app/types/experiments';
 import {NavigationItem, NavigationSection} from 'app/views/settings/types';
 
@@ -57,7 +50,7 @@ export type RouteHooks = {
 type DateRangeProps = React.ComponentProps<typeof DateRange>;
 type SelectorItemsProps = React.ComponentProps<typeof SelectorItems>;
 type GlobalNotificationProps = {className: string; organization?: Organization};
-type DisabledMemberViewProps = {organization: OrganizationSummary};
+type DisabledMemberViewProps = RouteComponentProps<{orgId: string}, {}>;
 type MemberListHeaderProps = {
   members: Member[];
   organization: Organization;

--- a/static/app/views/disabledMember/index.tsx
+++ b/static/app/views/disabledMember/index.tsx
@@ -1,13 +1,5 @@
-import {RouteComponentProps} from 'react-router';
-
 import NotFound from 'app/components/errors/notFound';
 import HookOrDefault from 'app/components/hookOrDefault';
-import {OrganizationSummary} from 'app/types';
-import withOrganizations from 'app/utils/withOrganizations';
-
-type Props = {
-  organizations: OrganizationSummary[];
-} & RouteComponentProps<{orgId: string}, {}>;
 
 //getsentry will add the view
 const DisabledMemberComponent = HookOrDefault({
@@ -15,16 +7,4 @@ const DisabledMemberComponent = HookOrDefault({
   defaultComponent: () => <NotFound />,
 });
 
-function DisabledMember(props: Props) {
-  const {
-    organizations,
-    params: {orgId},
-  } = props;
-  const org = organizations.find(o => o.slug === orgId);
-  if (!org) {
-    return <NotFound />;
-  }
-  return <DisabledMemberComponent organization={org} />;
-}
-
-export default withOrganizations(DisabledMember);
+export default DisabledMemberComponent;

--- a/tests/js/spec/components/sidebar/sidebarDrodown/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/sidebarDrodown/index.spec.jsx
@@ -1,0 +1,31 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import SidebarDropdown from 'app/components/sidebar/sidebarDropdown';
+import ConfigStore from 'app/stores/configStore';
+
+function renderDropdown(props) {
+  const user = ConfigStore.get('user');
+  const config = ConfigStore.get('config');
+  const organization = TestStubs.Organization();
+  return mountWithTheme(
+    <SidebarDropdown
+      orientation="left"
+      collapsed={false}
+      user={user}
+      config={config}
+      organization={organization}
+      {...props}
+    />
+  );
+}
+
+describe('SidebarDropdown', function () {
+  it('renders', function () {
+    const component = renderDropdown();
+    expect(component).toSnapshot();
+  });
+  it('renders without org links', function () {
+    const component = renderDropdown({hideOrgLinks: true});
+    expect(component).toSnapshot();
+  });
+});


### PR DESCRIPTION
This PR modifies the hook for the disabled member view and adds a `hideOrgLinks` prop to the `SidebarDropdown` component to hide links we don't want to show in a disabled member view. This is needed because a disabled member will not be able to access links within an organization. This PR is paired with the following getsentry PR: https://github.com/getsentry/getsentry/pull/5663


![Screen Shot 2021-06-01 at 2 04 35 PM](https://user-images.githubusercontent.com/8533851/120390241-52a6e980-c2e2-11eb-9f3b-1748bd757e19.png)

Note that while disabled members will be able to access user settings, we will render the full sidebar with organization links. When a user clicks on those links, they will be redirected back to the disabled member view. It's not an ideal experience but I don't expect too many disabled members to access user settings.
