### PR TITLE
feat(ui): Minute session resolution

### DIFF
--- a/static/app/views/releases/detail/overview/chart/utils.tsx
+++ b/static/app/views/releases/detail/overview/chart/utils.tsx
@@ -21,8 +21,15 @@ type ChartData = Record<string, Series>;
 
 const SESSIONS_CHART_PALETTE = CHART_PALETTE[3];
 
-export function getInterval(datetimeObj: DateTimeObject) {
+export function getInterval(datetimeObj: DateTimeObject, organization?: Organization) {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
+
+  if (
+    organization?.features.includes('minute-resolution-sessions') &&
+    diffInMinutes < 360 // limit on backend is set to six hour
+  ) {
+    return '5m';
+  }
 
   if (diffInMinutes > TWO_WEEKS) {
     return '6h';

--- a/static/app/views/releases/detail/overview/chart/utils.tsx
+++ b/static/app/views/releases/detail/overview/chart/utils.tsx
@@ -21,11 +21,18 @@ type ChartData = Record<string, Series>;
 
 const SESSIONS_CHART_PALETTE = CHART_PALETTE[3];
 
-export function getInterval(datetimeObj: DateTimeObject, organization?: Organization) {
+type GetIntervalOptions = {
+  highFidelity?: boolean;
+};
+
+export function getInterval(
+  datetimeObj: DateTimeObject,
+  {highFidelity}: GetIntervalOptions = {}
+) {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
 
   if (
-    organization?.features.includes('minute-resolution-sessions') &&
+    highFidelity &&
     diffInMinutes < 360 // limit on backend is set to six hour
   ) {
     return '5m';

--- a/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -109,7 +109,9 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
 
     return {
       query: stringifyQueryObject(new QueryResults([`release:"${version}"`])),
-      interval: getInterval(selection.datetime, organization),
+      interval: getInterval(selection.datetime, {
+        highFidelity: organization.features.includes('minute-resolution-sessions'),
+      }),
       ...getParams(pick(location.query, Object.values(URL_PARAM)), {
         defaultStatsPeriod,
       }),

--- a/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -105,11 +105,11 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
   }
 
   get baseQueryParams() {
-    const {version, location, selection, defaultStatsPeriod} = this.props;
+    const {version, organization, location, selection, defaultStatsPeriod} = this.props;
 
     return {
       query: stringifyQueryObject(new QueryResults([`release:"${version}"`])),
-      interval: getInterval(selection.datetime),
+      interval: getInterval(selection.datetime, organization),
       ...getParams(pick(location.query, Object.values(URL_PARAM)), {
         defaultStatsPeriod,
       }),


### PR DESCRIPTION
We are testing the impact of allowing to query sessions with sub-hour resolution.
It's feature flagged for now.