### PR TITLE
fix(performance): Release tag should not be wrapped when navigating

### DIFF
--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -45,6 +45,12 @@ import {generateTitle, getExpandedResults} from '../utils';
 
 import LinkedIssue from './linkedIssue';
 
+/**
+ * Some tag keys should never be formatted as `tag[...]`
+ * when used as a filter because they are predefined.
+ */
+const EXCLUDED_TAG_KEYS = new Set(['release']);
+
 type Props = {
   organization: Organization;
   location: Location;
@@ -99,7 +105,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     // Some tags may be normalized from context, but not all of them are.
     // This supports a user making a custom tag with the same name as one
     // that comes from context as all of these are also tags.
-    if (tag.key in FIELD_TAGS) {
+    if (tag.key in FIELD_TAGS && !EXCLUDED_TAG_KEYS.has(tag.key)) {
       return `tags[${tag.key}]`;
     }
     return tag.key;

--- a/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
+++ b/tests/js/spec/views/eventsV2/eventDetails.spec.jsx
@@ -59,6 +59,7 @@ describe('EventsV2 > EventDetails', function () {
         tags: [
           {key: 'browser', value: 'Firefox'},
           {key: 'device.uuid', value: 'test-uuid'},
+          {key: 'release', value: '82ebf297206a'},
         ],
       },
     });
@@ -205,6 +206,18 @@ describe('EventsV2 > EventDetails', function () {
     expect(deviceUUIDTagTarget.query.query).toEqual(
       'tags[device.uuid]:test-uuid title:"Oh no something bad"'
     );
+
+    // Get the third link
+    const releaseTagLink = wrapper.find('EventDetails KeyValueTable Value Link').at(4);
+
+    // Should append raw tag value without tags[] as release is exempt from being wrapped
+    const releaseTagTarget = releaseTagLink.props().to;
+    expect(releaseTagTarget.pathname).toEqual(
+      '/organizations/org-slug/discover/results/'
+    );
+    expect(releaseTagTarget.query.query).toEqual(
+      'release:82ebf297206a title:"Oh no something bad"'
+    );
   });
 
   it('appends tag value to existing query when clicked', async function () {
@@ -252,6 +265,18 @@ describe('EventsV2 > EventDetails', function () {
     );
     expect(deviceUUIDTagTarget.query.query).toEqual(
       'Dumpster tags[device.uuid]:test-uuid title:"Oh no something bad"'
+    );
+
+    // Get the third link
+    const releaseTagLink = wrapper.find('EventDetails KeyValueTable Value Link').at(4);
+
+    // Should append raw tag value without tags[] as release is exempt from being wrapped
+    const releaseTagTarget = releaseTagLink.props().to;
+    expect(releaseTagTarget.pathname).toEqual(
+      '/organizations/org-slug/discover/results/'
+    );
+    expect(releaseTagTarget.query.query).toEqual(
+      'Dumpster release:82ebf297206a title:"Oh no something bad"'
     );
   });
 });


### PR DESCRIPTION
The release tag should not be wrapped with `tags[...]` because it is not a user
defined tag. Always use the tag key as is for releases.