### PR TITLE
fix(discover): any with field alias queries should not error

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -497,10 +497,10 @@ def resolve_field_list(
     if aggregations:
         for column in columns:
             is_iterable = isinstance(column, (list, tuple))
-            if is_iterable and column[2] not in FIELD_ALIASES:
-                if column[0] == "transform":
-                    # When there's a project transform, we already group by project_id
-                    continue
+            if is_iterable and column[0] == "transform":
+                # When there's a project transform, we already group by project_id
+                continue
+            elif is_iterable and column[2] not in FIELD_ALIASES:
                 groupby.append(column[2])
             else:
                 column_key = to_tuple([column[:2]]) if is_iterable else column

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -361,9 +361,9 @@ def parse_arguments(function, columns):
     return [arg for arg in args if arg]
 
 
-def to_tuple(x):
+def format_column_as_key(x):
     if isinstance(x, list):
-        return tuple(to_tuple(y) for y in x)
+        return tuple(format_column_as_key(y) for y in x)
     return x
 
 
@@ -425,7 +425,7 @@ def resolve_field_list(
             if function.details is not None and isinstance(function.aggregate, (list, tuple)):
                 functions[function.aggregate[-1]] = function.details
                 if function.details.instance.redundant_grouping:
-                    aggregate_fields[to_tuple(function.aggregate[1])].add(field)
+                    aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     # Only auto aggregate when there's one other so the group by is not unexpectedly changed
     if auto_aggregations and snuba_filter.having and len(aggregations) > 0:
@@ -440,7 +440,7 @@ def resolve_field_list(
                         functions[function.aggregate[-1]] = function.details
 
                         if function.details.instance.redundant_grouping:
-                            aggregate_fields[to_tuple(function.aggregate[1])].add(field)
+                            aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     rollup = snuba_filter.rollup
     if not rollup and auto_fields:
@@ -503,7 +503,7 @@ def resolve_field_list(
             elif is_iterable and column[2] not in FIELD_ALIASES:
                 groupby.append(column[2])
             else:
-                column_key = to_tuple([column[:2]]) if is_iterable else column
+                column_key = format_column_as_key([column[:2]]) if is_iterable else column
                 if column_key in aggregate_fields:
                     conflicting_functions = list(aggregate_fields[column_key])
                     raise InvalidSearchQuery(

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -335,8 +335,8 @@ class ResolveFieldListTest(unittest.TestCase):
             "issue.id",
             ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
             "message",
-            "timestamp.to_hour",
-            "timestamp.to_day",
+            ["toStartOfHour", ["timestamp"], "timestamp.to_hour"],
+            ["toStartOfDay", ["timestamp"], "timestamp.to_day"],
             "project.id",
         ]
 


### PR DESCRIPTION
When using the any function with a field alias, it should not use lists as
dictionary keys causing an error. This change converts them to tuples which are
hashable as dictionary keys.