### PR TITLE
feat(search): A few more validation checks (take 2)

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -572,7 +572,7 @@ class TokenConverter {
     }
 
     if (!value.quoted && value.value === '') {
-      return t('Filter must have a value');
+      return t('Filter must have a value.');
     }
 
     return null;


### PR DESCRIPTION
- No quotes without escapes if outside of quotes. The regex used on this
  check is slightly different from GH-26698, which used a negative
  lookbehind and is not supported in Safari and caused us an outage.

- No blank values unless quoted

- Duration key checks