### PR TITLE
ref(grouping-ui): Update design

### DIFF
--- a/static/app/components/pagination/index.tsx
+++ b/static/app/components/pagination/index.tsx
@@ -1,4 +1,4 @@
-import {Component} from 'react';
+import {Component, ReactElement} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Query} from 'history';
@@ -8,6 +8,7 @@ import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {IconChevron} from 'app/icons';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 
@@ -27,9 +28,13 @@ type DefaultProps = {
 };
 
 type Props = DefaultProps & {
-  className?: string;
   pageLinks?: string | null;
   to?: string;
+  /**
+   * The caption must be the PaginationCaption component
+   */
+  caption?: ReactElement;
+  className?: string;
 };
 
 class Pagination extends Component<Props> {
@@ -40,7 +45,7 @@ class Pagination extends Component<Props> {
   static defaultProps = defaultProps;
 
   render() {
-    const {className, onCursor, pageLinks, size} = this.props;
+    const {className, onCursor, pageLinks, size, caption} = this.props;
     if (!pageLinks) {
       return null;
     }
@@ -53,7 +58,8 @@ class Pagination extends Component<Props> {
     const nextDisabled = links.next.results === false;
 
     return (
-      <div className={className}>
+      <Wrapper className={className}>
+        {caption}
         <ButtonBar merged>
           <Button
             icon={<IconChevron direction="left" size="sm" />}
@@ -74,14 +80,16 @@ class Pagination extends Component<Props> {
             }}
           />
         </ButtonBar>
-      </div>
+      </Wrapper>
     );
   }
 }
 
-export default styled(Pagination)`
+const Wrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  margin: 20px 0 0 0;
+  margin: ${space(3)} 0 0 0;
 `;
+
+export default Pagination;

--- a/static/app/components/pagination/paginationCaption.tsx
+++ b/static/app/components/pagination/paginationCaption.tsx
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+import space from 'app/styles/space';
+
+type Props = {
+  caption: React.ReactNode;
+};
+
+function PaginationCaption({caption}: Props) {
+  return <Wrapper>{caption}</Wrapper>;
+}
+
+export default PaginationCaption;
+
+const Wrapper = styled('span')`
+  color: ${p => p.theme.gray400};
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-right: ${space(2)};
+`;

--- a/static/app/components/pagination/paginationCaption.tsx
+++ b/static/app/components/pagination/paginationCaption.tsx
@@ -13,7 +13,7 @@ function PaginationCaption({caption}: Props) {
 export default PaginationCaption;
 
 const Wrapper = styled('span')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
   margin-right: ${space(2)};
 `;

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -229,6 +229,10 @@ const StyledPanelTable = styled(PanelTable)<{isReloading: boolean}>`
     `}
 
   > * {
+    padding: ${space(1.5)} ${space(2)};
+    :nth-child(-n + 2) {
+      padding: ${space(2)};
+    }
     :nth-child(2n) {
       display: flex;
       text-align: right;

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -145,7 +145,7 @@ function Grouping({api, groupId, location, organization}: Props) {
     <Wrapper>
       <Description>
         {t(
-          'This issue is built up of multiple events that sentry thinks come from the same root-cause. Use this page to refine this issue into more fine-grained groups.'
+          'This issue is an aggregate of multiple events that sentry determined originate from the same root-cause. Use this page to explore more detailed groupings that exist within this issue.'
         )}
       </Description>
       <Content>
@@ -257,7 +257,7 @@ const SliderWrapper = styled('div')`
   align-items: flex-start;
   position: relative;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.subText};
   padding-bottom: ${space(2)};
 
   @media (min-width: 700px) {

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -123,7 +123,7 @@ function Grouping({api, groupId, location, organization}: Props) {
       return;
     }
 
-    if (groupingLevels.length === 2) {
+    if (groupingLevels.length > 1) {
       setActiveGroupingLevel(Number(groupingLevels[1].id));
       return;
     }

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -180,11 +180,11 @@ function Grouping({api, groupId, location, organization}: Props) {
               <PaginationCaption
                 caption={
                   hasMore
-                    ? tct('Showing [current] of [total] Issues', {
+                    ? tct('Showing [current] of [total] results', {
                         current: paginationCurrentQuantity,
                         total: `${paginationCurrentQuantity}+`,
                       })
-                    : tct('Showing [current] of [total] Issue', {
+                    : tct('Showing [current] of [total] result', {
                         current: paginationCurrentQuantity,
                         total: paginationCurrentQuantity,
                       })
@@ -220,7 +220,7 @@ const Content = styled('div')`
 `;
 
 const StyledPanelTable = styled(PanelTable)<{isReloading: boolean}>`
-  grid-template-columns: 1fr max-content;
+  grid-template-columns: 1fr minmax(60px, auto);
   ${p =>
     p.isReloading &&
     `
@@ -233,11 +233,11 @@ const StyledPanelTable = styled(PanelTable)<{isReloading: boolean}>`
       display: flex;
       text-align: right;
       justify-content: flex-end;
-      width: 60px;
-      @media (min-width: ${p => p.theme.breakpoints[3]}) {
-        width: 80px;
-      }
     }
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[3]}) {
+    grid-template-columns: 1fr minmax(80px, auto);
   }
 `;
 

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -145,7 +145,7 @@ function Grouping({api, groupId, location, organization}: Props) {
     <Wrapper>
       <Description>
         {t(
-          'This issue is built up of multiple events that sentry thinks come from the same root-cause. Use this page to drill down this issue into more fine-grained groups.'
+          'This issue is built up of multiple events that sentry thinks come from the same root-cause. Use this page to refine this issue into more fine-grained groups.'
         )}
       </Description>
       <Content>

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -13,6 +13,7 @@ import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Group, Organization} from 'app/types';
 import {Event} from 'app/types/event';
+import {defined} from 'app/utils';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import withApi from 'app/utils/withApi';
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
@@ -87,7 +88,7 @@ function Grouping({api, groupId, location, organization}: Props) {
   }
 
   async function fetchGroupingLevelDetails() {
-    if (!groupingLevels.length) {
+    if (!groupingLevels.length || !defined(activeGroupingLevel)) {
       return;
     }
 
@@ -118,11 +119,16 @@ function Grouping({api, groupId, location, organization}: Props) {
   }
 
   function setSecondGrouping() {
-    const secondGrouping = groupingLevels[1];
-    if (!secondGrouping) {
+    if (!groupingLevels.length) {
       return;
     }
-    setActiveGroupingLevel(Number(secondGrouping.id));
+
+    if (groupingLevels.length === 2) {
+      setActiveGroupingLevel(Number(groupingLevels[1].id));
+      return;
+    }
+
+    setActiveGroupingLevel(Number(groupingLevels[0].id));
   }
 
   if (isLoading) {

--- a/static/app/views/organizationGroupDetails/grouping/index.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/index.tsx
@@ -4,7 +4,7 @@ import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
-import {Group, Organization, Project} from 'app/types';
+import {Group, Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 
 import Grouping from './grouping';
@@ -13,10 +13,9 @@ type RouteParams = {groupId: Group['id']; orgId: Organization['slug']};
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
-  project: Project;
 };
 
-function GroupingContainer({organization, params, location, project}: Props) {
+function GroupingContainer({organization, params, location}: Props) {
   return (
     <Feature
       features={['grouping-tree-ui']}
@@ -31,7 +30,6 @@ function GroupingContainer({organization, params, location, project}: Props) {
         location={location}
         groupId={params.groupId}
         organization={organization}
-        project={project}
       />
     </Feature>
   );

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -27,7 +27,7 @@ function NewIssue({sampleEvent, eventCount, organization}: Props) {
         />
         <ExtraInfo>
           <TimeWrapper>
-            <IconClock size="11px" color="gray300" />
+            <StyledIconClock size="11px" />
             <TimeSince date={sampleEvent.dateCreated} suffix={t('old')} />
           </TimeWrapper>
         </ExtraInfo>
@@ -62,4 +62,8 @@ const TimeWrapper = styled('div')`
 const EventCount = styled('div')`
   align-items: center;
   line-height: 1.1;
+`;
+
+const StyledIconClock = styled(IconClock)`
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -21,14 +21,14 @@ type Props = {
 function NewIssue({sampleEvent, eventCount, organization, project}: Props) {
   return (
     <StyledPanelItem>
-      <div>
+      <EventDetails>
         <EventOrGroupHeader
           data={sampleEvent}
           organization={organization}
           hideIcons
           hideLevel
         />
-        <Details>
+        <ExtraInfo>
           {project && (
             <GroupShortId
               shortId={project.slug}
@@ -45,8 +45,8 @@ function NewIssue({sampleEvent, eventCount, organization, project}: Props) {
             <IconClock size="xs" />
             <TimeSince date={sampleEvent.dateCreated} />
           </TimeWrapper>
-        </Details>
-      </div>
+        </ExtraInfo>
+      </EventDetails>
       <ErrorsCount>
         {eventCount}
         <ErrorLabel>{tn('Error', 'Errors', eventCount)}</ErrorLabel>
@@ -66,7 +66,11 @@ const StyledPanelItem = styled(PanelItem)`
   word-break: break-word;
 `;
 
-const Details = styled('div')`
+const EventDetails = styled('div')`
+  overflow: hidden;
+`;
+
+const ExtraInfo = styled('div')`
   margin-top: ${space(0.5)};
   display: grid;
   grid-auto-flow: column;

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -1,26 +1,23 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
-import ProjectBadge from 'app/components/idBadge/projectBadge';
-import {PanelItem} from 'app/components/panels';
-import ShortId from 'app/components/shortId';
 import TimeSince from 'app/components/timeSince';
 import {IconClock} from 'app/icons';
-import {tn} from 'app/locale';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Organization, Project} from 'app/types';
+import {Organization} from 'app/types';
 import {Event} from 'app/types/event';
 
 type Props = {
   sampleEvent: Event;
   eventCount: number;
   organization: Organization;
-  project?: Project;
 };
 
-function NewIssue({sampleEvent, eventCount, organization, project}: Props) {
+function NewIssue({sampleEvent, eventCount, organization}: Props) {
   return (
-    <StyledPanelItem>
+    <Fragment>
       <EventDetails>
         <EventOrGroupHeader
           data={sampleEvent}
@@ -29,80 +26,40 @@ function NewIssue({sampleEvent, eventCount, organization, project}: Props) {
           hideLevel
         />
         <ExtraInfo>
-          {project && (
-            <GroupShortId
-              shortId={project.slug}
-              avatar={
-                project && <ProjectBadge project={project} avatarSize={14} hideName />
-              }
-              onClick={e => {
-                // prevent the clicks from propagating so that the short id can be selected
-                e.stopPropagation();
-              }}
-            />
-          )}
           <TimeWrapper>
-            <IconClock size="xs" />
-            <TimeSince date={sampleEvent.dateCreated} />
+            <IconClock size="11px" color="gray300" />
+            <TimeSince date={sampleEvent.dateCreated} suffix={t('old')} />
           </TimeWrapper>
         </ExtraInfo>
       </EventDetails>
-      <ErrorsCount>
-        {eventCount}
-        <ErrorLabel>{tn('Error', 'Errors', eventCount)}</ErrorLabel>
-      </ErrorsCount>
-    </StyledPanelItem>
+      <EventCount>{eventCount}</EventCount>
+    </Fragment>
   );
 }
 
 export default NewIssue;
 
-const StyledPanelItem = styled(PanelItem)`
-  display: grid;
-  grid-template-columns: 1fr max-content;
-  align-items: center;
-  padding: ${space(1.5)} ${space(2)};
-  grid-gap: ${space(2)};
-  word-break: break-word;
-`;
-
 const EventDetails = styled('div')`
   overflow: hidden;
+  line-height: 1.1;
 `;
 
 const ExtraInfo = styled('div')`
-  margin-top: ${space(0.5)};
   display: grid;
   grid-auto-flow: column;
   grid-gap: ${space(2)};
   justify-content: flex-start;
 `;
 
-const GroupShortId = styled(ShortId)`
-  flex-shrink: 0;
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
-`;
-
 const TimeWrapper = styled('div')`
   display: grid;
   grid-gap: ${space(0.5)};
-  grid-template-columns: min-content 1fr;
+  grid-template-columns: max-content 1fr;
   align-items: center;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.subText};
 `;
 
-const ErrorsCount = styled('div')`
-  display: grid;
+const EventCount = styled('div')`
   align-items: center;
-  justify-items: center;
-  font-size: ${p => p.theme.fontSizeLarge};
-`;
-
-const ErrorLabel = styled('div')`
-  text-transform: uppercase;
-  font-weight: 500;
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1.1;
 `;


### PR DESCRIPTION
We decided to update the design to be more like https://www.figma.com/file/KC1AVMpS8ot99Zkv88ewMW/Grouping?node-id=119%3A343  as it is the direction we want to go.

This PR:

 - Updates the grouping UI
 - Moves the `pagination.tsx ` file to a folder called pagination
 - Creates a `PaginationCaption` component
 - Adds a prop to the pagination component called `caption`

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/122574111-9a05d780-d04f-11eb-8e6c-580b16937d61.png)


![image](https://user-images.githubusercontent.com/29228205/122666953-8b830180-d1b0-11eb-9476-774794912bc9.png)

Fixes SENTRY-QT5