### PR TITLE
feat(notifications): Deploy Notifications Slow Query

### DIFF
--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -23,5 +23,5 @@ class CommitFileChange(Model):
     __repr__ = sane_repr("commit_id", "filename")
 
     @staticmethod
-    def is_valid_type(value):
+    def is_valid_type(value: str) -> bool:
         return value in COMMIT_FILE_CHANGE_TYPES

--- a/src/sentry/models/commitfilechange.py
+++ b/src/sentry/models/commitfilechange.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable
 
 from django.db import models
 
@@ -14,18 +14,8 @@ COMMIT_FILE_CHANGE_TYPES = frozenset(("A", "D", "M"))
 
 
 class CommitFileChangeManager(BaseManager):
-    def get_count_for_commits(
-        self, commits: Iterable[Any], organization_id: Optional[int] = None
-    ) -> int:
-        """
-        Warning: Because `sentry_commitfilechange` has no `organization_id`
-        index, do not pass an `organization_id` if there are many commits.
-        """
-        kwargs = {"commit__in": commits}
-        if organization_id:
-            kwargs["organization_id"] = organization_id
-
-        return int(self.filter(**kwargs).values("filename").distinct().count())
+    def get_count_for_commits(self, commits: Iterable[Any]) -> int:
+        return int(self.filter(commit__in=commits).values("filename").distinct().count())
 
 
 class CommitFileChange(Model):

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -1,11 +1,10 @@
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Set
 
-from sentry.models import Activity, Project, User
+from sentry.models import Activity, CommitFileChange, Project, User
 from sentry.notifications.utils import (
     get_commits_for_release,
     get_deploy,
     get_environment_for_deploy,
-    get_file_count,
     get_group_counts_by_project,
     get_projects,
     get_release,
@@ -65,7 +64,7 @@ class ReleaseActivityNotification(ActivityNotification):
             **self.get_base_context(),
             "commit_count": len(self.commit_list),
             "author_count": len(self.email_list),
-            "file_count": get_file_count(self.commit_list, self.organization),
+            "file_count": CommitFileChange.objects.get_count_for_commits(self.commit_list),
             "repos": self.repos,
             "release": self.release,
             "deploy": self.deploy,

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -22,7 +22,6 @@ from sentry.integrations import IntegrationFeatures, IntegrationProvider
 from sentry.models import (
     Activity,
     Commit,
-    CommitFileChange,
     Deploy,
     Environment,
     EventError,
@@ -144,15 +143,6 @@ def get_environment_for_deploy(deploy: Optional[Deploy]) -> str:
         if environment and environment.name:
             return str(environment.name)
     return "Default Environment"
-
-
-def get_file_count(commits: Iterable[Commit], organization: Organization) -> int:
-    return int(
-        CommitFileChange.objects.filter(commit__in=commits, organization_id=organization.id)
-        .values("filename")
-        .distinct()
-        .count()
-    )
 
 
 def summarize_issues(issues: Iterable[Any]) -> Iterable[Mapping[str, str]]:

--- a/tests/sentry/models/test_commitfilechange.py
+++ b/tests/sentry/models/test_commitfilechange.py
@@ -1,0 +1,21 @@
+from sentry.models import Commit, CommitFileChange, Repository
+from sentry.testutils import TestCase
+
+
+class CommitFileChangeTest(TestCase):
+    def test_get_count_for_commits(self):
+        group = self.create_group()
+        organization_id = group.organization.id
+        repo = Repository.objects.create(name="example", organization_id=organization_id)
+        commit = Commit.objects.create(
+            key="a" * 40,
+            repository_id=repo.id,
+            organization_id=organization_id,
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
+        )
+        CommitFileChange.objects.create(
+            organization_id=organization_id, commit=commit, filename=".gitignore", type="M"
+        )
+
+        count = CommitFileChange.objects.get_count_for_commits([commit])
+        assert count == 1


### PR DESCRIPTION
Counting the files in deploy notifications is a really slow because `sentry_commitfilechange` table doesn't have an index on `organization_id`. We already know that all of the commits passed to the function belong to the same release and organization so we can remove the `organization_id` filter.