### PR TITLE
ref(spans): Refactor span operation name filter to mobx

### DIFF
--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -10,8 +10,6 @@ import {t, tn} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
-import {ParsedTraceType} from './types';
-
 type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
 type NoFilter = {
@@ -30,34 +28,13 @@ export const noFilter: NoFilter = {
 export type ActiveOperationFilter = NoFilter | ActiveFilter;
 
 type Props = {
-  parsedTrace: ParsedTraceType;
+  operationNameCounts: Map<string, number>;
   operationNameFilter: ActiveOperationFilter;
   toggleOperationNameFilter: (operationName: string) => void;
-  toggleAllOperationNameFilters: (operationNames: string[]) => void;
+  toggleAllOperationNameFilters: () => void;
 };
 
 class Filter extends React.Component<Props> {
-  getOperationNameCounts(): Map<string, number> {
-    const {parsedTrace} = this.props;
-
-    const result = new Map<string, number>();
-    result.set(parsedTrace.op, 1);
-    for (const span of parsedTrace.spans) {
-      const operationName = span.op;
-
-      if (typeof operationName === 'string' && operationName.length > 0) {
-        result.set(operationName, (result.get(operationName) ?? 0) + 1);
-      }
-    }
-
-    // sort alphabetically using case insensitive comparison
-    return new Map(
-      [...result].sort((a, b) =>
-        String(a[0]).localeCompare(b[0], undefined, {sensitivity: 'base'})
-      )
-    );
-  }
-
   isOperationNameActive(operationName: string) {
     const {operationNameFilter} = this.props;
 
@@ -81,7 +58,7 @@ class Filter extends React.Component<Props> {
   }
 
   render() {
-    const operationNameCounts = this.getOperationNameCounts();
+    const {operationNameCounts} = this.props;
 
     if (operationNameCounts.size === 0) {
       return null;
@@ -143,9 +120,7 @@ class Filter extends React.Component<Props> {
                 }
                 onClick={event => {
                   event.stopPropagation();
-                  this.props.toggleAllOperationNameFilters(
-                    Array.from(operationNameCounts.keys())
-                  );
+                  this.props.toggleAllOperationNameFilters();
                 }}
               />
             </Header>

--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -16,7 +16,7 @@ type NoFilter = {
   type: 'no_filter';
 };
 
-type ActiveFilter = {
+export type ActiveFilter = {
   type: 'active_filter';
   operationNames: Set<string>;
 };

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -45,9 +45,14 @@ class SpansInterface extends PureComponent<Props, State> {
   };
 
   static getDerivedStateFromProps(props: Readonly<Props>, state: State): State {
+    if (state.waterfallModel.isEvent(props.event)) {
+      return state;
+    }
+
     return {
       ...state,
       parsedTrace: parseTrace(props.event),
+      waterfallModel: new WaterfallModel(props.event),
     };
   }
 

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -5,7 +5,7 @@ import {getSpanID} from './utils';
 
 class SpanTreeModel {
   // readonly state
-  span: SpanType;
+  span: Readonly<SpanType>;
   children: Array<SpanTreeModel> = [];
 
   constructor(parentSpan: SpanType, childSpans: SpanChildrenLookupType) {

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -1,0 +1,58 @@
+import {computed, makeObservable} from 'mobx';
+
+import {RawSpanType, SpanChildrenLookupType, SpanType} from './types';
+import {getSpanID} from './utils';
+
+class SpanTreeModel {
+  // readonly state
+  span: SpanType;
+  children: Array<SpanTreeModel> = [];
+
+  constructor(parentSpan: SpanType, childSpans: SpanChildrenLookupType) {
+    this.span = parentSpan;
+
+    const spanID = getSpanID(parentSpan);
+    const spanChildren: Array<RawSpanType> = childSpans?.[spanID] ?? [];
+
+    // Mark descendents as being rendered. This is to address potential recursion issues due to malformed data.
+    // For example if a span has a span_id that's identical to its parent_span_id.
+    childSpans = {
+      ...childSpans,
+    };
+    delete childSpans[spanID];
+
+    this.children = spanChildren.map(span => {
+      return new SpanTreeModel(span, childSpans);
+    });
+
+    makeObservable(this, {
+      operationNameCounts: computed.struct,
+    });
+  }
+
+  get operationNameCounts(): Map<string, number> {
+    const result = new Map<string, number>();
+
+    const operationName = this.span.op;
+
+    if (typeof operationName === 'string' && operationName.length > 0) {
+      result.set(operationName, 1);
+    }
+
+    for (const directChild of this.children) {
+      const operationNameCounts = directChild.operationNameCounts;
+      for (const [key, count] of operationNameCounts) {
+        result.set(key, (result.get(key) ?? 0) + count);
+      }
+    }
+
+    // sort alphabetically using case insensitive comparison
+    return new Map(
+      [...result].sort((a, b) =>
+        String(a[0]).localeCompare(b[0], undefined, {sensitivity: 'base'})
+      )
+    );
+  }
+}
+
+export default SpanTreeModel;

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -1,0 +1,60 @@
+import isEqual from 'lodash/isEqual';
+import {action, computed, makeObservable, observable} from 'mobx';
+
+import {EventTransaction} from 'app/types/event';
+
+import {ActiveOperationFilter, noFilter, toggleAllFilters, toggleFilter} from './filter';
+import SpanTreeModel from './spanTreeModel';
+import {ParsedTraceType} from './types';
+import {generateRootSpan, parseTrace} from './utils';
+
+class WaterfallModel {
+  // readonly state
+  event: Readonly<EventTransaction>;
+  rootSpan: SpanTreeModel;
+  parsedTrace: ParsedTraceType;
+
+  // readable/writable state
+  operationNameFilters: ActiveOperationFilter = noFilter;
+
+  constructor(event: Readonly<EventTransaction>) {
+    this.event = event;
+
+    this.parsedTrace = parseTrace(event);
+    const rootSpan = generateRootSpan(this.parsedTrace);
+    this.rootSpan = new SpanTreeModel(rootSpan, this.parsedTrace.childSpans);
+
+    makeObservable(this, {
+      rootSpan: observable,
+
+      // operation names filtering
+      operationNameFilters: observable,
+      toggleOperationNameFilter: action,
+      toggleAllOperationNameFilters: action,
+      operationNameCounts: computed.struct,
+    });
+  }
+
+  isEvent(otherEvent: Readonly<EventTransaction>) {
+    return isEqual(this.event, otherEvent);
+  }
+
+  toggleOperationNameFilter = (operationName: string) => {
+    this.operationNameFilters = toggleFilter(this.operationNameFilters, operationName);
+  };
+
+  toggleAllOperationNameFilters = () => {
+    const operationNames = Array.from(this.operationNameCounts.keys());
+
+    this.operationNameFilters = toggleAllFilters(
+      this.operationNameFilters,
+      operationNames
+    );
+  };
+
+  get operationNameCounts(): Map<string, number> {
+    return this.rootSpan.operationNameCounts;
+  }
+}
+
+export default WaterfallModel;

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -1,4 +1,3 @@
-// import {ActiveFilter, noFilter} from 'app/components/events/interfaces/spans/filter';
 import SpanTreeModel from 'app/components/events/interfaces/spans/spanTreeModel';
 import {generateRootSpan, parseTrace} from 'app/components/events/interfaces/spans/utils';
 import {EntryType, EventTransaction} from 'app/types/event';

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -1,0 +1,140 @@
+// import {ActiveFilter, noFilter} from 'app/components/events/interfaces/spans/filter';
+import SpanTreeModel from 'app/components/events/interfaces/spans/spanTreeModel';
+import {generateRootSpan, parseTrace} from 'app/components/events/interfaces/spans/utils';
+import {EntryType, EventTransaction} from 'app/types/event';
+
+describe('SpanTreeModel', () => {
+  const event = {
+    id: '2b658a829a21496b87fd1f14a61abf65',
+    eventID: '2b658a829a21496b87fd1f14a61abf65',
+    title: '/organizations/:orgId/discover/results/',
+    type: 'transaction',
+    startTimestamp: 1622079935.86141,
+    endTimestamp: 1622079940.032905,
+    contexts: {
+      trace: {
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        span_id: 'a934857184bdf5a6',
+        op: 'pageload',
+        status: 'unknown',
+        type: 'trace',
+      },
+    },
+    entries: [
+      {
+        data: [
+          {
+            timestamp: 1622079937.227645,
+            start_timestamp: 1622079936.90689,
+            description: 'GET /api/0/organizations/?member=1',
+            op: 'http',
+            span_id: 'b23703998ae619e7',
+            parent_span_id: 'a934857184bdf5a6',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            status: 'ok',
+            tags: {
+              'http.status_code': '200',
+            },
+            data: {
+              method: 'GET',
+              type: 'fetch',
+              url: '/api/0/organizations/?member=1',
+            },
+          },
+          {
+            timestamp: 1622079937.20331,
+            start_timestamp: 1622079936.907515,
+            description: 'GET /api/0/internal/health/',
+            op: 'http',
+            span_id: 'a453cc713e5baf9c',
+            parent_span_id: 'a934857184bdf5a6',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            status: 'ok',
+            tags: {
+              'http.status_code': '200',
+            },
+            data: {
+              method: 'GET',
+              type: 'fetch',
+              url: '/api/0/internal/health/',
+            },
+          },
+          {
+            timestamp: 1622079936.05839,
+            start_timestamp: 1622079936.048125,
+            description: '/_static/dist/sentry/sentry.541f5b.css',
+            op: 'resource.link',
+            span_id: 'a23f26b939d1a735',
+            parent_span_id: 'a453cc713e5baf9c',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+        ],
+        type: EntryType.SPANS,
+      },
+    ],
+  } as EventTransaction;
+
+  it('makes children', () => {
+    const parsedTrace = parseTrace(event);
+    const rootSpan = generateRootSpan(parsedTrace);
+
+    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans);
+
+    expect(spanTreeModel.children).toHaveLength(2);
+  });
+
+  it('handles recursive children', () => {
+    const event2 = {
+      ...event,
+      entries: [
+        {
+          data: [
+            {
+              timestamp: 1622079937.227645,
+              start_timestamp: 1622079936.90689,
+              description: 'GET /api/0/organizations/?member=1',
+              op: 'http',
+              span_id: 'a934857184bdf5a6',
+              parent_span_id: 'a934857184bdf5a6',
+              trace_id: '8cbbc19c0f54447ab702f00263262726',
+              status: 'ok',
+              tags: {
+                'http.status_code': '200',
+              },
+              data: {
+                method: 'GET',
+                type: 'fetch',
+                url: '/api/0/organizations/?member=1',
+              },
+            },
+          ],
+          type: EntryType.SPANS,
+        },
+      ],
+    } as EventTransaction;
+
+    const parsedTrace = parseTrace(event2);
+    const rootSpan = generateRootSpan(parsedTrace);
+
+    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans);
+    expect(spanTreeModel.children).toHaveLength(1);
+  });
+
+  it('operationNameCounts', () => {
+    const parsedTrace = parseTrace(event);
+    const rootSpan = generateRootSpan(parsedTrace);
+
+    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans);
+
+    expect(Object.fromEntries(spanTreeModel.operationNameCounts)).toMatchObject({
+      http: 2,
+      pageload: 1,
+      'resource.link': 1,
+    });
+  });
+});

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -1,0 +1,163 @@
+import {ActiveFilter, noFilter} from 'app/components/events/interfaces/spans/filter';
+import WaterfallModel from 'app/components/events/interfaces/spans/waterfallModel';
+import {EntryType, EventTransaction} from 'app/types/event';
+
+describe('WaterfallModel', () => {
+  const event = {
+    id: '2b658a829a21496b87fd1f14a61abf65',
+    eventID: '2b658a829a21496b87fd1f14a61abf65',
+    title: '/organizations/:orgId/discover/results/',
+    type: 'transaction',
+    startTimestamp: 1622079935.86141,
+    endTimestamp: 1622079940.032905,
+    contexts: {
+      trace: {
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        span_id: 'a934857184bdf5a6',
+        op: 'pageload',
+        status: 'unknown',
+        type: 'trace',
+      },
+    },
+    entries: [
+      {
+        data: [
+          {
+            timestamp: 1622079937.227645,
+            start_timestamp: 1622079936.90689,
+            description: 'GET /api/0/organizations/?member=1',
+            op: 'http',
+            span_id: 'b23703998ae619e7',
+            parent_span_id: 'a934857184bdf5a6',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            status: 'ok',
+            tags: {
+              'http.status_code': '200',
+            },
+            data: {
+              method: 'GET',
+              type: 'fetch',
+              url: '/api/0/organizations/?member=1',
+            },
+          },
+          {
+            timestamp: 1622079937.20331,
+            start_timestamp: 1622079936.907515,
+            description: 'GET /api/0/internal/health/',
+            op: 'http',
+            span_id: 'a453cc713e5baf9c',
+            parent_span_id: 'a934857184bdf5a6',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            status: 'ok',
+            tags: {
+              'http.status_code': '200',
+            },
+            data: {
+              method: 'GET',
+              type: 'fetch',
+              url: '/api/0/internal/health/',
+            },
+          },
+          {
+            timestamp: 1622079936.05839,
+            start_timestamp: 1622079936.048125,
+            description: '/_static/dist/sentry/sentry.541f5b.css',
+            op: 'resource.link',
+            span_id: 'a23f26b939d1a735',
+            parent_span_id: 'a453cc713e5baf9c',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+        ],
+        type: EntryType.SPANS,
+      },
+    ],
+  } as EventTransaction;
+
+  it('isEvent', () => {
+    const waterfallModel = new WaterfallModel(event);
+
+    expect(waterfallModel.event).toMatchObject(event);
+    expect(waterfallModel.isEvent(event)).toBe(true);
+    expect(
+      waterfallModel.isEvent({
+        ...event,
+        id: 'somethingelse',
+      })
+    ).toBe(false);
+  });
+
+  it('get operationNameCounts', () => {
+    const waterfallModel = new WaterfallModel(event);
+
+    expect(Object.fromEntries(waterfallModel.operationNameCounts)).toMatchObject({
+      http: 2,
+      pageload: 1,
+      'resource.link': 1,
+    });
+  });
+
+  it('toggleOperationNameFilter', () => {
+    const waterfallModel = new WaterfallModel(event);
+
+    expect(waterfallModel.operationNameFilters).toEqual(noFilter);
+
+    // toggle http filter
+    waterfallModel.toggleOperationNameFilter('http');
+
+    const operationNameFilters = waterfallModel.operationNameFilters as ActiveFilter;
+
+    expect(operationNameFilters.type).toBe('active_filter');
+    expect(Array.from(operationNameFilters.operationNames)).toEqual(['http']);
+
+    // un-toggle http filter
+    waterfallModel.toggleOperationNameFilter('http');
+    expect(waterfallModel.operationNameFilters).toEqual(noFilter);
+  });
+
+  it('toggleAllOperationNameFilters', () => {
+    const waterfallModel = new WaterfallModel(event);
+
+    expect(waterfallModel.operationNameFilters).toEqual(noFilter);
+
+    // toggle all operation names
+    waterfallModel.toggleAllOperationNameFilters();
+    let operationNameFilters = waterfallModel.operationNameFilters as ActiveFilter;
+
+    expect(operationNameFilters.type).toBe('active_filter');
+    expect(Array.from(operationNameFilters.operationNames)).toEqual([
+      'http',
+      'pageload',
+      'resource.link',
+    ]);
+
+    // toggle http filter
+    waterfallModel.toggleOperationNameFilter('http');
+    operationNameFilters = waterfallModel.operationNameFilters as ActiveFilter;
+
+    expect(operationNameFilters.type).toBe('active_filter');
+    expect(Array.from(operationNameFilters.operationNames)).toEqual([
+      'pageload',
+      'resource.link',
+    ]);
+
+    // toggle all operation names; expect un-toggled operation names to be toggled on
+    waterfallModel.toggleAllOperationNameFilters();
+    operationNameFilters = waterfallModel.operationNameFilters as ActiveFilter;
+
+    expect(operationNameFilters.type).toBe('active_filter');
+    expect(Array.from(operationNameFilters.operationNames)).toEqual([
+      'http',
+      'pageload',
+      'resource.link',
+    ]);
+
+    // un-toggle all operation names
+    waterfallModel.toggleAllOperationNameFilters();
+    expect(waterfallModel.operationNameFilters).toEqual(noFilter);
+  });
+});


### PR DESCRIPTION
This refactor is the starting point of a larger refactor work to lift states from the span interface to mobx. Changes will be introduced in steps so that they're easier to review.

-----

Two observable mobx classes will be used to construct the waterfall graph: `WaterfallModel` and `SpanTreeModel`. The advantages this brings is:

- easier to reason about the code compared to how the waterfall graph is constructed today,
- easier to test,
- and be able to insert span trees into the waterfall graph (for embedded transaction feature). 

The simplest refactor is to move the span operation name filtering feature into observable mobx states. 

