### PR TITLE
fix(tests): Fix bug in deleted subscription test

### DIFF
--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -98,7 +98,10 @@ class IncidentClearSubscriptionCacheTest(TestCase):
             cache.get(AlertRule.objects.CACHE_SUBSCRIPTION_KEY % self.subscription.id)
             == self.alert_rule
         )
+        subscription_id = self.subscription.id
         self.subscription.delete()
+        # Add the subscription id back in so we don't use `None` in the lookup check.
+        self.subscription.id = subscription_id
         with self.assertRaises(AlertRule.DoesNotExist):
             AlertRule.objects.get_for_subscription(self.subscription)
 


### PR DESCRIPTION
This test was never working correctly, since it was using a subscription with a `None` id to fetch
an alert rule via subscription. In Django 2.0, this leads to the query translating to "fetch me any
alert rows that have no related subscription", which is probably the correct interpretation here.