### PR TITLE
ref(ui) Convert settings form context to new context

### DIFF
--- a/static/app/views/settings/components/forms/formContext.tsx
+++ b/static/app/views/settings/components/forms/formContext.tsx
@@ -1,0 +1,29 @@
+import {createContext} from 'react';
+
+import FormModel from 'app/views/settings/components/forms/model';
+
+/**
+ * Context type used in 'settings' forms.
+ *
+ * These differ from the 'old' forms in that they use mobx observers
+ * to update state and expose it via the `FormModel`
+ */
+export type FormContextData = {
+  /**
+   * The default value is undefined so that FormField components
+   * not within a form context boundary create MockModels based
+   * on their props.
+   */
+  form?: FormModel;
+  /**
+   * Should fields do save requests on blur?
+   */
+  saveOnBlur?: boolean;
+};
+
+const FormContext = createContext<FormContextData>({
+  form: undefined,
+  saveOnBlur: undefined,
+});
+
+export default FormContext;

--- a/static/app/views/settings/components/forms/formField/index.tsx
+++ b/static/app/views/settings/components/forms/formField/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
 import {Observer} from 'mobx-react';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
@@ -14,6 +13,7 @@ import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
 import Field from 'app/views/settings/components/forms/field';
 import FieldControl from 'app/views/settings/components/forms/field/fieldControl';
 import FieldErrorReason from 'app/views/settings/components/forms/field/fieldErrorReason';
+import FormContext from 'app/views/settings/components/forms/formContext';
 import FormFieldControlState from 'app/views/settings/components/forms/formField/controlState';
 import FormModel, {MockModel} from 'app/views/settings/components/forms/model';
 import ReturnButton from 'app/views/settings/components/forms/returnButton';
@@ -147,11 +147,6 @@ type PassthroughProps<P> = Omit<
 >;
 
 class FormField<P extends {} = {}> extends React.Component<Props<P>> {
-  static contextTypes = {
-    location: PropTypes.object,
-    form: PropTypes.object,
-  };
-
   static defaultProps = {
     hideErrorMessage: false,
     flexibleControlStateSize: false,
@@ -165,6 +160,8 @@ class FormField<P extends {} = {}> extends React.Component<Props<P>> {
   componentWillUnmount() {
     this.getModel().removeField(this.props.name);
   }
+
+  static contextType = FormContext;
 
   getError() {
     return this.getModel().getError(this.props.name);
@@ -189,7 +186,8 @@ class FormField<P extends {} = {}> extends React.Component<Props<P>> {
    */
   handleInputMount = (node: HTMLElement | null) => {
     if (node && !this.input) {
-      const hash = this.context.location && this.context.location.hash;
+      // TODO(mark) Clean this up. FormContext could include the location
+      const hash = window.location?.hash;
 
       if (!hash) {
         return;

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -1,11 +1,11 @@
 import {Component, Fragment} from 'react';
 import find from 'lodash/find';
 import flatMap from 'lodash/flatMap';
-import PropTypes from 'prop-types';
 
 import {SENTRY_APP_PERMISSIONS} from 'app/constants';
 import {t} from 'app/locale';
 import {Permissions} from 'app/types/index';
+import FormContext from 'app/views/settings/components/forms/formContext';
 import SelectField from 'app/views/settings/components/forms/selectField';
 
 /**
@@ -89,13 +89,11 @@ type State = {
 };
 
 export default class PermissionSelection extends Component<Props, State> {
-  static contextTypes = {
-    form: PropTypes.object,
-  };
-
   state: State = {
     permissions: this.props.permissions,
   };
+
+  static contextType = FormContext;
 
   /**
    * Converts the "Permission" values held in `state` to a list of raw

--- a/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -1,5 +1,4 @@
 import {Component, Fragment} from 'react';
-import PropTypes from 'prop-types';
 
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
@@ -24,11 +23,6 @@ type State = {
 };
 
 export default class PermissionsObserver extends Component<Props, State> {
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-    form: PropTypes.object,
-  };
-
   static defaultProps: DefaultProps = {
     webhookDisabled: false,
     appPublished: false,
@@ -41,6 +35,7 @@ export default class PermissionsObserver extends Component<Props, State> {
       events: this.props.events,
     };
   }
+
   /**
    * Converts the list of raw API scopes passed in to an object that can
    * before stored and used via `state`. This object is structured by

--- a/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -1,9 +1,9 @@
 import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {Context} from 'app/components/forms/form';
 import {Permissions, WebhookEvent} from 'app/types';
+import FormContext from 'app/views/settings/components/forms/formContext';
 import {
   EVENT_CHOICES,
   PERMISSIONS_MAP,
@@ -23,11 +23,6 @@ type Props = DefaultProps & {
 };
 
 export default class Subscriptions extends Component<Props> {
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-    form: PropTypes.object,
-  };
-
   static defaultProps: DefaultProps = {
     webhookDisabled: false,
   };
@@ -55,6 +50,8 @@ export default class Subscriptions extends Component<Props> {
       this.save(permittedEvents);
     }
   }
+
+  static contextType = FormContext;
 
   onChange = (resource: Resource, checked: boolean) => {
     const events = new Set(this.props.events);

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionSelection.spec.jsx
@@ -1,7 +1,7 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {openMenu, selectByValue} from 'sentry-test/select-new';
 
-import FormModel from 'app/views/settings/components/forms/model';
+import Form from 'app/views/settings/components/forms/form';
 import PermissionSelection from 'app/views/settings/organizationDeveloperSettings/permissionSelection';
 
 describe('PermissionSelection', () => {
@@ -11,17 +11,19 @@ describe('PermissionSelection', () => {
   beforeEach(() => {
     onChange = jest.fn();
     wrapper = mountWithTheme(
-      <PermissionSelection
-        permissions={{
-          Event: 'no-access',
-          Team: 'no-access',
-          Project: 'write',
-          Release: 'admin',
-          Organization: 'admin',
-        }}
-        onChange={onChange}
-      />,
-      TestStubs.routerContext([{form: new FormModel()}])
+      <Form>
+        <PermissionSelection
+          permissions={{
+            Event: 'no-access',
+            Team: 'no-access',
+            Project: 'write',
+            Release: 'admin',
+            Organization: 'admin',
+          }}
+          onChange={onChange}
+        />
+      </Form>,
+      TestStubs.routerContext()
     );
   });
 
@@ -61,7 +63,8 @@ describe('PermissionSelection', () => {
   });
 
   it('converts permission state to a list of raw scopes', () => {
-    wrapper.instance().setState({
+    const instance = wrapper.find('PermissionSelection').instance();
+    instance.setState({
       permissions: {
         Project: 'write',
         Release: 'admin',
@@ -69,7 +72,7 @@ describe('PermissionSelection', () => {
       },
     });
 
-    expect(wrapper.instance().permissionStateToList()).toEqual([
+    expect(instance.permissionStateToList()).toEqual([
       'project:read',
       'project:write',
       'project:releases',
@@ -78,7 +81,8 @@ describe('PermissionSelection', () => {
   });
 
   it('stores the permissions the User has selected', () => {
-    const getStateValue = resource => wrapper.instance().state.permissions[resource];
+    const instance = wrapper.find('PermissionSelection').instance();
+    const getStateValue = resource => instance.state.permissions[resource];
 
     selectByValue(wrapper, 'write', {name: 'Project--permission'});
     selectByValue(wrapper, 'read', {name: 'Team--permission'});

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/permissionsObserver.spec.jsx
@@ -1,6 +1,6 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 
-import FormModel from 'app/views/settings/components/forms/model';
+import Form from 'app/views/settings/components/forms/form';
 import PermissionsObserver from 'app/views/settings/organizationDeveloperSettings/permissionsObserver';
 
 describe('PermissionsObserver', () => {
@@ -8,16 +8,19 @@ describe('PermissionsObserver', () => {
 
   beforeEach(() => {
     wrapper = mountWithTheme(
-      <PermissionsObserver
-        scopes={['project:read', 'project:write', 'project:releases', 'org:admin']}
-        events={['issue']}
-      />,
-      TestStubs.routerContext([{form: new FormModel()}])
+      <Form>
+        <PermissionsObserver
+          scopes={['project:read', 'project:write', 'project:releases', 'org:admin']}
+          events={['issue']}
+        />
+      </Form>,
+      TestStubs.routerContext()
     );
   });
 
   it('defaults to no-access for all resources not passed', () => {
-    expect(wrapper.instance().state.permissions).toEqual(
+    const instance = wrapper.find('PermissionsObserver').instance();
+    expect(instance.state.permissions).toEqual(
       expect.objectContaining({
         Team: 'no-access',
         Event: 'no-access',
@@ -27,7 +30,8 @@ describe('PermissionsObserver', () => {
   });
 
   it('converts a raw list of scopes into permissions', () => {
-    expect(wrapper.instance().state.permissions).toEqual(
+    const instance = wrapper.find('PermissionsObserver').instance();
+    expect(instance.state.permissions).toEqual(
       expect.objectContaining({
         Project: 'write',
         Release: 'admin',
@@ -37,6 +41,7 @@ describe('PermissionsObserver', () => {
   });
 
   it('selects the highest ranking scope to convert to permission', () => {
-    expect(wrapper.instance().state.permissions.Project).toEqual('write');
+    const instance = wrapper.find('PermissionsObserver').instance();
+    expect(instance.state.permissions.Project).toEqual('write');
   });
 });

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/resourceSubscriptions.spec.jsx
@@ -1,6 +1,6 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 
-import FormModel from 'app/views/settings/components/forms/model';
+import Form from 'app/views/settings/components/forms/form';
 import Subscriptions from 'app/views/settings/organizationDeveloperSettings/resourceSubscriptions';
 
 describe('Resource Subscriptions', () => {
@@ -11,23 +11,20 @@ describe('Resource Subscriptions', () => {
     beforeEach(() => {
       onChange = jest.fn();
       wrapper = mountWithTheme(
-        <Subscriptions
-          events={[]}
-          permissions={{
-            Event: 'no-access',
-            Team: 'no-access',
-            Project: 'write',
-            Release: 'admin',
-            Organization: 'admin',
-          }}
-          onChange={onChange}
-        />,
-        {
-          context: {
-            router: TestStubs.routerContext(),
-            form: new FormModel(),
-          },
-        }
+        <Form>
+          <Subscriptions
+            events={[]}
+            permissions={{
+              Event: 'no-access',
+              Team: 'no-access',
+              Project: 'write',
+              Release: 'admin',
+              Organization: 'admin',
+            }}
+            onChange={onChange}
+          />
+        </Form>,
+        TestStubs.routerContext()
       );
     });
 
@@ -45,8 +42,13 @@ describe('Resource Subscriptions', () => {
         Release: 'admin',
         Organization: 'admin',
       };
+      wrapper = mountWithTheme(
+        <Form>
+          <Subscriptions events={[]} permissions={permissions} onChange={onChange} />
+        </Form>,
+        TestStubs.routerContext()
+      );
 
-      wrapper.setProps({permissions});
       expect(
         wrapper.find('SubscriptionBox').first().prop('disabledFromPermissions')
       ).toBe(false);
@@ -57,23 +59,20 @@ describe('Resource Subscriptions', () => {
     beforeEach(() => {
       onChange = jest.fn();
       wrapper = mountWithTheme(
-        <Subscriptions
-          events={['issue']}
-          permissions={{
-            Event: 'read',
-            Team: 'no-access',
-            Project: 'write',
-            Release: 'admin',
-            Organization: 'admin',
-          }}
-          onChange={onChange}
-        />,
-        {
-          context: {
-            router: TestStubs.routerContext(),
-            form: new FormModel(),
-          },
-        }
+        <Form>
+          <Subscriptions
+            events={['issue']}
+            permissions={{
+              Event: 'read',
+              Team: 'no-access',
+              Project: 'write',
+              Release: 'admin',
+              Organization: 'admin',
+            }}
+            onChange={onChange}
+          />
+        </Form>,
+        TestStubs.routerContext()
       );
     });
 
@@ -91,6 +90,16 @@ describe('Resource Subscriptions', () => {
         Release: 'admin',
         Organization: 'admin',
       };
+      wrapper = mountWithTheme(
+        <Form>
+          <Subscriptions
+            events={['issue']}
+            permissions={permissions}
+            onChange={onChange}
+          />
+        </Form>,
+        TestStubs.routerContext()
+      );
 
       wrapper.setProps({permissions});
       expect(


### PR DESCRIPTION
Convert the settings forms context to a 'new' context, removing the legacy context implementation. This required a few tests to be updated as they were directly settings the legacy context. The default value of undefined is to support settings form controls being used outside of a form context. In this situations the inputs should create a stub model that lets them access their value and errors via props.