### PR TITLE
fix(ui): Release pagination encoding

### DIFF
--- a/static/app/views/releases/detail/releaseActions.tsx
+++ b/static/app/views/releases/detail/releaseActions.tsx
@@ -116,7 +116,9 @@ function ReleaseActions({
   function replaceReleaseUrl(toRelease: string | null) {
     return toRelease
       ? {
-          pathname: location.pathname.replace(release.version, toRelease),
+          pathname: location.pathname
+            .replace(encodeURIComponent(release.version), toRelease)
+            .replace(release.version, toRelease),
           query: {...location.query, activeRepo: undefined},
         }
       : '';


### PR DESCRIPTION
The older/newer pagination on the release detail page was flakey for releases with the package in name because the `@` sign got encoded and the replacement of the URL did not work properly.