### PR TITLE
feat(performance): Add tags for num of team key txns

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -25,6 +25,7 @@ from sentry.models import (
 from sentry.utils import auth
 from sentry.utils.compat import map
 from sentry.utils.hashlib import hash_values
+from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import bind_organization_context
 
 
@@ -311,10 +312,7 @@ class OrganizationEndpoint(Endpoint):
 
         len_projects = len(projects)
         sentry_sdk.set_tag("query.num_projects", len_projects)
-        sentry_sdk.set_tag(
-            "query.num_projects.grouped",
-            "<10" if len_projects < 10 else "<100" if len_projects < 100 else ">100",
-        )
+        sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
 
         params = {
             "start": start,

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -29,6 +29,7 @@ from sentry.api.serializers.models.event import get_tags_with_meta
 from sentry.eventstore.models import Event
 from sentry.models import Organization
 from sentry.snuba import discover
+from sentry.utils.numbers import format_grouped_length
 from sentry.utils.snuba import Dataset, SnubaQueryParams, bulk_raw_query
 from sentry.utils.validators import INVALID_EVENT_DETAILS, is_event_id
 
@@ -210,17 +211,6 @@ def child_sort_key(item: TraceEvent) -> List[int]:
         return [0]
 
 
-def group_length(length: int) -> str:
-    if length == 1:
-        return "1"
-    elif length < 10:
-        return "<10"
-    elif length < 100:
-        return "<100"
-    else:
-        return ">100"
-
-
 def query_trace_data(
     trace_id: str, params: Mapping[str, str]
 ) -> Tuple[Sequence[SnubaTransaction], Sequence[SnubaError]]:
@@ -345,14 +335,16 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):  # 
 
             sentry_sdk.set_tag("trace_view.trace", trace_id)
             sentry_sdk.set_tag("trace_view.transactions", len_transactions)
-            sentry_sdk.set_tag("trace_view.transactions.grouped", group_length(len_transactions))
+            sentry_sdk.set_tag(
+                "trace_view.transactions.grouped", format_grouped_length(len_transactions)
+            )
             projects: Set[int] = set()
             for transaction in transactions:
                 projects.add(transaction["project.id"])
 
             len_projects = len(projects)
             sentry_sdk.set_tag("trace_view.projects", len_projects)
-            sentry_sdk.set_tag("trace_view.projects.grouped", group_length(len_projects))
+            sentry_sdk.set_tag("trace_view.projects.grouped", format_grouped_length(len_projects))
 
     def get(self, request: HttpRequest, organization: Organization, trace_id: str) -> HttpResponse:
         if not self.has_feature(organization, request):

--- a/src/sentry/utils/numbers.py
+++ b/src/sentry/utils/numbers.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 BASE36_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 BASE32_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
@@ -73,3 +75,20 @@ def format_bytes(number, units=DEFAULT_UNITS, decimal_places=2):
         number /= block
         u += 1
     return ("{:.%df} {}" % (decimal_places,)).format(number, units[u])
+
+
+def format_grouped_length(length: int, steps: Optional[List[int]] = None) -> str:
+    if steps is None:
+        steps = [10, 100]
+
+    if length == 0:
+        return "0"
+
+    if length == 1:
+        return "1"
+
+    for step in steps:
+        if length < step:
+            return f"<{step}"
+
+    return f">{steps[-1]}"

--- a/tests/sentry/utils/test_numbers.py
+++ b/tests/sentry/utils/test_numbers.py
@@ -4,6 +4,7 @@ from sentry.utils.numbers import (
     base36_decode,
     base36_encode,
     format_bytes,
+    format_grouped_length,
 )
 
 
@@ -287,3 +288,13 @@ def test_format_bytes():
     assert format_bytes(3000000000000) == "2.73 TB"
 
     assert format_bytes(3000000000000, units=["B", "KB", "MB", "GB"]) == "2793.97 GB"
+
+
+def test_format_grouped_length():
+    assert format_grouped_length(0) == "0"
+    assert format_grouped_length(1) == "1"
+    assert format_grouped_length(2) == "<10"
+    assert format_grouped_length(10) == "<100"
+    assert format_grouped_length(50) == "<100"
+    assert format_grouped_length(100) == ">100"
+    assert format_grouped_length(25, [50]) == "<50"


### PR DESCRIPTION
Because there is a limit on the number of team key transactions we can query at
a time, this adds a tag to help us keep an eye on this.