### PR TITLE
feat(growth): redirect out of disabled member page

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -102,9 +102,8 @@ def is_member_disabled_from_limit(request, organization):
     try:
         member = get_cached_organization_member(user.id, organization.id)
     except OrganizationMember.DoesNotExist:
-        # should never happen but if it does, don't block auth
-        # but send error to logs/Sentry
-        logger.error("is_member_disabled_from_limit.member_missing")
+        # this happens for yet unknown reasons
+        # if it happens, don't block auth
         return False
     else:
         return member.flags["member-limit:restricted"]

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -102,8 +102,7 @@ def is_member_disabled_from_limit(request, organization):
     try:
         member = get_cached_organization_member(user.id, organization.id)
     except OrganizationMember.DoesNotExist:
-        # this happens for yet unknown reasons
-        # if it happens, don't block auth
+        # if org member doesn't exist, we should be getting an auth error later
         return False
     else:
         return member.flags["member-limit:restricted"]

--- a/src/sentry/web/frontend/disabled_member_view.py
+++ b/src/sentry/web/frontend/disabled_member_view.py
@@ -1,6 +1,28 @@
+from django.urls import reverse
+
+from sentry.auth.access import get_cached_organization_member
+from sentry.models import OrganizationMember
+
 from .react_page import ReactPageView
 
 
 class DisabledMemberView(ReactPageView):
     def is_member_disabled_from_limit(self, request, organization):
         return False
+
+    def handle(self, request, organization, **kwargs):
+        user = request.user
+        # if org member is not restricted, redirect user out of the disablerd view
+        try:
+            member = get_cached_organization_member(user.id, organization.id)
+            if not member.flags["member-limit:restricted"]:
+                return self.redirect(
+                    reverse("sentry-organization-issue-list", args=[organization.slug])
+                )
+        except OrganizationMember.DoesNotExist:
+            # this shouldn't happen but we can default to basic handling
+            # if it does
+            pass
+
+        # otherwise, just do the basic handling
+        return super().handle(request, organization, **kwargs)

--- a/src/sentry/web/frontend/disabled_member_view.py
+++ b/src/sentry/web/frontend/disabled_member_view.py
@@ -12,7 +12,7 @@ class DisabledMemberView(ReactPageView):
 
     def handle(self, request, organization, **kwargs):
         user = request.user
-        # if org member is not restricted, redirect user out of the disablerd view
+        # if org member is not restricted, redirect user out of the disabled view
         try:
             member = get_cached_organization_member(user.id, organization.id)
             if not member.flags["member-limit:restricted"]:
@@ -21,7 +21,6 @@ class DisabledMemberView(ReactPageView):
                 )
         except OrganizationMember.DoesNotExist:
             # this shouldn't happen but we can default to basic handling
-            # if it does
             pass
 
         # otherwise, just do the basic handling

--- a/tests/sentry/web/frontend/test_disabled_member_view.py
+++ b/tests/sentry/web/frontend/test_disabled_member_view.py
@@ -1,0 +1,34 @@
+from django.urls import reverse
+from exam import fixture
+
+from sentry.models import OrganizationMember
+from sentry.testutils import TestCase
+
+
+class DisabledMemberViewTest(TestCase):
+    @fixture
+    def path(self):
+        return reverse("sentry-organization-disabled-member", args=[self.org.slug])
+
+    def setUp(self):
+        super().setUp()
+        self.org = self.create_organization()
+        self.user = self.create_user()
+        self.login_as(self.user)
+
+    def create_one_member(self, flags=None):
+        self.create_member(user=self.user, organization=self.org, role="member", flags=flags)
+
+    def test_member_disabled_can_load(self):
+        self.create_one_member(
+            flags=OrganizationMember.flags["member-limit:restricted"],
+        )
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+
+    def test_member_active_member_redirect(self):
+        self.create_one_member()
+        resp = self.client.get(self.path)
+        assert resp.status_code == 302
+        redirect = reverse("sentry-organization-issue-list", args=[self.org.slug])
+        assert redirect == resp["Location"]


### PR DESCRIPTION
This PR adds a redirect out of the disabled member page if a member is not actually disabled anymore. Here's the progression how this happens:
1. Owner starts free trial
2. Owner invites members
3. Free trial ends (member limit is now 1)
4. Member becomes disabled
5. Member logs into product, gets redirected to disabled member view
6. Owner upgrades to increase member limit which reactivates members
7. Member presses refresh which will redirect them to the issues page

I also removed a Sentry capture exception related to checking if a member is disabled. The error wasn't a real error (basically it means the user is trying to do something they aren't authenticated for).

Fixes SENTRY-QG2