### PR TITLE
test(workflow): Hide dynamic alert text in screenshot

### DIFF
--- a/static/app/views/alerts/list/row.tsx
+++ b/static/app/views/alerts/list/row.tsx
@@ -105,7 +105,11 @@ class AlertListRow extends Component<Props> {
             <Title>
               <Link to={alertLink}>Alert #{incident.id}</Link>
               <div>
-                {t('Triggered ')} <TimeSince date={incident.dateStarted} extraShort />
+                {t('Triggered ')}{' '}
+                {getDynamicText({
+                  value: <TimeSince date={incident.dateStarted} extraShort />,
+                  fixed: '1w ago',
+                })}
                 <StyledTimeSeparator> | </StyledTimeSeparator>
                 {incident.status === IncidentStatus.CLOSED
                   ? tct('Active for [duration]', {


### PR DESCRIPTION
fixes these screenshots from incrementing "422w ago" every week. https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/6d197c8a53c0a649fb08adf5262b3e76660ad29a/index.html 