### PR TITLE
py38: bump django-sudo to django2.2 + python3.8 compatible version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,7 +10,7 @@ datadog==0.29.3
 django-crispy-forms==1.7.2
 django-manifest-loader==1.0.0
 django-picklefield==1.0.0
-django-sudo==3.1.0
+django-sudo @ https://github.com/getsentry/django-sudo/archive/c3d871ec66d8d1169c8cd4b2edd8402c6b39ab78.zip#egg=django-sudo
 Django==1.11.29
 djangorestframework==3.11.2
 email-reply-parser==0.5.12


### PR DESCRIPTION
I tested it to locally work. See also https://github.com/getsentry/django-sudo/pull/1. Two parts.

One, the SudoRequired SentryAPIException -> frontend modal (tests our own  sudo_required decorator for various API endpoints):

- login, see the `sudo` cookie set
- remove the cookie
- visit /settings/account/security/session-history/ and seeing the popup
- see that the cookie is restored

Two, the server-rendered redirect view

- put sudo_required = True on ReactPageView bc i'm lazy
- refreshed various pages and it works
