### PR TITLE
fix(killswitches): Coerce all types to str

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -98,7 +98,7 @@ def normalize_value(
                         raise ValueError(f"Condition {i}: Unknown field: {k}")
 
             if any(v is not None for v in condition.values()):
-                rv.append(condition)
+                rv.append({k: str(v) for k, v in condition.items() if v is not None})
 
     return rv
 

--- a/tests/sentry/runner/commands/test_killswitches.py
+++ b/tests/sentry/runner/commands/test_killswitches.py
@@ -57,7 +57,7 @@ class KillswitchesTest(CliTestCase):
         )
 
         assert self.invoke("pull", OPTION, "-").output == PREAMBLE + (
-            "\n" "\n" "- event_type: transaction\n" "  project_id: 42\n"
+            "\n" "\n" "- event_type: transaction\n" "  project_id: '42'\n"
         )
 
         rv = self.invoke(
@@ -86,9 +86,9 @@ class KillswitchesTest(CliTestCase):
             "\n"
             "\n"
             "- event_type: transaction\n"
-            "  project_id: 42\n"
+            "  project_id: '42'\n"
             "- event_type: null\n"
-            "  project_id: 43\n"
+            "  project_id: '43'\n"
         )
 
         rv = self.invoke(

--- a/tests/sentry/test_killswitches.py
+++ b/tests/sentry/test_killswitches.py
@@ -8,6 +8,10 @@ def test_normalize_value():
         {"project_id": "3"},
     ]
 
+    assert normalize_value("store.load-shed-group-creation-projects", [{"project_id": 123}]) == [
+        {"project_id": "123"},
+    ]
+
 
 def test_value_matches():
     assert _value_matches(
@@ -16,6 +20,16 @@ def test_value_matches():
             {"project_id": "1"},
             {"project_id": "2"},
             {"project_id": "3"},
+        ],
+        {"project_id": 2},
+    )
+
+    assert _value_matches(
+        "store.load-shed-group-creation-projects",
+        [
+            {"project_id": 1},
+            {"project_id": 2},
+            {"project_id": 3},
         ],
         {"project_id": 2},
     )


### PR DESCRIPTION
Killswitches are always compared as strings, make sure all types are
converted to strings before storing or comparing.

Without this PR, all killswitches need to be written like:

```
- project_id: '247802'
  ...
```

instead of

```
- project_id: 247802
  ...
```