### PR TITLE
feat(perf): Adjust ops breakdown to be purely relative

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -539,7 +539,10 @@ const spanOperationRelativeBreakdownRenderer = (
   data: EventData,
   {location, organization}: RenderFunctionBaggage
 ): React.ReactNode => {
-  const cumulativeSpanOpBreakdown = data['spans.total.time'];
+  const cumulativeSpanOpBreakdown = SPAN_OP_BREAKDOWN_FIELDS.reduce(
+    (prev, curr) => (isDurationValue(data, curr) ? prev + data[curr] : prev),
+    0
+  );
 
   if (
     !isDurationValue(data, 'spans.total.time') ||

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -539,10 +539,11 @@ const spanOperationRelativeBreakdownRenderer = (
   data: EventData,
   {location, organization}: RenderFunctionBaggage
 ): React.ReactNode => {
-  const cumulativeSpanOpBreakdown = SPAN_OP_BREAKDOWN_FIELDS.reduce(
+  const sumOfSpanTime = SPAN_OP_BREAKDOWN_FIELDS.reduce(
     (prev, curr) => (isDurationValue(data, curr) ? prev + data[curr] : prev),
     0
   );
+  const cumulativeSpanOpBreakdown = Math.max(sumOfSpanTime, data['transaction.duration']);
 
   if (
     !isDurationValue(data, 'spans.total.time') ||
@@ -573,7 +574,7 @@ const spanOperationRelativeBreakdownRenderer = (
             <Tooltip
               title={
                 <div>
-                  <div>{`${operationName} ${formatPercentage(widthPercentage, 0)}`}</div>
+                  <div>{operationName}</div>
                   <div>
                     <Duration
                       seconds={spanOpDuration / 1000}


### PR DESCRIPTION
### Summary
This is an example of what ops breakdown would look like if we only picked and showed relative difference between ops we specified, ignoring visualizing other operations.

### Screenshots
#### Before
<img width="419" alt="Screen Shot 2021-06-08 at 4 49 44 PM" src="https://user-images.githubusercontent.com/6111995/121271955-a634ac80-c879-11eb-8e6d-a46564788a46.png">

#### After
![Screen Shot 2021-06-09 at 12 35 50 PM](https://user-images.githubusercontent.com/6111995/121417887-3da00b00-c91f-11eb-971b-ad674c9868fe.png)

