### PR TITLE
feat(semver): Add semver filtering to the issue list and discover

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -481,7 +481,7 @@ class SearchVisitor(NodeVisitor):
                 raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, search_value)
 
-        return self._handle_text_filter(search_key, operator, SearchValue(search_value.text))
+        return self._handle_text_filter(search_key, operator, SearchValue("".join(search_value)))
 
     def visit_date_filter(self, node, children):
         (search_key, _, operator, search_value) = children

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -49,6 +49,7 @@ from sentry.notifications.helpers import (
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.reprocessing2 import get_progress
+from sentry.search.events.constants import SEMVER_ALIAS
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
@@ -756,6 +757,10 @@ class GroupSerializerSnuba(GroupSerializerBase):
         "times_seen",
         "date",  # We merge this with start/end, so don't want to include it as its own
         # condition
+        # We don't need to filter by the semver query again here since we're
+        # filtering to specific groups. Saves us making a second query to
+        # postgres for no reason
+        SEMVER_ALIAS,
     }
 
     def __init__(

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -13,6 +13,7 @@ PROJECT_NAME_ALIAS = "project.name"
 ISSUE_ALIAS = "issue"
 ISSUE_ID_ALIAS = "issue.id"
 RELEASE_ALIAS = "release"
+SEMVER_ALIAS = "sentry.semver"
 
 TAG_KEY_RE = re.compile(r"^tags\[(?P<tag>.*)\]$")
 # Based on general/src/protocol/tags.rs in relay
@@ -54,6 +55,7 @@ SEARCH_MAP = {
     "first_seen": "first_seen",
     "last_seen": "last_seen",
     "times_seen": "times_seen",
+    SEMVER_ALIAS: SEMVER_ALIAS,
 }
 SEARCH_MAP.update(**DATASETS[Dataset.Events])
 SEARCH_MAP.update(**DATASETS[Dataset.Discover])

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -35,6 +35,7 @@ from sentry.search.events.constants import (
     PROJECT_ALIAS,
     PROJECT_NAME_ALIAS,
     RELEASE_ALIAS,
+    SEMVER_ALIAS,
     SEMVER_FAKE_PACKAGE,
     SEMVER_MAX_SEARCH_RELEASES,
     TEAM_KEY_TRANSACTION_ALIAS,
@@ -433,7 +434,7 @@ def parse_semver_search(
     else:
         # TODO: We want to parse partial strings like 1.*, etc. For now, we'll just
         # handle the basic case and fail otherwise
-        raise InvalidSearchQuery("Invalid format for semver query")
+        raise InvalidSearchQuery(f"Invalid format for semver query {version}")
 
 
 key_conversion_map: Mapping[
@@ -449,6 +450,7 @@ key_conversion_map: Mapping[
     "error.handled": _error_handled_filter_converter,
     KEY_TRANSACTION_ALIAS: _key_transaction_filter_converter,
     TEAM_KEY_TRANSACTION_ALIAS: _team_key_transaction_filter_converter,
+    SEMVER_ALIAS: parse_semver_search,
 }
 
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -100,6 +100,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         project_ids,
         environment_ids,
         sort_field,
+        organization_id,
         cursor=None,
         group_ids=None,
         limit=None,
@@ -132,7 +133,9 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 search_filter.key.name == "date"
             ):
                 continue
-            converted_filter = convert_search_filter_to_snuba_query(search_filter)
+            converted_filter = convert_search_filter_to_snuba_query(
+                search_filter, params={"organization_id": organization_id}
+            )
             converted_filter = self._transform_converted_filter(
                 search_filter, converted_filter, project_ids, environment_ids
             )
@@ -459,6 +462,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 end=end,
                 project_ids=[p.id for p in projects],
                 environment_ids=environments and [environment.id for environment in environments],
+                organization_id=projects[0].organization_id,
                 sort_field=sort_field,
                 cursor=cursor,
                 group_ids=group_ids,
@@ -606,6 +610,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 end=end,
                 project_ids=[p.id for p in projects],
                 environment_ids=environments and [environment.id for environment in environments],
+                organization_id=projects[0].organization_id,
                 sort_field=sort_field,
                 limit=sample_size,
                 offset=0,

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -139,8 +139,8 @@ text_in_filter
 
 // standard key:val filter
 text_filter
-  = negation:negation? key:text_key sep value:search_value {
-      return tc.tokenFilter(FilterType.Text, key, value, TermOperator.Default, !!negation);
+  = negation:negation? key:text_key sep op:operator? value:search_value {
+      return tc.tokenFilter(FilterType.Text, key, value, op, !!negation);
     }
 
 // Filter keys

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -15,6 +15,7 @@ from sentry.api.event_search import (
     parse_search_query,
 )
 from sentry.exceptions import InvalidSearchQuery
+from sentry.search.events.constants import SEMVER_ALIAS
 
 
 class ParseSearchQueryTest(unittest.TestCase):
@@ -902,6 +903,34 @@ class ParseSearchQueryTest(unittest.TestCase):
         assert parse_search_query("!user.id:1") == [
             SearchFilter(
                 key=SearchKey(name="user.id"), operator="!=", value=SearchValue(raw_value="1")
+            )
+        ]
+
+    def test_semver(self):
+        assert parse_search_query(f"{SEMVER_ALIAS}:>1.2.3") == [
+            SearchFilter(
+                key=SearchKey(name=SEMVER_ALIAS), operator=">", value=SearchValue(raw_value="1.2.3")
+            )
+        ]
+        assert parse_search_query(f"{SEMVER_ALIAS}:>1.2.3-hi") == [
+            SearchFilter(
+                key=SearchKey(name=SEMVER_ALIAS),
+                operator=">",
+                value=SearchValue(raw_value="1.2.3-hi"),
+            )
+        ]
+        assert parse_search_query(f"{SEMVER_ALIAS}:>=1.2.3-hi") == [
+            SearchFilter(
+                key=SearchKey(name=SEMVER_ALIAS),
+                operator=">=",
+                value=SearchValue(raw_value="1.2.3-hi"),
+            )
+        ]
+        assert parse_search_query(f"{SEMVER_ALIAS}:1.2.3-hi") == [
+            SearchFilter(
+                key=SearchKey(name=SEMVER_ALIAS),
+                operator="=",
+                value=SearchValue(raw_value="1.2.3-hi"),
             )
         ]
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -6,6 +6,7 @@ from sentry.discover.arithmetic import ArithmeticValidationError
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import ProjectTransactionThreshold
 from sentry.models.transaction_threshold import TransactionMetric
+from sentry.search.events.constants import SEMVER_ALIAS
 from sentry.snuba import discover
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -286,6 +287,67 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert data[0]["id"] == self.event.event_id
         assert data[0]["message"] == self.event.message
         assert "event_id" not in data[0]
+
+    def test_semver_condition(self):
+        release_1 = self.create_release(version="test@1.2.3")
+        release_2 = self.create_release(version="test@1.2.4")
+        release_3 = self.create_release(version="test@1.2.5")
+
+        release_1_e_1 = self.store_event(
+            data={"release": release_1.version},
+            project_id=self.project.id,
+        ).event_id
+        release_1_e_2 = self.store_event(
+            data={"release": release_1.version},
+            project_id=self.project.id,
+        ).event_id
+        release_2_e_1 = self.store_event(
+            data={"release": release_2.version},
+            project_id=self.project.id,
+        ).event_id
+        release_2_e_2 = self.store_event(
+            data={"release": release_2.version},
+            project_id=self.project.id,
+        ).event_id
+        release_3_e_1 = self.store_event(
+            data={"release": release_3.version},
+            project_id=self.project.id,
+        ).event_id
+        release_3_e_2 = self.store_event(
+            data={"release": release_3.version},
+            project_id=self.project.id,
+        ).event_id
+
+        result = discover.query(
+            selected_columns=["id"],
+            query=f"{SEMVER_ALIAS}:>1.2.3",
+            params={"project_id": [self.project.id], "organization_id": self.organization.id},
+        )
+        assert {r["id"] for r in result["data"]} == {
+            release_2_e_1,
+            release_2_e_2,
+            release_3_e_1,
+            release_3_e_2,
+        }
+        result = discover.query(
+            selected_columns=["id"],
+            query=f"{SEMVER_ALIAS}:>=1.2.3",
+            params={"project_id": [self.project.id], "organization_id": self.organization.id},
+        )
+        assert {r["id"] for r in result["data"]} == {
+            release_1_e_1,
+            release_1_e_2,
+            release_2_e_1,
+            release_2_e_2,
+            release_3_e_1,
+            release_3_e_2,
+        }
+        result = discover.query(
+            selected_columns=["id"],
+            query=f"{SEMVER_ALIAS}:<1.2.4",
+            params={"project_id": [self.project.id], "organization_id": self.organization.id},
+        )
+        assert {r["id"] for r in result["data"]} == {release_1_e_1, release_1_e_2}
 
     def test_latest_release_condition(self):
         result = discover.query(

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -758,27 +758,27 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         release_3 = self.create_release(version="test@1.2.5")
 
         release_1_e_1 = self.store_event(
-            data={"release": release_1.version},
+            data={"release": release_1.version, "timestamp": self.min_ago},
             project_id=self.project.id,
         ).event_id
         release_1_e_2 = self.store_event(
-            data={"release": release_1.version},
+            data={"release": release_1.version, "timestamp": self.min_ago},
             project_id=self.project.id,
         ).event_id
         release_2_e_1 = self.store_event(
-            data={"release": release_2.version},
+            data={"release": release_2.version, "timestamp": self.min_ago},
             project_id=self.project.id,
         ).event_id
         release_2_e_2 = self.store_event(
-            data={"release": release_2.version},
+            data={"release": release_2.version, "timestamp": self.min_ago},
             project_id=self.project.id,
         ).event_id
         release_3_e_1 = self.store_event(
-            data={"release": release_3.version},
+            data={"release": release_3.version, "timestamp": self.min_ago},
             project_id=self.project.id,
         ).event_id
         release_3_e_2 = self.store_event(
-            data={"release": release_3.version},
+            data={"release": release_3.version, "timestamp": self.min_ago},
             project_id=self.project.id,
         ).event_id
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -34,6 +34,7 @@ from sentry.models import (
     add_group_to_inbox,
     remove_group_from_inbox,
 )
+from sentry.search.events.constants import SEMVER_ALIAS
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -1098,6 +1099,84 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         assert response.status_code == 200
         assert len(response.data) == 0
+
+    def test_semver(self):
+        release_1 = self.create_release(version="test@1.2.3")
+        release_2 = self.create_release(version="test@1.2.4")
+        release_3 = self.create_release(version="test@1.2.5")
+
+        release_1_g_1 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=1)),
+                "fingerprint": ["group-1"],
+                "release": release_1.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_1_g_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=2)),
+                "fingerprint": ["group-2"],
+                "release": release_1.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_2_g_1 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=3)),
+                "fingerprint": ["group-3"],
+                "release": release_2.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_2_g_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=4)),
+                "fingerprint": ["group-4"],
+                "release": release_2.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_3_g_1 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=5)),
+                "fingerprint": ["group-5"],
+                "release": release_3.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        release_3_g_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=6)),
+                "fingerprint": ["group-6"],
+                "release": release_3.version,
+            },
+            project_id=self.project.id,
+        ).group.id
+        self.login_as(user=self.user)
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:>1.2.3")
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.json()] == [
+            release_2_g_1,
+            release_2_g_2,
+            release_3_g_1,
+            release_3_g_2,
+        ]
+
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:>=1.2.3")
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.json()] == [
+            release_1_g_1,
+            release_1_g_2,
+            release_2_g_1,
+            release_2_g_2,
+            release_3_g_1,
+            release_3_g_2,
+        ]
+
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:<1.2.4")
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.json()] == [release_1_g_1, release_1_g_2]
 
     def test_aggregate_stats_regression_test(self):
         self.store_event(


### PR DESCRIPTION
This hooks up `parse_semver_search` into our `key_conversion_map`, which allows semver searching to
be used throughout the codebase. The one caveat here is that we require `params` to be passed with
an `organization_id` key, which isn't always done. We'll probably need to retroactively fix this, or
maybe even just pass `organization_id` around explicitly.

This also modifies the search grammar to allow for text fields with an operator, and restricts this
to only the SEMVER alias. Since semver values like `1.23` look like a decimal, we need to handle
these correctly in `visit_numeric_filter` as well, so I've moved this logic into
`_handle_text_filter` so that it can be shared, rather than calling `visit` functions directly,
which is typically fairly fragile.

The remainder of changes to this pr are just making sure we pass `params` correctly, then a bunch of
tests to make sure semver is working in various places.