### PR TITLE
fix(integrations) Consolidate bitbucket ip ranges

### DIFF
--- a/src/sentry/integrations/bitbucket/constants.py
+++ b/src/sentry/integrations/bitbucket/constants.py
@@ -1,0 +1,29 @@
+import ipaddress
+
+# Bitbucket Cloud IP range:
+# https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhookTriggeringwebhooks
+BITBUCKET_IP_RANGES = (
+    ipaddress.ip_network("104.192.136.0/21"),
+    # Not documented in the webhook docs, but defined here:
+    # https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
+    ipaddress.ip_network("18.205.93.0/25"),
+    ipaddress.ip_network("18.234.32.128/25"),
+    ipaddress.ip_network("13.52.5.0/25"),
+    # Also accept any outbound IPs that atlassian has.
+    # https://support.atlassian.com/organization-administration/docs/ip-addresses-and-domains-for-atlassian-cloud-products/
+    ipaddress.ip_network("13.52.5.96/28"),
+    ipaddress.ip_network("13.236.8.224/28"),
+    ipaddress.ip_network("18.136.214.96/28"),
+    ipaddress.ip_network("18.184.99.224/28"),
+    ipaddress.ip_network("18.234.32.224/28"),
+    ipaddress.ip_network("18.246.31.224/28"),
+    ipaddress.ip_network("52.215.192.224/28"),
+    ipaddress.ip_network("104.192.137.240/28"),
+    ipaddress.ip_network("104.192.138.240/28"),
+    ipaddress.ip_network("104.192.140.240/28"),
+    ipaddress.ip_network("104.192.142.240/28"),
+    ipaddress.ip_network("104.192.143.240/28"),
+    ipaddress.ip_network("185.166.143.240/28"),
+    ipaddress.ip_network("185.166.142.240/28"),
+)
+BITBUCKET_IPS = ["34.198.203.127", "34.198.178.64", "34.198.32.85"]

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -10,39 +10,13 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
+from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import json
 
 logger = logging.getLogger("sentry.webhooks")
 
-# Bitbucket Cloud IP range:
-# https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhookTriggeringwebhooks
-BITBUCKET_IP_RANGES = (
-    ipaddress.ip_network("104.192.136.0/21"),
-    # Not documented in the webhook docs, but defined here:
-    # https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
-    ipaddress.ip_network("18.205.93.0/25"),
-    ipaddress.ip_network("18.234.32.128/25"),
-    ipaddress.ip_network("13.52.5.0/25"),
-    # Also accept any outbound IPs that atlassian has.
-    # https://support.atlassian.com/organization-administration/docs/ip-addresses-and-domains-for-atlassian-cloud-products/
-    ipaddress.ip_network("13.52.5.96/28"),
-    ipaddress.ip_network("13.236.8.224/28"),
-    ipaddress.ip_network("18.136.214.96/28"),
-    ipaddress.ip_network("18.184.99.224/28"),
-    ipaddress.ip_network("18.234.32.224/28"),
-    ipaddress.ip_network("18.246.31.224/28"),
-    ipaddress.ip_network("52.215.192.224/28"),
-    ipaddress.ip_network("104.192.137.240/28"),
-    ipaddress.ip_network("104.192.138.240/28"),
-    ipaddress.ip_network("104.192.140.240/28"),
-    ipaddress.ip_network("104.192.142.240/28"),
-    ipaddress.ip_network("104.192.143.240/28"),
-    ipaddress.ip_network("185.166.143.240/28"),
-    ipaddress.ip_network("185.166.142.240/28"),
-)
-BITBUCKET_IPS = ["34.198.203.127", "34.198.178.64", "34.198.32.85"]
 PROVIDER_NAME = "integrations:bitbucket"
 
 

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -10,25 +10,12 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 
+from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCKET_IPS
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import RepositoryProvider
 from sentry.utils import json
 
 logger = logging.getLogger("sentry.webhooks")
-
-# Bitbucket Cloud IP range:
-# https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhookTriggeringwebhooks
-# Bitbucket Cloud IP range:
-# https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhookTriggeringwebhooks
-BITBUCKET_IP_RANGES = (
-    ipaddress.ip_network("104.192.136.0/21"),
-    # Not documented in the webhook docs, but defined here:
-    # https://bitbucket.org/blog/new-ip-addresses-bitbucket-cloud
-    ipaddress.ip_network("18.205.93.0/25"),
-    ipaddress.ip_network("18.234.32.128/25"),
-    ipaddress.ip_network("13.52.5.0/25"),
-)
-BITBUCKET_IPS = ["34.198.203.127", "34.198.178.64", "34.198.32.85"]
 
 
 class Webhook:


### PR DESCRIPTION
We had two copies of the IP ranges and the plugin one was still wrong. This should remove additional volume from SENTRY-KBH