### PR TITLE
feat(ui): Add empty semver message to releases

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -269,6 +269,14 @@ class ReleasesList extends AsyncView<Props, State> {
       );
     }
 
+    if (activeSort === SortOption.BUILD || activeSort === SortOption.SEMVER) {
+      return (
+        <EmptyStateWarning small>
+          {t('There are no releases with semantic versioning.')}
+        </EmptyStateWarning>
+      );
+    }
+
     if (activeSort !== SortOption.DATE) {
       const relativePeriod = getRelativeSummary(
         statsPeriod || DEFAULT_STATS_PERIOD

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -132,6 +132,15 @@ describe('ReleasesList', function () {
     expect(wrapper.find('EmptyMessage').text()).toEqual(
       'There are no releases with active user data (users in the last 24 hours).'
     );
+
+    location = {query: {sort: SortOption.BUILD}};
+    wrapper = mountWithTheme(
+      <ReleasesList {...props} location={location} />,
+      routerContext
+    );
+    expect(wrapper.find('EmptyMessage').text()).toEqual(
+      'There are no releases with semantic versioning.'
+    );
   });
 
   it('searches for a release', function () {


### PR DESCRIPTION
When sorting by build/semver we filter out releases that do not match the format. 
Adding nicer empty message when filtering by build/semver.

Relates to https://github.com/getsentry/sentry/pull/26518, https://github.com/getsentry/sentry/pull/26540, https://github.com/getsentry/sentry/pull/26540