### PR TITLE
fix: Downgrade error to warning in github plugin

### DIFF
--- a/src/sentry_plugins/github/endpoints/webhook.py
+++ b/src/sentry_plugins/github/endpoints/webhook.py
@@ -432,7 +432,7 @@ class GithubWebhookEndpoint(GithubWebhookBase):
         try:
             organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:
-            logger.error(
+            logger.info(
                 "github.webhook.invalid-organization", extra={"organization_id": organization_id}
             )
             return HttpResponse(status=400)


### PR DESCRIPTION
We consistently get invalid webhooks from GitHub and they are unactionable. These events are coming from organizations that no longer exist.

Fixes SENTRY-3B4