### PR TITLE
feat(arithmetic): Adding more column support to count_if

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -139,6 +139,7 @@ class ArithmeticVisitor(NodeVisitor):
     }
     function_allowlist = {
         "count",
+        "count_if",
         "count_unique",
         "failure_count",
         "min",

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2,7 +2,7 @@ import re
 from collections import defaultdict, namedtuple
 from copy import deepcopy
 from datetime import datetime
-from typing import List, Union
+from typing import List, Mapping, Union
 
 import sentry_sdk
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
@@ -19,6 +19,7 @@ from sentry.models.transaction_threshold import TRANSACTION_METRICS
 from sentry.search.events.base import QueryBase
 from sentry.search.events.constants import (
     ALIAS_PATTERN,
+    ARRAY_FIELDS,
     DEFAULT_PROJECT_THRESHOLD,
     DEFAULT_PROJECT_THRESHOLD_METRIC,
     ERROR_UNHANDLED_ALIAS,
@@ -257,6 +258,33 @@ def team_key_transaction_expression(organization_id, team_ids, project_ids):
             ],
         ],
     ]
+
+
+def calculate_count_if_value(args: Mapping[str, str]) -> Union[float, str]:
+    """Ensures that the type of the third parameter is compatible with the first
+    and cast the value if needed
+    eg. duration = numeric_value, and not duration = string_value
+    """
+    column = args["column"]
+    condition = args["condition"]
+    value = args["value"]
+    if (
+        column == "transaction.duration"
+        or is_duration_measurement(column)
+        or is_span_op_breakdown(column)
+    ):
+        try:
+            value = float(value.strip("'"))
+        except Exception:
+            raise InvalidSearchQuery(f"{value} is not a valid value to compare with {column}")
+
+    # TODO: not supporting field aliases or arrays yet
+    elif column in FIELD_ALIASES or column in ARRAY_FIELDS:
+        raise InvalidSearchQuery(f"{column} not supported by count_if")
+    # At this point only string or tag columns are left
+    elif condition not in ["equals", "notEquals"]:
+        raise InvalidSearchQuery(f"{condition} not compatible with {column}")
+    return value
 
 
 # When updating this list, also check if the following need to be updated:
@@ -752,7 +780,7 @@ def get_function_alias(field):
 
 
 def get_function_alias_with_columns(function_name, columns):
-    columns = re.sub(r"[^\w]", "_", "_".join(columns))
+    columns = re.sub(r"[^\w]", "_", "_".join(str(col) for col in columns))
     return f"{function_name}_{columns}".rstrip("_")
 
 
@@ -939,11 +967,13 @@ class Column(FunctionArg):
     def __init__(self, name, allowed_columns=None):
         super().__init__(name)
         # make sure to map the allowed columns to their snuba names
-        self.allowed_columns = [SEARCH_MAP.get(col) for col in allowed_columns]
+        self.allowed_columns = (
+            {SEARCH_MAP.get(col) for col in allowed_columns} if allowed_columns else set()
+        )
 
     def normalize(self, value, params):
         snuba_column = SEARCH_MAP.get(value)
-        if self.allowed_columns is not None:
+        if len(self.allowed_columns) > 0:
             if value in self.allowed_columns or snuba_column in self.allowed_columns:
                 return snuba_column
             else:
@@ -954,8 +984,8 @@ class Column(FunctionArg):
 
 
 class ColumnNoLookup(Column):
-    def __init__(self, name, allowed_columns=None):
-        super().__init__(name, allowed_columns=allowed_columns)
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
 
     def normalize(self, value, params):
         super().normalize(value, params)
@@ -1791,13 +1821,19 @@ FUNCTIONS = {
             ],
             default_result_type="number",
         ),
-        # Currently only used by trace meta so we can count event types which is why this only accepts strings
+        # The calculated arg will cast the string value according to the value in the column
         Function(
             "count_if",
             required_args=[
-                ColumnNoLookup("column", allowed_columns=["event.type", "http.status_code"]),
+                FunctionArg("column"),
                 ConditionArg("condition"),
                 StringArg("value"),
+            ],
+            calculated_args=[
+                {
+                    "name": "typed_value",
+                    "fn": calculate_count_if_value,
+                }
             ],
             aggregate=[
                 "countIf",
@@ -1806,7 +1842,7 @@ FUNCTIONS = {
                         ArgValue("condition"),
                         [
                             ArgValue("column"),
-                            ArgValue("value"),
+                            ArgValue("typed_value"),
                         ],
                     ]
                 ],

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -980,9 +980,6 @@ class Column(FunctionArg):
 
 
 class ColumnNoLookup(Column):
-    def __init__(self, name, **kwargs):
-        super().__init__(name, **kwargs)
-
     def normalize(self, value, params):
         super().normalize(value, params)
         return value

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -1461,8 +1461,23 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
 
     def test_invalid_count_if_fields(self):
-        with self.assertRaises(InvalidSearchQuery):
-            resolve_field_list(["count_if(project, equals, sentry)"], eventstore.Filter())
+        with self.assertRaises(InvalidSearchQuery) as query_error:
+            resolve_field_list(
+                ["count_if(transaction.duration, equals, sentry)"], eventstore.Filter()
+            )
+        assert (
+            str(query_error.exception)
+            == "'sentry' is not a valid value to compare with transaction.duration"
+        )
 
-        with self.assertRaises(InvalidSearchQuery):
+        with self.assertRaises(InvalidSearchQuery) as query_error:
+            resolve_field_list(["count_if(project, equals, sentry)"], eventstore.Filter())
+        assert str(query_error.exception) == "project is not supported by count_if"
+
+        with self.assertRaises(InvalidSearchQuery) as query_error:
             resolve_field_list(["count_if(stack.function, equals, test)"], eventstore.Filter())
+        assert str(query_error.exception) == "stack.function is not supported by count_if"
+
+        with self.assertRaises(InvalidSearchQuery) as query_error:
+            resolve_field_list(["count_if(http.status_code, greater, test)"], eventstore.Filter())
+        assert str(query_error.exception) == "greater is not compatible with http.status_code"


### PR DESCRIPTION
- This adds duration column support to count_if along with general tags support
  - eg. `count_if(transaction.duration, less, 300)` or `count_if(http.status, equals 400)`
- This also adds count_if to arithmetic
- Not added to the frontend yet