### PR TITLE
fix(dashboard): Issue search needs organization id

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -75,6 +75,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
                 "start": datetime.now() - timedelta(days=1),
                 "end": datetime.now(),
                 "project_id": [p.id for p in self.context.get("projects")],
+                "organization_id": self.context.get("organization").id,
             }
 
             snuba_filter = get_filter(conditions, params=params)


### PR DESCRIPTION
Validating a search on an issue by its short id requires the organization id.
Make sure to pass it along with the params.