### PR TITLE
perf(releases): Append-only version of release archive merge

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -177,6 +177,7 @@ def merge_release_archives(file1: IO, archive2: ReleaseArchive, target: IO):
     Skip files that are already present in archive 1.
     """
     # Create a copy
+    file1.seek(0)
     target.write(file1.read())
 
     with ReleaseArchive(file1) as archive1:

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -194,8 +194,7 @@ def merge_release_archives(file1: IO, archive2: ReleaseArchive, target: IO) -> b
             archive1.info(filename).CRC != archive2.info(filename).CRC
             for filename in files.keys() & files2.keys()
         ):
-            # TODO: Get release ID or something to associate this log line with
-            logger.info("Archives have different content for one or more files")
+            metrics.incr("release_file.archive.different_content")
 
         new_files = files2.keys() - files.keys()
         if not new_files:

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -213,14 +213,14 @@ def _merge_archives(release_file: ReleaseFile, new_file: File, new_archive: Rele
             buffer = BytesIO()
 
             with metrics.timer("tasks.assemble.merge_archives_pure"):
-                merge_release_archives(old_file_contents, new_archive, buffer)
+                did_merge = merge_release_archives(old_file_contents, new_archive, buffer)
 
-            replacement = File.objects.create(name=old_file.name, type=old_file.type)
-            buffer.seek(0)
-            replacement.putfile(buffer)
-            release_file.update(file=replacement)
-
-            old_file.delete()
+            if did_merge:
+                replacement = File.objects.create(name=old_file.name, type=old_file.type)
+                buffer.seek(0)
+                replacement.putfile(buffer)
+                release_file.update(file=replacement)
+                old_file.delete()
 
     except UnableToAcquireLock as error:
         logger.error("merge_archives.fail", extra={"error": error})

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -130,7 +130,6 @@ class ReleaseArchiveTestCase(TestCase):
         merge_release_archives(archive1, archive2, buffer)
 
         archive3 = ReleaseArchive(buffer)
-        print(archive3._zip_file.infolist())
 
         assert archive3.manifest["org"] == 1
         assert archive3.manifest["release"] == 2

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -229,9 +229,9 @@ class AssembleArtifactsTest(BaseAssembleTest):
                     assert release_file.file.headers == {"Sourcemap": "index.js.map"}
 
     def test_merge_archives(self):
-        file1 = File.objects.create()
+        file1 = File.objects.create(name="foo")
         file1.putfile(ContentFile(self.create_artifact_bundle()))
-        file2 = File.objects.create()
+        file2 = File.objects.create(name="foo")
         file2.putfile(ContentFile(self.create_artifact_bundle()))
 
         release_file = ReleaseFile.objects.create(

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -228,11 +228,32 @@ class AssembleArtifactsTest(BaseAssembleTest):
                 else:
                     assert release_file.file.headers == {"Sourcemap": "index.js.map"}
 
-    def test_merge_archives(self):
+    def test_merge_archives_same(self):
         file1 = File.objects.create(name="foo")
         file1.putfile(ContentFile(self.create_artifact_bundle()))
         file2 = File.objects.create(name="foo")
         file2.putfile(ContentFile(self.create_artifact_bundle()))
+
+        release_file = ReleaseFile.objects.create(
+            organization=self.organization,
+            release=self.release,
+            file=file1,
+        )
+
+        with ReleaseArchive(file2.getfile().file) as archive2:
+            _merge_archives(release_file, file2, archive2)
+            # Both archives contain the same files, so old archive remains
+            assert File.objects.filter(pk=file1.pk).exists()
+            assert not File.objects.filter(pk=file2.pk).exists()
+            assert ReleaseFile.objects.get(pk=release_file.pk).file == file1
+
+    def test_merge_archives_different(self):
+        file1 = File.objects.create(name="foo")
+        file1.putfile(ContentFile(self.create_artifact_bundle()))
+        file2 = File.objects.create(name="foo")
+        file2.putfile(
+            ContentFile(self.create_artifact_bundle(extra_files={"extra.js": "someFun()"}))
+        )
 
         release_file = ReleaseFile.objects.create(
             organization=self.organization,


### PR DESCRIPTION
In this PR: 

* Extend the scope of the merge lock to include reading the existing archive.
* Use `ReleaseFile.cache` to (hopefully) speed up archive read.
* Append files from new archive to old archive, s.t. only new files have to be recompressed.