### PR TITLE
ref(search): Break apart complex 'simple aggregate'

### DIFF
--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -47,7 +47,9 @@ filter
   / boolean_filter
   / numeric_in_filter
   / numeric_filter
-  / aggregate_filter
+  / aggregate_duration_filter
+  / aggregate_numeric_filter
+  / aggregate_percentage_filter
   / aggregate_date_filter
   / aggregate_rel_date_filter
   / has_filter
@@ -97,14 +99,22 @@ numeric_filter
       return tc.tokenFilter(FilterType.Numeric, key, value, op, false);
     }
 
+// aggregate duration filter
+aggregate_duration_filter
+  = negation:negation? key:aggregate_key sep op:operator? value:duration_format {
+      return tc.tokenFilter(FilterType.AggregateDuration, key, value, op, !!negation);
+    }
+
+// aggregate percentage filter
+aggregate_percentage_filter
+  = negation:negation? key:aggregate_key sep op:operator? value:percentage_format {
+      return tc.tokenFilter(FilterType.AggregatePercentage, key, value, op, !!negation);
+    }
+
 // aggregate numeric filter
-aggregate_filter
-  = negation:negation?
-    key:aggregate_key
-    sep
-    op:operator?
-    value:(duration_format / numeric_value / percentage_format) {
-      return tc.tokenFilter(FilterType.AggregateSimple, key, value, op, !!negation);
+aggregate_numeric_filter
+  = negation:negation? key:aggregate_key sep op:operator? value:numeric_value {
+      return tc.tokenFilter(FilterType.AggregateNumeric, key, value, op, !!negation);
     }
 
 // aggregate date filter

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -78,7 +78,9 @@ export enum FilterType {
   Numeric = 'numeric',
   NumericIn = 'numericIn',
   Boolean = 'boolean',
-  AggregateSimple = 'aggregateSimple',
+  AggregateDuration = 'aggregateDuration',
+  AggregatePercentage = 'aggregatePercentage',
+  AggregateNumeric = 'aggregateNumeric',
   AggregateDate = 'aggregateDate',
   AggregateRelativeDate = 'aggregateRelativeDate',
   Has = 'has',
@@ -166,10 +168,22 @@ export const filterTypeConfig = {
     validValues: [Token.ValueBoolean],
     canNegate: true,
   },
-  [FilterType.AggregateSimple]: {
+  [FilterType.AggregateDuration]: {
     validKeys: [Token.KeyAggregate],
     validOps: allOperators,
-    validValues: [Token.ValueDuration, Token.ValueNumber, Token.ValuePercentage],
+    validValues: [Token.ValueDuration],
+    canNegate: true,
+  },
+  [FilterType.AggregateNumeric]: {
+    validKeys: [Token.KeyAggregate],
+    validOps: allOperators,
+    validValues: [Token.ValueNumber],
+    canNegate: true,
+  },
+  [FilterType.AggregatePercentage]: {
+    validKeys: [Token.KeyAggregate],
+    validOps: allOperators,
+    validValues: [Token.ValuePercentage],
     canNegate: true,
   },
   [FilterType.AggregateDate]: {


### PR DESCRIPTION
This has a few advantages despite a marginally more verbose grammar / tree visitor:

 1. We no longer have an aggregate filter visitor that is responsible for parsing 3 different types of values, making for some deep nested logic.

 2. The frontend will more easily be able to predicate on each filter type, which will be handled in an upcoming commit.

 3. We already had some specific aggregate tokens, and no other filter token has multiple values (ignoring the special `has` filter)