### PR TITLE
feat(migrations): Don't generate migrations for metadata changes.

### DIFF
--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -1,6 +1,8 @@
 from django import VERSION
+from django.db import models
 
 from sentry.new_migrations.monkey.executor import SentryMigrationExecutor
+from sentry.new_migrations.monkey.fields import deconstruct
 from sentry.new_migrations.monkey.writer import SENTRY_MIGRATION_TEMPLATE
 
 LAST_VERIFIED_DJANGO_VERSION = (1, 11)
@@ -33,3 +35,4 @@ def monkey_migrations():
     executor.MigrationExecutor = SentryMigrationExecutor
     migration.Migration.initial = None
     writer.MIGRATION_TEMPLATE = SENTRY_MIGRATION_TEMPLATE
+    models.Field.deconstruct = deconstruct

--- a/src/sentry/new_migrations/monkey/fields.py
+++ b/src/sentry/new_migrations/monkey/fields.py
@@ -5,6 +5,11 @@ original_deconstruct = Field.deconstruct
 
 
 def deconstruct(self):
+    """
+    Overrides the default field deconstruct method. This is used to pop unwanted
+    keyword arguments from the field during deconstruction, so that they will be ignored
+    when generating migrations.
+    """
     name, path, args, kwargs = original_deconstruct(self)
     for attr in IGNORED_ATTRS:
         kwargs.pop(attr, None)

--- a/src/sentry/new_migrations/monkey/fields.py
+++ b/src/sentry/new_migrations/monkey/fields.py
@@ -1,0 +1,11 @@
+from django.db.models import Field
+
+IGNORED_ATTRS = ["verbose_name", "help_text", "choices"]
+original_deconstruct = Field.deconstruct
+
+
+def deconstruct(self):
+    name, path, args, kwargs = original_deconstruct(self)
+    for attr in IGNORED_ATTRS:
+        kwargs.pop(attr, None)
+    return name, path, args, kwargs

--- a/tests/sentry/new_migrations/monkey/test_monkey.py
+++ b/tests/sentry/new_migrations/monkey/test_monkey.py
@@ -1,6 +1,8 @@
 from django.db.migrations import executor, writer
+from django.db.models import Field
 
 from sentry.new_migrations.monkey.executor import SentryMigrationExecutor
+from sentry.new_migrations.monkey.fields import deconstruct, original_deconstruct
 from sentry.new_migrations.monkey.writer import SENTRY_MIGRATION_TEMPLATE
 from sentry.testutils import TestCase
 
@@ -9,3 +11,4 @@ class MonkeyTest(TestCase):
     def test(self):
         assert executor.MigrationExecutor is SentryMigrationExecutor
         assert writer.MIGRATION_TEMPLATE == SENTRY_MIGRATION_TEMPLATE
+        assert Field.deconstruct == deconstruct != original_deconstruct


### PR DESCRIPTION
Currently, whenever we modify `choices` on a model Django's migration tool generates a new migration
that only modifies state. This pr changes that, so that we only create migrations for relevant
changes. Originally I was considering adding an (allow|deny)list to decide which `Fields` should be
opted in, but I don't think it's worth doing so initially.

We don't really care about the state of choices in our migrations. Django is opinionated about this
and is unlikely to change it: https://code.djangoproject.com/ticket/22837. But since we know our own
usage this should be safe enough to do.

Based this on
https://stackoverflow.com/questions/26503826/why-does-django-make-migrations-for-help-text-and-verbose-name-changes.