### PR TITLE
ref(stacktrace-link): Try in_app check again

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -93,6 +93,7 @@ const Context = ({
               {organization?.features.includes('integrations-stacktrace-link') &&
                 isActive &&
                 isExpanded &&
+                frame.inApp &&
                 frame.filename && (
                   <ErrorBoundary customComponent={null}>
                     <StacktraceLink


### PR DESCRIPTION
This was originally added in https://github.com/getsentry/sentry/pull/22780#discussion_r545365182 and then taken out in https://github.com/getsentry/sentry/pull/22941, but re the following statement:

> but it also happens to have a side effect where it prevents valid stack frames from not showing up because we have deemed `in_app` to be False for other reasons.

This should have been fixed in https://github.com/getsentry/sentry/pull/23876 (and related followup PRs). So we going to add this back in again :)