### PR TITLE
feat(api): Adds Crash free rate + `hasHealthData` check to `OrganizationProjectsEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -102,11 +102,13 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
             def serialize_on_result(result):
                 transaction_stats = request.GET.get("transactionStats")
+                session_stats = request.GET.get("sessionStats")
                 environment_id = self._get_environment_id_from_request(request, organization.id)
                 serializer = ProjectSummarySerializer(
                     environment_id=environment_id,
                     stats_period=stats_period,
                     transaction_stats=transaction_stats,
+                    session_stats=session_stats,
                     collapse=collapse,
                 )
                 return serialize(result, request.user, serializer)

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytz
 
@@ -14,6 +14,7 @@ from sentry.snuba.sessions import (
     get_release_health_data_overview,
     get_release_sessions_time_bounds,
 )
+from sentry.utils.dates import to_timestamp
 from sentry.testutils import SnubaTestCase, TestCase
 
 
@@ -25,6 +26,26 @@ def format_timestamp(dt):
 
 def make_24h_stats(ts):
     return _make_stats(datetime.utcfromtimestamp(ts).replace(tzinfo=pytz.utc), 3600, 24)
+
+
+def generate_session_default_args(session_dict):
+    session_dict_default = {
+        "session_id": str(uuid.uuid4()),
+        "distinct_id": str(uuid.uuid4()),
+        "status": "ok",
+        "seq": 0,
+        "release": "random@1.0",
+        "environment": "prod",
+        "retention_days": 90,
+        "org_id": 0,
+        "project_id": 0,
+        "duration": 60.0,
+        "errors": 0,
+        "started": time.time() // 60 * 60,
+        "received": time.time(),
+    }
+    session_dict_default.update(session_dict)
+    return session_dict_default
 
 
 class SnubaSessionsTest(TestCase, SnubaTestCase):
@@ -119,6 +140,55 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             [(self.project.id, self.session_release), (self.project.id, "dummy-release")]
         )
         assert data == {(self.project.id, self.session_release)}
+
+    def test_check_has_health_data_without_releases_should_exlude_sessions_gt_90_days(self):
+        """
+        Test that ensures that `check_has_health_data` returns a set of projects that has health
+        data within the last 90d if only a list of project ids is provided and that any project
+        with session data older than 90 days should be exluded
+        """
+        project2 = self.create_project(
+            name="Bar2", slug="bar2", teams=[self.team], fire_project_created=True,
+            organization=self.organization
+        )
+
+        date_100_days_ago = \
+            to_timestamp((datetime.utcnow() - timedelta(days=100)).replace(tzinfo=pytz.utc))
+        self.store_session(
+            generate_session_default_args({
+                "started": date_100_days_ago // 60 * 60,
+                "received": date_100_days_ago,
+                "project_id": project2.id,
+                "org_id": project2.organization_id,
+                "status": "exited"
+            })
+        )
+        data = check_has_health_data(
+            [self.project.id, project2.id]
+        )
+        assert data == {self.project.id}
+
+    def test_check_has_health_data_without_releases_should_include_sessions_lte_90_days(self):
+        """
+        Test that ensures that `check_has_health_data` returns a set of projects that has health
+        data within the last 90d if only a list of project ids is provided and any project with
+        session data earlier than 90 days should be included
+        """
+        project2 = self.create_project(
+            name="Bar2", slug="bar2", teams=[self.team], fire_project_created=True,
+            organization=self.organization
+        )
+        self.store_session(
+            generate_session_default_args({
+                "project_id": project2.id,
+                "org_id": project2.organization_id,
+                "status": "exited"
+            })
+        )
+        data = check_has_health_data(
+            [self.project.id, project2.id]
+        )
+        assert data == {self.project.id, project2.id}
 
     def test_get_project_releases_by_stability(self):
         # Add an extra session with a different `distinct_id` so that sorting by users
@@ -456,26 +526,6 @@ class SnubaReleaseDetailPaginationBaseTestClass:
         adjacent_releases = get_adjacent_releases_based_on_adoption(**adj_releases_filters)
         assert adjacent_releases == releases_list
 
-    @staticmethod
-    def generate_session_default_args(session_dict):
-        session_dict_default = {
-            "session_id": str(uuid.uuid4()),
-            "distinct_id": str(uuid.uuid4()),
-            "status": "ok",
-            "seq": 0,
-            "release": "random@1.0",
-            "environment": "prod",
-            "retention_days": 90,
-            "org_id": 0,
-            "project_id": 0,
-            "duration": 60.0,
-            "errors": 0,
-            "started": time.time() // 60 * 60,
-            "received": time.time(),
-        }
-        session_dict_default.update(session_dict)
-        return session_dict_default
-
 
 class SnubaReleaseDetailPaginationOnSessionsTest(
     TestCase, SnubaTestCase, SnubaReleaseDetailPaginationBaseTestClass
@@ -527,7 +577,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
         # Time: < 24h
         # Total: 1 Session
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -542,7 +592,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
         # Total: 2 sessions
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started_gt_24h,
@@ -556,7 +606,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
         # Time: < 24h
         # Total: 1 Session
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -572,7 +622,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
         # Time: < 24h
         # Total: 2 Sessions
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -584,7 +634,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -597,7 +647,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -613,7 +663,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
         # Total: 3 Session
         for _ in range(0, 3):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -629,7 +679,7 @@ class SnubaReleaseDetailPaginationOnSessionsTest(
         # Total: 3 Sessions
         for _ in range(0, 3):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -788,7 +838,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         # Time: < 24h
         # Total: 1 Session -> 100% Crash Free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -803,7 +853,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         # Total: 3 sessions -> 1 Healthy + 2 Crashed -> 33.3333% Crash Free
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started_gt_24h,
@@ -817,7 +867,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         # Time: < 24h
         # Total: 1 Session -> 0% Crash Free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -833,7 +883,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         # Time: < 24h
         # Total: 2 Sessions -> 2 Crashed -> 0% Crash free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -845,7 +895,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -858,7 +908,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -873,7 +923,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         # Time: <24h
         # Total: 3 Session -> 2 Healthy + 1 Crashed -> 66.666% Crash free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -884,7 +934,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         )
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -899,7 +949,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         # Time: <24h
         # Total: 3 Sessions -> 2 Healthy + 1 Crashed -> 66.666% Crash free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -910,7 +960,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeSessionsTest(
         )
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -1060,7 +1110,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         # Time: < 24h
         # Total: 1 Session
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1075,7 +1125,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         # Total: 2 sessions
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started_gt_24h,
@@ -1089,7 +1139,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         # Time: < 24h
         # Total: 1 Session
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1105,7 +1155,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         # Time: < 24h
         # Total: 2 Sessions
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1117,7 +1167,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1131,7 +1181,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         )
 
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1147,7 +1197,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         # Total: 3 Session
         for _ in range(0, 3):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -1163,7 +1213,7 @@ class SnubaReleaseDetailPaginationOnUsersTest(
         # Total: 3 Sessions
         for _ in range(0, 3):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -1313,7 +1363,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         # Time: < 24h
         # Total: 1 Session -> 100% Crash Free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1328,7 +1378,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         # Total: 3 sessions -> 1 Healthy + 2 Crashed -> 33.3333% Crash Free
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started_gt_24h,
@@ -1341,7 +1391,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         # Time: < 24h
         # Total: 1 Session -> 0% Crash Free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1357,7 +1407,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         # Time: < 24h
         # Total: 2 Sessions -> 2 Crashed -> 0% Crash free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1369,7 +1419,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1382,7 +1432,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
             )
         )
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1397,7 +1447,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         # Time: <24h
         # Total: 3 Session -> 2 Healthy + 1 Crashed -> 66.666% Crash free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1408,7 +1458,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         )
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,
@@ -1423,7 +1473,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         # Time: <24h
         # Total: 3 Sessions -> 2 Healthy + 1 Crashed -> 66.666% Crash free
         self.store_session(
-            self.generate_session_default_args(
+            generate_session_default_args(
                 {
                     **self.common_session_args,
                     "started": self.session_started,
@@ -1434,7 +1484,7 @@ class SnubaReleaseDetailPaginationOnCrashFreeUsersTest(
         )
         for _ in range(0, 2):
             self.store_session(
-                self.generate_session_default_args(
+                generate_session_default_args(
                     {
                         **self.common_session_args,
                         "started": self.session_started,


### PR DESCRIPTION
This PR:-
- Modifies `check_has_health_data` to also accept only `projects` rather than project_release and thereby return if a project has health data in the last 90 days
- Modifies `OrganizationProjectsEndpoint` to accept `sessionStats` argument which if set, returns the `currentCrashFreeRate` and `previousCrashFreeRate` based on the `statsPeriod` provided + `hasHealthData` for that specific project
- Modifies the `ProjectSerializer` to return the Session stats mentioned in the previous point

#sync-getsentry