### PR TITLE
 fix(Jira): Don't crash if some log context can't be established 

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -330,7 +330,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             logging_context["integration_id"] = attrgetter("org_integration.integration.id")(self)
             logging_context["org_integration_id"] = attrgetter("org_integration.id")(self)
         except OrganizationIntegration.DoesNotExist:
-            # Just don't log the integration_od and/or org_integration id if we can't the org_integration row
+            # Just don't log the integration_id and/or org_integration id if we can't the org_integration row
             pass
         return JiraApiClient(
             self.model.metadata["base_url"],

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -336,11 +336,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             self.model.metadata["base_url"],
             JiraCloud(self.model.metadata["shared_secret"]),
             verify_ssl=True,
-            logging_context={
-                "org_id": self.organization_id,
-                "integration_id": attrgetter("org_integration.integration.id")(self),
-                "org_integration_id": attrgetter("org_integration.id")(self),
-            },
+            logging_context=logging_context,
         )
 
     def get_issue(self, issue_id, **kwargs):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -326,12 +326,11 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
     def get_client(self):
         logging_context = {"org_id": self.organization_id}
-        try:
+
+        if self.organization_id is not None:
             logging_context["integration_id"] = attrgetter("org_integration.integration.id")(self)
             logging_context["org_integration_id"] = attrgetter("org_integration.id")(self)
-        except OrganizationIntegration.DoesNotExist:
-            # Just don't log the integration_id and/or org_integration id if we can't the org_integration row
-            pass
+
         return JiraApiClient(
             self.model.metadata["base_url"],
             JiraCloud(self.model.metadata["shared_secret"]),

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -325,6 +325,13 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return "\n".join(output)
 
     def get_client(self):
+        logging_context = {"org_id": self.organization_id}
+        try:
+            logging_context["integration_id"] = attrgetter("org_integration.integration.id")(self)
+            logging_context["org_integration_id"] = attrgetter("org_integration.id")(self)
+        except OrganizationIntegration.DoesNotExist:
+            # Just don't log the integration_od and/or org_integration id if we can't the org_integration row
+            pass
         return JiraApiClient(
             self.model.metadata["base_url"],
             JiraCloud(self.model.metadata["shared_secret"]),


### PR DESCRIPTION
We can still establish a JiraApiClient eithout an organization_id. If the
organization_id is None, then don't attempt to add integration_id and
org_integration_id to the logging context.

Fixes SENTRY-FBQ