### PR TITLE
ref(spans): Refactor span search filtering to mobx

### DIFF
--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -33,13 +33,11 @@ type Props = {
 
 type State = {
   parsedTrace: ParsedTraceType;
-  searchQuery: string | undefined;
   waterfallModel: WaterfallModel;
 };
 
 class SpansInterface extends PureComponent<Props, State> {
   state: State = {
-    searchQuery: undefined,
     parsedTrace: parseTrace(this.props.event),
     waterfallModel: new WaterfallModel(this.props.event),
   };
@@ -57,9 +55,8 @@ class SpansInterface extends PureComponent<Props, State> {
   }
 
   handleSpanFilter = (searchQuery: string) => {
-    this.setState({
-      searchQuery: searchQuery || undefined,
-    });
+    const {waterfallModel} = this.state;
+    waterfallModel.querySpanSearch(searchQuery);
   };
 
   renderTraceErrorsAlert({
@@ -163,10 +160,10 @@ class SpansInterface extends PureComponent<Props, State> {
                 errors: quickTrace?.currentEvent?.errors,
                 parsedTrace,
               })}
-              <Search>
-                <Observer>
-                  {() => {
-                    return (
+              <Observer>
+                {() => {
+                  return (
+                    <Search>
                       <Filter
                         operationNameCounts={waterfallModel.operationNameCounts}
                         operationNameFilter={waterfallModel.operationNameFilters}
@@ -177,26 +174,25 @@ class SpansInterface extends PureComponent<Props, State> {
                           waterfallModel.toggleAllOperationNameFilters
                         }
                       />
-                    );
-                  }}
-                </Observer>
-                <StyledSearchBar
-                  defaultQuery=""
-                  query={this.state.searchQuery || ''}
-                  placeholder={t('Search for spans')}
-                  onSearch={this.handleSpanFilter}
-                />
-              </Search>
+                      <StyledSearchBar
+                        defaultQuery=""
+                        query={waterfallModel.searchQuery || ''}
+                        placeholder={t('Search for spans')}
+                        onSearch={this.handleSpanFilter}
+                      />
+                    </Search>
+                  );
+                }}
+              </Observer>
               <Panel>
                 <Observer>
                   {() => {
                     return (
                       <TraceView
                         event={event}
-                        searchQuery={this.state.searchQuery}
+                        waterfallModel={waterfallModel}
                         organization={organization}
                         parsedTrace={parsedTrace}
-                        operationNameFilters={waterfallModel.operationNameFilters}
                       />
                     );
                   }}

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 
 import {MessageRow} from 'app/components/performance/waterfall/messageRow';
 import {pickBarColour} from 'app/components/performance/waterfall/utils';
@@ -9,9 +10,10 @@ import {EventTransaction} from 'app/types/event';
 
 import {DragManagerChildrenProps} from './dragManager';
 import {ActiveOperationFilter} from './filter';
+import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
 import SpanGroup from './spanGroup';
-import {FilterSpans} from './traceView';
 import {
+  FilterSpans,
   GapSpanType,
   OrphanTreeDepth,
   ParsedTraceType,
@@ -40,7 +42,7 @@ type RenderedSpanTree = {
   numOfFilteredSpansAbove: number;
 };
 
-type PropType = {
+type PropType = ScrollbarManagerChildrenProps & {
   organization: Organization;
   trace: ParsedTraceType;
   dragProps: DragManagerChildrenProps;
@@ -57,6 +59,13 @@ class SpanTree extends React.Component<PropType> {
     }
 
     return true;
+  }
+
+  componentDidUpdate(prevProps: PropType) {
+    if (!isEqual(prevProps.filterSpans, this.props.filterSpans)) {
+      // Update horizontal scroll states after a search has been performed
+      this.props.updateScrollState();
+    }
   }
 
   generateInfoMessage(input: {
@@ -439,4 +448,4 @@ function hasAllSpans(trace: ParsedTraceType): boolean {
   return missingDuration < 0.1;
 }
 
-export default SpanTree;
+export default withScrollbarManager(SpanTree);

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -110,8 +110,10 @@ export type FilterSpans = {
   spanIDs: Set<string>;
 };
 
+type FuseKey = 'indexed' | 'tagKeys' | 'tagValues' | 'dataKeys' | 'dataValues';
+
 export type SpanFuseOptions = {
-  keys: ('indexed' | 'tagKeys' | 'tagValues' | 'dataKeys' | 'dataValues')[];
+  keys: FuseKey[];
   includeMatches: false;
   threshold: number;
   location: number;

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -90,3 +90,31 @@ export type OrphanTreeDepth = {
 };
 
 export type TreeDepthType = SpanTreeDepth | OrphanTreeDepth;
+
+export type IndexedFusedSpan = {
+  span: RawSpanType;
+  indexed: string[];
+  tagKeys: string[];
+  tagValues: string[];
+  dataKeys: string[];
+  dataValues: string[];
+};
+
+export type FuseResult = {
+  item: IndexedFusedSpan;
+  score: number;
+};
+
+export type FilterSpans = {
+  results: FuseResult[];
+  spanIDs: Set<string>;
+};
+
+export type SpanFuseOptions = {
+  keys: ('indexed' | 'tagKeys' | 'tagValues' | 'dataKeys' | 'dataValues')[];
+  includeMatches: false;
+  threshold: number;
+  location: number;
+  distance: number;
+  maxPatternLength: number;
+};

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -1,21 +1,33 @@
 import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 import {action, computed, makeObservable, observable} from 'mobx';
 
 import {EventTransaction} from 'app/types/event';
+import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 
 import {ActiveOperationFilter, noFilter, toggleAllFilters, toggleFilter} from './filter';
 import SpanTreeModel from './spanTreeModel';
-import {ParsedTraceType} from './types';
-import {generateRootSpan, parseTrace} from './utils';
+import {
+  FilterSpans,
+  FuseResult,
+  IndexedFusedSpan,
+  ParsedTraceType,
+  RawSpanType,
+  SpanFuseOptions,
+} from './types';
+import {generateRootSpan, getSpanID, parseTrace} from './utils';
 
 class WaterfallModel {
   // readonly state
   event: Readonly<EventTransaction>;
   rootSpan: SpanTreeModel;
   parsedTrace: ParsedTraceType;
+  fuse: Fuse<string, SpanFuseOptions> | undefined = undefined;
 
   // readable/writable state
   operationNameFilters: ActiveOperationFilter = noFilter;
+  filterSpans: FilterSpans | undefined = undefined;
+  searchQuery: string | undefined = undefined;
 
   constructor(event: Readonly<EventTransaction>) {
     this.event = event;
@@ -23,6 +35,8 @@ class WaterfallModel {
     this.parsedTrace = parseTrace(event);
     const rootSpan = generateRootSpan(this.parsedTrace);
     this.rootSpan = new SpanTreeModel(rootSpan, this.parsedTrace.childSpans);
+
+    this.indexSearch(this.parsedTrace, rootSpan);
 
     makeObservable(this, {
       rootSpan: observable,
@@ -32,6 +46,11 @@ class WaterfallModel {
       toggleOperationNameFilter: action,
       toggleAllOperationNameFilters: action,
       operationNameCounts: computed.struct,
+
+      // span search
+      filterSpans: observable,
+      searchQuery: observable,
+      querySpanSearch: action,
     });
   }
 
@@ -54,6 +73,110 @@ class WaterfallModel {
 
   get operationNameCounts(): Map<string, number> {
     return this.rootSpan.operationNameCounts;
+  }
+
+  async indexSearch(parsedTrace: ParsedTraceType, rootSpan: RawSpanType) {
+    this.filterSpans = undefined;
+    this.searchQuery = undefined;
+
+    const {spans} = parsedTrace;
+
+    const transformed: IndexedFusedSpan[] = [rootSpan, ...spans].map(
+      (span): IndexedFusedSpan => {
+        const indexed: string[] = [];
+
+        // basic properties
+
+        const pickedSpan = pick(span, [
+          // TODO: do we want this?
+          // 'trace_id',
+          'span_id',
+          'start_timestamp',
+          'timestamp',
+          'op',
+          'description',
+        ]);
+
+        const basicValues: string[] = Object.values(pickedSpan)
+          .filter(value => !!value)
+          .map(value => String(value));
+
+        indexed.push(...basicValues);
+
+        // tags
+
+        let tagKeys: string[] = [];
+        let tagValues: string[] = [];
+        const tags: {[tag_name: string]: string} | undefined = span?.tags;
+
+        if (tags) {
+          tagKeys = Object.keys(tags);
+          tagValues = Object.values(tags);
+        }
+
+        const data: {[data_name: string]: any} | undefined = span?.data ?? {};
+
+        let dataKeys: string[] = [];
+        let dataValues: string[] = [];
+        if (data) {
+          dataKeys = Object.keys(data);
+          dataValues = Object.values(data).map(
+            value => JSON.stringify(value, null, 4) || ''
+          );
+        }
+
+        return {
+          span,
+          indexed,
+          tagKeys,
+          tagValues,
+          dataKeys,
+          dataValues,
+        };
+      }
+    );
+
+    this.fuse = await createFuzzySearch(transformed, {
+      keys: ['indexed', 'tagKeys', 'tagValues', 'dataKeys', 'dataValues'],
+      includeMatches: false,
+      threshold: 0.6,
+      location: 0,
+      distance: 100,
+      maxPatternLength: 32,
+    });
+  }
+
+  querySpanSearch(searchQuery: string | undefined) {
+    if (!searchQuery) {
+      // reset
+      if (this.filterSpans !== undefined) {
+        this.filterSpans = undefined;
+        this.searchQuery = undefined;
+      }
+      return;
+    }
+
+    if (!this.fuse) {
+      return;
+    }
+
+    const results = this.fuse.search<FuseResult>(searchQuery);
+
+    const spanIDs: Set<string> = results.reduce((setOfSpanIDs: Set<string>, result) => {
+      const spanID = getSpanID(result.item.span);
+
+      if (spanID) {
+        setOfSpanIDs.add(spanID);
+      }
+
+      return setOfSpanIDs;
+    }, new Set<string>());
+
+    this.searchQuery = searchQuery;
+    this.filterSpans = {
+      results,
+      spanIDs,
+    };
   }
 }
 

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -160,4 +160,26 @@ describe('WaterfallModel', () => {
     waterfallModel.toggleAllOperationNameFilters();
     expect(waterfallModel.operationNameFilters).toEqual(noFilter);
   });
+
+  it('querySpanSearch', async () => {
+    const waterfallModel = new WaterfallModel(event);
+    expect(waterfallModel.fuse).toBe(undefined);
+
+    // Fuzzy search needs to be loaded asynchronously
+    // @ts-expect-error
+    await tick();
+
+    // expect fuse index to be created
+    expect(waterfallModel.fuse).not.toBe(undefined);
+
+    expect(waterfallModel.filterSpans).toBe(undefined);
+    expect(waterfallModel.searchQuery).toBe(undefined);
+
+    waterfallModel.querySpanSearch('GET /api/0/organizations/?member=1');
+
+    expect(Array.from(waterfallModel.filterSpans!.spanIDs).sort()).toEqual(
+      ['a453cc713e5baf9c', 'b23703998ae619e7'].sort()
+    );
+    expect(waterfallModel.searchQuery).toBe('GET /api/0/organizations/?member=1');
+  });
 });


### PR DESCRIPTION
This is a continuation of https://github.com/getsentry/sentry/pull/26495 .

This pull request moves the client-side span fuzzy search feature into mobx. This is necessary for the eventual delegation of the waterfall graph construction responsibility to the mobx states (i.e. `WaterfallModel` class).

Most of the changes are moved. But there are notable changes/fix:

- The scrollbar states are now re-calculated if the span tree has been filtered whenever a search query has been performed. Previously, it wasn't doing this.
- The fuse index is initialized once and re-used. Previously the index was re-created on every search query; which is not optimal. This is also an optimization opportunity for the trace details page; to be followed up in another pull request.
- There are now tests for the fuzzy span search. 