### PR TITLE
fix(api): Reverse prev and next release in `OrganizationReleaseDetailsEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -165,9 +165,20 @@ class OrganizationReleaseDetailsPaginationMixin:
         else:
             raise InvalidSortException
 
+        # This is reversed on purpose and the reason for that is that the prev and next releases
+        # are computed in the same order as the releases list page and so for example if you have a
+        # releases list ordered by date_created, that looks like this
+        # * Release 3.0.0 -> Created last
+        # * Release 2.0.0 -> Created before last
+        # * Release 1.0.0 -> Created first
+        # Then the prev and next for Release 2.0.0 would be Release 3.0.0 (more recent) and Release
+        # 1.0.0 (less recent) respectively. This would however result in non-intuitive behaviour
+        # in the UI because when you click on "<" (prev) you expect to go back to an "older"
+        # release, but prev here will give you a more recent release as this list is ordered
+        # in DESC order, and the same case can be made for when you click on ">" or next.
         return {
-            "next_release_version": next_release_version,
-            "prev_release_version": prev_release_version,
+            "next_release_version": prev_release_version,
+            "prev_release_version": next_release_version,
         }
 
 

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -196,8 +196,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@3.0.0"
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@1.0.0"
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@3.0.0"
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@1.0.0"
 
         # Test for first release of the list
         url = reverse(
@@ -206,8 +206,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] is None
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@2.0.0"
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] is None
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@2.0.0"
 
         # Test for last release of the list
         url = reverse(
@@ -216,8 +216,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@2.0.0"
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] is None
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@2.0.0"
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] is None
 
     def test_get_prev_and_next_release_to_current_release_on_date_sort_with_same_date(self):
         """
@@ -246,8 +246,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@2.0.0"
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] is None
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@2.0.0"
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] is None
 
         # Test for first release of the list
         url = reverse(
@@ -256,8 +256,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] is None
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@1.0.0"
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] is None
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@1.0.0"
 
     def test_get_prev_and_next_release_to_current_release_on_date_sort_env_filter_applied(self):
         """
@@ -306,8 +306,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id, "environment": ["prod"]})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] is None
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@1.0.0"
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] is None
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@1.0.0"
 
     def test_get_prev_and_next_release_on_date_sort_does_not_apply_stats_period_filter(self):
         """
@@ -343,8 +343,8 @@ class ReleaseDetailsTest(APITestCase):
         )
         response = self.client.get(url, {"project": self.project1.id, "summaryStatsPeriod": "24h"})
         assert response.status_code == 200
-        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@2.0.0"
-        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@3.0.0"
+        assert response.data["currentProjectMeta"]["nextReleaseVersion"] == "foobar@2.0.0"
+        assert response.data["currentProjectMeta"]["prevReleaseVersion"] == "foobar@3.0.0"
 
 
 class UpdateReleaseDetailsTest(APITestCase):


### PR DESCRIPTION
This PR:-
- Reverses the prev and next releases returned from ` OrganizationReleaseDetailsEndpoint` to be more intuitive for users when navigating releases since when users click on "<" or prev, they expect to receive an older release for example, whereas in what we already have "prev" would return a more recent release since the releases in the releases list are ordered in DESC order in `date_added` . However the same also applies for (`sessions`, `users`, `crash_free_sessions`, `crash_free_users`)