### PR TITLE
fix(transaction-summary): Do not pass project to issue search query

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -574,6 +574,8 @@ export const TRACING_FIELDS = [
   'user_misery',
   'eps',
   'epm',
+  'key_transaction',
+  'team_key_transaction',
   ...Object.keys(MEASUREMENTS),
 ];
 

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -55,9 +55,11 @@ class RelatedIssues extends Component<Props> {
     });
     currentFilter.addQuery('is:unresolved').setTagValues('transaction', [transaction]);
 
-    // Filter out key_transaction from being passed to issues as it will cause an error.
-    currentFilter.removeTag('key_transaction');
-    currentFilter.removeTag('team_key_transaction');
+    // Filter out these search terms from being passed to issues as they will cause an error.
+    currentFilter
+      .removeTag('key_transaction')
+      .removeTag('team_key_transaction')
+      .removeTag('project');
 
     return {
       path: `/organizations/${organization.slug}/issues/`,

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -48,18 +48,15 @@ class RelatedIssues extends Component<Props> {
         // transaction event fields
         TRACING_FIELDS.includes(tagKey) ||
         // event type can be "transaction" but we're searching for issues
-        tagKey === 'event.type'
+        tagKey === 'event.type' ||
+        // the project is already determined by the transaction,
+        // and issue search does not support the project filter
+        tagKey === 'project'
       ) {
         currentFilter.removeTag(tagKey);
       }
     });
     currentFilter.addQuery('is:unresolved').setTagValues('transaction', [transaction]);
-
-    // Filter out these search terms from being passed to issues as they will cause an error.
-    currentFilter
-      .removeTag('key_transaction')
-      .removeTag('team_key_transaction')
-      .removeTag('project');
 
     return {
       path: `/organizations/${organization.slug}/issues/`,


### PR DESCRIPTION
Issue search currently does not support the project filter in the search syntax.
This filters out the project tag from the filter since the project is already
specified in the project param in the related issues query.