### PR TITLE
test: Use node's v8 as test coverage provider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,7 @@ module.exports = {
     'tests/js/spec/**/*.{js,jsx,tsx}',
     'static/app/**/*.{js,jsx,ts,tsx}',
   ],
+  coverageProvider: 'v8',
   coverageReporters: ['html', 'cobertura'],
   coverageDirectory: '.artifacts/coverage',
   snapshotSerializers: ['enzyme-to-json/serializer'],


### PR DESCRIPTION
The default is to use babel, using v8 itself is potentially faster

fixes #26462 