### PR TITLE
ref(hierarchical-grouping):  Add UI improvements - part 2

### DIFF
--- a/src/sentry/api/endpoints/grouping_levels.py
+++ b/src/sentry/api/endpoints/grouping_levels.py
@@ -12,8 +12,8 @@ from sentry.utils import snuba
 
 class NoEvents(SentryAPIException):
     status_code = status.HTTP_403_FORBIDDEN
-    message = "This issue has no events."
     code = "no_events"
+    message = "This issue has no events."
 
 
 class MergedIssues(SentryAPIException):

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -21,8 +21,8 @@ import withOrganization from 'app/utils/withOrganization';
 
 type Props = WithRouterProps<{orgId: string}> & {
   data: Event | Group;
-  showAssignee?: boolean;
   organization: Organization;
+  showAssignee?: boolean;
   hasGuideAnchor?: boolean;
   showInboxTime?: boolean;
 };

--- a/static/app/views/organizationGroupDetails/grouping/errorMessage.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/errorMessage.tsx
@@ -1,0 +1,88 @@
+import Button from 'app/components/button';
+import LoadingError from 'app/components/loadingError';
+import {Panel} from 'app/components/panels';
+import {t} from 'app/locale';
+import {Group} from 'app/types';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+
+type ErrorCode = 'not_hierarchical' | 'no_events' | 'merged_issues' | 'missing_feature';
+
+type Error = {
+  status: number;
+  responseJSON?: {
+    detail: {
+      code: ErrorCode;
+      extra: Record<string, any>;
+      message: string;
+    };
+  };
+};
+
+type Props = {
+  error: Error;
+  groupId: Group['id'];
+  onRetry: () => void;
+};
+
+function ErrorMessage({error, groupId, onRetry}: Props) {
+  function getErrorMessage(errorCode: ErrorCode) {
+    switch (errorCode) {
+      case 'merged_issues':
+        return {
+          title: t('An issue can only contain one fingerprint'),
+          subTitle: t(
+            'This issue needs to be fully unmerged before grouping levels can be shown'
+          ),
+        };
+      case 'missing_feature':
+        return {
+          title: t('This project does not have the grouping tree feature'),
+        };
+
+      case 'no_events':
+        return {
+          title: t('This issue has no events'),
+        };
+      case 'not_hierarchical':
+        return {
+          title: t('This issue does not have hierarchical grouping'),
+        };
+      default:
+        return undefined;
+    }
+  }
+
+  if (error.status === 403 && error.responseJSON?.detail) {
+    const {code, message} = error.responseJSON.detail;
+    const errorMessage = getErrorMessage(code);
+
+    return (
+      <Panel>
+        <EmptyMessage
+          size="large"
+          title={errorMessage?.title ?? message}
+          description={errorMessage?.subTitle}
+          action={
+            code === 'merged_issues' ? (
+              <Button
+                priority="primary"
+                to={`/organizations/sentry/issues/${groupId}/merged/?${location.search}`}
+              >
+                {t('Unmerge issue')}
+              </Button>
+            ) : undefined
+          }
+        />
+      </Panel>
+    );
+  }
+
+  return (
+    <LoadingError
+      message={t('Unable to load grouping levels, please try again later')}
+      onRetry={onRetry}
+    />
+  );
+}
+
+export default ErrorMessage;

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -1,23 +1,51 @@
 import styled from '@emotion/styled';
 
 import Card from 'app/components/card';
+import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import ShortId from 'app/components/shortId';
+import TimeSince from 'app/components/timeSince';
+import {IconClock} from 'app/icons';
 import {tn} from 'app/locale';
 import space from 'app/styles/space';
+import {Organization, Project} from 'app/types';
 import {Event} from 'app/types/event';
 
 type Props = {
   sampleEvent: Event;
   eventCount: number;
-  isReloading: boolean;
+  organization: Organization;
+  project?: Project;
 };
 
-function NewIssue({sampleEvent, eventCount, isReloading}: Props) {
-  const {title, culprit} = sampleEvent;
+function NewIssue({sampleEvent, eventCount, organization, project}: Props) {
   return (
-    <StyledCard interactive={false} isReloading={isReloading}>
+    <StyledCard interactive={false}>
       <div>
-        <Title>{title}</Title>
-        <CulPrint>{culprit}</CulPrint>
+        <EventOrGroupHeader
+          data={sampleEvent}
+          organization={organization}
+          hideIcons
+          hideLevel
+        />
+        <Details>
+          {project && (
+            <GroupShortId
+              shortId={project.slug}
+              avatar={
+                project && <ProjectBadge project={project} avatarSize={14} hideName />
+              }
+              onClick={e => {
+                // prevent the clicks from propagating so that the short id can be selected
+                e.stopPropagation();
+              }}
+            />
+          )}
+          <TimeWrapper>
+            <IconClock size="xs" />
+            <TimeSince date={sampleEvent.dateCreated} />
+          </TimeWrapper>
+        </Details>
       </div>
       <ErrorsCount>
         {eventCount}
@@ -29,7 +57,7 @@ function NewIssue({sampleEvent, eventCount, isReloading}: Props) {
 
 export default NewIssue;
 
-const StyledCard = styled(Card)<{isReloading: boolean}>`
+const StyledCard = styled(Card)`
   margin-bottom: -1px;
   overflow: hidden;
   display: grid;
@@ -38,27 +66,36 @@ const StyledCard = styled(Card)<{isReloading: boolean}>`
   padding: ${space(1.5)} ${space(2)};
   grid-gap: ${space(2)};
   word-break: break-word;
-  ${p =>
-    p.isReloading &&
-    `
-      opacity: 0.5;
-      pointer-events: none;
-    `}
 `;
 
-const Title = styled('div')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  font-weight: 700;
+const Details = styled('div')`
+  margin-top: ${space(0.5)};
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(2)};
+  justify-content: flex-start;
 `;
 
-const CulPrint = styled('div')`
-  font-size: ${p => p.theme.fontSizeMedium};
+const GroupShortId = styled(ShortId)`
+  flex-shrink: 0;
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+`;
+
+const TimeWrapper = styled('div')`
+  display: grid;
+  grid-gap: ${space(0.5)};
+  grid-template-columns: min-content 1fr;
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
 `;
 
 const ErrorsCount = styled('div')`
   display: grid;
   align-items: center;
   justify-items: center;
+  font-size: ${p => p.theme.fontSizeLarge};
 `;
 
 const ErrorLabel = styled('div')`

--- a/static/app/views/settings/components/emptyMessage.tsx
+++ b/static/app/views/settings/components/emptyMessage.tsx
@@ -29,7 +29,7 @@ const EmptyMessage = styled(
   }: EmptyMessageProps) => (
     <div data-test-id="empty-message" {...props}>
       {icon && <IconWrapper>{icon}</IconWrapper>}
-      {title && <Title>{title}</Title>}
+      {title && <Title noMargin={!description && !children && !action}>{title}</Title>}
       {description && <Description>{description}</Description>}
       {children && <Description noMargin>{children}</Description>}
       {action && <Action>{action}</Action>}
@@ -60,9 +60,9 @@ const IconWrapper = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-const Title = styled('strong')`
+const Title = styled('strong')<{noMargin: boolean}>`
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  margin-bottom: ${space(1)};
+  ${p => !p.noMargin && `margin-bottom: ${space(1)};`}
 `;
 
 const Description = styled(TextBlock)`


### PR DESCRIPTION
. Map backend error code to frontend messages

![image](https://user-images.githubusercontent.com/29228205/122199411-4dc56680-ce9a-11eb-9965-35425052d95f.png)

![image](https://user-images.githubusercontent.com/29228205/122199608-81a08c00-ce9a-11eb-8d5c-ac81f43facb9.png)

![image](https://user-images.githubusercontent.com/29228205/122199674-954bf280-ce9a-11eb-9f04-742b11e74402.png)


![image](https://user-images.githubusercontent.com/29228205/122199528-67ff4480-ce9a-11eb-891a-a7a7bfe14993.png)

. Uses the EventOrGroupHeader to display a nice issue title with stack traces on hover 


![image](https://user-images.githubusercontent.com/29228205/122200026-f07de500-ce9a-11eb-96b8-201ad4ac1379.png)

