### PR TITLE
feat(dev): Add support for pyenv v2 and drop support for pyenv v1

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -42,7 +42,7 @@ jobs:
         # Sometimes, brew needs to be updated before brew bundle would work
         # After installing Docker (via homebrew) we need to make sure that it is properly initialized on Mac
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew bundle -q --no-upgrade || brew update && brew bundle
+          brew update -q && brew bundle -q
           SENTRY_NO_VENV_CHECK=1 ./scripts/do.sh init-docker
 
       - name: Install Python (via Pyenv)
@@ -51,7 +51,7 @@ jobs:
         # We echo to $GITHUB_ENV to make the PATH changes by pyenv init permanent for the rest of the execution
         run: |
           make setup-pyenv
-          eval "$(pyenv init -)"
+          eval "$(pyenv init --path)"
           echo "PATH=$PATH" >> $GITHUB_ENV
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -37,19 +37,21 @@ get_shell_startup_script() {
   echo "$_startup_script"
 }
 
+# The first \n is important on Github workers sicne it was being appended to
+# the last line rather than on a new line. I never figured out why
 _append_to_startup_script() {
   if [[ -n "$SHELL" ]]; then
     case "$SHELL" in
     */bash)
       # shellcheck disable=SC2016
-      echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >>"${1}"
+      echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\nfi' >>"${1}"
       ;;
     */zsh)
       # shellcheck disable=SC2016
-      echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >>"${1}"
+      echo -e '\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init --path)"\nfi' >>"${1}"
       ;;
     */fish)
-      echo -e '\n\n# pyenv init\nif command -v pyenv 1>/dev/null 2>&1\n  pyenv init - | source\nend' >>"$1"
+      echo -e '\n\n# pyenv init\nif command -v pyenv 1>/dev/null 2>&1\n  pyenv init --path | source\nend' >>"$1"
       ;;
     esac
 
@@ -60,12 +62,11 @@ _append_to_startup_script() {
 
 append_to_config() {
   if [[ -n "$1" ]]; then
-    echo "Adding pyenv init (if missing) to ${1}..."
+    echo "Adding pyenv init --path (if missing) to ${1}..."
+    # XXX: Ask user to remove old style from their file
     # shellcheck disable=SC2016
-    if ! grep -qF "pyenv init" "${1}"; then
-      # pyenv init - is needed to include the pyenv shims in your PATH
-      # The first \n is very important since on Github workers the output was being appended to
-      # the last line rather than on a new line. I never figured out why
+    if ! grep -qF "pyenv init --path" "${1}"; then
+      # pyenv init --path is needed to include the pyenv shims in your PATH
       _append_to_startup_script "${1}"
     fi
   fi
@@ -77,9 +78,9 @@ install_pyenv() {
     local pyenv_version
     pyenv_version=$(pyenv -v | awk '{print $2}')
     python_version=$(xargs -n1 <.python-version)
-    # NOTE: Older pyenv does not have access to the latest Python we require
-    if [[ "$pyenv_version" < 1.2.26 ]]; then
-      echo >&2 "!!! Your pyenv is old and does not know how to find the Python we require." \
+    # NOTE: We're dropping support for older pyenv versions
+    if [[ "$pyenv_version" < 2.0.0 ]]; then
+      echo >&2 "!!! We've dropped support for pyenv v1." \
         "Run the following (this is slow) and try again."
       echo >&2 "brew update && brew upgrade pyenv"
       exit 1
@@ -110,7 +111,7 @@ setup_pyenv() {
   # If the script is called with the "dot space right" approach (. ./scripts/pyenv_setup.sh),
   # the effects of this will be persistent outside of this script
   echo "Activating pyenv and validating Python version"
-  eval "$(pyenv init -)"
+  eval "$(pyenv init --path)"
   python_version=$(python -V | sed s/Python\ //g)
   [[ $python_version == $(cat .python-version) ]] ||
     (echo "Wrong Python version: $python_version. Please report in #discuss-dev-tooling" && exit 1)


### PR DESCRIPTION
The latest release of pyenv does not allow using `pyenv init -`, instead,
it requires using `--path` (i.e. `pyenv init --path`).

Anyone calling `make setup-pyenv` will have to update to the latest `pyenv`.

Not fixing this currently affects new engineers when they set up their computers.