### PR TITLE
fix(grouping-levels): More idiomatic error handling

### DIFF
--- a/src/sentry/api/endpoints/grouping_level_new_issues.py
+++ b/src/sentry/api/endpoints/grouping_level_new_issues.py
@@ -5,10 +5,10 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.query import Column, Entity, Function, Query
 
-from sentry import features, nodestore
+from sentry import nodestore
 from sentry.api.bases import GroupEndpoint
 from sentry.api.endpoints.group_hashes_split import _get_group_filters
-from sentry.api.endpoints.grouping_levels import LevelsOverview, get_levels_overview
+from sentry.api.endpoints.grouping_levels import LevelsOverview, check_feature, get_levels_overview
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, serialize
 from sentry.eventstore.models import Event
@@ -64,13 +64,7 @@ class GroupingLevelNewIssuesEndpoint(GroupEndpoint):
         the new issues are more than what the current issue has).
         """
 
-        if not features.has(
-            "organizations:grouping-tree-ui", group.project.organization, actor=request.user
-        ):
-            return self.respond(
-                {"error": "This project does not have the grouping tree feature"},
-                status=403,
-            )
+        check_feature(group.project.organization, request)
 
         def data_fn(offset=None, limit=None):
             return _query_snuba(group, id, offset=offset, limit=limit)

--- a/src/sentry/api/endpoints/grouping_levels.py
+++ b/src/sentry/api/endpoints/grouping_levels.py
@@ -1,25 +1,37 @@
 from dataclasses import dataclass
 
-from rest_framework.exceptions import APIException
 from snuba_sdk.query import Column, Entity, Function, Query
 
 from sentry import features
 from sentry.api.bases import GroupEndpoint
 from sentry.api.endpoints.group_hashes_split import _construct_arraymax, _get_group_filters
+from sentry.api.exceptions import SentryAPIException, status
 from sentry.models import Group, GroupHash
 from sentry.utils import snuba
 
 
-class NoEvents(APIException):
-    status_code = 403
-    default_detail = "This issue has no events."
-    default_code = "no_events"
+class NoEvents(SentryAPIException):
+    status_code = status.HTTP_403_FORBIDDEN
+    message = "This issue has no events."
+    code = "no_events"
 
 
-class MergedIssues(APIException):
-    status_code = 403
-    default_detail = "The issue can only contain one fingerprint. It needs to be fully unmerged before grouping levels can be shown."
-    default_code = "merged_issues"
+class MergedIssues(SentryAPIException):
+    status_code = status.HTTP_403_FORBIDDEN
+    code = "merged_issues"
+    message = "The issue can only contain one fingerprint. It needs to be fully unmerged before grouping levels can be shown."
+
+
+class MissingFeature(SentryAPIException):
+    status_code = status.HTTP_403_FORBIDDEN
+    code = "missing_feature"
+    message = "This project does not have the grouping tree feature."
+
+
+class NotHierarchical(SentryAPIException):
+    status_code = status.HTTP_403_FORBIDDEN
+    code = "not_hierarchical"
+    message = "This issue does not have hierarchical grouping."
 
 
 class GroupingLevelsEndpoint(GroupEndpoint):
@@ -51,15 +63,14 @@ class GroupingLevelsEndpoint(GroupEndpoint):
         featureflags are missing.
         """
 
-        if not features.has(
-            "organizations:grouping-tree-ui", group.project.organization, actor=request.user
-        ):
-            return self.respond(
-                {"error": "This project does not have the grouping tree feature"},
-                status=403,
-            )
+        check_feature(group.project.organization, request)
 
         return self.respond(_list_levels(group), status=200)
+
+
+def check_feature(organization, request):
+    if not features.has("organizations:grouping-tree-ui", organization, actor=request.user):
+        raise MissingFeature()
 
 
 def _current_level_expr(group):
@@ -114,6 +125,9 @@ def get_levels_overview(group):
     assert len(res["data"]) == 1
 
     fields = res["data"][0]
+
+    if fields["num_levels"] <= 0:
+        raise NotHierarchical()
 
     # TODO: Cache this if it takes too long. This is called from multiple
     # places, grouping overview and then again in the new-issues endpoint.


### PR DESCRIPTION
Make sure we conform to Sentry's way of handling errors, handle more
errors properly and make sure we include an error code in the response.

Fix SENTRY-QPK

Example response data is:

```
{"detail": {"message": "...", "code": "not_hierarchical"}}
```