### PR TITLE
fix(discover): Handle rendering issues when user misery is null

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -453,6 +453,11 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
       return <NumberContainer>{emptyValue}</NumberContainer>;
     }
 
+    const userMisery = data[userMiseryField];
+    if (userMisery === null || isNaN(userMisery)) {
+      return <NumberContainer>{emptyValue}</NumberContainer>;
+    }
+
     const projectThresholdConfig = 'project_threshold_config';
     let countMiserableUserField: string = '';
 
@@ -472,7 +477,6 @@ const SPECIAL_FUNCTIONS: SpecialFunctions = {
     }
 
     const uniqueUsers = data.count_unique_user;
-    const userMisery = data[userMiseryField];
 
     let miserableUsers: number | undefined;
 


### PR DESCRIPTION
Introduced a regression that didn't catch for null cases in
user misery. explicitly checking for it now.