### PR TITLE
fix(alert): Fix partial member select

### DIFF
--- a/static/app/views/settings/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/settings/incidentRules/ruleNameOwnerForm.tsx
@@ -39,7 +39,7 @@ class RuleNameOwnerForm extends PureComponent<Props> {
               {({model}) => {
                 const owner = model.getValue('owner');
                 const ownerId = owner && owner.split(':')[1];
-                const filteredTeamIds = new Set(...userTeamIds);
+                const filteredTeamIds = new Set(userTeamIds);
                 // Add the current team that owns the alert
                 if (ownerId) {
                   filteredTeamIds.add(ownerId);

--- a/static/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/static/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -522,7 +522,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     // check if superuser or if user is on the alert's team
     const canEdit = isActiveSuperuser() || (ownerId ? userTeams.includes(ownerId) : true);
 
-    const filteredTeamIds = new Set(...userTeams);
+    const filteredTeamIds = new Set(userTeams);
     if (ownerId) {
       filteredTeamIds.add(ownerId);
     }


### PR DESCRIPTION
In a previous PR https://github.com/getsentry/sentry/pull/26160, I introduced a small bug where I would deconstruct an array into a set unnecessarily leading to some of the entries in the array not making it fully into the set.

We don't need to use `...` here and that will fix the issue