### PR TITLE
fix(search): Correct line height on search + highlight

### DIFF
--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -101,7 +101,6 @@ export default function renderQuery(query: string) {
 }
 
 const SearchQuery = styled('span')`
-  line-height: 24px;
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.familyMono};
 `;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1331,7 +1331,7 @@ const Highlight = styled('div')`
   bottom: 0;
   user-select: none;
   white-space: pre-wrap;
-  line-height: 24px;
+  line-height: 25px;
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.familyMono};
 `;


### PR DESCRIPTION
Kinda subtle but the height of the selection is now consistent 
![image](https://user-images.githubusercontent.com/1421724/120407395-eb009680-c301-11eb-97f9-c4c37ad5c696.png)
