### PR TITLE
py38: bump LAST_VERIFIED_DJANGO_VERSION to 2.0

### DIFF
--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -5,7 +5,7 @@ from sentry.new_migrations.monkey.executor import SentryMigrationExecutor
 from sentry.new_migrations.monkey.fields import deconstruct
 from sentry.new_migrations.monkey.writer import SENTRY_MIGRATION_TEMPLATE
 
-LAST_VERIFIED_DJANGO_VERSION = (1, 11)
+LAST_VERIFIED_DJANGO_VERSION = (2, 0)
 CHECK_MESSAGE = """Looks like you're trying to upgrade Django! Since we monkeypatch
 the Django migration library in several places, please verify that we have the latest
 code, and that the monkeypatching still works as expected. Currently the main things


### PR DESCRIPTION
I did the following successfully:

1. Check for any migration template deviations: `src/sentry/new_migrations/monkey/writer.py`

2. Generate and run a migration, checking that it should be generated with the new template.

- Modify Project.name max_length to 201
- Generate migration with `sentry django makemigrations`, verified generated with new template.
- Run `sentry upgrade`, verify change is reflected in `sentry_project`'s `name` column.
  - `docker exec sentry_postgres psql sentry -h 127.0.0.1 -U postgres -c '\d sentry_project;'`

3. Do the same, but this time with a dangerous migration.

- Modify Project.name max_length to 202
- Generate migration, modify is_dangerous to be true, and run `MIGRATION_SKIP_DANGEROUS=1 sentry upgrade`, see that it was reported to have been faked
- Unapply it by migrating to the previous migration (`sentry django migrate sentry NUMBER`)
- `sentry upgrade` without `MIGRATION_SKIP_DANGEROUS=1`, and see that it succeeds.