### PR TITLE
fix(discover): Minicard should not crash on empty results

### DIFF
--- a/static/app/views/eventsV2/miniGraph.tsx
+++ b/static/app/views/eventsV2/miniGraph.tsx
@@ -194,7 +194,9 @@ class MiniGraph extends React.Component<Props> {
           }));
 
           const chartOptions = {
-            colors: [...theme.charts.getColorPalette(allSeries.length - 2)],
+            colors: allSeries.length
+              ? [...theme.charts.getColorPalette(allSeries.length - 2)]
+              : undefined,
             height: 100,
             series: [...data],
             xAxis: {


### PR DESCRIPTION
Getting a colour palette for 0 items results in `undefined` which crashes with
a TypeError.

Fixes JAVASCRIPT-241M