### PR TITLE
feat(dev): Fix fish pyenv setup and use zprofile for zsh

### DIFF
--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -47,11 +47,12 @@ _append_to_startup_script() {
       echo "Visit https://github.com/pyenv/pyenv#installation on how to fully set up your Bash shell.";;
     */zsh)
       # shellcheck disable=SC2016
-      echo -e '\neval "$(pyenv init --path)"' >> "${1}"
+      echo -e '\n# It is assumed that pyenv is installed via Brew, so this is all we need to do.\n' \
+        '\neval "$(pyenv init --path)"' >>"${1}"
       ;;
     */fish)
       # shellcheck disable=SC2016
-      echo -e 'n# pyenv init\nstatus is-login; and pyenv init --path | source' >> "${1}"
+      echo -e '\n# pyenv init\nstatus is-login; and pyenv init --path | source' >> "${1}"
       ;;
     esac
 

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -20,7 +20,7 @@ get_shell_startup_script() {
       _startup_script="${HOME}/.bash_profile"
       ;;
     */zsh)
-      _startup_script="${HOME}/.zshrc"
+      _startup_script="${HOME}/.zprofile"
       ;;
     */fish)
       _startup_script="${HOME}/.config/fish/config.fish"
@@ -44,15 +44,14 @@ _append_to_startup_script() {
     case "$SHELL" in
     */bash)
       # shellcheck disable=SC2016
-      echo -e '\neval "$(pyenv init --path)"\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >>"${1}"
-      ;;
+      echo "Visit https://github.com/pyenv/pyenv#installation on how to fully set up your Bash shell.";;
     */zsh)
       # shellcheck disable=SC2016
-      echo -e '\neval "$(pyenv init --path)"\nif command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >>"${1}"
+      echo -e '\neval "$(pyenv init --path)"' >> "${1}"
       ;;
     */fish)
       # shellcheck disable=SC2016
-      echo -e '\n\n# pyenv init\nstatus is-login; and pyenv init --path | source\nif command -v pyenv 1>/dev/null 2>&1;\n  pyenv init - | source\nend' >>"$1"
+      echo -e 'n# pyenv init\nstatus is-login; and pyenv init --path | source' >> "${1}"
       ;;
     esac
 

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -117,10 +117,8 @@ setup_pyenv() {
   # If the script is called with the "dot space right" approach (. ./scripts/pyenv_setup.sh),
   # the effects of this will be persistent outside of this script
   echo "Activating pyenv and validating Python version"
-  # Sets up PATH
+  # Sets up PATH for pyenv
   eval "$(pyenv init --path)"
-  # Enables autocompletion and all subcommands
-  eval "$(pyenv init -)"
   python_version=$(python -V | sed s/Python\ //g)
   [[ $python_version == $(cat .python-version) ]] ||
     (echo "Wrong Python version: $python_version. Please report in #discuss-dev-tooling" && exit 1)

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -47,8 +47,8 @@ _append_to_startup_script() {
       echo "Visit https://github.com/pyenv/pyenv#installation on how to fully set up your Bash shell.";;
     */zsh)
       # shellcheck disable=SC2016
-      echo -e '\n# It is assumed that pyenv is installed via Brew, so this is all we need to do.\n' \
-        '\neval "$(pyenv init --path)"' >>"${1}"
+      echo -e '# It is assumed that pyenv is installed via Brew, so this is all we need to do.\n' \
+        'eval "$(pyenv init --path)"' >>"${1}"
       ;;
     */fish)
       # shellcheck disable=SC2016


### PR DESCRIPTION
The lines inserted into fish's startup script weren't working, so those were updated to match
pyenv's README. It appears that the script was also missing an additional step which sets up
autocompletion and subcommands for pyenv.

Update to docs: https://github.com/getsentry/develop/pull/351