### PR TITLE
fix(search): Improve numeric grammar matching

### DIFF
--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -207,8 +207,8 @@ search_value
   = quoted_value / value
 
 numeric_value
-  = value:("-"? [0-9\.]+) unit:[kmb]? &(end_set / comma / closed_bracket) {
-      return tc.tokenValueNumber(value.flat().join(''), unit);
+  = value:("-"? numeric) unit:[kmb]? &(end_set / comma / closed_bracket) {
+      return tc.tokenValueNumber(value.join(''), unit);
     }
 
 boolean_value
@@ -244,15 +244,15 @@ rel_date_format
     }
 
 duration_format
-  = value:[0-9\.]+
+  = value:numeric
     unit:("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w")
     end_lookahead {
-      return tc.tokenValueDuration(value.join(''), unit);
+      return tc.tokenValueDuration(value, unit);
     }
 
 percentage_format
-  = value:[0-9\.]+ "%" {
-      return tc.tokenValuePercentage(value.join(''));
+  = value:numeric "%" {
+      return tc.tokenValuePercentage(value);
     }
 
 // NOTE: the order in which these operators are listed matters because for
@@ -260,6 +260,7 @@ percentage_format
 operator       = ">=" / "<=" / ">" / "<" / "=" / "!="
 or_operator    = "OR"i  &(" " / eol)
 and_operator   = "AND"i &(" " / eol)
+numeric        = [0-9]+ ("." [0-9]*)? { return text(); }
 open_paren     = "("
 closed_paren   = ")"
 open_bracket   = "["


### PR DESCRIPTION
The regex used for numbers was pretty forgiving `[0-9\.]` which includes numbers with multiple dots.

This constrains the grammar for numbers to only allow things that are _actually_ numbers.

This does cause some tests to change minorly since we not longer match weird things

---

I've also updated how duration and percentage formats are handled. The
tokens now produce tuples where the first element specifies what they
are. We do this so we can differentiate them from each other. This is a
tad easier than what we were doing before (checking the `expr_name`)
since we can do the transformation of each in the actual node visitor
(`visit_duration_format`, and `visit_percentage_format`).