### PR TITLE
ref(repos): Ensure repository link opens in new tab

### DIFF
--- a/static/app/components/repositoryRow.tsx
+++ b/static/app/components/repositoryRow.tsx
@@ -7,6 +7,7 @@ import {Client} from 'app/api';
 import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
+import ExternalLink from 'app/components/links/externalLink';
 import {PanelItem} from 'app/components/panels';
 import RepositoryEditForm from 'app/components/repositoryEditForm';
 import Tooltip from 'app/components/tooltip';
@@ -162,7 +163,9 @@ class RepositoryRow extends Component<Props> {
                 {showProvider && repository.url && <span>&nbsp;&mdash;&nbsp;</span>}
                 {repository.url && (
                   <small>
-                    <a href={repository.url}>{repository.url.replace('https://', '')}</a>
+                    <ExternalLink href={repository.url}>
+                      {repository.url.replace('https://', '')}
+                    </ExternalLink>
                   </small>
                 )}
               </div>


### PR DESCRIPTION
Leverage the EnternalLink tag to ensure clicking on a repository opens in a new tab instead of replacing the current context.

Fixes API-1947