### PR TITLE
fix(alert): Moving from wizard to builder doesn't persist scroll

### DIFF
--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -9,6 +9,7 @@ import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import Projects from 'app/utils/projects';
 import withApi from 'app/utils/withApi';
+import ScrollToTop from 'app/views/settings/components/scrollToTop';
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
@@ -43,7 +44,7 @@ function AlertBuilderProjectProvider(props: Props) {
         fetchOrgMembers(api, organization.slug, [project.id]);
 
         return (
-          <React.Fragment>
+          <ScrollToTop location={props.location} disable={() => false}>
             {children && React.isValidElement(children)
               ? React.cloneElement(children, {
                   ...other,
@@ -52,7 +53,7 @@ function AlertBuilderProjectProvider(props: Props) {
                   organization,
                 })
               : children}
-          </React.Fragment>
+          </ScrollToTop>
         );
       }}
     </Projects>


### PR DESCRIPTION
Previously moving from the alert wizard to the alert builder would maintain your scroll position. So in some cases when you were scrolled to the bottom of the wizard then you would be navigated to a builder where you start scrolled to the bottom. This experience can be quite confusing since the user doesn't know what they're looking at.

So this PR borrows the `ScrollToTop` component from settings to maintain scroll positions at the top of the page on each redirect with the alert builder or alert wizard.

Before:
![Kapture 2021-06-04 at 15 14 48](https://user-images.githubusercontent.com/9372512/120852101-c3027480-c547-11eb-8b2b-fd8b45c241b9.gif)

After:
![Kapture 2021-06-04 at 15 15 20](https://user-images.githubusercontent.com/9372512/120852095-c138b100-c547-11eb-9fdf-8ba74a01867c.gif)

