### PR TITLE
fix(event-errors): Fix the logic that displays  not match distribution error message

### DIFF
--- a/static/app/components/events/errors.tsx
+++ b/static/app/components/events/errors.tsx
@@ -174,7 +174,7 @@ class Errors extends Component<Props, State> {
                     return false;
                   });
 
-                  if (releaseArtifact && !releaseArtifact.dist) {
+                  if (releaseArtifact && !!releaseArtifact.dist) {
                     error.message = t(
                       'Source code was not found because the distribution did not match'
                     );


### PR DESCRIPTION
The error message should be displayed if `dist` is available 