### PR TITLE
feat(search): Frontend search has learned filter predications

### DIFF
--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -1,6 +1,8 @@
 {
-  const {TokenConverter, TermOperator, FilterType} = options;
-  const tc = new TokenConverter(text, location);
+  const {TokenConverter, TermOperator, FilterType, config} = options;
+  const tc = new TokenConverter({text, location, config});
+
+  const opDefault = TermOperator.Default;
 }
 
 search
@@ -59,98 +61,138 @@ filter
 
 // filter for dates
 date_filter
-  = key:search_key sep op:operator value:iso_8601_date_format {
+  = key:search_key sep op:operator value:iso_8601_date_format &{
+      return tc.predicateFilter(FilterType.Date, key, value, op)
+    } {
       return tc.tokenFilter(FilterType.Date, key, value, op, false);
     }
 
 // filter for exact dates
 specific_date_filter
-  = key:search_key sep value:iso_8601_date_format {
-      return tc.tokenFilter(FilterType.SpecificDate, key, value, TermOperator.Default, false);
+  = key:search_key sep value:iso_8601_date_format &{
+      return tc.predicateFilter(FilterType.SpecificDate, key)
+    } {
+      return tc.tokenFilter(FilterType.SpecificDate, key, value, opDefault, false);
     }
 
 // filter for relative dates
 rel_date_filter
-  = key:search_key sep value:rel_date_format {
-      return tc.tokenFilter(FilterType.RelativeDate, key, value, TermOperator.Default, false);
+  = key:search_key sep value:rel_date_format &{
+      return tc.predicateFilter(FilterType.RelativeDate, key)
+    } {
+      return tc.tokenFilter(FilterType.RelativeDate, key, value, opDefault, false);
     }
 
 // filter for durations
 duration_filter
-  = key:search_key sep op:operator? value:duration_format {
+  = key:search_key sep op:operator? value:duration_format &{
+      return tc.predicateFilter(FilterType.Duration, key)
+    } {
       return tc.tokenFilter(FilterType.Duration, key, value, op, false);
     }
 
 // boolean comparison filter
 boolean_filter
-  = negation:negation? key:search_key sep value:boolean_value {
-      return tc.tokenFilter(FilterType.Boolean, key, value, TermOperator.Default, !!negation);
+  = negation:negation? key:search_key sep value:boolean_value &{
+      return tc.predicateFilter(FilterType.Boolean, key)
+    } {
+      return tc.tokenFilter(FilterType.Boolean, key, value, opDefault, !!negation);
     }
 
 // numeric in filter
 numeric_in_filter
-  = key:search_key sep value:numeric_in_list {
-      return tc.tokenFilter(FilterType.NumericIn, key, value, TermOperator.Default, false);
+  = key:search_key sep value:numeric_in_list &{
+      return tc.predicateFilter(FilterType.NumericIn, key)
+    } {
+      return tc.tokenFilter(FilterType.NumericIn, key, value, opDefault, false);
     }
 
 // numeric comparison filter
 numeric_filter
-  = key:search_key sep op:operator? value:numeric_value {
+  = key:search_key sep op:operator? value:numeric_value &{
+      return tc.predicateFilter(FilterType.Numeric, key)
+    } {
       return tc.tokenFilter(FilterType.Numeric, key, value, op, false);
     }
 
 // aggregate duration filter
 aggregate_duration_filter
-  = negation:negation? key:aggregate_key sep op:operator? value:duration_format {
+  = negation:negation? key:aggregate_key sep op:operator? value:duration_format &{
+      return tc.predicateFilter(FilterType.AggregateDuration, key)
+  } {
       return tc.tokenFilter(FilterType.AggregateDuration, key, value, op, !!negation);
     }
 
 // aggregate percentage filter
 aggregate_percentage_filter
-  = negation:negation? key:aggregate_key sep op:operator? value:percentage_format {
+  = negation:negation? key:aggregate_key sep op:operator? value:percentage_format &{
+      return tc.predicateFilter(FilterType.AggregatePercentage, key)
+    } {
       return tc.tokenFilter(FilterType.AggregatePercentage, key, value, op, !!negation);
     }
 
 // aggregate numeric filter
 aggregate_numeric_filter
-  = negation:negation? key:aggregate_key sep op:operator? value:numeric_value {
+  = negation:negation? key:aggregate_key sep op:operator? value:numeric_value &{
+      return tc.predicateFilter(FilterType.AggregateNumeric, key)
+    } {
       return tc.tokenFilter(FilterType.AggregateNumeric, key, value, op, !!negation);
     }
 
 // aggregate date filter
 aggregate_date_filter
-  = negation:negation? key:aggregate_key sep op:operator? value:iso_8601_date_format {
+  = negation:negation? key:aggregate_key sep op:operator? value:iso_8601_date_format &{
+      return tc.predicateFilter(FilterType.AggregateDate, key)
+    } {
       return tc.tokenFilter(FilterType.AggregateDate, key, value, op, !!negation);
     }
 
 // filter for relative dates
 aggregate_rel_date_filter
-  = negation:negation? key:aggregate_key sep op:operator? value:rel_date_format {
+  = negation:negation? key:aggregate_key sep op:operator? value:rel_date_format &{
+      return tc.predicateFilter(FilterType.AggregateRelativeDate, key)
+    } {
       return tc.tokenFilter(FilterType.AggregateRelativeDate, key, value, op, !!negation);
     }
 
 // has filter for not null type checks
 has_filter
-  = negation:negation? &"has:" key:search_key sep value:(search_key / search_value) {
-      return tc.tokenFilter(FilterType.Has, key, value, TermOperator.Default, !!negation);
+  = negation:negation? &"has:" key:search_key sep value:(search_key / search_value) &{
+      return tc.predicateFilter(FilterType.Has, key)
+    } {
+      return tc.tokenFilter(FilterType.Has, key, value, opDefault, !!negation);
     }
 
 // is filter. Specific to issue search
 is_filter
-  = negation:negation? &"is:" key:search_key sep value:search_value {
-      return tc.tokenFilter(FilterType.Has, key, value, TermOperator.Default, !!negation);
+  = negation:negation? &"is:" key:search_key sep value:search_value &{
+      return tc.predicateFilter(FilterType.Is, key)
+    } {
+      return tc.tokenFilter(FilterType.Is, key, value, opDefault, !!negation);
     }
 
 // in filter key:[val1, val2]
 text_in_filter
-  = negation:negation? key:text_key sep value:text_in_list {
-      return tc.tokenFilter(FilterType.TextIn, key, value, TermOperator.Default, !!negation);
+  = negation:negation? key:text_key sep value:text_in_list &{
+      return tc.predicateFilter(FilterType.TextIn, key)
+    } {
+      return tc.tokenFilter(FilterType.TextIn, key, value, opDefault, !!negation);
     }
 
 // standard key:val filter
+//
+// The text_filter is a little special since it may not have an operator
+// depending on the configuration of the search parser, thus we have a
+// predicate for the operator.
 text_filter
-  = negation:negation? key:text_key sep op:operator? value:search_value {
-      return tc.tokenFilter(FilterType.Text, key, value, op, !!negation);
+  = negation:negation?
+    key:text_key
+    sep
+    op:(operator &{ return tc.predicateTextOperator(key); })?
+    value:search_value &{
+      return tc.predicateFilter(FilterType.Text, key)
+    } {
+      return tc.tokenFilter(FilterType.Text, key, value, op ? op[0] : opDefault, !!negation);
     }
 
 // Filter keys

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1,6 +1,13 @@
 import moment from 'moment';
 import {LocationRange} from 'pegjs';
 
+import {t} from 'app/locale';
+import {
+  isMeasurement,
+  isSpanOperationBreakdownField,
+  measurementType,
+} from 'app/utils/discover/fields';
+
 import grammar from './grammar.pegjs';
 
 type TextFn = () => string;
@@ -223,6 +230,7 @@ type FilterMap = {
     value: KVConverter<FilterTypeConfig[F]['validValues'][number]>;
     operator: FilterTypeConfig[F]['validOps'][number];
     negated: FilterTypeConfig[F]['canNegate'] extends true ? boolean : false;
+    invalidReason: string | null;
   };
 };
 
@@ -236,16 +244,58 @@ type FilterMap = {
 type FilterResult = FilterMap[FilterType];
 
 /**
+ * Utility to get the string name of any type of key.
+ */
+const getKeyName = (
+  key: ReturnType<
+    TokenConverter['tokenKeySimple' | 'tokenKeyExplicitTag' | 'tokenKeyAggregate']
+  >
+) => {
+  switch (key.type) {
+    case Token.KeySimple:
+      return key.value;
+    case Token.KeyExplicitTag:
+      return key.key.value;
+    case Token.KeyAggregate:
+      return key.name.value;
+    default:
+      return '';
+  }
+};
+
+type TokenConverterOpts = {
+  text: TextFn;
+  location: LocationFn;
+  config: SearchConfig;
+};
+
+/**
  * Used to construct token results via the token grammar
  */
 class TokenConverter {
   text: TextFn;
   location: LocationFn;
+  config: SearchConfig;
 
-  constructor(text: TextFn, location: LocationFn) {
+  constructor({text, location, config}: TokenConverterOpts) {
     this.text = text;
     this.location = location;
+    this.config = config;
   }
+
+  /**
+   * Validates various types of keys
+   */
+  keyValidation = {
+    isNumeric: (key: string) => this.config.numericKeys.has(key) || isMeasurement(key),
+    isBoolean: (key: string) => this.config.booleanKeys.has(key),
+    isPercentage: (key: string) => this.config.percentageKeys.has(key),
+    isDate: (key: string) => this.config.dateKeys.has(key),
+    isDuration: (key: string) =>
+      this.config.durationKeys.has(key) ||
+      isSpanOperationBreakdownField(key) ||
+      measurementType(key) === 'duration',
+  };
 
   /**
    * Creates a token with common `text` and `location` keys.
@@ -277,6 +327,7 @@ class TokenConverter {
       key,
       operator: operator ?? TermOperator.Default,
       value,
+      invalidReason: type === FilterType.Text ? this.checkInvalidTextFilter(key) : null,
     } as FilterResult);
 
   tokenFreeText = (value: string, quoted: boolean) =>
@@ -392,13 +443,6 @@ class TokenConverter {
       unit,
     });
 
-  tokenValueText = (value: string, quoted: boolean) =>
-    this.makeToken({
-      type: Token.ValueText as const,
-      value,
-      quoted,
-    });
-
   tokenValueNumberList = (
     item1: ReturnType<TokenConverter['tokenValueNumber']>,
     items: ListItem<ReturnType<TokenConverter['tokenValueNumber']>>[]
@@ -416,6 +460,97 @@ class TokenConverter {
       type: Token.ValueTextList as const,
       items: [{separator: '', value: item1}, ...items.map(listJoiner)],
     });
+
+  tokenValueText = (value: string, quoted: boolean) =>
+    this.makeToken({
+      type: Token.ValueText as const,
+      value,
+      quoted,
+    });
+
+  /**
+   * This method is used while tokenizing to predicate whether a filter should
+   * match or not. We do this because not all keys are valid for specific
+   * filter types. For example, boolean filters should only match for keys
+   * which can be filtered as booleans.
+   *
+   * See [0] and look for &{ predicate } to understand how predicates are
+   * declared in the grammar
+   *
+   * [0]:https://pegjs.org/documentation
+   */
+  predicateFilter = <T extends FilterType>(type: T, key: FilterMap[T]['key']) => {
+    const keyName = getKeyName(key);
+    const aggregateKey = key as ReturnType<TokenConverter['tokenKeyAggregate']>;
+
+    const {isNumeric, isDuration, isBoolean, isDate, isPercentage} = this.keyValidation;
+
+    switch (type) {
+      case FilterType.Numeric:
+      case FilterType.NumericIn:
+        return isNumeric(keyName);
+
+      case FilterType.Duration:
+        return isDuration(keyName);
+
+      case FilterType.Boolean:
+        return isBoolean(keyName);
+
+      case FilterType.Date:
+      case FilterType.RelativeDate:
+      case FilterType.SpecificDate:
+        return isDate(keyName);
+
+      case FilterType.AggregateDuration:
+        return aggregateKey.args?.args.some(arg => isDuration(arg.value.value));
+
+      case FilterType.AggregateDate:
+        return aggregateKey.args?.args.some(arg => isDate(arg.value.value));
+
+      case FilterType.AggregatePercentage:
+        return aggregateKey.args?.args.some(arg => isPercentage(arg.value.value));
+
+      default:
+        return true;
+    }
+  };
+
+  /**
+   * Predicates weather a text filter have operators for specific keys.
+   */
+  predicateTextOperator = (key: FilterMap[FilterType.Text]['key']) =>
+    this.config.textOperatorKeys.has(getKeyName(key));
+
+  /**
+   * Validates that a text filter is not using a non-text key.
+   */
+  checkInvalidTextFilter = (key: FilterMap[FilterType]['key']) => {
+    // Explicit tag keys are always treated as text filters
+    if (key.type === Token.KeyExplicitTag) {
+      return null;
+    }
+
+    const keyName = getKeyName(key);
+
+    if (this.keyValidation.isDate(keyName)) {
+      return t(
+        'Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).',
+        new Date().toISOString()
+      );
+    }
+
+    if (this.keyValidation.isBoolean(keyName)) {
+      return t('Invalid boolean. Expected true, 1, false, or 0.');
+    }
+
+    if (this.keyValidation.isNumeric(keyName)) {
+      return t(
+        'Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).'
+      );
+    }
+
+    return null;
+  };
 }
 
 /**
@@ -455,12 +590,95 @@ export type ParseResult = Array<
   | TokenResult<Token.Spaces>
 >;
 
+/**
+ * Configures behavior of search parsing
+ */
+export type SearchConfig = {
+  /**
+   * Keys which are considered valid for duration filters
+   */
+  durationKeys: Set<string>;
+  /**
+   * Text filter keys we allow to have operators
+   */
+  textOperatorKeys: Set<string>;
+  /**
+   * Keys considered valid for the percentage aggregate and may have percentage
+   * search values
+   */
+  percentageKeys: Set<string>;
+  /**
+   * Keys considered valid for numeric filter types
+   */
+  numericKeys: Set<string>;
+  /**
+   * Keys considered valid for date filter types
+   */
+  dateKeys: Set<string>;
+  /**
+   * Keys considered valid for boolean filter types
+   */
+  booleanKeys: Set<string>;
+  /**
+   * Enables boolean filtering (AND / OR)
+   */
+  allowBoolean: boolean;
+};
+
+const defaultConfig: SearchConfig = {
+  textOperatorKeys: new Set(['sentry.semver']),
+  durationKeys: new Set(['transaction.duration']),
+  percentageKeys: new Set(['percentage']),
+  numericKeys: new Set([
+    'project_id',
+    'project.id',
+    'issue.id',
+    'stack.colno',
+    'stack.lineno',
+    'stack.stack_level',
+    'transaction.duration',
+    'apdex',
+    'p75',
+    'p95',
+    'p99',
+    'failure_rate',
+    'count_miserable',
+    'user_misery',
+    'count_miserable_new',
+    'user_miser_new',
+  ]),
+  dateKeys: new Set([
+    'start',
+    'end',
+    'first_seen',
+    'last_seen',
+    'time',
+    'timestamp',
+    'timestamp.to_hour',
+    'timestamp.to_day',
+    'transaction.start_time',
+    'transaction.end_time',
+  ]),
+  booleanKeys: new Set([
+    'error.handled',
+    'error.unhandled',
+    'stack.in_app',
+    'key_transaction',
+    'team_key_transaction',
+  ]),
+  allowBoolean: true,
+};
+
 const options = {
   TokenConverter,
   TermOperator,
   FilterType,
+  config: defaultConfig,
 };
 
+/**
+ * Parse a search query into a ParseResult
+ */
 export function parseSearch(query: string): ParseResult {
   return grammar.parse(query, options);
 }


### PR DESCRIPTION
Some filter types may match, but based on additional search configurations, should not be considered matches.

Most of the predication is based on a predefined set of keys which are allowed for specific filter types.

This adds a new method to the TokenConverter called `predicateFilter` which determines if given a filter type and the key being filtered, should this filter match, otherwise the grammar will not consume and will move to the next possible filter match.

Validation of text filters is now also handled, since we now know what keys are of what types.

The configuration design is similar to the backend refactor in GH-26596