### PR TITLE
ref(releases): Common codebase for release files endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_release_file_details.py
+++ b/src/sentry/api/endpoints/organization_release_file_details.py
@@ -1,33 +1,18 @@
-import posixpath
-
-from django.http import StreamingHttpResponse
 from rest_framework import serializers
-from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.endpoints.project_release_file_details import ReleaseFileDetailsMixin
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.serializers import serialize
-from sentry.models import Release, ReleaseFile
+from sentry.models import Release
 
 
 class ReleaseFileSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=200, required=True)
 
 
-class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
-    def download(self, releasefile):
-        file = releasefile.file
-        fp = file.getfile()
-        response = StreamingHttpResponse(
-            iter(lambda: fp.read(4096), b""),
-            content_type=file.headers.get("content-type", "application/octet-stream"),
-        )
-        response["Content-Length"] = file.size
-        response["Content-Disposition"] = 'attachment; filename="%s"' % posixpath.basename(
-            " ".join(releasefile.name.split())
-        )
-        return response
-
+class OrganizationReleaseFileDetailsEndpoint(
+    OrganizationReleasesBaseEndpoint, ReleaseFileDetailsMixin
+):
     def get(self, request, organization, version, file_id):
         """
         Retrieve an Organization Release's File
@@ -51,17 +36,12 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        try:
-            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
-        except ReleaseFile.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        download_requested = request.GET.get("download") is not None
-        if download_requested and (request.access.has_scope("project:write")):
-            return self.download(releasefile)
-        elif download_requested:
-            return Response(status=403)
-        return Response(serialize(releasefile, request.user))
+        return self.get_releasefile(
+            request,
+            release,
+            file_id,
+            check_permission_fn=lambda: request.access.has_scope("project:write"),
+        )
 
     def put(self, request, organization, version, file_id):
         """
@@ -87,21 +67,7 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        try:
-            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
-        except ReleaseFile.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        serializer = ReleaseFileSerializer(data=request.data)
-
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
-
-        result = serializer.validated_data
-
-        releasefile.update(name=result["name"])
-
-        return Response(serialize(releasefile, request.user))
+        return self.update_releasefile(request, release, file_id)
 
     def delete(self, request, organization, version, file_id):
         """
@@ -126,16 +92,4 @@ class OrganizationReleaseFileDetailsEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        try:
-            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
-        except ReleaseFile.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        file = releasefile.file
-
-        # TODO(dcramer): this doesnt handle a failure from file.deletefile() to
-        # the actual deletion of the db row
-        releasefile.delete()
-        file.delete()
-
-        return Response(status=204)
+        return self.delete_releasefile(release, file_id)

--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -1,41 +1,12 @@
 import logging
-import re
-
-from django.db import IntegrityError, transaction
-from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationReleasesBaseEndpoint
+from sentry.api.endpoints.project_release_files import ReleaseFilesMixin
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.paginator import OffsetPaginator
-from sentry.api.serializers import serialize
-from sentry.constants import MAX_RELEASE_FILES_OFFSET
-from sentry.models import Distribution, File, Release, ReleaseFile
-
-ERR_FILE_EXISTS = "A file matching this name already exists for the given release"
-_filename_re = re.compile(r"[\n\t\r\f\v\\]")
+from sentry.models import Release
 
 
-def load_dist(results):
-    # Dists are pretty uncommon.  In case they do appear load them now
-    # as trying to join this on the DB does terrible things with large
-    # offsets (it would otherwise generate a left outer join).
-    dists = dict.fromkeys(x.dist_id for x in results)
-    if not dists:
-        return results
-
-    for dist in Distribution.objects.filter(pk__in=dists.keys()):
-        dists[dist.id] = dist
-
-    for result in results:
-        if result.dist_id is not None:
-            dist = dists.get(result.dist_id)
-            if dist is not None:
-                result.dist = dist
-
-    return results
-
-
-class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
+class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseFilesMixin):
     def get(self, request, organization, version):
         """
         List an Organization Release's Files
@@ -56,20 +27,7 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        file_list = (
-            ReleaseFile.public_objects.filter(release=release)
-            .select_related("file")
-            .order_by("name")
-        )
-
-        return self.paginate(
-            request=request,
-            queryset=file_list,
-            order_by="name",
-            paginator_cls=OffsetPaginator,
-            max_offset=MAX_RELEASE_FILES_OFFSET,
-            on_results=lambda r: serialize(load_dist(r), request.user),
-        )
+        return self.get_releasefiles(request, release)
 
     def post(self, request, organization, version):
         """
@@ -109,65 +67,4 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        if "file" not in request.data:
-            return Response({"detail": "Missing uploaded file"}, status=400)
-
-        fileobj = request.data["file"]
-
-        full_name = request.data.get("name", fileobj.name)
-        if not full_name or full_name == "file":
-            return Response({"detail": "File name must be specified"}, status=400)
-
-        name = full_name.rsplit("/", 1)[-1]
-
-        if _filename_re.search(name):
-            return Response(
-                {"detail": "File name must not contain special whitespace characters"}, status=400
-            )
-
-        dist_name = request.data.get("dist")
-        dist = None
-        if dist_name:
-            dist = release.add_dist(dist_name)
-
-        # Quickly check for the presence of this file before continuing with
-        # the costly file upload process.
-        if ReleaseFile.objects.filter(
-            organization_id=release.organization_id,
-            release=release,
-            name=full_name,
-            dist=dist,
-        ).exists():
-            return Response({"detail": ERR_FILE_EXISTS}, status=409)
-
-        headers = {"Content-Type": fileobj.content_type}
-        for headerval in request.data.getlist("header") or ():
-            try:
-                k, v = headerval.split(":", 1)
-            except ValueError:
-                return Response({"detail": "header value was not formatted correctly"}, status=400)
-            else:
-                if _filename_re.search(v):
-                    return Response(
-                        {"detail": "header value must not contain special whitespace characters"},
-                        status=400,
-                    )
-                headers[k] = v.strip()
-
-        file = File.objects.create(name=name, type="release.file", headers=headers)
-        file.putfile(fileobj, logger=logger)
-
-        try:
-            with transaction.atomic():
-                releasefile = ReleaseFile.objects.create(
-                    organization_id=release.organization_id,
-                    release=release,
-                    file=file,
-                    name=full_name,
-                    dist=dist,
-                )
-        except IntegrityError:
-            file.delete()
-            return Response({"detail": ERR_FILE_EXISTS}, status=409)
-
-        return Response(serialize(releasefile, request.user), status=201)
+        return self.post_releasefile(request, release, logger)

--- a/src/sentry/api/endpoints/project_release_file_details.py
+++ b/src/sentry/api/endpoints/project_release_file_details.py
@@ -15,10 +15,14 @@ class ReleaseFileSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=200, required=True)
 
 
-class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
-    permission_classes = (ProjectReleasePermission,)
+class ReleaseFileDetailsMixin:
+    """Shared functionality of ProjectReleaseFileDetails and OrganizationReleaseFileDetails
 
-    def download(self, releasefile):
+    Only has class methods, but keep it as a class to be consistent with ReleaseFilesMixin.
+    """
+
+    @staticmethod
+    def download(releasefile):
         file = releasefile.file
         fp = file.getfile()
         response = StreamingHttpResponse(
@@ -30,6 +34,58 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
             " ".join(releasefile.name.split())
         )
         return response
+
+    @classmethod
+    def get_releasefile(cls, request, release, file_id, check_permission_fn):
+        try:
+            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
+        except ReleaseFile.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        download_requested = request.GET.get("download") is not None
+        if download_requested and check_permission_fn():
+            return cls.download(releasefile)
+        elif download_requested:
+            return Response(status=403)
+        return Response(serialize(releasefile, request.user))
+
+    @staticmethod
+    def update_releasefile(request, release, file_id):
+        try:
+            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
+        except ReleaseFile.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        serializer = ReleaseFileSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        result = serializer.validated_data
+
+        releasefile.update(name=result["name"])
+
+        return Response(serialize(releasefile, request.user))
+
+    @staticmethod
+    def delete_releasefile(release, file_id):
+        try:
+            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
+        except ReleaseFile.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        file = releasefile.file
+
+        # TODO(dcramer): this doesnt handle a failure from file.deletefile() to
+        # the actual deletion of the db row
+        releasefile.delete()
+        file.delete()
+
+        return Response(status=204)
+
+
+class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint, ReleaseFileDetailsMixin):
+    permission_classes = (ProjectReleasePermission,)
 
     def get(self, request, project, version, file_id):
         """
@@ -55,17 +111,12 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        try:
-            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
-        except ReleaseFile.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        download_requested = request.GET.get("download") is not None
-        if download_requested and (has_download_permission(request, project)):
-            return self.download(releasefile)
-        elif download_requested:
-            return Response(status=403)
-        return Response(serialize(releasefile, request.user))
+        return self.get_releasefile(
+            request,
+            release,
+            file_id,
+            check_permission_fn=lambda: has_download_permission(request, project),
+        )
 
     def put(self, request, project, version, file_id):
         """
@@ -91,21 +142,7 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        try:
-            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
-        except ReleaseFile.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        serializer = ReleaseFileSerializer(data=request.data)
-
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
-
-        result = serializer.validated_data
-
-        releasefile.update(name=result["name"])
-
-        return Response(serialize(releasefile, request.user))
+        return self.update_releasefile(request, release, file_id)
 
     def delete(self, request, project, version, file_id):
         """
@@ -131,16 +168,4 @@ class ProjectReleaseFileDetailsEndpoint(ProjectEndpoint):
         except Release.DoesNotExist:
             raise ResourceDoesNotExist
 
-        try:
-            releasefile = ReleaseFile.public_objects.get(release=release, id=file_id)
-        except ReleaseFile.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        file = releasefile.file
-
-        # TODO(dcramer): this doesnt handle a failure from file.deletefile() to
-        # the actual deletion of the db row
-        releasefile.delete()
-        file.delete()
-
-        return Response(status=204)
+        return self.delete_releasefile(release, file_id)

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -6,43 +6,39 @@ from django.db.models import Q
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.api.endpoints.organization_release_files import load_dist
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.constants import MAX_RELEASE_FILES_OFFSET
-from sentry.models import File, Release, ReleaseFile
+from sentry.models import Distribution, File, Release, ReleaseFile
 
 ERR_FILE_EXISTS = "A file matching this name already exists for the given release"
 _filename_re = re.compile(r"[\n\t\r\f\v\\]")
 
 
-class ProjectReleaseFilesEndpoint(ProjectEndpoint):
-    permission_classes = (ProjectReleasePermission,)
+def load_dist(results):
+    # Dists are pretty uncommon.  In case they do appear load them now
+    # as trying to join this on the DB does terrible things with large
+    # offsets (it would otherwise generate a left outer join).
+    dists = dict.fromkeys(x.dist_id for x in results)
+    if not dists:
+        return results
 
-    def get(self, request, project, version):
-        """
-        List a Project Release's Files
-        ``````````````````````````````
+    for dist in Distribution.objects.filter(pk__in=dists.keys()):
+        dists[dist.id] = dist
 
-        Retrieve a list of files for a given release.
+    for result in results:
+        if result.dist_id is not None:
+            dist = dists.get(result.dist_id)
+            if dist is not None:
+                result.dist = dist
 
-        :pparam string organization_slug: the slug of the organization the
-                                          release belongs to.
-        :pparam string project_slug: the slug of the project to list the
-                                     release files of.
-        :pparam string version: the version identifier of the release.
-        :qparam string query: If set, this parameter is used to search files.
-        :auth: required
-        """
+    return results
+
+
+class ReleaseFilesMixin:
+    def get_releasefiles(self, request, release):
         query = request.GET.getlist("query")
-
-        try:
-            release = Release.objects.get(
-                organization_id=project.organization_id, projects=project, version=version
-            )
-        except Release.DoesNotExist:
-            raise ResourceDoesNotExist
 
         file_list = (
             ReleaseFile.public_objects.filter(release=release)
@@ -68,45 +64,8 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
             on_results=lambda r: serialize(load_dist(r), request.user),
         )
 
-    def post(self, request, project, version):
-        """
-        Upload a New Project Release File
-        `````````````````````````````````
-
-        Upload a new file for the given release.
-
-        Unlike other API requests, files must be uploaded using the
-        traditional multipart/form-data content-type.
-
-        The optional 'name' attribute should reflect the absolute path
-        that this file will be referenced as. For example, in the case of
-        JavaScript you might specify the full web URI.
-
-        :pparam string organization_slug: the slug of the organization the
-                                          release belongs to.
-        :pparam string project_slug: the slug of the project to change the
-                                     release of.
-        :pparam string version: the version identifier of the release.
-        :param string name: the name (full path) of the file.
-        :param string dist: the name of the dist.
-        :param file file: the multipart encoded file.
-        :param string header: this parameter can be supplied multiple times
-                              to attach headers to the file.  Each header
-                              is a string in the format ``key:value``.  For
-                              instance it can be used to define a content
-                              type.
-        :auth: required
-        """
-        try:
-            release = Release.objects.get(
-                organization_id=project.organization_id, projects=project, version=version
-            )
-        except Release.DoesNotExist:
-            raise ResourceDoesNotExist
-
-        logger = logging.getLogger("sentry.files")
-        logger.info("projectreleasefile.start")
-
+    @staticmethod
+    def post_releasefile(request, release, logger):
         if "file" not in request.data:
             return Response({"detail": "Missing uploaded file"}, status=400)
 
@@ -169,3 +128,72 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
             return Response({"detail": ERR_FILE_EXISTS}, status=409)
 
         return Response(serialize(releasefile, request.user), status=201)
+
+
+class ProjectReleaseFilesEndpoint(ProjectEndpoint, ReleaseFilesMixin):
+    permission_classes = (ProjectReleasePermission,)
+
+    def get(self, request, project, version):
+        """
+        List a Project Release's Files
+        ``````````````````````````````
+
+        Retrieve a list of files for a given release.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to list the
+                                     release files of.
+        :pparam string version: the version identifier of the release.
+        :qparam string query: If set, this parameter is used to search files.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id, projects=project, version=version
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        return self.get_releasefiles(request, release)
+
+    def post(self, request, project, version):
+        """
+        Upload a New Project Release File
+        `````````````````````````````````
+
+        Upload a new file for the given release.
+
+        Unlike other API requests, files must be uploaded using the
+        traditional multipart/form-data content-type.
+
+        The optional 'name' attribute should reflect the absolute path
+        that this file will be referenced as. For example, in the case of
+        JavaScript you might specify the full web URI.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          release belongs to.
+        :pparam string project_slug: the slug of the project to change the
+                                     release of.
+        :pparam string version: the version identifier of the release.
+        :param string name: the name (full path) of the file.
+        :param string dist: the name of the dist.
+        :param file file: the multipart encoded file.
+        :param string header: this parameter can be supplied multiple times
+                              to attach headers to the file.  Each header
+                              is a string in the format ``key:value``.  For
+                              instance it can be used to define a content
+                              type.
+        :auth: required
+        """
+        try:
+            release = Release.objects.get(
+                organization_id=project.organization_id, projects=project, version=version
+            )
+        except Release.DoesNotExist:
+            raise ResourceDoesNotExist
+
+        logger = logging.getLogger("sentry.files")
+        logger.info("projectreleasefile.start")
+
+        return self.post_releasefile(request, release, logger)


### PR DESCRIPTION
The endpoints for organization release files and project release files are almost identical. This PR gives them a common codebase.

The only intended change in functionality in this PR is that the organization release files endpoint now also accepts the `query` parameter.

This prepares for https://github.com/getsentry/sentry/pull/26351.