### PR TITLE
fix(api): Fix typo in Release serializer check

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -456,7 +456,7 @@ class ReleaseSerializer(Serializer):
                 rv["sessionsUpperBound"] = current_project_meta["sessions_upper_bound"]
             if "next_release_version" in current_project_meta:
                 rv["nextReleaseVersion"] = current_project_meta["next_release_version"]
-            if "next_release_version" in current_project_meta:
+            if "prev_release_version" in current_project_meta:
                 rv["prevReleaseVersion"] = current_project_meta["prev_release_version"]
             return rv
 


### PR DESCRIPTION
This PR:
- Fixes typo in `Release` serializer check