### PR TITLE
ref(ui) Convert GuideAnchor away from createReactClass

### DIFF
--- a/static/app/actionCreators/guides.tsx
+++ b/static/app/actionCreators/guides.tsx
@@ -34,12 +34,12 @@ export function closeGuide(dismissed?: boolean) {
   GuideActions.closeGuide(dismissed);
 }
 
-export function dismissGuide(guide: string, step: number, orgId: string) {
+export function dismissGuide(guide: string, step: number, orgId: string | null) {
   recordDismiss(guide, step, orgId);
   closeGuide(true);
 }
 
-export function recordFinish(guide: string, orgId: string) {
+export function recordFinish(guide: string, orgId: string | null) {
   api.request('/assistant/', {
     method: 'PUT',
     data: {
@@ -63,7 +63,7 @@ export function recordFinish(guide: string, orgId: string) {
   trackAnalyticsEvent(data);
 }
 
-export function recordDismiss(guide: string, step: number, orgId: string) {
+export function recordDismiss(guide: string, step: number, orgId: string | null) {
   api.request('/assistant/', {
     method: 'PUT',
     data: {


### PR DESCRIPTION
Remove another usage of createReactClass and update the ref usage to the current ref API. I also had to expand some types in the guide action creators, but the downstream functions were already compatible.