### PR TITLE
feat(arithmetic): Add function support to discover arithmetic

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -83,7 +83,6 @@ mul_div              = mul_div_operator primary
 
 add_sub_operator     = spaces (plus / minus) spaces
 mul_div_operator     = spaces (multiply / divide) spaces
-# TODO(wmak) allow variables
 primary              = spaces (numeric_value / function_value / field_value) spaces
 
 # Operator names should match what's in clickhouse
@@ -92,7 +91,11 @@ minus                = "-"
 multiply             = "*"
 divide               = "/"
 
-# Minor differences in parsing means that these cannot be shared with api/event_search
+# Minor differences in parsing means that these cannot be shared with
+# api/event_search. Arithmetic can support something like duration-duration as
+# subtraction, but event_search needs to treat that as a single field since `-`
+# is a valid tag character, which isn't supported in Arithmetic
+
 function_value       = function_name open_paren spaces function_args? spaces closed_paren
 function_args        = function_arg (spaces comma spaces function_arg)*
 # Different from a field value, since a function arg may not be a valid field

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -787,7 +787,7 @@ class SnubaTagStorage(TagStorage):
                 # and resolve it to the corresponding snuba query
                 resolver = snuba.resolve_column(dataset)
                 snuba_name = FIELD_ALIASES[USER_DISPLAY_ALIAS].get_field()
-                snuba.resolve_complex_column(snuba_name, resolver)
+                snuba.resolve_complex_column(snuba_name, resolver, [])
             elif snuba_name in BLACKLISTED_COLUMNS:
                 snuba_name = f"tags[{key}]"
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1329,6 +1329,8 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
                 if len(col) == 3:
                     # Add the name from columns, and remove project backticks so its not treated as a new col
                     derived_columns.add(col[2].strip("`"))
+                # Equations use aggregation aliases as arguments, and we don't want those resolved since they'll resolve
+                # as tags instead
                 resolve_complex_column(col, resolve_func, aggregation_aliases)
             else:
                 name = resolve_func(col)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1300,13 +1300,13 @@ def _aliased_query_impl(
 # TODO (evanh) Since we are assuming that all string values are columns,
 # this will get tricky if we ever have complex columns where there are
 # string arguments to the functions that aren't columns
-def resolve_complex_column(col, resolve_func):
+def resolve_complex_column(col, resolve_func, ignored):
     args = col[1]
 
     for i in range(len(args)):
         if isinstance(args[i], (list, tuple)):
-            resolve_complex_column(args[i], resolve_func)
-        elif isinstance(args[i], str):
+            resolve_complex_column(args[i], resolve_func, ignored)
+        elif isinstance(args[i], str) and args[i] not in ignored:
             args[i] = resolve_func(args[i])
 
 
@@ -1314,19 +1314,22 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
     resolved = snuba_filter.clone()
     translated_columns = {}
     derived_columns = set()
+    aggregations = resolved.aggregations
+
     if function_translations:
         for snuba_name, sentry_name in function_translations.items():
             derived_columns.add(snuba_name)
             translated_columns[snuba_name] = sentry_name
 
     selected_columns = resolved.selected_columns
+    aggregation_aliases = [aggregation[-1] for aggregation in aggregations]
     if selected_columns:
         for (idx, col) in enumerate(selected_columns):
             if isinstance(col, (list, tuple)):
                 if len(col) == 3:
                     # Add the name from columns, and remove project backticks so its not treated as a new col
                     derived_columns.add(col[2].strip("`"))
-                resolve_complex_column(col, resolve_func)
+                resolve_complex_column(col, resolve_func, aggregation_aliases)
             else:
                 name = resolve_func(col)
                 selected_columns[idx] = name
@@ -1347,7 +1350,6 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
             groupby[idx] = name
         resolved.groupby = groupby
 
-    aggregations = resolved.aggregations
     # need to get derived_columns first, so that they don't get resolved as functions
     derived_columns = derived_columns.union([aggregation[2] for aggregation in aggregations])
     for aggregation in aggregations or []:

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -670,6 +670,10 @@ export function generateAggregateFields(
 }
 
 export function explodeFieldString(field: string): Column {
+  if (isEquation(field)) {
+    return {kind: 'equation', field: getEquation(field)};
+  }
+
   const results = field.match(AGGREGATE_PATTERN);
 
   if (results && results.length >= 3) {
@@ -681,9 +685,6 @@ export function explodeFieldString(field: string): Column {
         results[3] as AggregationRefinement,
       ],
     };
-  }
-  if (isEquation(field)) {
-    return {kind: 'equation', field: getEquation(field)};
   }
 
   return {kind: 'field', field};

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -7,6 +7,7 @@ from sentry.discover.arithmetic import (
     Operation,
     parse_arithmetic,
 )
+from sentry.search.events.fields import get_function_alias
 
 op_map = {
     "+": "plus",
@@ -17,7 +18,7 @@ op_map = {
 
 
 def test_single_term():
-    result, _ = parse_arithmetic("12")
+    result, _, _ = parse_arithmetic("12")
     assert result == 12.0
 
 
@@ -44,7 +45,7 @@ def test_single_term():
 )
 def test_simple_arithmetic(a, op, b):
     equation = f"{a}{op}{b}"
-    result, _ = parse_arithmetic(equation)
+    result, _, _ = parse_arithmetic(equation)
     assert result.operator == op_map[op.strip()], equation
     assert result.lhs == float(a), equation
     assert result.rhs == float(b), equation
@@ -66,7 +67,7 @@ def test_simple_arithmetic(a, op, b):
 def test_homogenous_arithmetic(a, op1, b, op2, c):
     """Test that literal order of ops is respected assuming we don't have to worry about BEDMAS"""
     equation = f"{a}{op1}{b}{op2}{c}"
-    result, _ = parse_arithmetic(equation)
+    result, _, _ = parse_arithmetic(equation)
     assert result.operator == op_map[op2.strip()], equation
     assert isinstance(result.lhs, Operation), equation
     assert result.lhs.operator == op_map[op1.strip()], equation
@@ -76,7 +77,7 @@ def test_homogenous_arithmetic(a, op1, b, op2, c):
 
 
 def test_mixed_arithmetic():
-    result, _ = parse_arithmetic("12 + 34 * 56")
+    result, _, _ = parse_arithmetic("12 + 34 * 56")
     assert result.operator == "plus"
     assert result.lhs == 12.0
     assert isinstance(result.rhs, Operation)
@@ -84,7 +85,7 @@ def test_mixed_arithmetic():
     assert result.rhs.lhs == 34.0
     assert result.rhs.rhs == 56.0
 
-    result, _ = parse_arithmetic("12 / 34 - 56")
+    result, _, _ = parse_arithmetic("12 / 34 - 56")
     assert result.operator == "minus"
     assert isinstance(result.lhs, Operation)
     assert result.lhs.operator == "divide"
@@ -94,7 +95,7 @@ def test_mixed_arithmetic():
 
 
 def test_four_terms():
-    result, _ = parse_arithmetic("1 + 2 / 3 * 4")
+    result, _, _ = parse_arithmetic("1 + 2 / 3 * 4")
     assert result.operator == "plus"
     assert result.lhs == 1.0
     assert isinstance(result.rhs, Operation)
@@ -125,7 +126,7 @@ def test_homogenous_four_terms(a, op1, b, op2, c, op3, d):
     flatten only kicks in when its a chain of the same operator type
     """
     equation = f"{a}{op1}{b}{op2}{c}{op3}{d}"
-    result, _ = parse_arithmetic(equation)
+    result, _, _ = parse_arithmetic(equation)
     assert result.operator == op_map[op3.strip()], equation
     assert isinstance(result.lhs, Operation), equation
     assert result.lhs.operator == op_map[op2.strip()], equation
@@ -155,14 +156,40 @@ def test_max_operators():
 )
 def test_field_values(a, op, b):
     equation = f"{a}{op}{b}"
-    result, fields = parse_arithmetic(equation)
+    result, fields, functions = parse_arithmetic(equation)
     assert result.operator == op_map[op.strip()], equation
     assert result.lhs == a, equation
     assert result.rhs == b, equation
+    assert len(functions) == 0
     if isinstance(a, str):
         assert a in fields, equation
     if isinstance(b, str):
         assert b in fields, equation
+
+
+@pytest.mark.parametrize(
+    "a,op,b",
+    [
+        ("failure_count()", "/", "count()"),
+        ("percentile(0.5, transaction.duration)", "/", "max(transaction.duration)"),
+        (500, "+", "count_miserable(user, 300)"),
+        ("count_miserable(user, 300)", "-", 500),
+        ("p50(transaction.duration)", "/", "p100(transaction.duration)"),
+    ],
+)
+def test_function_values(a, op, b):
+    equation = f"{a}{op}{b}"
+    result, fields, functions = parse_arithmetic(equation)
+    assert result.operator == op_map[op.strip()], equation
+    lhs = a if isinstance(a, int) else get_function_alias(a)
+    rhs = b if isinstance(b, int) else get_function_alias(b)
+    assert result.lhs == lhs, equation
+    assert result.rhs == rhs, equation
+    assert len(fields) == 0
+    if isinstance(a, str):
+        assert a in functions, equation
+    if isinstance(b, str):
+        assert b in functions, equation
 
 
 @pytest.mark.parametrize(
@@ -188,6 +215,10 @@ def test_unparseable_arithmetic(equation):
         "spans.http/0",
         # Transaction status isn't something we want arithmetic on
         "1 + transaction.status",
+        # last_seen is an aggregate, but we aren't supporting arithmetic on dates
+        "last_seen() + 1",
+        # Mixing fields/functions is invalid
+        "p50(transaction.duration) + transaction.duration",
     ],
 )
 def test_invalid_arithmetic(equation):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -3350,6 +3350,18 @@ class ArithmeticTest(SnubaTestCase, TestCase):
                 params=self.params,
             )
 
+    def test_invalid_function(self):
+        with self.assertRaises(ArithmeticValidationError):
+            discover.query(
+                selected_columns=[
+                    "p50(transaction.duration)",
+                    "last_seen()",
+                ],
+                equations=["p50(transaction.duration) / last_seen()"],
+                query=self.query,
+                params=self.params,
+            )
+
     def test_unselected_field(self):
         with self.assertRaises(InvalidSearchQuery):
             discover.query(
@@ -3357,6 +3369,17 @@ class ArithmeticTest(SnubaTestCase, TestCase):
                     "spans.http",
                 ],
                 equations=["spans.http / transaction.duration"],
+                query=self.query,
+                params=self.params,
+            )
+
+    def test_unselected_function(self):
+        with self.assertRaises(InvalidSearchQuery):
+            discover.query(
+                selected_columns=[
+                    "p50(transaction.duration)",
+                ],
+                equations=["p50(transaction.duration) / p100(transaction.duration)"],
                 query=self.query,
                 params=self.params,
             )
@@ -3408,3 +3431,31 @@ class ArithmeticTest(SnubaTestCase, TestCase):
                 query=self.query,
                 params=self.params,
             )
+
+    def test_aggregate_equation(self):
+        results = discover.query(
+            selected_columns=[
+                "p50(transaction.duration)",
+            ],
+            equations=["p50(transaction.duration) / 2"],
+            query=self.query,
+            params=self.params,
+        )
+        assert len(results["data"]) == 1
+        result = results["data"][0]
+        assert result["equation[0]"] == result["p50_transaction_duration"] / 2
+
+    def test_multiple_aggregate_equation(self):
+        results = discover.query(
+            selected_columns=[
+                "p50(transaction.duration)",
+                "count()",
+            ],
+            equations=["p50(transaction.duration) + 2", "p50(transaction.duration) / count()"],
+            query=self.query,
+            params=self.params,
+        )
+        assert len(results["data"]) == 1
+        result = results["data"][0]
+        assert result["equation[0]"] == result["p50_transaction_duration"] + 2
+        assert result["equation[1]"] == result["p50_transaction_duration"] / result["count"]


### PR DESCRIPTION
- This allows the arithmetic parser to understand functions
- Not allowing functions + fields to be included together in an equation as this will result in awkward grouping
  - eg duration/p50(duration) means that we group by duration so p50 will always be identical
- This also fixes a bug in the column editor with aggregates