### PR TITLE
test(js): Fix `eventsv2/results` tests running poorly

### DIFF
--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -247,9 +247,10 @@ describe('EventsV2 > Results', function () {
         statsPeriod: '14d',
       },
     });
+    wrapper.unmount();
   });
 
-  it('renders a y-axis selector', function () {
+  it('renders a y-axis selector', async function () {
     const organization = TestStubs.Organization({
       features,
       projects: [TestStubs.Project()],
@@ -278,10 +279,12 @@ describe('EventsV2 > Results', function () {
 
     // Click one of the options.
     selector.find('DropdownMenu MenuItem span').first().simulate('click');
+    await tick();
     wrapper.update();
 
     const eventsRequest = wrapper.find('EventsChart');
     expect(eventsRequest.props().yAxis).toEqual('count()');
+    wrapper.unmount();
   });
 
   it('renders a display selector', async function () {
@@ -321,14 +324,16 @@ describe('EventsV2 > Results', function () {
       .find('DropdownMenu MenuItem [data-test-id="option-default"]')
       .first()
       .simulate('click');
+    await tick();
     wrapper.update();
 
     const eventsRequest = wrapper.find('EventsChart').props();
     expect(eventsRequest.disableReleases).toEqual(false);
     expect(eventsRequest.disablePrevious).toEqual(true);
+    wrapper.unmount();
   });
 
-  it('excludes top5 options when plan does not include discover-query', function () {
+  it('excludes top5 options when plan does not include discover-query', async function () {
     const organization = TestStubs.Organization({
       features: ['discover-basic'],
       projects: [TestStubs.Project()],
@@ -354,6 +359,7 @@ describe('EventsV2 > Results', function () {
 
     // Open the selector
     selector.find('StyledDropdownButton button').simulate('click');
+    await tick();
 
     // Make sure the top5 option isn't present
     const options = selector
@@ -362,6 +368,7 @@ describe('EventsV2 > Results', function () {
     expect(options).not.toContain('option-top5');
     expect(options).not.toContain('option-dailytop5');
     expect(options).toContain('option-default');
+    wrapper.unmount();
   });
 
   it('needs confirmation on long queries', async function () {
@@ -391,6 +398,7 @@ describe('EventsV2 > Results', function () {
     const results = wrapper.find('Results');
 
     expect(results.state('needConfirmation')).toEqual(true);
+    wrapper.unmount();
   });
 
   it('needs confirmation on long query with explicit projects', async function () {
@@ -426,6 +434,7 @@ describe('EventsV2 > Results', function () {
     const results = wrapper.find('Results');
 
     expect(results.state('needConfirmation')).toEqual(true);
+    wrapper.unmount();
   });
 
   it('does not need confirmation on short queries', async function () {
@@ -455,6 +464,7 @@ describe('EventsV2 > Results', function () {
     const results = wrapper.find('Results');
 
     expect(results.state('needConfirmation')).toEqual(false);
+    wrapper.unmount();
   });
 
   it('does not need confirmation with to few projects', async function () {
@@ -486,6 +496,7 @@ describe('EventsV2 > Results', function () {
     const results = wrapper.find('Results');
 
     expect(results.state('needConfirmation')).toEqual(false);
+    wrapper.unmount();
   });
 
   it('retrieves saved query', async function () {
@@ -525,6 +536,7 @@ describe('EventsV2 > Results', function () {
     expect(savedQuery.projects).toEqual([]);
     expect(savedQuery.range).toEqual('24h');
     expect(mockSaved).toHaveBeenCalled();
+    wrapper.unmount();
   });
 
   it('creates event view from saved query', async function () {
@@ -558,6 +570,7 @@ describe('EventsV2 > Results', function () {
     expect(eventView.project).toEqual([]);
     expect(eventView.statsPeriod).toEqual('24h');
     expect(eventView.sorts).toEqual([{field: 'user.display', kind: 'desc'}]);
+    wrapper.unmount();
   });
 
   it('overrides saved query params with location query params', async function () {
@@ -598,6 +611,7 @@ describe('EventsV2 > Results', function () {
     expect(eventView.project).toEqual([2]);
     expect(eventView.statsPeriod).toEqual('7d');
     expect(eventView.environment).toEqual(['production']);
+    wrapper.unmount();
   });
 
   it('updates chart whenever yAxis parameter changes', async function () {
@@ -660,6 +674,7 @@ describe('EventsV2 > Results', function () {
         }),
       })
     );
+    wrapper.unmount();
   });
 
   it('updates chart whenever display parameter changes', async function () {
@@ -722,6 +737,7 @@ describe('EventsV2 > Results', function () {
         }),
       })
     );
+    wrapper.unmount();
   });
 
   it('updates chart whenever display and yAxis parameters change', async function () {
@@ -784,5 +800,6 @@ describe('EventsV2 > Results', function () {
         }),
       })
     );
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
These tests were running poorly, taking over 60s to complete - they now finish in around 20s. The solution is to unmount wrapper after each test.


https://sentry.io/organizations/sentry/discover/jest:4fc587975bff44e1be5822240456f18f/?display=top5&field=title&field=transaction.duration&name=All+Events&project=4857230&query=transaction.op%3A%22jest+test+suite%22+title%3A%2Ftests%2Fjs%2Fspec%2Fviews%2FeventsV2%2Fresults.spec.jsx&sort=-transaction.duration&statsPeriod=24h&widths=-1&widths=-1
