### PR TITLE
ref(app-store-connect): update app Store connect frontend with backend changes

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1864,11 +1864,6 @@ urlpatterns = [
                     name="sentry-api-0-project-appstoreconnect-credentials-create",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
-                    AppStoreConnectUpdateCredentialsEndpoint.as_view(),
-                    name="sentry-api-0-project-appstoreconnect-credentials-update",
-                ),
-                url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/apps/$",
                     AppStoreConnectAppsEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-apps",
@@ -1892,6 +1887,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/2fa/$",
                     AppStoreConnect2FactorAuthEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-2fa",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
+                    AppStoreConnectUpdateCredentialsEndpoint.as_view(),
+                    name="sentry-api-0-project-appstoreconnect-credentials-update",
                 ),
             ]
         ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1893,11 +1893,6 @@ urlpatterns = [
                     AppStoreConnect2FactorAuthEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-2fa",
                 ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
-                    AppStoreConnectUpdateCredentialsEndpoint.as_view(),
-                    name="sentry-api-0-project-appstoreconnect-credentials-update",
-                ),
             ]
         ),
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1893,6 +1893,11 @@ urlpatterns = [
                     AppStoreConnect2FactorAuthEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-2fa",
                 ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
+                    AppStoreConnectUpdateCredentialsEndpoint.as_view(),
+                    name="sentry-api-0-project-appstoreconnect-credentials-update",
+                ),
             ]
         ),
     ),

--- a/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
+++ b/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
@@ -36,7 +36,12 @@ function UpdateAlert({api, Wrapper, isCompact, project, organization, className}
   }, []);
 
   async function checkPrompt() {
-    if (!project || !appStoreConnectContext || isDismissed) {
+    if (
+      !project ||
+      !appStoreConnectContext ||
+      !appStoreConnectContext.updateAlertMessage ||
+      isDismissed
+    ) {
       return;
     }
 
@@ -130,7 +135,12 @@ function UpdateAlert({api, Wrapper, isCompact, project, organization, className}
     );
   }
 
-  if (!project || !appStoreConnectContext || isDismissed) {
+  if (
+    !project ||
+    !appStoreConnectContext ||
+    !appStoreConnectContext.updateAlertMessage ||
+    isDismissed
+  ) {
     return null;
   }
 

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
@@ -33,16 +33,29 @@ import {
   StepTwoData,
 } from './types';
 
+type SessionContext = {
+  auth_key: string;
+  scnt: string;
+  session_id: string;
+};
+
+type ItunesRevalidationSessionContext = SessionContext & {
+  itunes_created: string;
+  itunes_person_id: string;
+  itunes_session: string;
+};
+
 type IntialData = {
   appId: string;
   appName: string;
   appconnectIssuer: string;
   appconnectKey: string;
   appconnectPrivateKey: string;
-  encrypted: string;
   id: string;
   itunesCreated: string;
   itunesPassword: string;
+  itunesPersonId: string;
+  itunesSession: string;
   itunesUser: string;
   name: string;
   orgId: number;
@@ -90,7 +103,9 @@ function AppStoreConnect({
   const [appStoreApps, setAppStoreApps] = useState<AppStoreApp[]>([]);
   const [appleStoreOrgs, setAppleStoreOrgs] = useState<AppleStoreOrg[]>([]);
   const [useSms, setUseSms] = useState(false);
-  const [sessionContext, setSessionContext] = useState('');
+  const [sessionContext, setSessionContext] = useState<SessionContext | undefined>(
+    undefined
+  );
 
   const [stepOneData, setStepOneData] = useState<StepOneData>({
     issuer: initialData?.appconnectIssuer,
@@ -205,7 +220,7 @@ function AppStoreConnect({
     }
   }
 
-  async function persistData(newSessionContext?: string) {
+  async function persistData(newSessionContext?: ItunesRevalidationSessionContext) {
     if (!stepTwoData.app || !stepFifthData.org || !stepThreeData.username) {
       return;
     }
@@ -242,7 +257,6 @@ function AppStoreConnect({
           sessionContext: newSessionContext ?? sessionContext,
         },
       });
-
       onSubmit(response);
     } catch (error) {
       setIsLoading(false);

--- a/static/app/views/settings/projectDebugFiles/externalSources/symbolSources.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/symbolSources.tsx
@@ -268,6 +268,7 @@ function SymbolSources({
         reloadPage();
       }
     } catch {
+      handleCloseImageDetailsModal();
       addErrorMessage(errorMessage);
     }
   }

--- a/static/app/views/settings/projectDebugFiles/externalSources/symbolSources.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/symbolSources.tsx
@@ -377,6 +377,7 @@ function SymbolSources({
           removeConfirm={{
             onConfirm: item => {
               if (item.type === 'appStoreConnect') {
+                handleCloseImageDetailsModal();
                 window.location.reload();
               }
             },


### PR DESCRIPTION
- Updates types
- Fixes a minor issue in the alert logic
- Moves the `/appstoreconnect/${id}/` endpoint to be after some other endpoints  