### PR TITLE
fix(vitals): User Misery refining filter on Vitals endpoint

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -449,8 +449,7 @@ def resolve_field_list(
                     aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     # Only auto aggregate when there's one other so the group by is not unexpectedly changed
-    auto_aggregate = auto_aggregations and snuba_filter.having and len(aggregations) > 0
-    if auto_aggregate:
+    if auto_aggregations and snuba_filter.having and len(aggregations) > 0:
         for agg in snuba_filter.condition_aggregates:
             if agg not in snuba_filter.aliases:
                 function = resolve_field(agg, snuba_filter.params, functions_acl)
@@ -464,10 +463,7 @@ def resolve_field_list(
                         if function.details.instance.redundant_grouping:
                             aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
-    snuba_filter_condition_aggregates = (
-        set(snuba_filter.condition_aggregates or []) if auto_aggregate else set()
-    )
-    for field in set(fields[:]).union(snuba_filter_condition_aggregates):
+    for field in aggregations:
         if isinstance(field, str) and field in {
             "apdex()",
             "count_miserable(user)",

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -433,7 +433,7 @@ def resolve_field_list(
         if "project.id" not in fields:
             fields.append("project.id")
 
-    for field in fields[:]:
+    for field in fields[:] + snuba_filter.condition_aggregates:
         if isinstance(field, str) and field in {
             "apdex()",
             "count_miserable(user)",

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -433,7 +433,8 @@ def resolve_field_list(
         if "project.id" not in fields:
             fields.append("project.id")
 
-    for field in fields[:] + snuba_filter.condition_aggregates:
+    snuba_condition_aggregates = snuba_filter.condition_aggregates or []
+    for field in fields[:] + snuba_condition_aggregates:
         if isinstance(field, str) and field in {
             "apdex()",
             "count_miserable(user)",

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -449,9 +449,8 @@ def resolve_field_list(
                     aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     # Only auto aggregate when there's one other so the group by is not unexpectedly changed
-    check_auto_aggregates = False
-    if auto_aggregations and snuba_filter.having and len(aggregations) > 0:
-        check_auto_aggregates = True
+    auto_aggregate = auto_aggregations and snuba_filter.having and len(aggregations) > 0
+    if auto_aggregate:
         for agg in snuba_filter.condition_aggregates:
             if agg not in snuba_filter.aliases:
                 function = resolve_field(agg, snuba_filter.params, functions_acl)
@@ -466,7 +465,7 @@ def resolve_field_list(
                             aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     snuba_filter_condition_aggregates = (
-        set(snuba_filter.condition_aggregates or []) if check_auto_aggregates else set()
+        set(snuba_filter.condition_aggregates or []) if auto_aggregate else set()
     )
     for field in set(fields[:]).union(snuba_filter_condition_aggregates):
         if isinstance(field, str) and field in {

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -468,6 +468,10 @@ def resolve_field_list(
             }:
                 if PROJECT_THRESHOLD_CONFIG_ALIAS not in fields:
                     fields.append(PROJECT_THRESHOLD_CONFIG_ALIAS)
+                    function = resolve_field(
+                        PROJECT_THRESHOLD_CONFIG_ALIAS, snuba_filter.params, functions_acl
+                    )
+                    columns.append(function.column)
 
             if agg not in snuba_filter.aliases:
                 function = resolve_field(agg, snuba_filter.params, functions_acl)

--- a/tests/snuba/api/endpoints/test_organization_events_vitals.py
+++ b/tests/snuba/api/endpoints/test_organization_events_vitals.py
@@ -91,6 +91,28 @@ class OrganizationEventsVitalsEndpointTest(APITestCase, SnubaTestCase):
             "p75": 4000,
         }
 
+    def test_simple_with_refining_user_misery_filter(self):
+        self.query.update({"query": "user_misery():>0.050"})
+
+        data = self.transaction_data.copy()
+        for lcp in [2000, 3000, 5000]:
+            self.store_event(
+                data,
+                {"lcp": lcp},
+                project_id=self.project.id,
+            )
+
+        self.query.update({"vital": ["measurements.lcp"]})
+        response = self.do_request()
+        assert response.status_code == 200, response.content
+        assert response.data["measurements.lcp"] == {
+            "good": 1,
+            "meh": 1,
+            "poor": 1,
+            "total": 3,
+            "p75": 4000,
+        }
+
     def test_grouping(self):
         counts = [
             (100, 2),


### PR DESCRIPTION
Project transaction config column does not get properly
resolved when user misery is not a part of the selected
columns but a part of the search filter.

Sentry issue: [SENTRY-QT8](https://sentry.io/organizations/sentry/issues/2464627452/?referrer=github_integration)