### PR TITLE
fix(snql) Add missing list wrapper

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -297,7 +297,7 @@ def query_facet_performance(
             [
                 "divide",
                 [
-                    ["sum", ["minus", [translated_aggregate_column, transaction_aggregate]]],
+                    ["sum", [["minus", [translated_aggregate_column, transaction_aggregate]]]],
                     frequency_sample_rate,
                 ],
                 "sumdelta",


### PR DESCRIPTION
This function was missing an extra array wrapper. I'm not actually sure why the
legacy Snuba parser worked but I fixed it for SnQL going forward.