### PR TITLE
feat(api): switch to prefixed strings for auth tokens and client secrets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ line_length = 100
 lines_between_sections = 1
 known_first_party = "sentry"
 skip = "migrations"
+filter_files = true
 
 [tool.pytest.ini_options]
 # note: When updating the traceback format, make sure to update .github/pytest.json

--- a/src/sentry/migrations/0001_initial.py
+++ b/src/sentry/migrations/0001_initial.py
@@ -205,7 +205,7 @@ class Migration(migrations.Migration):
                 (
                     "client_id",
                     models.CharField(
-                        default=sentry.models.apiapplication.generate_token,
+                        default=sentry.models.apiapplication.generate_id,
                         unique=True,
                         max_length=64,
                     ),
@@ -213,7 +213,7 @@ class Migration(migrations.Migration):
                 (
                     "client_secret",
                     sentry.db.models.fields.encrypted.EncryptedTextField(
-                        default=sentry.models.apiapplication.generate_token
+                        default=sentry.models.apiapplication.generate_secret
                     ),
                 ),
                 (

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -1,6 +1,6 @@
+from secrets import token_urlsafe
 from urllib.parse import urlparse
 from uuid import uuid4
-from secrets import token_urlsafe
 
 import petname
 from django.db import models

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
 from uuid import uuid4
+from secrets import token_urlsafe
 
 import petname
 from django.db import models
@@ -20,9 +21,12 @@ def generate_name():
     return petname.Generate(2, " ", letters=10).title()
 
 
-def generate_token():
+def generate_id():
     return uuid4().hex + uuid4().hex
 
+
+def generate_secret():
+    return 'sentry_cs_' + token_urlsafe(40).replace('-', '0').replace('_', '0')
 
 class ApiApplicationStatus:
     active = 0
@@ -34,8 +38,8 @@ class ApiApplicationStatus:
 class ApiApplication(Model):
     __core__ = True
 
-    client_id = models.CharField(max_length=64, unique=True, default=generate_token)
-    client_secret = EncryptedTextField(default=generate_token)
+    client_id = models.CharField(max_length=64, unique=True, default=generate_id)
+    client_secret = EncryptedTextField(default=generate_secret)
     owner = FlexibleForeignKey("sentry.User")
     name = models.CharField(max_length=64, blank=True, default=generate_name)
     status = BoundedPositiveIntegerField(

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -26,7 +26,7 @@ def generate_id():
 
 
 def generate_secret():
-    return 'sentry_cs_' + token_urlsafe(40).replace('-', '0').replace('_', '0')
+    return "sentry_cs_" + token_urlsafe(40).replace("-", "0").replace("_", "0")
 
 class ApiApplicationStatus:
     active = 0

--- a/src/sentry/models/apiapplication.py
+++ b/src/sentry/models/apiapplication.py
@@ -28,6 +28,7 @@ def generate_id():
 def generate_secret():
     return "sentry_cs_" + token_urlsafe(40).replace("-", "0").replace("_", "0")
 
+
 class ApiApplicationStatus:
     active = 0
     inactive = 1

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -16,7 +16,7 @@ def default_expiration():
 
 
 def generate_token():
-    return 'sentry_at_' + token_urlsafe(40).replace('-', '0').replace('_', '0')
+    return "sentry_at_" + token_urlsafe(40).replace("-", "0").replace("_", "0")
 
 
 @python_2_unicode_compatible

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from uuid import uuid4
+from secrets import token_urlsafe
 
 from django.db import models, transaction
 from django.utils import timezone
@@ -16,7 +16,7 @@ def default_expiration():
 
 
 def generate_token():
-    return uuid4().hex + uuid4().hex
+    return 'sentry_at_' + token_urlsafe(40).replace('-', '0').replace('_', '0')
 
 
 @python_2_unicode_compatible

--- a/src/sentry/models/monitor.py
+++ b/src/sentry/models/monitor.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from uuid import uuid4
 
 import pytz
 from croniter import croniter
@@ -25,10 +24,6 @@ SCHEDULE_INTERVAL_MAP = {
     "hour": rrule.HOURLY,
     "minute": rrule.MINUTELY,
 }
-
-
-def generate_secret():
-    return uuid4().hex + uuid4().hex
 
 
 def get_next_schedule(base_datetime, schedule_type, schedule):


### PR DESCRIPTION
Currently, Sentry uses `uuid4().hex + uuid4().hex` to generate its auth tokens and application client secrets. This PR switches to prefixed strings generated with [`secrets.token_urlsafe`](https://docs.python.org/3/library/secrets.html#generating-tokens). Both strings remain 64 characters long.

There are a couple of benefits to this approach:
* More entropy, since the new strings encode ~40 bytes of randomness (the old ones had ~30)
* Easier to detect with regex scanning (and would be a perfect candidate for [GitHub secret scanning](https://docs.github.com/en/developers/overview/secret-scanning), which is part of my day job)
    * Note that the existing strings can already be detected with regex scanning, since they use UUID4. I don't think there's a security through obscurity argument here - the following pattern will pick the existing tokens up relatively accurately, but with some false positives (e.g., Sentry client IDs):
        ```
        /[a-f0-9]{12}4[a-f0-9]{3}[89aAbB][a-f0-9]{27}4[a-f0-9]{3}[89aAbB][a-f0-9]{15}/
        ```

Note: I've replaced `-` and `_` characters in the output of `secrets.token_urlsafe`. This slightly reduces the entropy of the output strings, but is more aesthetically pleasing and removes the (minorly) irritating problem that `-` characters act as word boundaries. A more robust implementation would be to use `secrets.token_bytes` and write the logic to encode that as base62, rather than base64. If the small loss in entropy is important to you (note: still a gain on the current setup) let me know.