### PR TITLE
feat(snql) Add SnQL query to new subscriptions

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import sentry_sdk
 from django.utils import timezone
+from snuba_sdk.legacy import json_to_snql
 
 from sentry.search.events.fields import resolve_field_list
 from sentry.search.events.filter import get_filter
@@ -193,21 +194,36 @@ def _create_in_snuba(subscription):
         snuba_query.environment,
         snuba_query.event_types,
     )
+
+    body = {
+        "project_id": subscription.project_id,
+        "project": subscription.project_id,  # for SnQL SDK
+        "dataset": snuba_query.dataset,
+        "conditions": snuba_filter.conditions,
+        "aggregations": snuba_filter.aggregations,
+        "time_window": snuba_query.time_window,
+        "resolution": snuba_query.resolution,
+    }
+    try:
+        metrics.incr("snuba.snql.subscription.create", tags={"dataset": snuba_query.dataset})
+        snql_query = json_to_snql(body, snuba_query.dataset)
+        snql_query.validate()
+        body["query"] = str(snql_query)
+        body["type"] = "delegate"  # mark this as a combined subscription
+    except Exception as e:
+        logger.warning(
+            "snuba.snql.subscription.parsing.error",
+            extra={"error": str(e), "params": json.dumps(body), "dataset": snuba_query.dataset},
+        )
+        metrics.incr("snuba.snql.subscription.parsing.error", tags={"dataset": snuba_query.dataset})
+
     response = _snuba_pool.urlopen(
         "POST",
         f"/{snuba_query.dataset}/subscriptions",
-        body=json.dumps(
-            {
-                "project_id": subscription.project_id,
-                "dataset": snuba_query.dataset,
-                "conditions": snuba_filter.conditions,
-                "aggregations": snuba_filter.aggregations,
-                "time_window": snuba_query.time_window,
-                "resolution": snuba_query.resolution,
-            }
-        ),
+        body=json.dumps(body),
     )
     if response.status != 202:
+        metrics.incr("snuba.snql.subscription.http.error", tags={"dataset": snuba_query.dataset})
         raise SnubaError("HTTP %s response from Snuba!" % response.status)
     return json.loads(response.data)["subscription_id"]
 

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -93,9 +93,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
             QuerySubscription.Status.CREATING, subscription_id=uuid4().hex
         )
         create_subscription_in_snuba(sub.id)
-        self.metrics.incr.assert_called_once_with(
-            "snuba.subscriptions.create.already_created_in_snuba"
-        )
+        self.metrics.incr.assert_any_call("snuba.subscriptions.create.already_created_in_snuba")
 
     def test(self):
         sub = self.create_subscription(QuerySubscription.Status.CREATING)
@@ -426,10 +424,7 @@ class SubscriptionCheckerTest(TestCase):
                 status,
                 date_updated=timezone.now() - SUBSCRIPTION_STATUS_MAX_AGE * 2,
             )
-            sub_new = self.create_subscription(
-                status,
-                date_updated=timezone.now(),
-            )
+            sub_new = self.create_subscription(status, date_updated=timezone.now())
             with self.tasks():
                 subscription_checker()
             if status == QuerySubscription.Status.DELETING:


### PR DESCRIPTION
When a subscription is created, also automatically create a SnQL query for the
subscription and send it to Snuba. The "delegate" type is already in Snuba and
is a container for subscriptions that have both legacy and SnQL queries.