### PR TITLE
ref(device-context): Remove sentry capture error from getFullLanguageDescription

### DIFF
--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import moment from 'moment-timezone';
 
 import {t} from 'app/locale';
@@ -92,8 +91,7 @@ export function getFullLanguageDescription(locale: string) {
     }
 
     return languageName;
-  } catch (error) {
-    Sentry.captureException(error);
+  } catch {
     return locale;
   }
 }


### PR DESCRIPTION
`Intl. DisplayNames` is only supported by some browsers after a determinate version and as we are getting quite some annoying errors, it's better to remove `Sentry.captureException(error)`;