### PR TITLE
fix(semver): Fix semver backfill when version numbers are larger than a bigint

### DIFF
--- a/src/sentry/migrations/0205_semver_backfill.py
+++ b/src/sentry/migrations/0205_semver_backfill.py
@@ -15,11 +15,15 @@ def convert_build_code_to_build_number(build_code):
     if build_code is not None:
         try:
             build_code_as_int = int(build_code)
-            if build_code_as_int >= 0 and build_code_as_int.bit_length() <= 63:
+            if validate_bigint(build_code_as_int):
                 build_number = build_code_as_int
         except ValueError:
             pass
     return build_number
+
+
+def validate_bigint(value):
+    return isinstance(value, int) and value >= 0 and value.bit_length() <= 63
 
 
 UPDATE_QUERY = """
@@ -51,6 +55,10 @@ def backfill_semver(apps, schema_editor):
 
         version_parsed = version_info.get("version_parsed")
         if version_parsed is None:
+            continue
+
+        bigint_fields = ["major", "minor", "patch", "revision"]
+        if not all(validate_bigint(version_parsed[field]) for field in bigint_fields):
             continue
 
         build_code = version_parsed.get("build_code")


### PR DESCRIPTION
This fixes an edge case where we end up with major/minor/patch/revision numbers that end up larger
than a postgres bigint can handle. We just skip these, since we have no way to store them.