### PR TITLE
fix(slack): Ignore 404s from webhook

### DIFF
--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -15,11 +15,10 @@ class SlackApiClient(ApiClient):
 
     def request(self, data):
         try:
-            resp = self._request(
+            return self._request(
                 path=self.webhook, method="post", data=data, json=False, allow_text=True
             )
         except ApiError as e:
             # Ignore 404 from slack webhooks
             if e.code != 404:
                 raise e
-        return resp

--- a/src/sentry_plugins/slack/client.py
+++ b/src/sentry_plugins/slack/client.py
@@ -1,3 +1,4 @@
+from sentry.shared_integrations.exceptions import ApiError
 from sentry_plugins.client import ApiClient
 
 
@@ -13,6 +14,12 @@ class SlackApiClient(ApiClient):
         super().__init__()
 
     def request(self, data):
-        return self._request(
-            path=self.webhook, method="post", data=data, json=False, allow_text=True
-        )
+        try:
+            resp = self._request(
+                path=self.webhook, method="post", data=data, json=False, allow_text=True
+            )
+        except ApiError as e:
+            # Ignore 404 from slack webhooks
+            if e.code != 404:
+                raise e
+        return resp

--- a/tests/sentry_plugins/slack/test_plugin.py
+++ b/tests/sentry_plugins/slack/test_plugin.py
@@ -1,11 +1,13 @@
 from urllib.parse import parse_qs
 
+import pytest
 import responses
 from exam import fixture
 
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR
 from sentry.models import Rule
 from sentry.plugins.base import Notification
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils import PluginTestCase
 from sentry.utils import json
 from sentry_plugins.slack.plugin import SlackPlugin
@@ -127,3 +129,28 @@ class SlackPluginTest(PluginTestCase):
                 }
             ],
         }
+
+    @responses.activate
+    def test_no_error_on_404(self):
+        responses.add("POST", "http://example.com/slack", status=404)
+        self.plugin.set_option("webhook", "http://example.com/slack", self.project)
+
+        event = self.store_event(
+            data={"message": "Hello world", "level": "warning", "culprit": "foo.bar"},
+            project_id=self.project.id,
+        )
+
+        rule = Rule.objects.create(project=self.project, label="my rule")
+
+        notification = Notification(event=event, rule=rule)
+
+        # No exception since 404s are supposed to be ignored
+        with self.options({"system.url-prefix": "http://example.com"}):
+            self.plugin.notify(notification)
+
+        responses.replace("POST", "http://example.com/slack", status=400)
+
+        # Other exceptions should not be ignored
+        with self.options({"system.url-prefix": "http://example.com"}):
+            with pytest.raises(ApiError):
+                self.plugin.notify(notification)


### PR DESCRIPTION
Slack Webhook 404s are an expected response and we should not be raising an exception everytime we get a 404. This change catches 404 errors while letting others through

Fixes SENTRY-MEN