### PR TITLE
feat(dev): Include an example .env file that's used as a template for new environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Do not report development environment errors to Sentry.io.
-SENTRY_DEVENV_NO_REPORT=1
-# Print debug messages to stdout.
-SENTRY_DIRENV_DEBUG=0
+# SENTRY_DEVENV_NO_REPORT=1
+# Print debug messages when Direnv executes (read: .envrc file if direnv is installed).
+# SENTRY_DIRENV_DEBUG=1

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Do not report development environment errors to Sentry.io.
+SENTRY_DEVENV_NO_REPORT=1
+# Print debug messages to stdout.
+SENTRY_DIRENV_DEBUG=0

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -184,7 +184,10 @@ build-platform-assets() {
 copy-template-dotenv() {
     # Assumes this is being run from the root directory of the repository.
     if [[ ! -f .env ]]; then
+        echo "--> Copying template .env file"
         cp .env.example .env
+    else
+        echo "--> .env file already exists, skipping template copying"
     fi
 }
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -181,8 +181,16 @@ build-platform-assets() {
     echo "from sentry.utils.integrationdocs import sync_docs; sync_docs(quiet=True)" | sentry exec
 }
 
+copy-template-dotenv() {
+    # Assumes this is being run from the root directory of the repository.
+    if [[ ! -f .env ]]; then
+        cp .env.example .env
+    fi
+}
+
 bootstrap() {
     develop
+    copy-template-dotenv
     init-config
     run-dependent-services
     create-db


### PR DESCRIPTION
This adds in an example .env file that contains reasonable, useful defaults for new developers. 

Related to updates being made to docs here: getsentry/develop#351