### PR TITLE
fix: Expand IP range for bitbucket

### DIFF
--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -22,9 +22,22 @@ BITBUCKET_IP_RANGES = (
     ipaddress.ip_network("104.192.136.0/21"),
     # Not documented in the webhook docs, but defined here:
     # https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
-    ipaddress.ip_network("18.205.93.0/25"),
-    ipaddress.ip_network("18.234.32.128/25"),
-    ipaddress.ip_network("13.52.5.0/25"),
+    # and in the outgoing IP list for atlassian cloud
+    # https://support.atlassian.com/organization-administration/docs/ip-addresses-and-domains-for-atlassian-cloud-products/
+    ipaddress.ip_network("13.52.5.96/28"),
+    ipaddress.ip_network("13.236.8.224/28"),
+    ipaddress.ip_network("18.136.214.96/28"),
+    ipaddress.ip_network("18.184.99.224/28"),
+    ipaddress.ip_network("18.234.32.224/28"),
+    ipaddress.ip_network("18.246.31.224/28"),
+    ipaddress.ip_network("52.215.192.224/28"),
+    ipaddress.ip_network("104.192.137.240/28"),
+    ipaddress.ip_network("104.192.138.240/28"),
+    ipaddress.ip_network("104.192.140.240/28"),
+    ipaddress.ip_network("104.192.142.240/28"),
+    ipaddress.ip_network("104.192.143.240/28"),
+    ipaddress.ip_network("185.166.143.240/28"),
+    ipaddress.ip_network("185.166.142.240/28"),
 )
 BITBUCKET_IPS = ["34.198.203.127", "34.198.178.64", "34.198.32.85"]
 PROVIDER_NAME = "integrations:bitbucket"

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -22,7 +22,10 @@ BITBUCKET_IP_RANGES = (
     ipaddress.ip_network("104.192.136.0/21"),
     # Not documented in the webhook docs, but defined here:
     # https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
-    # and in the outgoing IP list for atlassian cloud
+    ipaddress.ip_network("18.205.93.0/25"),
+    ipaddress.ip_network("18.234.32.128/25"),
+    ipaddress.ip_network("13.52.5.0/25"),
+    # Also accept any outbound IPs that atlassian has.
     # https://support.atlassian.com/organization-administration/docs/ip-addresses-and-domains-for-atlassian-cloud-products/
     ipaddress.ip_network("13.52.5.96/28"),
     ipaddress.ip_network("13.236.8.224/28"),


### PR DESCRIPTION
Atlassian has a wider IP range in their documentation than we currently accept hooks from. Expanding the IP list should reduce volume to the current sentry error.

* [Bitbucket IP ranges](https://support.atlassian.com/bitbucket-cloud/docs/what-are-the-bitbucket-cloud-ip-addresses-i-should-use-to-configure-my-corporate-firewall/)
* [Atlassian cloud outgoing IPs](https://support.atlassian.com/organization-administration/docs/ip-addresses-and-domains-for-atlassian-cloud-products/#AtlassiancloudIPrangesanddomains-OutgoingConnections)

Refs SENTRY-KBH