### PR TITLE
fix(discover): Allow 0ms satisfaction threshold

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -660,7 +660,7 @@ def resolve_function(field, match=None, params=None, functions_acl=False):
         if alias is None:
             alias = get_function_alias_with_columns(function.name, columns)
 
-        if arguments[condition.arg]:
+        if arguments[condition.arg] is not None:
             snuba_string = match.format(**arguments)
         else:
             snuba_string = fallback.format(**arguments)
@@ -1417,7 +1417,9 @@ FUNCTIONS = {
             calculated_args=[
                 {
                     "name": "tolerated",
-                    "fn": lambda args: args["satisfaction"] * 4.0 if args["satisfaction"] else None,
+                    "fn": lambda args: args["satisfaction"] * 4.0
+                    if args["satisfaction"] is not None
+                    else None,
                 }
             ],
             conditional_transform=ConditionalFunction(
@@ -1456,7 +1458,9 @@ FUNCTIONS = {
             calculated_args=[
                 {
                     "name": "tolerated",
-                    "fn": lambda args: args["satisfaction"] * 4.0 if args["satisfaction"] else None,
+                    "fn": lambda args: args["satisfaction"] * 4.0
+                    if args["satisfaction"] is not None
+                    else None,
                 },
                 {"name": "parameter_sum", "fn": lambda args: args["alpha"] + args["beta"]},
             ],

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1147,6 +1147,40 @@ class QueryTransformTest(TestCase):
         )
 
     @patch("sentry.snuba.discover.raw_query")
+    def test_apdex_allows_zero_threshold(self, mock_query):
+        mock_query.return_value = {
+            "meta": [{"name": "transaction"}, {"name": "apdex_0"}],
+            "data": [{"transaction": "api.do_things", "apdex_0": 15}],
+        }
+        discover.query(
+            selected_columns=["transaction", "apdex(0)"],
+            query="",
+            params={"project_id": [self.project.id]},
+            auto_fields=True,
+        )
+        mock_query.assert_called_with(
+            selected_columns=["transaction"],
+            aggregations=[
+                [
+                    "apdex(duration, 0)",
+                    None,
+                    "apdex_0",
+                ],
+            ],
+            filter_keys={"project_id": [self.project.id]},
+            dataset=Dataset.Discover,
+            groupby=["transaction"],
+            conditions=[],
+            end=None,
+            start=None,
+            orderby=None,
+            having=[],
+            limit=50,
+            offset=None,
+            referrer=None,
+        )
+
+    @patch("sentry.snuba.discover.raw_query")
     def test_selected_columns_project_threshold_config_alias_no_configured_thresholds(
         self, mock_query
     ):


### PR DESCRIPTION
The conditional transform (currently only used for
apdex, user_miser and count_miserable) defaults
to None when value not specified. So explicitly
check for None when determining which equations
to use so that user may specify a 0ms satisfaction
threshold.

Screenshot:
![Screen Shot 2021-06-14 at 3 42 47 PM](https://user-images.githubusercontent.com/63818634/121950144-416ccc80-cd27-11eb-9b5d-ab38310d3205.png)


Fixes SENTRY-PXR