### PR TITLE
feat(releases): Link user to release details page when clicked on the adoption chart

### DIFF
--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -186,7 +186,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
   }
 
   handleClick = (params: {seriesId: string}) => {
-    const {organization, router, selection} = this.props;
+    const {organization, router, selection, location} = this.props;
 
     const project = selection.projects[0];
 
@@ -194,7 +194,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
       pathname: `/organizations/${organization?.slug}/releases/${encodeURIComponent(
         params.seriesId
       )}/`,
-      query: {project},
+      query: {project, environment: location.query.environment},
     });
   };
 

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -92,7 +92,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
             interval: getInterval(
               {
                 start: location.query.start,
-                end: location.query.start,
+                end: location.query.end,
                 period: location.query.statsPeriod,
                 utc: location.query.utc,
               },
@@ -132,7 +132,6 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
         sessionDisplayToField(activeDisplay)
       ];
       return {
-        type: 'line',
         id: release as string,
         seriesName: formatVersion(release as string),
         data:
@@ -140,9 +139,6 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
             name: moment(interval).valueOf(),
             value: percent(releaseData?.[index] ?? 0, totalData?.[index] ?? 0),
           })) ?? [],
-        emphasis: {
-          focus: 'series',
-        },
       };
     });
   }

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -17,8 +17,6 @@ import {
 } from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
-import TransitionChart from 'app/components/charts/transitionChart';
-import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {
   DateTimeObject,
   getDiffInMinutes,
@@ -42,8 +40,6 @@ import {
   sessionDisplayToField,
 } from 'app/views/releases/utils/releaseHealthRequest';
 
-import {getInterval} from '../detail/overview/chart/utils';
-
 type Props = AsyncComponent['props'] & {
   api: Client;
   organization: Organization;
@@ -56,6 +52,31 @@ type Props = AsyncComponent['props'] & {
 type State = AsyncComponent['state'] & {
   sessions: SessionApiResponse | null;
 };
+
+type GetIntervalOptions = {
+  highFidelity?: boolean;
+};
+
+// TODO(release-adoption-chart): refactor duplication
+function getInterval(
+  datetimeObj: DateTimeObject,
+  {highFidelity}: GetIntervalOptions = {}
+) {
+  const diffInMinutes = getDiffInMinutes(datetimeObj);
+
+  if (
+    highFidelity &&
+    diffInMinutes < 360 // limit on backend is set to six hour
+  ) {
+    return '10m';
+  }
+
+  if (diffInMinutes >= ONE_WEEK) {
+    return '1d';
+  } else {
+    return '1h';
+  }
+}
 class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
   shouldReload = true;
 
@@ -136,24 +157,19 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
       [] as number[]
     );
 
-    return releases
-      .map(release => {
-        const releaseData = sessions?.groups.find(({by}) => by.release === release)
-          ?.series[sessionDisplayToField(activeDisplay)];
-        return {
-          seriesName: formatVersion(release as string),
-          data:
-            sessions?.intervals.map((interval, index) => ({
-              name: moment(interval).valueOf(),
-              value: percent(releaseData?.[index] ?? 0, totalData?.[index] ?? 0),
-            })) ?? [],
-        };
-      })
-      .sort(
-        (a, b) =>
-          (b.data?.findIndex(({value}) => value > 0) ?? 0) -
-          (a.data?.findIndex(({value}) => value > 0) ?? 0)
-      );
+    return releases.map(release => {
+      const releaseData = sessions?.groups.find(({by}) => by.release === release)?.series[
+        sessionDisplayToField(activeDisplay)
+      ];
+      return {
+        seriesName: formatVersion(release as string),
+        data:
+          sessions?.intervals.map((interval, index) => ({
+            name: moment(interval).valueOf(),
+            value: percent(releaseData?.[index] ?? 0, totalData?.[index] ?? 0),
+          })) ?? [],
+      };
+    });
   }
 
   getTotal() {

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -132,6 +132,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
         sessionDisplayToField(activeDisplay)
       ];
       return {
+        type: 'line',
         id: release as string,
         seriesName: formatVersion(release as string),
         data:
@@ -139,6 +140,9 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
             name: moment(interval).valueOf(),
             value: percent(releaseData?.[index] ?? 0, totalData?.[index] ?? 0),
           })) ?? [],
+        emphasis: {
+          focus: 'series',
+        },
       };
     });
   }

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -83,36 +83,6 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization, location, activeDisplay} = this.props;
 
-type GetIntervalOptions = {
-  highFidelity?: boolean;
-};
-
-// TODO(release-adoption-chart): refactor duplication
-function getInterval(
-  datetimeObj: DateTimeObject,
-  {highFidelity}: GetIntervalOptions = {}
-) {
-  const diffInMinutes = getDiffInMinutes(datetimeObj);
-
-  if (
-    highFidelity &&
-    diffInMinutes < 360 // limit on backend is set to six hour
-  ) {
-    return '10m';
-  }
-
-  if (diffInMinutes >= ONE_WEEK) {
-    return '1d';
-  } else {
-    return '1h';
-  }
-}
-class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
-  shouldReload = true;
-
-  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization, location, activeDisplay} = this.props;
-
     return [
       [
         'sessions',

--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -162,6 +162,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
         sessionDisplayToField(activeDisplay)
       ];
       return {
+        id: release as string,
         seriesName: formatVersion(release as string),
         data:
           sessions?.intervals.map((interval, index) => ({
@@ -183,6 +184,19 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
       ) || 0
     );
   }
+
+  handleClick = (params: {seriesId: string}) => {
+    const {organization, router, selection} = this.props;
+
+    const project = selection.projects[0];
+
+    router.push({
+      pathname: `/organizations/${organization?.slug}/releases/${encodeURIComponent(
+        params.seriesId
+      )}/`,
+      query: {project},
+    });
+  };
 
   renderEmpty() {
     return (
@@ -285,6 +299,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
                       ].join('');
                     },
                   }}
+                  onClick={this.handleClick}
                 />
               )}
             </ChartZoom>


### PR DESCRIPTION
This adds a click listener to the release adoption chart, it sends user to the release details page. You need to click very precisely on the line on the chart: the red circled area in the screenshot.

![Screen Shot 2021-06-08 at 8 39 32 PM](https://user-images.githubusercontent.com/15015880/121289465-d55b1600-c899-11eb-866f-c64def939860.png)


Resolves [WOR-941](https://getsentry.atlassian.net/browse/WOR-941)