### PR TITLE
feat(releases): Use redis lock to sync merging of release archives

### DIFF
--- a/src/sentry/utils/locking/lock.py
+++ b/src/sentry/utils/locking/lock.py
@@ -43,7 +43,7 @@ class Lock:
 
         return releaser()
 
-    def blocking_acquire(self, initial_delay: float, timeout: float):
+    def blocking_acquire(self, initial_delay: float, timeout: float, exp_base=1.6):
         """
         Try to acquire the lock in a polling loop.
 
@@ -59,7 +59,7 @@ class Lock:
             try:
                 return self.acquire()
             except UnableToAcquireLock:
-                delay = 2 ** attempt * random.random() * initial_delay
+                delay = (exp_base ** attempt) * random.random() * initial_delay
                 # Redundant check to prevent futile sleep in last iteration:
                 if time.monotonic() + delay > stop:
                     break

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -42,3 +43,22 @@ class LockTestCase(unittest.TestCase):
             backend.acquire.assert_called_once_with(key, duration, routing_key)
 
         backend.release.assert_called_once_with(key, routing_key)
+
+    @patch("sentry.utils.locking.lock.Lock.acquire", side_effect=UnableToAcquireLock)
+    def test_blocking_aqcuire(self, mock_acquire):
+        backend = mock.Mock(spec=LockBackend)
+        key = "lock"
+        duration = 60
+        routing_key = None
+
+        lock = Lock(backend, key, duration, routing_key)
+
+        with self.assertRaises(UnableToAcquireLock):
+            lock.blocking_acquire(interval=0, max_attempts=3)
+
+        assert len(mock_acquire.mock_calls) == 3
+
+        # Success case:
+        mock_acquire.return_value = "foo"
+        mock_acquire.side_effect = None
+        assert lock.blocking_acquire(interval=1, max_attempts=1) == "foo"

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -65,7 +65,7 @@ class LockTestCase(unittest.TestCase):
             "sentry.utils.locking.lock.time.monotonic", side_effect=lambda: MockTime.time
         ), patch("sentry.utils.locking.lock.time.sleep", side_effect=MockTime.incr) as mock_sleep:
             with self.assertRaises(UnableToAcquireLock):
-                lock.blocking_acquire(initial_delay=0.1, timeout=1)
+                lock.blocking_acquire(initial_delay=0.1, timeout=1, exp_base=2)
 
             # 0.0, 0.05, 0.15, 0.35, 0.75
             assert len(mock_acquire.mock_calls) == 5


### PR DESCRIPTION
This PR introduces a helper method to block on `Lock` acquisition. It is implemented as a polling loop, sleeping for random intervals between retries. The range from which the random interval is selected is doubled in every iteration.

This new method is used to replace the retry loop for merging release archives, which failed as soon as a moderate number of uploads occurred at the same time.