### PR TITLE
ref(performance): Lift team key transaction state to context manager

### DIFF
--- a/static/app/actionCreators/performance.tsx
+++ b/static/app/actionCreators/performance.tsx
@@ -12,11 +12,13 @@ type KeyTransaction = {
   transaction: string;
 };
 
-export type TeamKeyTransaction = {
+type TeamKeyTransaction = {
   team: string;
   count: number;
   keyed: KeyTransaction[];
 };
+
+export type TeamKeyTransactions = TeamKeyTransaction[];
 
 export async function fetchTeamKeyTransactions(
   api: Client,
@@ -26,10 +28,9 @@ export async function fetchTeamKeyTransactions(
 ): Promise<TeamKeyTransaction[]> {
   const url = `/organizations/${orgSlug}/key-transactions-list/`;
 
+  const datas: TeamKeyTransactions[] = [];
   let cursor: string | undefined = undefined;
   let hasMore = true;
-
-  const teamKeyTransactions: TeamKeyTransaction[][] = [];
 
   while (hasMore) {
     try {
@@ -47,7 +48,7 @@ export async function fetchTeamKeyTransactions(
         query: payload,
       });
 
-      teamKeyTransactions.push(data);
+      datas.push(data);
 
       const pageLinks = xhr && xhr.getResponseHeader('Link');
       if (pageLinks) {
@@ -65,7 +66,7 @@ export async function fetchTeamKeyTransactions(
     }
   }
 
-  return teamKeyTransactions.flat();
+  return datas.flat();
 }
 
 export function toggleKeyTransaction(

--- a/static/app/actionCreators/performance.tsx
+++ b/static/app/actionCreators/performance.tsx
@@ -7,13 +7,15 @@ import {Client} from 'app/api';
 import {t} from 'app/locale';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 
-type TeamKeyTransaction = {
+type KeyTransaction = {
+  project_id: string;
+  transaction: string;
+};
+
+export type TeamKeyTransaction = {
   team: string;
   count: number;
-  keyed: {
-    project_id: string;
-    transaction: string;
-  }[];
+  keyed: KeyTransaction[];
 };
 
 export async function fetchTeamKeyTransactions(
@@ -24,9 +26,10 @@ export async function fetchTeamKeyTransactions(
 ): Promise<TeamKeyTransaction[]> {
   const url = `/organizations/${orgSlug}/key-transactions-list/`;
 
-  const datas: TeamKeyTransaction[][] = [];
   let cursor: string | undefined = undefined;
   let hasMore = true;
+
+  const teamKeyTransactions: TeamKeyTransaction[][] = [];
 
   while (hasMore) {
     try {
@@ -43,7 +46,8 @@ export async function fetchTeamKeyTransactions(
         includeAllArgs: true,
         query: payload,
       });
-      datas.push(data);
+
+      teamKeyTransactions.push(data);
 
       const pageLinks = xhr && xhr.getResponseHeader('Link');
       if (pageLinks) {
@@ -61,7 +65,7 @@ export async function fetchTeamKeyTransactions(
     }
   }
 
-  return datas.flat();
+  return teamKeyTransactions.flat();
 }
 
 export function toggleKeyTransaction(

--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -168,7 +168,7 @@ class UnwrappedProvider extends Component<Props> {
           count: count - 1,
           keyed: keyed.filter(
             keyTransaction =>
-              keyTransaction.project_id !== String(project) &&
+              keyTransaction.project_id !== String(project) ||
               keyTransaction.transaction !== transactionName
           ),
         };

--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -76,14 +76,20 @@ class UnwrappedProvider extends Component<Props> {
 
   componentDidUpdate(prevProps: Props) {
     const orgSlugChanged = prevProps.organization.slug !== this.props.organization.slug;
-
     const selectedTeamsChanged =
       prevProps.selectedTeams.length !== this.props.selectedTeams.length ||
       prevProps.selectedTeams.every(
         (teamId, i) => this.props.selectedTeams[i] !== teamId
       );
+    const selectedProjectsChanged =
+      prevProps.selectedProjects &&
+      this.props.selectedProjects &&
+      prevProps.selectedProjects.length !== this.props.selectedProjects.length &&
+      prevProps.selectedProjects.every(
+        (projectId, i) => this.props.selectedProjects?.[i] !== projectId
+      );
 
-    if (orgSlugChanged || selectedTeamsChanged) {
+    if (orgSlugChanged || selectedTeamsChanged || selectedProjectsChanged) {
       this.fetchData();
     }
   }

--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -1,0 +1,249 @@
+import {Component, createContext, ReactNode} from 'react';
+
+import {
+  fetchTeamKeyTransactions,
+  TeamKeyTransaction,
+  toggleKeyTransaction,
+} from 'app/actionCreators/performance';
+import {Client} from 'app/api';
+import {t} from 'app/locale';
+import {Organization, Team} from 'app/types';
+import withApi from 'app/utils/withApi';
+
+export type SelectionBase = {
+  action: 'key' | 'unkey';
+  project: number;
+  transactionName: string;
+};
+export type MyTeamSelection = SelectionBase & {type: 'my teams'};
+export type TeamIdSelection = SelectionBase & {type: 'id'; teamId: string};
+export type TeamSelection = MyTeamSelection | TeamIdSelection;
+
+export function isMyTeamSelection(
+  selection: TeamSelection
+): selection is MyTeamSelection {
+  return selection.type === 'my teams';
+}
+
+export type TeamKeyTransactionManagerChildrenProps = {
+  teams: Team[];
+  isLoading: boolean;
+  error: string | null;
+  counts: Map<string, number> | null;
+  getKeyedTeams: (project: string, transactionName: string) => Set<string> | null;
+  handleToggleKeyTransaction: (selection: TeamSelection) => void;
+};
+
+const TeamKeyTransactionsManagerContext = createContext<TeamKeyTransactionManagerChildrenProps>(
+  {
+    teams: [],
+    isLoading: false,
+    error: null,
+    counts: null,
+    getKeyedTeams: () => null,
+    handleToggleKeyTransaction: () => {},
+  }
+);
+
+type Props = {
+  api: Client;
+  children: ReactNode;
+  organization: Organization;
+  teams: Team[];
+  selectedTeams: string[];
+  selectedProjects?: string[];
+};
+
+type State = Omit<
+  TeamKeyTransactionManagerChildrenProps,
+  'teams' | 'counts' | 'getKeyedTeams' | 'handleToggleKeyTransaction'
+> & {
+  keyFetchID: symbol | null;
+  teamKeyTransactions: TeamKeyTransaction[];
+};
+
+class UnwrappedProvider extends Component<Props> {
+  state: State = {
+    keyFetchID: null,
+    isLoading: true,
+    error: null,
+    teamKeyTransactions: [],
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const orgSlugChanged = prevProps.organization.slug !== this.props.organization.slug;
+
+    const selectedTeamsChanged =
+      prevProps.selectedTeams.length !== this.props.selectedTeams.length ||
+      prevProps.selectedTeams.every(
+        (teamId, i) => this.props.selectedTeams[i] !== teamId
+      );
+
+    if (orgSlugChanged || selectedTeamsChanged) {
+      this.fetchData();
+    }
+  }
+
+  async fetchData() {
+    const {api, organization, selectedTeams, selectedProjects} = this.props;
+    const keyFetchID = Symbol('keyFetchID');
+    this.setState({isLoading: true, keyFetchID});
+
+    let teamKeyTransactions: TeamKeyTransaction[] = [];
+    let error: string | null = null;
+
+    try {
+      teamKeyTransactions = await fetchTeamKeyTransactions(
+        api,
+        organization.slug,
+        selectedTeams,
+        selectedProjects
+      );
+    } catch (err) {
+      error = err.responseJSON?.detail ?? t('Error fetching team key transactions');
+    }
+
+    this.setState({
+      isLoading: false,
+      keyFetchID: undefined,
+      error,
+      teamKeyTransactions,
+    });
+  }
+
+  getCounts() {
+    const {teamKeyTransactions} = this.state;
+
+    const counts: Map<string, number> = new Map();
+
+    teamKeyTransactions.forEach(({team, count}) => {
+      counts.set(team, count);
+    });
+
+    return counts;
+  }
+
+  getKeyedTeams = (projectId: string, transactionName: string) => {
+    const {teamKeyTransactions} = this.state;
+
+    const keyedTeams: Set<string> = new Set();
+
+    teamKeyTransactions.forEach(({team, keyed}) => {
+      const isKeyedByTeam = keyed.find(
+        keyedTeam =>
+          keyedTeam.project_id === projectId && keyedTeam.transaction === transactionName
+      );
+      if (isKeyedByTeam) {
+        keyedTeams.add(team);
+      }
+    });
+
+    return keyedTeams;
+  };
+
+  handleToggleKeyTransaction = async (selection: TeamSelection) => {
+    const {api, organization} = this.props;
+    const {teamKeyTransactions} = this.state;
+    const {action, project, transactionName} = selection;
+    const isKeyTransaction = action === 'unkey';
+
+    const {teamIds} = isMyTeamSelection(selection)
+      ? this.toggleKeyTransactionForMyTeams()
+      : this.toggleKeyTransactionForTeam(selection);
+
+    const teamIdSet = new Set(teamIds);
+
+    const newTeamKeyTransactions = teamKeyTransactions.map(({team, count, keyed}) => {
+      if (teamIdSet.has(team)) {
+        if (isKeyTransaction) {
+          return {
+            team,
+            count: count - 1,
+            keyed: keyed.filter(
+              keyTransaction =>
+                keyTransaction.project_id !== String(project) &&
+                keyTransaction.transaction !== transactionName
+            ),
+          };
+        } else {
+          return {
+            team,
+            count: count + 1,
+            keyed: [
+              ...keyed,
+              {
+                project_id: String(project),
+                transaction: transactionName,
+              },
+            ],
+          };
+        }
+      }
+      return {
+        team,
+        count,
+        keyed,
+      };
+    });
+
+    try {
+      await toggleKeyTransaction(
+        api,
+        isKeyTransaction,
+        organization.slug,
+        [project],
+        transactionName,
+        teamIds
+      );
+      this.setState({teamKeyTransactions: newTeamKeyTransactions});
+    } catch (err) {
+      this.setState({
+        error: err.responseJSON?.detail ?? null,
+      });
+    }
+  };
+
+  toggleKeyTransactionForMyTeams() {
+    const {teams} = this.props;
+
+    return {
+      teamIds: teams.filter(({isMember}) => isMember).map(({id}) => id),
+    };
+  }
+
+  toggleKeyTransactionForTeam(selection: TeamIdSelection) {
+    const {teamId} = selection;
+
+    return {
+      teamIds: [teamId],
+    };
+  }
+
+  render() {
+    const {teams} = this.props;
+    const {isLoading, error} = this.state;
+
+    const childrenProps: TeamKeyTransactionManagerChildrenProps = {
+      teams,
+      isLoading,
+      error,
+      counts: this.getCounts(),
+      getKeyedTeams: this.getKeyedTeams,
+      handleToggleKeyTransaction: this.handleToggleKeyTransaction,
+    };
+
+    return (
+      <TeamKeyTransactionsManagerContext.Provider value={childrenProps}>
+        {this.props.children}
+      </TeamKeyTransactionsManagerContext.Provider>
+    );
+  }
+}
+
+export const Provider = withApi(UnwrappedProvider);
+
+export const Consumer = TeamKeyTransactionsManagerContext.Consumer;

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
@@ -1,20 +1,15 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
-import {
-  fetchTeamKeyTransactions,
-  toggleKeyTransaction,
-} from 'app/actionCreators/performance';
-import {Client} from 'app/api';
 import Button from 'app/components/button';
-import TeamKeyTransaction, {
+import TeamKeyTransactionComponent, {
   TitleProps,
 } from 'app/components/performance/teamKeyTransaction';
+import * as TeamKeyTransactionManager from 'app/components/performance/teamKeyTransactionsManager';
 import {IconStar} from 'app/icons';
 import {t, tn} from 'app/locale';
 import {Organization, Team} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
-import withApi from 'app/utils/withApi';
 import withTeams from 'app/utils/withTeams';
 
 /**
@@ -38,147 +33,71 @@ class TitleButton extends Component<TitleProps> {
 }
 
 type BaseProps = {
-  api: Client;
   organization: Organization;
   transactionName: string;
   teams: Team[];
 };
 
-type Props = BaseProps & {
-  project: number;
-};
-
-type State = {
-  isLoading: boolean;
-  keyFetchID: symbol | undefined;
-  error: null | string;
-  keyedTeams: Set<string>;
-  counts: Map<string, number>;
-};
-
-class TeamKeyTransactionButton extends Component<Props, State> {
-  state: State = {
-    isLoading: true,
-    keyFetchID: undefined,
-    error: null,
-    keyedTeams: new Set(),
-    counts: new Map(),
+type Props = BaseProps &
+  TeamKeyTransactionManager.TeamKeyTransactionManagerChildrenProps & {
+    project: number;
   };
 
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    const orgSlugChanged = prevProps.organization.slug !== this.props.organization.slug;
-    const projectsChanged = prevProps.project !== this.props.project;
-    const transactionChanged = prevProps.transactionName !== this.props.transactionName;
-    if (orgSlugChanged || projectsChanged || transactionChanged) {
-      this.fetchData();
-    }
-  }
-
-  async fetchData() {
-    const {api, organization, project, transactionName} = this.props;
-    const keyFetchID = Symbol('keyFetchID');
-    this.setState({isLoading: true, keyFetchID});
-
-    let keyedTeams: Set<string> = new Set();
-    let counts: Map<string, number> = new Map();
-
-    let error: string | null = null;
-
-    try {
-      const teams = await fetchTeamKeyTransactions(
-        api,
-        organization.slug,
-        ['myteams'],
-        [String(project)]
-      );
-
-      keyedTeams = new Set(
-        teams
-          .filter(({keyed}) =>
-            keyed.find(
-              ({project_id, transaction}) =>
-                project_id === String(project) && transaction === transactionName
-            )
-          )
-          .map(({team}) => team)
-      );
-      counts = new Map(teams.map(({team, count}) => [team, count]));
-    } catch (err) {
-      error = err.responseJSON?.detail ?? t('Error fetching team key transactions');
-    }
-
-    this.setState({
-      isLoading: false,
-      keyFetchID: undefined,
-      error,
-      keyedTeams,
-      counts,
-    });
-  }
-
-  handleToggleKeyTransaction = async (
-    isKey: boolean,
-    teamIds: string[],
-    counts: Map<string, number>,
-    keyedTeams: Set<string>
-  ) => {
-    const {api, organization, project, transactionName} = this.props;
-    try {
-      await toggleKeyTransaction(
-        api,
-        isKey,
-        organization.slug,
-        [project],
-        transactionName,
-        teamIds
-      );
-      this.setState({
-        counts,
-        keyedTeams,
-      });
-    } catch (err) {
-      this.setState({
-        error: err.responseJSON?.detail ?? null,
-      });
-    }
-  };
-
-  render() {
-    const {isLoading, error, counts, keyedTeams} = this.state;
-    return (
-      <TeamKeyTransaction
-        isLoading={isLoading}
-        error={error}
-        counts={counts}
-        keyedTeams={keyedTeams}
-        handleToggleKeyTransaction={this.handleToggleKeyTransaction}
-        title={TitleButton}
-        {...this.props}
-      />
-    );
-  }
+function TeamKeyTransactionButton({
+  counts,
+  getKeyedTeams,
+  project,
+  transactionName,
+  ...props
+}: Props) {
+  const keyedTeams = getKeyedTeams(String(project), transactionName);
+  return (
+    <TeamKeyTransactionComponent
+      counts={counts}
+      keyedTeams={keyedTeams}
+      title={TitleButton}
+      project={project}
+      transactionName={transactionName}
+      {...props}
+    />
+  );
 }
 
 type WrapperProps = BaseProps & {
   eventView: EventView;
 };
 
-function TeamKeyTransactionButtonWrapper({eventView, teams, ...props}: WrapperProps) {
+function TeamKeyTransactionButtonWrapper({
+  eventView,
+  organization,
+  teams,
+  ...props
+}: WrapperProps) {
   if (eventView.project.length !== 1) {
     return <TitleButton disabled keyedTeamsCount={0} />;
   }
 
+  const projectId = eventView.project[0];
   const userTeams = teams.filter(({isMember}) => isMember);
+
   return (
-    <TeamKeyTransactionButton
+    <TeamKeyTransactionManager.Provider
+      organization={organization}
       teams={userTeams}
-      project={eventView.project[0]}
-      {...props}
-    />
+      selectedTeams={['myteams']}
+      selectedProjects={[String(projectId)]}
+    >
+      <TeamKeyTransactionManager.Consumer>
+        {results => (
+          <TeamKeyTransactionButton
+            organization={organization}
+            project={projectId}
+            {...props}
+            {...results}
+          />
+        )}
+      </TeamKeyTransactionManager.Consumer>
+    </TeamKeyTransactionManager.Provider>
   );
 }
 
@@ -186,4 +105,4 @@ const StyledButton = styled(Button)`
   width: 180px;
 `;
 
-export default withApi(withTeams(TeamKeyTransactionButtonWrapper));
+export default withTeams(TeamKeyTransactionButtonWrapper);


### PR DESCRIPTION
This lifts the stateful components of the team key transaction button into a
context that will be reused for the performance landing page.