### PR TITLE
fix(ui): Fetch all teams on lightweight org pageload

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -116,6 +116,12 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             else team_serializers.TeamSerializer
         )
 
+        get_all_teams = request.GET.get("all_teams") == "1"
+
+        if get_all_teams:
+            queryset = queryset.order_by("slug")
+            return Response(serialize(list(queryset), request.user, serializer()))
+
         return self.paginate(
             request=request,
             queryset=queryset,

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -116,7 +116,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             else team_serializers.TeamSerializer
         )
 
-        get_all_teams = request.GET.get("all_teams") == "1"
+        get_all_teams = request.GET.get("allTeams") == "1"
 
         if get_all_teams:
             queryset = queryset.order_by("slug")

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -70,7 +70,7 @@ async function fetchProjectsAndTeams(
         () =>
           uncancelableApi.requestPromise(`/organizations/${slug}/teams/`, {
             query: {
-              all_teams: 1,
+              allTeams: 1,
             },
           }),
         isInitialFetch

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -67,7 +67,12 @@ async function fetchProjectsAndTeams(
         slug,
         // This data should get preloaded in static/sentry/index.ejs
         // If this url changes make sure to update the preload
-        () => uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),
+        () =>
+          uncancelableApi.requestPromise(`/organizations/${slug}/teams/`, {
+            query: {
+              all_teams: 1,
+            },
+          }),
         isInitialFetch
       ),
     ]);

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -135,13 +135,13 @@ class OrganizationTeamsListTest(APITestCase):
     def test_all_teams(self):
         user = self.create_user()
         org = self.create_organization(owner=self.user)
-        team1 = self.create_team(organization=org, name="foo")
+        team = self.create_team(organization=org, name="foo")
         self.create_team(organization=org, name="bar")
 
-        self.create_member(organization=org, user=user, has_global_access=False, teams=[team1])
+        self.create_member(organization=org, user=user, has_global_access=False, teams=[team])
 
         # all_teams should override the per_page url param
-        path = f"/api/0/organizations/{org.slug}/teams/?all_teams=1&per_page=1"
+        path = f"/api/0/organizations/{org.slug}/teams/?allTeams=1&per_page=1"
 
         self.login_as(user=user)
 

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -132,6 +132,24 @@ class OrganizationTeamsListTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
 
+    def test_all_teams(self):
+        user = self.create_user()
+        org = self.create_organization(owner=self.user)
+        team1 = self.create_team(organization=org, name="foo")
+        self.create_team(organization=org, name="bar")
+
+        self.create_member(organization=org, user=user, has_global_access=False, teams=[team1])
+
+        # all_teams should override the per_page url param
+        path = f"/api/0/organizations/{org.slug}/teams/?all_teams=1&per_page=1"
+
+        self.login_as(user=user)
+
+        response = self.client.get(path)
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 2
+
 
 class OrganizationTeamsCreateTest(APITestCase):
     endpoint = "sentry-api-0-organization-teams"


### PR DESCRIPTION
This PR adds an option to the organization team endpoint to allow fetching of all teams within the org. This is necessary for when we first load into a lightweight organization page route as we need to populate the TeamStore with all teams. 

Otherwise the endpoint paginates the list of teams to just 100 sorted by slug. This has caused problems on the `Create Project` page where users will not be able to find their project if an org has over 100 teams.

more notes about this issue: https://www.notion.so/sentry/All-Project-Team-Instances-7ee0271b496648b0b760eb8a636d0286