### PR TITLE
feat(arithmetic): Add field support to the arithmetic parser

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -1,7 +1,9 @@
-from typing import Optional
+from typing import List, Optional, Tuple, Union
 
 from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar, NodeVisitor
+
+SUPPORTED_OPERATORS = {"plus", "minus", "multiply", "divide"}
 
 
 class ArithmeticError(Exception):
@@ -20,15 +22,37 @@ class ArithmeticParseError(ArithmeticError):
     pass
 
 
+class ArithmeticValidationError(ArithmeticError):
+    """ The math itself isn't valid """
+
+    pass
+
+
+OperationSideType = Union["Operation", float]
+
+
 class Operation:
     __slots__ = "operator", "lhs", "rhs"
 
-    def __init__(self, operator, lhs=None, rhs=None):
+    def __init__(
+        self,
+        operator: str,
+        lhs: Optional[OperationSideType] = None,
+        rhs: Optional[OperationSideType] = None,
+    ) -> None:
         self.operator = operator
-        self.lhs = lhs
-        self.rhs = rhs
+        self.lhs: Optional[OperationSideType] = lhs
+        self.rhs: Optional[OperationSideType] = rhs
 
-    def __repr__(self):
+    def validate(self) -> None:
+        # This shouldn't really happen, but the operator value is based on the grammar so enforcing it to be safe
+        if self.operator not in SUPPORTED_OPERATORS:
+            raise ArithmeticParseError(f"{self.operator} is not a supported operator")
+
+        if self.operator == "divide" and self.rhs == 0:
+            raise ArithmeticValidationError("division by 0 is not allowed")
+
+    def __repr__(self) -> str:
         return repr([self.operator, self.lhs, self.rhs])
 
 
@@ -46,7 +70,7 @@ mul_div              = mul_div_operator primary
 add_sub_operator     = spaces (plus / minus) spaces
 mul_div_operator     = spaces (multiply / divide) spaces
 # TODO(wmak) allow variables
-primary              = spaces numeric_value spaces
+primary              = spaces (numeric_value / field_value) spaces
 
 # Operator names should match what's in clickhouse
 plus                 = "+"
@@ -54,9 +78,10 @@ minus                = "-"
 multiply             = "*"
 divide               = "/"
 
-# TODO(wmak) share these with api/event_search and support decimals
-numeric_value        = ~r"[+-]?[0-9]+"
-spaces               = ~r"\ *"
+# TODO(wmak) share these with api/event_search
+numeric_value        = ~r"[+-]?[0-9]+\.?[0-9]*"
+field_value          = ~r"[a-zA-Z_.]+"
+spaces               = " "*
 """
 )
 
@@ -65,12 +90,22 @@ class ArithmeticVisitor(NodeVisitor):
     DEFAULT_MAX_OPERATORS = 10
 
     # Don't wrap in VisitationErrors
-    unwrapped_exceptions = (MaxOperatorError,)
+    unwrapped_exceptions = (ArithmeticError,)
+
+    allowlist = {
+        "transaction.duration",
+        "spans.http",
+        "spans.db",
+        "spans.resource",
+        "spans.browser",
+        "spans.total.time",
+    }
 
     def __init__(self, max_operators):
         super().__init__()
         self.operators = 0
         self.max_operators = max_operators if max_operators else self.DEFAULT_MAX_OPERATORS
+        self.fields: set[str] = set()
 
     def flatten(self, remaining):
         """ Take all the remaining terms and reduce them to a single tree """
@@ -126,7 +161,8 @@ class ArithmeticVisitor(NodeVisitor):
         return self.strip_spaces(children)
 
     def visit_primary(self, _, children):
-        return self.strip_spaces(children)
+        # Return the 0th element since this is a (numeric/field)
+        return self.strip_spaces(children)[0]
 
     @staticmethod
     def parse_operator(operator):
@@ -142,11 +178,20 @@ class ArithmeticVisitor(NodeVisitor):
     def visit_numeric_value(self, node, _):
         return float(node.text)
 
+    def visit_field_value(self, node, _):
+        field = node.text
+        if field not in self.allowlist:
+            raise ArithmeticValidationError(f"{field} not allowed in arithmetic")
+        self.fields.add(field)
+        return field
+
     def generic_visit(self, node, children):
         return children or node
 
 
-def parse_arithmetic(equation: str, max_operators: Optional[int] = None) -> Operation:
+def parse_arithmetic(
+    equation: str, max_operators: Optional[int] = None
+) -> Tuple[Operation, List[str]]:
     """ Given a string equation try to parse it into a set of Operations """
     try:
         tree = arithmetic_grammar.parse(equation)
@@ -154,4 +199,6 @@ def parse_arithmetic(equation: str, max_operators: Optional[int] = None) -> Oper
         raise ArithmeticParseError(
             "Unable to parse your equation, make sure it is well formed arithmetic"
         )
-    return ArithmeticVisitor(max_operators).visit(tree)
+    visitor = ArithmeticVisitor(max_operators)
+    result = visitor.visit(tree)
+    return result, list(visitor.fields)

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -2,6 +2,7 @@ import pytest
 
 from sentry.discover.arithmetic import (
     ArithmeticParseError,
+    ArithmeticValidationError,
     MaxOperatorError,
     Operation,
     parse_arithmetic,
@@ -190,5 +191,5 @@ def test_unparseable_arithmetic(equation):
     ],
 )
 def test_invalid_arithmetic(equation):
-    with pytest.raises(ArithmeticParseError):
+    with pytest.raises(ArithmeticValidationError):
         parse_arithmetic(equation)

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -1,6 +1,11 @@
 import pytest
 
-from sentry.discover.arithmetic import ArithmeticParseError, MaxOperatorError, parse_arithmetic
+from sentry.discover.arithmetic import (
+    ArithmeticParseError,
+    MaxOperatorError,
+    Operation,
+    parse_arithmetic,
+)
 
 op_map = {
     "+": "plus",
@@ -11,7 +16,7 @@ op_map = {
 
 
 def test_single_term():
-    result = parse_arithmetic("12")
+    result, _ = parse_arithmetic("12")
     assert result == 12.0
 
 
@@ -30,11 +35,15 @@ def test_single_term():
         ("+12", "+", "+34"),
         ("-12", "+", "+34"),
         ("+12", "+", "-34"),
+        (1.2345, "+", 6.7890),
+        (1.2345, "-", 6.7890),
+        (1.2345, "*", 6.7890),
+        (1.2345, "/", 6.7890),
     ],
 )
 def test_simple_arithmetic(a, op, b):
     equation = f"{a}{op}{b}"
-    result = parse_arithmetic(equation)
+    result, _ = parse_arithmetic(equation)
     assert result.operator == op_map[op.strip()], equation
     assert result.lhs == float(a), equation
     assert result.rhs == float(b), equation
@@ -56,8 +65,9 @@ def test_simple_arithmetic(a, op, b):
 def test_homogenous_arithmetic(a, op1, b, op2, c):
     """ Test that literal order of ops is respected assuming we don't have to worry about BEDMAS """
     equation = f"{a}{op1}{b}{op2}{c}"
-    result = parse_arithmetic(equation)
+    result, _ = parse_arithmetic(equation)
     assert result.operator == op_map[op2.strip()], equation
+    assert isinstance(result.lhs, Operation), equation
     assert result.lhs.operator == op_map[op1.strip()], equation
     assert result.lhs.lhs == float(a), equation
     assert result.lhs.rhs == float(b), equation
@@ -65,26 +75,30 @@ def test_homogenous_arithmetic(a, op1, b, op2, c):
 
 
 def test_mixed_arithmetic():
-    result = parse_arithmetic("12 + 34 * 56")
-    result.operator == "plus"
-    result.lhs = 12.0
-    result.rhs.operator = "multiply"
-    result.rhs.lhs = 34.0
-    result.rhs.rhs = 56.0
+    result, _ = parse_arithmetic("12 + 34 * 56")
+    assert result.operator == "plus"
+    assert result.lhs == 12.0
+    assert isinstance(result.rhs, Operation)
+    assert result.rhs.operator == "multiply"
+    assert result.rhs.lhs == 34.0
+    assert result.rhs.rhs == 56.0
 
-    result = parse_arithmetic("12 / 34 - 56")
-    result.operator == "subtract"
-    result.lhs.operator = "divide"
-    result.lhs.lhs = 12.0
-    result.lhs.rhs = 34.0
-    result.rhs = 56.0
+    result, _ = parse_arithmetic("12 / 34 - 56")
+    assert result.operator == "minus"
+    assert isinstance(result.lhs, Operation)
+    assert result.lhs.operator == "divide"
+    assert result.lhs.lhs == 12.0
+    assert result.lhs.rhs == 34.0
+    assert result.rhs == 56.0
 
 
 def test_four_terms():
-    result = parse_arithmetic("1 + 2 / 3 * 4")
+    result, _ = parse_arithmetic("1 + 2 / 3 * 4")
     assert result.operator == "plus"
     assert result.lhs == 1.0
+    assert isinstance(result.rhs, Operation)
     assert result.rhs.operator == "multiply"
+    assert isinstance(result.rhs.lhs, Operation)
     assert result.rhs.lhs.operator == "divide"
     assert result.rhs.lhs.lhs == 2.0
     assert result.rhs.lhs.rhs == 3.0
@@ -110,9 +124,11 @@ def test_homogenous_four_terms(a, op1, b, op2, c, op3, d):
     flatten only kicks in when its a chain of the same operator type
     """
     equation = f"{a}{op1}{b}{op2}{c}{op3}{d}"
-    result = parse_arithmetic(equation)
+    result, _ = parse_arithmetic(equation)
     assert result.operator == op_map[op3.strip()], equation
+    assert isinstance(result.lhs, Operation), equation
     assert result.lhs.operator == op_map[op2.strip()], equation
+    assert isinstance(result.lhs.lhs, Operation), equation
     assert result.lhs.lhs.operator == op_map[op1.strip()], equation
     assert result.lhs.lhs.lhs == float(a), equation
     assert result.lhs.lhs.rhs == float(b), equation
@@ -129,6 +145,26 @@ def test_max_operators():
 
 
 @pytest.mark.parametrize(
+    "a,op,b",
+    [
+        ("spans.http", "+", "spans.db"),
+        ("transaction.duration", "*", 2),
+        (3.1415, "+", "spans.resource"),
+    ],
+)
+def test_field_values(a, op, b):
+    equation = f"{a}{op}{b}"
+    result, fields = parse_arithmetic(equation)
+    assert result.operator == op_map[op.strip()], equation
+    assert result.lhs == a, equation
+    assert result.rhs == b, equation
+    if isinstance(a, str):
+        assert a in fields, equation
+    if isinstance(b, str):
+        assert b in fields, equation
+
+
+@pytest.mark.parametrize(
     "equation",
     [
         "1 +",
@@ -139,6 +175,20 @@ def test_max_operators():
         "hello world",
     ],
 )
-def test_bad_arithmetic(equation):
+def test_unparseable_arithmetic(equation):
+    with pytest.raises(ArithmeticParseError):
+        parse_arithmetic(equation)
+
+
+@pytest.mark.parametrize(
+    "equation",
+    [
+        "5/0",
+        "spans.http/0",
+        # Transaction status isn't something we want arithmetic on
+        "1 + transaction.status",
+    ],
+)
+def test_invalid_arithmetic(equation):
     with pytest.raises(ArithmeticParseError):
         parse_arithmetic(equation)


### PR DESCRIPTION
- There will only be a few fields that make sense to perform arithmetic
  on, so using an allowlist to prevent other fields from being used
- We'll want the list of fields in arithmetic to either validate that
  they're selected, or to make sure we can group by them if an aggregate
  is selected