### PR TITLE
feat(migrations) Add migration signal for getsentry to use

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.db import ProgrammingError, connections
 
 from sentry.runner.decorators import configuration
+from sentry.signals import cli_upgrade
 
 # List of migrations which we'll fake if we're coming from South
 DJANGO_MIGRATIONS = (
@@ -136,6 +137,11 @@ def _upgrade(interactive, traceback, verbosity, repair, with_nodestore):
         from sentry.runner import call_command
 
         call_command("sentry.runner.commands.repair.repair")
+
+    # Used in getsentry.
+    cli_upgrade.send_robust(
+        sender="cli", traceback=traceback, interactive=interactive, verbosity=verbosity
+    )
 
 
 @click.command()

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -114,6 +114,8 @@ issue_deleted = BetterSignal(providing_args=["group", "user", "delete_type"])
 
 monitor_failed = BetterSignal(providing_args=["monitor"])
 
+cli_upgrade = BetterSignal(providing_args=["interactive", "traceback", "verbosity"])
+
 # experiments
 join_request_created = BetterSignal(providing_args=["member"])
 join_request_link_viewed = BetterSignal(providing_args=["organization"])


### PR DESCRIPTION
Add a signal that is fired during `sentry upgrade`. This will allow saas sentry to hook in and run migrations on non-primary database clusters.

This approach felt simpler than trying to hook into `sentry.runner:cli` and splice in more commands before click runs.