### PR TITLE
fix(alerts): Alert details related issues should respect environment

### DIFF
--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -46,6 +46,7 @@ class RelatedIssues extends Component<Props> {
       end,
       groupStatsPeriod: 'auto',
       limit: 5,
+      ...(rule.environment ? {environment: rule.environment} : {}),
       sort: rule.aggregate === 'count_unique(user)' ? 'user' : 'freq',
       query: [
         rule.query,


### PR DESCRIPTION
This adds `the rule.environment` to related issues query in the alert details page, this was missing previously.

Resolves: [WOR-952](https://getsentry.atlassian.net/browse/WOR-952)