### PR TITLE
fix: Update symbolicator snapshots

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -181,7 +181,7 @@ debug_meta:
     image_addr: '0x75050000'
     image_size: 917504
     type: pe
-    unwind_status: unused
+    unwind_status: missing
   - code_file: C:\Windows\System32\bcryptPrimitives.dll
     code_id: 59b0df8f5a000
     debug_file: bcryptprimitives.pdb
@@ -251,7 +251,7 @@ debug_meta:
     image_addr: '0x77170000'
     image_size: 1585152
     type: pe
-    unwind_status: unused
+    unwind_status: missing
 errors: []
 exception:
   values:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
@@ -180,7 +180,7 @@ debug_meta:
     image_addr: '0x75050000'
     image_size: 917504
     type: pe
-    unwind_status: unused
+    unwind_status: missing
   - code_file: C:\Windows\System32\bcryptPrimitives.dll
     code_id: 59b0df8f5a000
     debug_file: bcryptprimitives.pdb
@@ -250,7 +250,7 @@ debug_meta:
     image_addr: '0x77170000'
     image_size: 1585152
     type: pe
-    unwind_status: unused
+    unwind_status: missing
 errors:
 - image_path: C:\projects\breakpad-tools\windows\Release\crash.exe
   image_uuid: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_initial.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_initial.pysnap
@@ -180,7 +180,7 @@ debug_meta:
     image_addr: '0x75050000'
     image_size: 917504
     type: pe
-    unwind_status: unused
+    unwind_status: missing
   - code_file: C:\Windows\System32\bcryptPrimitives.dll
     code_id: 59b0df8f5a000
     debug_file: bcryptprimitives.pdb
@@ -250,7 +250,7 @@ debug_meta:
     image_addr: '0x77170000'
     image_size: 1585152
     type: pe
-    unwind_status: unused
+    unwind_status: missing
 errors:
 - image_path: C:\projects\breakpad-tools\windows\Release\crash.exe
   image_uuid: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
@@ -181,7 +181,7 @@ debug_meta:
     image_addr: '0x75050000'
     image_size: 917504
     type: pe
-    unwind_status: unused
+    unwind_status: missing
   - code_file: C:\Windows\System32\bcryptPrimitives.dll
     code_id: 59b0df8f5a000
     debug_file: bcryptprimitives.pdb
@@ -251,7 +251,7 @@ debug_meta:
     image_addr: '0x77170000'
     image_size: 1585152
     type: pe
-    unwind_status: unused
+    unwind_status: missing
 errors: []
 exception:
   values:


### PR DESCRIPTION
Symbolicator will now try to use more debuginfo, and report the unwind status correctly as `missing` instead of `unused` where previously it would just not try to use some debug info.