### PR TITLE
fix(api): Increase pagination limit for primary snuba query

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -304,7 +304,7 @@ class MergingOffsetPaginator(OffsetPaginator):
         if offset < 0:
             raise BadPaginationError("Pagination offset cannot be negative")
 
-        primary_results = self.data_load_func(offset=offset, limit=limit)
+        primary_results = self.data_load_func(offset=offset, limit=self.max_limit)
 
         queryset = self.apply_to_queryset(self.queryset, primary_results)
 


### PR DESCRIPTION
Increases the pagination limit for primary results snuba query from 20 to 100 (max limit) because currently we are never able to get more than 20 results since the results from snuba are always limited to 20.
This is true for all `OrganizationReleasesEndpoint` returns for adoption based sorts.