### PR TITLE
fix(alerts): Change the old alert details link in the sidebar with new

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -387,7 +387,12 @@ export default class DetailsBody extends React.Component<Props> {
                 </Layout.Main>
                 <Layout.Side>
                   {this.renderMetricStatus()}
-                  <Timeline api={api} orgId={orgId} rule={rule} incidents={incidents} />
+                  <Timeline
+                    api={api}
+                    organization={organization}
+                    rule={rule}
+                    incidents={incidents}
+                  />
                   {this.renderRuleDetails()}
                 </Layout.Side>
               </StyledLayoutBodyWrapper>

--- a/static/app/views/alerts/rules/details/timeline.tsx
+++ b/static/app/views/alerts/rules/details/timeline.tsx
@@ -13,6 +13,8 @@ import SeenByList from 'app/components/seenByList';
 import TimeSince from 'app/components/timeSince';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
+import {Organization} from 'app/types';
+import {alertDetailsLink} from 'app/views/alerts/details';
 import {getTriggerName} from 'app/views/alerts/details/activity/statusItem';
 import {
   ActivityType,
@@ -25,7 +27,7 @@ import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 type IncidentProps = {
   api: Client;
-  orgId: string;
+  organization: Organization;
   incident: Incident;
   rule: IncidentRule;
 };
@@ -131,12 +133,16 @@ class TimelineIncident extends React.Component<IncidentProps> {
   }
 
   render() {
-    const {incident, orgId} = this.props;
+    const {incident, organization} = this.props;
+
     return (
       <IncidentSection key={incident.identifier}>
         <IncidentHeader>
           <Link
-            to={`/organizations/${orgId}/alerts/${incident.identifier}/?redirect=false`}
+            to={{
+              pathname: alertDetailsLink(organization, incident),
+              query: {alert: incident.identifier},
+            }}
           >
             {tct('Alert #[id]', {id: incident.identifier})}
           </Link>
@@ -165,7 +171,7 @@ class TimelineIncident extends React.Component<IncidentProps> {
 type Props = {
   api: Client;
   rule?: IncidentRule;
-  orgId: string;
+  organization: Organization;
   incidents?: Incident[];
 };
 
@@ -179,7 +185,7 @@ class Timeline extends React.Component<Props> {
   };
 
   render() {
-    const {api, incidents, orgId, rule} = this.props;
+    const {api, incidents, organization, rule} = this.props;
 
     return (
       <History>
@@ -191,7 +197,7 @@ class Timeline extends React.Component<Props> {
                   <TimelineIncident
                     key={incident.identifier}
                     api={api}
-                    orgId={orgId}
+                    organization={organization}
                     incident={incident}
                     rule={rule}
                   />


### PR DESCRIPTION
This replaces the last old alert details page link with the new one. The old ui is still accessible with a url parameter passed to the old alert details link: `/organizations/${orgId}/alerts/${alertId}/?redirect=false`

Reported here: https://github.com/getsentry/sentry/issues/26324