### PR TITLE
fix: Remove additional field in Incident definition

### DIFF
--- a/src/sentry/migrations/0001_squashed_0200_release_indices.py
+++ b/src/sentry/migrations/0001_squashed_0200_release_indices.py
@@ -4950,7 +4950,6 @@ class Migration(migrations.Migration):
                 ("status", models.PositiveSmallIntegerField(default=1)),
                 ("type", models.PositiveSmallIntegerField(default=1)),
                 ("title", models.TextField()),
-                ("query", models.TextField()),
                 ("date_started", models.DateTimeField(default=django.utils.timezone.now)),
                 ("date_detected", models.DateTimeField(default=django.utils.timezone.now)),
                 ("date_added", models.DateTimeField(default=django.utils.timezone.now)),


### PR DESCRIPTION
This field slipped into the squash migration and shouldn't be part of the models.