### PR TITLE
fix(performance): Remove FCP as a Threshold Metric

### DIFF
--- a/src/sentry/models/transaction_threshold.py
+++ b/src/sentry/models/transaction_threshold.py
@@ -8,13 +8,11 @@ from sentry.db.models import DefaultFieldsModel, FlexibleForeignKey
 class TransactionMetric(Enum):
     DURATION = 1
     LCP = 2
-    FCP = 3
 
 
 TRANSACTION_METRICS = {
     TransactionMetric.DURATION.value: "duration",
     TransactionMetric.LCP.value: "lcp",
-    TransactionMetric.FCP.value: "fcp",
 }
 
 

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -89,7 +89,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
         name: 'metric',
         type: 'select',
         label: t('Metric'),
-        choices: () => ['duration', 'lcp', 'fcp'],
+        choices: () => ['duration', 'lcp'],
         help: t(
           'Set the measurement to apply the Response Time Threshold to. This metric will be used to calculate the Apdex and User Misery Scores.'
         ),


### PR DESCRIPTION
We couldn't get the multiIf working with the JSON syntax and
so removing the option for now.