### PR TITLE
fix(performance): Remove N+1 query in key transactions list end point

### DIFF
--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -236,9 +236,13 @@ class KeyTransactionTeamSerializer(Serializer):
         self.project_ids = {project.id for project in projects}
 
     def get_attrs(self, item_list, user, **kwargs):
-        team_key_transactions = TeamKeyTransaction.objects.filter(
-            project_team__in=ProjectTeam.objects.filter(team__in=item_list),
-        ).order_by("transaction", "project_team__project_id")
+        team_key_transactions = (
+            TeamKeyTransaction.objects.filter(
+                project_team__in=ProjectTeam.objects.filter(team__in=item_list),
+            )
+            .select_related("project_team__project", "project_team__team")
+            .order_by("transaction", "project_team__project_id")
+        )
 
         attrs = defaultdict(
             lambda: {


### PR DESCRIPTION
There is a N+1 query in the key transactions list end point. This change fetches
the related tables to remove the N+1 query.

# Before

![image](https://user-images.githubusercontent.com/10239353/121433251-c338b080-c949-11eb-8626-05fa36a40126.png)

# After
![image (1)](https://user-images.githubusercontent.com/10239353/121433263-c7fd6480-c949-11eb-8edc-e6e136cf6279.png)

