### PR TITLE
fix(tooltip-copy): operation breakdown

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -79,7 +79,7 @@ class TransactionsTable extends React.PureComponent<Props> {
                       {title}
                       <Tooltip
                         title={t(
-                          'Durations are calculated by summing span durations over the course of the transaction. Percentages are then calculated by dividing the individual op duration by the sum of total op durations. Overlapping/parallel spans are only counted once.'
+                          'Span durations are summed over the course of an entire transaction. Any overlapping spans are only counted once.'
                         )}
                       >
                         <StyledIconQuestion size="xs" color="gray400" />

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -280,7 +280,7 @@ class OpsBreakdown extends Component<Props> {
               size="sm"
               containerDisplayMode="block"
               title={t(
-                'Durations are calculated by summing span durations over the course of the transaction. Percentages are then calculated by dividing the individual op duration by the sum of total op durations. Overlapping/parallel spans are only counted once.'
+                'Span durations are summed over the course of an entire transaction. Any overlapping spans are only counted once. Percentages are calculated by dividing the summed span durations by the total of all span durations.'
               )}
             />
           </SectionHeading>


### PR DESCRIPTION
**Before:**
![Screen Shot 2021-06-17 at 5 22 11 PM](https://user-images.githubusercontent.com/4830259/122487685-b0009300-cf90-11eb-97ae-a779a72349e3.png)

**After:** 
![Screen Shot 2021-06-17 at 5 21 48 PM](https://user-images.githubusercontent.com/4830259/122487691-b262ed00-cf90-11eb-9480-b334c33d45e3.png)