### PR TITLE
ref(images-loaded): Update  images loaded candidate icon+tooltip logic

### DIFF
--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/index.tsx
@@ -68,7 +68,7 @@ function Information({
   function getTimeSinceData(dateCreated: string) {
     const dateTime = <DateTime date={dateCreated} />;
 
-    if (candidate.download.status === CandidateDownloadStatus.OK) {
+    if (candidate.download.status !== CandidateDownloadStatus.UNAPPLIED) {
       return {
         tooltipDesc: dateTime,
         displayIcon: false,
@@ -91,7 +91,7 @@ function Information({
               <DateTimeWrapper>{dateTime}</DateTimeWrapper>
             </React.Fragment>
           ),
-          displayIcon: candidate.download.status === CandidateDownloadStatus.UNAPPLIED,
+          displayIcon: true,
         };
       }
 
@@ -116,7 +116,7 @@ function Information({
             <DateTimeWrapper>{dateTime}</DateTimeWrapper>
           </React.Fragment>
         ),
-        displayIcon: candidate.download.status === CandidateDownloadStatus.UNAPPLIED,
+        displayIcon: true,
       };
     }
 
@@ -133,7 +133,7 @@ function Information({
             <DateTimeWrapper>{dateTime}</DateTimeWrapper>
           </React.Fragment>
         ),
-        displayIcon: candidate.download.status === CandidateDownloadStatus.UNAPPLIED,
+        displayIcon: true,
       };
     }
 
@@ -146,7 +146,7 @@ function Information({
           <DateTimeWrapper>{dateTime}</DateTimeWrapper>
         </React.Fragment>
       ),
-      displayIcon: candidate.download.status === CandidateDownloadStatus.UNAPPLIED,
+      displayIcon: true,
     };
   }
 


### PR DESCRIPTION
if the debug file was uploaded >= 60m before the event, the UI will no longer display the warning icon + a tooltip explanation, but only the dateTime