### PR TITLE
feat(semver): Move semver filtering logic out of `parse_semver_search` into `ReleaseQuerySet`

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -5,7 +5,7 @@ from time import time
 
 import sentry_sdk
 from django.db import IntegrityError, models, transaction
-from django.db.models import Case, F, When
+from django.db.models import Case, F, Func, Q, Value, When
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
@@ -22,6 +22,7 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models import CommitFileChange, GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.signals import issue_resolved
 from sentry.utils import metrics
@@ -102,6 +103,8 @@ class ReleaseStatus:
 
 
 class ReleaseQuerySet(models.QuerySet):
+    SEMVER_FAKE_PACKAGE = "__sentry_fake__"
+
     def annotate_prerelease_column(self):
         """
         Adds a `prerelease_case` column to the queryset which is used to properly sort
@@ -120,6 +123,65 @@ class ReleaseQuerySet(models.QuerySet):
         """
         return self.filter(major__isnull=False)
 
+    def filter_by_semver(
+        self, organization_id: int, operator: str, version: str
+    ) -> models.QuerySet:
+        """
+        Filter releases down based on semver syntax. version should be in format
+        `<package_name>@<version>` or `<version>`, where package_name is a string and
+        version is a version string matching semver format (https://semver.org/). We've
+        slightly extended this format to allow up to 4 integers. EG
+         - sentry@1.2.3.4
+         - sentry@1.2.3.4-alpha
+         - 1.2.3.4
+         - 1.2.3.4-alpha
+        """
+        # TODO: Probably move the parsing logic into a separate function once we start
+        # to handle wildcards
+        # Our semver parser expects a package at the start of the version, so just add a
+        # dummy one here if not already provided.
+        version = version if "@" in version else f"{self.SEMVER_FAKE_PACKAGE}@{version}"
+        parsed = parse_release(version)
+        parsed_version = parsed.get("version_parsed")
+        if parsed_version:
+            # The version matches semver format, so we can use it for comparison
+            release_filter = Q(organization_id=organization_id)
+            if parsed["package"] and parsed["package"] != self.SEMVER_FAKE_PACKAGE:
+                release_filter &= Q(package=parsed["package"])
+            # Convert `pre` to always be a string
+            prerelease = parsed_version["pre"] if parsed_version["pre"] else ""
+            filter_func = Func(
+                parsed_version["major"],
+                parsed_version["minor"],
+                parsed_version["patch"],
+                parsed_version["revision"],
+                0 if prerelease else 1,
+                Value(prerelease),
+                function="ROW",
+            )
+
+            return (
+                Release.objects.filter(release_filter)
+                .annotate_prerelease_column()
+                .annotate(
+                    semver=Func(
+                        F("major"),
+                        F("minor"),
+                        F("patch"),
+                        F("revision"),
+                        F("prerelease_case"),
+                        F("prerelease"),
+                        function="ROW",
+                        output_field=ArrayField(),
+                    ),
+                )
+                .filter(**{f"semver__{operator}": filter_func})
+            )
+        else:
+            # TODO: We want to parse partial strings like 1.*, etc. For now, we'll just
+            # handle the basic case and fail otherwise
+            raise InvalidSearchQuery(f"Invalid format for semver query {version}")
+
 
 class ReleaseModelManager(models.Manager):
     def get_queryset(self):
@@ -130,6 +192,11 @@ class ReleaseModelManager(models.Manager):
 
     def filter_to_semver(self):
         return self.get_queryset().filter_to_semver()
+
+    def filter_by_semver(
+        self, organization_id: int, operator: str, version: str
+    ) -> models.QuerySet:
+        return self.get_queryset().filter_by_semver(organization_id, operator, version)
 
     @staticmethod
     def _convert_build_code_to_build_number(build_code):

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -86,4 +86,3 @@ OPERATOR_NEGATION_MAP = {
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt"}
 
 SEMVER_MAX_SEARCH_RELEASES = 1000
-SEMVER_FAKE_PACKAGE = "__sentry_fake__"

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -1,10 +1,8 @@
 from datetime import datetime
 from typing import Callable, List, Mapping, Optional, Sequence, Tuple, Union
 
-from django.db.models import BigIntegerField, F, Func, Q, Value
 from parsimonious.exceptions import ParseError
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
-from sentry_relay.processing import parse_release as relay_parse_release
 from snuba_sdk.conditions import Condition, Op, Or
 from snuba_sdk.function import Function
 
@@ -36,7 +34,6 @@ from sentry.search.events.constants import (
     PROJECT_NAME_ALIAS,
     RELEASE_ALIAS,
     SEMVER_ALIAS,
-    SEMVER_FAKE_PACKAGE,
     SEMVER_MAX_SEARCH_RELEASES,
     TEAM_KEY_TRANSACTION_ALIAS,
     USER_DISPLAY_ALIAS,
@@ -359,82 +356,41 @@ def parse_semver_search(
     version: str = search_filter.value.value
     operator: str = search_filter.operator
 
-    # Our semver parser expects a package at the start of the version, so just add a
-    # dummy one here if not already provided.
-    version = version if "@" in version else f"{SEMVER_FAKE_PACKAGE}@{version}"
-    parsed = relay_parse_release(version)
-    parsed_version = parsed.get("version_parsed")
-    if parsed_version:
-        # The version matches semver format, so we can use it for comparison
-        release_filter = Q(organization_id=organization_id)
-        if parsed["package"] and parsed["package"] != SEMVER_FAKE_PACKAGE:
-            release_filter &= Q(package=parsed["package"])
-        # Convert `pre` to always be a string
-        prerelease = parsed_version["pre"] if parsed_version["pre"] else ""
-        filter_func = Func(
-            parsed_version["major"],
-            parsed_version["minor"],
-            parsed_version["patch"],
-            parsed_version["revision"],
-            0 if prerelease else 1,
-            Value(prerelease),
-            function="ROW",
+    # Note that we sort this such that if we end up fetching more than
+    # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
+    # the passed filter.
+    order_by = Release.SEMVER_SORT_COLS
+    if operator.startswith("<"):
+        order_by = list(map(_flip_field_sort, order_by))
+    qs = (
+        Release.objects.filter_by_semver(organization_id, OPERATOR_TO_DJANGO[operator], version)
+        .values_list("version", flat=True)
+        .order_by(*order_by)[:SEMVER_MAX_SEARCH_RELEASES]
+    )
+    versions = list(qs)
+    final_operator = "IN"
+    if len(versions) == SEMVER_MAX_SEARCH_RELEASES:
+        # We want to limit how many versions we pass through to Snuba. If we've hit
+        # the limit, make an extra query and see whether the inverse has fewer ids.
+        # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
+        # do our best.
+        operator = OPERATOR_NEGATION_MAP[operator]
+        # Note that the `order_by` here is important for index usage. Postgres seems
+        # to seq scan with this query if the `order_by` isn't included, so we
+        # include it even though we don't really care about order for this query
+        qs_flipped = (
+            Release.objects.filter_by_semver(organization_id, OPERATOR_TO_DJANGO[operator], version)
+            .order_by(*map(_flip_field_sort, order_by))
+            .values_list("version", flat=True)[:SEMVER_MAX_SEARCH_RELEASES]
         )
 
-        # Note that we sort this such that if we end up fetching more than
-        # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
-        # the passed filter.
-        order_by = Release.SEMVER_SORT_COLS
-        if operator.startswith("<"):
-            order_by = list(map(_flip_field_sort, order_by))
-        qs = (
-            Release.objects.filter(release_filter)
-            .annotate_prerelease_column()
-            .annotate(
-                semver=Func(
-                    F("major"),
-                    F("minor"),
-                    F("patch"),
-                    F("revision"),
-                    F("prerelease_case"),
-                    F("prerelease"),
-                    function="ROW",
-                    # XXX: The output_field doesn't matter here, but Django complains
-                    # that it needs to be set since we have a mix of types in the `Func`
-                    output_field=BigIntegerField(),
-                ),
-            )
-            .values_list("version", flat=True)
-        )
-        qs_initial = qs.filter(**{f"semver__{OPERATOR_TO_DJANGO[operator]}": filter_func}).order_by(
-            *order_by
-        )[:SEMVER_MAX_SEARCH_RELEASES]
-        versions = list(qs_initial)
-        final_operator = "IN"
-        if len(versions) == SEMVER_MAX_SEARCH_RELEASES:
-            # We want to limit how many versions we pass through to Snuba. If we've hit
-            # the limit, make an extra query and see whether the inverse has fewer ids.
-            # If so, we can do a NOT IN query with these ids instead. Otherwise, we just
-            # do our best.
-            django_operator = OPERATOR_TO_DJANGO[OPERATOR_NEGATION_MAP[operator]]
-            # Note that the `order_by` here is important for index usage. Postgres seems
-            # to seq scan with this query if the `order_by` isn't included, so we
-            # include it even though we don't really care about order for this query
-            qs_flipped = qs.filter(**{f"semver__{django_operator}": filter_func}).order_by(
-                *map(_flip_field_sort, order_by)
-            )[:SEMVER_MAX_SEARCH_RELEASES]
-            exclude_versions = list(qs_flipped)
-            if exclude_versions and len(exclude_versions) < len(versions):
-                # Do a negative search instead
-                final_operator = "NOT IN"
-                versions = exclude_versions
+        exclude_versions = list(qs_flipped)
+        if exclude_versions and len(exclude_versions) < len(versions):
+            # Do a negative search instead
+            final_operator = "NOT IN"
+            versions = exclude_versions
 
-        return ["release", final_operator, versions]
-
-    else:
-        # TODO: We want to parse partial strings like 1.*, etc. For now, we'll just
-        # handle the basic case and fail otherwise
-        raise InvalidSearchQuery(f"Invalid format for semver query {version}")
+    return ["release", final_operator, versions]
 
 
 key_conversion_map: Mapping[

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -16,6 +16,7 @@ from sentry.models import (
     GroupResolution,
     GroupStatus,
     Integration,
+    InvalidSearchQuery,
     OrganizationIntegration,
     Release,
     ReleaseCommit,
@@ -796,3 +797,55 @@ class SemverReleaseParseTestCase(TestCase):
         assert release.build_code is None
         assert release.build_number is None
         assert release.package is None
+
+
+class ReleaseFilterBySemverTest(TestCase):
+    def test_invalid_query(self):
+        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+            Release.objects.filter_by_semver(self.organization.id, "gt", "1.2.*")
+
+    def run_test(self, operator, version, expected_releases, organization_id=None):
+        organization_id = organization_id if organization_id else self.organization.id
+        assert set(Release.objects.filter_by_semver(organization_id, operator, version)) == set(
+            expected_releases
+        )
+
+    def test(self):
+        release = self.create_release(version="test@1.2.3")
+        release_2 = self.create_release(version="test@1.2.4")
+        self.run_test("gt", "1.2.3", [release_2])
+        self.run_test("gte", "1.2.4", [release_2])
+        self.run_test("lt", "1.2.4", [release])
+        self.run_test("lte", "1.2.3", [release])
+
+    def test_prerelease(self):
+        # Prerelease has weird sorting rules, where an empty string is higher priority
+        # than a non-empty string. Make sure this sorting works
+        release = self.create_release(version="test@1.2.3-alpha")
+        release_1 = self.create_release(version="test@1.2.3-beta")
+        release_2 = self.create_release(version="test@1.2.3")
+        release_3 = self.create_release(version="test@1.2.4-alpha")
+        release_4 = self.create_release(version="test@1.2.4")
+        self.run_test("gte", "1.2.3", [release_2, release_3, release_4])
+        self.run_test(
+            "gte",
+            "1.2.3-beta",
+            [release_1, release_2, release_3, release_4],
+        )
+        self.run_test("lt", "1.2.3", [release_1, release])
+
+    def test_granularity(self):
+        self.create_release(version="test@1.0.0.0")
+        release_2 = self.create_release(version="test@1.2.0.0")
+        release_3 = self.create_release(version="test@1.2.3.0")
+        release_4 = self.create_release(version="test@1.2.3.4")
+        release_5 = self.create_release(version="test@2.0.0.0")
+        self.run_test(
+            "gt",
+            "1",
+            [release_2, release_3, release_4, release_5],
+        )
+        self.run_test("gt", "1.2", [release_3, release_4, release_5])
+        self.run_test("gt", "1.2.3", [release_4, release_5])
+        self.run_test("gt", "1.2.3.4", [release_5])
+        self.run_test("gt", "2", [])


### PR DESCRIPTION
This refactors the semver filtering logic so that we can filter `Releases` by semver outside of
issue search and discover. We'll use this to allow semver filtering on the
`OrganizationReleasesEndpoint` and in other places that need to do so.