### PR TITLE
fix(performance): Should update key transactions list on project change

### DIFF
--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -1,4 +1,5 @@
 import {Component, createContext, ReactNode} from 'react';
+import isEqual from 'lodash/isEqual';
 
 import {
   fetchTeamKeyTransactions,
@@ -68,18 +69,14 @@ class UnwrappedProvider extends Component<Props> {
 
   componentDidUpdate(prevProps: Props) {
     const orgSlugChanged = prevProps.organization.slug !== this.props.organization.slug;
-    const selectedTeamsChanged =
-      prevProps.selectedTeams.length !== this.props.selectedTeams.length ||
-      prevProps.selectedTeams.every(
-        (teamId, i) => this.props.selectedTeams[i] !== teamId
-      );
-    const selectedProjectsChanged =
-      prevProps.selectedProjects &&
-      this.props.selectedProjects &&
-      prevProps.selectedProjects.length !== this.props.selectedProjects.length &&
-      prevProps.selectedProjects.every(
-        (projectId, i) => this.props.selectedProjects?.[i] !== projectId
-      );
+    const selectedTeamsChanged = !isEqual(
+      prevProps.selectedTeams,
+      this.props.selectedTeams
+    );
+    const selectedProjectsChanged = !isEqual(
+      prevProps.selectedProjects,
+      this.props.selectedProjects
+    );
 
     if (orgSlugChanged || selectedTeamsChanged || selectedProjectsChanged) {
       this.fetchData();


### PR DESCRIPTION
The check for when the projects change isn't correct. Use lodash/isEqual for the
check instead.