### PR TITLE
fix(notifications platform) Handle multiple identities for one user

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -32,12 +32,12 @@ def get_context(
 def get_channel_and_integration_by_user(
     user: User, organization: Organization
 ) -> Tuple[Optional[str], Optional[Integration]]:
-    try:
-        identities = Identity.objects.filter(
-            idp__type=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],
-            user=user.id,
-        )
-    except Identity.DoesNotExist:
+
+    identities = Identity.objects.filter(
+        idp__type=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],
+        user=user.id,
+    )
+    if not identities:
         # The user may not have linked their identity so just move on
         # since there are likely other users or teams in the list of
         # recipients.

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -43,23 +43,19 @@ def get_channel_and_integration_by_user(
         # recipients.
         return None, None
 
-    identity = [
-        identity
-        for identity in identities
-        if identity.user.org_memberships.filter(id=organization.id)
-    ]
-    if not identity:
-        return None, None
-
     try:
         integration = Integration.objects.get(
-            provider=identity[0].idp.type,
+            provider=EXTERNAL_PROVIDERS[ExternalProviders.SLACK],
             organizations=organization,
+            external_id__in=[identity.idp.external_id for identity in identities],
         )
     except Integration.DoesNotExist:
         return None, None
 
-    return identity[0].external_id, integration
+    matched_identity = [
+        identity for identity in identities if integration.external_id == identity.idp.external_id
+    ]
+    return matched_identity[0].external_id, integration
 
 
 def get_channel_and_integration_by_team(

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -172,6 +172,59 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
 
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_multiple_orgs(self, mock_func):
+        """
+        Test that if a user is in 2 orgs with Slack and has an Identity linked in each,
+        we're only going to notify them for the relevant org
+        """
+        org2 = self.create_organization(owner=self.user)
+        integration2 = Integration.objects.create(
+            provider="slack",
+            name="Team B",
+            external_id="TXXXXXXX2",
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+        integration2.add_organization(org2, self.user)
+        idp2 = IdentityProvider.objects.create(type="slack", external_id="TXXXXXXX2", config={})
+        Identity.objects.create(
+            external_id="UXXXXXXX2",
+            idp=idp2,
+            user=self.user,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
+        # create a second response that won't actually be used, but here to make sure it's not a false positive
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+
+        notification = AssignedActivityNotification(
+            Activity(
+                project=self.project,
+                group=self.group,
+                user=self.user,
+                type=ActivityType.ASSIGNED,
+                data={"assignee": self.user.id},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        assert len(responses.calls) == 1
+        data = parse_qs(responses.calls[0].request.body)
+        assert "channel" in data
+        channel = data["channel"][0]
+        assert channel == self.identity.external_id
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_assignment(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is assigned


### PR DESCRIPTION
If a user belongs to an organization that has multiple Slack integrations, send a notification to each of them because it's impossible to determine which one it should go to.

If a user has multiple identities (either because of the above situation or because they belong to multiple orgs that each have a Slack integration) handle that and notify them in the appropriate location.

Fixes [SENTRY-QM4](https://sentry.io/organizations/sentry/issues/2431646441/?project=1&referrer=jira_integration)