### PR TITLE
fix(jwt): Wrap InvalidSignatureError

### DIFF
--- a/src/sentry/integrations/atlassian_connect.py
+++ b/src/sentry/integrations/atlassian_connect.py
@@ -1,6 +1,8 @@
 import hashlib
+from typing import Mapping, Optional, Sequence, Union
 
 from jwt import InvalidSignatureError
+from rest_framework.request import Request
 
 from sentry.models import Integration
 from sentry.utils import jwt
@@ -13,7 +15,9 @@ class AtlassianConnectValidationError(Exception):
     pass
 
 
-def get_query_hash(uri, method, query_params=None):
+def get_query_hash(
+    uri: str, method: str, query_params: Optional[Mapping[str, Union[str, Sequence[str]]]] = None
+) -> str:
     # see
     # https://developer.atlassian.com/static/connect/docs/latest/concepts/understanding-jwt.html#qsh
     uri = uri.rstrip("/")
@@ -35,7 +39,13 @@ def get_query_hash(uri, method, query_params=None):
     return hashlib.sha256(query_string.encode("utf8")).hexdigest()
 
 
-def get_integration_from_jwt(token, path, provider, query_params, method="GET"):
+def get_integration_from_jwt(
+    token: Optional[str],
+    path: str,
+    provider: str,
+    query_params: Optional[Mapping[str, str]],
+    method: str = "GET",
+) -> Integration:
     # https://developer.atlassian.com/static/connect/docs/latest/concepts/authentication.html
     # Extract the JWT token from the request's jwt query
     # parameter or the authorization header.
@@ -73,5 +83,5 @@ def get_integration_from_jwt(token, path, provider, query_params, method="GET"):
     return integration
 
 
-def get_integration_from_request(request, provider):
+def get_integration_from_request(request: Request, provider: str) -> Integration:
     return get_integration_from_jwt(request.GET.get("jwt"), request.path, provider, request.GET)

--- a/src/sentry/integrations/atlassian_connect.py
+++ b/src/sentry/integrations/atlassian_connect.py
@@ -1,5 +1,7 @@
 import hashlib
 
+from jwt import InvalidSignatureError
+
 from sentry.models import Integration
 from sentry.utils import jwt
 from sentry.utils.http import percent_encode
@@ -56,7 +58,11 @@ def get_integration_from_jwt(token, path, provider, query_params, method="GET"):
     # alg field.  We only need the token + shared secret and do not want to provide an
     # audience to the JWT validation that is require to match.  Bitbucket does give us an
     # audience claim however, so disable verification of this.
-    decoded_verified = jwt.decode(token, integration.metadata["shared_secret"], audience=False)
+    try:
+        decoded_verified = jwt.decode(token, integration.metadata["shared_secret"], audience=False)
+    except InvalidSignatureError:
+        raise AtlassianConnectValidationError("Signature is invalid")
+
     # Verify the query has not been tampered by Creating a Query Hash
     # and comparing it against the qsh claim on the verified token.
 

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -111,7 +111,7 @@ def authorization_header(token: str, *, scheme: str = "Bearer") -> Mapping[str, 
     authorization header.
 
     Typically JWT uses the token in the "Bearer" scheme for the authorisation header.  If
-    you need to use a differnt scheme use the `scheme` argument to change this.
+    you need to use a different scheme use the `scheme` argument to change this.
 
     :param token: The JWT token to use in the authorization header.
     :param scheme: The authorisation scheme to use.


### PR DESCRIPTION
We're 500ing on an invalid signature so catch the `InvalidSignatureError` and turn it into a 400.

Fixes [SENTRY-QQ3](https://sentry.io/organizations/sentry/issues/2447256355/).
