### PR TITLE
fix(breakdowns): Remove breakdowns from project details serializer

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -791,7 +791,6 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "builtinSymbolSources": get_value_with_default("sentry:builtin_symbol_sources"),
                 "symbolSources": attrs["options"].get("sentry:symbol_sources"),
                 "dynamicSampling": get_value_with_default("sentry:dynamic_sampling"),
-                "breakdowns": get_value_with_default("sentry:breakdowns"),
             }
         )
         return data


### PR DESCRIPTION
It doesn't seem like this is necessary for span operation breakdowns to be computed on Relay. I had originally added this since `dynamicSampling` was injected as well. 