### PR TITLE
fix(discover): Allow appending selected columns to aggregates

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -271,7 +271,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 }
                 query_columns = [column_map.get(column, column) for column in columns]
             with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):
-                result = get_event_stats(query_columns, query, params, rollup)
+                result = get_event_stats(query_columns[:], query, params, rollup)
 
         serializer = SnubaTSResultSerializer(organization, None, request.user)
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -404,6 +404,7 @@ def timeseries_query(selected_columns, query, params, rollup, referrer=None):
             aggregations=snuba_filter.aggregations,
             conditions=snuba_filter.conditions,
             filter_keys=snuba_filter.filter_keys,
+            selected_columns=snuba_filter.selected_columns,
             start=snuba_filter.start,
             end=snuba_filter.end,
             rollup=rollup,

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2924,7 +2924,7 @@ class TimeseriesQueryTest(TimeseriesBase):
         )
 
         result = discover.timeseries_query(
-            selected_columns=["release", "count()"],
+            selected_columns=["count()"],
             query="(release:{} OR release:{}) AND project:{}".format(
                 "a" * 32, "b" * 32, self.project.slug
             ),


### PR DESCRIPTION
The new apdex aggregate (which uses project level thresholds)
requires an extra project_config_thresholds column to be loaded
as well. Adding selected columns to the snuba query to accomodate
for this requirement. Furthermore, the list of columns `query_columns`
passed to get_event_stats is modified when the fields are resolved
and `project_config_thresholds` is added as a selected column
since lists are mutable. This means we end up with two query
column fields `['apdex_new()', 'project_config_threshold']` and
try to serialize it as if we had multiple axes. To prevent that,
we can just pass a copy of query_columns to get_event_stats.