### PR TITLE
feat(ui): Add support for archived artifacts

### DIFF
--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -1891,6 +1891,12 @@ export type SourceMapsArchive = {
   fileCount: number;
 };
 
+export enum ArtifactType {
+  INDIVIDUAL = 'individual',
+  ARCHIVED = 'archived',
+  ZIP = 'zip',
+}
+
 export type Artifact = {
   dateCreated: string;
   dist: string | null;
@@ -1899,6 +1905,7 @@ export type Artifact = {
   sha1: string;
   size: number;
   headers: {'Content-Type': string};
+  type: ArtifactType;
 };
 
 export type EventGroupInfo = Record<EventGroupVariantKey, EventGroupVariant>;

--- a/static/app/views/settings/projectSourceMaps/detail/index.tsx
+++ b/static/app/views/settings/projectSourceMaps/detail/index.tsx
@@ -367,6 +367,15 @@ const Title = styled('div')`
 
 const StyledButtonBar = styled(ButtonBar)`
   justify-content: flex-start;
+  margin: ${space(1)} 0;
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: flex;
+    flex-wrap: wrap;
+    > * {
+      margin-bottom: ${space(1)};
+    }
+  }
 `;
 
 const StyledSelectControl = styled(SelectControl)`

--- a/static/app/views/settings/projectSourceMaps/detail/index.tsx
+++ b/static/app/views/settings/projectSourceMaps/detail/index.tsx
@@ -72,6 +72,7 @@ class ProjectSourceMapsDetail extends AsyncView<Props, State> {
         this.getArtifactsUrl(),
         {query: {query: this.getQuery(), type: this.getType()}},
       ],
+      ['filesMeta', this.getFilesMetaUrl()],
     ];
   }
 

--- a/static/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
+++ b/static/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
@@ -66,49 +66,59 @@ const SourceMapsArtifactRow = ({
         <FileSize bytes={size} />
       </SizeColumn>
       <ActionsColumn>
-        {type === ArtifactType.INDIVIDUAL && (
-          <ButtonBar gap={0.5}>
-            <Role role={downloadRole}>
-              {({hasRole}) => (
-                <Tooltip
-                  title={t('You do not have permission to download artifacts.')}
-                  disabled={hasRole}
+        <ButtonBar gap={0.5}>
+          <Role role={downloadRole}>
+            {({hasRole}) => (
+              <Tooltip
+                title={
+                  !hasRole
+                    ? t('You do not have permission to download artifacts.')
+                    : type !== ArtifactType.INDIVIDUAL
+                    ? t(
+                        'This artifact is part of an archive. Only individual artifacts can be downloaded one by one.'
+                      )
+                    : t('Download Artifact')
+                }
+              >
+                <Button
+                  size="small"
+                  icon={<IconDownload size="sm" />}
+                  label={t('Download Artifact')}
+                  disabled={!hasRole || type !== ArtifactType.INDIVIDUAL}
+                  href={downloadUrl}
+                />
+              </Tooltip>
+            )}
+          </Role>
+
+          <Access access={['project:releases']}>
+            {({hasAccess}) => (
+              <Tooltip
+                title={
+                  !hasAccess
+                    ? t('You do not have permission to delete artifacts.')
+                    : type !== ArtifactType.INDIVIDUAL
+                    ? t(
+                        'This artifact is part of an archive. Only individual artifacts can be removed one by one.'
+                      )
+                    : t('Remove Artifact')
+                }
+              >
+                <Confirm
+                  message={t('Are you sure you want to remove this artifact?')}
+                  onConfirm={handleDeleteClick}
+                  disabled={!hasAccess || type !== ArtifactType.INDIVIDUAL}
                 >
                   <Button
                     size="small"
-                    icon={<IconDownload size="sm" />}
-                    disabled={!hasRole}
-                    href={downloadUrl}
-                    title={hasRole ? t('Download Artifact') : undefined}
+                    icon={<IconDelete size="sm" />}
+                    label={t('Remove Artifact')}
                   />
-                </Tooltip>
-              )}
-            </Role>
-
-            <Access access={['project:releases']}>
-              {({hasAccess}) => (
-                <Tooltip
-                  disabled={hasAccess}
-                  title={t('You do not have permission to delete artifacts.')}
-                >
-                  <Confirm
-                    message={t('Are you sure you want to remove this artifact?')}
-                    onConfirm={handleDeleteClick}
-                    disabled={!hasAccess}
-                  >
-                    <Button
-                      size="small"
-                      icon={<IconDelete size="sm" />}
-                      title={hasAccess ? t('Remove Artifact') : undefined}
-                      label={t('Remove Artifact')}
-                      disabled={!hasAccess}
-                    />
-                  </Confirm>
-                </Tooltip>
-              )}
-            </Access>
-          </ButtonBar>
-        )}
+                </Confirm>
+              </Tooltip>
+            )}
+          </Access>
+        </ButtonBar>
       </ActionsColumn>
     </Fragment>
   );

--- a/static/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
+++ b/static/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
@@ -13,7 +13,7 @@ import Tooltip from 'app/components/tooltip';
 import {IconClock, IconDelete, IconDownload} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Artifact} from 'app/types';
+import {Artifact, ArtifactType} from 'app/types';
 
 type Props = {
   artifact: Artifact;
@@ -28,10 +28,20 @@ const SourceMapsArtifactRow = ({
   downloadUrl,
   downloadRole,
 }: Props) => {
-  const {name, size, dateCreated, id, dist} = artifact;
+  const {name, size, dateCreated, id, dist, type} = artifact;
 
   const handleDeleteClick = () => {
     onDelete(id);
+  };
+
+  const getTypeTooltip = (tooltipType: ArtifactType) => {
+    if (tooltipType === ArtifactType.INDIVIDUAL) {
+      return t('This artifact has been uploaded individually.');
+    }
+    if (tooltipType === ArtifactType.ARCHIVED) {
+      return t('This artifact is part of a zip archive.');
+    }
+    return undefined;
   };
 
   return (
@@ -49,53 +59,56 @@ const SourceMapsArtifactRow = ({
           >
             {dist ?? t('none')}
           </StyledTag>
+          {type && <StyledTag tooltipText={getTypeTooltip(type)}>{type}</StyledTag>}
         </TimeAndDistWrapper>
       </NameColumn>
       <SizeColumn>
         <FileSize bytes={size} />
       </SizeColumn>
       <ActionsColumn>
-        <ButtonBar gap={0.5}>
-          <Role role={downloadRole}>
-            {({hasRole}) => (
-              <Tooltip
-                title={t('You do not have permission to download artifacts.')}
-                disabled={hasRole}
-              >
-                <Button
-                  size="small"
-                  icon={<IconDownload size="sm" />}
-                  disabled={!hasRole}
-                  href={downloadUrl}
-                  title={hasRole ? t('Download Artifact') : undefined}
-                />
-              </Tooltip>
-            )}
-          </Role>
-
-          <Access access={['project:releases']}>
-            {({hasAccess}) => (
-              <Tooltip
-                disabled={hasAccess}
-                title={t('You do not have permission to delete artifacts.')}
-              >
-                <Confirm
-                  message={t('Are you sure you want to remove this artifact?')}
-                  onConfirm={handleDeleteClick}
-                  disabled={!hasAccess}
+        {type === ArtifactType.INDIVIDUAL && (
+          <ButtonBar gap={0.5}>
+            <Role role={downloadRole}>
+              {({hasRole}) => (
+                <Tooltip
+                  title={t('You do not have permission to download artifacts.')}
+                  disabled={hasRole}
                 >
                   <Button
                     size="small"
-                    icon={<IconDelete size="sm" />}
-                    title={hasAccess ? t('Remove Artifact') : undefined}
-                    label={t('Remove Artifact')}
-                    disabled={!hasAccess}
+                    icon={<IconDownload size="sm" />}
+                    disabled={!hasRole}
+                    href={downloadUrl}
+                    title={hasRole ? t('Download Artifact') : undefined}
                   />
-                </Confirm>
-              </Tooltip>
-            )}
-          </Access>
-        </ButtonBar>
+                </Tooltip>
+              )}
+            </Role>
+
+            <Access access={['project:releases']}>
+              {({hasAccess}) => (
+                <Tooltip
+                  disabled={hasAccess}
+                  title={t('You do not have permission to delete artifacts.')}
+                >
+                  <Confirm
+                    message={t('Are you sure you want to remove this artifact?')}
+                    onConfirm={handleDeleteClick}
+                    disabled={!hasAccess}
+                  >
+                    <Button
+                      size="small"
+                      icon={<IconDelete size="sm" />}
+                      title={hasAccess ? t('Remove Artifact') : undefined}
+                      label={t('Remove Artifact')}
+                      disabled={!hasAccess}
+                    />
+                  </Confirm>
+                </Tooltip>
+              )}
+            </Access>
+          </ButtonBar>
+        )}
       </ActionsColumn>
     </Fragment>
   );

--- a/static/app/views/settings/projectSourceMaps/list/index.tsx
+++ b/static/app/views/settings/projectSourceMaps/list/index.tsx
@@ -86,10 +86,10 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
 
   getEmptyMessage() {
     if (this.getQuery()) {
-      return t('There are no archives that match your search.');
+      return t('There are no releases that match your search.');
     }
 
-    return t('There are no archives for this project.');
+    return t('There are no releases for this project.');
   }
 
   renderLoading() {
@@ -127,7 +127,7 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
           title={t('Source Maps')}
           action={
             <SearchBar
-              placeholder={t('Filter Archives')}
+              placeholder={t('Filter Releases')}
               onSearch={this.handleSearch}
               query={this.getQuery()}
               width="280px"
@@ -137,7 +137,7 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
 
         <TextBlock>
           {tct(
-            `These source map archives help Sentry identify where to look when Javascript is minified. By providing this information, you can get better context for your stack traces when debugging. To learn more about source maps, [link: read the docs].`,
+            `Source maps help Sentry identify where to look when Javascript is minified. By providing this information, you can get better context for your stack traces when debugging. To learn more about source maps, [link: read the docs].`,
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/sourcemaps/" />
@@ -148,9 +148,8 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
 
         <StyledPanelTable
           headers={[
-            t('Archive'),
+            t('Release'),
             <ArtifactsColumn key="artifacts">{t('Artifacts')}</ArtifactsColumn>,
-            t('Type'),
             t('Date Created'),
             '',
           ]}
@@ -168,7 +167,7 @@ class ProjectSourceMaps extends AsyncView<Props, State> {
 
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns:
-    minmax(120px, 1fr) max-content minmax(85px, max-content) minmax(265px, max-content)
+    minmax(120px, 1fr) max-content minmax(265px, max-content)
     75px;
 `;
 

--- a/static/app/views/settings/projectSourceMaps/list/sourceMapsArchiveRow.tsx
+++ b/static/app/views/settings/projectSourceMaps/list/sourceMapsArchiveRow.tsx
@@ -54,7 +54,7 @@ const SourceMapsArchiveRow = ({archive, orgId, projectId, onDelete}: Props) => {
                 <Confirm
                   onConfirm={() => onDelete(name)}
                   message={t(
-                    'Are you sure you want to remove all artifacts in this archive?'
+                    'Are you sure you want to remove all artifacts in this release?'
                   )}
                   disabled={!hasAccess}
                 >

--- a/static/app/views/settings/projectSourceMaps/list/sourceMapsArchiveRow.tsx
+++ b/static/app/views/settings/projectSourceMaps/list/sourceMapsArchiveRow.tsx
@@ -40,7 +40,6 @@ const SourceMapsArchiveRow = ({archive, orgId, projectId, onDelete}: Props) => {
       <ArtifactsColumn>
         <Count value={fileCount} />
       </ArtifactsColumn>
-      <Column>{t('release')}</Column>
       <Column>
         <DateTime date={date} />
       </Column>

--- a/tests/js/sentry-test/fixtures/sourceMapArtifact.js
+++ b/tests/js/sentry-test/fixtures/sourceMapArtifact.js
@@ -7,6 +7,7 @@ export function SourceMapArtifact(params) {
     headers: {'Content-Type': ''},
     id: '5678',
     size: 8276,
+    type: 'individual',
     ...params,
   };
 }

--- a/tests/js/spec/views/settings/projectSourceMaps.spec.jsx
+++ b/tests/js/spec/views/settings/projectSourceMaps.spec.jsx
@@ -42,7 +42,7 @@ describe('ProjectSourceMaps', function () {
     const wrapper = mountWithTheme(<ProjectSourceMaps {...props} />);
 
     expect(wrapper.find('EmptyStateWarning').text()).toBe(
-      'There are no archives for this project.'
+      'There are no releases for this project.'
     );
   });
 
@@ -144,7 +144,7 @@ describe('ProjectSourceMapsDetail', function () {
     const wrapper = mountWithTheme(<ProjectSourceMapsDetail {...props} />);
 
     expect(wrapper.find('EmptyStateWarning').text()).toBe(
-      'There are no artifacts in this archive.'
+      'There are no artifacts in this release.'
     );
   });
 

--- a/tests/js/spec/views/settings/projectSourceMaps.spec.jsx
+++ b/tests/js/spec/views/settings/projectSourceMaps.spec.jsx
@@ -118,6 +118,11 @@ describe('ProjectSourceMapsDetail', function () {
     router,
   };
 
+  MockApiClient.addMockResponse({
+    url: `/projects/${organization.slug}/${project.slug}/releases/${archiveName}/files-meta/`,
+    body: {},
+  });
+
   it('renders', function () {
     MockApiClient.addMockResponse({
       url: endpoint,


### PR DESCRIPTION
- [x] change wording from archives to releases
- [x] remove type column on source maps index page
- [x] add artifact type badge
- [x] remove the ability to delete/download single artifacts of type archived
- [x] add the ability to filter artifacts by type
- [x] add the button to download zip archive

Requires https://github.com/getsentry/sentry/pull/26351