### PR TITLE
fix(sessions): Fixes set indexing error in check health data

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -114,19 +114,20 @@ def check_has_health_data(projects_list):
         return set()
 
     conditions = None
+    projects_list = list(projects_list)
     # Check if projects_list also contains releases as a tuple of (project_id, releases)
     includes_releases = type(projects_list[0]) == tuple
 
     if includes_releases:
-        filter_keys = {"project_id": list({x[0] for x in projects_list})}
-        conditions = [["release", "IN", list(x[1] for x in projects_list)]]
+        filter_keys = {"project_id": {x[0] for x in projects_list}}
+        conditions = [["release", "IN", [x[1] for x in projects_list]]]
         query_cols = ["release", "project_id"]
 
         def data_tuple(x):
             return x["project_id"], x["release"]
 
     else:
-        filter_keys = {"project_id": list({x for x in projects_list})}
+        filter_keys = {"project_id": {x for x in projects_list}}
         query_cols = ["project_id"]
 
         def data_tuple(x):

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -143,7 +143,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         )
         assert data == {(self.project.id, self.session_release)}
 
-    def test_check_has_health_data_without_releases_should_exlude_sessions_gt_90_days(self):
+    def test_check_has_health_data_without_releases_should_exclude_sessions_gt_90_days(self):
         """
         Test that ensures that `check_has_health_data` returns a set of projects that has health
         data within the last 90d if only a list of project ids is provided and that any project
@@ -194,6 +194,10 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         )
         data = check_has_health_data([self.project.id, project2.id])
         assert data == {self.project.id, project2.id}
+
+    def test_check_has_health_data_does_not_crash_when_sending_projects_list_as_set(self):
+        data = check_has_health_data({self.project.id})
+        assert data == {self.project.id}
 
     def test_get_project_releases_by_stability(self):
         # Add an extra session with a different `distinct_id` so that sorting by users


### PR DESCRIPTION
Fixes an error caused by trying to access an element of set in check_has_health_data to identify if the argument passed contains tuples of project_id and release by converting set to list