### PR TITLE
fix: Create a new File when rewriting artifact index

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -236,7 +236,7 @@ class _ArtifactIndexGuard:
     def __init__(self, release: Release, dist: Optional[Distribution]):
         self._release = release
         self._dist = dist
-        self._ident = ReleaseFile.get_ident(ARTIFACT_INDEX_FILENAME, dist)
+        self._ident = ReleaseFile.get_ident(ARTIFACT_INDEX_FILENAME, dist and dist.name)
 
     def readable_data(self) -> Optional[dict]:
         """Simple read, no synchronization necessary"""

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -298,17 +298,14 @@ class _ArtifactIndexGuard:
     def _get_or_create_releasefile(self):
         """Make sure that the release file exists"""
 
-        def create_empty_index():
-            file_ = File.objects.create(
-                name=ARTIFACT_INDEX_FILENAME,
-                type=ARTIFACT_INDEX_TYPE,
-            )
-            file_.putfile(BytesIO(b"{}"))  # Empty JSON object
-            return file_
-
         return ReleaseFile.objects.select_for_update().get_or_create(
             **self._key_fields(),
-            defaults={"file": create_empty_index},
+            defaults={
+                "file": lambda: File.objects.create(
+                    name=ARTIFACT_INDEX_FILENAME,
+                    type=ARTIFACT_INDEX_TYPE,
+                )
+            },
         )
 
     def _releasefile_qs(self):

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -236,6 +236,7 @@ class _ArtifactIndexGuard:
     def __init__(self, release: Release, dist: Optional[Distribution]):
         self._release = release
         self._dist = dist
+        self._ident = ReleaseFile.get_ident(ARTIFACT_INDEX_FILENAME, dist)
 
     def readable_data(self) -> Optional[dict]:
         """Simple read, no synchronization necessary"""
@@ -308,6 +309,7 @@ class _ArtifactIndexGuard:
             dist=self._dist,
             name=ARTIFACT_INDEX_FILENAME,
             file__type=ARTIFACT_INDEX_TYPE,  # Make sure we don't get a user-uploaded file
+            ident=self._ident,
         )
 
 

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -6,6 +6,8 @@ from threading import Thread
 from time import sleep
 from zipfile import ZipFile
 
+import pytest
+
 from sentry import options
 from sentry.models import ReleaseFile
 from sentry.models.distribution import Distribution
@@ -224,7 +226,7 @@ class ReleaseArchiveTestCase(TestCase):
         assert file_.checksum == index["files"]["fake://foo"]["sha1"]
 
 
-# @pytest.mark.skip(reason="Causes 'There is 1 other session using the database.'")
+@pytest.mark.skip(reason="Causes 'There is 1 other session using the database.'")
 class ArtifactIndexGuardTestCase(TransactionTestCase):
     tick = 0.1  # seconds
 

--- a/tests/sentry/models/test_releasefile.py
+++ b/tests/sentry/models/test_releasefile.py
@@ -6,8 +6,6 @@ from threading import Thread
 from time import sleep
 from zipfile import ZipFile
 
-import pytest
-
 from sentry import options
 from sentry.models import ReleaseFile
 from sentry.models.distribution import Distribution
@@ -226,7 +224,7 @@ class ReleaseArchiveTestCase(TestCase):
         assert file_.checksum == index["files"]["fake://foo"]["sha1"]
 
 
-@pytest.mark.skip(reason="Causes 'There is 1 other session using the database.'")
+# @pytest.mark.skip(reason="Causes 'There is 1 other session using the database.'")
 class ArtifactIndexGuardTestCase(TransactionTestCase):
     tick = 0.1  # seconds
 


### PR DESCRIPTION
Consider `File` immutable, so create a new one any time the artifact index is updated.