### PR TITLE
ref(dev): direnv to call ensure-venv script without using PWD

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,10 @@
 # If you'd like to override or set any custom environment variables, this .envrc will read a .env file at the end.
 
 set -e
+HERE="$(
+    cd "$(dirname "${BASH_SOURCE[0]}")"
+    pwd -P
+)"
 
 bold="$(tput bold)"
 red="$(tput setaf 1)"
@@ -177,7 +181,7 @@ source "${venv_name}/bin/activate"
 unset PS1
 
 debug "Ensuring proper virtualenv..."
-"${PWD}/scripts/ensure-venv.sh"
+"${HERE}/scripts/ensure-venv.sh"
 
 if ! require sentry; then
     warn "Your virtualenv is activated, but sentry doesn't seem to be installed."


### PR DESCRIPTION
This change allows the `getsentry` to source `.envrc` and not need it's own fork of the file.