### PR TITLE
feat(ui): Add more interval options to issue alerts

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -11,6 +11,8 @@ from sentry.utils import metrics
 
 intervals = {
     "1m": ("one minute", timedelta(minutes=1)),
+    "5m": ("5 minutes", timedelta(minutes=5)),
+    "15m": ("15 minutes", timedelta(minutes=15)),
     "1h": ("one hour", timedelta(hours=1)),
     "1d": ("one day", timedelta(hours=24)),
     "1w": ("one week", timedelta(days=7)),


### PR DESCRIPTION
Add more interval options (5 minutes, 15 minutes) to issue alert conditions:

```
The issue is seen by more than {value} times in {interval}
The issue is seen by more than {value} users in {interval}
```

FIXES [WOR-791](https://getsentry.atlassian.net/browse/WOR-791)

<img width="202" alt="Screen Shot 2021-06-04 at 4 29 02 AM" src="https://user-images.githubusercontent.com/20312973/120796253-77bc7780-c4ef-11eb-8ae1-ab2db0d36c6d.png">

