### PR TITLE
fix(arithmetic): removing equation from autocomplete/yaxis

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -16,6 +16,7 @@ import {
   Field,
   FIELD_TAGS,
   isAggregateField,
+  isEquation,
   isMeasurement,
   TRACING_FIELDS,
 } from 'app/utils/discover/fields';
@@ -101,7 +102,10 @@ class SearchBar extends React.PureComponent<SearchBarProps> {
     const functionTags = fields
       ? Object.fromEntries(
           fields
-            .filter(item => !Object.keys(FIELD_TAGS).includes(item.field))
+            .filter(
+              item =>
+                !Object.keys(FIELD_TAGS).includes(item.field) && !isEquation(item.field)
+            )
             .map(item => [item.field, {key: item.field, name: item.field}])
         )
       : {};

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1157,7 +1157,10 @@ class EventView {
     return uniqBy(
       this.getAggregateFields()
         // Only include aggregates that make sense to be graphable (eg. not string or date)
-        .filter((field: Field) => isLegalYAxisType(aggregateOutputType(field.field)))
+        .filter(
+          (field: Field) =>
+            isLegalYAxisType(aggregateOutputType(field.field)) && !isEquation(field.field)
+        )
         .map((field: Field) => ({label: field.field, value: field.field}))
         .concat(CHART_AXIS_OPTIONS),
       'value'


### PR DESCRIPTION
- Equations were showing up in autocomplete and the y-axis even though
  they're not currently supported in either, but because they're in the
  list of fields were being picked up by these two things