### PR TITLE
ref(banner): Collocate banner specific logic

### DIFF
--- a/static/app/utils/useMedia.tsx
+++ b/static/app/utils/useMedia.tsx
@@ -1,0 +1,33 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * Hook that updates when a media query result changes
+ */
+export default function useMedia(query: string) {
+  if (!window.matchMedia) {
+    return false;
+  }
+
+  const [state, setState] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    let mounted = true;
+    const mql = window.matchMedia(query);
+    const onChange = () => {
+      if (!mounted) {
+        return;
+      }
+      setState(!!mql.matches);
+    };
+
+    mql.addListener(onChange);
+    setState(mql.matches);
+
+    return () => {
+      mounted = false;
+      mql.removeListener(onChange);
+    };
+  }, [query]);
+
+  return state;
+}

--- a/static/app/views/eventsV2/banner.tsx
+++ b/static/app/views/eventsV2/banner.tsx
@@ -13,6 +13,8 @@ import FeatureTourModal, {
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import theme from 'app/utils/theme';
+import useMedia from 'app/utils/useMedia';
 
 import BackgroundSpace from './backgroundSpace';
 
@@ -75,11 +77,9 @@ const TOUR_STEPS: TourStep[] = [
 type Props = {
   organization: Organization;
   resultsUrl: string;
-  isSmallBanner: boolean;
-  onHideBanner: () => void;
 };
 
-function DiscoverBanner({organization, resultsUrl, isSmallBanner, onHideBanner}: Props) {
+function DiscoverBanner({organization, resultsUrl}: Props) {
   function onAdvance(step: number, duration: number) {
     trackAnalyticsEvent({
       eventKey: 'discover_v2.tour.advance',
@@ -99,6 +99,8 @@ function DiscoverBanner({organization, resultsUrl, isSmallBanner, onHideBanner}:
     });
   }
 
+  const isSmallBanner = useMedia(`(max-width: ${theme.breakpoints[1]})`);
+
   return (
     <Banner
       title={t('Discover Trends')}
@@ -106,7 +108,7 @@ function DiscoverBanner({organization, resultsUrl, isSmallBanner, onHideBanner}:
         'Customize and save queries by search conditions, event fields, and tags'
       )}
       backgroundComponent={<BackgroundSpace />}
-      onCloseClick={onHideBanner}
+      dismissKey="discover"
     >
       <Button
         size={isSmallBanner ? 'xsmall' : undefined}

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -7,6 +7,7 @@ import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
+import Banner from 'app/components/banner';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
@@ -21,7 +22,6 @@ import EventView from 'app/utils/discover/eventView';
 import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import withApi from 'app/utils/withApi';
 import withProjects from 'app/utils/withProjects';
-import {setBannerHidden} from 'app/views/eventsV2/utils';
 import InputControl from 'app/views/settings/components/forms/controls/input';
 
 import {handleCreateQuery, handleDeleteQuery, handleUpdateQuery} from './utils';
@@ -161,7 +161,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
       (savedQuery: SavedQuery) => {
         const view = EventView.fromSavedQuery(savedQuery);
 
-        setBannerHidden(true);
+        Banner.dismiss('discover');
         this.setState({queryName: ''});
         browserHistory.push(view.getResultsViewUrlTarget(organization.slug));
       }

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -523,15 +523,6 @@ export function generateFieldOptions({
   return fieldOptions;
 }
 
-const BANNER_DISMISSED_KEY = 'discover-banner-dismissed';
-
-export function isBannerHidden(): boolean {
-  return localStorage.getItem(BANNER_DISMISSED_KEY) === 'true';
-}
-export function setBannerHidden(value: boolean) {
-  localStorage.setItem(BANNER_DISMISSED_KEY, value ? 'true' : 'false');
-}
-
 const RENDER_PREBUILT_KEY = 'discover-render-prebuilt';
 
 export function shouldRenderPrebuilt(): boolean {

--- a/tests/js/spec/components/banner.spec.tsx
+++ b/tests/js/spec/components/banner.spec.tsx
@@ -1,0 +1,20 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import Banner from 'app/components/banner';
+
+describe('Banner', function () {
+  it('can be dismissed', function () {
+    const banner = mountWithTheme(<Banner dismissKey="test" />);
+    expect(banner.find('BannerWrapper').exists()).toBe(true);
+
+    banner.find('CloseButton').simulate('click');
+
+    expect(banner.find('BannerWrapper').exists()).toBe(false);
+    expect(localStorage.getItem('test-banner-dismissed')).toBe('true');
+  });
+
+  it('is not dismissable', function () {
+    const banner = mountWithTheme(<Banner isDismissable={false} />);
+    expect(banner.find('CloseButton').exists()).toBe(false);
+  });
+});

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -1,10 +1,10 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import EventView from 'app/utils/discover/eventView';
+import DiscoverBanner from 'app/views/eventsV2/banner';
 import {ALL_VIEWS} from 'app/views/eventsV2/data';
 import SavedQueryButtonGroup from 'app/views/eventsV2/savedQuery';
 import * as utils from 'app/views/eventsV2/savedQuery/utils';
-import {isBannerHidden, setBannerHidden} from 'app/views/eventsV2/utils';
 
 const SELECTOR_BUTTON_SAVE_AS = 'button[aria-label="Save as"]';
 const SELECTOR_BUTTON_SAVED = '[data-test-id="discover2-savedquery-button-saved"]';
@@ -100,7 +100,6 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
         errorsView,
         undefined
       );
-      setBannerHidden(false);
 
       // Click on ButtonSaveAs to open dropdown
       const buttonSaveAs = wrapper.find('DropdownControl').first();
@@ -114,8 +113,10 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
 
       // Click on Save in the Dropdown
       await buttonSaveAs.find('ButtonSaveDropDown Button').simulate('click');
-      // Banner should be hidden.
-      expect(isBannerHidden()).toEqual(true);
+
+      // The banner should not render
+      const banner = mountWithTheme(<DiscoverBanner />);
+      expect(banner.find('BannerTitle').exists()).toBe(false);
     });
 
     it('saves a well-formed query', async () => {


### PR DESCRIPTION
 - Moves the localstorage dismissing functionality into the base banner
 - Moves the media query size check into the discover (eventsv2) banner