### PR TITLE
fix(release): Adoption chart to respect the global time selection

### DIFF
--- a/static/app/views/releases/detail/overview/releaseStats.tsx
+++ b/static/app/views/releases/detail/overview/releaseStats.tsx
@@ -55,45 +55,45 @@ function ReleaseStats({
 }: Props) {
   const {lastDeploy, dateCreated, version} = release;
 
-  const crashCount = getHealthData.getCrashCount(
+  const crashCount = getHealthData.getCrashCount?.(
     version,
     project.id,
     DisplayOption.SESSIONS
   );
-  const crashFreeSessions = getHealthData.getCrashFreeRate(
+  const crashFreeSessions = getHealthData.getCrashFreeRate?.(
     version,
     project.id,
     DisplayOption.SESSIONS
   );
-  const crashFreeUsers = getHealthData.getCrashFreeRate(
+  const crashFreeUsers = getHealthData.getCrashFreeRate?.(
     version,
     project.id,
     DisplayOption.USERS
   );
-  const get24hSessionCountByRelease = getHealthData.get24hCountByRelease(
+  const get24hSessionCountByRelease = getHealthData.get24hCountByRelease?.(
     version,
     project.id,
     DisplayOption.SESSIONS
   );
-  const get24hSessionCountByProject = getHealthData.get24hCountByProject(
+  const get24hSessionCountByProject = getHealthData.get24hCountByProject?.(
     project.id,
     DisplayOption.SESSIONS
   );
-  const get24hUserCountByRelease = getHealthData.get24hCountByRelease(
+  const get24hUserCountByRelease = getHealthData.get24hCountByRelease?.(
     version,
     project.id,
     DisplayOption.USERS
   );
-  const get24hUserCountByProject = getHealthData.get24hCountByProject(
+  const get24hUserCountByProject = getHealthData.get24hCountByProject?.(
     project.id,
     DisplayOption.USERS
   );
-  const sessionAdoption = getHealthData.getAdoption(
+  const sessionAdoption = getHealthData.getAdoption?.(
     version,
     project.id,
     DisplayOption.SESSIONS
   );
-  const userAdoption = getHealthData.getAdoption(
+  const userAdoption = getHealthData.getAdoption?.(
     version,
     project.id,
     DisplayOption.USERS

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -373,8 +373,7 @@ class ReleasesList extends AsyncView<Props, State> {
           <Feature features={['organizations:release-adoption-chart']}>
             <Projects orgId={organization.slug} slugs={[selectedProject.slug]}>
               {({projects, initiallyLoaded, fetchError}) => {
-                const releaseVersions =
-                  getHealthData.getReleaseVersions && getHealthData.getReleaseVersions();
+                const releaseVersions = getHealthData.getReleaseVersions?.();
 
                 const project = projects && projects.length === 1 && projects[0];
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -354,7 +354,12 @@ class ReleasesList extends AsyncView<Props, State> {
       p => p.id === `${selectedProjectId}`
     );
 
-    if (this.shouldShowLoadingIndicator() || !releases?.length || !selectedProject) {
+    if (
+      this.shouldShowLoadingIndicator() ||
+      !releases?.length ||
+      !selectedProject ||
+      !hasSessions
+    ) {
       return null;
     }
 
@@ -374,7 +379,7 @@ class ReleasesList extends AsyncView<Props, State> {
               {({projects, initiallyLoaded, fetchError}) => {
                 const project = projects && projects.length === 1 && projects[0];
 
-                if (!initiallyLoaded || fetchError || !project || !hasSessions) {
+                if (!initiallyLoaded || fetchError || !project) {
                   return null;
                 }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -367,7 +367,7 @@ class ReleasesList extends AsyncView<Props, State> {
         display={[this.getDisplay()]}
         releasesReloading={reloading}
         healthStatsPeriod={HealthStatsPeriodOption.AUTO}
-        timeSeriesReleases
+        timeSeriesReleasesOnly
       >
         {({isHealthLoading, getHealthData}) => (
           <Feature features={['organizations:release-adoption-chart']}>

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -19,7 +19,7 @@ import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {GlobalSelection, Organization, Project, Release} from 'app/types';
+import {GlobalSelection, Organization, Project} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
 import withApi from 'app/utils/withApi';
 import {DisplayOption} from 'app/views/releases/list/utils';
@@ -29,7 +29,7 @@ type Props = WithRouterProps & {
   api: Client;
   organization: Organization;
   selection: GlobalSelection;
-  releases: Release[];
+  releaseVersions: string[];
   project: Project;
   getHealthData: ReleaseHealthRequestRenderProps['getHealthData'];
   activeDisplay: DisplayOption;
@@ -99,7 +99,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
   render() {
     const {
       showPlaceholders,
-      releases,
+      releaseVersions,
       project,
       activeDisplay,
       router,
@@ -113,9 +113,7 @@ class ReleaseAdoptionChart extends React.PureComponent<Props, State> {
       return this.renderEmpty();
     }
 
-    const releasesSeries = releases.map(release => {
-      const releaseVersion = release.version;
-
+    const releasesSeries = releaseVersions.map(releaseVersion => {
       const timeSeries = getHealthData.getTimeSeries(
         releaseVersion,
         Number(project.id),

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -95,22 +95,22 @@ const Content = ({
           {projects.map((project, index) => {
             const {id, slug, newGroups} = project;
 
-            const crashCount = getHealthData.getCrashCount(
+            const crashCount = getHealthData.getCrashCount?.(
               releaseVersion,
               id,
               DisplayOption.SESSIONS
             );
-            const crashFreeRate = getHealthData.getCrashFreeRate(
+            const crashFreeRate = getHealthData.getCrashFreeRate?.(
               releaseVersion,
               id,
               activeDisplay
             );
-            const get24hCountByRelease = getHealthData.get24hCountByRelease(
+            const get24hCountByRelease = getHealthData.get24hCountByRelease?.(
               releaseVersion,
               id,
               activeDisplay
             );
-            const get24hCountByProject = getHealthData.get24hCountByProject(
+            const get24hCountByProject = getHealthData.get24hCountByProject?.(
               id,
               activeDisplay
             );
@@ -119,7 +119,11 @@ const Content = ({
               id,
               activeDisplay
             );
-            const adoption = getHealthData.getAdoption(releaseVersion, id, activeDisplay);
+            const adoption = getHealthData.getAdoption?.(
+              releaseVersion,
+              id,
+              activeDisplay
+            );
             // we currently don't support sub-hour session intervals, we rather hide the count histogram than to show only two bars
             const hasCountHistogram =
               timeSeries?.[0].data.length > 7 &&


### PR DESCRIPTION
Release details chart previously used the same release health data as the row mini bar charts on the releases page. This caused the issue where the period used is the global selection period only when the mini bar chart period has the right option selected in the periods above it, ie. `healthStatsPeriod=auto`. This makes a new release health request with the global selection periods for the chart itself. Also split the rendering accordingly.