### PR TITLE
fix(release-files): Catch-all around get_artifact_index

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -413,7 +413,12 @@ def get_artifact_index(release, dist):
 
 
 def get_index_entry(release, dist, url) -> Optional[dict]:
-    index = get_artifact_index(release, dist)
+    try:
+        index = get_artifact_index(release, dist)
+    except BaseException as exc:
+        logger.error("sourcemaps.index_read_failed", exc_info=exc)
+        return None
+
     if index:
         for candidate in ReleaseFile.normalize(url):
             entry = index.get("files", {}).get(candidate)


### PR DESCRIPTION
When the artifact index of a release cannot be loaded (e.g. JSON decode error), proceed as if the entry were not present in the index.