### PR TITLE
feat(metrics): Scrub spammy sources for beacon metrics

### DIFF
--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -88,6 +88,43 @@ const makeBeaconRequest = throttle(
   {trailing: true, leading: false}
 );
 
+/**
+ * First checks if stacktrace should be ignored, and then returns
+ * a scrubbed and limited stacktrace.
+ *
+ * Returns `null` if it should be ignored
+ */
+export function getCleanStack(stack: string): string | null {
+  // Scrub out any hostnames
+  const scrubbedStack = stack.replace(/https?:\/\/.*?\//, '/');
+
+  // This is an exclude list of strings. If any of these appear in the stack,
+  // then it should be ignored.
+  const excludeList = [
+    '__puppeteer_evaluation_script__',
+    '-extension',
+    'papaparse',
+    'AdGuard',
+  ];
+
+  if (excludeList.some(str => scrubbedStack.includes(str))) {
+    return null;
+  }
+
+  // Split stack by lines and filter out empty strings
+  const stackArr = scrubbedStack?.split('\n').filter(s => !!s) || [];
+
+  // There's an issue with Firefox where this getter for jQuery gets called many times (> 100)
+  // The stacktrace doesn't show it being called outside of this block either.
+  // (this works fine in Chrome...)
+  if (stackArr.length <= 1) {
+    return null;
+  }
+
+  // First limit to last 5 frames and limit to first 1024 characters
+  return stackArr.slice(0, 5).join('\n').slice(0, 1024);
+}
+
 [
   [SentryApp, globals.SentryApp],
   [globals, window],
@@ -101,17 +138,11 @@ const makeBeaconRequest = throttle(
           enumerable: false,
           get() {
             try {
-              const stack = new Error().stack;
-              // Split stack by lines and filter out empty strings
-              const stackArr = stack?.split('\n').filter(s => !!s) || [];
-              // There's an issue with Firefox where this getter for jQuery gets called many times (> 100)
-              // The stacktrace doesn't show it being called outside of this block either.
-              // And this works fine in Chrome...
-              if (key !== 'SentryApp' && stackArr.length > 1) {
-                // Limit the number of frames to include, as well as the total size of the string
+              const stack = getCleanStack(new Error().stack ?? '');
+              if (key !== 'SentryApp' && stack !== null) {
                 _beaconComponents.push({
                   component: key,
-                  stack: stackArr.slice(0, 5).join('\n').slice(0, 1024),
+                  stack,
                 });
                 makeBeaconRequest();
               }

--- a/tests/js/spec/bootstrap/exportGlobals.spec.jsx
+++ b/tests/js/spec/bootstrap/exportGlobals.spec.jsx
@@ -1,0 +1,56 @@
+import {getCleanStack} from 'app/bootstrap/exportGlobals';
+
+/**
+ * This should be temporary
+ */
+describe('exportGlobals', function () {
+  it('scrubs any http hostnames', function () {
+    expect(
+      getCleanStack(`Error at get (https://s1.sentry-cdn.com/_static/dist/sentry/app.7831ef2f533f69df6c88.js:1:75508)
+  at <anonymous>:22:20
+  at <anonymous>:37:3`)
+    ).toBe(
+      `Error at get (/_static/dist/sentry/app.7831ef2f533f69df6c88.js:1:75508)
+  at <anonymous>:22:20
+  at <anonymous>:37:3`
+    );
+
+    expect(
+      getCleanStack(`Error at get (http://s1.sentry-cdn.com/_static/dist/sentry/app.7831ef2f533f69df6c88.js:1:75508)
+  at <anonymous>:22:20
+  at <anonymous>:37:3`)
+    ).toBe(`Error at get (/_static/dist/sentry/app.7831ef2f533f69df6c88.js:1:75508)
+  at <anonymous>:22:20
+  at <anonymous>:37:3`);
+  });
+
+  it('ignores single stack traces', function () {
+    expect(
+      getCleanStack('get@webpack-internal:///./app/bootstrap/exportGlobals.tsx:259:53')
+    ).toBe(null);
+  });
+
+  it('ignores when accessed from a browser extension', function () {
+    expect(
+      getCleanStack(
+        'Error at get (https://sentry.io/_static/dist/sentry/app.33ea1fef36e2625bd1b7.js:1:78763) at chrome-extension://gppongmhjkpfnbhagpmjfkannfbllamg/js/inject.js:25:30 at Array.reduce (<anonymous>) at chrome-extension://gppongmhjkpfnbhagpmjfkannfbllamg/js/inject.js:20:18'
+      )
+    ).toBe(null);
+  });
+
+  it('ignores when accessed from `papaparse`', function () {
+    expect(
+      getCleanStack(
+        'Error at get (http://sentry.io/_static/dist/sentry/app.d90b66b3633145480691.js:1:78622) at Object.e (http://sentry.io/_static/dist/sentry/vendor.1773e9fe32bdfb905d54.js:2:1441549) at Object.../node_modules/papaparse/papaparse.min.js (http://sentry.io/_static/dist/sentry/vendor.1773e9fe32bdfb905d54.js:2:1456482) at n (http://sentry.io/_static/dist/sentry/runtime.eac5a039e1af7f397580.js:1:149)'
+      )
+    ).toBe(null);
+  });
+
+  it('ignores when accessed from puppeteer', function () {
+    expect(
+      getCleanStack(
+        'Error at get (https://sentry.io/_static/dist/sentry/app.46cd9429804a08faf9dd.js:1:78622) at __puppeteer_evaluation_script__:18:25 at Array.map (<anonymous>) at __puppeteer_evaluation_script__:10:18'
+      )
+    ).toBe(null);
+  });
+});


### PR DESCRIPTION
Follow-up for https://github.com/getsentry/sentry/pull/26079 --

* Scrubs URLs from stack
* Ignores certain "spammy" sources in stack frames (e.g. browser extensions)
* Adds tests