### PR TITLE
meta: Add deprecation warning for js globals in custom plugins

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Unreleased
+----------
+The frontend bundle will be loaded asynchronously. This is a breaking change that can affect custom plugins that access certain globals in the django template. Please see https://forum.sentry.io/t/breaking-frontend-changes-for-custom-plugins/14184 for more information.
+
 21.5.1
 ------
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
-Unreleased
-----------
-The frontend bundle will be loaded asynchronously. This is a breaking change that can affect custom plugins that access certain globals in the django template. Please see https://forum.sentry.io/t/breaking-frontend-changes-for-custom-plugins/14184 for more information.
+Deprecation Warning (2021-06-07)
+--------------------------------
+There will be a future change to where the frontend bundle will be loaded asynchronously. This will be a breaking change that can affect custom plugins that access certain globals in the django template. Please see https://forum.sentry.io/t/breaking-frontend-changes-for-custom-plugins/14184 for more information.
 
 21.5.1
 ------

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
-Deprecation Warning (2021-06-07)
---------------------------------
+Unreleased
+----------
+
+### Deprecation Warning
+
 There will be a future change to where the frontend bundle will be loaded asynchronously. This will be a breaking change that can affect custom plugins that access certain globals in the django template. Please see https://forum.sentry.io/t/breaking-frontend-changes-for-custom-plugins/14184 for more information.
 
 21.5.1


### PR DESCRIPTION
This adds a breaking change notice to our changelog regarding custom plugins:

The frontend bundle will be loaded asynchronously. This is a breaking change that can affect custom plugins that access certain globals in the django template. Please see https://forum.sentry.io/t/breaking-frontend-changes-for-custom-plugins/14184 for more information