### PR TITLE
ref(notifications): More should_be_participating tests

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -18,7 +18,7 @@ from sentry.api.helpers.group_index import (
 )
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
 from sentry.api.serializers.models.plugin import PluginSerializer
-from sentry.models import Activity, Group, GroupSeen, User, UserReport
+from sentry.models import Activity, Group, GroupSeen, GroupSubscriptionManager, UserReport
 from sentry.models.groupinbox import get_inbox_details
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
@@ -183,11 +183,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 3600 * 24,
             )[group.id]
 
-            participants = list(
-                User.objects.filter(
-                    groupsubscription__is_active=True, groupsubscription__group=group
-                )
-            )
+            participants = GroupSubscriptionManager.get_participating_users(group)
 
             if "inbox" in expand:
                 inbox_map = get_inbox_details([group])

--- a/src/sentry/api/endpoints/group_participants.py
+++ b/src/sentry/api/endpoints/group_participants.py
@@ -2,13 +2,11 @@ from rest_framework.response import Response
 
 from sentry.api.bases import GroupEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import User
+from sentry.models import GroupSubscriptionManager
 
 
 class GroupParticipantsEndpoint(GroupEndpoint):
     def get(self, request, group):
-        participants = list(
-            User.objects.filter(groupsubscription__is_active=True, groupsubscription__group=group)
-        )
+        participants = GroupSubscriptionManager.get_participating_users(group)
 
         return Response(serialize(participants, request.user))

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, transaction
@@ -121,6 +121,15 @@ class GroupSubscriptionManager(BaseManager):
                 result[provider][user] = value
 
         return result
+
+    @staticmethod
+    def get_participating_users(group) -> Sequence[Any]:
+        """Return the list of users participating in this issue."""
+        from sentry.models import User
+
+        return list(
+            User.object.filter(groupsubscription__is_active=True, groupsubscription__group=group)
+        )
 
 
 class GroupSubscription(Model):

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -90,35 +90,35 @@ class GroupSubscriptionManager(BaseManager):
         """
         from sentry.models import NotificationSetting, User
 
-        users = User.objects.get_from_group(group)
-        user_ids = [user.id for user in users]
-        subscriptions = self.filter(group=group, user_id__in=user_ids)
+        all_possible_users = User.objects.get_from_group(group)
+        active_and_disabled_subscriptions = self.filter(group=group, user__in=all_possible_users)
         notification_settings = NotificationSetting.objects.get_for_recipient_by_parent(
             NotificationSettingTypes.WORKFLOW,
-            recipients=users,
+            recipients=all_possible_users,
             parent=group.project,
         )
         subscriptions_by_user_id = {
-            subscription.user_id: subscription for subscription in subscriptions
+            subscription.user_id: subscription for subscription in active_and_disabled_subscriptions
         }
         notification_settings_by_user = transform_to_notification_settings_by_user(
-            notification_settings, users
+            notification_settings, all_possible_users
         )
 
         result = defaultdict(dict)
-        for user in users:
+        for user in all_possible_users:
+            subscription = subscriptions_by_user_id[user.id]
             providers = where_should_be_participating(
                 user,
-                subscriptions_by_user_id,
+                subscription,
                 notification_settings_by_user,
             )
             for provider in providers:
-                value = getattr(
-                    subscriptions_by_user_id.get(user.id),
+                reason = getattr(
+                    subscription,
                     "reason",
                     GroupSubscriptionReason.implicit,
                 )
-                result[provider][user] = value
+                result[provider][user] = reason
 
         return result
 

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -106,19 +106,18 @@ class GroupSubscriptionManager(BaseManager):
 
         result = defaultdict(dict)
         for user in all_possible_users:
-            subscription = subscriptions_by_user_id[user.id]
+            subscription_option = subscriptions_by_user_id.get(user.id)
             providers = where_should_be_participating(
                 user,
-                subscription,
+                subscription_option,
                 notification_settings_by_user,
             )
             for provider in providers:
-                reason = getattr(
-                    subscription,
-                    "reason",
-                    GroupSubscriptionReason.implicit,
+                result[provider][user] = (
+                    subscription_option
+                    and subscription_option.reason
+                    or GroupSubscriptionReason.implicit
                 )
-                result[provider][user] = reason
 
         return result
 
@@ -128,7 +127,7 @@ class GroupSubscriptionManager(BaseManager):
         from sentry.models import User
 
         return list(
-            User.object.filter(groupsubscription__is_active=True, groupsubscription__group=group)
+            User.objects.filter(groupsubscription__is_active=True, groupsubscription__group=group)
         )
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -104,11 +104,14 @@ def where_should_user_be_notified(
 
 
 def should_be_participating(
-    subscriptions_by_user_id: Mapping[int, "GroupSubscription"],
-    user: "User",
+    subscription: Optional[Any],
     value: NotificationSettingOptionValues,
 ) -> bool:
-    subscription = subscriptions_by_user_id.get(user.id)
+    """
+    Give a user's subscription (on, off, or null) to a group and their
+    notification setting value(on, off, or sometimes), decide whether or not to
+    send the user a notification.
+    """
     return (
         subscription and subscription.is_active and value != NotificationSettingOptionValues.NEVER
     ) or (not subscription and value == NotificationSettingOptionValues.ALWAYS)
@@ -116,7 +119,7 @@ def should_be_participating(
 
 def where_should_be_participating(
     user: "User",
-    subscriptions_by_user_id: Mapping[int, "GroupSubscription"],
+    subscription: Optional["GroupSubscription"],
     notification_settings_by_user: Mapping[
         "User",
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
@@ -137,7 +140,7 @@ def where_should_be_participating(
     return [
         provider
         for provider, value in mapping.items()
-        if should_be_participating(subscriptions_by_user_id, user, value)
+        if should_be_participating(subscription, value)
     ]
 
 

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -182,6 +182,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
+        # TODO MARCOS FIRST
         assert response.data["annotations"] == [
             '<a href="https://example.com/browse/api-123">api-123</a>'
         ]

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -182,7 +182,6 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
-        # TODO MARCOS FIRST
         assert response.data["annotations"] == [
             '<a href="https://example.com/browse/api-123">api-123</a>'
         ]

--- a/tests/sentry/api/endpoints/test_group_participants.py
+++ b/tests/sentry/api/endpoints/test_group_participants.py
@@ -3,18 +3,18 @@ from sentry.testutils import APITestCase
 
 
 class GroupParticipantsTest(APITestCase):
+    endpoint = "sentry-api-0-group-stats"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
     def test_simple(self):
-        self.login_as(user=self.user)
-
         group = self.create_group()
-
         GroupSubscription.objects.create(
             user=self.user, group=group, project=group.project, is_active=True
         )
 
-        url = f"/api/0/issues/{group.id}/participants/"
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(group.id)
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.user.id)

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -10,11 +10,9 @@ from sentry.notifications.helpers import (
     get_target_id,
     get_user_subscriptions_for_groups,
     get_values_by_provider_by_type,
-    should_be_participating,
     transform_to_notification_settings_by_parent_id,
     transform_to_notification_settings_by_user,
     validate,
-    where_should_be_participating,
     where_should_user_be_notified,
 )
 from sentry.notifications.notify import notification_providers
@@ -120,32 +118,6 @@ class NotificationHelpersTest(TestCase):
             ExternalProviders.EMAIL,
             ExternalProviders.SLACK,
         ]
-
-    def test_should_be_participating(self):
-        subscriptions_by_user_id = {ExternalProviders.EMAIL: {self.user: -1}}
-        self.assertTrue(
-            should_be_participating(
-                subscriptions_by_user_id, self.user, NotificationSettingOptionValues.ALWAYS
-            )
-        )
-
-    def test_where_should_be_participating(self):
-        subscriptions_by_user_id = {ExternalProviders.EMAIL: {self.user: -1}}
-        notification_settings = {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
-                }
-            }
-        }
-        assert (
-            where_should_be_participating(
-                self.user,
-                subscriptions_by_user_id,
-                notification_settings,
-            )
-            == [ExternalProviders.EMAIL]
-        )
 
     def test_get_deploy_values_by_provider_empty_settings(self):
         values_by_provider = get_values_by_provider_by_type(

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -13,7 +13,6 @@ from sentry.notifications.helpers import (
     transform_to_notification_settings_by_parent_id,
     transform_to_notification_settings_by_user,
     validate,
-    where_should_user_be_notified,
 )
 from sentry.notifications.notify import notification_providers
 from sentry.notifications.types import (
@@ -92,32 +91,6 @@ class NotificationHelpersTest(TestCase):
             NotificationSettingTypes.WORKFLOW,
         )
         assert mapping == {ExternalProviders.EMAIL: NotificationSettingOptionValues.SUBSCRIBE_ONLY}
-
-    def test_where_should_user_be_notified(self):
-        notification_settings = {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
-                }
-            }
-        }
-        assert where_should_user_be_notified(notification_settings, self.user) == [
-            ExternalProviders.EMAIL
-        ]
-
-    def test_where_should_user_be_notified_two_providers(self):
-        notification_settings = {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
-                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
-                }
-            }
-        }
-        assert where_should_user_be_notified(notification_settings, self.user) == [
-            ExternalProviders.EMAIL,
-            ExternalProviders.SLACK,
-        ]
 
     def test_get_deploy_values_by_provider_empty_settings(self):
         values_by_provider = get_values_by_provider_by_type(

--- a/tests/sentry/notifications/utils/test_should_be_notified.py
+++ b/tests/sentry/notifications/utils/test_should_be_notified.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+from sentry.models import User
+from sentry.notifications.helpers import where_should_user_be_notified
+from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
+from sentry.types.integrations import ExternalProviders
+
+
+class WhereShouldBeNotifiedTest(TestCase):
+    def setUp(self) -> None:
+        self.user = User(id=1)
+
+    def test_where_should_user_be_notified(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
+                }
+            }
+        }
+        assert where_should_user_be_notified(notification_settings, self.user) == [
+            ExternalProviders.EMAIL
+        ]
+
+    def test_where_should_user_be_notified_two_providers(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+                }
+            }
+        }
+        assert where_should_user_be_notified(notification_settings, self.user) == [
+            ExternalProviders.EMAIL,
+            ExternalProviders.SLACK,
+        ]

--- a/tests/sentry/notifications/utils/test_should_be_participating.py
+++ b/tests/sentry/notifications/utils/test_should_be_participating.py
@@ -1,0 +1,68 @@
+from unittest import TestCase
+
+from sentry.models import GroupSubscription, User
+from sentry.notifications.helpers import should_be_participating, where_should_be_participating
+from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
+from sentry.types.integrations import ExternalProviders
+
+
+class ShouldBeParticipatingTest(TestCase):
+    def test_subscription_on_notification_settings_always(self):
+        subscription = GroupSubscription(is_active=True)
+        value = should_be_participating(subscription, NotificationSettingOptionValues.ALWAYS)
+        assert value
+
+    def test_subscription_off_notification_settings_always(self):
+        subscription = GroupSubscription(is_active=False)
+        value = should_be_participating(subscription, NotificationSettingOptionValues.ALWAYS)
+        assert not value
+
+    def test_subscription_null_notification_settings_always(self):
+        value = should_be_participating(None, NotificationSettingOptionValues.ALWAYS)
+        assert value
+
+    def test_subscription_on_notification_setting_never(self):
+        subscription = GroupSubscription(is_active=True)
+        value = should_be_participating(subscription, NotificationSettingOptionValues.NEVER)
+        assert not value
+
+    def test_subscription_off_notification_setting_never(self):
+        subscription = GroupSubscription(is_active=False)
+        value = should_be_participating(subscription, NotificationSettingOptionValues.NEVER)
+        assert not value
+
+    def test_subscription_on_subscribe_only(self):
+        subscription = GroupSubscription(is_active=True)
+        value = should_be_participating(
+            subscription, NotificationSettingOptionValues.SUBSCRIBE_ONLY
+        )
+        assert value
+
+    def test_subscription_off_subscribe_only(self):
+        subscription = GroupSubscription(is_active=False)
+        value = should_be_participating(
+            subscription, NotificationSettingOptionValues.SUBSCRIBE_ONLY
+        )
+        assert not value
+
+    def test_subscription_null_subscribe_only(self):
+        value = should_be_participating(None, NotificationSettingOptionValues.SUBSCRIBE_ONLY)
+        assert not value
+
+    def test_where_should_be_participating(self):
+        user = User(id=1)
+        subscription = GroupSubscription(is_active=True)
+        notification_settings = {
+            user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
+                }
+            }
+        }
+
+        providers = where_should_be_participating(
+            user,
+            subscription,
+            notification_settings,
+        )
+        assert providers == [ExternalProviders.EMAIL]

--- a/tests/sentry/notifications/utils/test_should_be_participating.py
+++ b/tests/sentry/notifications/utils/test_should_be_participating.py
@@ -49,20 +49,45 @@ class ShouldBeParticipatingTest(TestCase):
         value = should_be_participating(None, NotificationSettingOptionValues.SUBSCRIBE_ONLY)
         assert not value
 
+
+class WhereShouldBeParticipatingTest(TestCase):
+    def setUp(self) -> None:
+        self.user = User(id=1)
+
     def test_where_should_be_participating(self):
-        user = User(id=1)
         subscription = GroupSubscription(is_active=True)
         notification_settings = {
-            user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
+            self.user: {
+                NotificationScopeType.self.user: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                    ExternalProviders.PAGERDUTY: NotificationSettingOptionValues.NEVER,
                 }
             }
         }
 
         providers = where_should_be_participating(
-            user,
+            self.user,
             subscription,
+            notification_settings,
+        )
+        assert providers == [ExternalProviders.EMAIL, ExternalProviders.SLACK]
+
+    def test_subscription_null(self):
+        self.user = self.user(id=1)
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.self.user: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                    ExternalProviders.PAGERDUTY: NotificationSettingOptionValues.NEVER,
+                }
+            }
+        }
+
+        providers = where_should_be_participating(
+            self.user,
+            None,
             notification_settings,
         )
         assert providers == [ExternalProviders.EMAIL]

--- a/tests/sentry/notifications/utils/test_should_be_participating.py
+++ b/tests/sentry/notifications/utils/test_should_be_participating.py
@@ -58,7 +58,7 @@ class WhereShouldBeParticipatingTest(TestCase):
         subscription = GroupSubscription(is_active=True)
         notification_settings = {
             self.user: {
-                NotificationScopeType.self.user: {
+                NotificationScopeType.USER: {
                     ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
                     ExternalProviders.SLACK: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
                     ExternalProviders.PAGERDUTY: NotificationSettingOptionValues.NEVER,
@@ -74,10 +74,10 @@ class WhereShouldBeParticipatingTest(TestCase):
         assert providers == [ExternalProviders.EMAIL, ExternalProviders.SLACK]
 
     def test_subscription_null(self):
-        self.user = self.user(id=1)
+        self.user = User(id=1)
         notification_settings = {
             self.user: {
-                NotificationScopeType.self.user: {
+                NotificationScopeType.USER: {
                     ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
                     ExternalProviders.SLACK: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
                     ExternalProviders.PAGERDUTY: NotificationSettingOptionValues.NEVER,


### PR DESCRIPTION
I updated the tests to test every case here:
<table>
<tr>
	<td> 
	<td> GroupSubscription<BR>.is_active = 1
	<td> GroupSubscription<BR>.is_active = 0
	<td> null
<tr>
	<td> ALWAYS
	<td>✉️ 
	<td>🚫 
	<td>✉️ 
<tr>
	<td> SUBSCRIBE_ONLY
	<td>✉️ 
	<td>🚫 
	<td>🚫 
<tr>
	<td> NEVER
	<td> 🚫 
	<td> 🚫  
	<td> 🚫 
</table>
