### PR TITLE
fix(eventid): Validate the event id being passed

### DIFF
--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,6 +6,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
+from sentry.utils.validators import INVALID_EVENT_DETAILS, is_event_id
 
 
 class EventIdLookupEndpoint(OrganizationEndpoint):
@@ -23,6 +24,9 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
                                 regex in the URL.
         :auth: required
         """
+        if event_id and not is_event_id(event_id):
+            return Response({"detail": INVALID_EVENT_DETAILS.format("Event")}, status=400)
+
         project_slugs_by_id = dict(
             Project.objects.filter(organization=organization).values_list("id", "slug")
         )

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -71,3 +71,11 @@ class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
                     "event_id": "not-an-event",
                 },
             )
+
+        url = reverse(
+            "sentry-api-0-event-id-lookup",
+            kwargs={"organization_slug": self.org.slug, "event_id": 123456},
+        )
+        resp = self.client.get(url, format="json")
+
+        assert resp.status_code == 400


### PR DESCRIPTION
- This adds additional validation to the event id being passed
- Will revisit why \d+ is part of the event_id regex later, this is just
  a quickfix so we can give a decent error message for now