### PR TITLE
ref(perf): Update codeowners for facet performance endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,6 +120,7 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/api/endpoints/organization_event_details.py         @getsentry/visibility
 /src/sentry/api/endpoints/organization_events.py                @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_facets.py         @getsentry/visibility
+/src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_meta.py           @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_stats.py          @getsentry/visibility
 /src/sentry/api/endpoints/organization_events_trace.py          @getsentry/visibility


### PR DESCRIPTION
### Summary
Codeowners wasn't picking up this file as belonging to the vis team.