### PR TITLE
feat(releases): Do not store small zip files as archives

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -342,7 +342,7 @@ register("processing.save-release-archives", default=False)
 
 # Minimum number of files in an archive. Small archives are extracted and its contents
 # are stored as separate release files.
-register("processing.release-archive-min-size", default=10)
+register("processing.release-archive-min-files", default=10)
 
 # Try to read release artifacts from zip archives
 register("processing.use-release-archives-sample-rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -340,5 +340,9 @@ register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
 # Store release files bundled as zip files
 register("processing.save-release-archives", default=False)
 
+# Minimum number of files in an archive. Small archives are extracted and its contents
+# are stored as separate release files.
+register("processing.release-archive-min-size", default=10)
+
 # Try to read release artifacts from zip archives
 register("processing.use-release-archives-sample-rate", default=0.0)

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -314,7 +314,7 @@ def assemble_artifacts(org_id, version, checksum, chunks, **kwargs):
             num_files = len(manifest.get("files", {}))
 
             if options.get("processing.save-release-archives"):
-                min_size = options.get("processing.release-archive-min-size")
+                min_size = options.get("processing.release-archive-min-files")
                 if num_files >= min_size:
                     kwargs = dict(meta, name=RELEASE_ARCHIVE_FILENAME)
                     _upsert_release_file(bundle, archive, _merge_archives, **kwargs)

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -192,7 +192,12 @@ class AssembleArtifactsTest(BaseAssembleTest):
         total_checksum = sha1(bundle_file).hexdigest()
 
         for has_release_archives in (True, False):
-            with self.options({"processing.save-release-archives": has_release_archives}):
+            with self.options(
+                {
+                    "processing.save-release-archives": has_release_archives,
+                    "processing.release-archive-min-size": 1,
+                }
+            ):
 
                 assemble_artifacts(
                     org_id=self.organization.id,

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -195,7 +195,7 @@ class AssembleArtifactsTest(BaseAssembleTest):
             with self.options(
                 {
                     "processing.save-release-archives": has_release_archives,
-                    "processing.release-archive-min-size": 1,
+                    "processing.release-archive-min-files": 1,
                 }
             ):
 


### PR DESCRIPTION
Introduce a threshold s.t. small ZIP files are not stored as release archives.