### PR TITLE
fix(workflow): Missing class level form_fields

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -13,8 +13,10 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
 
         def info_extractor(rule_cls):
             context = {"id": rule_cls.id, "label": rule_cls.label}
-            if hasattr(rule_cls, "form_fields"):
-                context["formFields"] = rule_cls.form_fields
+            node = rule_cls(None)
+            if hasattr(node, "form_fields"):
+                context["formFields"] = node.form_fields
+
             return context
 
         has_percent_condition = features.has("organizations:issue-percent-filters", organization)


### PR DESCRIPTION
I recently refactored a few of the classes this code uses (namely `BaseEventFrequencyCondition`), and in part of doing so moved the declaration of form_fields to `__init__` which broke this endpoint. I now declare the rule like we do in other spots (such as `project_rules_configuration.py`), passing it `None` for `project`.

This seems to have fixed the frontend bug and the form fields all appear to be passed properly.

Fixes JAVASCRIPT-24P6