### PR TITLE
fix(sessions): Filter out zero users releases in users sort

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -176,6 +176,11 @@ def get_project_releases_by_stability(
     filter_keys = {"project_id": project_ids}
     rv = []
 
+    # Filter out releases with zero users when sorting by either `users` or `crash_free_users`
+    having_dict = {}
+    if scope in ["users", "crash_free_users"]:
+        having_dict["having"] = [["users", ">", 0]]
+
     for x in raw_query(
         dataset=Dataset.Sessions,
         selected_columns=["project_id", "release"],
@@ -185,6 +190,7 @@ def get_project_releases_by_stability(
         offset=offset,
         limit=limit,
         conditions=conditions,
+        **having_dict,
         filter_keys=filter_keys,
         referrer="sessions.stability-sort",
     )["data"]:

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -244,6 +244,43 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
                 (self.project.id, self.session_release),
             ]
 
+    def test_get_project_releases_by_stability_for_releases_with_users_data(self):
+        """
+        Test that ensures if releases contain no users data, then those releases should not be
+        returned on `users` and `crash_free_users` sorts
+        """
+        self.store_session(
+            {
+                "session_id": "bd1521fc-d27c-11eb-b8bc-0242ac130003",
+                "status": "ok",
+                "seq": 0,
+                "release": "release-with-no-users",
+                "environment": "prod",
+                "retention_days": 90,
+                "org_id": self.project.organization_id,
+                "project_id": self.project.id,
+                "duration": None,
+                "errors": 0,
+                "started": self.session_started,
+                "received": self.received,
+            }
+        )
+        data = get_project_releases_by_stability(
+            [self.project.id], offset=0, limit=100, scope="users", stats_period="24h"
+        )
+        assert data == [
+            (self.project.id, self.session_release),
+            (self.project.id, self.session_crashed_release),
+        ]
+
+        data = get_project_releases_by_stability(
+            [self.project.id], offset=0, limit=100, scope="crash_free_users", stats_period="24h"
+        )
+        assert data == [
+            (self.project.id, self.session_crashed_release),
+            (self.project.id, self.session_release),
+        ]
+
     def test_get_release_adoption(self):
         data = get_release_adoption(
             [


### PR DESCRIPTION
This PR:
- Removes releases with zero users in `OrganizationReleasesEndpoint` on `users` and `crash_free_users` sorts

Ref: https://app.asana.com/0/1199560214229133/1200478327680009/f