### PR TITLE
ref(django 2.0): use urlencode rather than roll our own qs builder

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -95,11 +95,17 @@ class Endpoint(APIView):
     cursor_name = "cursor"
 
     def build_cursor_link(self, request, name, cursor):
-        querystring = "&".join(
-            f"{urlquote(k)}={urlquote(v)}" for k, v in request.GET.items() if k != "cursor"
-        )
+        querystring = None
+        if request.GET.get("cursor") is None:
+            querystring = request.GET.urlencode()
+        else:
+            mutable_query_dict = request.GET.copy()
+            mutable_query_dict.pop("cursor")
+            querystring = mutable_query_dict.urlencode()
+
         base_url = absolute_uri(urlquote(request.path))
-        if querystring:
+
+        if querystring is not None:
             base_url = f"{base_url}?{querystring}"
         else:
             base_url = base_url + "?"

--- a/tests/sentry/api/bases/test_endpoint.py
+++ b/tests/sentry/api/bases/test_endpoint.py
@@ -1,3 +1,5 @@
+from django.http import QueryDict
+
 from sentry.api.base import Endpoint
 from sentry.testutils import TestCase
 from sentry.utils.compat.mock import Mock
@@ -6,26 +8,26 @@ from sentry.utils.compat.mock import Mock
 class EndpointTest(TestCase):
     def test_simple(self):
         request = Mock()
-        request.GET = {"member": ["1"]}
+        request.GET = QueryDict("member=1&cursor=foo")
         request.method = "GET"
         request.path = "/api/0/organizations/"
         endpoint = Endpoint()
         result = endpoint.build_cursor_link(request, "next", "1492107369532:0:0")
 
         assert result == (
-            "<http://testserver/api/0/organizations/?member=%5B%271%27%5D&cursor=1492107369532:0:0>;"
+            "<http://testserver/api/0/organizations/?member=1&cursor=1492107369532:0:0>;"
             ' rel="next"; results="true"; cursor="1492107369532:0:0"'
         )
 
     def test_unicode_path(self):
         request = Mock()
-        request.GET = {"member": ["1"]}
+        request.GET = QueryDict("member=1")
         request.method = "GET"
         request.path = "/api/0/organizations/üuuuu/"
         endpoint = Endpoint()
         result = endpoint.build_cursor_link(request, "next", "1492107369532:0:0")
 
         assert result == (
-            "<http://testserver/api/0/organizations/%C3%BCuuuu/?member=%5B%271%27%5D&cursor=1492107369532:0:0>;"
+            "<http://testserver/api/0/organizations/%C3%BCuuuu/?member=1&cursor=1492107369532:0:0>;"
             ' rel="next"; results="true"; cursor="1492107369532:0:0"'
         )


### PR DESCRIPTION
...which breaks on Django 2.0 for the specific way the test is set up.

Under Django 2.0 you cannot pass things like `["1"]` to `urlquote`, it'll tell you `TypeError: quote_from_bytes() expected bytes`. Previously this was allowed, and incorrectly made it into the tests:

```
>>> urlquote(["1"])
'%5B%271%27%5D'
```

We should just use `urlencode` rather than rolling our own. Doing so also requires adjusting the mock request to have an actual QueryDict object.