### PR TITLE
fix(ui): Remove margin from search ellipsis

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1221,7 +1221,7 @@ class SmartSearchBar extends React.Component<Props, State> {
               anchorRight
               caret={false}
               title={
-                <EllipsisButton
+                <InputButton
                   size="zero"
                   borderless
                   tooltipProps={{
@@ -1381,14 +1381,6 @@ const StyledDropdownLink = styled(DropdownLink)`
 
 const DropdownElement = styled('a')<Omit<DropdownElementStylesProps, 'theme'>>`
   ${getDropdownElementStyles}
-`;
-
-const EllipsisButton = styled(InputButton)`
-  /*
-   * this is necessary because DropdownLink wraps the button in an unstyled
-   * span
-   */
-  margin: 6px 0 0 0;
 `;
 
 const VerticalEllipsisIcon = styled(IconEllipsis)`


### PR DESCRIPTION
padding on ellipsis on smaller search bar sizes

![image](https://user-images.githubusercontent.com/1400464/121444798-ff1d4700-c944-11eb-8ed7-d5b901c264e1.png)
