### PR TITLE
feat(semver): Add function to parse semver search and return a snuba condition representing it (WOR-896)

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -11,6 +11,7 @@ from parsimonious.nodes import Node, RegexNode
 
 from sentry.search.events.constants import (
     KEY_TRANSACTION_ALIAS,
+    OPERATOR_NEGATION_MAP,
     SEARCH_MAP,
     TAG_KEY_RE,
     TEAM_KEY_TRANSACTION_ALIAS,
@@ -30,15 +31,6 @@ from sentry.utils.snuba import is_duration_measurement, is_measurement, is_span_
 from sentry.utils.validators import is_event_id
 
 WILDCARD_CHARS = re.compile(r"[\*]")
-NEGATION_MAP = {
-    "=": "!=",
-    "<": ">=",
-    "<=": ">",
-    ">": "<=",
-    ">=": "<",
-    "IN": "NOT IN",
-}
-
 
 event_search_grammar = Grammar(
     r"""
@@ -489,7 +481,7 @@ class SearchVisitor(NodeVisitor):
         elif not isinstance(operator, str):
             operator = operator[0]
         if self.is_negated(negation):
-            return NEGATION_MAP.get(operator, "!=")
+            return OPERATOR_NEGATION_MAP.get(operator, "!=")
         return operator
 
     def visit_aggregate_filter(self, node, children):

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -69,3 +69,13 @@ SNQL_FIELD_ALLOWLIST = {
     "release",
     "environment",
 }
+
+OPERATOR_NEGATION_MAP = {
+    "=": "!=",
+    "<": ">=",
+    "<=": ">",
+    ">": "<=",
+    ">=": "<",
+    "IN": "NOT IN",
+}
+OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt"}

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -79,3 +79,6 @@ OPERATOR_NEGATION_MAP = {
     "IN": "NOT IN",
 }
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt"}
+
+SEMVER_MAX_SEARCH_RELEASES = 1000
+SEMVER_FAKE_PACKAGE = "__sentry_fake__"

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -25,7 +25,7 @@ from sentry.models import (
     User,
 )
 from sentry.search.base import SearchBackend
-from sentry.search.events.constants import EQUALITY_OPERATORS
+from sentry.search.events.constants import EQUALITY_OPERATORS, OPERATOR_TO_DJANGO
 from sentry.search.snuba.executors import PostgresSnubaQueryExecutor
 
 
@@ -276,14 +276,12 @@ class ScalarCondition(Condition):
     instances
     """
 
-    OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt"}
-
     def __init__(self, field, extra=None):
         self.field = field
         self.extra = extra
 
     def _get_operator(self, search_filter):
-        django_operator = self.OPERATOR_TO_DJANGO.get(search_filter.operator, "")
+        django_operator = OPERATOR_TO_DJANGO.get(search_filter.operator, "")
         if django_operator:
             django_operator = f"__{django_operator}"
         return django_operator

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -277,7 +277,9 @@ def get_latest_release(projects, environments, organization_id=None):
     )
 
 
-def parse_release(value, projects, environments, organization_id=None):
+def parse_release(
+    value: object, projects: object, environments: object, organization_id: object = None
+) -> object:
     if value == "latest":
         try:
             return get_latest_release(projects, environments, organization_id)

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -277,9 +277,7 @@ def get_latest_release(projects, environments, organization_id=None):
     )
 
 
-def parse_release(
-    value: object, projects: object, environments: object, organization_id: object = None
-) -> object:
+def parse_release(value, projects, environments, organization_id=None):
     if value == "latest":
         try:
             return get_latest_release(projects, environments, organization_id)

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1462,7 +1462,7 @@ class ParseSemverSearchTest(TestCase):
         self.create_release(version="test@1.2.4")
         release_2 = self.create_release(version="test@1.2.5")
 
-        with patch("sentry.search.events.filter.MAX_SEMVER_SEARCH_RELEASES", 2):
+        with patch("sentry.search.events.filter.SEMVER_MAX_SEARCH_RELEASES", 2):
             self.run_test(">", "1.2.3", "NOT IN", [release.version])
             self.run_test(">=", "1.2.4", "NOT IN", [release.version])
             self.run_test("<", "1.2.5", "NOT IN", [release_2.version])
@@ -1478,7 +1478,7 @@ class ParseSemverSearchTest(TestCase):
         release_3 = self.create_release(version="test@1.2.4")
         self.create_release(version="test@1.2.5")
 
-        with patch("sentry.search.events.filter.MAX_SEMVER_SEARCH_RELEASES", 2):
+        with patch("sentry.search.events.filter.SEMVER_MAX_SEARCH_RELEASES", 2):
             self.run_test(">", "1.2.2", "IN", [release_2.version, release_3.version])
             self.run_test(">=", "1.2.3", "IN", [release_2.version, release_3.version])
             self.run_test("<", "1.2.4", "IN", [release_2.version, release_1.version])


### PR DESCRIPTION
This implements a function that understands basic semver comparison and sorting, and uses it to
return a snuba condition to fetch events/transactions from snuba using a list of release versions.

This isn't plugged into the search yet, I will do that in a separate pr. It's likely that parts of
this function will need to be extracted and moved to common places so that they can be shared with
`Release` search etc.

We also still need to handle wildcard matching etc, which will come later.

The idea with this function is that we want to return all versions associated with a given semver
condition. For orgs with many `Releases` this can prove to be a lot of rows, so we return a max of
1000 releases. If we hit this max, we also try inverting the query and see if that returns a smaller
number of rows. If it does, we use those rows instead as a `NOT IN` query. Otherwise, we return the
1000 releases we fetched, which are ordered so that they're as close to the passed filter as
possible, which hopefully gives the user the results they're looking for regardless.