### PR TITLE
feat(notifications platform): Sort projects in fine tuning page

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
@@ -4,6 +4,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import Pagination from 'app/components/pagination';
 import {t} from 'app/locale';
 import {Project} from 'app/types';
+import {sortProjects} from 'app/utils';
 import {
   MIN_PROJECTS_FOR_PAGINATION,
   MIN_PROJECTS_FOR_SEARCH,
@@ -64,7 +65,7 @@ class NotificationSettingsByProjects extends AsyncComponent<Props, State> {
 
     return Object.fromEntries(
       Object.values(
-        groupByOrganization(stateProjects)
+        groupByOrganization(sortProjects(stateProjects))
       ).map(({organization, projects}) => [`${organization.name} Projects`, projects])
     );
   };


### PR DESCRIPTION
Use the `sortProjects` util to sort the projects in the notification settings fine tuning pages. 

**Before**:
<img width="959" alt="Screen Shot 2021-06-11 at 4 01 56 PM" src="https://user-images.githubusercontent.com/29959063/121756261-5b5fa280-cace-11eb-8096-d9e6880dd320.png">

**After**:
<img width="948" alt="Screen Shot 2021-06-11 at 4 02 49 PM" src="https://user-images.githubusercontent.com/29959063/121756298-79c59e00-cace-11eb-8aef-47f8b5a8ce0f.png">

