### PR TITLE
ref(notification platform): Link Identities in post_install if possible

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -171,6 +171,7 @@ class SlackIntegrationProvider(IntegrationProvider):
             # TODO look into more lookups for email if member.email is missing such as in UserOption
             if member.email:
                 try:
+                    # TODO use users.list instead to reduce API calls
                     resp = client.get(
                         "/users.lookupByEmail/", headers=headers, params={"email": member.email}
                     )
@@ -234,7 +235,7 @@ class SlackIntegrationProvider(IntegrationProvider):
                                     )
                                 else:
                                     logger.info(
-                                        "finish_pipeline.identity_linked_different_user",
+                                        "post_install.identity_linked_different_user",
                                         extra={
                                             "idp_id": idp.id,
                                             "external_id": resp["user"]["id"],

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -157,7 +157,7 @@ class SlackIntegrationProvider(IntegrationProvider):
 
     def post_install(self, integration, organization, extra=None):
         """
-        Create Identity records for an organizations's users if their emails match in Sentry and Slack
+        Create Identity records for an organization's users if their emails match in Sentry and Slack
         """
         run_args = {"integration": integration, "organization": organization}
         tasks.link_slack_user_identities.apply_async(kwargs=run_args)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -302,6 +302,7 @@ def get_slack_data_by_user(integration, organization, emails_by_user):
                     "team_id": resp["user"]["team_id"],
                     "slack_id": resp["user"]["id"],
                 }
+            continue
     return slack_data_by_user
 
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -196,11 +196,6 @@ def get_channel_id_with_timeout(integration: Integration, name: str, timeout: in
     return (prefix, None, False)
 
 
-def get_users_emails(organization, integration):
-    # use users.list
-    pass
-
-
 def send_incident_alert_notification(action, incident, metric_value, method):
     from sentry.integrations.slack.message_builder.incidents import build_incident_attachment
 

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -302,7 +302,7 @@ def get_slack_data_by_user(integration, organization, emails_by_user):
                     "team_id": resp["user"]["team_id"],
                     "slack_id": resp["user"]["id"],
                 }
-            continue
+                break
     return slack_data_by_user
 
 

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 
 from django.conf import settings
@@ -7,8 +8,21 @@ from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr
+from sentry.db.models.manager import BaseManager
 
 CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+class UserEmailManager(BaseManager):
+    def get_for_organization(self, organization):
+        return self.filter(user__sentry_orgmember_set__organization=organization)
+
+    def get_emails_by_user(self, organization):
+        emails_by_user = defaultdict(set)
+        user_emails = self.get_for_organization(organization).select_related("user")
+        for entry in user_emails:
+            emails_by_user[entry.user].add(entry.email)
+        return emails_by_user
 
 
 def default_validation_hash():
@@ -27,6 +41,7 @@ class UserEmail(Model):
         default=False,
         help_text=_("Designates whether this user has confirmed their email."),
     )
+    objects = UserEmailManager()
 
     class Meta:
         app_label = "sentry"

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -184,8 +184,7 @@ class SlackIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_reassign_user(self):
-        """Test that when you install and then later re-install and the user who installs it(?)
-        (who also installed it the first time?)
+        """Test that when you install and then later re-install and the user who installs it
         has a different external ID, their Identity is updated to reflect that
         """
         with self.tasks():
@@ -200,7 +199,7 @@ class SlackIntegrationTest(IntegrationTestCase):
     @responses.activate
     def test_link_multiple_users(self):
         """
-        Test that when an organization has multiple users, we create Identity records for them
+        Test that with an organization with multiple users, we create Identity records for them
         if their Sentry email matches their Slack email
         """
         with self.tasks():

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -127,7 +127,8 @@ class SlackIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_bot_flow(self):
-        self.assert_setup_flow()
+        with self.tasks():
+            self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
         assert integration.external_id == "TXXXXXXX1"
@@ -153,8 +154,10 @@ class SlackIntegrationTest(IntegrationTestCase):
 
     @responses.activate
     def test_multiple_integrations(self):
-        self.assert_setup_flow()
-        self.assert_setup_flow(team_id="TXXXXXXX2", authorizing_user_id="UXXXXXXX2")
+        with self.tasks():
+            self.assert_setup_flow()
+        with self.tasks():
+            self.assert_setup_flow(team_id="TXXXXXXX2", authorizing_user_id="UXXXXXXX2")
 
         integrations = Integration.objects.filter(provider=self.provider.key).order_by(
             "external_id"
@@ -185,11 +188,12 @@ class SlackIntegrationTest(IntegrationTestCase):
         (who also installed it the first time?)
         has a different external ID, their Identity is updated to reflect that
         """
-        self.assert_setup_flow()
+        with self.tasks():
+            self.assert_setup_flow()
         identity = Identity.objects.get()
         assert identity.external_id == "UXXXXXXX1"
-
-        self.assert_setup_flow(authorizing_user_id="UXXXXXXX2")
+        with self.tasks():
+            self.assert_setup_flow(authorizing_user_id="UXXXXXXX2")
         identity = Identity.objects.get()
         assert identity.external_id == "UXXXXXXX2"
 
@@ -199,7 +203,8 @@ class SlackIntegrationTest(IntegrationTestCase):
         Test that when an organization has multiple users, we create Identity records for them
         if their Sentry email matches their Slack email
         """
-        self.assert_setup_flow(multiple_users=True)
+        with self.tasks():
+            self.assert_setup_flow(multiple_users=True)
         self_user_identity = Identity.objects.get(user=self.user)
         assert self_user_identity
         assert self_user_identity.external_id == "UXXXXXXX1"

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -186,12 +186,12 @@ class SlackIntegrationTest(IntegrationTestCase):
         has a different external ID, their Identity is updated to reflect that
         """
         self.assert_setup_flow()
-        identity = Identity.objects.get(external_id="UXXXXXXX1")
-        assert identity.user == self.user
+        identity = Identity.objects.get()
+        assert identity.external_id == "UXXXXXXX1"
 
         self.assert_setup_flow(authorizing_user_id="UXXXXXXX2")
-        identity = Identity.objects.get(external_id="UXXXXXXX2")
-        assert identity.user == self.user
+        identity = Identity.objects.get()
+        assert identity.external_id == "UXXXXXXX2"
 
     @responses.activate
     def test_link_multiple_users(self):

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -66,6 +66,20 @@ class SlackIntegrationTest(IntegrationTestCase):
             },
         )
 
+        responses.add(
+            responses.GET,
+            "https://slack.com/api/users.lookupByEmail/",
+            json={
+                "ok": True,
+                "user": {
+                    "id": "UXXXXXXXX",
+                    "team_id": "TXXXXXXXX",
+                    "profile": {
+                        "email": "admin@localhost",
+                    },
+                },
+            },
+        )
         resp = self.client.get(
             "{}?{}".format(
                 self.setup_path,
@@ -83,6 +97,9 @@ class SlackIntegrationTest(IntegrationTestCase):
 
         assert resp.status_code == 200
         self.assertDialogSuccess(resp)
+
+        identity = Identity.objects.get(external_id="UXXXXXXXX", user=self.user)
+        assert identity
 
     @responses.activate
     def test_bot_flow(self):

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -192,8 +192,9 @@ class SlackIntegrationPostInstallTest(APITestCase):
         self.idp = IdentityProvider.objects.create(type="slack", external_id="TXXXXXXX1", config={})
 
         responses.add(
-            responses.GET,
-            "https://slack.com/api/users.lookupByEmail/",
+            method=responses.GET,
+            url=f"https://slack.com/api/users.lookupByEmail/?email={self.user2.email}",
+            match_querystring=True,
             json={
                 "ok": True,
                 "user": {
@@ -206,8 +207,9 @@ class SlackIntegrationPostInstallTest(APITestCase):
             },
         )
         responses.add(
-            responses.GET,
-            "https://slack.com/api/users.lookupByEmail/",
+            method=responses.GET,
+            url=f"https://slack.com/api/users.lookupByEmail/?email={self.user.email}",
+            match_querystring=True,
             json={
                 "ok": True,
                 "user": {
@@ -253,8 +255,9 @@ class SlackIntegrationPostInstallTest(APITestCase):
             teams=[self.team],
         )
         responses.add(
-            responses.GET,
-            "https://slack.com/api/users.lookupByEmail/",
+            method=responses.GET,
+            url=f"https://slack.com/api/users.lookupByEmail/email={user3.email}",
+            match_querystring=True,
             json={
                 "ok": True,
                 "user": {


### PR DESCRIPTION
In order to reduce friction for the notification platform Slack alerts, we'll automatically create an `Identity` record for each user in an organization when the Slack integration is installed if the users' Sentry emails and Slack emails match. If they don't match, we just skip the linking and the user can manually link it themselves later on (either by interacting with an action or by using slash commands which will be built out in future, separate PRs). If we already have one we can check if it needs to be updated and do so if applicable.

TODO which will be done in another PR:
- [x] Use the [users.list](https://api.slack.com/methods/users.list) endpoint instead to reduce the number of API calls (will also require implementing pagination and may need to be in an async task). Worth noting this uses the `users.read` scope (instead of `users.read:email`) BUT we'll still want to use `users.lookupByEmail` for when a new user joins Slack or Sentry.