### PR TITLE
fix(releases): Do not list or count release archive as artifact

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -13,6 +13,7 @@ from sentry.models import (
     ReleaseFile,
     ReleaseProject,
 )
+from sentry.tasks.assemble import RELEASE_ARCHIVE_FILENAME
 
 
 class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
@@ -77,7 +78,11 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
             for pr in project_releases
         ]
 
-        release_file_count = ReleaseFile.objects.filter(release=release).count()
+        release_file_count = (
+            ReleaseFile.objects.filter(release=release)
+            .exclude(name=RELEASE_ARCHIVE_FILENAME)
+            .count()
+        )
 
         return Response(
             {

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -12,6 +12,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import MAX_RELEASE_FILES_OFFSET
 from sentry.models import File, Release, ReleaseFile
+from sentry.tasks.assemble import RELEASE_ARCHIVE_FILENAME
 
 ERR_FILE_EXISTS = "A file matching this name already exists for the given release"
 _filename_re = re.compile(r"[\n\t\r\f\v\\]")
@@ -46,7 +47,7 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
 
         file_list = (
             ReleaseFile.objects.filter(release=release).select_related("file").order_by("name")
-        )
+        ).exclude(name=RELEASE_ARCHIVE_FILENAME)
 
         if query:
             if not isinstance(query, list):


### PR DESCRIPTION
Hide the newly created release file `release-artifacts.zip` from lists and counts.