### PR TITLE
fix(sessions): Handle zero division error on crash free rate calculation

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -1021,7 +1021,11 @@ def get_current_and_previous_crash_free_rates(
         totals = (
             healthy_sessions + errored_sessions + row["sessions_crashed"] + row["sessions_abnormal"]
         )
-        return 100 - (row["sessions_crashed"] / totals) * 100
+        try:
+            crash_free_rate = 100 - (row["sessions_crashed"] / totals) * 100
+        except ZeroDivisionError:
+            crash_free_rate = None
+        return crash_free_rate
 
     # currentCrashFreeRate
     current_crash_free_data = __get_crash_free_rate_data(

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1708,3 +1708,25 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             self.project2.id: {"currentCrashFreeRate": 50.0, "previousCrashFreeRate": None},
             self.project3.id: {"currentCrashFreeRate": None, "previousCrashFreeRate": 80.0},
         }
+
+    def test_get_current_and_previous_crash_free_rates_with_zero_sessions(self):
+        now = timezone.now()
+        last_48h_start = now - 2 * 24 * timedelta(hours=1)
+        last_72h_start = now - 3 * 24 * timedelta(hours=1)
+        last_96h_start = now - 4 * 24 * timedelta(hours=1)
+
+        data = get_current_and_previous_crash_free_rates(
+            project_ids=[self.project.id],
+            current_start=last_72h_start,
+            current_end=last_48h_start,
+            previous_start=last_96h_start,
+            previous_end=last_72h_start,
+            rollup=86400,
+        )
+
+        assert data == {
+            self.project.id: {
+                "currentCrashFreeRate": None,
+                "previousCrashFreeRate": None,
+            },
+        }


### PR DESCRIPTION
This PR:
- Handles the edge case when total number of sessions in `get_current_and_previous_crash_free_rates` maybe zero and so raises a `ZeroDivisionError`