### PR TITLE
ref(ui): Make page time range selector reusable

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -78,6 +78,15 @@ const defaultProps = {
    * Show relative date selectors
    */
   showRelative: true,
+  /**
+   * When the default period is selected, it is visually dimmed and
+   * makes the selector unclearable.
+   */
+  defaultPeriod: DEFAULT_STATS_PERIOD,
+  /**
+   * Callback when value changes
+   */
+  onChange: (() => {}) as (data: ChangeData) => void,
 };
 
 type Props = ReactRouter.WithRouterProps & {
@@ -90,12 +99,6 @@ type Props = ReactRouter.WithRouterProps & {
    * End date value for absolute date selector
    */
   end: DateString;
-
-  /**
-   * When the default period is selected, it is visually dimmed and
-   * makes the selector unclearable.
-   */
-  defaultPeriod: string;
 
   /**
    * Relative date value
@@ -116,11 +119,6 @@ type Props = ReactRouter.WithRouterProps & {
    * Replace the default calendar icon for label
    */
   label?: React.ReactNode;
-
-  /**
-   * Callback when value changes
-   */
-  onChange: (data: ChangeData) => void;
 
   /**
    * Callback when "Update" button is clicked

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -231,7 +231,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
   };
 
   handleAbsoluteClick = () => {
-    const {relative, onChange} = this.props;
+    const {relative, onChange, defaultPeriod} = this.props;
 
     // Set default range to equivalent of last relative period,
     // or use default stats period
@@ -239,7 +239,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
       relative: null,
       start: getPeriodAgo(
         'hours',
-        parsePeriodToHours(relative || DEFAULT_STATS_PERIOD)
+        parsePeriodToHours(relative || defaultPeriod || DEFAULT_STATS_PERIOD)
       ).toDate(),
       end: new Date(),
     };
@@ -270,10 +270,10 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
   };
 
   handleClear = () => {
-    const {onChange} = this.props;
+    const {onChange, defaultPeriod} = this.props;
 
     const newDateTime: ChangeData = {
-      relative: DEFAULT_STATS_PERIOD,
+      relative: defaultPeriod || DEFAULT_STATS_PERIOD,
       start: undefined,
       end: undefined,
       utc: null,
@@ -371,10 +371,12 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
       isAbsoluteSelected && start && end ? (
         <DateSummary start={start} end={end} />
       ) : (
-        getRelativeSummary(relative || defaultPeriod)
+        getRelativeSummary(relative || defaultPeriod || DEFAULT_STATS_PERIOD)
       );
 
-    const relativeSelected = isAbsoluteSelected ? '' : relative || defaultPeriod;
+    const relativeSelected = isAbsoluteSelected
+      ? ''
+      : relative || defaultPeriod || DEFAULT_STATS_PERIOD;
 
     return (
       <DropdownMenu

--- a/static/app/components/organizations/timeRangeSelector/pageTimeRangeSelector.tsx
+++ b/static/app/components/organizations/timeRangeSelector/pageTimeRangeSelector.tsx
@@ -1,0 +1,83 @@
+import {ComponentProps, useState} from 'react';
+import styled from '@emotion/styled';
+
+import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
+import {Panel} from 'app/components/panels';
+import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+
+type Props = Omit<
+  ComponentProps<typeof TimeRangeSelector>,
+  'defaultPeriod' | 'onChange'
+> & {
+  className?: string;
+  defaultPeriod?: ComponentProps<typeof TimeRangeSelector>['defaultPeriod'];
+  onChange?: ComponentProps<typeof TimeRangeSelector>['onChange'];
+};
+
+function PageTimeRangeSelector({className, ...props}: Props) {
+  const [isCalendarOpen, setIsCalendarOpen] = useState(false);
+
+  return (
+    <DropdownDate className={className} isCalendarOpen={isCalendarOpen}>
+      <TimeRangeSelector
+        label={<DropdownLabel>{t('Date Range:')}</DropdownLabel>}
+        onToggleSelector={isOpen => setIsCalendarOpen(isOpen)}
+        defaultPeriod={DEFAULT_STATS_PERIOD}
+        onChange={() => {}}
+        relativeOptions={DEFAULT_RELATIVE_PERIODS}
+        {...props}
+      />
+    </DropdownDate>
+  );
+}
+
+const DropdownDate = styled(Panel)<{isCalendarOpen: boolean}>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 42px;
+
+  background: ${p => p.theme.background};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p =>
+    p.isCalendarOpen
+      ? `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`
+      : p.theme.borderRadius};
+  padding: 0;
+  margin: 0;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.textColor};
+  z-index: ${p => p.theme.zIndex.globalSelectionHeader};
+
+  /* TimeRageRoot in TimeRangeSelector */
+  > div {
+    width: 100%;
+    align-self: stretch;
+  }
+
+  /* StyledItemHeader used to show selected value of TimeRangeSelector */
+  > div > div:first-child {
+    padding: 0 ${space(2)};
+  }
+
+  /* Menu that dropdowns from TimeRangeSelector */
+  > div > div:last-child {
+    /* Remove awkward 1px width difference on dropdown due to border */
+    box-sizing: content-box;
+    font-size: 1em;
+  }
+`;
+
+const DropdownLabel = styled('span')`
+  text-align: left;
+  font-weight: 600;
+  color: ${p => p.theme.textColor};
+
+  > span:last-child {
+    font-weight: 400;
+  }
+`;
+
+export default PageTimeRangeSelector;

--- a/static/app/components/organizations/timeRangeSelector/pageTimeRangeSelector.tsx
+++ b/static/app/components/organizations/timeRangeSelector/pageTimeRangeSelector.tsx
@@ -3,17 +3,12 @@ import styled from '@emotion/styled';
 
 import TimeRangeSelector from 'app/components/organizations/timeRangeSelector';
 import {Panel} from 'app/components/panels';
-import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
+import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 
-type Props = Omit<
-  ComponentProps<typeof TimeRangeSelector>,
-  'defaultPeriod' | 'onChange'
-> & {
+type Props = ComponentProps<typeof TimeRangeSelector> & {
   className?: string;
-  defaultPeriod?: ComponentProps<typeof TimeRangeSelector>['defaultPeriod'];
-  onChange?: ComponentProps<typeof TimeRangeSelector>['onChange'];
 };
 
 function PageTimeRangeSelector({className, ...props}: Props) {
@@ -24,8 +19,6 @@ function PageTimeRangeSelector({className, ...props}: Props) {
       <TimeRangeSelector
         label={<DropdownLabel>{t('Date Range:')}</DropdownLabel>}
         onToggleSelector={isOpen => setIsCalendarOpen(isOpen)}
-        defaultPeriod={DEFAULT_STATS_PERIOD}
-        onChange={() => {}}
         relativeOptions={DEFAULT_RELATIVE_PERIODS}
         {...props}
       />

--- a/static/app/components/organizations/timeRangeSelector/pageTimeRangeSelector.tsx
+++ b/static/app/components/organizations/timeRangeSelector/pageTimeRangeSelector.tsx
@@ -51,7 +51,7 @@ const DropdownDate = styled(Panel)<{isCalendarOpen: boolean}>`
   color: ${p => p.theme.textColor};
   z-index: ${p => p.theme.zIndex.globalSelectionHeader};
 
-  /* TimeRageRoot in TimeRangeSelector */
+  /* TimeRangeRoot in TimeRangeSelector */
   > div {
     width: 100%;
     align-self: stretch;

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -10,11 +10,9 @@ import {DateTimeObject} from 'app/components/charts/utils';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import ErrorBoundary from 'app/components/errorBoundary';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
-import TimeRangeSelector, {
-  ChangeData,
-} from 'app/components/organizations/timeRangeSelector';
+import {ChangeData} from 'app/components/organizations/timeRangeSelector';
+import PageTimeRangeSelector from 'app/components/organizations/timeRangeSelector/pageTimeRangeSelector';
 import PageHeading from 'app/components/pageHeading';
-import {Panel} from 'app/components/panels';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
@@ -50,15 +48,7 @@ type Props = {
   organization: Organization;
 } & RouteComponentProps<{orgId: string}, {}>;
 
-type State = {
-  isCalendarOpen: boolean;
-};
-
-export class OrganizationStats extends Component<Props, State> {
-  state: State = {
-    isCalendarOpen: false,
-  };
-
+export class OrganizationStats extends Component<Props> {
   get dataCategory(): DataCategory {
     const dataCategory = this.props.location?.query?.dataCategory;
 
@@ -228,27 +218,20 @@ export class OrganizationStats extends Component<Props, State> {
 
   renderPageControl = () => {
     const {organization} = this.props;
-    const {isCalendarOpen} = this.state;
 
     const {start, end, period, utc} = this.dataDatetime;
 
     return (
       <Fragment>
-        <DropdownDate isCalendarOpen={isCalendarOpen}>
-          <TimeRangeSelector
-            organization={organization}
-            relative={period ?? ''}
-            start={start ?? null}
-            end={end ?? null}
-            utc={utc ?? null}
-            label={<DropdownLabel>{t('Date Range:')}</DropdownLabel>}
-            onChange={() => {}}
-            onUpdate={this.handleUpdateDatetime}
-            onToggleSelector={isOpen => this.setState({isCalendarOpen: isOpen})}
-            relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h'])}
-            defaultPeriod={DEFAULT_STATS_PERIOD}
-          />
-        </DropdownDate>
+        <StyledPageTimeRangeSelector
+          organization={organization}
+          relative={period ?? ''}
+          start={start ?? null}
+          end={end ?? null}
+          utc={utc ?? null}
+          onUpdate={this.handleUpdateDatetime}
+          relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h'])}
+        />
 
         <DropdownDataCategory
           label={
@@ -362,42 +345,8 @@ const DropdownDataCategory = styled(DropdownControl)`
   }
 `;
 
-const DropdownDate = styled(Panel)<{isCalendarOpen: boolean}>`
+const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
   grid-column: auto / span 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 42px;
-
-  background: ${p => p.theme.background};
-  border: 1px solid ${p => p.theme.border};
-  border-radius: ${p =>
-    p.isCalendarOpen
-      ? `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`
-      : p.theme.borderRadius};
-  padding: 0;
-  margin: 0;
-  font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.textColor};
-  z-index: ${p => p.theme.zIndex.globalSelectionHeader};
-
-  /* TimeRageRoot in TimeRangeSelector */
-  > div {
-    width: 100%;
-    align-self: stretch;
-  }
-
-  /* StyledItemHeader used to show selected value of TimeRangeSelector */
-  > div > div:first-child {
-    padding: 0 ${space(2)};
-  }
-
-  /* Menu that dropdowns from TimeRangeSelector */
-  > div > div:last-child {
-    /* Remove awkward 1px width difference on dropdown due to border */
-    box-sizing: content-box;
-    font-size: 1em;
-  }
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     grid-column: auto / span 2;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/122765113-74234180-d2a0-11eb-9e80-b590e2d9e876.png)

Moving the PageTimeRangeSelector from org stats to a reusable component.
I'm going to need the same thing on the release details page.
No change in functionality.