### PR TITLE
feat(relay): Upgrade sentry-relay to 0.8.7

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ requests==2.25.1
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay==0.8.6
+sentry-relay==0.8.7
 sentry-sdk>=1.0.0,<1.2.0
 snuba-sdk>=0.0.15,<1.0.0
 simplejson==3.17.2


### PR DESCRIPTION
This PR updates to relay 0.8.7 which includes necessary chances for parsing Semver release versions