### PR TITLE
feat: Initialize `__onSentryInit` in `layout.html`

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -40,6 +40,15 @@
   {% endblock %}
 
   {% script %}
+  <script>
+    // if the ads.js file loads below it will mark this variable as false
+    window.adblockSuspected = true;
+    // Initialize this so that we can queue up tasks when Sentry SPA is initialized
+    window.__onSentryInit = window.__onSentryInit || [];
+  </script>
+  {% endscript %}
+
+  {% script %}
     {% include "sentry/partial/preload-data.html" %}
   {% endscript %}
 
@@ -61,13 +70,6 @@
   {% for asset_url in injected_assets %}
     {% script src=asset_url %}{% endscript %}
   {% endfor %}
-
-  {% script %}
-  <script>
-    // if the ads.js file loads below it will mark this variable as false
-    window.adblockSuspected = true;
-  </script>
-  {% endscript %}
 
   {% asset_url 'sentry' 'js/ads.js' as asset_url %}
   {% script src=asset_url %}{% endscript %}


### PR DESCRIPTION
`__onSentryInit` was added in #25821 in order to allow integrations to access a callback when the Sentry SPA is initialized and ready. However, we did not initialize `__onSentryInit` as an array in our main django template (`layout.html`). This adds an initialization (and uses an existing script block that is now moved before JS bundles are included)