### PR TITLE
fix(ui): Change tooltip text of dynamic counts in release details

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -30,6 +30,7 @@ const defaultProps = {
   withPagination: true,
   useFilteredStats: true,
   useTintRow: true,
+  narrowGroups: false,
 };
 
 type Props = WithRouterProps & {
@@ -197,6 +198,7 @@ class GroupList extends React.Component<Props, State> {
       customStatsPeriod,
       queryParams,
       queryFilterDescription,
+      narrowGroups,
     } = this.props;
     const {loading, error, groups, memberList, pageLinks} = this.state;
 
@@ -231,7 +233,7 @@ class GroupList extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <Panel>
-          <GroupListHeader withChart={!!withChart} />
+          <GroupListHeader withChart={!!withChart} narrowGroups={narrowGroups} />
           <PanelBody>
             {groups.map(({id, project}) => {
               const members = memberList?.hasOwnProperty(project.slug)
@@ -250,6 +252,7 @@ class GroupList extends React.Component<Props, State> {
                   customStatsPeriod={customStatsPeriod}
                   statsPeriod={statsPeriod}
                   queryFilterDescription={queryFilterDescription}
+                  narrowGroups={narrowGroups}
                 />
               );
             })}

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -49,6 +49,7 @@ type Props = WithRouterProps & {
       pageDiff: number
     ) => void
   ) => void;
+  queryFilterDescription?: string;
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -195,6 +196,7 @@ class GroupList extends React.Component<Props, State> {
       useTintRow,
       customStatsPeriod,
       queryParams,
+      queryFilterDescription,
     } = this.props;
     const {loading, error, groups, memberList, pageLinks} = this.state;
 
@@ -247,6 +249,7 @@ class GroupList extends React.Component<Props, State> {
                   useTintRow={useTintRow}
                   customStatsPeriod={customStatsPeriod}
                   statsPeriod={statsPeriod}
+                  queryFilterDescription={queryFilterDescription}
                 />
               );
             })}

--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -6,13 +6,16 @@ import space from 'app/styles/space';
 
 type Props = {
   withChart: boolean;
+  narrowGroups?: boolean;
 };
 
-const GroupListHeader = ({withChart = true}: Props) => (
+const GroupListHeader = ({withChart = true, narrowGroups = false}: Props) => (
   <PanelHeader disablePadding>
     <IssueWrapper>{t('Issue')}</IssueWrapper>
     {withChart && (
-      <ChartWrapper className="hidden-xs hidden-sm">{t('Graph')}</ChartWrapper>
+      <ChartWrapper className={`hidden-xs hidden-sm ${narrowGroups ? 'hidden-md' : ''}`}>
+        {t('Graph')}
+      </ChartWrapper>
     )}
     <EventUserWrapper>{t('events')}</EventUserWrapper>
     <EventUserWrapper>{t('users')}</EventUserWrapper>

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -89,6 +89,7 @@ type Props = {
   customStatsPeriod?: TimePeriodType;
   display?: IssueDisplayOptions;
   // TODO(ts): higher order functions break defaultprops export types
+  queryFilterDescription?: string;
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -359,6 +360,7 @@ class StreamGroup extends React.Component<Props, State> {
       useTintRow,
       customStatsPeriod,
       display,
+      queryFilterDescription,
     } = this.props;
 
     const {period, start, end} = selection.datetime || {};
@@ -482,7 +484,8 @@ class StreamGroup extends React.Component<Props, State> {
                                 <React.Fragment>
                                   <StyledMenuItem to={this.getDiscoverUrl(true)}>
                                     <MenuItemText>
-                                      {t('Matching search filters')}
+                                      {queryFilterDescription ??
+                                        t('Matching search filters')}
                                     </MenuItemText>
                                     {primaryPercent ? (
                                       <MenuItemPercent>{primaryPercent}</MenuItemPercent>
@@ -554,7 +557,8 @@ class StreamGroup extends React.Component<Props, State> {
                               <React.Fragment>
                                 <StyledMenuItem to={this.getDiscoverUrl(true)}>
                                   <MenuItemText>
-                                    {t('Matching search filters')}
+                                    {queryFilterDescription ??
+                                      t('Matching search filters')}
                                   </MenuItemText>
                                   <MenuItemCount value={data.filtered.userCount} />
                                 </StyledMenuItem>

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -74,6 +74,7 @@ const defaultProps = {
   useFilteredStats: false,
   useTintRow: true,
   display: DEFAULT_DISPLAY,
+  narrowGroups: false,
 };
 
 type Props = {
@@ -361,6 +362,7 @@ class StreamGroup extends React.Component<Props, State> {
       customStatsPeriod,
       display,
       queryFilterDescription,
+      narrowGroups,
     } = this.props;
 
     const {period, start, end} = selection.datetime || {};
@@ -426,7 +428,9 @@ class StreamGroup extends React.Component<Props, State> {
         </GroupSummary>
         {hasGuideAnchor && <GuideAnchor target="issue_stream" />}
         {withChart && !displayReprocessingLayout && (
-          <ChartWrapper className="hidden-xs hidden-sm">
+          <ChartWrapper
+            className={`hidden-xs hidden-sm ${narrowGroups ? 'hidden-md' : ''}`}
+          >
             {!data.filtered?.stats && !data.stats ? (
               <Placeholder height="24px" />
             ) : (

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -507,61 +507,63 @@ class ReleaseOverview extends AsyncView<Props> {
                       location={location}
                       defaultStatsPeriod={defaultStatsPeriod}
                       releaseBounds={releaseBounds}
-                  queryFilterDescription={t('In this release')}
-                  withChart
-                />
-                <Feature features={['performance-view']}>
-                  <TransactionsList
-                    location={location}
-                    organization={organization}
-                    eventView={releaseEventView}
-                    trendView={releaseTrendView}
-                    selected={selectedSort}
-                    options={sortOptions}
-                    handleDropdownChange={this.handleTransactionsListSortChange}
-                    titles={titles}
-                    generateLink={generateLink}
-                  />
-                </Feature>
-              </Main>
-              <Side>
-                <ReleaseStats
-                  organization={organization}
-                  release={release}
-                  project={project}
-                  location={location}
-                  selection={selection}
-                  hasHealthData={hasHealthData}
-                  getHealthData={getHealthData}
-                  isHealthLoading={isHealthLoading}
-                />
-                <ProjectReleaseDetails
-                  release={release}
-                  releaseMeta={releaseMeta}
-                  orgSlug={organization.slug}
-                  projectSlug={project.slug}
-                />
-                {commitCount > 0 && (
-                  <CommitAuthorBreakdown
-                    version={version}
-                    orgId={organization.slug}
-                    projectSlug={project.slug}
-                  />
-                )}
-                {releaseMeta.projects.length > 1 && (
-                  <OtherProjects
-                    projects={releaseMeta.projects.filter(p => p.slug !== project.slug)}
-                    location={location}
-                    version={version}
-                    organization={organization}
-                  />
-                )}
-                {hasHealthData && (
-                  <TotalCrashFreeUsers
-                    organization={organization}
-                    version={version}
-                    projectSlug={project.slug}
-                    location={location}
+                      queryFilterDescription={t('In this release')}
+                      withChart
+                    />
+                    <Feature features={['performance-view']}>
+                      <TransactionsList
+                        location={location}
+                        organization={organization}
+                        eventView={releaseEventView}
+                        trendView={releaseTrendView}
+                        selected={selectedSort}
+                        options={sortOptions}
+                        handleDropdownChange={this.handleTransactionsListSortChange}
+                        titles={titles}
+                        generateLink={generateLink}
+                      />
+                    </Feature>
+                  </Main>
+                  <Side>
+                    <ReleaseStats
+                      organization={organization}
+                      release={release}
+                      project={project}
+                      location={location}
+                      selection={selection}
+                      hasHealthData={hasHealthData}
+                      getHealthData={getHealthData}
+                      isHealthLoading={isHealthLoading}
+                    />
+                    <ProjectReleaseDetails
+                      release={release}
+                      releaseMeta={releaseMeta}
+                      orgSlug={organization.slug}
+                      projectSlug={project.slug}
+                    />
+                    {commitCount > 0 && (
+                      <CommitAuthorBreakdown
+                        version={version}
+                        orgId={organization.slug}
+                        projectSlug={project.slug}
+                      />
+                    )}
+                    {releaseMeta.projects.length > 1 && (
+                      <OtherProjects
+                        projects={releaseMeta.projects.filter(
+                          p => p.slug !== project.slug
+                        )}
+                        location={location}
+                        version={version}
+                        organization={organization}
+                      />
+                    )}
+                    {hasHealthData && (
+                      <TotalCrashFreeUsers
+                        organization={organization}
+                        version={version}
+                        projectSlug={project.slug}
+                        location={location}
                       />
                     )}
                     {deploys.length > 0 && (

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -507,6 +507,7 @@ class ReleaseOverview extends AsyncView<Props> {
                       location={location}
                       defaultStatsPeriod={defaultStatsPeriod}
                       releaseBounds={releaseBounds}
+                      queryFilterDescription={t('In this release')}
                     />
                     <Feature features={['performance-view']}>
                       <TransactionsList

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -507,62 +507,61 @@ class ReleaseOverview extends AsyncView<Props> {
                       location={location}
                       defaultStatsPeriod={defaultStatsPeriod}
                       releaseBounds={releaseBounds}
-                      queryFilterDescription={t('In this release')}
-                    />
-                    <Feature features={['performance-view']}>
-                      <TransactionsList
-                        location={location}
-                        organization={organization}
-                        eventView={releaseEventView}
-                        trendView={releaseTrendView}
-                        selected={selectedSort}
-                        options={sortOptions}
-                        handleDropdownChange={this.handleTransactionsListSortChange}
-                        titles={titles}
-                        generateLink={generateLink}
-                      />
-                    </Feature>
-                  </Main>
-                  <Side>
-                    <ReleaseStats
-                      organization={organization}
-                      release={release}
-                      project={project}
-                      location={location}
-                      selection={selection}
-                      hasHealthData={hasHealthData}
-                      getHealthData={getHealthData}
-                      isHealthLoading={isHealthLoading}
-                    />
-                    <ProjectReleaseDetails
-                      release={release}
-                      releaseMeta={releaseMeta}
-                      orgSlug={organization.slug}
-                      projectSlug={project.slug}
-                    />
-                    {commitCount > 0 && (
-                      <CommitAuthorBreakdown
-                        version={version}
-                        orgId={organization.slug}
-                        projectSlug={project.slug}
-                      />
-                    )}
-                    {releaseMeta.projects.length > 1 && (
-                      <OtherProjects
-                        projects={releaseMeta.projects.filter(
-                          p => p.slug !== project.slug
-                        )}
-                        location={location}
-                        version={version}
-                        organization={organization}
-                      />
-                    )}
-                    {hasHealthData && (
-                      <TotalCrashFreeUsers
-                        organization={organization}
-                        version={version}
-                        projectSlug={project.slug}
-                        location={location}
+                  queryFilterDescription={t('In this release')}
+                  withChart
+                />
+                <Feature features={['performance-view']}>
+                  <TransactionsList
+                    location={location}
+                    organization={organization}
+                    eventView={releaseEventView}
+                    trendView={releaseTrendView}
+                    selected={selectedSort}
+                    options={sortOptions}
+                    handleDropdownChange={this.handleTransactionsListSortChange}
+                    titles={titles}
+                    generateLink={generateLink}
+                  />
+                </Feature>
+              </Main>
+              <Side>
+                <ReleaseStats
+                  organization={organization}
+                  release={release}
+                  project={project}
+                  location={location}
+                  selection={selection}
+                  hasHealthData={hasHealthData}
+                  getHealthData={getHealthData}
+                  isHealthLoading={isHealthLoading}
+                />
+                <ProjectReleaseDetails
+                  release={release}
+                  releaseMeta={releaseMeta}
+                  orgSlug={organization.slug}
+                  projectSlug={project.slug}
+                />
+                {commitCount > 0 && (
+                  <CommitAuthorBreakdown
+                    version={version}
+                    orgId={organization.slug}
+                    projectSlug={project.slug}
+                  />
+                )}
+                {releaseMeta.projects.length > 1 && (
+                  <OtherProjects
+                    projects={releaseMeta.projects.filter(p => p.slug !== project.slug)}
+                    location={location}
+                    version={version}
+                    organization={organization}
+                  />
+                )}
+                {hasHealthData && (
+                  <TotalCrashFreeUsers
+                    organization={organization}
+                    version={version}
+                    projectSlug={project.slug}
+                    location={location}
                       />
                     )}
                     {deploys.length > 0 && (

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -249,9 +249,9 @@ class Issues extends Component<Props, State> {
             endpointPath={path}
             queryParams={queryParams}
             query=""
-            queryFilterDescription={queryFilterDescription}
             canSelectGroups={false}
-            withChart={Boolean(withChart)}
+            queryFilterDescription={t('In this release')}
+            withChart
             renderEmptyMessage={this.renderEmptyMessage}
             withPagination={false}
             onFetchSuccess={this.handleFetchSuccess}

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -257,6 +257,7 @@ class Issues extends Component<Props, State> {
             canSelectGroups={false}
             queryFilterDescription={queryFilterDescription}
             withChart={withChart}
+            narrowGroups
             renderEmptyMessage={this.renderEmptyMessage}
             withPagination={false}
             onFetchSuccess={this.handleFetchSuccess}

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -43,6 +43,7 @@ type Props = {
   defaultStatsPeriod: string;
   queryFilterDescription?: string;
   releaseBounds: ReleaseBounds;
+  withChart?: boolean;
 };
 
 type State = {
@@ -108,6 +109,7 @@ class Issues extends Component<Props, State> {
       }),
       limit: 10,
       sort: IssueSortOptions.FREQ,
+      groupStatsPeriod: 'auto',
     };
 
     switch (issuesType) {
@@ -187,7 +189,7 @@ class Issues extends Component<Props, State> {
 
   render() {
     const {issuesType, pageLinks, onCursor} = this.state;
-    const {organization, queryFilterDescription} = this.props;
+    const {organization, queryFilterDescription, withChart} = this.props;
     const {path, queryParams} = this.getIssuesEndpoint();
     const issuesTypes = [
       {value: IssuesType.NEW, label: t('New Issues')},
@@ -249,7 +251,7 @@ class Issues extends Component<Props, State> {
             query=""
             queryFilterDescription={queryFilterDescription}
             canSelectGroups={false}
-            withChart={false}
+            withChart={Boolean(withChart)}
             renderEmptyMessage={this.renderEmptyMessage}
             withPagination={false}
             onFetchSuccess={this.handleFetchSuccess}

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -35,6 +35,10 @@ type IssuesQueryParams = {
   query: string;
 };
 
+const defaultProps = {
+  withChart: false,
+};
+
 type Props = {
   organization: Organization;
   version: string;
@@ -43,8 +47,7 @@ type Props = {
   defaultStatsPeriod: string;
   queryFilterDescription?: string;
   releaseBounds: ReleaseBounds;
-  withChart?: boolean;
-};
+} & Partial<typeof defaultProps>;
 
 type State = {
   issuesType: IssuesType;
@@ -53,6 +56,8 @@ type State = {
 };
 
 class Issues extends Component<Props, State> {
+  static defaultProps = defaultProps;
+
   state: State = {
     issuesType: IssuesType.NEW,
   };
@@ -250,8 +255,8 @@ class Issues extends Component<Props, State> {
             queryParams={queryParams}
             query=""
             canSelectGroups={false}
-            queryFilterDescription={t('In this release')}
-            withChart
+            queryFilterDescription={queryFilterDescription}
+            withChart={withChart}
             renderEmptyMessage={this.renderEmptyMessage}
             withPagination={false}
             onFetchSuccess={this.handleFetchSuccess}

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -45,8 +45,8 @@ type Props = {
   selection: GlobalSelection;
   location: Location;
   defaultStatsPeriod: string;
-  queryFilterDescription?: string;
   releaseBounds: ReleaseBounds;
+  queryFilterDescription?: string;
 } & Partial<typeof defaultProps>;
 
 type State = {

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -41,6 +41,7 @@ type Props = {
   selection: GlobalSelection;
   location: Location;
   defaultStatsPeriod: string;
+  queryFilterDescription?: string;
   releaseBounds: ReleaseBounds;
 };
 
@@ -186,7 +187,7 @@ class Issues extends Component<Props, State> {
 
   render() {
     const {issuesType, pageLinks, onCursor} = this.state;
-    const {organization} = this.props;
+    const {organization, queryFilterDescription} = this.props;
     const {path, queryParams} = this.getIssuesEndpoint();
     const issuesTypes = [
       {value: IssuesType.NEW, label: t('New Issues')},
@@ -246,6 +247,7 @@ class Issues extends Component<Props, State> {
             endpointPath={path}
             queryParams={queryParams}
             query=""
+            queryFilterDescription={queryFilterDescription}
             canSelectGroups={false}
             withChart={false}
             renderEmptyMessage={this.renderEmptyMessage}

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -25,19 +25,19 @@ describe('Release Issues', function () {
     });
 
     newIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?limit=10&query=first-release%3A1.0.0&sort=freq&statsPeriod=14d`,
+      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0&sort=freq&statsPeriod=14d`,
       body: [],
     });
     resolvedIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/releases/1.0.0/resolved/?limit=10&query=&sort=freq&statsPeriod=14d`,
+      url: `/organizations/${props.organization.slug}/releases/1.0.0/resolved/?groupStatsPeriod=auto&limit=10&query=&sort=freq&statsPeriod=14d`,
       body: [],
     });
     unhandledIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=freq&statsPeriod=14d`,
+      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=freq&statsPeriod=14d`,
       body: [],
     });
     allIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?limit=10&query=release%3A1.0.0&sort=freq&statsPeriod=14d`,
+      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=release%3A1.0.0&sort=freq&statsPeriod=14d`,
       body: [],
     });
   });
@@ -147,6 +147,7 @@ describe('Release Issues', function () {
         cursor: undefined,
         limit: undefined,
         statsPeriod: '14d',
+        groupStatsPeriod: 'auto',
       },
     });
 
@@ -159,6 +160,7 @@ describe('Release Issues', function () {
         cursor: undefined,
         limit: undefined,
         statsPeriod: '14d',
+        groupStatsPeriod: 'auto',
       },
     });
 
@@ -171,6 +173,7 @@ describe('Release Issues', function () {
         cursor: undefined,
         limit: undefined,
         statsPeriod: '14d',
+        groupStatsPeriod: 'auto',
       },
     });
 
@@ -183,6 +186,7 @@ describe('Release Issues', function () {
         cursor: undefined,
         limit: undefined,
         statsPeriod: '14d',
+        groupStatsPeriod: 'auto',
       },
     });
   });


### PR DESCRIPTION
This adds an optional filter description to dynamic counts tooltips for issue lists and changes the one in the release details page to `In this release`, there is a specific filter of release id, applied in the release details page that isn't visible to user because there is no search bar on the page. This helps clarify the counts a bit. Also added the mini bar chart to issue rows with the `groupStatsPeriod: 'auto'` in the issue stats query so the period follows the global selection.

Before:
![Screen Shot 2021-06-03 at 3 05 51 PM](https://user-images.githubusercontent.com/15015880/120718002-6aff3b80-c47d-11eb-9961-e6db166bc6c7.png)


After:
![Screen Shot 2021-06-03 at 3 04 44 PM](https://user-images.githubusercontent.com/15015880/120717849-1b207480-c47d-11eb-9b35-a044aa72b4f4.png)


[WOR-947](https://getsentry.atlassian.net/browse/WOR-947)