### PR TITLE
feat(snuba): Reverse crash free sort releases order to be ASC

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -135,8 +135,8 @@ def get_project_releases_by_stability(
     _, stats_start, _ = get_rollup_starts_and_buckets(stats_period)
 
     orderby = {
-        "crash_free_sessions": [["divide", ["sessions_crashed", "sessions"]]],
-        "crash_free_users": [["divide", ["users_crashed", "users"]]],
+        "crash_free_sessions": [["-divide", ["sessions_crashed", "sessions"]]],
+        "crash_free_users": [["-divide", ["users_crashed", "users"]]],
         "sessions": ["-sessions"],
         "users": ["-users"],
     }[scope]

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -151,6 +151,20 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
                 (self.project.id, self.session_crashed_release),
             ]
 
+    def test_get_project_releases_by_stability_for_crash_free_sort(self):
+        """
+        Test that ensures that using crash free rate sort options, returns a list of ASC releases
+        according to the chosen crash_free sort option
+        """
+        for scope in "crash_free_sessions", "crash_free_users":
+            data = get_project_releases_by_stability(
+                [self.project.id], offset=0, limit=100, scope=scope, stats_period="24h"
+            )
+            assert data == [
+                (self.project.id, self.session_crashed_release),
+                (self.project.id, self.session_release),
+            ]
+
     def test_get_release_adoption(self):
         data = get_release_adoption(
             [


### PR DESCRIPTION
This PR reverses release list ordering (eventually in `OrganizationReleasesEndpoint`) to be in ASC instead of DESC for `crash_free_users` and `crash_free_sessions` sort order options