### PR TITLE
fix(serializer): Changes start interval to be non inclusive in a 24h period

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -294,8 +294,8 @@ class ProjectSerializer(Serializer):
         segments, interval = STATS_PERIOD_CHOICES[self.stats_period]
 
         now = timezone.now()
-        current_interval_start = now - (segments * interval)
-        previous_interval_start = now - (2 * segments * interval)
+        current_interval_start = now - ((segments - 1) * interval)
+        previous_interval_start = now - (2 * (segments - 1) * interval)
 
         project_health_data_dict = get_current_and_previous_crash_free_rates(
             project_ids=project_ids,


### PR DESCRIPTION
This PR:
- Changes start interval to be non inclusive for the first hour of a 24h period when retrieving `sessionStats` like the following -> 
https://github.com/getsentry/sentry/blob/41463266544fbe1bf62484a38e4636f889f75ae5/src/sentry/api/serializers/models/project.py#L263