### PR TITLE
feat(ui): Release Details breadcrumbs title

### DIFF
--- a/static/app/views/releases/detail/releaseHeader.tsx
+++ b/static/app/views/releases/detail/releaseHeader.tsx
@@ -18,7 +18,7 @@ import {IconCopy, IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Release, ReleaseMeta, ReleaseProject} from 'app/types';
-import {formatAbbreviatedNumber, formatVersion} from 'app/utils/formatters';
+import {formatAbbreviatedNumber} from 'app/utils/formatters';
 
 import ReleaseActions from './releaseActions';
 
@@ -94,7 +94,7 @@ const ReleaseHeader = ({
               label: t('Releases'),
               preserveGlobalSelection: true,
             },
-            {label: formatVersion(version)},
+            {label: t('Release Details')},
           ]}
         />
         <Layout.Title>


### PR DESCRIPTION
Minor change to make the breadcrumbs more unified across the product.

## Before
![image](https://user-images.githubusercontent.com/9060071/122394383-35c31500-cf76-11eb-98cc-845337f49b6d.png)


## After
![image](https://user-images.githubusercontent.com/9060071/122394323-22b04500-cf76-11eb-8216-1d77e95bbe03.png)
