### PR TITLE
feat(configurable-thresholds): Introduce an auto/number type to allow new apdex in discover

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -228,7 +228,9 @@ function incompatibleYAxis(eventView: EventView): boolean {
   }
 
   const isNumericParameter = aggregation.parameters.some(
-    param => param.kind === 'value' && param.dataType === 'number'
+    param =>
+      param.kind === 'value' &&
+      (param.dataType === 'number' || param.dataType === 'autoNumber')
   );
   // There are other measurements possible, but for the time being, only allow alerting
   // on the predefined set of measurements for alerts.

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -23,6 +23,7 @@ export type ColumnType =
   | 'string';
 
 export type ColumnValueType = ColumnType | 'never'; // Matches to nothing
+export type DataType = ColumnType | 'autoNumber';
 
 type ValidateColumnValueFunction = ({name: string, dataType: ColumnType}) => boolean;
 
@@ -37,7 +38,7 @@ export type AggregateParameter =
     }
   | {
       kind: 'value';
-      dataType: ColumnType;
+      dataType: DataType;
       defaultValue?: string;
       required: boolean;
     };
@@ -263,14 +264,16 @@ export const AGGREGATIONS = {
   },
   apdex: {
     generateDefaultValue({parameter, organization}: DefaultValueInputs) {
-      return organization.apdexThreshold?.toString() ?? parameter.defaultValue;
+      return organization.features.includes('project-transaction-threshold')
+        ? 'auto'
+        : organization.apdexThreshold?.toString() ?? parameter.defaultValue;
     },
     parameters: [
       {
         kind: 'value',
-        dataType: 'number',
+        dataType: 'autoNumber',
         defaultValue: '300',
-        required: true,
+        required: false,
       },
     ],
     outputType: 'number',
@@ -279,12 +282,14 @@ export const AGGREGATIONS = {
   },
   user_misery: {
     generateDefaultValue({parameter, organization}: DefaultValueInputs) {
-      return organization.apdexThreshold?.toString() ?? parameter.defaultValue;
+      return organization.features.includes('project-transaction-threshold')
+        ? 'auto'
+        : organization.apdexThreshold?.toString() ?? parameter.defaultValue;
     },
     parameters: [
       {
         kind: 'value',
-        dataType: 'number',
+        dataType: 'autoNumber',
         defaultValue: '300',
         required: true,
       },
@@ -310,7 +315,9 @@ export const AGGREGATIONS = {
       if (parameter.kind === 'column') {
         return 'user';
       }
-      return organization.apdexThreshold?.toString() ?? parameter.defaultValue;
+      return organization.features.includes('project-transaction-threshold')
+        ? 'auto'
+        : organization.apdexThreshold?.toString() ?? parameter.defaultValue;
     },
     parameters: [
       {
@@ -321,7 +328,7 @@ export const AGGREGATIONS = {
       },
       {
         kind: 'value',
-        dataType: 'number',
+        dataType: 'autoNumber',
         defaultValue: '300',
         required: true,
       },

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -273,7 +273,7 @@ export const AGGREGATIONS = {
         kind: 'value',
         dataType: 'autoNumber',
         defaultValue: '300',
-        required: false,
+        required: true,
       },
     ],
     outputType: 'number',

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -66,6 +66,11 @@ type State = {
   incompatibleAlertNotice: React.ReactNode;
 };
 const SHOW_TAGS_STORAGE_KEY = 'discover2:show-tags';
+const OMIT_SEARCH_TAGS = [
+  'apdex(auto)',
+  'user_misery(auto)',
+  'count_miserable(user,auto)',
+];
 
 function readShowTagsState() {
   const value = localStorage.getItem(SHOW_TAGS_STORAGE_KEY);
@@ -441,6 +446,7 @@ class Results extends React.Component<Props, State> {
                   fields={fields}
                   onSearch={this.handleSearch}
                   maxQueryLength={MAX_QUERY_LENGTH}
+                  omitTags={OMIT_SEARCH_TAGS}
                 />
                 <ResultsChart
                   router={router}

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -391,10 +391,10 @@ class QueryField extends React.Component<Props> {
             return (
               <BufferedInput
                 name="refinement"
-                key="parameter:number"
+                key="parameter:autoNumber"
                 type="text"
                 inputMode="numeric"
-                pattern="auto|aut|au|a|[0-9]*(\.[0-9]*)?"
+                pattern="auto|[0-9]*(\.[0-9]*)?"
                 {...inputProps}
               />
             );
@@ -630,9 +630,7 @@ class BufferedInput extends React.Component<InputProps, InputState> {
   };
 
   handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (this.isValid) {
-      this.setState({value: event.target.value});
-    }
+    this.setState({value: event.target.value});
   };
 
   render() {

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -57,6 +57,10 @@ describe('EventsV2 -> ColumnEditModal', function () {
     },
     {
       kind: 'function',
+      function: ['apdex', 'auto'],
+    },
+    {
+      kind: 'function',
       function: ['count_unique', 'issue.id'],
     },
   ];
@@ -260,6 +264,44 @@ describe('EventsV2 -> ColumnEditModal', function () {
       wrapper.find('Button[priority="primary"]').simulate('click');
       expect(onApply).toHaveBeenCalledWith([
         {kind: 'function', function: ['failure_rate', '', undefined]},
+      ]);
+    });
+  });
+
+  describe('handles auto fields', function () {
+    const initialDataAuto = initializeOrg({
+      organization: {
+        features: ['performance-view', 'project-transaction-threshold'],
+        apdexThreshold: 400,
+      },
+    });
+    let onApply, wrapper;
+    beforeEach(function () {
+      onApply = jest.fn();
+      wrapper = mountModal(
+        {
+          columns: [columns[0]],
+          onApply,
+          tagKeys,
+        },
+        initialDataAuto
+      );
+    });
+
+    it('handles scalar field parameters', function () {
+      selectByLabel(wrapper, 'apdex(\u2026)', {name: 'field', at: 0, control: true});
+
+      // Parameter select should display and use the default value.
+      const field = wrapper.find('QueryField input[name="refinement"]');
+      expect(field.props().value).toBe('auto');
+
+      // Trigger a blur and make sure the column is not wrong.
+      field.simulate('blur');
+
+      // Apply the changes so we can see the new columns.
+      wrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['apdex', '', undefined]},
       ]);
     });
   });


### PR DESCRIPTION
Allow the user to type auto or a number into the new
apdex, user misery and count miserable fields so they
may use project level thresholds in the Discover Saved
Query Column Editor Modal.

There is some general weirdness around the columnEditModal
that I've documented in this [ticket](https://getsentry.atlassian.net/jira/software/c/projects/VIS/boards/93/roadmap?selectedIssue=VIS-1070) that will be addressed in
a follow up PR since it exists independent of any changes
in here.