### PR TITLE
fix(discover): Render multiple User Misery Fields correctly

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -433,8 +433,12 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
 };
 
+type SpecialFunctionFieldRenderer = (
+  fieldName: string
+) => (data: EventData, baggage: RenderFunctionBaggage) => React.ReactNode;
+
 type SpecialFunctions = {
-  user_misery: SpecialFieldRenderFunc;
+  user_misery: SpecialFunctionFieldRenderer;
 };
 
 /**
@@ -442,38 +446,37 @@ type SpecialFunctions = {
  * or they require custom UI formatting that can't be handled by the datatype formatters.
  */
 const SPECIAL_FUNCTIONS: SpecialFunctions = {
-  user_misery: data => {
-    let userMiseryField: string = '';
-    let countMiserableUserField: string = '';
-    let projectThresholdConfig: string = '';
-    for (const field in data) {
-      if (field.startsWith('user_misery')) {
-        userMiseryField = field;
-      } else if (
-        field.startsWith('count_miserable_user') ||
-        field.startsWith('count_miserable_new_user')
-      ) {
-        countMiserableUserField = field;
-      } else if (field === 'project_threshold_config') {
-        projectThresholdConfig = field;
-      }
+  user_misery: fieldName => data => {
+    const userMiseryField = fieldName;
+
+    if (!(userMiseryField in data)) {
+      return <NumberContainer>{emptyValue}</NumberContainer>;
     }
 
-    if (!userMiseryField) {
-      return <NumberContainer>{emptyValue}</NumberContainer>;
+    const projectThresholdConfig = 'project_threshold_config';
+    let countMiserableUserField: string = '';
+
+    let miseryLimit: number | undefined = parseInt(
+      userMiseryField.split('_').pop() || '',
+      10
+    );
+    if (isNaN(miseryLimit)) {
+      countMiserableUserField = 'count_miserable_user';
+      if (projectThresholdConfig in data) {
+        miseryLimit = data[projectThresholdConfig][1];
+      } else {
+        miseryLimit = undefined;
+      }
+    } else {
+      countMiserableUserField = `count_miserable_user_${miseryLimit}`;
     }
 
     const uniqueUsers = data.count_unique_user;
     const userMisery = data[userMiseryField];
 
-    let miseryLimit = parseInt(userMiseryField.split('_').pop() || '', 10);
-    if (isNaN(miseryLimit)) {
-      miseryLimit = projectThresholdConfig ? data[projectThresholdConfig][1] : undefined;
-    }
-
     let miserableUsers: number | undefined;
 
-    if (countMiserableUserField) {
+    if (countMiserableUserField in data) {
       const countMiserableMiseryLimit = parseInt(
         countMiserableUserField.split('_').pop() || '',
         10
@@ -669,7 +672,7 @@ export function getFieldRenderer(
 
   for (const alias in SPECIAL_FUNCTIONS) {
     if (fieldName.startsWith(alias)) {
-      return SPECIAL_FUNCTIONS[alias];
+      return SPECIAL_FUNCTIONS[alias](fieldName);
     }
   }
 


### PR DESCRIPTION
In the current state we just check for `startswith('user_misery')`
while rendering the user misery bars, but when (in a discover query)
we try to add multiple user misery columns there is no way to
differentiate between them. Modified the function to take in
field name to be able to make the distinction between
different user misery fields.

Before:
![Screen Shot 2021-06-16 at 12 52 46 PM](https://user-images.githubusercontent.com/63818634/122260973-e0b5cf00-cea1-11eb-82f8-61a3fe006f29.png)

After:
![Screen Shot 2021-06-16 at 12 54 46 PM](https://user-images.githubusercontent.com/63818634/122261133-0e9b1380-cea2-11eb-9bbd-6016241619ac.png)

