### PR TITLE
fix(ui): Fix releases empty message conditions

### DIFF
--- a/static/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
@@ -6,7 +6,7 @@ import FeatureTourModal from 'app/components/modals/featureTourModal';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import {RELEASES_TOUR_STEPS} from 'app/views/releases/list/releaseLanding';
+import {RELEASES_TOUR_STEPS} from 'app/views/releases/list/releasePromo';
 
 const DOCS_URL = 'https://docs.sentry.io/product/releases/';
 const DOCS_HEALTH_URL = 'https://docs.sentry.io/product/releases/health/';

--- a/static/app/views/projectDetail/projectLatestReleases.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.tsx
@@ -18,7 +18,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Release} from 'app/types';
 import {analytics} from 'app/utils/analytics';
-import {RELEASES_TOUR_STEPS} from 'app/views/releases/list/releaseLanding';
+import {RELEASES_TOUR_STEPS} from 'app/views/releases/list/releasePromo';
 
 import MissingReleasesButtons from './missingFeatureButtons/missingReleasesButtons';
 import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -29,7 +29,6 @@ import {
   ReleaseStatus,
   SessionApiResponse,
 } from 'app/types';
-import {defined} from 'app/utils';
 import Projects from 'app/utils/projects';
 import routeTitleGen from 'app/utils/routeTitle';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
@@ -42,9 +41,9 @@ import ReleaseHealthRequest from '../utils/releaseHealthRequest';
 import ReleaseAdoptionChart from './releaseAdoptionChart';
 import ReleaseCard from './releaseCard';
 import ReleaseDisplayOptions from './releaseDisplayOptions';
-import ReleaseLanding from './releaseLanding';
 import ReleaseListSortOptions from './releaseListSortOptions';
 import ReleaseListStatusOptions from './releaseListStatusOptions';
+import ReleasePromo from './releasePromo';
 import {DisplayOption, SortOption, StatusOption} from './utils';
 
 type RouteParams = {
@@ -284,21 +283,17 @@ class ReleasesList extends AsyncView<Props, State> {
       );
     }
 
-    if (defined(statsPeriod) && statsPeriod !== '14d') {
-      return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
-    }
-
     return (
-      <ReleaseLanding
+      <ReleasePromo
         organization={organization}
         projectId={selection.projects.filter(p => p !== ALL_ACCESS_PROJECTS)[0]}
       />
     );
   }
 
-  renderAlertBanner() {
+  renderHealthCta() {
     const {selection, organization} = this.props;
-    const {hasSessions} = this.state;
+    const {hasSessions, releases} = this.state;
 
     const selectedProjectId =
       selection.projects && selection.projects.length === 1 && selection.projects[0];
@@ -306,7 +301,7 @@ class ReleasesList extends AsyncView<Props, State> {
       p => p.id === `${selectedProjectId}`
     );
 
-    if (!selectedProject || hasSessions !== false) {
+    if (!selectedProject || hasSessions !== false || !releases.length) {
       return null;
     }
 
@@ -425,7 +420,7 @@ class ReleasesList extends AsyncView<Props, State> {
               <PageHeading>{t('Releases')}</PageHeading>
             </PageHeader>
 
-            {this.renderAlertBanner()}
+            {this.renderHealthCta()}
 
             <SortAndFilterWrapper>
               <SearchBar

--- a/static/app/views/releases/list/releasePromo.tsx
+++ b/static/app/views/releases/list/releasePromo.tsx
@@ -9,7 +9,6 @@ import statsImage from 'sentry-images/spot/releases-tour-stats.svg';
 
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
 import FeatureTourModal, {
   TourImage,
   TourStep,
@@ -19,7 +18,6 @@ import OnboardingPanel from 'app/components/onboardingPanel';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import AsyncView from 'app/views/asyncView';
 
 const releasesSetupUrl = 'https://docs.sentry.io/product/releases/';
 
@@ -82,38 +80,9 @@ export const RELEASES_TOUR_STEPS: TourStep[] = [
 type Props = {
   organization: Organization;
   projectId?: number;
-} & AsyncView['props'];
-
-class ReleaseLanding extends AsyncView<Props> {
-  // if there are no releases in the last 30 days, we want to show releases promo, otherwise empty message
-  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {slug} = this.props.organization;
-
-    const query = {
-      per_page: 1,
-      summaryStatsPeriod: '30d',
-    };
-
-    return [['releases', `/organizations/${slug}/releases/`, {query}]];
-  }
-
-  renderBody() {
-    const {organization, projectId} = this.props;
-
-    if (this.state.releases.length === 0) {
-      return <Promo organization={organization} projectId={projectId} />;
-    }
-
-    return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
-  }
-}
-
-type PromoProps = {
-  organization: Organization;
-  projectId?: number;
 };
 
-class Promo extends Component<PromoProps> {
+class ReleasePromo extends Component<Props> {
   componentDidMount() {
     const {organization, projectId} = this.props;
 
@@ -187,4 +156,4 @@ const ButtonList = styled(ButtonBar)`
   grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
 `;
 
-export default ReleaseLanding;
+export default ReleasePromo;

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -96,7 +96,7 @@ describe('ReleasesList', function () {
       routerContext
     );
     expect(wrapper.find('StyledPanel')).toHaveLength(0);
-    expect(wrapper.find('Promo').text()).toContain('Demystify Releases');
+    expect(wrapper.find('ReleasePromo').text()).toContain('Demystify Releases');
 
     location = {query: {statsPeriod: '30d'}};
     wrapper = mountWithTheme(
@@ -104,7 +104,7 @@ describe('ReleasesList', function () {
       routerContext
     );
     expect(wrapper.find('StyledPanel')).toHaveLength(0);
-    expect(wrapper.find('EmptyMessage').text()).toEqual('There are no releases.');
+    expect(wrapper.find('ReleasePromo').text()).toContain('Demystify Releases');
 
     location = {query: {query: 'abc'}};
     wrapper = mountWithTheme(


### PR DESCRIPTION
We want to show the setup sessions CTA only when releases are already being used.
Otherwise, show the releases promo illustration.