### PR TITLE
fix(alerts): Fix related issues query on alerts page

### DIFF
--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -53,7 +53,7 @@ class RelatedIssues extends Component<Props> {
         rule.eventTypes?.length
           ? `event.type:[${rule.eventTypes.join(`, `)}]`
           : DATASET_EVENT_TYPE_FILTERS[rule.dataset],
-      ],
+      ].join(' '),
       project: projects.map(project => project.id),
     };
     const issueSearch = {


### PR DESCRIPTION
This joins the related issues query items with a space. If there are multiple query parameters they are not applied correctly.

You can see the difference between these two queries:
[Without `join(' ')`](https://sentry.io/organizations/sentry/issues/?end=2021-06-17T16%3A35%3A24&groupStatsPeriod=auto&limit=5&project=11276&query=error.type%3AChunkLoadError&query=event.type%3A%5Berror%5D&sort=freq&start=2021-06-10T16%3A35%3A24
)

[With `join(' ')`](https://sentry.io/organizations/sentry/issues/?end=2021-06-17T16%3A35%3A24&groupStatsPeriod=auto&project=11276&query=error.type%3AChunkLoadError+event.type%3A%5Berror%5D&sort=freq&start=2021-06-10T16%3A35%3A24)

Resolves [WOR-976](https://getsentry.atlassian.net/browse/WOR-976)
