### PR TITLE
fix(ui): Add missing state property types to some components

### DIFF
--- a/static/app/components/issues/compactIssue.tsx
+++ b/static/app/components/issues/compactIssue.tsx
@@ -95,7 +95,7 @@ type State = {
 };
 
 class CompactIssue extends Component<Props, State> {
-  state = {
+  state: State = {
     issue: this.props.data || GroupStore.get(this.props.id),
   };
 

--- a/static/app/components/stream/groupCheckBox.tsx
+++ b/static/app/components/stream/groupCheckBox.tsx
@@ -14,7 +14,7 @@ type State = {
 };
 
 class GroupCheckBox extends Component<Props, State> {
-  state = {
+  state: State = {
     isSelected: SelectedGroupStore.isSelected(this.props.id),
   };
 

--- a/static/app/utils/withTags.tsx
+++ b/static/app/utils/withTags.tsx
@@ -19,7 +19,7 @@ function withTags<P extends InjectedTagsProps>(WrappedComponent: React.Component
   class WithTags extends React.Component<Omit<P, keyof InjectedTagsProps>, State> {
     static displayName = `withTags(${getDisplayName(WrappedComponent)})`;
 
-    state = {
+    state: State = {
       tags: TagStore.getAllTags(),
     };
 

--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -87,7 +87,7 @@ class ConnectedSettingsBreadcrumb extends Component<
   Omit<Props, 'pathMap'>,
   ConnectedState
 > {
-  state = {pathMap: SettingsBreadcrumbStore.getPathMap()};
+  state: ConnectedState = {pathMap: SettingsBreadcrumbStore.getPathMap()};
 
   componentWillUnmount() {
     this.unsubscribe();


### PR DESCRIPTION
some states had the right type like if it had just a boolean, but others created new union types and stuff.