### PR TITLE
ref(django 2.0): address some property deprecations

### DIFF
--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -60,8 +60,8 @@ def sort_dependencies():
             # Now add a dependency for any FK relation with a model that
             # defines a natural key
             for field in model._meta.fields:
-                if hasattr(field.rel, "to"):
-                    rel_model = field.rel.to
+                if hasattr(field.remote_field, "model"):
+                    rel_model = field.remote_field.model
                     if rel_model != model:
                         deps.append(rel_model)
 
@@ -69,7 +69,7 @@ def sort_dependencies():
             # that defines a natural key.  M2M relations with explicit through
             # models don't count as dependencies.
             for field in model._meta.many_to_many:
-                rel_model = field.rel.to
+                rel_model = field.remote_field.model
                 if rel_model != model:
                     deps.append(rel_model)
             model_dependencies.append((model, deps))

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -51,7 +51,7 @@ def attach_foreignkey(objects, field, related=(), database=None):
     if not is_foreignkey:
         field = field.field
         accessor = "_%s_cache" % field.name
-        model = field.rel.to
+        model = field.remote_field.model
         lookup = "pk"
         column = field.column
         key = lookup


### PR DESCRIPTION
Field.rel -> Field.remote_field, ForeignObjectRel.to -> ForeignObjectRel.model.

In Django's Field:

    @property
    def rel(self):
        warnings.warn(
            "Usage of field.rel has been deprecated. Use field.remote_field instead.",
            RemovedInDjango20Warning, 2)
        return self.remote_field

And in Django's ForeignObjectRel:

    @property
    def to(self):
        warnings.warn(
            "Usage of ForeignObjectRel.to attribute has been deprecated. "
            "Use the model attribute instead.",
            RemovedInDjango20Warning, 2)
        return self.model

So, field.rel.to becomes field.remote_field.model.

I'll probably try and figure out how to turn on warning reporting to Sentry for `RemovedInDjango20Warning`s, have this feeling some are sneaking by test coverage.

