### PR TITLE
feat(semver): Add semver cols on Release creation 

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -140,7 +140,7 @@ class ReleaseModelManager(models.Manager):
                             "minor": version_parsed.get("minor"),
                             "patch": version_parsed.get("patch"),
                             "revision": version_parsed.get("revision"),
-                            "prerelease": version_parsed.get("pre"),
+                            "prerelease": version_parsed.get("pre") or "",
                             "build_code": build_code,
                             "build_number": build_number,
                         }

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -108,8 +108,9 @@ class ReleaseModelManager(models.Manager):
         build_number = None
         if build_code is not None:
             try:
-                if int(build_code).bit_length() <= 63:
-                    build_number = int(build_code)
+                build_code_as_int = int(build_code)
+                if build_code_as_int >= 0 and build_code_as_int.bit_length() <= 63:
+                    build_number = build_code_as_int
             except ValueError:
                 pass
         return build_number

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -126,6 +126,7 @@ class ReleaseModelManager(models.Manager):
         if "version" in kwargs:
             try:
                 version_info = parse_release(kwargs["version"])
+                package = version_info.get("package")
                 version_parsed = version_info.get("version_parsed")
 
                 if version_parsed is not None:
@@ -143,6 +144,7 @@ class ReleaseModelManager(models.Manager):
                             "prerelease": version_parsed.get("pre") or "",
                             "build_code": build_code,
                             "build_number": build_number,
+                            "package": package,
                         }
                     )
             except RelayError:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -94,6 +94,70 @@ class ReleaseStatus:
             raise ValueError(repr(value))
 
 
+class ReleaseModelManager(models.Manager):
+    @staticmethod
+    def _convert_build_code_to_build_number(build_code):
+        """
+        Helper function that takes the build_code and checks if that build code can be parsed into
+        a 64 bit integer
+        Inputs:
+            * build_code: str
+        Returns:
+            * build_number
+        """
+        build_number = None
+        if build_code is not None:
+            try:
+                if int(build_code).bit_length() <= 63:
+                    build_number = int(build_code)
+            except ValueError:
+                pass
+        return build_number
+
+    @staticmethod
+    def _massage_semver_cols_into_release_object_data(kwargs):
+        """
+        Helper function that takes kwargs as an argument and massages into it the release semver
+        columns (if possible)
+        Inputs:
+            * kwargs: data of the release that is about to be created
+        """
+        if "version" in kwargs:
+            try:
+                version_info = parse_release(kwargs["version"])
+                version_parsed = version_info.get("version_parsed")
+
+                if version_parsed is not None:
+                    build_code = version_parsed.get("build_code")
+                    build_number = ReleaseModelManager._convert_build_code_to_build_number(
+                        build_code
+                    )
+
+                    kwargs.update(
+                        {
+                            "major": version_parsed.get("major"),
+                            "minor": version_parsed.get("minor"),
+                            "patch": version_parsed.get("patch"),
+                            "revision": version_parsed.get("revision"),
+                            "prerelease": version_parsed.get("pre"),
+                            "build_code": build_code,
+                            "build_number": build_number,
+                        }
+                    )
+            except RelayError:
+                # This can happen on invalid legacy releases
+                pass
+
+    def create(self, *args, **kwargs):
+        """
+        Override create method to parse semver release if it follows semver format, and updates the
+        release object that is about to be created with semver columns i.e. major, minor, patch,
+        revision, prerelease, build_code and build_number
+        """
+        self._massage_semver_cols_into_release_object_data(kwargs)
+        return super().create(*args, **kwargs)
+
+
 class Release(Model):
     """
     A release is generally created when a new version is pushed into a
@@ -161,6 +225,9 @@ class Release(Model):
     # later split up releases by project again.  This is for instance used
     # by the org release listing.
     _for_project_id = None
+
+    # Custom Model Manager required to override create method
+    objects = ReleaseModelManager()
 
     class Meta:
         app_label = "sentry"

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -735,6 +735,22 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.build_code == "202001011005464576758979789794566455464746"
         assert release.build_number is None
 
+    def test_parse_release_into_semver_cols_with_negative_build_code(self):
+        """
+        Test that ensures that if the build_code passed as part of the semver version can be
+        parsed as a 64 bit integer but has a negative sign then build number is left
+        empty
+        """
+        version = "org.example.FooApp@1.0rc1+-2020"
+        release = Release.objects.create(organization=self.org, version=version)
+        assert release.major == 1
+        assert release.minor == 0
+        assert release.patch == 0
+        assert release.revision == 0
+        assert release.prerelease == "rc1"
+        assert release.build_code == "-2020"
+        assert release.build_number is None
+
     def test_parse_non_semver_should_not_fail(self):
         """
         Test that ensures nothing breaks when sending a non semver compatible release

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -751,6 +751,21 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.build_code == "-2020"
         assert release.build_number is None
 
+    def test_parse_release_into_semver_cols_with_no_prerelease(self):
+        """
+        Test that ensures that prerelease is stores as an empty string if not included
+        in the version.
+        """
+        version = "org.example.FooApp@1.0+whatever"
+        release = Release.objects.create(organization=self.org, version=version)
+        assert release.major == 1
+        assert release.minor == 0
+        assert release.patch == 0
+        assert release.revision == 0
+        assert release.prerelease == ""
+        assert release.build_code == "whatever"
+        assert release.build_number is None
+
     def test_parse_non_semver_should_not_fail(self):
         """
         Test that ensures nothing breaks when sending a non semver compatible release

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -688,6 +688,7 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.prerelease == "rc1"
         assert release.build_code == "20200101100"
         assert release.build_number == 20200101100
+        assert release.package == "org.example.FooApp"
 
     def test_parse_release_into_semver_cols_using_custom_get_or_create(self):
         """
@@ -704,6 +705,7 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.prerelease == "rc1"
         assert release.build_code == "20200101100"
         assert release.build_number == 20200101100
+        assert release.package == "org.example.FooApp"
 
     def test_parse_release_into_semver_cols_with_non_int_build_code(self):
         """
@@ -719,6 +721,7 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.prerelease == "rc1"
         assert release.build_code == "whatever"
         assert release.build_number is None
+        assert release.package == "org.example.FooApp"
 
     def test_parse_release_into_semver_cols_with_int_build_code_gt_64_int(self):
         """
@@ -734,6 +737,7 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.prerelease == "rc1"
         assert release.build_code == "202001011005464576758979789794566455464746"
         assert release.build_number is None
+        assert release.package == "org.example.FooApp"
 
     def test_parse_release_into_semver_cols_with_negative_build_code(self):
         """
@@ -750,6 +754,7 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.prerelease == "rc1"
         assert release.build_code == "-2020"
         assert release.build_number is None
+        assert release.package == "org.example.FooApp"
 
     def test_parse_release_into_semver_cols_with_no_prerelease(self):
         """
@@ -765,6 +770,7 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.prerelease == ""
         assert release.build_code == "whatever"
         assert release.build_number is None
+        assert release.package == "org.example.FooApp"
 
     def test_parse_non_semver_should_not_fail(self):
         """


### PR DESCRIPTION
This PR:
- Introduces a custom model manager that overrides `create` method of model `Release`
- Release version is checked upon `Release` instance creation and if it follows semver versioning, it uses relay to parse the release version and populates the corresponding semver cols on `Release` model i.e.`major, minor, patch, revision, prerelease, build_code, build_number, package`
- Checks if `build_code` can be parsed into a 64 bit integer and if so converts it and stores it in `Release` model as `build_number`