### PR TITLE
fix(notifications platform) feature flag post install

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 from django.utils.translation import ugettext_lazy as _
 
+from sentry import features
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations import (
     FeatureDescription,
@@ -159,5 +160,6 @@ class SlackIntegrationProvider(IntegrationProvider):
         """
         Create Identity records for an organization's users if their emails match in Sentry and Slack
         """
-        run_args = {"integration": integration, "organization": organization}
-        tasks.link_slack_user_identities.apply_async(kwargs=run_args)
+        if features.has("organizations:notification-platform", organization):
+            run_args = {"integration": integration, "organization": organization}
+            tasks.link_slack_user_identities.apply_async(kwargs=run_args)

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -229,7 +229,8 @@ class SlackIntegrationPostInstallTest(APITestCase):
         if their Sentry email matches their Slack email
         """
         with self.tasks():
-            SlackIntegrationProvider().post_install(self.integration, self.organization)
+            with self.feature("organizations:notification-platform"):
+                SlackIntegrationProvider().post_install(self.integration, self.organization)
 
         user1_identity = Identity.objects.get(user=self.user)
         assert user1_identity
@@ -270,7 +271,8 @@ class SlackIntegrationPostInstallTest(APITestCase):
             },
         )
         with self.tasks():
-            SlackIntegrationProvider().post_install(self.integration, self.organization)
+            with self.feature("organizations:notification-platform"):
+                SlackIntegrationProvider().post_install(self.integration, self.organization)
 
         identities = Identity.objects.all()
         assert identities.count() == 2
@@ -311,7 +313,8 @@ class SlackIntegrationPostInstallTest(APITestCase):
             },
         )
         with self.tasks():
-            SlackIntegrationProvider().post_install(self.integration, self.organization)
+            with self.feature("organizations:notification-platform"):
+                SlackIntegrationProvider().post_install(self.integration, self.organization)
 
         user3_identity = Identity.objects.get(user=user3)
         assert user3_identity


### PR DESCRIPTION
Add a feature flag to `post_install` for Slack so that we only try to link identities if they have the notifications platform feature. Not having it has no consequences (aside from triggering issues) since we don't have the correct scope anyway, but this should be behind a flag.

Fixes [SENTRY-QPW](https://sentry.io/organizations/sentry/issues/2446681812/?project=1)