### PR TITLE
fix(discover): Transaction details tag link should work

### DIFF
--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -26,7 +26,6 @@ import {Organization, Project} from 'app/types';
 import {Event, EventTag} from 'app/types/event';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
-import {FIELD_TAGS} from 'app/utils/discover/fields';
 import {eventDetailsRoute} from 'app/utils/discover/urls';
 import {getMessage} from 'app/utils/events';
 import * as QuickTraceContext from 'app/utils/performance/quickTrace/quickTraceContext';
@@ -95,16 +94,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return this.props.eventSlug.split(':')[0];
   }
 
-  generateTagKey = (tag: EventTag) => {
-    // Some tags may be normalized from context, but not all of them are.
-    // This supports a user making a custom tag with the same name as one
-    // that comes from context as all of these are also tags.
-    if (tag.key in FIELD_TAGS) {
-      return `tags[${tag.key}]`;
-    }
-    return tag.key;
-  };
-
   generateTagUrl = (tag: EventTag) => {
     const {eventView, organization} = this.props;
     const {event} = this.state;
@@ -115,8 +104,11 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     if (eventReference.id) {
       delete (eventReference as any).id;
     }
-    const tagKey = this.generateTagKey(tag);
-    const nextView = getExpandedResults(eventView, {[tagKey]: tag.value}, eventReference);
+    const nextView = getExpandedResults(
+      eventView,
+      {[tag.key]: tag.value},
+      eventReference
+    );
     return nextView.getResultsViewUrlTarget(organization.slug);
   };
 

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -197,13 +197,12 @@ describe('EventsV2 > EventDetails', function () {
     // Get the second link
     const deviceUUIDTagLink = wrapper.find('EventDetails KeyValueTable Value Link').at(2);
 
-    // Should append tag value wrapped with tags[] as device.uuid is part of our fields
     const deviceUUIDTagTarget = deviceUUIDTagLink.props().to;
     expect(deviceUUIDTagTarget.pathname).toEqual(
       '/organizations/org-slug/discover/results/'
     );
     expect(deviceUUIDTagTarget.query.query).toEqual(
-      'tags[device.uuid]:test-uuid title:"Oh no something bad"'
+      'device.uuid:test-uuid title:"Oh no something bad"'
     );
   });
 
@@ -245,13 +244,12 @@ describe('EventsV2 > EventDetails', function () {
     // Get the second link
     const deviceUUIDTagLink = wrapper.find('EventDetails KeyValueTable Value Link').at(2);
 
-    // Should append tag value wrapped with tags[] as device.uuid is part of our fields
     const deviceUUIDTagTarget = deviceUUIDTagLink.props().to;
     expect(deviceUUIDTagTarget.pathname).toEqual(
       '/organizations/org-slug/discover/results/'
     );
     expect(deviceUUIDTagTarget.query.query).toEqual(
-      'Dumpster tags[device.uuid]:test-uuid title:"Oh no something bad"'
+      'Dumpster device.uuid:test-uuid title:"Oh no something bad"'
     );
   });
 });


### PR DESCRIPTION
Tags like `releases` are actually columns, so the `tag[...]` syntax is wrong.
This change simply removes the `tag[...]` to be consistenty with how issue and
performance handles these links.