### PR TITLE
fix(discover): No user set for snuba params

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -50,6 +50,16 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         except InvalidSearchQuery as e:
             raise ParseError(detail=str(e))
 
+    def get_team_ids(self, request, organization):
+        if not request.user:
+            return []
+
+        teams = get_teams(request, organization)
+        if not teams:
+            teams = Team.objects.get_for_user(organization, request.user)
+
+        return [team.id for team in teams]
+
     def get_snuba_params(self, request, organization, check_global_views=True):
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params"):
             if (
@@ -64,10 +74,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             params = self.get_filter_params(request, organization)
             params = self.quantize_date_params(request, params)
             params["user_id"] = request.user.id if request.user else None
-            teams = get_teams(request, organization)
-            if not teams:
-                teams = Team.objects.get_for_user(organization, request.user)
-            params["team_id"] = [team.id for team in teams]
+            params["team_id"] = self.get_team_ids(request, organization)
 
             if check_global_views:
                 has_global_views = features.has(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -122,7 +122,12 @@ class UnfurlTest(TestCase):
             UnfurlableUrl(url=url, args=args),
         ]
 
-        with self.feature("organizations:chart-unfurls"):
+        with self.feature(
+            [
+                "organizations:discover-basic",
+                "organizations:chart-unfurls",
+            ]
+        ):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links)
 
         assert unfurls[url] == build_discover_attachment(
@@ -165,10 +170,11 @@ class UnfurlTest(TestCase):
         ]
 
         with self.feature(
-            {
-                "organizations:discover": True,
-                "organizations:chart-unfurls": True,
-            }
+            [
+                "organizations:discover",
+                "organizations:discover-basic",
+                "organizations:chart-unfurls",
+            ]
         ):
             unfurls = link_handlers[link_type].fn(self.request, self.integration, links)
 


### PR DESCRIPTION
When unfurling discover urls in slack, there is no user associated with the bot
that makes the request. This should not cause an error.

Fixes SENTRY-QRY