### PR TITLE
fix(semver): Fix potential overflow error during release creation when parsing semver

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -138,11 +138,15 @@ class ReleaseModelManager(models.Manager):
         if build_code is not None:
             try:
                 build_code_as_int = int(build_code)
-                if build_code_as_int >= 0 and build_code_as_int.bit_length() <= 63:
+                if ReleaseModelManager.validate_bigint(build_code_as_int):
                     build_number = build_code_as_int
             except ValueError:
                 pass
         return build_number
+
+    @staticmethod
+    def validate_bigint(value):
+        return isinstance(value, int) and value >= 0 and value.bit_length() <= 63
 
     @staticmethod
     def _massage_semver_cols_into_release_object_data(kwargs):
@@ -158,7 +162,10 @@ class ReleaseModelManager(models.Manager):
                 package = version_info.get("package")
                 version_parsed = version_info.get("version_parsed")
 
-                if version_parsed is not None:
+                if version_parsed is not None and all(
+                    ReleaseModelManager.validate_bigint(version_parsed[field])
+                    for field in ("major", "minor", "patch", "revision")
+                ):
                     build_code = version_parsed.get("build_code")
                     build_number = ReleaseModelManager._convert_build_code_to_build_number(
                         build_code

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -779,3 +779,20 @@ class SemverReleaseParseTestCase(TestCase):
         version = "hello world"
         release = Release.objects.create(organization=self.org, version=version)
         assert release.version == "hello world"
+
+    def test_parse_release_overflow_bigint(self):
+        """
+        Tests that we don't error if we have a version component that is larger than
+        a postgres bigint.
+        """
+        version = "org.example.FooApp@9223372036854775808.1.2.3-r1+12345"
+        release = Release.objects.create(organization=self.org, version=version)
+        assert release.version == version
+        assert release.major is None
+        assert release.minor is None
+        assert release.patch is None
+        assert release.revision is None
+        assert release.prerelease is None
+        assert release.build_code is None
+        assert release.build_number is None
+        assert release.package is None


### PR DESCRIPTION
If part of a version is a value larger than postgres can handle we can fail to create the release.
Limit this to 63 bits like we do for `build_number`.