### PR TITLE
fix(notifications): Check feature flag one organization at a time

### DIFF
--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Sequence
 
 from rest_framework.response import Response
 

--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -1,6 +1,15 @@
+from typing import Any, Callable, Optional, Sequence
+
 from rest_framework.response import Response
 
 from sentry import features
+from sentry.models import Organization
+
+
+def any_organization_has_feature(
+    feature: str, organizations: Sequence[Organization], **kwargs: Any
+) -> bool:
+    return any([features.has(feature, organization, **kwargs) for organization in organizations])
 
 
 def requires_feature(feature, any_org=None):
@@ -27,9 +36,8 @@ def requires_feature(feature, any_org=None):
             # The endpoint is accessible if any of the User's Orgs have the feature
             # flag enabled.
             if any_org:
-                if not any(
-                    features.has(feature, org, actor=request.user)
-                    for org in request.user.get_orgs()
+                if not any_organization_has_feature(
+                    feature, request.user.get_orgs(), actor=request.user
                 ):
                     return Response(status=404)
 

--- a/src/sentry/integrations/slack/message_builder/event.py
+++ b/src/sentry/integrations/slack/message_builder/event.py
@@ -11,7 +11,6 @@ DM_COMMAND_HEADER = "*Direct Message Commands:*"
 CHANNEL_COMMANDS_HEADER = "*Channel Commands:*"
 GENERAL_MESSAGE = "Just want to learn more about Sentry? Check out our documentation."
 
-
 DM_COMMANDS = {
     "link": "Link your Slack account to Sentry",
     "unlink": "Unlink your Slack account from Sentry",
@@ -21,19 +20,18 @@ CHANNEL_COMMANDS = {
     "link team": "Type this into the channel in which you want your team to receive issue alert notifications"
 }
 
-DM_COMMANDS_MESSAGE = "\n".join(
-    (
-        f"• `/sentry {command}`: {description}"
-        for command, description in sorted(tuple(DM_COMMANDS.items()))
-    )
-)
 
-CHANNEL_COMMANDS_MESSAGE = "\n".join(
-    (
-        f"• `/sentry {command}`: {description}"
-        for command, description in sorted(tuple(CHANNEL_COMMANDS.items()))
+def list_commands(commands: Mapping[str, str]) -> str:
+    return "\n".join(
+        (
+            f"• `/sentry {command}`: {description}"
+            for command, description in sorted(tuple(commands.items()))
+        )
     )
-)
+
+
+DM_COMMANDS_MESSAGE = list_commands(DM_COMMANDS)
+CHANNEL_COMMANDS_MESSAGE = list_commands(CHANNEL_COMMANDS)
 
 
 class SlackEventMessageBuilder(BlockSlackMessageBuilder):

--- a/src/sentry/integrations/slack/message_builder/event.py
+++ b/src/sentry/integrations/slack/message_builder/event.py
@@ -1,4 +1,6 @@
-from sentry import features
+from typing import Mapping
+
+from sentry.features.helpers import any_organization_has_feature
 from sentry.integrations.slack.message_builder import SlackBody
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.models import Integration
@@ -49,7 +51,7 @@ class SlackEventMessageBuilder(BlockSlackMessageBuilder):
                 )
             ]
         )
-        if not features.has(
+        if not any_organization_has_feature(
             "organizations:notification-platform", self.integration.organizations.all()
         ):
             return self._build_blocks(

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.features import OrganizationFeature
-from sentry.features.helpers import requires_feature
+from sentry.features.helpers import any_organization_has_feature, requires_feature
 from sentry.testutils import TestCase
 from sentry.utils.compat.mock import patch
 
@@ -20,6 +20,11 @@ class TestFeatureHelpers(TestCase):
         self.request.user = self.user
 
         features.add("foo", OrganizationFeature)
+
+    def test_any_organization_has_feature(self):
+        assert not any_organization_has_feature("foo", self.user.get_orgs())
+        with org_with_feature(self.org, "foo"):
+            assert any_organization_has_feature("foo", self.user.get_orgs())
 
     def test_org_missing_from_request_fails(self):
         @requires_feature("foo")


### PR DESCRIPTION
It looks like `features.has()` cannot handle a list or organizations so I'm iterating and testing one at a time.

Fixes [SENTRY-QRX](https://sentry.io/organizations/sentry/issues/2459003043/).