### PR TITLE
test(jest): Throw on unhandled rejections

### DIFF
--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,4 +1,4 @@
-/* global __dirname */
+/* global __dirname process */
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
 import Enzyme from 'enzyme'; // eslint-disable-line no-restricted-imports
 import MockDate from 'mockdate';
@@ -148,6 +148,13 @@ jest.mock('popper.js', () => {
       };
     }
   };
+});
+
+// Makes the script crash on unhandled rejections instead of silently
+// ignoring them. In the future, promise rejections that are not handled will
+// terminate the Node.js process with a non-zero exit code.
+process.on('unhandledRejection', err => {
+  throw err;
 });
 
 /**


### PR DESCRIPTION
For whatever reason the `unhandledRejection` event was not being caught in our test running script wrapper. Duplicated this to our test env setup file. Left the original in `scripts/test.js` just in case it catches a class of unhandled rejections that the env listener does not.