### PR TITLE
feat(performance): Add team selector to performance landing and vital…

### DIFF
--- a/static/app/components/performance/teamSelector.tsx
+++ b/static/app/components/performance/teamSelector.tsx
@@ -1,0 +1,84 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import Input from 'app/components/forms/input';
+import {t} from 'app/locale';
+import {Team} from 'app/types';
+import {defined} from 'app/utils';
+import Filter from 'app/views/alerts/rules/filter';
+
+type Props = {
+  teams: Team[];
+  selectedTeams: Set<string>;
+  handleChangeFilter: (activeFilters: Set<string>) => void;
+};
+
+export function getSelectedTeamIdsFromLocation(location: Location): string[] {
+  const team = location.query.team;
+
+  if (!defined(team)) {
+    return ['myteams'];
+  }
+
+  if (Array.isArray(team)) {
+    return team;
+  }
+
+  return [team];
+}
+
+export function getSelectedTeams(teams: Team[], selectedTeamIds: Set<string>) {
+  const userTeams = teams.filter(({isMember}) => isMember);
+
+  if (selectedTeamIds.has('myteams')) {
+    return userTeams;
+  }
+
+  return userTeams.filter(({id}) => selectedTeamIds.has(id));
+}
+
+export default function TeamSelector({teams, selectedTeams, handleChangeFilter}: Props) {
+  const [teamFilterSearch, setTeamFilterSearch] = useState<string | undefined>();
+
+  const teamItems = teams.map(({id, name}) => ({
+    label: name,
+    value: id,
+    filtered: teamFilterSearch
+      ? name.toLowerCase().includes(teamFilterSearch.toLowerCase())
+      : true,
+    checked: selectedTeams.has(id),
+  }));
+
+  return (
+    <Filter
+      header={
+        <StyledInput
+          autoFocus
+          placeholder={t('Filter by team name')}
+          onClick={event => {
+            event.stopPropagation();
+          }}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            setTeamFilterSearch(event.target.value);
+          }}
+          value={teamFilterSearch || ''}
+        />
+      }
+      onFilterChange={(_sectionId, activeFilters) => handleChangeFilter(activeFilters)}
+      dropdownSections={[
+        {
+          id: 'my teams',
+          label: t('My Teams'),
+          items: teamItems,
+        },
+      ]}
+    />
+  );
+}
+
+const StyledInput = styled(Input)`
+  border: none;
+  border-bottom: 1px solid ${p => p.theme.gray200};
+  border-radius: 0;
+`;

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -362,11 +362,17 @@ class EventView {
         ? newQuery.projects
         : decodeProjects(location);
 
+    const teams =
+      Array.isArray(newQuery.teams) && newQuery.teams.length > 0
+        ? newQuery.teams
+        : decodeTeams(location);
+
     const saved: NewQuery = {
       ...newQuery,
 
       environment,
       projects: project,
+      teams,
 
       // datetime selection
       start: newQuery.start || decodeScalar(query.start),

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -593,10 +593,12 @@ export function generatePerformanceEventView(
   }
 
   if (organization.features.includes('team-key-transactions')) {
-    return eventView.withTeams(['myteams']);
-  } else {
-    return eventView;
+    if (eventView.team.length <= 0) {
+      eventView = eventView.withTeams(['myteams']);
+    }
   }
+
+  return eventView;
 }
 
 export function generatePerformanceVitalDetailView(
@@ -646,14 +648,16 @@ export function generatePerformanceVitalDetailView(
   }
   savedQuery.query = stringifyQueryObject(conditions);
 
-  const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
+  let eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions
     .addTagValues('event.type', ['transaction'])
     .addTagValues('has', [vitalName]);
 
   if (organization.features.includes('team-key-transactions')) {
-    return eventView.withTeams(['myteams']);
-  } else {
-    return eventView;
+    if (eventView.team.length <= 0) {
+      eventView = eventView.withTeams(['myteams']);
+    }
   }
+
+  return eventView;
 }

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -375,6 +375,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
     name: 'All Events',
     query: '',
     projects: [],
+    teams: [],
     fields: ['title', 'event.type', 'project', 'user', 'timestamp'],
     orderby: '-timestamp',
     version: 2,
@@ -402,6 +403,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
       sorts: [{field: 'timestamp', kind: 'desc'}],
       query: '',
       project: [],
+      team: [],
       start: undefined,
       end: undefined,
       // statsPeriod has precedence
@@ -416,6 +418,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
       query: {
         statsPeriod: '99d',
         project: ['456'],
+        team: ['1', '2'],
         environment: ['prod'],
       },
     };
@@ -435,6 +438,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
       sorts: [{field: 'timestamp', kind: 'desc'}],
       query: '',
       project: [456],
+      team: [1, 2],
       start: undefined,
       end: undefined,
       statsPeriod: '99d',
@@ -448,6 +452,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
       query: {
         statsPeriod: '99d',
         project: ['456'],
+        team: ['1', '2'],
         environment: ['prod'],
       },
     };
@@ -456,6 +461,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
       ...prebuiltQuery,
       range: '42d',
       projects: [987],
+      teams: ['myteams'],
       environment: ['staging'],
     };
 
@@ -474,6 +480,7 @@ describe('EventView.fromNewQueryWithLocation()', function () {
       sorts: [{field: 'timestamp', kind: 'desc'}],
       query: '',
       project: [987],
+      team: ['myteams'],
       start: undefined,
       end: undefined,
       statsPeriod: '42d',

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.jsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.jsx
@@ -179,7 +179,7 @@ describe('Performance > VitalDetail', function () {
     wrapper.update();
 
     // It shows a search bar
-    expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
+    expect(wrapper.find('SearchBar')).toHaveLength(1);
 
     // It shows the vital card
     expect(wrapper.find('vitalInfo')).toHaveLength(1);


### PR DESCRIPTION
… details

This adds a team selector to the performance landing page as well as the vital
details page that will allow users to select which teams they want to see key
transactions for. This selector only contains the teams the user belongs to.

![image](https://user-images.githubusercontent.com/10239353/121431541-87045080-c947-11eb-9b2e-c0ef9c1639bd.png)