### PR TITLE
ref(search): Bring backend / frontend grammar very-close to unison

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -57,7 +57,7 @@ class IssueSearchVisitor(SearchVisitor):
 
     def visit_is_filter(self, node, children):
         # the key is "is" here, which we don't need
-        negation, _, _, search_value = children
+        negation, _, _, _, search_value = children
 
         if search_value.raw_value.startswith("["):
             raise InvalidSearchQuery('"in" syntax invalid for "is" search')

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -121,13 +121,13 @@ aggregate_rel_date_filter
 
 // has filter for not null type checks
 has_filter
-  = negation:negation? &"has" key:search_key sep value:(search_key / search_value) {
+  = negation:negation? &"has:" key:search_key sep value:(search_key / search_value) {
       return tc.tokenFilter(FilterType.Has, key, value, TermOperator.Default, !!negation);
     }
 
 // is filter. Specific to issue search
 is_filter
-  = negation:negation? &"is" key:search_key sep value:search_value {
+  = negation:negation? &"is:" key:search_key sep value:search_value {
       return tc.tokenFilter(FilterType.Has, key, value, TermOperator.Default, !!negation);
     }
 
@@ -145,13 +145,13 @@ text_filter
 
 // Filter keys
 key
-  = value:[a-zA-Z0-9_\.-]+ {
+  = value:[a-zA-Z0-9_.-]+ {
       return tc.tokenKeySimple(value.join(''), false);
     }
 
 quoted_key
-  = '"' key:key '"' {
-      return tc.tokenKeySimple(key.value, true);
+  = '"' key:[a-zA-Z0-9_.:-]+ '"' {
+      return tc.tokenKeySimple(key.join(''), true);
     }
 
 explicit_tag_key
@@ -179,7 +179,7 @@ text_key
 // Filter values
 
 value
-  = value:[^() ]* {
+  = value:[^()\t\n ]* {
       return tc.tokenValueText(value.join(''), false);
     }
 
@@ -189,44 +189,61 @@ quoted_value
     }
 
 in_value
-  = (&in_value_termination [^(), ])* {
+  = (&in_value_termination in_value_char)+ {
         return tc.tokenValueText(text(), false);
     }
 
-// See: https://stackoverflow.com/a/39617181/790169
-in_value_termination
-  = [^(), ] (!in_value_terminator [^(), ])* in_value_terminator
-
-in_value_terminator
-  = closed_bracket / spaces comma
-
-text_value
+text_in_value
   = quoted_value / in_value
 
 search_value
   = quoted_value / value
 
 numeric_value
-  = value:("-"? numeric) unit:[kmb]? &(end_set / comma / closed_bracket) {
+  = value:("-"? numeric) unit:[kmb]? &(end_value / comma / closed_bracket) {
       return tc.tokenValueNumber(value.join(''), unit);
     }
 
 boolean_value
-  = value:("true"i / "1" / "false"i / "0") end_lookahead {
+  = value:("true"i / "1" / "false"i / "0") &end_value {
       return tc.tokenValueBoolean(value);
     }
 
 text_in_list
-  = open_bracket item1:text_value items:(spaces comma spaces text_value)* closed_bracket {
+  = open_bracket
+    item1:text_in_value
+    items:(spaces comma spaces text_in_value)*
+    closed_bracket
+    &end_value {
       return tc.tokenValueTextList(item1, items);
     }
 
 numeric_in_list
-  = open_bracket item1:numeric_value items:(spaces comma spaces numeric_value)* closed_bracket {
+  = open_bracket
+    item1:numeric_value
+    items:(spaces comma spaces numeric_value)*
+    closed_bracket
+    &end_value {
       return tc.tokenValueNumberList(item1, items);
     }
 
+// See: https://stackoverflow.com/a/39617181/790169
+in_value_termination
+  = in_value_char (!in_value_end in_value_char)* in_value_end
+
+in_value_char
+  = [^(), ]
+
+in_value_end
+  = closed_bracket / (spaces comma)
+
 // Format values
+
+// XXX: Since pegjs does not support regex there is no easy way to repeat
+// groups n times. So we have some dumb tokens here to handle that. We don't do
+// this in the backend grammar since we just use regex there.
+num2 = [0-9] [0-9]
+num4 = [0-9] [0-9] [0-9] [0-9]
 
 date_format = num4 "-" num2 "-" num2
 time_format = "T" num2 ":" num2 ":" num2 ("." ms_format)?
@@ -234,19 +251,19 @@ ms_format   = [0-9] [0-9]? [0-9]? [0-9]? [0-9]? [0-9]?
 tz_format   = [+-] num2 ":" num2
 
 iso_8601_date_format
-  = date_format time_format? ("Z" / tz_format)? end_lookahead {
+  = date_format time_format? ("Z" / tz_format)? &end_value {
       return tc.tokenValueIso8601Date(text());
     }
 
 rel_date_format
-  = sign:[+-] value:[0-9]+ unit:[wdhm] end_lookahead {
+  = sign:[+-] value:[0-9]+ unit:[wdhm] &end_value {
       return tc.tokenValueRelativeDate(value.join(''), sign, unit);
     }
 
 duration_format
   = value:numeric
     unit:("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w")
-    end_lookahead {
+    &end_value {
       return tc.tokenValueDuration(value, unit);
     }
 
@@ -258,8 +275,8 @@ percentage_format
 // NOTE: the order in which these operators are listed matters because for
 // example, if < comes before <= it will match that even if the operator is <=
 operator       = ">=" / "<=" / ">" / "<" / "=" / "!="
-or_operator    = "OR"i  &(" " / eol)
-and_operator   = "AND"i &(" " / eol)
+or_operator    = "OR"i  &end_value
+and_operator   = "AND"i &end_value
 numeric        = [0-9]+ ("." [0-9]*)? { return text(); }
 open_paren     = "("
 closed_paren   = ")"
@@ -269,10 +286,5 @@ sep            = ":"
 negation       = "!"
 comma          = ","
 spaces         = " "* { return tc.tokenSpaces(text()) }
-eol            = !.
-num            = [0-9]
-num2           = num num
-num4           = num num num num
 
-end_set = " " / "\\" / ")" / eol
-end_lookahead = &end_set
+end_value = [\t\n )] / !.


### PR DESCRIPTION
This changes (mostly the backend) grammar to more closely match the frontend.

This breaks apart a number of regex tokens to more closely match the frontend grammar, since pegjs only supports character classes, it inherently is a bit more verbose.