### PR TITLE
fix(performance): Remove aggregate filter conditions on vitals

### DIFF
--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -55,7 +55,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
                 referrer="api.events.vitals",
                 auto_fields=True,
                 auto_aggregations=True,
-                use_aggregate_conditions=True,
+                use_aggregate_conditions=False,
             )
 
         results = {}

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -54,7 +54,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
                 limit=1,
                 referrer="api.events.vitals",
                 auto_fields=True,
-                auto_aggregations=True,
+                auto_aggregations=False,
                 use_aggregate_conditions=False,
             )
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -464,8 +464,8 @@ def resolve_field_list(
                             aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     check_aggregations = snuba_filter.having and len(aggregations) > 0
-    snuba_filter_condition_aggregates = set(
-        snuba_filter.condition_aggregates or [] if check_aggregations else set()
+    snuba_filter_condition_aggregates = (
+        set(snuba_filter.condition_aggregates or []) if check_aggregations else set()
     )
     for field in set(fields[:]).union(snuba_filter_condition_aggregates):
         if isinstance(field, str) and field in {

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -449,8 +449,7 @@ def resolve_field_list(
                     aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
     # Only auto aggregate when there's one other so the group by is not unexpectedly changed
-    auto_aggregate = auto_aggregations and snuba_filter.having and len(aggregations) > 0
-    if auto_aggregate:
+    if auto_aggregations and snuba_filter.having and len(aggregations) > 0:
         for agg in snuba_filter.condition_aggregates:
             if agg not in snuba_filter.aliases:
                 function = resolve_field(agg, snuba_filter.params, functions_acl)
@@ -464,8 +463,9 @@ def resolve_field_list(
                         if function.details.instance.redundant_grouping:
                             aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
-    snuba_filter_condition_aggregates = (
-        set(snuba_filter.condition_aggregates or []) if auto_aggregate else set()
+    check_aggregations = snuba_filter.having and len(aggregations) > 0
+    snuba_filter_condition_aggregates = set(
+        snuba_filter.condition_aggregates or [] if check_aggregations else set()
     )
     for field in set(fields[:]).union(snuba_filter_condition_aggregates):
         if isinstance(field, str) and field in {

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -463,9 +463,11 @@ def resolve_field_list(
                         if function.details.instance.redundant_grouping:
                             aggregate_fields[format_column_as_key(function.aggregate[1])].add(field)
 
-    check_aggregations = snuba_filter.having and len(aggregations) > 0
+    check_aggregations = (
+        snuba_filter.having and len(aggregations) > 0 and snuba_filter.condition_aggregates
+    )
     snuba_filter_condition_aggregates = (
-        set(snuba_filter.condition_aggregates or []) if check_aggregations else set()
+        set(snuba_filter.condition_aggregates) if check_aggregations else set()
     )
     for field in set(fields[:]).union(snuba_filter_condition_aggregates):
         if isinstance(field, str) and field in {


### PR DESCRIPTION
Don't use aggregate filter on the vitals cards because
when filtering on aggregate conditions, we do not want
to apply the filter on the aggregate data.