### PR TITLE
test: Speed up issuelist actions test speed, reduce listeners

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -38,7 +38,6 @@ type Props = {
 };
 
 type State = {
-  datePickerActive: boolean;
   anySelected: boolean;
   multiSelected: boolean;
   pageSelected: boolean;
@@ -49,7 +48,6 @@ type State = {
 
 class IssueListActions extends React.Component<Props, State> {
   state: State = {
-    datePickerActive: false,
     anySelected: false,
     multiSelected: false, // more than one selected
     pageSelected: false, // all on current page selected (e.g. 25)

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -9,6 +9,7 @@ import {IssueListActions} from 'app/views/issueList/actions';
 
 describe('IssueListActions', function () {
   let actions;
+  let actionsWrapper;
   let wrapper;
 
   afterEach(() => {
@@ -43,6 +44,10 @@ describe('IssueListActions', function () {
           />,
           routerContext
         );
+      });
+
+      afterAll(() => {
+        wrapper.unmount();
       });
 
       it('after checking "Select all" checkbox, displays bulk select message', async function () {
@@ -110,6 +115,10 @@ describe('IssueListActions', function () {
         );
       });
 
+      afterAll(() => {
+        wrapper.unmount();
+      });
+
       it('after checking "Select all" checkbox, displays bulk select message', async function () {
         wrapper.find('ActionsCheckbox Checkbox').simulate('change');
         expect(wrapper.find('SelectAllNotice')).toSnapshot();
@@ -172,6 +181,10 @@ describe('IssueListActions', function () {
           />,
           TestStubs.routerContext()
         );
+      });
+
+      afterAll(() => {
+        wrapper.unmount();
       });
 
       it('resolves selected items', function () {
@@ -248,7 +261,7 @@ describe('IssueListActions', function () {
   describe('actionSelectedGroups()', function () {
     beforeEach(function () {
       jest.spyOn(SelectedGroupStore, 'deselectAll');
-      actions = mountWithTheme(
+      actionsWrapper = mountWithTheme(
         <IssueListActions
           api={new MockApiClient()}
           query=""
@@ -265,7 +278,12 @@ describe('IssueListActions', function () {
           realtimeActive={false}
           statsPeriod="24h"
         />
-      ).instance();
+      );
+      actions = actionsWrapper.instance();
+    });
+
+    afterEach(() => {
+      actionsWrapper.unmount();
     });
 
     describe('for all items', function () {
@@ -328,6 +346,10 @@ describe('IssueListActions', function () {
       );
     });
 
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
     it('should disable resolve dropdown but not resolve action', function () {
       const resolve = wrapper.find('ResolveActions').first();
       expect(resolve.props().disabled).toBe(false);
@@ -377,6 +399,10 @@ describe('IssueListActions', function () {
         url: '/organizations/org-slug/issues/',
         method: 'PUT',
       });
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
     });
 
     it('acknowledges group', async function () {

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -346,9 +346,7 @@ describe('IssueListActions', function () {
   describe('with inbox feature', function () {
     let issuesApiMock;
     beforeEach(async () => {
-      GroupStore.init();
-      SelectedGroupStore.init();
-      await tick();
+      SelectedGroupStore.records = {};
       const {organization} = TestStubs.routerContext().context;
       wrapper = mountWithTheme(
         <IssueListActions


### PR DESCRIPTION
its slow https://sentry.io/organizations/sentry/discover/jest:9228414b1a4c47d19350bbb2c591f0d8/?field=title&field=transaction.duration&name=All+Events&project=4857230&query=issueList%2Factions.spec.jsx&sort=-title&statsPeriod=24h&widths=-1&widths=-1#span-9aa9950c596496a0

this reduces the time from 24s to 10s on my machine