### PR TITLE
feat(semver): Add support for sorting by `build_number` on org release endpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -32,6 +32,8 @@ from sentry.utils.compat.mock import patch
 
 
 class OrganizationReleaseListTest(APITestCase):
+    endpoint = "sentry-api-0-organization-releases"
+
     def test_simple(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization
@@ -133,6 +135,26 @@ class OrganizationReleaseListTest(APITestCase):
         assert response.data[0]["version"] == release8.version
         assert response.data[1]["version"] == release7.version
         assert response.data[2]["version"] == release6.version
+
+    def test_release_list_order_by_build_number(self):
+        """
+        Test that ensures that by relying on the default date sorting, releases
+        will only be sorted according to `Release.date_added`, and
+        `Release.date_released` should have no effect whatsoever on that order
+        """
+        self.login_as(user=self.user)
+        release_1 = self.create_release(version="test@1.2+1000")
+        release_2 = self.create_release(version="test@1.2+1")
+        release_3 = self.create_release(version="test@1.2+200")
+        self.create_release(version="test@1.2")
+        self.create_release(version="test@1.2+500alpha")
+
+        response = self.get_valid_response(self.organization.slug, sort="build")
+        assert [r["version"] for r in response.data] == [
+            release_1.version,
+            release_3.version,
+            release_2.version,
+        ]
 
     def test_query_filter(self):
         user = self.create_user(is_staff=False, is_superuser=False)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -137,11 +137,6 @@ class OrganizationReleaseListTest(APITestCase):
         assert response.data[2]["version"] == release6.version
 
     def test_release_list_order_by_build_number(self):
-        """
-        Test that ensures that by relying on the default date sorting, releases
-        will only be sorted according to `Release.date_added`, and
-        `Release.date_released` should have no effect whatsoever on that order
-        """
         self.login_as(user=self.user)
         release_1 = self.create_release(version="test@1.2+1000")
         release_2 = self.create_release(version="test@1.2+1")


### PR DESCRIPTION
We want the option to sort by `build_number` on the release page. This field will only be populated
for versions that match semver and contain a build code that is numeric. We'll filter out other rows
as part of this sort.