### PR TITLE
feat(dev): Install wheel as part of make install-py-dev

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -92,7 +92,6 @@ jobs:
           eval "$(pyenv init --path)"
           python -m venv .venv
           source .venv/bin/activate
-          pip install wheel
           make bootstrap
 
       - name: Test direnv

--- a/.github/workflows/python-versions.yml
+++ b/.github/workflows/python-versions.yml
@@ -56,5 +56,4 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install wheel
           make install-py-dev

--- a/scripts/bootstrap-py3-venv
+++ b/scripts/bootstrap-py3-venv
@@ -50,6 +50,7 @@ fi
 python3 -m pip install -U pip           || { echo "bootstrap failed!"; return 1; }
 python3 -m venv "${venv_name}"          || { echo "bootstrap failed!"; return 1; }
 source "${venv_name}/bin/activate"      || { echo "bootstrap failed!"; return 1; }
+python3 -m pip install -U pip      || { echo "bootstrap failed!"; return 1; }
 make setup-git                          || { echo "bootstrap failed!"; return 1; }
 make install-py-dev                     || { echo "bootstrap failed!"; return 1; }
 deactivate                              || { echo "bootstrap failed!"; return 1; }

--- a/scripts/bootstrap-py3-venv
+++ b/scripts/bootstrap-py3-venv
@@ -50,7 +50,7 @@ fi
 python3 -m pip install -U pip           || { echo "bootstrap failed!"; return 1; }
 python3 -m venv "${venv_name}"          || { echo "bootstrap failed!"; return 1; }
 source "${venv_name}/bin/activate"      || { echo "bootstrap failed!"; return 1; }
-python3 -m pip install -U pip      || { echo "bootstrap failed!"; return 1; }
+python3 -m pip install -U pip           || { echo "bootstrap failed!"; return 1; }
 make setup-git                          || { echo "bootstrap failed!"; return 1; }
 make install-py-dev                     || { echo "bootstrap failed!"; return 1; }
 deactivate                              || { echo "bootstrap failed!"; return 1; }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -80,11 +80,7 @@ start-docker() {
 }
 
 upgrade-pip() {
-    # pip versions before 20.1 do not have `pip cache` as a command which is necessary for the CI
-    pip install --no-cache-dir --upgrade "pip==21.1.2"
-    # The Python version installed via pyenv does not come with wheel pre-installed
-    # Installing wheel will speed up installation of Python dependencies
-    require wheel || pip install wheel
+    pip install --upgrade "pip==21.1.2" "wheel==0.36.2"
 }
 
 install-py-dev() {
@@ -93,15 +89,10 @@ install-py-dev() {
     # This helps when getsentry calls into this script
     cd "${HERE}/.." || exit
     echo "--> Installing Sentry (for development)"
-    # In Big Sur, versions of pip before 20.3 require SYSTEM_VERSION_COMPAT set
-    if query_big_sur && python -c 'from sys import exit; import pip; from pip._vendor.packaging.version import parse; exit(1 if parse(pip.__version__) < parse("20.3") else 0)'; then
-        SENTRY_LIGHT_BUILD=1 SYSTEM_VERSION_COMPAT=1 pip install -e '.[dev]'
-    else
-        # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
-        # Webpacked assets are only necessary for devserver (which does it lazily anyways)
-        # and acceptance tests, which webpack automatically if run.
-        SENTRY_LIGHT_BUILD=1 pip install -e '.[dev]'
-    fi
+    # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
+    # Webpacked assets are only necessary for devserver (which does it lazily anyways)
+    # and acceptance tests, which webpack automatically if run.
+    SENTRY_LIGHT_BUILD=1 pip install -e '.[dev]'
 }
 
 setup-git-config() {


### PR DESCRIPTION
wheel is necessary to install certain packages that are already built on pypi rather
than having to build them from source.

Making them part of the make target makes sure that it is installed before trying
to install all other packages.

Fixes #24351