### PR TITLE
feat: Use `Cache-Control: no-cache` for frontend asset caching

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -64,15 +64,11 @@ jobs:
           name: jest-html
           path: .artifacts/visual-snapshots/jest
 
-      - name: Get CSS filename
-        id: css-manifest
-        run: echo "::set-output name=sentrycss::$(jq -r '.["sentry.css"]' src/sentry/static/sentry/dist/manifest.json)"
-
       - name: Create Images from HTML
         uses: getsentry/action-html-to-image@main
         with:
           base-path: .artifacts/visual-snapshots/jest
-          css-path: src/sentry/static/sentry/dist/${{ steps.css-manifest.outputs.sentrycss }}
+          css-path: src/sentry/static/sentry/dist/sentry.css
 
       - name: Save snapshots
         if: always()

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,6 @@
 import os
 import sys
 
-dist_path = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "src", "sentry", "static", "sentry", "dist")
-)
-manifest_path = os.path.join(dist_path, "manifest.json")
 pytest_plugins = ["sentry.utils.pytest"]
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -16,24 +12,3 @@ def pytest_configure(config):
     # XXX(dcramer): Kombu throws a warning due to transaction.commit_manually
     # being used
     warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
-
-    # Create an empty webpack manifest file - otherwise tests will crash if it does not exist
-    os.makedirs(dist_path, exist_ok=True)
-
-    # Only create manifest if it doesn't exist
-    # (e.g. acceptance tests will have an actual manifest from webpack)
-    if os.path.exists(manifest_path):
-        return
-
-    with open(manifest_path, "w+") as fp:
-        fp.write("{}")
-
-
-def pytest_unconfigure():
-    if not os.path.exists(manifest_path):
-        return
-
-    # Clean up manifest file if contents are empty
-    with open(manifest_path) as f:
-        if f.read() == "{}":
-            os.remove(manifest_path)

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "u2f-api": "1.0.10",
     "webpack": "5.27.2",
     "webpack-cli": "4.5.0",
-    "webpack-manifest-plugin": "^3.1.0",
     "webpack-remove-empty-scripts": "^0.7.1",
     "wink-jaro-distance": "^2.0.0",
     "zxcvbn": "^4.4.2"

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -8,7 +8,6 @@ confluent-kafka==1.6.0; python_version == '3.9'
 croniter==0.3.37
 datadog==0.29.3
 django-crispy-forms==1.7.2
-django-manifest-loader==1.0.0
 django-picklefield==1.0.0
 django-sudo==3.1.0
 Django==1.11.29

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -332,7 +332,6 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "crispy_forms",
     "rest_framework",
-    "manifest_loader",
     "sentry",
     "sentry.analytics",
     "sentry.incidents.apps.Config",
@@ -372,15 +371,12 @@ STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned
 # as we configure webpack to include file content based hash in the filename
-STATIC_MANIFEST_URL = "/_static/dist/"
+STATIC_UNVERSIONED_URL = "/_static/dist/"
 
-# The webpack output directory, used by django-manifest-loader
+# The webpack output directory
 STATICFILES_DIRS = [
     os.path.join(STATIC_ROOT, "sentry", "dist"),
 ]
-
-# django-manifest-loader settings
-MANIFEST_LOADER = {"cache": True}
 
 # various middleware will use this to identify resources which should not access
 # cookies

--- a/src/sentry/middleware/user.py
+++ b/src/sentry/middleware/user.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 class UserActiveMiddleware:
     disallowed_paths = (
+        "sentry.web.frontend.generic.unversioned_static_media",
         "sentry.web.frontend.generic.static_media",
         "sentry.web.frontend.organization_avatar",
         "sentry.web.frontend.project_avatar",

--- a/src/sentry/templates/sentry/base-react.html
+++ b/src/sentry/templates/sentry/base-react.html
@@ -9,7 +9,7 @@
       <div class="loading-mask"></div>
 
       <div class="loading-indicator">
-        <img src="{% manifest_asset_url 'sentry' 'images/sentry-loader.svg' %}" />
+        <img src="{% asset_url 'sentry' 'images/sentry-loader.svg' %}" />
       </div>
 
       <div class="loading-message">

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% manifest_asset_url "sentry" "pipeline.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "pipeline.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% manifest_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
+  <link href="{% unversioned_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -46,11 +46,11 @@
   {% block scripts %}
   {% locale_js_include %}
 
-  {% manifest_asset_url "sentry" "runtime.js" as asset_url %}
+  {% unversioned_asset_url "sentry" "runtime.js" as asset_url %}
   {% script src=asset_url %}{% endscript %}
 
   {% block scripts_main_entrypoint %}
-    {% manifest_asset_url "sentry" "app.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -6,13 +6,13 @@ from django.template.base import token_kwargs
 from django.utils.safestring import mark_safe
 
 from sentry import options
-from sentry.utils.assets import get_asset_url, get_manifest_url
+from sentry.utils.assets import get_asset_url, get_unversioned_asset_url
 from sentry.utils.http import absolute_uri
 
 register = template.Library()
 
 register.simple_tag(get_asset_url, name="asset_url")
-register.simple_tag(get_manifest_url, name="manifest_asset_url")
+register.simple_tag(get_unversioned_asset_url, name="unversioned_asset_url")
 
 
 @register.simple_tag
@@ -62,7 +62,7 @@ def locale_js_include(context):
     if hasattr(request, "csp_nonce"):
         nonce = f' nonce="{request.csp_nonce}"'
 
-    href = get_manifest_url("sentry", "locale/" + lang_code + ".js")
+    href = get_unversioned_asset_url("sentry", "locale/" + lang_code + ".js")
     return mark_safe(f'<script src="{href}"{crossorigin()}{nonce}></script>')
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -108,36 +108,6 @@ class BaseTestCase(Fixtures, Exam):
 
     @classmethod
     @contextmanager
-    def static_asset_manifest(cls, manifest_data):
-        dist_path = "src/sentry/static/sentry/dist"
-        manifest_path = f"{dist_path}/manifest.json"
-
-        with open(manifest_path, "w") as manifest_fp:
-            json.dump(manifest_data, manifest_fp)
-
-        files = []
-        for file_path in manifest_data.values():
-            full_path = f"{dist_path}/{file_path}"
-            # make directories in case they don't exist
-            # (e.g. dist path should exist, but subdirs won't)
-            os.makedirs(os.path.dirname(full_path), exist_ok=True)
-            open(full_path, "a").close()
-            files.append(full_path)
-
-        try:
-            yield {"manifest": manifest_data, "files": files}
-        finally:
-            with open(manifest_path, "w") as manifest_fp:
-                # Instead of unlinking, preserve an empty manifest file so that other tests that
-                # may or may not load static assets, do not fail
-                manifest_fp.write("{}")
-
-            # Remove any files created from the test manifest
-            for filepath in files:
-                os.unlink(filepath)
-
-    @classmethod
-    @contextmanager
     def capture_on_commit_callbacks(cls, using=DEFAULT_DB_ALIAS, execute=False):
         """
         Context manager to capture transaction.on_commit() callbacks.

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,29 +1,18 @@
 from django.conf import settings
-from manifest_loader.utils import _get_manifest, _load_from_manifest
 
 
-def get_manifest_obj():
+def get_unversioned_asset_url(module, key):
     """
-    Returns the webpack asset manifest as a dict of <file key, hashed file name>
-
-    The `manifest_loader` library caches this (if `cache` settings is set)
-    """
-    return _get_manifest()
-
-
-def get_manifest_url(module, key):
-    """
-    Returns an asset URL that is produced by webpack. Uses webpack's manifest to map
-    `key` to the asset produced by webpack. Required if using file contents based hashing for filenames.
+    Returns an asset URL that is unversioned. These assets should have a
+    `Cache-Control: no-cache` so that clients must validate with the origin
+    server before using their locally cached asset.
 
     Example:
-      {% manifest_asset_url 'sentry' 'sentry.css' %}
-      =>  "/_static/dist/sentry/sentry.filehash123.css"
+      {% unversioned_asset_url 'sentry' 'sentry.css' %}
+      =>  "/_static/dist/sentry/sentry.css"
     """
-    manifest_obj = get_manifest_obj()
-    manifest_value = _load_from_manifest(manifest_obj, key=key)
 
-    return "{}/{}/{}".format(settings.STATIC_MANIFEST_URL.rstrip("/"), module, manifest_value)
+    return "{}/{}/{}".format(settings.STATIC_UNVERSIONED_URL.rstrip("/"), module, key.lstrip("/"))
 
 
 def get_asset_url(module, path):
@@ -31,7 +20,7 @@ def get_asset_url(module, path):
     Returns a versioned asset URL (located within Sentry's static files).
 
     Example:
-      {% asset_url 'sentry' 'images/sentry.png' %}
-      =>  "/_static/74d127b78dc7daf2c51f/sentry/sentry.png"
+    {% asset_url 'sentry' 'images/sentry.png' %}
+    =>  "/_static/74d127b78dc7daf2c51f/sentry/sentry.png"
     """
     return "{}/{}/{}".format(settings.STATIC_URL.rstrip("/"), module, path.lstrip("/"))

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -12,7 +12,7 @@ from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
-from sentry.utils.assets import get_manifest_url
+from sentry.utils.assets import get_unversioned_asset_url
 from sentry.utils.email import is_smtp_enabled
 from sentry.utils.support import get_support_mail
 
@@ -146,7 +146,7 @@ def get_client_config(request=None):
         "urlPrefix": options.get("system.url-prefix"),
         "version": version_info,
         "features": enabled_features,
-        "distPrefix": get_manifest_url("sentry", ""),
+        "distPrefix": get_unversioned_asset_url("sentry", ""),
         "needsUpgrade": needs_upgrade,
         "dsn": public_dsn,
         "dsn_requests": _get_dsn_requests(),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -96,8 +96,8 @@ urlpatterns += [
     # a filecontent-based hash in its filenames so that it can be cached long term
     url(
         r"^_static/dist/(?P<module>[^/]+)/(?P<path>.*)$",
-        generic.static_media_with_manifest,
-        name="sentry-webpack-media",
+        generic.unversioned_static_media,
+        name="sentry-unversioned-media",
     ),
     # The static version is either a 10 digit timestamp, a sha1, or md5 hash
     url(

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -16,32 +16,20 @@ class AssetsTest(TestCase):
     MANIFEST_PATH = f"{DIST_PATH}/manifest.json"
 
     def test_supported_foreign_lang(self):
-        # Locale files are generated from webpack, so we need to have a manifest file,
-        # otherwise this will 404
-        locale_manifest = {
-            "locale/fr.js": "locale/fr.f00f00.js",
-        }
-        with self.static_asset_manifest(locale_manifest):
-            request = RequestFactory().get("/")
-            request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
-            result = self.TEMPLATE.render(request=request)
+        # Locale files are generated from webpack
+        request = RequestFactory().get("/")
+        request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
+        result = self.TEMPLATE.render(request=request)
 
-            assert '<script src="/_static/dist/sentry/locale/fr.f00f00.js"></script>' in result
+        assert '<script src="/_static/dist/sentry/locale/fr.js"></script>' in result
 
     def test_supported_foreign_lang_csp_nonce(self):
-        locale_manifest = {
-            "locale/fr.js": "locale/fr.f00f00.js",
-        }
-        with self.static_asset_manifest(locale_manifest):
-            request = RequestFactory().get("/")
-            request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
-            request.csp_nonce = "r@nD0m"
-            result = self.TEMPLATE.render(request=request)
+        request = RequestFactory().get("/")
+        request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
+        request.csp_nonce = "r@nD0m"
+        result = self.TEMPLATE.render(request=request)
 
-            assert (
-                '<script src="/_static/dist/sentry/locale/fr.f00f00.js" nonce="r@nD0m"></script>'
-                in result
-            )
+        assert '<script src="/_static/dist/sentry/locale/fr.js" nonce="r@nD0m"></script>' in result
 
     def test_unsupported_foreign_lang(self):
         request = RequestFactory().get("/")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -385,7 +385,13 @@ let appConfig = {
   output: {
     path: distPath,
     publicPath: '',
-    filename: '[name].[contenthash].js',
+    filename: pathData => {
+      const unversioned = ['runtime', 'app'];
+
+      return unversioned.includes(pathData.chunk.name)
+        ? '[name].js'
+        : '[name].[contenthash].js';
+    },
     chunkFilename: '[name].[contenthash].js',
     sourceMapFilename: '[name].js.map',
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const path = require('path');
 
 const {CleanWebpackPlugin} = require('clean-webpack-plugin'); // installed via npm
-const {WebpackManifestPlugin} = require('webpack-manifest-plugin');
 const webpack = require('webpack');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -292,8 +291,6 @@ let appConfig = {
   plugins: [
     new CleanWebpackPlugin(),
 
-    new WebpackManifestPlugin({}),
-
     /**
      * jQuery must be provided in the global scope specifically and only for
      * bootstrap, as it will not import jQuery itself.
@@ -310,7 +307,13 @@ let appConfig = {
      * Extract CSS into separate files.
      */
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash:6].css',
+      filename: pathData => {
+        // We want the sentry css file to be unversioned for frontend-only deploys
+        // We will cache using `Cache-Control` headers
+        return pathData.chunk.name === 'sentry'
+          ? '[name].css'
+          : '[name].[contenthash:6].css';
+      },
     }),
 
     /**
@@ -481,9 +484,6 @@ if (
         '/api/{1..9}*({0..9})/**': relayAddress,
         '/api/0/relays/outcomes/': relayAddress,
         '!/_static/dist/sentry/**': backendAddress,
-      },
-      writeToDisk: filePath => {
-        return /manifest\.json/.test(filePath);
       },
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15374,14 +15374,6 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-manifest-plugin@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.0.tgz#9030b8839bed093d93930a9d1d3a7ab00f7ac4f7"
-  integrity sha512-7jgB8Kb0MRWXq3YaDfe+0smv5c7MLMfze8YvG6eBEXZmy6fhwMe/eT47A0KEIF30c0DDEYKbbYTXzaMQETaZ0Q==
-  dependencies:
-    tapable "^2.0.0"
-    webpack-sources "^2.2.0"
-
 webpack-merge@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
@@ -15403,7 +15395,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^2.1.1, webpack-sources@^2.2.0:
+webpack-sources@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
   integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==


### PR DESCRIPTION
...instead of using versioned asset paths using `webpack` content hashes
in the filename.

WIP
* Remove django-manifest-plugin