### PR TITLE
ref(search): Extract helper functions from complex SearchVisitor

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -8,6 +8,7 @@ from sentry.api.event_search import (
     SearchValue,
     SearchVisitor,
     event_search_grammar,
+    is_negated,
 )
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.group import STATUS_QUERY_CHOICES
@@ -70,7 +71,7 @@ class IssueSearchVisitor(SearchVisitor):
 
         search_key, search_value = self.is_filter_translators[search_value.raw_value]
 
-        operator = "!=" if self.is_negated(negation) else "="
+        operator = "!=" if is_negated(negation) else "="
 
         return SearchFilter(search_key, operator, search_value)
 


### PR DESCRIPTION
In an effor to make reading this already complicated AST visitor easier, I've removed all of the helper functions that really don't need to be part of the class