### PR TITLE
fix(dev): dataclasses should not install for Python 3.8

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -6,7 +6,7 @@ click==7.1.2
 confluent-kafka==1.5.0; python_version <= '3.8'
 confluent-kafka==1.6.0; python_version == '3.9'
 croniter==0.3.37
-dataclasses==0.8
+dataclasses==0.8; python_version <= '3.6'
 datadog==0.29.3
 django-crispy-forms==1.7.2
 django-manifest-loader==1.0.0


### PR DESCRIPTION
This fixes a regression introduced in #26618