### PR TITLE
fix(discover): Disable export button when discover query has errors

### DIFF
--- a/static/app/views/eventsV2/table/tableActions.tsx
+++ b/static/app/views/eventsV2/table/tableActions.tsx
@@ -18,6 +18,7 @@ import {downloadAsCsv} from '../utils';
 
 type Props = {
   isLoading: boolean;
+  error: string | null;
   title: string;
   organization: OrganizationSummary;
   eventView: EventView;
@@ -48,11 +49,10 @@ function renderDownloadButton(canEdit: boolean, props: Props) {
   );
 }
 
-function renderBrowserExportButton(canEdit: boolean, {isLoading, ...props}: Props) {
-  const disabled = isLoading || canEdit === false;
-  const onClick = disabled
-    ? undefined
-    : () => handleDownloadAsCsv(props.title, {isLoading, ...props});
+function renderBrowserExportButton(canEdit: boolean, props: Props) {
+  const {isLoading, error} = props;
+  const disabled = isLoading || error !== null || canEdit === false;
+  const onClick = disabled ? undefined : () => handleDownloadAsCsv(props.title, props);
 
   return (
     <Button
@@ -68,8 +68,8 @@ function renderBrowserExportButton(canEdit: boolean, {isLoading, ...props}: Prop
 }
 
 function renderAsyncExportButton(canEdit: boolean, props: Props) {
-  const {isLoading, location, eventView} = props;
-  const disabled = isLoading || canEdit === false;
+  const {isLoading, error, location, eventView} = props;
+  const disabled = isLoading || error !== null || canEdit === false;
   return (
     <DataExport
       payload={{

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -444,6 +444,7 @@ class TableView extends React.Component<TableViewProps> {
       title,
       eventView,
       isLoading,
+      error,
       tableData,
       location,
       onChangeShowTags,
@@ -454,6 +455,7 @@ class TableView extends React.Component<TableViewProps> {
       <TableActions
         title={title}
         isLoading={isLoading}
+        error={error}
         organization={organization}
         eventView={eventView}
         onEdit={this.handleEditColumns}


### PR DESCRIPTION
When the query contains errors, the export will fail as well. So disable the
export button until the errors are fixed.