### PR TITLE
fix(files): Allow calling putfile() repeatedly

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -406,7 +406,10 @@ class File(Model):
             blob_fileobj = ContentFile(contents)
             blob = FileBlob.from_file(blob_fileobj, logger=logger)
 
-            results.append(FileBlobIndex.objects.create(file=self, blob=blob, offset=offset))
+            index, _created = FileBlobIndex.objects.get_or_create(
+                file=self, blob=blob, offset=offset
+            )
+            results.append(index)
             offset += blob.size
         self.size = offset
         self.checksum = checksum.hexdigest()


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/26529 we introduce an index
file per release+dist which is updated every time the user uploads or
deletes release artifacts.

During testing I noticed that because of blob
deduplication, the current implementation of `File.putfile()` raises an
IntegrityError when writing the same content twice (because of blob
deduplication). This would happen to the index file when a user uploads,
deletes, and then uploads the same file again.

An alternative solution to this PR would be to create a new `File`
instance for every update.