### PR TITLE
style(js): Always ` ` whitespace after comments

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -191,7 +191,7 @@ export type SentryAppDetailsModalOptions = {
   isInstalled: boolean;
   onInstall: () => Promise<void>;
   organization: Organization;
-  onCloseModal?: () => void; //used for analytics
+  onCloseModal?: () => void; // used for analytics
 };
 
 type DebugFileSourceModalOptions = {

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -316,7 +316,7 @@ function getDemoModeGuides(): GuidesContent {
     {
       guide: 'sidebar',
       requiredTargets: ['projects', 'issues'],
-      priority: 1, //lower number means higher priority
+      priority: 1, // lower number means higher priority
       markOthersAsSeen: true,
       steps: [
         {

--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -20,7 +20,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
 type Props = {
-  target?: string; //Shouldn't target be mandatory?
+  target?: string; // Shouldn't target be mandatory?
   position?: React.ComponentProps<typeof Hovercard>['position'];
   offset?: string;
   to?: {

--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -301,7 +301,7 @@ export default class AsyncComponent<
         return state;
       },
       () => {
-        //if everything is loaded and we don't have an error, call the callback
+        // if everything is loaded and we don't have an error, call the callback
         if (this.state.remainingRequests === 0 && !this.state.error) {
           this.onLoadAllEndpointsSuccess();
         }

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -246,7 +246,7 @@ class ContextPickerModal extends Component<Props> {
     });
   };
 
-  //TODO(TS): Fix typings
+  // TODO(TS): Fix typings
   customOptionProject = ({label, ...props}: any) => {
     const project = this.props.projects.find(({slug}) => props.value === slug);
     if (!project) {
@@ -278,7 +278,7 @@ class ContextPickerModal extends Component<Props> {
     if (integrationConfigs.length) {
       return t('Select a configuration to continue');
     }
-    //if neither project nor org needs to be selected, nothing will render anyways
+    // if neither project nor org needs to be selected, nothing will render anyways
     return '';
   }
 

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -79,7 +79,7 @@ export default function DemoHeader() {
   );
 }
 
-//Note many of the colors don't come from the theme as they come from the marketing site
+// Note many of the colors don't come from the theme as they come from the marketing site
 const Wrapper = styled('div')<{collapsed: boolean}>`
   padding-right: ${space(3)};
   background-color: ${p => p.theme.white};
@@ -117,7 +117,7 @@ const BaseButton = styled(Button)`
   text-transform: uppercase;
 `;
 
-//Note many of the colors don't come from the theme as they come from the marketing site
+// Note many of the colors don't come from the theme as they come from the marketing site
 const GetStarted = styled(BaseButton)`
   border-color: transparent;
   box-shadow: 0 2px 0 rgb(54 45 89 / 10%);

--- a/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
+++ b/static/app/components/dropdownAutoComplete/autoCompleteFilter.tsx
@@ -46,7 +46,7 @@ function autoCompleteFilter(
   }
 
   if (hasRootGroup(items)) {
-    //if the first item has children, we assume it is a group
+    // if the first item has children, we assume it is a group
     return flatMap(filterGroupedItems(items, inputValue), item => {
       const groupItems = item.items.map(groupedItem => ({
         ...groupedItem,

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -101,7 +101,7 @@ class EventOrGroupHeader extends Component<Props> {
             query: {
               query: this.props.query,
               ...(location.query.sort !== undefined ? {sort: location.query.sort} : {}), // This adds sort to the query if one was selected from the issues list page
-              ...(location.query.project !== undefined ? {} : {_allp: 1}), //This appends _allp to the URL parameters if they have no project selected ("all" projects included in results). This is so that when we enter the issue details page and lock them to a project, we can properly take them back to the issue list page with no project selected (and not the locked project selected)
+              ...(location.query.project !== undefined ? {} : {_allp: 1}), // This appends _allp to the URL parameters if they have no project selected ("all" projects included in results). This is so that when we enter the issue details page and lock them to a project, we can properly take them back to the issue list page with no project selected (and not the locked project selected)
             },
           }}
           onClick={onClick}

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/processingIcon.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/processingIcon.tsx
@@ -35,7 +35,7 @@ function ProcessingIcon({processingInfo}: Props) {
           new Error('Unknown image candidate ProcessingIcon status')
         );
       });
-      return null; //this shall never happen
+      return null; // this shall never happen
     }
   }
 }

--- a/static/app/components/events/interfaces/stacktraceContent.tsx
+++ b/static/app/components/events/interfaces/stacktraceContent.tsx
@@ -222,7 +222,7 @@ class StacktraceContent extends React.Component<Props, State> {
             onAddressToggle={this.handleToggleAddresses}
             image={image}
             maxLengthOfRelativeAddress={maxLengthOfAllRelativeAddresses}
-            registers={{}} //TODO: Fix registers
+            registers={{}} // TODO: Fix registers
             isFrameAfterLastNonApp={isFrameAfterLastNonApp}
             includeSystemFrames={includeSystemFrames}
             onFunctionNameToggle={this.handleToggleFunctionName}

--- a/static/app/components/events/interfaces/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/stacktraceLink.tsx
@@ -35,7 +35,7 @@ type Props = AsyncComponent['props'] & {
   projects: Project[];
 };
 
-//format of the ProjectStacktraceLinkEndpoint response
+// format of the ProjectStacktraceLinkEndpoint response
 type StacktraceResultItem = {
   integrations: Integration[];
   config?: RepositoryProjectPathConfigWithIntegration;
@@ -199,7 +199,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
   }
 
   renderLoading() {
-    //TODO: Add loading
+    // TODO: Add loading
     return null;
   }
 

--- a/static/app/components/forms/inputField.tsx
+++ b/static/app/components/forms/inputField.tsx
@@ -20,7 +20,7 @@ class InputField<
   getField() {
     return (
       <input
-        id={this.getId()} //TODO(Priscila): check the reason behind this. We are getting warnings if we have 2 or more fields with the same name, for instance in the DATA PRIVACY RULES
+        id={this.getId()} // TODO(Priscila): check the reason behind this. We are getting warnings if we have 2 or more fields with the same name, for instance in the DATA PRIVACY RULES
         type={this.getType()}
         className="form-control"
         autoComplete={this.props.autoComplete}
@@ -29,7 +29,7 @@ class InputField<
         disabled={this.props.disabled}
         name={this.props.name}
         required={this.props.required}
-        value={this.state.value as string | number} //can't pass in boolean here
+        value={this.state.value as string | number} // can't pass in boolean here
         style={this.props.inputStyle}
         onBlur={this.props.onBlur}
         onFocus={this.props.onFocus}

--- a/static/app/components/forms/selectAsyncControl.tsx
+++ b/static/app/components/forms/selectAsyncControl.tsx
@@ -15,7 +15,7 @@ type Result = {
 
 type Props = {
   url: string;
-  onResults: (data: any) => Result[]; //TODO(ts): Improve data type
+  onResults: (data: any) => Result[]; // TODO(ts): Improve data type
   onQuery: (query: string | undefined) => {};
 } & Pick<ControlProps, 'value' | 'forwardedRef'>;
 

--- a/static/app/components/group/externalIssuesList.tsx
+++ b/static/app/components/group/externalIssuesList.tsx
@@ -167,7 +167,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
       const installation = sentryAppInstallations.find(
         i => i.app.uuid === sentryApp.uuid
       );
-      //should always find a match but TS complains if we don't handle this case
+      // should always find a match but TS complains if we don't handle this case
       if (!installation) {
         return null;
       }

--- a/static/app/components/group/inboxBadges/inboxReason.tsx
+++ b/static/app/components/group/inboxBadges/inboxReason.tsx
@@ -49,7 +49,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
     } = reasonDetails;
     if (until) {
       // Was ignored until `until` has passed.
-      //`until` format: "2021-01-20T03:59:03+00:00"
+      // `until` format: "2021-01-20T03:59:03+00:00"
       return tct('Was ignored until [window]', {
         window: <DateTime date={until} dateOnly />,
       });

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -17,7 +17,7 @@ import Form from 'app/views/settings/components/forms/form';
 import FormModel from 'app/views/settings/components/forms/model';
 import {Field, FieldValue} from 'app/views/settings/components/forms/type';
 
-//0 is a valid choice but empty string, undefined, and null are not
+// 0 is a valid choice but empty string, undefined, and null are not
 const hasValue = value => !!value || value === 0;
 
 type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
@@ -35,7 +35,7 @@ type Config = {
   optional_fields?: FieldFromSchema[];
 };
 
-//only need required_fields and optional_fields
+// only need required_fields and optional_fields
 type State = Omit<Config, 'uri'> & {
   optionsByField: Map<string, Array<{label: string; value: any}>>;
 };
@@ -67,14 +67,14 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
 
   model = new FormModel();
 
-  //reset the state when we mount or the action changes
+  // reset the state when we mount or the action changes
   resetStateFromProps() {
     const {config, action, group} = this.props;
     this.setState({
       required_fields: config.required_fields,
       optional_fields: config.optional_fields,
     });
-    //we need to pass these fields in the API so just set them as values so we don't need hidden form fields
+    // we need to pass these fields in the API so just set them as values so we don't need hidden form fields
     this.model.setInitialData({
       action,
       groupId: group.id,
@@ -128,7 +128,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
         accum[dependentField] = this.model.getValue(dependentField);
         return accum;
       }, {});
-      //stringify the data
+      // stringify the data
       query.dependentData = JSON.stringify(dependentData);
     }
 
@@ -186,7 +186,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
 
     const fieldList: FieldFromSchema[] = requiredFields.concat(optionalFields);
 
-    //could have multiple impacted fields
+    // could have multiple impacted fields
     const impactedFields = fieldList.filter(({depends_on}) => {
       if (!depends_on) {
         return false;
@@ -195,20 +195,20 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
       return depends_on.includes(id);
     });
 
-    //load all options in parallel
+    // load all options in parallel
     const choiceArray = await Promise.all(
       impactedFields.map(field => {
-        //reset all impacted fields first
+        // reset all impacted fields first
         this.model.setValue(field.name || '', '', {quiet: true});
         return this.makeExternalRequest(field, '');
       })
     );
 
     this.setState(state => {
-      //pull the field lists from latest state
+      // pull the field lists from latest state
       requiredFields = state.required_fields || [];
       optionalFields = state.optional_fields || [];
-      //iterate through all the impacted fields and get new values
+      // iterate through all the impacted fields and get new values
       impactedFields.forEach((impactedField, i) => {
         const choices = choiceArray[i];
         const requiredIndex = requiredFields.indexOf(impactedField);
@@ -216,7 +216,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
 
         const updatedField = {...impactedField, choices};
 
-        //immutably update the lists with the updated field depending where we got it from
+        // immutably update the lists with the updated field depending where we got it from
         if (requiredIndex > -1) {
           requiredFields = replaceAtArrayIndex(
             requiredFields,
@@ -239,8 +239,8 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
   };
 
   renderField = (field: FieldFromSchema, required: boolean) => {
-    //This function converts the field we get from the backend into
-    //the field we need to pass down
+    // This function converts the field we get from the backend into
+    // the field we need to pass down
     let fieldToPass: Field = {
       ...field,
       inline: false,
@@ -249,8 +249,8 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
       required,
     };
 
-    //async only used for select components
-    const isAsync = typeof field.async === 'undefined' ? true : !!field.async; //default to true
+    // async only used for select components
+    const isAsync = typeof field.async === 'undefined' ? true : !!field.async; // default to true
 
     if (fieldToPass.type === 'select') {
       // find the options from state to pass down
@@ -260,7 +260,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
       }));
       const options = this.state.optionsByField.get(field.name) || defaultOptions;
       const allowClear = !required;
-      //filter by what the user is typing
+      // filter by what the user is typing
       const filterOption = createFilter({});
       fieldToPass = {
         ...fieldToPass,
@@ -269,7 +269,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
         filterOption,
         allowClear,
       };
-      //default message for async select fields
+      // default message for async select fields
       if (isAsync) {
         fieldToPass.noOptionsMessage = () => 'Type to search';
       }
@@ -278,7 +278,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
     }
 
     if (field.depends_on) {
-      //check if this is dependent on other fields which haven't been set yet
+      // check if this is dependent on other fields which haven't been set yet
       const shouldDisable = field.depends_on.some(
         dependentField => !hasValue(this.model.getValue(dependentField))
       );
@@ -287,7 +287,7 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
       }
     }
 
-    //if we have a uri, we need to set extra parameters
+    // if we have a uri, we need to set extra parameters
     const extraProps = field.uri
       ? {
           loadOptions: (input: string) => this.getOptions(field, input),

--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -42,14 +42,14 @@ class SuggestedOwners extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props) {
     if (this.props.event && prevProps.event) {
       if (this.props.event.id !== prevProps.event.id) {
-        //two events, with different IDs
+        // two events, with different IDs
         this.fetchData(this.props.event);
       }
       return;
     }
 
     if (this.props.event) {
-      //going from having no event to having an event
+      // going from having no event to having an event
       this.fetchData(this.props.event);
     }
   }

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -130,7 +130,7 @@ const StyledButton = styled(Button)`
   margin: ${space(0.5)};
 `;
 
-//Columns below
+// Columns below
 const Column = styled('span')`
   overflow: hidden;
   overflow-wrap: break-word;

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -10,7 +10,7 @@ type AnchorProps = React.HTMLProps<HTMLAnchorElement>;
 type ToLocationFunction = (location: Location) => LocationDescriptor;
 
 type Props = WithRouterProps & {
-  //URL
+  // URL
   to: ToLocationFunction | LocationDescriptor;
   // Styles applied to the component's root
   className?: string;

--- a/static/app/components/list/utils.tsx
+++ b/static/app/components/list/utils.tsx
@@ -13,7 +13,7 @@ const bulletStyle = (theme: Theme) => css`
 
 type Options = {
   isSolid?: boolean;
-  //setting initialCounterValue to 0 means the first visible step is 1
+  // setting initialCounterValue to 0 means the first visible step is 1
   initialCounterValue?: number;
 };
 

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -31,10 +31,10 @@ type State = {
   featureData: IntegrationFeature[];
 } & AsyncComponent['state'];
 
-//No longer a modal anymore but yea :)
+// No longer a modal anymore but yea :)
 export default class SentryAppDetailsModal extends AsyncComponent<Props, State> {
   componentDidUpdate(prevProps: Props) {
-    //if the user changes org, count this as a fresh event to track
+    // if the user changes org, count this as a fresh event to track
     if (this.props.organization.id !== prevProps.organization.id) {
       this.trackOpened();
     }
@@ -80,8 +80,8 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
 
   async onInstall() {
     const {onInstall} = this.props;
-    //we want to make sure install finishes before we close the modal
-    //and we should close the modal if there is an error as well
+    // we want to make sure install finishes before we close the modal
+    // and we should close the modal if there is an error as well
     try {
       await onInstall();
     } catch (_err) {

--- a/static/app/components/modals/sentryAppPublishRequestModal.tsx
+++ b/static/app/components/modals/sentryAppPublishRequestModal.tsx
@@ -33,7 +33,7 @@ const getPermissionSelectionsFromScopes = (scopes: Scope[]) => {
       }
     }
     if (highestChoice) {
-      //we can remove the read part of "Read & Write"
+      // we can remove the read part of "Read & Write"
       const label = highestChoice.label.replace('Read & Write', 'Write');
       permissions.push(`${permObj.resource} ${label}`);
     }
@@ -44,9 +44,9 @@ const getPermissionSelectionsFromScopes = (scopes: Scope[]) => {
 class PublishRequestFormModel extends FormModel {
   getTransformedData() {
     const data = this.getData();
-    //map object to list of questions
+    // map object to list of questions
     const questionnaire = Array.from(this.fieldDescriptor.values()).map(field =>
-      //we read the meta for the question that has a react node for the label
+      // we read the meta for the question that has a react node for the label
       ({
         question: field.meta || field.label,
         answer: data[field.name],
@@ -85,7 +85,7 @@ export default class SentryAppPublishRequestModal extends Component<Props> {
       </Fragment>
     );
 
-    //No translations since we need to be able to read this email :)
+    // No translations since we need to be able to read this email :)
     const baseFields: React.ComponentProps<typeof JsonForm>['fields'] = [
       {
         type: 'textarea',
@@ -116,7 +116,7 @@ export default class SentryAppPublishRequestModal extends Component<Props> {
       },
     ];
 
-    //Only add the permissions question if there are perms to add
+    // Only add the permissions question if there are perms to add
     if (permissions.length > 0) {
       baseFields.push({
         type: 'textarea',

--- a/static/app/components/projects/bookmarkStar.tsx
+++ b/static/app/components/projects/bookmarkStar.tsx
@@ -41,10 +41,10 @@ const BookmarkStar = ({
       addErrorMessage(t('Unable to toggle bookmark for %s', project.slug));
     });
 
-    //needed to dismiss tooltip
+    // needed to dismiss tooltip
     (document.activeElement as HTMLElement).blur();
 
-    //prevent dropdowns from closing
+    // prevent dropdowns from closing
     event.stopPropagation();
 
     if (onToggle) {

--- a/static/app/components/repositoryProjectPathConfigRow.tsx
+++ b/static/app/components/repositoryProjectPathConfigRow.tsx
@@ -96,12 +96,12 @@ const ProjectAndBranch = styled('div')`
   color: ${p => p.theme.gray300};
 `;
 
-//match the line height of the badge
+// match the line height of the badge
 const BranchWrapper = styled('div')`
   line-height: 1.2;
 `;
 
-//Columns below
+// Columns below
 const Column = styled('span')`
   overflow: hidden;
   overflow-wrap: break-word;

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -144,7 +144,7 @@ async function createPluginResults(
   const plugins = (await pluginsPromise) || [];
   return plugins
     .filter(plugin => {
-      //show a plugin if it is not hidden (aka legacy) or if we have projects with it configured
+      // show a plugin if it is not hidden (aka legacy) or if we have projects with it configured
       return !plugin.isHidden || !!plugin.projectList.length;
     })
     .map(plugin => ({
@@ -210,7 +210,7 @@ async function createSentryAppResults(
   }));
 }
 
-//Not really async but we need to return a promise
+// Not really async but we need to return a promise
 async function creatDocIntegrationResults(orgId: string): Promise<ResultItem[]> {
   return documentIntegrationList.map(integration => ({
     title: integration.name,
@@ -442,7 +442,7 @@ class ApiSource extends React.Component<Props, State> {
       this.getDirectResults([shortIdLookup, eventIdLookup]),
     ]);
 
-    //TODO(XXX): Might consider adding logic to maintain consistent ordering of results so things don't switch positions
+    // TODO(XXX): Might consider adding logic to maintain consistent ordering of results so things don't switch positions
     const fuzzy = createFuzzySearch<ResultItem>(searchResults, {
       ...searchOptions,
       keys: ['title', 'description'],

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -26,7 +26,7 @@ import {CommonSidebarProps} from '../types';
 import Divider from './divider.styled';
 import SwitchOrganization from './switchOrganization';
 
-//TODO: make org and user optional props
+// TODO: make org and user optional props
 type Props = Pick<CommonSidebarProps, 'orientation' | 'collapsed'> & {
   api: Client;
   org: Organization;

--- a/static/app/components/suggestProjectCTA.tsx
+++ b/static/app/components/suggestProjectCTA.tsx
@@ -52,22 +52,22 @@ class SuggestProjectCTA extends Component<Props, State> {
     this.fetchData();
   }
 
-  //Returns the matched user agent string
-  //otherwise, returns an empty string
+  // Returns the matched user agent string
+  // otherwise, returns an empty string
   get matchedUserAgentString() {
     const {entries} = this.props.event;
     const requestEntry = entries.find(item => item.type === 'request');
     if (!requestEntry) {
       return '';
     }
-    //find the user agent header out of our list of headers
+    // find the user agent header out of our list of headers
     const userAgent = (requestEntry as EntryRequest)?.data?.headers?.find(
       item => item[0].toLowerCase() === 'user-agent'
     );
     if (!userAgent) {
       return '';
     }
-    //check if any of our mobile agent headers matches the event mobile agent
+    // check if any of our mobile agent headers matches the event mobile agent
     return (
       MOBILE_USER_AGENTS.find(mobileAgent =>
         userAgent[1]?.toLowerCase().includes(mobileAgent.toLowerCase())
@@ -75,15 +75,15 @@ class SuggestProjectCTA extends Component<Props, State> {
     );
   }
 
-  //check our projects to see if there is a mobile project
+  // check our projects to see if there is a mobile project
   get hasMobileProject() {
     return this.props.projects.some(project =>
       MOBILE_PLATFORMS.includes(project.platform || '')
     );
   }
 
-  //returns true if the current event is mobile from the user agent
-  //or if we found a mobile event with the API
+  // returns true if the current event is mobile from the user agent
+  // or if we found a mobile event with the API
   get hasMobileEvent() {
     const {mobileEventResult} = this.state;
     return !!this.matchedUserAgentString || !!mobileEventResult;
@@ -103,13 +103,13 @@ class SuggestProjectCTA extends Component<Props, State> {
   }
 
   async fetchData() {
-    //no need to catch error since we have error boundary wrapping
+    // no need to catch error since we have error boundary wrapping
     const [isDismissed, mobileEventResult] = await Promise.all([
       this.checkMobilePrompt(),
       this.checkOrgHasMobileEvent(),
     ]);
 
-    //set the new state
+    // set the new state
     this.setState(
       {
         isDismissed,
@@ -119,7 +119,7 @@ class SuggestProjectCTA extends Component<Props, State> {
       () => {
         const matchedUserAgentString = this.matchedUserAgentString;
         if (this.showCTA) {
-          //now record the results
+          // now record the results
           trackAdvancedAnalyticsEvent(
             'growth.show_mobile_prompt_banner',
             {
@@ -150,7 +150,7 @@ class SuggestProjectCTA extends Component<Props, State> {
   async checkMobilePrompt() {
     const {api, organization} = this.props;
 
-    //check our prompt backend
+    // check our prompt backend
     const promptData = await promptsCheck(api, {
       organizationId: organization.id,
       feature: 'suggest_mobile_project',

--- a/static/app/data/forms/sentryApplication.tsx
+++ b/static/app/data/forms/sentryApplication.tsx
@@ -127,11 +127,11 @@ export const publicIntegrationForms = [
 ];
 
 const getInternalFormFields = () => {
-  /***
-   * Generate internal form fields copy copying the public form fields and making adjustments:
-   *    1. remove fields not needed for internal integrations
-   *    2. make webhookUrl optional
-   ***/
+  // Generate internal form fields copy copying the public form fields and
+  // making adjustments:
+  //
+  //   1. remove fields not needed for internal integrations
+  //   2. make webhookUrl optional
 
   const internalFormFields = getPublicFormFields().filter(
     formField =>

--- a/static/app/plugins/components/issueActions.tsx
+++ b/static/app/plugins/components/issueActions.tsx
@@ -158,7 +158,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
     const pluginSlug = this.props.plugin.slug;
     const url = `/issues/${groupId}/plugins/${pluginSlug}/options/`;
 
-    //find the fields that this field is dependent on
+    // find the fields that this field is dependent on
     const dependentFormValues = Object.fromEntries(
       field.depends.map(fieldKey => [fieldKey, formData[fieldKey]])
     );
@@ -184,11 +184,11 @@ class IssueActions extends PluginComponentBase<Props, State> {
       return;
     }
 
-    //find the location of the field in our list and replace it
+    // find the location of the field in our list and replace it
     const indexOfField = fieldList.findIndex(({name}) => name === field.name);
     field = {...field, choices};
 
-    //make a copy of the array to avoid mutation
+    // make a copy of the array to avoid mutation
     fieldList = fieldList.slice();
     fieldList[indexOfField] = field;
 
@@ -207,7 +207,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
   getInputProps(field: Field) {
     const props: {isLoading?: boolean; readonly?: boolean} = {};
 
-    //special logic for fields that have dependencies
+    // special logic for fields that have dependencies
     if (field.depends && field.depends.length > 0) {
       switch (this.state.dependentFieldState[field.name]) {
         case FormState.LOADING:
@@ -251,7 +251,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
   onLoadSuccess() {
     super.onLoadSuccess();
 
-    //dependent fields need to be set to disabled upon loading
+    // dependent fields need to be set to disabled upon loading
     const fieldList = this.getFieldList();
     fieldList.forEach(field => {
       if (field.depends && field.depends.length > 0) {
@@ -342,7 +342,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
   changeField(action: ActionType, name: string, value: any) {
     const formDataKey = this.getFormDataKey(action);
 
-    //copy so we don't mutate
+    // copy so we don't mutate
     const formData = {...this.state[formDataKey]};
     const fieldList = this.getFieldList();
 
@@ -350,7 +350,7 @@ class IssueActions extends PluginComponentBase<Props, State> {
 
     let callback = () => {};
 
-    //only works with one impacted field
+    // only works with one impacted field
     const impactedField = fieldList.find(({depends}) => {
       if (!depends || !depends.length) {
         return false;
@@ -360,11 +360,11 @@ class IssueActions extends PluginComponentBase<Props, State> {
     });
 
     if (impactedField) {
-      //if every dependent field is set, then search
+      // if every dependent field is set, then search
       if (!impactedField.depends?.some(dependentField => !formData[dependentField])) {
         callback = () => this.loadOptionsForDependentField(impactedField);
       } else {
-        //otherwise reset the options
+        // otherwise reset the options
         callback = () => this.resetOptionsOfDependentField(impactedField);
       }
     }

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -83,8 +83,8 @@ class PluginSettings<
 
   onSubmit() {
     if (!this.state.wasConfiguredOnPageLoad) {
-      //Users cannot install plugins like other integrations but we need the events for the funnel
-      //we will treat a user saving a plugin that wasn't already configured as an installation event
+      // Users cannot install plugins like other integrations but we need the events for the funnel
+      // we will treat a user saving a plugin that wasn't already configured as an installation event
       this.trackPluginEvent('integrations.installation_start');
     }
 
@@ -140,7 +140,7 @@ class PluginSettings<
         data.config.forEach((field: BackendField) => {
           formData[field.name] = field.value || field.defaultValue;
           initialData[field.name] = field.value;
-          //for simplicity sake, we will consider a plugin was configured if we have any value that is stored in the DB
+          // for simplicity sake, we will consider a plugin was configured if we have any value that is stored in the DB
           wasConfiguredOnPageLoad = wasConfiguredOnPageLoad || !!field.value;
         });
         this.setState(

--- a/static/app/plugins/defaultPlugin.tsx
+++ b/static/app/plugins/defaultPlugin.tsx
@@ -2,7 +2,7 @@ import BasePlugin from 'app/plugins/basePlugin';
 
 class DefaultPlugin extends BasePlugin {
   static displayName = 'DefaultPlugin';
-  //should never be be called since this is a non-issue plugin
+  // should never be be called since this is a non-issue plugin
   renderGroupActions() {
     return null;
   }

--- a/static/app/plugins/sessionstack/index.tsx
+++ b/static/app/plugins/sessionstack/index.tsx
@@ -4,7 +4,7 @@ import Settings from './components/settings';
 
 class SessionStackPlugin extends BasePlugin {
   displayName = 'SessionStack';
-  //should never be be called since this is a non-issue plugin
+  // should never be be called since this is a non-issue plugin
   renderGroupActions() {
     return null;
   }

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -132,8 +132,8 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
 
   onCloseGuide(dismissed?: boolean) {
     const {currentGuide, guides} = this.state;
-    //update the current guide seen to true or all guides
-    //if markOthersAsSeen is true and the user is dismissing
+    // update the current guide seen to true or all guides
+    // if markOthersAsSeen is true and the user is dismissing
     guides
       .filter(
         guide =>

--- a/static/app/stores/pluginsStore.tsx
+++ b/static/app/stores/pluginsStore.tsx
@@ -27,7 +27,7 @@ const PluginStoreConfig: Reflux.StoreDefinition & PluginStoreInterface = {
   updating: new Map(),
 
   reset() {
-    //reset our state
+    // reset our state
     this.plugins = null;
     this.state = {...defaultState};
     this.updating = new Map();

--- a/static/app/types/breadcrumbs.tsx
+++ b/static/app/types/breadcrumbs.tsx
@@ -32,7 +32,7 @@ export enum BreadcrumbType {
 
 type BreadcrumbTypeBase = {
   level: BreadcrumbLevelType;
-  timestamp?: string; //it's recommended
+  timestamp?: string; // it's recommended
   category?: string | null;
   message?: string;
   event_id?: string;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -63,7 +63,7 @@ type EntryStacktrace = {
 
 type EntrySpans = {
   type: EntryType.SPANS;
-  data: any; //data is not used
+  data: any; // data is not used
 };
 
 type EntryMessage = {

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -105,8 +105,8 @@ declare global {
      */
     adblockSuspected?: boolean;
 
-    //typing currently used for demo add on
-    //TODO: improve typing
+    // typing currently used for demo add on
+    // TODO: improve typing
     SentryApp?: {
       HookStore: any;
       ConfigStore: any;
@@ -1289,11 +1289,11 @@ export type SentryApp = {
   schema: {
     elements?: SentryAppSchemaElement[];
   };
-  //possible null params
+  // possible null params
   webhookUrl: string | null;
   redirectUrl: string | null;
   overview: string | null;
-  //optional params below
+  // optional params below
   datePublished?: string;
   clientId?: string;
   clientSecret?: string;
@@ -1395,7 +1395,7 @@ export type Permissions = {
   Team: PermissionValue;
 };
 
-//See src/sentry/api/serializers/models/apitoken.py for the differences based on application
+// See src/sentry/api/serializers/models/apitoken.py for the differences based on application
 type BaseApiToken = {
   id: string;
   scopes: Scope[];
@@ -1404,7 +1404,7 @@ type BaseApiToken = {
   state: string;
 };
 
-//We include the token for API tokens used for internal apps
+// We include the token for API tokens used for internal apps
 export type InternalAppApiToken = BaseApiToken & {
   application: null;
   token: string;
@@ -2007,7 +2007,7 @@ export type Identity = {
   providerLabel: string;
 };
 
-//taken from https://stackoverflow.com/questions/46634876/how-can-i-change-a-readonly-property-in-typescript
+// taken from https://stackoverflow.com/questions/46634876/how-can-i-change-a-readonly-property-in-typescript
 export type Writable<T> = {-readonly [K in keyof T]: T[K]};
 
 export type InternetProtocol = {

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -261,7 +261,7 @@ export function sortProjects(projects: Array<Project>): Array<Project> {
   return projects.sort(projectDisplayCompare);
 }
 
-//build actorIds
+// build actorIds
 export const buildUserId = id => `user:${id}`;
 export const buildTeamId = id => `team:${id}`;
 

--- a/static/app/utils/advancedAnalytics.tsx
+++ b/static/app/utils/advancedAnalytics.tsx
@@ -52,7 +52,7 @@ export function trackAdvancedAnalyticsEvent<T extends AnalyticsKey>(
 
     const eventName = allEventMap[eventKey];
 
-    //we should always have a session id but if we don't, we should generate one
+    // we should always have a session id but if we don't, we should generate one
     if (hasAnalyticsDebug() && !sessionId) {
       // eslint-disable-next-line no-console
       console.warn(`analytics_session_id absent from event ${eventKey}`);
@@ -62,7 +62,7 @@ export function trackAdvancedAnalyticsEvent<T extends AnalyticsKey>(
     let custom_referrer: string | undefined;
 
     try {
-      //pull the referrer from the query parameter of the page
+      // pull the referrer from the query parameter of the page
       const {referrer} = qs.parse(window.location.search) || {};
       if (typeof referrer === 'string') {
         // Amplitude has its own referrer which inteferes with our custom referrer
@@ -74,7 +74,7 @@ export function trackAdvancedAnalyticsEvent<T extends AnalyticsKey>(
       // e.g. unencoded "%"
     }
 
-    //if org is null, we want organization_id to be null
+    // if org is null, we want organization_id to be null
     const organization_id = org ? org.id : org;
 
     let params = {
@@ -91,7 +91,7 @@ export function trackAdvancedAnalyticsEvent<T extends AnalyticsKey>(
       params = mapValuesFn(params) as any;
     }
 
-    //could put this into a debug method or for the main trackAnalyticsEvent event
+    // could put this into a debug method or for the main trackAnalyticsEvent event
     if (hasAnalyticsDebug()) {
       // eslint-disable-next-line no-console
       console.log('trackAdvancedAnalytics', params);

--- a/static/app/utils/growthAnalyticsEvents.tsx
+++ b/static/app/utils/growthAnalyticsEvents.tsx
@@ -8,7 +8,7 @@ type ShowParams = MobilePromptBannerParams & {
   mobileEventClientOsName: string;
 };
 
-//define the event key to payload mappings
+// define the event key to payload mappings
 export type GrowthEventParameters = {
   'growth.show_mobile_prompt_banner': ShowParams;
   'growth.dismissed_mobile_prompt_banner': MobilePromptBannerParams;

--- a/static/app/utils/integrationEvents.tsx
+++ b/static/app/utils/integrationEvents.tsx
@@ -1,6 +1,6 @@
 import {IntegrationType, PlatformType, SentryAppStatus} from 'app/types';
 
-//define the various event paylaods
+// define the various event paylaods
 type View = {
   view?:
     | 'external_install'
@@ -15,11 +15,11 @@ type View = {
 };
 
 type SingleIntegrationEventParams = {
-  integration: string; //the slug
+  integration: string; // the slug
   integration_type: IntegrationType;
   already_installed?: boolean;
   plan?: string;
-  //include the status since people might do weird things testing unpublished integrations
+  // include the status since people might do weird things testing unpublished integrations
   integration_status?: SentryAppStatus;
   integration_tab?: 'configurations' | 'overview';
 } & View;
@@ -56,7 +56,7 @@ type IntegrationInstalltionInputValueChangeEventParams = {
   field_name: string;
 } & SingleIntegrationEventParams;
 
-//define the event key to payload mappings
+// define the event key to payload mappings
 export type IntegrationEventParameters = {
   'integrations.upgrade_plan_modal_opened': SingleIntegrationEventParams;
   'integrations.install_modal_opened': SingleIntegrationEventParams;
@@ -73,7 +73,7 @@ export type IntegrationEventParameters = {
   'integrations.resolve_now_clicked': SingleIntegrationEventParams;
   'integrations.request_install': SingleIntegrationEventParams;
   'integrations.code_mappings_viewed': SingleIntegrationEventParams;
-  'integrations.details_viewed': SingleIntegrationEventParams; //for an individual configuration
+  'integrations.details_viewed': SingleIntegrationEventParams; // for an individual configuration
   'integrations.index_viewed': MultipleIntegrationsEventParams;
   'integrations.directory_item_searched': IntegrationSearchEventParams;
   'integrations.directory_category_selected': IntegrationCategorySelectEventParams;
@@ -94,7 +94,7 @@ export type IntegrationEventParameters = {
 
 export type IntegrationAnalyticsKey = keyof IntegrationEventParameters;
 
-//define the event key to event name mappings
+// define the event key to event name mappings
 export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
   'integrations.upgrade_plan_modal_opened': 'Integrations: Upgrade Plan Modal Opened',
   'integrations.install_modal_opened': 'Integrations: Install Modal Opened',

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -26,8 +26,8 @@ import {EventParameters, trackAdvancedAnalyticsEvent} from 'app/utils/advancedAn
 import {IntegrationAnalyticsKey} from 'app/utils/integrationEvents';
 
 const mapIntegrationParams = analyticsParams => {
-  //Reload expects integration_status even though it's not relevant for non-sentry apps
-  //Passing in a dummy value of published in those cases
+  // Reload expects integration_status even though it's not relevant for non-sentry apps
+  // Passing in a dummy value of published in those cases
   const fullParams = {...analyticsParams};
   if (analyticsParams.integration && analyticsParams.integration_type !== 'sentry_app') {
     fullParams.integration_status = 'published';
@@ -35,8 +35,8 @@ const mapIntegrationParams = analyticsParams => {
   return fullParams;
 };
 
-//wrapper around trackAdvancedAnalyticsEvent which has some extra
-//data massaging above
+// wrapper around trackAdvancedAnalyticsEvent which has some extra
+// data massaging above
 export function trackIntegrationEvent<T extends IntegrationAnalyticsKey>(
   eventKey: T,
   analyticsParams: EventParameters[T],
@@ -212,8 +212,8 @@ export const getIntegrationIcon = (integrationType?: string, size?: string) => {
   }
 };
 
-//used for project creation and onboarding
-//determines what integration maps to what project platform
+// used for project creation and onboarding
+// determines what integration maps to what project platform
 export const platfromToIntegrationMap = {
   'node-awslambda': 'aws_lambda',
   'python-awslambda': 'aws_lambda',

--- a/static/app/utils/isMemberDisabledFromLimit.tsx
+++ b/static/app/utils/isMemberDisabledFromLimit.tsx
@@ -1,6 +1,6 @@
 import {Member} from 'app/types';
 
-//check to see if a member has been disabled because of the member limit
+// check to see if a member has been disabled because of the member limit
 export default function isMemberDisabledFromLimit(member?: Member | null) {
   return member?.flags['member-limit:restricted'] ?? false;
 }

--- a/static/app/utils/promptIsDismissed.tsx
+++ b/static/app/utils/promptIsDismissed.tsx
@@ -8,7 +8,7 @@ export const promptIsDismissed = (prompt: PromptData, daysToSnooze: number = 14)
   if (dismissedTime) {
     return true;
   }
-  //check if it has been snoozed
+  // check if it has been snoozed
   return !snoozedTime ? false : snoozedDays(snoozedTime) < daysToSnooze;
 };
 

--- a/static/app/views/disabledMember/index.tsx
+++ b/static/app/views/disabledMember/index.tsx
@@ -1,7 +1,7 @@
 import NotFound from 'app/components/errors/notFound';
 import HookOrDefault from 'app/components/hookOrDefault';
 
-//getsentry will add the view
+// getsentry will add the view
 const DisabledMemberComponent = HookOrDefault({
   hookName: 'component:disabled-member',
   defaultComponent: () => <NotFound />,

--- a/static/app/views/integrationOrganizationLink.tsx
+++ b/static/app/views/integrationOrganizationLink.tsx
@@ -24,7 +24,7 @@ import AsyncView from 'app/views/asyncView';
 import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import Field from 'app/views/settings/components/forms/field';
 
-//installationId present for Github flow
+// installationId present for Github flow
 type Props = RouteComponentProps<{integrationSlug: string; installationId?: string}, {}>;
 
 type State = AsyncView['state'] & {
@@ -47,7 +47,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     startSession?: boolean
   ) => {
     const {organization, provider} = this.state;
-    //should have these set but need to make TS happy
+    // should have these set but need to make TS happy
     if (!organization || !provider) {
       return;
     }
@@ -57,7 +57,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
       {
         integration_type: 'first_party',
         integration: provider.key,
-        //We actually don't know if it's installed but neither does the user in the view and multiple installs is possible
+        // We actually don't know if it's installed but neither does the user in the view and multiple installs is possible
         already_installed: false,
         view: 'external_install',
       },
@@ -87,7 +87,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
   };
 
   onLoadAllEndpointsSuccess() {
-    //auto select the org if there is only one
+    // auto select the org if there is only one
     const {organizations} = this.state;
     if (organizations.length === 1) {
       this.onSelectOrg({value: organizations[0].slug});
@@ -126,7 +126,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     return organization?.access.includes('org:integrations');
   };
 
-  //used with Github to redirect to the the integration detail
+  // used with Github to redirect to the the integration detail
   onInstallWithInstallationId = (data: Integration) => {
     const {organization} = this.state;
     const orgId = organization && organization.slug;
@@ -135,7 +135,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
     );
   };
 
-  //non-Github redirects to the extension view where the backend will finish the installation
+  // non-Github redirects to the extension view where the backend will finish the installation
   finishInstallation = () => {
     // add the selected org to the query parameters and then redirect back to configure
     const {selectedOrgSlug} = this.state;
@@ -167,10 +167,10 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
 
     const {IntegrationDirectoryFeatures} = getIntegrationFeatureGate();
 
-    //Github uses a different installation flow with the installationId as a parameter
-    //We have to wrap our installation button with AddIntegration so we can get the
-    //addIntegrationWithInstallationId callback.
-    //if we don't hve an installationId, we need to use the finishInstallation callback.
+    // Github uses a different installation flow with the installationId as a parameter
+    // We have to wrap our installation button with AddIntegration so we can get the
+    // addIntegrationWithInstallationId callback.
+    // if we don't hve an installationId, we need to use the finishInstallation callback.
     return (
       <IntegrationDirectoryFeatures
         organization={organization}
@@ -224,7 +224,7 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
 
   customValueContainer = containerProps => {
     const valueList = containerProps.getValue();
-    //if no value set, we want to return the default component that is rendered
+    // if no value set, we want to return the default component that is rendered
     if (valueList.length === 0) {
       return <components.ValueContainer {...containerProps} />;
     }

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -84,7 +84,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
     // generate the cloudformation URL using the params we get from the server
     // and the external id we generate
     const {baseCloudformationUrl, templateUrl, stackName} = this.props;
-    //always us the generated AWS External ID in local storage
+    // always us the generated AWS External ID in local storage
     const awsExternalId = getAwsExternalId();
     const query = qs.stringify({
       templateURL: templateUrl,
@@ -101,7 +101,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
   handleSubmit = (e: React.MouseEvent) => {
     this.setState({submitting: true});
     e.preventDefault();
-    //use the external ID from the form on on the submission
+    // use the external ID from the form on on the submission
     const {accountNumber, region, awsExternalId} = this.state;
     const data = {
       accountNumber,
@@ -168,7 +168,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
     return !!region && testAccountNumber(accountNumber || '') && !!awsExternalId;
   }
 
-  //debounce so we don't send a request on every input change
+  // debounce so we don't send a request on every input change
   debouncedTrackValueChanged = debounce((fieldName: string) => {
     trackIntegrationEvent(
       'integrations.installation_input_value_changed',

--- a/static/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
@@ -68,8 +68,8 @@ export default class AwsLambdaFunctionSelect extends Component<Props, State> {
 
   @computed
   get toggleAllState() {
-    //check if any of the lambda functions have a falsy value
-    //no falsy values means everything is enabled
+    // check if any of the lambda functions have a falsy value
+    // no falsy values means everything is enabled
     return Object.values(this.model.getData()).every(val => val);
   }
 
@@ -222,7 +222,7 @@ const StyledSwitch = styled(Switch)`
   margin: auto;
 `;
 
-//padding is based on fom control width
+// padding is based on fom control width
 const StyledPanelHeader = styled(PanelHeader)`
   padding-right: 36px;
 `;

--- a/static/app/views/integrationPipeline/components/footerWithButtons.tsx
+++ b/static/app/views/integrationPipeline/components/footerWithButtons.tsx
@@ -18,7 +18,7 @@ export default function FooterWithButtons({buttonText, ...rest}: Props) {
   );
 }
 
-//wrap in form so we can keep form submission behavior
+// wrap in form so we can keep form submission behavior
 const Footer = styled('form')`
   width: 100%;
   position: fixed;

--- a/static/app/views/onboarding/components/integrations/addInstallationInstructions.tsx
+++ b/static/app/views/onboarding/components/integrations/addInstallationInstructions.tsx
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import ExternalLink from 'app/components/links/externalLink';
 import {t, tct} from 'app/locale';
 
-//TODO: Make dyanmic for other platforms/integrations
+// TODO: Make dyanmic for other platforms/integrations
 export default function AddInstallationInstructions() {
   return (
     <Fragment>

--- a/static/app/views/onboarding/components/integrations/postInstallCodeSnippet.tsx
+++ b/static/app/views/onboarding/components/integrations/postInstallCodeSnippet.tsx
@@ -16,7 +16,7 @@ export default function PostInstallCodeSnippet({
   platform,
   isOnboarding,
 }: Props) {
-  //currently supporting both Python and Node
+  // currently supporting both Python and Node
   const token_punctuation: string = platform === 'python-awslambda' ? '()' : '();';
   return (
     <div>

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -370,12 +370,24 @@ class GroupDetails extends React.Component<Props, State> {
           locationWithProject.query.project === undefined &&
           locationWithProject.query._allp === undefined
         ) {
-          //We use _allp as a temporary measure to know they came from the issue list page with no project selected (all projects included in filter).
-          //If it is not defined, we add the locked project id to the URL (this is because if someone navigates directly to an issue on single-project priveleges, then goes back - they were getting assigned to the first project).
-          //If it is defined, we do not so that our back button will bring us to the issue list page with no project selected instead of the locked project.
+          // We use _allp as a temporary measure to know they came from the
+          // issue list page with no project selected (all projects included in
+          // filter).
+          //
+          // If it is not defined, we add the locked project id to the URL
+          // (this is because if someone navigates directly to an issue on
+          // single-project priveleges, then goes back - they were getting
+          // assigned to the first project).
+          //
+          // If it is defined, we do not so that our back button will bring us
+          // to the issue list page with no project selected instead of the
+          // locked project.
           locationWithProject.query.project = project.id;
         }
-        delete locationWithProject.query._allp; //We delete _allp from the URL to keep the hack a bit cleaner, but this is not an ideal solution and will ultimately be replaced with something smarter.
+        // We delete _allp from the URL to keep the hack a bit cleaner, but
+        // this is not an ideal solution and will ultimately be replaced with
+        // something smarter.
+        delete locationWithProject.query._allp;
         ReactRouter.browserHistory.replace(locationWithProject);
       }
 
@@ -525,7 +537,8 @@ class GroupDetails extends React.Component<Props, State> {
             fetchError ? (
               <LoadingError message={t('Error loading the specified project')} />
             ) : (
-              this.renderContent(projects[0], group!) // TODO(ts): Update renderContent function to deal with empty group
+              // TODO(ts): Update renderContent function to deal with empty group
+              this.renderContent(projects[0], group!)
             )
           ) : (
             <LoadingIndicator />

--- a/static/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
+++ b/static/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
@@ -17,7 +17,7 @@ type Props = {
  */
 export default class SplitInstallationIdModal extends Component<Props> {
   onCopy = async () =>
-    //This hack is needed because the normal copying methods with TextCopyInput do not work correctly
+    // This hack is needed because the normal copying methods with TextCopyInput do not work correctly
     await navigator.clipboard.writeText(this.props.installationId);
 
   handleContinue = () => {
@@ -31,7 +31,7 @@ export default class SplitInstallationIdModal extends Component<Props> {
 
   render() {
     const {installationId, closeModal} = this.props;
-    //no need to translate this temporary component
+    // no need to translate this temporary component
     return (
       <div>
         <ItemHolder>

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -69,11 +69,11 @@ class AbstractIntegrationDetailedView<
     });
   }
 
-  /***
+  /**
    * Abstract methods defined below
    */
 
-  //The analytics type used in analytics which is snake case
+  // The analytics type used in analytics which is snake case
   get integrationType(): IntegrationType {
     // Allow children to implement this
     throw new Error('Not implemented');
@@ -90,11 +90,11 @@ class AbstractIntegrationDetailedView<
   }
 
   get alerts(): AlertType[] {
-    //default is no alerts
+    // default is no alerts
     return [];
   }
 
-  //Returns a list of the resources displayed at the bottom of the overview card
+  // Returns a list of the resources displayed at the bottom of the overview card
   get resourceLinks(): Array<{title: string; url: string}> {
     // Allow children to implement this
     throw new Error('Not implemented');
@@ -139,24 +139,24 @@ class AbstractIntegrationDetailedView<
     this.setState({tab: value});
   };
 
-  //Returns the string that is shown as the title of a tab
+  // Returns the string that is shown as the title of a tab
   getTabDisplay(tab: Tab): string {
-    //default is return the tab
+    // default is return the tab
     return tab;
   }
 
-  //Render the button at the top which is usually just an installation button
+  // Render the button at the top which is usually just an installation button
   renderTopButton(
-    _disabledFromFeatures: boolean, //from the feature gate
-    _userHasAccess: boolean //from user permissions
+    _disabledFromFeatures: boolean, // from the feature gate
+    _userHasAccess: boolean // from user permissions
   ): React.ReactElement {
     // Allow children to implement this
     throw new Error('Not implemented');
   }
 
-  //Returns the permission descriptions, only use by Sentry Apps
+  // Returns the permission descriptions, only use by Sentry Apps
   renderPermissions(): React.ReactElement | null {
-    //default is don't render permissions
+    // default is don't render permissions
     return null;
   }
 
@@ -174,13 +174,13 @@ class AbstractIntegrationDetailedView<
     );
   }
 
-  //Returns the list of configurations for the integration
+  // Returns the list of configurations for the integration
   renderConfigurations() {
     // Allow children to implement this
     throw new Error('Not implemented');
   }
 
-  /***
+  /**
    * Actually implemented methods below
    */
 
@@ -188,24 +188,24 @@ class AbstractIntegrationDetailedView<
     return this.props.params.integrationSlug;
   }
 
-  //Wrapper around trackIntegrationEvent that automatically provides many fields and the org
+  // Wrapper around trackIntegrationEvent that automatically provides many fields and the org
   trackIntegrationEvent = <T extends IntegrationAnalyticsKey>(
     eventKey: IntegrationAnalyticsKey,
     options?: Partial<IntegrationEventParameters[T]>
   ) => {
     options = options || {};
-    //If we use this intermediate type we get type checking on the things we care about
+    // If we use this intermediate type we get type checking on the things we care about
     const params = {
       view: 'integrations_directory_integration_detail',
       integration: this.integrationSlug,
       integration_type: this.integrationType,
-      already_installed: this.installationStatus !== 'Not Installed', //pending counts as installed here
+      already_installed: this.installationStatus !== 'Not Installed', // pending counts as installed here
       ...options,
     };
     trackIntegrationEvent(eventKey, params, this.props.organization);
   };
 
-  //Returns the props as needed by the hooks integrations:feature-gates
+  // Returns the props as needed by the hooks integrations:feature-gates
   get featureProps() {
     const {organization} = this.props;
     const featureData = this.featureData;
@@ -269,7 +269,7 @@ class AbstractIntegrationDetailedView<
     );
   }
 
-  //Returns the content shown in the top section of the integration detail
+  // Returns the content shown in the top section of the integration detail
   renderTopSection() {
     const tags = this.cleanTags();
 
@@ -296,9 +296,9 @@ class AbstractIntegrationDetailedView<
     );
   }
 
-  //Returns the tabs divider with the clickable tabs
+  // Returns the tabs divider with the clickable tabs
   renderTabs() {
-    //TODO: Convert to styled component
+    // TODO: Convert to styled component
     return (
       <ul className="nav nav-tabs border-bottom" style={{paddingTop: '30px'}}>
         {this.tabs.map(tabName => (
@@ -314,7 +314,7 @@ class AbstractIntegrationDetailedView<
     );
   }
 
-  //Returns the information about the integration description and features
+  // Returns the information about the integration description and features
   renderInformationCard() {
     const {IntegrationDirectoryFeatureList} = getIntegrationFeatureGate();
 

--- a/static/app/views/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/organizationIntegrations/addIntegration.tsx
@@ -13,7 +13,7 @@ type Props = {
   provider: IntegrationProvider;
   onInstall: (data: IntegrationWithConfig) => void;
   account?: string;
-  organization: Organization; //for analytics
+  organization: Organization; // for analytics
   analyticsParams?: {
     view:
       | 'integrations_directory_integration_detail'
@@ -38,7 +38,7 @@ export default class AddIntegration extends React.Component<Props> {
   dialog: Window | null = null;
 
   computeCenteredWindow(width: number, height: number) {
-    //Taken from: https://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen
+    // Taken from: https://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen
     const screenLeft =
       window.screenLeft !== undefined ? window.screenLeft : window.screenX;
 

--- a/static/app/views/organizationIntegrations/constants.tsx
+++ b/static/app/views/organizationIntegrations/constants.tsx
@@ -64,7 +64,7 @@ export const POPULARITY_WEIGHT: {
   'amazon-sqs': 2,
   splunk: 2,
 
-  //doc integrations
+  // doc integrations
   fullstory: 8,
   datadog: 8,
   netlify: 8,

--- a/static/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/organizationIntegrations/installedIntegration.tsx
@@ -23,7 +23,7 @@ export type Props = {
   integration: Integration;
   onRemove: (integration: Integration) => void;
   onDisable: (integration: Integration) => void;
-  trackIntegrationEvent: (eventKey: IntegrationAnalyticsKey) => void; //analytics callback
+  trackIntegrationEvent: (eventKey: IntegrationAnalyticsKey) => void; // analytics callback
   className?: string;
 };
 

--- a/static/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/static/app/views/organizationIntegrations/installedPlugin.tsx
@@ -27,7 +27,7 @@ export type Props = {
   organization: Organization;
   onResetConfiguration: (projectId: string) => void;
   onPluginEnableStatusChange: (projectId: string, status: boolean) => void;
-  trackIntegrationEvent: (eventKey: IntegrationAnalyticsKey) => void; //analytics callback
+  trackIntegrationEvent: (eventKey: IntegrationAnalyticsKey) => void; // analytics callback
   className?: string;
 };
 
@@ -104,7 +104,7 @@ export class InstalledPlugin extends Component<Props> {
   };
 
   get projectForBadge(): AvatarProject {
-    //this function returns the project as needed for the ProjectBadge component
+    // this function returns the project as needed for the ProjectBadge component
     const {projectItem} = this.props;
     return {
       slug: projectItem.projectSlug,

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -68,8 +68,8 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
   }
 
   get repos() {
-    //endpoint doesn't support loading only the repos for this integration
-    //but most people only have one source code repo so this should be fine
+    // endpoint doesn't support loading only the repos for this integration
+    // but most people only have one source code repo so this should be fine
     return this.state.repos.filter(repo => repo.integrationId === this.integrationId);
   }
 

--- a/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -57,7 +57,7 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
       addSuccessMessage(t('Deletion successful'));
       this.fetchData();
     } catch {
-      //no 4xx errors should happen on delete
+      // no 4xx errors should happen on delete
       addErrorMessage(t('An error occurred'));
     }
   };
@@ -116,7 +116,7 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
 
       model.saveForm();
     } catch {
-      //no 4xx errors should happen on delete
+      // no 4xx errors should happen on delete
       addErrorMessage(t('An error occurred'));
     }
   };

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -47,7 +47,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
       addSuccessMessage(t('Deletion successful'));
       this.fetchData();
     } catch {
-      //no 4xx errors should happen on delete
+      // no 4xx errors should happen on delete
       addErrorMessage(t('An error occurred'));
     }
   };

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -129,19 +129,19 @@ export class IntegrationListDirectory extends AsyncComponent<
   }
 
   trackPageViewed() {
-    //count the number of installed apps
+    // count the number of installed apps
 
     const {integrations, publishedApps, plugins} = this.state;
     const integrationsInstalled = new Set();
-    //add installed integrations
+    // add installed integrations
     integrations?.forEach((integration: Integration) => {
       integrationsInstalled.add(integration.provider.key);
     });
-    //add sentry apps
+    // add sentry apps
     publishedApps?.filter(this.getAppInstall).forEach((sentryApp: SentryApp) => {
       integrationsInstalled.add(sentryApp.slug);
     });
-    //add plugins
+    // add plugins
     plugins?.forEach((plugin: PluginWithProjectList) => {
       if (plugin.projectList.length) {
         integrationsInstalled.add(plugin.slug);
@@ -199,7 +199,7 @@ export class IntegrationListDirectory extends AsyncComponent<
   getAppInstall = (app: SentryApp) =>
     this.state.appInstalls?.find(i => i.app.slug === app.slug);
 
-  //Returns 0 if uninstalled, 1 if pending, and 2 if installed
+  // Returns 0 if uninstalled, 1 if pending, and 2 if installed
   getInstallValue(integration: AppOrProviderOrPlugin) {
     const {integrations} = this.state;
 
@@ -239,17 +239,17 @@ export class IntegrationListDirectory extends AsyncComponent<
 
   sortIntegrations(integrations: AppOrProviderOrPlugin[]) {
     return integrations.sort((a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) => {
-      //sort by whether installed first
+      // sort by whether installed first
       const diffWeight = this.sortByInstalled(a, b);
       if (diffWeight !== 0) {
         return diffWeight;
       }
-      //then sort by popularity
+      // then sort by popularity
       const diffPop = this.sortByPopularity(a, b);
       if (diffPop !== 0) {
         return diffPop;
       }
-      //then sort by name
+      // then sort by name
       return this.sortByName(a, b);
     });
   }
@@ -364,7 +364,7 @@ export class IntegrationListDirectory extends AsyncComponent<
   // Rendering
   renderProvider = (provider: IntegrationProvider) => {
     const {organization} = this.props;
-    //find the integration installations for that provider
+    // find the integration installations for that provider
     const integrations =
       this.state.integrations?.filter(i => i.provider.key === provider.key) ?? [];
 
@@ -389,7 +389,7 @@ export class IntegrationListDirectory extends AsyncComponent<
 
     const isLegacy = plugin.isHidden;
     const displayName = `${plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
-    //hide legacy integrations if we don't have any projects with them
+    // hide legacy integrations if we don't have any projects with them
     if (isLegacy && !plugin.projectList.length) {
       return null;
     }
@@ -409,7 +409,7 @@ export class IntegrationListDirectory extends AsyncComponent<
     );
   };
 
-  //render either an internal or non-internal app
+  // render either an internal or non-internal app
   renderSentryApp = (app: SentryApp) => {
     const {organization} = this.props;
     const status = getSentryAppInstallStatus(this.getAppInstall(app));

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -58,7 +58,7 @@ const IntegrationRow = (props: Props) => {
     if (type === 'sentryApp') {
       return publishStatus !== 'published' && <PublishStatus status={publishStatus} />;
     }
-    //TODO: Use proper translations
+    // TODO: Use proper translations
     return configurations > 0 ? (
       <StyledLink to={`${baseUrl}?tab=configurations`}>{`${configurations} Configuration${
         configurations > 1 ? 's' : ''
@@ -67,7 +67,7 @@ const IntegrationRow = (props: Props) => {
   };
 
   const renderStatus = () => {
-    //status should be undefined for document integrations
+    // status should be undefined for document integrations
     if (status) {
       return <IntegrationStatus status={status} />;
     }

--- a/static/app/views/organizationIntegrations/integrationServerlessRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationServerlessRow.tsx
@@ -60,18 +60,18 @@ class IntegrationServerlessRow extends Component<Props, State> {
     try {
       addLoadingMessage();
       this.setState({submitting: true});
-      //optimistically update enable state
+      // optimistically update enable state
       this.props.onUpdateFunction({enabled: !this.enabled});
       this.recordAction(action);
       const resp = await this.props.api.requestPromise(this.endpoint, {
         method: 'POST',
         data,
       });
-      //update remaining after response
+      // update remaining after response
       this.props.onUpdateFunction(resp);
       addSuccessMessage(t('Success'));
     } catch (err) {
-      //restore original on failure
+      // restore original on failure
       this.props.onUpdateFunction(serverlessFunction);
       addErrorMessage(err.responseJSON?.detail ?? t('Error occurred'));
     }
@@ -93,11 +93,11 @@ class IntegrationServerlessRow extends Component<Props, State> {
         method: 'POST',
         data,
       });
-      //update remaining after response
+      // update remaining after response
       this.props.onUpdateFunction(resp);
       addSuccessMessage(t('Success'));
     } catch (err) {
-      //restore original on failure
+      // restore original on failure
       this.props.onUpdateFunction(serverlessFunction);
       addErrorMessage(err.responseJSON?.detail ?? t('Error occurred'));
     }
@@ -117,7 +117,7 @@ class IntegrationServerlessRow extends Component<Props, State> {
   render() {
     const {serverlessFunction} = this.props;
     const {version} = serverlessFunction;
-    //during optimistic update, we might be enabled without a version
+    // during optimistic update, we might be enabled without a version
     const versionText =
       this.enabled && version > 0 ? <Fragment>&nbsp;|&nbsp;v{version}</Fragment> : null;
     return (

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -61,39 +61,39 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   }
 
   handleResetConfiguration = (projectId: string) => {
-    //make a copy of our project list
+    // make a copy of our project list
     const projectList = this.plugin.projectList.slice();
-    //find the index of the project
+    // find the index of the project
     const index = projectList.findIndex(item => item.projectId === projectId);
-    //should match but quit if it doesn't
+    // should match but quit if it doesn't
     if (index < 0) {
       return;
     }
-    //remove from array
+    // remove from array
     projectList.splice(index, 1);
-    //update state
+    // update state
     this.setState({
       plugins: [{...this.state.plugins[0], projectList}],
     });
   };
 
   handlePluginEnableStatus = (projectId: string, enable: boolean = true) => {
-    //make a copy of our project list
+    // make a copy of our project list
     const projectList = this.plugin.projectList.slice();
-    //find the index of the project
+    // find the index of the project
     const index = projectList.findIndex(item => item.projectId === projectId);
-    //should match but quit if it doesn't
+    // should match but quit if it doesn't
     if (index < 0) {
       return;
     }
 
-    //update item in array
+    // update item in array
     projectList[index] = {
       ...projectList[index],
       enabled: enable,
     };
 
-    //update state
+    // update state
     this.setState({
       plugins: [{...this.state.plugins[0], projectList}],
     });
@@ -121,7 +121,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   };
 
   getTabDisplay(tab: Tab) {
-    //we want to show project configurations to make it more clear
+    // we want to show project configurations to make it more clear
     if (tab === 'configurations') {
       return 'project configurations';
     }

--- a/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -56,7 +56,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       router,
     } = this.props;
 
-    //redirect for internal integrations
+    // redirect for internal integrations
     if (this.sentryApp.status === 'internal') {
       router.push(
         `/settings/${organization.slug}/developer-settings/${integrationSlug}/`
@@ -85,7 +85,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get resourceLinks() {
-    //only show links for published sentry apps
+    // only show links for published sentry apps
     if (this.sentryApp.status !== 'published') {
       return [];
     }
@@ -140,7 +140,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     // installSentryApp adds a message on failure
     const install = await installSentryApp(this.api, organization.slug, sentryApp);
 
-    //installation is complete if the status is installed
+    // installation is complete if the status is installed
     if (install.status === 'installed') {
       this.trackIntegrationEvent('integrations.installation_complete', {
         integration_status: sentryApp.status,
@@ -151,8 +151,8 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       addSuccessMessage(t(`${sentryApp.slug} successfully installed.`));
       this.setState({appInstalls: [install, ...this.state.appInstalls]});
 
-      //hack for split so we can show the install ID to users for them to copy
-      //Will remove once the proper fix is in place
+      // hack for split so we can show the install ID to users for them to copy
+      // Will remove once the proper fix is in place
       if (['split', 'split-dev', 'split-testing'].includes(sentryApp.slug)) {
         openModal(({closeModal}) => (
           <SplitInstallationIdModal
@@ -244,8 +244,8 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
           message={tct('Are you sure you want to remove the [slug] installation?', {
             slug: this.integrationSlug,
           })}
-          onConfirm={() => this.handleUninstall(install)} //called when the user confirms the action
-          onConfirming={this.recordUninstallClicked} //called when the confirm modal opens
+          onConfirm={() => this.handleUninstall(install)} // called when the user confirms the action
+          onConfirming={this.recordUninstallClicked} // called when the confirm modal opens
           priority="danger"
         >
           <StyledUninstallButton size="small" data-test-id="sentry-app-uninstall">
@@ -274,7 +274,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     return this.renderRequestIntegrationButton();
   }
 
-  //no configurations for sentry apps
+  // no configurations for sentry apps
   renderConfigurations() {
     return null;
   }

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -52,7 +52,7 @@ class ProjectInstallPlatform extends Component<Props, State> {
 
     const {platform} = this.props.params;
 
-    //redirect if platform is not known.
+    // redirect if platform is not known.
     if (!platform || platform === 'other') {
       this.redirectToNeutralDocs();
     }

--- a/static/app/views/projectInstall/platformIntegrationSetup.tsx
+++ b/static/app/views/projectInstall/platformIntegrationSetup.tsx
@@ -48,7 +48,7 @@ class PlatformIntegrationSetup extends AsyncComponent<Props, State> {
 
     const {platform} = this.props.params;
 
-    //redirect if platform is not known.
+    // redirect if platform is not known.
     if (!platform || platform === 'other') {
       this.redirectToNeutralDocs();
     }
@@ -112,7 +112,7 @@ class PlatformIntegrationSetup extends AsyncComponent<Props, State> {
     }
     const gettingStartedLink = `/organizations/${orgId}/projects/${projectId}/getting-started/`;
 
-    //TODO: make dynamic when adding more integrations
+    // TODO: make dynamic when adding more integrations
     const docsLink = 'https://docs.sentry.io/product/integrations/aws-lambda/';
 
     return (

--- a/static/app/views/sentryAppExternalInstallation.tsx
+++ b/static/app/views/sentryAppExternalInstallation.tsx
@@ -69,7 +69,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
 
   get isSentryAppUnavailableForOrg() {
     const {sentryApp, selectedOrgSlug} = this.state;
-    //if the app is unpublished for a different org
+    // if the app is unpublished for a different org
     return (
       selectedOrgSlug &&
       sentryApp?.owner?.slug !== selectedOrgSlug &&
@@ -85,7 +85,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
   hasAccess = (org: LightWeightOrganization) => org.access.includes('org:integrations');
 
   onClose = () => {
-    //if we came from somewhere, go back there. Otherwise, back to the integrations page
+    // if we came from somewhere, go back there. Otherwise, back to the integrations page
     const {selectedOrgSlug} = this.state;
     const newUrl = document.referrer || `/settings/${selectedOrgSlug}/integrations/`;
     window.location.assign(newUrl);
@@ -108,7 +108,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
     );
 
     const install = await installSentryApp(this.api, organization.slug, sentryApp);
-    //installation is complete if the status is installed
+    // installation is complete if the status is installed
     if (install.status === 'installed') {
       trackIntegrationEvent(
         'integrations.installation_complete',
@@ -148,7 +148,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
       const isInstalled = installations
         .map(install => install.app.slug)
         .includes(this.sentryAppSlug);
-      //all state fields should be set at the same time so analytics in SentryAppDetailsModal works properly
+      // all state fields should be set at the same time so analytics in SentryAppDetailsModal works properly
       this.setState({organization, isInstalled, reloading: false});
     } catch (err) {
       addErrorMessage(t('Failed to retrieve organization or integration details'));
@@ -157,7 +157,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
   };
 
   onRequestSuccess = ({stateKey, data}) => {
-    //if only one org, we can immediately update our selected org
+    // if only one org, we can immediately update our selected org
     if (stateKey === 'organizations' && data.length === 1) {
       this.onSelectOrg(data[0].slug);
     }
@@ -263,7 +263,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
 
   renderSingleOrgView() {
     const {organizations, sentryApp} = this.state;
-    //pull the name out of organizations since state.organization won't be loaded initially
+    // pull the name out of organizations since state.organization won't be loaded initially
     const organizationName = organizations[0].name;
     return (
       <div>

--- a/static/app/views/settings/account/apiTokenRow.tsx
+++ b/static/app/views/settings/account/apiTokenRow.tsx
@@ -44,7 +44,7 @@ function ApiTokenRow({token, onRemove}: Props) {
             <DateTime
               date={getDynamicText({
                 value: token.dateCreated,
-                fixed: new Date(1508208080000), //National Pasta Day
+                fixed: new Date(1508208080000), // National Pasta Day
               })}
             />
           </Time>

--- a/static/app/views/settings/components/forms/choiceMapperField.tsx
+++ b/static/app/views/settings/components/forms/choiceMapperField.tsx
@@ -139,7 +139,7 @@ export default class ChoiceMapper extends React.Component<FieldProps> {
     };
 
     const removeRow = (itemKey: string) => {
-      //eslint-disable-next-line no-unused-vars
+      // eslint-disable-next-line no-unused-vars
       const {[itemKey]: _, ...updatedValue} = value;
       saveChanges(updatedValue);
     };

--- a/static/app/views/settings/components/forms/field/index.tsx
+++ b/static/app/views/settings/components/forms/field/index.tsx
@@ -85,7 +85,7 @@ type Props = InheritedFieldControlProps &
      * Error message to display for the field
      */
     error?: string;
-    validate?: Function; //TODO(TS): Do we need this?
+    validate?: Function; // TODO(TS): Do we need this?
     /**
      * The control to render. May be given a function to render with resolved
      * props.

--- a/static/app/views/settings/components/forms/formField/index.tsx
+++ b/static/app/views/settings/components/forms/formField/index.tsx
@@ -121,7 +121,7 @@ type BaseProps<P> = {
   defaultValue?: FieldValue;
   resetOnError?: boolean;
   placeholder?: ObservedFnOrValue<P, React.ReactNode>;
-  formatMessageValue?: boolean | Function; //used in prettyFormString
+  formatMessageValue?: boolean | Function; // used in prettyFormString
 };
 
 type Props<P> = BaseProps<P> & ObservableProps<P> & Omit<Field['props'], PropToObserve>;

--- a/static/app/views/settings/components/forms/model.tsx
+++ b/static/app/views/settings/components/forms/model.tsx
@@ -10,7 +10,7 @@ import {defined} from 'app/utils';
 type Snapshot = Map<string, FieldValue>;
 type SaveSnapshot = (() => number) | null;
 
-export type FieldValue = string | number | boolean | undefined; //is undefined valid here?
+export type FieldValue = string | number | boolean | undefined; // is undefined valid here?
 
 export type FormOptions = {
   apiEndpoint?: string;
@@ -161,7 +161,7 @@ class FormModel {
    */
   @action
   setFieldDescriptor(id: string, props) {
-    //TODO(TS): add type to props
+    // TODO(TS): add type to props
     this.fieldDescriptor.set(id, props);
 
     // Set default value iff initialData for field is undefined
@@ -553,7 +553,7 @@ class FormModel {
         // 1) map of {[fieldName] => Array<ErrorMessages>}
         // 2) {'non_field_errors' => Array<ErrorMessages>}
         if (resp && resp.responseJSON) {
-          //non-field errors can be camelcase or snake case
+          // non-field errors can be camelcase or snake case
           const nonFieldErrors =
             resp.responseJSON.non_field_errors || resp.responseJSON.nonFieldErrors;
 
@@ -688,7 +688,7 @@ class FormModel {
 
     // Show resp msg from API endpoint if possible
     Object.keys(resp).forEach(id => {
-      //non-field errors can be camelcase or snake case
+      // non-field errors can be camelcase or snake case
       const nonFieldErrors = resp.non_field_errors || resp.nonFieldErrors;
       if (
         (id === 'non_field_errors' || id === 'nonFieldErrors') &&
@@ -729,7 +729,7 @@ class FormModel {
  * lot of functionality however.
  */
 export class MockModel {
-  //TODO(TS)
+  // TODO(TS)
   props: any;
 
   initialData: object;

--- a/static/app/views/settings/components/forms/projectMapperField.tsx
+++ b/static/app/views/settings/components/forms/projectMapperField.tsx
@@ -35,7 +35,7 @@ type State = {
   selectedMappedValue: MappedValue | null;
 };
 
-//Get the icon
+// Get the icon
 const getIcon = (iconType: string) => {
   switch (iconType) {
     case 'vercel':
@@ -82,7 +82,7 @@ export class RenderField extends Component<RenderProps, State> {
       mappedDropdownItems.map(item => [item.value, item])
     );
 
-    //build sets of values used so we don't let the user select them twice
+    // build sets of values used so we don't let the user select them twice
     const projectIdsUsed = new Set(existingValues.map(tuple => tuple[0]));
     const mappedValuesUsed = new Set(existingValues.map(tuple => tuple[1]));
 
@@ -103,12 +103,12 @@ export class RenderField extends Component<RenderProps, State> {
     };
 
     const handleAdd = () => {
-      //add the new value to the list of existing values
+      // add the new value to the list of existing values
       const projectMappings = [
         ...existingValues,
         [selectedSentryProjectId, selectedMappedValue],
       ];
-      //trigger events so we save the value and show the check mark
+      // trigger events so we save the value and show the check mark
       onChange?.(projectMappings, []);
       onBlur?.(projectMappings, []);
       this.setState({selectedSentryProjectId: null, selectedMappedValue: null});
@@ -116,7 +116,7 @@ export class RenderField extends Component<RenderProps, State> {
 
     const handleDelete = (index: number) => {
       const projectMappings = removeAtArrayIndex(existingValues, index);
-      //trigger events so we save the value and show the check mark
+      // trigger events so we save the value and show the check mark
       onChange?.(projectMappings, []);
       onBlur?.(projectMappings, []);
     };
@@ -168,7 +168,7 @@ export class RenderField extends Component<RenderProps, State> {
     };
 
     const customValueContainer = containerProps => {
-      //if no value set, we want to return the default component that is rendered
+      // if no value set, we want to return the default component that is rendered
       const project = sentryProjectsById[selectedSentryProjectId || ''];
       if (!project) {
         return <components.ValueContainer {...containerProps} />;
@@ -188,7 +188,7 @@ export class RenderField extends Component<RenderProps, State> {
 
     const customOptionProject = projectProps => {
       const project = sentryProjectsById[projectProps.value];
-      //Should never happen for a dropdown item
+      // Should never happen for a dropdown item
       if (!project) {
         return null;
       }
@@ -206,7 +206,7 @@ export class RenderField extends Component<RenderProps, State> {
     };
 
     const customMappedValueContainer = containerProps => {
-      //if no value set, we want to return the default component that is rendered
+      // if no value set, we want to return the default component that is rendered
       const mappedValue = mappedItemsByValue[selectedMappedValue || ''];
       if (!mappedValue) {
         return <components.ValueContainer {...containerProps} />;

--- a/static/app/views/settings/components/forms/selectAsyncField.tsx
+++ b/static/app/views/settings/components/forms/selectAsyncField.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import SelectAsyncControl from 'app/components/forms/selectAsyncControl';
 import InputField from 'app/views/settings/components/forms/inputField';
 
-//projects can be passed as a direct prop as well
+// projects can be passed as a direct prop as well
 type Props = Omit<InputField['props'], 'highlighted' | 'visible' | 'required'>;
 
 export type SelectAsyncFieldProps = React.ComponentPropsWithoutRef<

--- a/static/app/views/settings/components/forms/sentryProjectSelectorField.tsx
+++ b/static/app/views/settings/components/forms/sentryProjectSelectorField.tsx
@@ -12,18 +12,18 @@ const defaultProps = {
   placeholder: t('Choose Sentry project'),
 };
 
-//projects can be passed as a direct prop as well
+// projects can be passed as a direct prop as well
 type Props = {projects?: Project[]} & InputField['props'];
 
 type RenderProps = {
-  projects: Project[]; //can't use AvatarProject since we need the ID
+  projects: Project[]; // can't use AvatarProject since we need the ID
 } & Omit<Partial<Readonly<typeof defaultProps>>, 'placeholder'> &
   Props;
 
 class RenderField extends React.Component<RenderProps> {
   static defaultProps = defaultProps;
 
-  //need to map the option object to the value
+  // need to map the option object to the value
   handleChange = (
     onBlur: Props['onBlur'],
     onChange: Props['onChange'],
@@ -42,7 +42,7 @@ class RenderField extends React.Component<RenderProps> {
 
     const customOptionProject = projectProps => {
       const project = projects.find(proj => proj.id === projectProps.value);
-      //shouldn't happen but need to account for it
+      // shouldn't happen but need to account for it
       if (!project) {
         return <components.Option {...projectProps} />;
       }
@@ -61,7 +61,7 @@ class RenderField extends React.Component<RenderProps> {
     const customValueContainer = containerProps => {
       const selectedValue = containerProps.getValue()[0];
       const project = projects.find(proj => proj.id === selectedValue?.value);
-      //shouldn't happen but need to account for it
+      // shouldn't happen but need to account for it
       if (!project) {
         return <components.ValueContainer {...containerProps} />;
       }

--- a/static/app/views/settings/components/forms/tableField.tsx
+++ b/static/app/views/settings/components/forms/tableField.tsx
@@ -56,13 +56,13 @@ export default class TableField extends React.Component<Props> {
     const saveChanges = (nextValue: object[]) => {
       onChange?.(nextValue, []);
 
-      //nextValue is an array of ObservableObjectAdministration objects
+      // nextValue is an array of ObservableObjectAdministration objects
       const validValues = !flatten(Object.values(nextValue).map(Object.entries)).some(
-        ([key, val]) => key !== 'id' && !val //don't allow empty values except if it's the ID field
+        ([key, val]) => key !== 'id' && !val // don't allow empty values except if it's the ID field
       );
 
       if (allowEmpty || validValues) {
-        //TOOD: add debouncing or use a form save button
+        // TOOD: add debouncing or use a form save button
         onBlur?.(nextValue, []);
       }
     };
@@ -89,7 +89,7 @@ export default class TableField extends React.Component<Props> {
       saveChanges(newValue);
     };
 
-    //should not be a function for this component
+    // should not be a function for this component
     const disabled = typeof rawDisabled === 'function' ? false : rawDisabled;
 
     const button = (
@@ -171,7 +171,7 @@ export default class TableField extends React.Component<Props> {
   };
 
   render() {
-    //We need formatMessageValue=false since we're saving an object
+    // We need formatMessageValue=false since we're saving an object
     // and there isn't a great way to render the
     // change within the toast. Just turn off displaying the from/to portion of
     // the message

--- a/static/app/views/settings/components/forms/type.tsx
+++ b/static/app/views/settings/components/forms/type.tsx
@@ -115,7 +115,7 @@ type InputType = {type: 'string' | 'secret'} & {
 type SelectControlType = {type: 'choice' | 'select'} & {
   multiple?: boolean;
   allowClear?: boolean;
-  options?: Array<{label: string; value: any}>; //for new select
+  options?: Array<{label: string; value: any}>; // for new select
   defaultOptions?: Array<{label: string; value: any}> | boolean;
   filterOption?: ReturnType<typeof createFilter>;
   noOptionsMessage?: () => string;
@@ -147,10 +147,10 @@ export type TableType = {
    * The confirmation message before a a row is deleted
    */
   confirmDeleteMessage?: string;
-  //TODO(TS): Should we have addButtonText and allowEmpty here as well?
+  // TODO(TS): Should we have addButtonText and allowEmpty here as well?
 };
 
-//maps a sentry project to another field
+// maps a sentry project to another field
 export type ProjectMapperType = {
   type: 'project_mapper';
   mappedDropdown: {
@@ -159,7 +159,7 @@ export type ProjectMapperType = {
   };
   sentryProjects: Array<AvatarProject & {id: number; name: string}>;
   nextButton: {
-    text: string; //url comes from the `next` parameter in the QS
+    text: string; // url comes from the `next` parameter in the QS
     description?: string;
     allowedDomain: string;
   };
@@ -170,7 +170,7 @@ export type ChoiceMapperType = {
   type: 'choice_mapper';
 } & ChoiceMapperProps;
 
-//selects a sentry project with avatars
+// selects a sentry project with avatars
 export type SentryProjectSelectorType = {
   type: 'sentry_project_selector';
   projects: Project[];

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -22,7 +22,7 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
     });
 
     const handleClick = () => {
-      //only call the analytics event if the URL is changing
+      // only call the analytics event if the URL is changing
       if (recordAnalytics && to !== window.location.pathname) {
         trackAnalyticsEvent({
           organization_id: organization ? organization.id : null,

--- a/static/app/views/settings/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/settings/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
@@ -16,7 +16,7 @@ const getPlaceholderForType = (type: ActionType) => {
     case ActionType.SLACK:
       return '@username or #channel';
     case ActionType.MSTEAMS:
-      //no prefixes for msteams
+      // no prefixes for msteams
       return 'username or channel';
     case ActionType.PAGERDUTY:
       return 'service';

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -93,12 +93,12 @@ class SentryAppFormModel extends FormModel {
     const formErrors = omit(responseJSON, ['scopes']);
     if (responseJSON.scopes) {
       responseJSON.scopes.forEach((message: string) => {
-        //find the scope from the error message of a specific format
+        // find the scope from the error message of a specific format
         const matches = message.match(/Requested permission of (\w+:\w+)/);
         if (matches) {
           const scope = matches[1];
           const resource = getResourceFromScope(scope as Scope);
-          //should always match but technically resource can be undefined
+          // should always match but technically resource can be undefined
           if (resource) {
             formErrors[`${resource}--permission`] = [message];
           }
@@ -273,7 +273,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
 
   onFieldChange = (name: string, value: FieldValue): void => {
     if (name === 'webhookUrl' && !value && this.isInternal) {
-      //if no webhook, then set isAlertable to false
+      // if no webhook, then set isAlertable to false
       this.form.setValue('isAlertable', false);
     }
   };
@@ -289,10 +289,10 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
     const forms = this.isInternal ? internalIntegrationForms : publicIntegrationForms;
     let verifyInstall: boolean;
     if (this.isInternal) {
-      //force verifyInstall to false for all internal apps
+      // force verifyInstall to false for all internal apps
       verifyInstall = false;
     } else {
-      //use the existing value for verifyInstall if the app exists, otherwise default to true
+      // use the existing value for verifyInstall if the app exists, otherwise default to true
       verifyInstall = app ? app.verifyInstall : true;
     }
 
@@ -310,7 +310,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
             schema: {},
             scopes: [],
             ...app,
-            verifyInstall, //need to overwrite the value in app for internal if it is true
+            verifyInstall, // need to overwrite the value in app for internal if it is true
           }}
           model={this.form}
           onSubmitSuccess={this.handleSubmitSuccess}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -24,7 +24,7 @@ export default class SentryApplicationRow extends PureComponent<Props> {
   }
 
   hideStatus() {
-    //no publishing for internal apps so hide the status on the developer settings page
+    // no publishing for internal apps so hide the status on the developer settings page
     return this.isInternal;
   }
 

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -143,7 +143,7 @@ class ConfigureIntegration extends AsyncView<Props, State> {
     return action;
   };
 
-  //TODO(Steve): Refactor components into separate tabs and use more generic tab logic
+  // TODO(Steve): Refactor components into separate tabs and use more generic tab logic
   renderMainTab(provider: IntegrationProvider) {
     const {orgId} = this.props.params;
     const {integration} = this.state;
@@ -229,13 +229,13 @@ class ConfigureIntegration extends AsyncView<Props, State> {
     );
   }
 
-  //renders everything below header
+  // renders everything below header
   renderMainContent(provider: IntegrationProvider) {
-    //if no code mappings, render the single tab
+    // if no code mappings, render the single tab
     if (!this.hasStacktraceLinking(provider)) {
       return this.renderMainTab(provider);
     }
-    //otherwise render the tab view
+    // otherwise render the tab view
     const tabs = [
       ['repos', t('Repositories')],
       ['codeMappings', t('Code Mappings')],

--- a/static/app/views/settings/organizationRelay/modals/form.tsx
+++ b/static/app/views/settings/organizationRelay/modals/form.tsx
@@ -49,7 +49,7 @@ const Form = ({
   // code below copied from app/views/organizationIntegrations/SplitInstallationIdModal.tsx
   // TODO: fix the common method selectText
   const onCopy = (value: string) => async () =>
-    //This hack is needed because the normal copying methods with TextCopyInput do not work correctly
+    // This hack is needed because the normal copying methods with TextCopyInput do not work correctly
     await navigator.clipboard.writeText(value);
 
   return (

--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -168,7 +168,7 @@ class TeamDetails extends React.Component<Props, State> {
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    const routePrefix = recreateRoute('', {routes, params, stepBack: -1}); //`/organizations/${orgId}/teams/${teamId}`;
+    const routePrefix = recreateRoute('', {routes, params, stepBack: -1}); // `/organizations/${orgId}/teams/${teamId}`;
     return (
       <div>
         <SentryDocumentTitle title={t('Team Details')} orgSlug={params.orgId} />

--- a/static/app/views/settings/project/filtersAndSampling/rules/rule/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/rule/conditions.tsx
@@ -54,7 +54,7 @@ function Conditions({condition}: Props) {
     }
     default: {
       Sentry.captureException(new Error('Unknown dynamic sampling condition operator'));
-      return null; //this shall not happen
+      return null; // this shall not happen
     }
   }
 }

--- a/static/app/views/settings/project/filtersAndSampling/rules/rule/type.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/rule/type.tsx
@@ -18,7 +18,7 @@ function Type({type}: Props) {
       return <TransactionLabel>{t('Transaction traces')}</TransactionLabel>;
     default: {
       Sentry.captureException(new Error('Unknown dynamic sampling rule type'));
-      return null; //this shall never happen
+      return null; // this shall never happen
     }
   }
 }

--- a/static/app/views/settings/project/filtersAndSampling/rules/rule/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/rule/utils.tsx
@@ -27,7 +27,7 @@ export function getInnerNameLabel(name: DynamicSamplingInnerName) {
       return t('Legacy Browsers');
     default: {
       Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
-      return null; //this shall never happen
+      return null; // this shall never happen
     }
   }
 }

--- a/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -132,7 +132,7 @@ class KeyRateLimitsForm extends React.Component<Props> {
                   label={t('Rate Limit')}
                   disabled={disabled || !hasFeature}
                   validate={({form}) => {
-                    //TODO(TS): is validate actually doing anything because it's an unexpected prop
+                    // TODO(TS): is validate actually doing anything because it's an unexpected prop
                     const isValid =
                       form &&
                       form.rateLimit &&

--- a/static/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -29,7 +29,7 @@ class CodeOwnersPanel extends Component<Props> {
       onDelete(codeowner);
       addSuccessMessage(t('Deletion successful'));
     } catch {
-      //no 4xx errors should happen on delete
+      // no 4xx errors should happen on delete
       addErrorMessage(t('An error occurred'));
     }
   };

--- a/tests/js/sentry-test/select-new.js
+++ b/tests/js/sentry-test/select-new.js
@@ -47,7 +47,7 @@ export function selectByValue(wrapper, value, options = {}) {
   findOption(wrapper, {value}, options).at(0).simulate('click');
 }
 
-//used for the text input to replicate a user typing
+// used for the text input to replicate a user typing
 export function changeInputValue(element, value) {
   element.instance().value = value;
   element.simulate('change', {target: {value}});

--- a/tests/js/spec/components/dropdownMenu.spec.jsx
+++ b/tests/js/spec/components/dropdownMenu.spec.jsx
@@ -237,7 +237,7 @@ describe('DropdownMenu', function () {
     expect(wrapper.find('[data-test-id="menu-item"]')).toHaveLength(1);
 
     wrapper.find('button').simulate('click');
-    //Should still be visible.
+    // Should still be visible.
     expect(wrapper.find('[data-test-id="menu-item"]')).toHaveLength(1);
   });
 });

--- a/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
@@ -24,7 +24,7 @@ describe('SentryAppExternalIssueActions', () => {
         name: sentryApp.name,
       },
     });
-    //unable to use the selectByValue here so remove the select option
+    // unable to use the selectByValue here so remove the select option
     component.schema.create.required_fields.pop();
     install = TestStubs.SentryAppInstallation({sentryApp});
     submitUrl = `/sentry-app-installations/${install.uuid}/external-issue-actions/`;

--- a/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
@@ -281,11 +281,11 @@ describe('SentryAppExternalIssueForm Dependent fields', () => {
       expect(wrapper.find(optionLabelSelector('project A')).exists()).toBe(true);
       expect(wrapper.find(optionLabelSelector('project B')).exists()).toBe(true);
 
-      //project select should be disabled and we shouldn't fetch the options yet
+      // project select should be disabled and we shouldn't fetch the options yet
       expect(wrapper.find('SelectControl#board_id').prop('disabled')).toBe(true);
       expect(boardMock).not.toHaveBeenCalled();
 
-      //when we set the value for project we should get the values for the board
+      // when we set the value for project we should get the values for the board
       selectByValue(wrapper, 'A', {name: 'project_id'});
       await tick();
       wrapper.update();

--- a/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/dateRange.spec.jsx
@@ -8,7 +8,7 @@ import ConfigStore from 'app/stores/configStore';
 // 2017-10-14T02:38:00.000Z
 // 2017-10-17T02:38:00.000Z
 const start = new Date(1507948680000);
-const end = new Date(1508207880000); //National Pasta Day
+const end = new Date(1508207880000); // National Pasta Day
 
 const getSelectedRange = wrapper => [
   wrapper.find('.rdrStartEdge').closest('DayCell').find('.rdrDayNumber span').text(),

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -87,7 +87,7 @@ describe('CreateProject', function () {
     node.simulate('click');
     expect(wrapper.find('ProjectNameInput input').props().value).toBe('Rails');
 
-    //but not replace it when project name is something else:
+    // but not replace it when project name is something else:
     wrapper.setState({projectName: 'another'});
 
     node = wrapper.find('PlatformCard').first();

--- a/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
@@ -67,7 +67,7 @@ describe('Data Scrubbing', () => {
       // PanelHeader
       expect(wrapper.find('PanelHeader').text()).toEqual('Advanced Data Scrubbing');
 
-      //PanelAlert
+      // PanelAlert
       const panelAlert = wrapper.find('PanelAlert');
       expect(panelAlert.text()).toEqual(
         `${additionalContext} The new rules will only apply to upcoming events.  For more details, see full documentation on data scrubbing.`
@@ -79,7 +79,7 @@ describe('Data Scrubbing', () => {
         'https://docs.sentry.io/product/data-management-settings/advanced-datascrubbing/'
       );
 
-      //PanelBody
+      // PanelBody
       const panelBody = wrapper.find('PanelBody');
       expect(panelBody).toHaveLength(1);
       expect(panelBody.find('ListItem')).toHaveLength(3);
@@ -99,7 +99,7 @@ describe('Data Scrubbing', () => {
     it('render disabled', () => {
       const wrapper = renderComponent({disabled: true, endpoint});
 
-      //PanelBody
+      // PanelBody
       const panelBody = wrapper.find('PanelBody');
       expect(panelBody).toHaveLength(1);
       expect(panelBody.find('List').prop('isDisabled')).toEqual(true);
@@ -126,7 +126,7 @@ describe('Data Scrubbing', () => {
       // PanelHeader
       expect(wrapper.find('PanelHeader').text()).toEqual('Advanced Data Scrubbing');
 
-      //PanelAlert
+      // PanelAlert
       const panelAlert = wrapper.find('PanelAlert');
       expect(panelAlert.text()).toEqual(
         `${additionalContext} The new rules will only apply to upcoming events.  For more details, see full documentation on data scrubbing.`
@@ -138,7 +138,7 @@ describe('Data Scrubbing', () => {
         'https://docs.sentry.io/product/data-management-settings/advanced-datascrubbing/'
       );
 
-      //PanelBody
+      // PanelBody
       const panelBody = wrapper.find('PanelBody');
       expect(panelBody).toHaveLength(1);
       expect(panelBody.find('ListItem')).toHaveLength(3);
@@ -161,7 +161,7 @@ describe('Data Scrubbing', () => {
     it('render disabled', () => {
       const wrapper = renderComponent({disabled: true, endpoint});
 
-      //PanelBody
+      // PanelBody
       const panelBody = wrapper.find('PanelBody');
       expect(panelBody).toHaveLength(1);
       expect(panelBody.find('List').prop('isDisabled')).toEqual(true);

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -89,7 +89,7 @@ describe('Organization Developer Settings', function () {
     });
 
     it('can make a request to publish an integration', async () => {
-      //add mocks that App calls
+      // add mocks that App calls
       Client.addMockResponse({
         url: '/internal/health/',
         body: {
@@ -125,7 +125,7 @@ describe('Organization Developer Settings', function () {
         method: 'POST',
       });
 
-      //mock with App to render modal
+      // mock with App to render modal
       wrapper = mountWithTheme(
         <App>
           <OrganizationDeveloperSettings params={{orgId: org.slug}} organization={org} />


### PR DESCRIPTION
Applies the `--fix` from https://eslint.org/docs/rules/spaced-comment (though does not include every change produced by this)

I am fairly sure `// ` (note the space at the end) is the predominant style. I will follow up with enabling the eslint to enforce this