### PR TITLE
feat(performance): Use duration component to render span on duration value

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -11,7 +11,6 @@ import UserBadge from 'app/components/idBadge/userBadge';
 import {DurationPill, RowRectangle} from 'app/components/performance/waterfall/rowBar';
 import {
   getDurationDisplay,
-  getHumanDuration,
   pickBarColour,
   toPercent,
 } from 'app/components/performance/waterfall/utils';
@@ -546,7 +545,7 @@ const spanOperationBreakdownRenderer = (field: string) => (
           showDetail={false}
           spanBarHatch={false}
         >
-          {getHumanDuration(spanOpDuration / 1000)}
+          <Duration seconds={spanOpDuration / 1000} fixedDigits={2} abbreviation />
         </DurationPill>
       </RowRectangle>
     </div>


### PR DESCRIPTION
Currently the span ops view only displays the duration value in `ms`. This may not be the most readable format for all events:
![image](https://user-images.githubusercontent.com/83961295/120501236-74aa7580-c38f-11eb-84bb-2344bf6071ed.png)

This updates the duration display to be more dynamic and display using more appropriate bases:

![image](https://user-images.githubusercontent.com/83961295/120501666-ca7f1d80-c38f-11eb-8dbe-43929a395857.png)

![image](https://user-images.githubusercontent.com/83961295/120501601-baffd480-c38f-11eb-9d54-320d04d55136.png)

![image](https://user-images.githubusercontent.com/83961295/120501107-56dd1080-c38f-11eb-8bfe-b71ecbc0d9c1.png)

`ms` is still used when relevant:

![image](https://user-images.githubusercontent.com/83961295/120501709-d4088580-c38f-11eb-8b36-e6351abeff39.png)
