### PR TITLE
fix(codeowners): User id instead of member id

### DIFF
--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -61,7 +61,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
           // For organizations with >100 users, we want to make sure their
           // saved mapping gets populated in the results if it wouldn't have
           // been in the inital 100 API results, which is why we add it here
-          if (mapping && !result.find(({id}) => id === mapping.userId)) {
+          if (mapping && !result.find(({user}) => user.id === mapping.userId)) {
             result = [{id: mapping.userId, name: mapping.sentryName}, ...result];
           }
           this.props.onResults?.(result);


### PR DESCRIPTION
We use the `organization_members_index.py` endpoint and so we need to make sure we use the `id` of the user instead of the member `id`.

We fixed this in one place https://github.com/getsentry/sentry/pull/26254#discussion_r640209516 but then introduced the same thing when trying to append an initial mapping to the results.

