### PR TITLE
feat(ui): adds optional suffix for local storage key for sidebar items

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -65,6 +65,10 @@ type Props = ReactRouter.WithRouterProps & {
    * Sidebar is at "top" or "left" of screen
    */
   orientation: SidebarOrientation;
+  /**
+   * An optional prefix that can be used to reset the "new" indicator
+   */
+  localStorageNewSuffix?: string;
 };
 
 const SidebarItem = ({
@@ -82,6 +86,7 @@ const SidebarItem = ({
   collapsed,
   className,
   orientation,
+  localStorageNewSuffix,
   onClick,
   ...props
 }: Props) => {
@@ -107,7 +112,8 @@ const SidebarItem = ({
   const isTop = orientation === 'top';
   const placement = isTop ? 'bottom' : 'right';
 
-  const isNewSeenKey = `sidebar-new-seen:${id}`;
+  const seenSuffix = localStorageNewSuffix ?? '';
+  const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
 
   return (

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -68,7 +68,7 @@ type Props = ReactRouter.WithRouterProps & {
   /**
    * An optional prefix that can be used to reset the "new" indicator
    */
-  isNewSeenKeySufix?: string;
+  isNewSeenKeySuffix?: string;
 };
 
 const SidebarItem = ({
@@ -86,7 +86,7 @@ const SidebarItem = ({
   collapsed,
   className,
   orientation,
-  isNewSeenKeySufix,
+  isNewSeenKeySuffix,
   onClick,
   ...props
 }: Props) => {
@@ -112,7 +112,7 @@ const SidebarItem = ({
   const isTop = orientation === 'top';
   const placement = isTop ? 'bottom' : 'right';
 
-  const seenSuffix = isNewSeenKeySufix ?? '';
+  const seenSuffix = isNewSeenKeySuffix ?? '';
   const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
 

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -68,7 +68,7 @@ type Props = ReactRouter.WithRouterProps & {
   /**
    * An optional prefix that can be used to reset the "new" indicator
    */
-  isNewCacheKeySuffix?: string;
+  isNewSeenKeySufix?: string;
 };
 
 const SidebarItem = ({
@@ -86,7 +86,7 @@ const SidebarItem = ({
   collapsed,
   className,
   orientation,
-  isNewCacheKeySuffix,
+  isNewSeenKeySufix,
   onClick,
   ...props
 }: Props) => {
@@ -112,7 +112,7 @@ const SidebarItem = ({
   const isTop = orientation === 'top';
   const placement = isTop ? 'bottom' : 'right';
 
-  const seenSuffix = isNewCacheKeySuffix ?? '';
+  const seenSuffix = isNewSeenKeySufix ?? '';
   const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
 

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -68,7 +68,7 @@ type Props = ReactRouter.WithRouterProps & {
   /**
    * An optional prefix that can be used to reset the "new" indicator
    */
-  localStorageNewSuffix?: string;
+  isNewCacheBustKey?: string;
 };
 
 const SidebarItem = ({
@@ -86,7 +86,7 @@ const SidebarItem = ({
   collapsed,
   className,
   orientation,
-  localStorageNewSuffix,
+  isNewCacheBustKey,
   onClick,
   ...props
 }: Props) => {
@@ -112,7 +112,7 @@ const SidebarItem = ({
   const isTop = orientation === 'top';
   const placement = isTop ? 'bottom' : 'right';
 
-  const seenSuffix = localStorageNewSuffix ?? '';
+  const seenSuffix = isNewCacheBustKey ?? '';
   const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
 

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -68,7 +68,7 @@ type Props = ReactRouter.WithRouterProps & {
   /**
    * An optional prefix that can be used to reset the "new" indicator
    */
-  isNewCacheBustKey?: string;
+  isNewCacheKeySuffix?: string;
 };
 
 const SidebarItem = ({
@@ -86,7 +86,7 @@ const SidebarItem = ({
   collapsed,
   className,
   orientation,
-  isNewCacheBustKey,
+  isNewCacheKeySuffix,
   onClick,
   ...props
 }: Props) => {
@@ -112,7 +112,7 @@ const SidebarItem = ({
   const isTop = orientation === 'top';
   const placement = isTop ? 'bottom' : 'right';
 
-  const seenSuffix = isNewCacheBustKey ?? '';
+  const seenSuffix = isNewCacheKeySuffix ?? '';
   const isNewSeenKey = `sidebar-new-seen:${id}${seenSuffix}`;
   const showIsNew = isNew && !localStorage.getItem(isNewSeenKey);
 


### PR DESCRIPTION
Sometimes it's useful for us to show the "new" icon on sidebar item on a later date if we add new features to an existing sidebar item. I'm adding a new optional suffix called `isNewSeenKeySuffix` which will change the seen key in local storage. When you change `isNewSeenKeySuffix` for an existing sidebar item, it effectively reset the status on whether or not the item has been seen. I'm specifically imagining we do this for free trials each time we reset trials for organizations to let folks know it's available again.

![Screen Shot 2021-06-17 at 4 10 34 PM](https://user-images.githubusercontent.com/8533851/122483078-a2dea680-cf86-11eb-8a1e-293f653a71d7.png)
