### PR TITLE
feat(arithmetic): Add the ability to query by equations

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar, NodeVisitor
 
-from sentry import eventstore
 from sentry.exceptions import InvalidSearchQuery
 
 SUPPORTED_OPERATORS = {"plus", "minus", "multiply", "divide"}
@@ -224,15 +223,15 @@ def parse_arithmetic(
     return result, list(visitor.fields)
 
 
-def resolve_equation_list(
-    equations: List[str], snuba_filter: eventstore.Filter
-) -> Dict[str, JsonQueryType]:
-    selected_columns = snuba_filter.selected_columns
+def resolve_equation_list(equations: Optional[List[str]]) -> Optional[List[JsonQueryType]]:
+    if equations is None:
+        return None
+    resolved_equations = []
     for index, equation in enumerate(equations):
         # only supporting 1 operation for now
         parsed_equation, fields = parse_arithmetic(equation, max_operators=1)
         for field in fields:
             if field not in fields:
                 raise InvalidSearchQuery(f"{field} used in an equation but is not a selected field")
-        selected_columns.append(parsed_equation.to_snuba_json(f"equation[{index}]"))
-    return {"selected_columns": selected_columns}
+        resolved_equations.append(parsed_equation.to_snuba_json(f"equation[{index}]"))
+    return resolved_equations

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -14,6 +14,7 @@ ISSUE_ID_ALIAS = "issue.id"
 RELEASE_ALIAS = "release"
 
 TAG_KEY_RE = re.compile(r"^tags\[(?P<tag>.*)\]$")
+EQUATION_KEY_RE = re.compile(r"^equation\[(?P<index>.*)\]$")
 # Based on general/src/protocol/tags.rs in relay
 VALID_FIELD_PATTERN = re.compile(r"^[a-zA-Z0-9_.:-]*$")
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1121,7 +1121,9 @@ def resolve_column(dataset):
             return col
         if isinstance(col, int) or isinstance(col, float):
             return col
-        if isinstance(col, str) and (col.startswith("tags[") or QUOTED_LITERAL_RE.match(col)):
+        if isinstance(col, str) and (
+            col.startswith("tags[") or col.startswith("equation[") or QUOTED_LITERAL_RE.match(col)
+        ):
             return col
 
         # Some dataset specific logic:


### PR DESCRIPTION
- This adds the ability to use equation aliases in the query, eg `equation[0]>0` to query for where the first equation is greater than 0
- If the corresponding equation doesn't exist this will raise an invalid query error
- This changed is_numeric_key to take the entire SearchKey instead so it'd be easier to check properties of the key