### PR TITLE
 ref(breakdowns): Rename keys in span operation breakdown config

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -70,7 +70,7 @@ register(
     epoch_defaults={
         1: {
             "span_ops": {
-                "type": "span_operations",
+                "type": "spanOperations",
                 "matches": ["http", "db", "browser", "resource"],
             }
         },

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -167,7 +167,7 @@ def get_project_config(project, full_config=True, project_keys=None):
         return ProjectConfig(project, **cfg)
 
     if features.has("organizations:performance-ops-breakdown", project.organization):
-        cfg["config"]["breakdowns"] = project.get_option("sentry:breakdowns")
+        cfg["config"]["breakdownsV2"] = project.get_option("sentry:breakdowns")
     with Hub.current.start_span(op="get_filter_settings"):
         cfg["config"]["filterSettings"] = get_filter_settings(project)
     with Hub.current.start_span(op="get_grouping_config_dict_for_project"):

--- a/tests/relay_integration/tests.py
+++ b/tests/relay_integration/tests.py
@@ -3,8 +3,8 @@ from uuid import uuid4
 
 from sentry.models.eventattachment import EventAttachment
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
-from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
 from sentry.testutils.helpers import Feature
+from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
 
 
 class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):

--- a/tests/relay_integration/tests.py
+++ b/tests/relay_integration/tests.py
@@ -3,7 +3,8 @@ from uuid import uuid4
 
 from sentry.models.eventattachment import EventAttachment
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
-from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
+from sentry.testutils.helpers import Feature
 
 
 class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
@@ -115,3 +116,81 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
         # Finally, fetch the updated attachment and compare the group id
         attachment = EventAttachment.objects.get(project_id=self.project.id, event_id=event_id)
         assert attachment.group_id == event.group_id
+
+    def test_transaction(self):
+        event_data = {
+            "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",
+            "type": "transaction",
+            "transaction": "/organizations/:orgId/performance/:eventSlug/",
+            "start_timestamp": iso_format(before_now(minutes=1, milliseconds=500)),
+            "timestamp": iso_format(before_now(minutes=1)),
+            "contexts": {
+                "trace": {
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                    "span_id": "8f5a2b8768cafb4e",
+                    "type": "trace",
+                }
+            },
+            "spans": [
+                {
+                    "description": "<OrganizationContext>",
+                    "op": "react.mount",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "bd429c44b67a3eb4",
+                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=250)),
+                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                },
+                {
+                    "description": "browser span",
+                    "op": "browser",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "a99fd04e79e17631",
+                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
+                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                },
+                {
+                    "description": "resource span",
+                    "op": "resource",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "a71a5e67db5ce938",
+                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
+                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                },
+                {
+                    "description": "http span",
+                    "op": "http",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "abe79ad9292b90a9",
+                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
+                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                },
+                {
+                    "description": "db span",
+                    "op": "db",
+                    "parent_span_id": "8f5a2b8768cafb4e",
+                    "span_id": "9c045ea336297177",
+                    "start_timestamp": timestamp_format(before_now(minutes=1, milliseconds=200)),
+                    "timestamp": timestamp_format(before_now(minutes=1)),
+                    "trace_id": "ff62a8b040f340bda5d830223def1d81",
+                },
+            ],
+        }
+
+        with Feature({"organizations:performance-ops-breakdown": True}):
+            event = self.post_and_retrieve_event(event_data)
+            raw_event = event.get_raw_data()
+
+            assert raw_event["spans"] == event_data["spans"]
+            assert raw_event["breakdowns"] == {
+                "span_ops": {
+                    "ops.browser": {"value": 200.000048},
+                    "ops.resource": {"value": 200.000048},
+                    "ops.http": {"value": 200.000048},
+                    "ops.db": {"value": 200.000048},
+                    "total.time": {"value": 1050.000192},
+                }
+            }

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-21T13:05:27.726107Z'
+created: '2021-06-14T21:14:00.494403Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -9,4 +9,4 @@ span_ops:
   - db
   - browser
   - resource
-  type: span_operations
+  type: spanOperations

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -104,4 +104,4 @@ def test_project_config_with_breakdown(default_project, insta_snapshot):
         cfg = get_project_config(default_project, full_config=True)
 
     cfg = cfg.to_dict()
-    insta_snapshot(cfg["config"]["breakdowns"])
+    insta_snapshot(cfg["config"]["breakdownsV2"])


### PR DESCRIPTION
To be merged after https://github.com/getsentry/relay/pull/1020

## TODO

- [x] add one E2E test to `tests/relay_integration/` that ingests a transaction, and then check for the computed operations breakdown