### PR TITLE
fix(arithmetic): Prevent single term arithmetic

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -155,7 +155,8 @@ class ArithmeticVisitor(NodeVisitor):
 
     def __init__(self, max_operators):
         super().__init__()
-        self.operators = 0
+        self.operators: int = 0
+        self.terms: int = 0
         self.max_operators = max_operators if max_operators else self.DEFAULT_MAX_OPERATORS
         self.fields: set[str] = set()
         self.functions: set[str] = set()
@@ -214,7 +215,8 @@ class ArithmeticVisitor(NodeVisitor):
         return self.strip_spaces(children)
 
     def visit_primary(self, _, children):
-        # Return the 0th element since this is a (numeric/field)
+        # Return the 0th element since this is a (numeric/function/field)
+        self.terms += 1
         return self.strip_spaces(children)[0]
 
     @staticmethod
@@ -266,6 +268,8 @@ def parse_arithmetic(
     result = visitor.visit(tree)
     if len(visitor.fields) > 0 and len(visitor.functions) > 0:
         raise ArithmeticValidationError("Cannot mix functions and fields in arithmetic")
+    if visitor.terms == 1:
+        raise ArithmeticValidationError("Need at least 2 terms to do math")
     return result, list(visitor.fields), list(visitor.functions)
 
 

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -269,7 +269,7 @@ def parse_arithmetic(
     if len(visitor.fields) > 0 and len(visitor.functions) > 0:
         raise ArithmeticValidationError("Cannot mix functions and fields in arithmetic")
     if visitor.terms <= 1:
-        raise ArithmeticValidationError("Need at least 2 terms to do math")
+        raise ArithmeticValidationError("Arithmetic expression must contain at least 2 terms")
     return result, list(visitor.fields), list(visitor.functions)
 
 

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -268,7 +268,7 @@ def parse_arithmetic(
     result = visitor.visit(tree)
     if len(visitor.fields) > 0 and len(visitor.functions) > 0:
         raise ArithmeticValidationError("Cannot mix functions and fields in arithmetic")
-    if visitor.terms == 1:
+    if visitor.terms <= 1:
         raise ArithmeticValidationError("Need at least 2 terms to do math")
     return result, list(visitor.fields), list(visitor.functions)
 

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -17,11 +17,6 @@ op_map = {
 }
 
 
-def test_single_term():
-    result, _, _ = parse_arithmetic("12")
-    assert result == 12.0
-
-
 @pytest.mark.parametrize(
     "a,op,b",
     [
@@ -219,6 +214,10 @@ def test_unparseable_arithmetic(equation):
         "last_seen() + 1",
         # Mixing fields/functions is invalid
         "p50(transaction.duration) + transaction.duration",
+        # Single fields are invalid cause there's no reason to use arithmetic for them
+        "12",
+        "p50(transaction.duration)",
+        "measurements.lcp",
     ],
 )
 def test_invalid_arithmetic(equation):

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -196,6 +196,8 @@ def test_function_values(a, op, b):
         "1 ** 2",
         "1 -- 1",
         "hello world",
+        "",
+        "+",
     ],
 )
 def test_unparseable_arithmetic(equation):


### PR DESCRIPTION
- Fixes SENTRY-QQP
- This prevents single term arithmetic, which is equivalent to just a
  single field/function, while we could still construct a valid query
  from this, I think users should use the fields for this instead since
  we can provide a better user experience that way