### PR TITLE
fix(vercel): Catch 403s from Vercel 

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1028,6 +1028,7 @@ urlpatterns = [
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/$",
                     OrganizationIntegrationDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-integration-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/repos/$",

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -143,18 +143,17 @@ class VercelIntegration(IntegrationInstallation):
             return user["username"]
 
     def _get_vercel_projects(self):
-        """If the API returns a 403, just silently replace the slug."""
+        """If the API returns a 403, just silently return an empty list."""
+        client = self.get_client()
         try:
+            projects = client.get_projects()
             slug = self.get_slug()
         except ApiError:
-            slug = ""
+            return []
 
-        base_url = "https://vercel.com/%s" % slug
-
-        client = self.get_client()
         return [
-            {"value": p["id"], "label": p["name"], "url": "{}/{}".format(base_url, p["name"])}
-            for p in client.get_projects()
+            {"value": p["id"], "label": p["name"], "url": f"https://vercel.com/{slug}/{p['name']}"}
+            for p in projects
         ]
 
     def _get_sentry_projects(self):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Mapping, Sequence
 from urllib.parse import urlencode
 
 from django.utils.translation import ugettext_lazy as _
@@ -133,7 +134,7 @@ class VercelIntegration(IntegrationInstallation):
         )
         return None
 
-    def get_slug(self):
+    def get_slug(self) -> str:
         client = self.get_client()
         if self.metadata["installation_type"] == "team":
             team = client.get_team()
@@ -142,7 +143,7 @@ class VercelIntegration(IntegrationInstallation):
             user = client.get_user()
             return user["username"]
 
-    def _get_vercel_projects(self):
+    def _get_vercel_projects(self) -> Sequence[Mapping[str, str]]:
         """If the API returns a 403, just silently return an empty list."""
         client = self.get_client()
         try:
@@ -156,7 +157,7 @@ class VercelIntegration(IntegrationInstallation):
             for p in projects
         ]
 
-    def _get_sentry_projects(self):
+    def _get_sentry_projects(self) -> Sequence[Mapping[str, str]]:
         proj_fields = ["id", "platform", "name", "slug"]
 
         return map(

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -179,7 +179,7 @@ class VercelIntegration(IntegrationInstallation):
                     "items": self._get_vercel_projects(),
                     "placeholder": _("Vercel project..."),
                 },
-                "sentry_projects": self._get_sentry_projects(),
+                "sentryProjects": self._get_sentry_projects(),
                 "nextButton": {
                     "allowedDomain": "https://vercel.com",
                     "description": _(

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -1,3 +1,6 @@
+import responses
+
+from sentry.integrations.vercel.client import VercelClient
 from sentry.models import (
     Identity,
     IdentityProvider,
@@ -10,11 +13,10 @@ from sentry.testutils.helpers import with_feature
 
 
 class OrganizationIntegrationDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-integration-details"
+
     def setUp(self):
         super().setUp()
-
-        self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user, name="baz")
         self.integration = Integration.objects.create(
             provider="gitlab", name="Gitlab", external_id="gitlab:1"
         )
@@ -24,83 +26,44 @@ class OrganizationIntegrationDetailsTest(APITestCase):
             external_id="base_id",
             data={},
         )
-        self.integration.add_organization(self.org, self.user, default_auth_id=self.identity.id)
+        self.integration.add_organization(
+            self.organization, self.user, default_auth_id=self.identity.id
+        )
 
         self.repo = Repository.objects.create(
             provider="gitlab",
             name="getsentry/sentry",
-            organization_id=self.org.id,
+            organization_id=self.organization.id,
             integration_id=self.integration.id,
         )
 
-        self.path = f"/api/0/organizations/{self.org.slug}/integrations/{self.integration.id}/"
+        self.login_as(self.user)
 
+
+class OrganizationIntegrationDetailsGetTest(OrganizationIntegrationDetailsTest):
     def test_simple(self):
-        response = self.client.get(self.path, format="json")
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(self.organization.slug, self.integration.id)
         assert response.data["id"] == str(self.integration.id)
 
-    def test_removal(self):
-        with self.tasks():
-            response = self.client.delete(self.path, format="json")
 
-            assert response.status_code == 204, response.content
-            assert Integration.objects.filter(id=self.integration.id).exists()
-
-            # Ensure Organization integrations are removed
-            assert not OrganizationIntegration.objects.filter(
-                integration=self.integration, organization=self.org
-            ).exists()
-            assert not Identity.objects.filter(user=self.user).exists()
-
-            # make sure repo is dissociated from integration
-            assert Repository.objects.get(id=self.repo.id).integration_id is None
-
-    def test_update_config(self):
-        config = {"setting": "new_value", "setting2": "baz"}
-
-        response = self.client.post(self.path, format="json", data=config)
-
-        assert response.status_code == 200, response.content
-
-        org_integration = OrganizationIntegration.objects.get(
-            integration=self.integration, organization=self.org
-        )
-
-        assert org_integration.config == config
-
-    def test_removal_default_identity_already_removed(self):
-        with self.tasks():
-            self.identity.delete()
-            response = self.client.delete(self.path, format="json")
-
-            assert response.status_code == 204, response.content
-            assert Integration.objects.filter(id=self.integration.id).exists()
-
-            # Ensure Organization integrations are removed
-            assert not OrganizationIntegration.objects.filter(
-                integration=self.integration, organization=self.org
-            ).exists()
+class OrganizationIntegrationDetailsPutTest(OrganizationIntegrationDetailsTest):
+    method = "put"
 
     def test_no_access_put_request(self):
-        data = {"name": "Example Name"}
-
-        response = self.client.put(self.path, format="json", data=data)
-        assert response.status_code == 404
+        self.get_error_response(
+            self.organization.slug, self.integration.id, name="Example Name", status_code=404
+        )
 
     @with_feature("organizations:integrations-custom-scm")
     def test_valid_put_request(self):
         integration = Integration.objects.create(
             provider="custom_scm", name="A Name", external_id="1232948573948579127"
         )
-        integration.add_organization(self.org, self.user)
-        path = f"/api/0/organizations/{self.org.slug}/integrations/{integration.id}/"
+        integration.add_organization(self.organization, self.user)
 
         data = {"name": "New Name", "domain": "https://example.com/"}
 
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(self.organization.slug, integration.id, **data)
 
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "New Name"
@@ -111,27 +74,68 @@ class OrganizationIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(
             provider="custom_scm", name="A Name", external_id="1232948573948579127"
         )
-        integration.add_organization(self.org, self.user)
-        path = f"/api/0/organizations/{self.org.slug}/integrations/{integration.id}/"
+        integration.add_organization(self.organization, self.user)
 
         data = {"domain": "https://example.com/"}
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(self.organization.slug, integration.id, **data)
 
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "A Name"
         assert updated.metadata["domain_name"] == "https://example.com/"
 
         data = {"name": "Newness"}
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(self.organization.slug, integration.id, **data)
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "Newness"
         assert updated.metadata["domain_name"] == "https://example.com/"
 
         data = {"domain": ""}
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(self.organization.slug, integration.id, **data)
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "Newness"
         assert updated.metadata["domain_name"] == ""
+
+
+class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest):
+    method = "post"
+
+    def test_update_config(self):
+        config = {"setting": "new_value", "setting2": "baz"}
+
+        self.get_success_response(self.organization.slug, self.integration.id, **config)
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=self.integration, organization=self.organization
+        )
+
+        assert org_integration.config == config
+
+
+class OrganizationIntegrationDetailsDeleteTest(OrganizationIntegrationDetailsTest):
+    method = "delete"
+
+    def test_removal(self):
+        with self.tasks():
+            self.get_success_response(self.organization.slug, self.integration.id)
+            assert Integration.objects.filter(id=self.integration.id).exists()
+
+            # Ensure Organization integrations are removed
+            assert not OrganizationIntegration.objects.filter(
+                integration=self.integration, organization=self.organization
+            ).exists()
+            assert not Identity.objects.filter(user=self.user).exists()
+
+            # make sure repo is dissociated from integration
+            assert Repository.objects.get(id=self.repo.id).integration_id is None
+
+    def test_removal_default_identity_already_removed(self):
+        with self.tasks():
+            self.identity.delete()
+            self.get_success_response(self.organization.slug, self.integration.id)
+
+            assert Integration.objects.filter(id=self.integration.id).exists()
+
+            # Ensure Organization integrations are removed
+            assert not OrganizationIntegration.objects.filter(
+                integration=self.integration, organization=self.organization
+            ).exists()


### PR DESCRIPTION
Fixes [SENTRY-NNT](https://sentry.io/organizations/sentry/issues/2238040441/), [API-1722](https://getsentry.atlassian.net/browse/API-1722).

The integration details GET endpoint is supposed to return data about integrations. When the integration is Vercel, we make some API calls to populate some of the data. Sometimes the API call fails. This PR catches those API failures and silently moves on with the other integration details.