### PR TITLE
Revert "py38: bump django-sudo to django2.2, python3.8 compatible version (#26602)"

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -11,7 +11,7 @@ datadog==0.29.3
 django-crispy-forms==1.7.2
 django-manifest-loader==1.0.0
 django-picklefield==1.0.0
-django-sudo @ https://github.com/getsentry/django-sudo/archive/c3d871ec66d8d1169c8cd4b2edd8402c6b39ab78.zip#egg=django-sudo
+django-sudo==3.1.0
 Django==1.11.29
 djangorestframework==3.11.2
 email-reply-parser==0.5.12


### PR DESCRIPTION
This reverts commit c051738964aecec10bc4a5c39d986a4f65635692 as we
cannot have direct git/http dependencies to be able to publish to
PyPI.
