### PR TITLE
feat(semver): Add support for sorting by `semver` on org release endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -223,6 +223,10 @@ class OrganizationReleasesEndpoint(
         elif sort == "build":
             queryset = queryset.filter(build_number__isnull=False).order_by("-build_number")
             paginator_kwargs["order_by"] = "-build_number"
+        elif sort == "semver":
+            order_by = [f"-{col}" for col in Release.SEMVER_SORT_COLS]
+            queryset = queryset.annotate_prerelease_column().filter_to_semver().order_by(*order_by)
+            paginator_kwargs["order_by"] = order_by
         elif sort in self.SESSION_SORTS:
             if not flatten:
                 return Response(

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -151,6 +151,27 @@ class OrganizationReleaseListTest(APITestCase):
             release_2.version,
         ]
 
+    def test_release_list_order_by_semver(self):
+        self.login_as(user=self.user)
+        release_1 = self.create_release(version="test@2.2")
+        release_2 = self.create_release(version="test@10.0")
+        release_3 = self.create_release(version="test@2.2-alpha")
+        release_4 = self.create_release(version="test@2.2.3")
+        release_5 = self.create_release(version="test@2.20.3")
+        release_6 = self.create_release(version="test@2.20.3.3")
+        self.create_release(version="test@some_thing")
+        self.create_release(version="random_junk")
+
+        response = self.get_valid_response(self.organization.slug, sort="semver")
+        assert [r["version"] for r in response.data] == [
+            release_2.version,
+            release_6.version,
+            release_5.version,
+            release_4.version,
+            release_1.version,
+            release_3.version,
+        ]
+
     def test_query_filter(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.organization


### PR DESCRIPTION
We want to be able to sort releases by semver order on the release page. These fields will only be
populated for versions that match semver, and we'll filter out non-semver rows from the results when
using this sort.