### PR TITLE
fix(semver): Fix backfill migration

### DIFF
--- a/src/sentry/migrations/0205_semver_backfill.py
+++ b/src/sentry/migrations/0205_semver_backfill.py
@@ -31,7 +31,7 @@ UPDATE_QUERY = """
     revision = data.revision,
     prerelease = data.prerelease,
     build_code = data.build_code,
-    build_number = data.build_number
+    build_number = data.build_number::bigint
     FROM (VALUES %s) AS data (id, package, major, minor, patch, revision, prerelease, build_code, build_number)
     WHERE sentry_release.id = data.id"""
 


### PR DESCRIPTION
We need to cast `build_number` as a bigint, otherwise it's treated as `text` when the value is null
and causes an error.