### PR TITLE
feat(api): Return first and last releases on date sort

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -411,7 +411,7 @@ class OrganizationReleaseDetailsEndpoint(
                         **self.get_first_and_last_releases(
                             org=organization,
                             environment=filter_params.get("environment"),
-                            project_id=filter_params["project_id"],
+                            project_id=[project_id],
                             sort=sort,
                         ),
                     }

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -458,6 +458,10 @@ class ReleaseSerializer(Serializer):
                 rv["nextReleaseVersion"] = current_project_meta["next_release_version"]
             if "prev_release_version" in current_project_meta:
                 rv["prevReleaseVersion"] = current_project_meta["prev_release_version"]
+            if "first_release_version" in current_project_meta:
+                rv["firstReleaseVersion"] = current_project_meta["first_release_version"]
+            if "last_release_version" in current_project_meta:
+                rv["lastReleaseVersion"] = current_project_meta["last_release_version"]
             return rv
 
         d = {

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -555,19 +555,13 @@ class ReleaseDetailsTest(APITestCase):
         Test that ensures that the first release and the last release in terms of `date_added` are
         retrieved correctly
         """
-        release_1 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@1.0.0"
-        )
+        release_1 = self.create_release(project=self.project1, version="foobar@1.0.0")
         release_1.add_project(self.project1)
 
-        release_2 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@2.0.0"
-        )
+        release_2 = self.create_release(project=self.project1, version="foobar@2.0.0")
         release_2.add_project(self.project1)
 
-        release_3 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@3.0.0"
-        )
+        release_3 = self.create_release(project=self.project1, version="foobar@3.0.0")
         release_3.add_project(self.project1)
 
         self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
@@ -591,18 +585,18 @@ class ReleaseDetailsTest(APITestCase):
         need to fallback to comparison with id
         """
         date_now = datetime.utcnow()
-        release_2 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@2.0.0", date_added=date_now
+        release_2 = self.create_release(
+            project=self.project1, version="foobar@2.0.0", date_added=date_now
         )
         release_2.add_project(self.project1)
 
-        release_1 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@1.0.0", date_added=date_now
+        release_1 = self.create_release(
+            project=self.project1, version="foobar@1.0.0", date_added=date_now
         )
         release_1.add_project(self.project1)
 
-        release_3 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@3.0.0", date_added=date_now
+        release_3 = self.create_release(
+            project=self.project1, version="foobar@3.0.0", date_added=date_now
         )
         release_3.add_project(self.project1)
 
@@ -625,24 +619,16 @@ class ReleaseDetailsTest(APITestCase):
         Test that ensures that environment filter is applied when fetching first and last
         releases on date sort order
         """
-        release_1 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@1.0.0"
-        )
+        release_1 = self.create_release(project=self.project1, version="foobar@1.0.0")
         release_1.add_project(self.project1)
 
-        release_2 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@2.0.0"
-        )
+        release_2 = self.create_release(project=self.project1, version="foobar@2.0.0")
         release_2.add_project(self.project1)
 
-        release_3 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@3.0.0"
-        )
+        release_3 = self.create_release(project=self.project1, version="foobar@3.0.0")
         release_3.add_project(self.project1)
 
-        release_4 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@4.0.0"
-        )
+        release_4 = self.create_release(project=self.project1, version="foobar@4.0.0")
         release_4.add_project(self.project1)
 
         environment = Environment.objects.create(organization_id=self.organization.id, name="prod")
@@ -681,9 +667,7 @@ class ReleaseDetailsTest(APITestCase):
         is not `date`, then the values of `firstReleaseVersion` and `lastReleaseVersion` are None
         values
         """
-        release_1 = Release.objects.create(
-            organization_id=self.organization.id, version="foobar@1.0.0"
-        )
+        release_1 = self.create_release(project=self.project1, version="foobar@1.0.0")
         release_1.add_project(self.project1)
 
         self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -90,6 +90,8 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
             "next_release_version": "foobar@2.0.0",
             "sessions_lower_bound": current_formatted_datetime,
             "sessions_upper_bound": current_formatted_datetime,
+            "first_release_version": "foobar@1.0.0",
+            "last_release_version": "foobar@2.0.0",
         }
 
         result = serialize(
@@ -114,6 +116,14 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         assert (
             result["currentProjectMeta"]["sessionsUpperBound"]
             == current_project_meta["sessions_upper_bound"]
+        )
+        assert (
+            result["currentProjectMeta"]["firstReleaseVersion"]
+            == current_project_meta["first_release_version"]
+        )
+        assert (
+            result["currentProjectMeta"]["lastReleaseVersion"]
+            == current_project_meta["last_release_version"]
         )
 
     def test_mobile_version(self):


### PR DESCRIPTION
This PR:
- Returns the first ever created Release and the last ever created release in `OrganizationReleaseDetailsEndpoint` on `('date_added', 'id')`
- Applies both `project` filter and `env` filter when retrieving the first and last releases
- Modifies the `Release` serializer to include keys `firstReleaseVersion` and `lastReleaseVersion` in `currentProjectMeta` key
