### PR TITLE
feat(performance): Limit query to 500 transaction thresholds 

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -7,5 +7,5 @@ will then be regenerated, and you should be able to merge without conflicts.
 
 jira_ac: 0001_initial
 nodestore: 0002_nodestore_no_dictfield
-sentry: 0211_test
+sentry: 0210_backfill_project_transaction_thresholds
 social_auth: 0001_initial

--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -7,5 +7,5 @@ will then be regenerated, and you should be able to merge without conflicts.
 
 jira_ac: 0001_initial
 nodestore: 0002_nodestore_no_dictfield
-sentry: 0210_backfill_project_transaction_thresholds
+sentry: 0211_test
 social_auth: 0001_initial

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -159,7 +159,9 @@ def project_threshold_config_expression(organization_id, project_ids):
     if num_configured == 0:
         return ["tuple", [f"'{DEFAULT_PROJECT_THRESHOLD_METRIC}'", DEFAULT_PROJECT_THRESHOLD]]
     elif num_configured > MAX_QUERYABLE_TRANSACTION_THRESHOLDS:
-        raise InvalidSearchQuery("Too many configured thresholds, try with fewer projects.")
+        raise InvalidSearchQuery(
+            f"Exceeded {MAX_QUERYABLE_TRANSACTION_THRESHOLDS} configured transaction thresholds limit, try with fewer Projects."
+        )
 
     return [
         "if",

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -150,6 +150,12 @@ def project_threshold_config_expression(organization_id, project_ids):
     )
 
     num_configured = threshold_configs.count()
+    sentry_sdk.set_tag("project_threshold.count", num_configured)
+    sentry_sdk.set_tag(
+        "project_threshold.count.grouped",
+        format_grouped_length(num_configured, [10, 100, 250, 500]),
+    )
+
     if num_configured == 0:
         return ["tuple", [f"'{DEFAULT_PROJECT_THRESHOLD_METRIC}'", DEFAULT_PROJECT_THRESHOLD]]
     elif num_configured > MAX_QUERYABLE_TRANSACTION_THRESHOLDS:


### PR DESCRIPTION
Raise an error message if user tries to query with more than
500 project transaction thresholds. Also add tags to track
how many projects with thresholds are being queried.