### PR TITLE
fix(config): Remove static Relays from default server config

### DIFF
--- a/src/sentry/data/config/config.yml.default
+++ b/src/sentry/data/config/config.yml.default
@@ -80,16 +80,3 @@ filestore.options:
 #   access_key: 'AKIXXXXXX'
 #   secret_key: 'XXXXXXX'
 #   bucket_name: 's3-bucket-name'
-
-#########
-# Relay #
-#########
-
-# statically configured relays have the following structure
-#  relay:
-#    static_auth:
-#      7a4905dd-0eeb-497c-aa49-fb9949906388:   # the relay id
-#        public_key: "SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"
-#        internal: true   # if true the relay is internal and will have access to all project configs
-relay:
-  static_auth: {}


### PR DESCRIPTION
Removes invalid static relay configuration from the default server configuration used during `sentry init`, introduced in https://github.com/getsentry/sentry/pull/26155. There is no need for adding Relays to the default configuration for development. 

If we were to add default configuration for onpremise, that would happen in the onpremise installation script.

The correct configuration format would also be:

```yaml
# statically configured relays have the following structure
relay.static_auth:
  7a4905dd-0eeb-497c-aa49-fb9949906388:   # the relay id
    public_key: "SMSesqan65THCV6M4qs4kBzPai60LzuDn-xNsvYpuP8"
    internal: true   # if true the relay is internal and will have access to all project configs
```

cc @tonyo @beezz 