### PR TITLE
feat(notification platform): Add slash command for team linking

### DIFF
--- a/src/sentry/integrations/slack/command_endpoint.py
+++ b/src/sentry/integrations/slack/command_endpoint.py
@@ -13,7 +13,7 @@ from sentry.models import Identity, IdentityProvider
 
 logger = logging.getLogger("sentry.integrations.slack")
 LINK_TEAM_MESSAGE = "Link your Sentry team to this Slack channel! <{associate_url}|Link your team now> to receive notifications of issues in Sentry in Slack."
-LINK_USER_MESSAGE = "Who dis? Type `/sentry link` to tell me and btw you better be an admin or you're still not gonna be able to link your team."
+LINK_USER_MESSAGE = "You must first link your identity to Sentry by typing /sentry link. Be aware that you must be an admin or higher in your Sentry organization to link your team."
 
 
 def get_command(payload: Mapping[str, str]) -> str:

--- a/src/sentry/integrations/slack/command_endpoint.py
+++ b/src/sentry/integrations/slack/command_endpoint.py
@@ -60,9 +60,7 @@ class SlackCommandsEndpoint(Endpoint):
                 )
                 raise Http404
 
-            try:
-                Identity.objects.select_related("user").get(idp=idp, external_id=user_id)
-            except Identity.DoesNotExist:
+            if not Identity.objects.filter(idp=idp, external_id=user_id).exists():
                 return self.send_ephemeral_notification(LINK_USER_MESSAGE)
             channel_id = payload.get("channel_id", "")
             channel_name = payload.get("channel_name", "")

--- a/src/sentry/integrations/slack/link_team.py
+++ b/src/sentry/integrations/slack/link_team.py
@@ -139,9 +139,10 @@ class SlackLinkTeamView(BaseView):
         )
         # if the org has open membership and the user is an admin or above
         # OR if closed, ensure user is admin AND member of the team
-        if not (
-            organization.flags.allow_joinleave and org_member.role in ["admin", "manager", "owner"]
-        ) or (org_member.role in ["admin", "manager", "owner"] and team in [org_member.teams]):
+        allowed_roles = ["admin", "manager", "owner"]
+        if not (organization.flags.allow_joinleave and org_member.role in allowed_roles) or (
+            org_member.role in allowed_roles and team in [org_member.teams]
+        ):
             return self.send_slack_message(
                 request,
                 client,

--- a/src/sentry/integrations/slack/link_team.py
+++ b/src/sentry/integrations/slack/link_team.py
@@ -102,7 +102,6 @@ class SlackLinkTeamView(BaseView):
         ).order_by("slug")
         channel_name = params["channel_name"]
         channel_id = params["channel_id"]
-
         form = SelectTeamForm(teams, request.POST or None)
         if form.is_valid():
             team_id = form.cleaned_data["team"]

--- a/src/sentry/integrations/slack/link_team.py
+++ b/src/sentry/integrations/slack/link_team.py
@@ -178,8 +178,7 @@ class SlackLinkTeamView(BaseView):
 
         if created:
             # turn on notifications for all of a team's projects
-            # TODO(ceo): Update this when the manager has been updated to handle
-            # team scope types
+            # TODO(ceo): Update this when API-1951 has been merged
             team_projects = team.get_projects()
             for project in team_projects:
                 NotificationSetting.objects.update_settings(

--- a/src/sentry/integrations/slack/link_team.py
+++ b/src/sentry/integrations/slack/link_team.py
@@ -1,0 +1,124 @@
+from django import forms
+from django.urls import reverse
+from django.views.decorators.cache import never_cache
+
+from sentry.models import ExternalActor, Integration, NotificationSetting, Team, TeamStatus
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.types.integrations import ExternalProviders
+from sentry.utils.http import absolute_uri
+from sentry.utils.signing import sign, unsign
+from sentry.web.decorators import transaction_start
+from sentry.web.frontend.base import BaseView
+
+from .client import SlackClient
+from .utils import logger
+
+
+def build_linking_url(integration, slack_id, channel_id, channel_name, response_url):
+    signed_params = sign(
+        integration_id=integration.id,
+        slack_id=slack_id,
+        channel_id=channel_id,
+        channel_name=channel_name,
+        response_url=response_url,
+    )
+
+    return absolute_uri(
+        reverse("sentry-integration-slack-link-team", kwargs={"signed_params": signed_params})
+    )
+
+
+class SelectTeamForm(forms.Form):
+    team = forms.ChoiceField(label="Team")
+
+    def __init__(self, teams, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["team"].choices = [(team.id, team.slug) for team in teams]
+        self.fields["team"].widget.choices = self.fields["team"].choices
+
+
+class SlackLinkTeamView(BaseView):
+    @transaction_start("SlackLinkTeamView")
+    @never_cache
+    def handle(self, request, signed_params):
+        params = unsign(signed_params)
+        """
+        # params:
+        #'integration_id': 15,
+        #'slack_id': UA1J9RTE1,
+        #'channel_id': CA2FRA079,
+        #'channel_name': general
+        #'response_url': 'https://hooks.slack.com/commands/TA17GH2QL/2177038069364/unDYN7ciEtuZGfCLEzR9KxMw'
+        """
+        integration = Integration.objects.get(id=params["integration_id"])
+        teams = Team.objects.filter(
+            organization__in=integration.organizations.all(), status=TeamStatus.VISIBLE
+        ).order_by("slug")
+
+        form = SelectTeamForm(teams, request.POST or None)
+        if form.is_valid():
+            team_id = form.cleaned_data["team"]
+
+        if request.method != "POST":
+            return self.respond(
+                "sentry/slack-link-team.html",
+                {
+                    "form": form,
+                    "teams": teams,
+                    "channel_name": params["channel_name"],
+                    "provider": integration.get_provider(),
+                },
+            )
+
+        team = Team.objects.get(id=team_id)
+        # TODO handle non-happy paths
+        # add a check to see if the team is already linked to any channel?
+        external_team, created = ExternalActor.objects.get_or_create(
+            actor_id=team.actor_id,
+            organization=integration.organizations.all()[
+                0
+            ],  # I think you can only have a Slack installed on one org so this is safe?
+            integration=integration,
+            provider=ExternalProviders.SLACK.value,
+            external_name=params["channel_name"],
+            external_id=params["channel_id"],
+        )
+
+        if created:
+            # turn on notifications for all of a team's projects
+            # maybe we can add checkboxes in the form later but this is quick n dirty
+            team_projects = team.get_projects()
+            for project in team_projects:
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.SLACK,
+                    NotificationSettingTypes.ISSUE_ALERTS,
+                    NotificationSettingOptionValues.ALWAYS,
+                    team=team,
+                    project=project,
+                )
+
+            payload = {
+                "replace_original": False,
+                "response_type": "ephemeral",
+                "text": f"The {team.slug} team will now receive notifications in this channel.",
+            }
+
+            client = SlackClient()
+            try:
+                client.post(params["response_url"], data=payload, json=True)
+            except ApiError as e:
+                message = str(e)
+                # If the user took their time to link their slack account, we may no
+                # longer be able to respond, and we're not guaranteed able to post into
+                # the channel. Ignore Expired url errors.
+                #
+                # XXX(epurkhiser): Yes the error string has a space in it.
+                if message != "Expired url":
+                    logger.error("slack.link-notify.response-error", extra={"error": message})
+
+            return self.response(
+                "sentry/slack-linked-team.html",
+                {"channel_id": params["channel_id"], "team_id": integration.external_id},
+            )

--- a/src/sentry/integrations/slack/link_team.py
+++ b/src/sentry/integrations/slack/link_team.py
@@ -68,7 +68,9 @@ class SlackLinkTeamView(BaseView):
         return identity
 
     def send_error_message(self, request, client, message, response_url, channel_id, integration):
-        token = integration.metadata.get("user_access_token") or integration.metadata["access_token"]
+        token = (
+            integration.metadata.get("user_access_token") or integration.metadata["access_token"]
+        )
         payload = {
             "token": token,
             "channel": channel_id,
@@ -125,8 +127,14 @@ class SlackLinkTeamView(BaseView):
         ) or (org_member.role in ["admin", "manager", "owner"] and team in [org_member.teams]):
             INSUFFICIENT_ROLE_MESSAGE = "You must be an admin or higher and a member of the team you wish to link in your Sentry organization to link teams."
             # TODO(ceo) write a test for this case
-            return self.send_error_message(request, client, INSUFFICIENT_ROLE_MESSAGE, params["response_url"], params["channel_id"], integration)
-
+            return self.send_error_message(
+                request,
+                client,
+                INSUFFICIENT_ROLE_MESSAGE,
+                params["response_url"],
+                params["channel_id"],
+                integration,
+            )
 
         already_linked = ExternalActor.objects.filter(
             actor_id=team.actor_id,
@@ -138,7 +146,14 @@ class SlackLinkTeamView(BaseView):
             ALREADY_LINKED_MESSAGE = (
                 f"The {team.slug} team has already been linked to a Slack channel."
             )
-            return self.send_error_message(request, client, ALREADY_LINKED_MESSAGE, params["response_url"], params["channel_id"], integration)
+            return self.send_error_message(
+                request,
+                client,
+                ALREADY_LINKED_MESSAGE,
+                params["response_url"],
+                params["channel_id"],
+                integration,
+            )
 
         external_team, created = ExternalActor.objects.get_or_create(
             actor_id=team.actor_id,
@@ -162,7 +177,10 @@ class SlackLinkTeamView(BaseView):
                     team=team,
                     project=project,
                 )
-            token = integration.metadata.get("user_access_token") or integration.metadata["access_token"]
+            token = (
+                integration.metadata.get("user_access_token")
+                or integration.metadata["access_token"]
+            )
             headers = {"Authorization": "Bearer %s" % token}
             payload = {
                 "token": token,

--- a/src/sentry/integrations/slack/link_team.py
+++ b/src/sentry/integrations/slack/link_team.py
@@ -192,16 +192,12 @@ class SlackLinkTeamView(BaseView):
 
         if created:
             # turn on notifications for all of a team's projects
-            # TODO(ceo): Update this when API-1951 has been merged
-            team_projects = team.get_projects()
-            for project in team_projects:
-                NotificationSetting.objects.update_settings(
-                    ExternalProviders.SLACK,
-                    NotificationSettingTypes.ISSUE_ALERTS,
-                    NotificationSettingOptionValues.ALWAYS,
-                    team=team,
-                    project=project,
-                )
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.SLACK,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.ALWAYS,
+                team=team,
+            )
             return self.send_slack_message(
                 request,
                 client,

--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -4,6 +4,7 @@ from .action_endpoint import SlackActionEndpoint
 from .command_endpoint import SlackCommandsEndpoint
 from .event_endpoint import SlackEventEndpoint
 from .link_identity import SlackLinkIdentityView
+from .link_team import SlackLinkTeamView
 from .unlink_identity import SlackUnlinkIdentityView
 
 urlpatterns = [
@@ -19,5 +20,10 @@ urlpatterns = [
         r"^unlink-identity/(?P<signed_params>[^\/]+)/$",
         SlackUnlinkIdentityView.as_view(),
         name="sentry-integration-slack-unlink-identity",
+    ),
+    url(
+        r"^link-team/(?P<signed_params>[^\/]+)/$",
+        SlackLinkTeamView.as_view(),
+        name="sentry-integration-slack-link-team",
     ),
 ]

--- a/src/sentry/templates/sentry/slack-link-team-error.html
+++ b/src/sentry/templates/sentry/slack-link-team-error.html
@@ -1,0 +1,14 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Error" %} | {{ block.super }}{% endblock %}
+{% block wrapperclass %}narrow auth{% endblock %}
+
+{% block main %}
+  <div class="align-center">
+    <p>
+      {% trans body_text %}
+    </p>
+  </div>
+{% endblock %}

--- a/src/sentry/templates/sentry/slack-link-team.html
+++ b/src/sentry/templates/sentry/slack-link-team.html
@@ -1,0 +1,35 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load sentry_assets %}
+
+{% block title %}{% trans "Link Team" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+<form class="form-stacked" action="" method="post">
+  {% csrf_token %}
+
+  <div class="align-center">
+    <img src="{% asset_url "sentry" "images/logos/default-organization-logo.png" %}" class="org-avatar">
+  </div>
+
+  <div class="align-center">
+    <p>Choose which team you'd like to link to the <b>#{{ channel_name }}</b> channel.</p>
+
+    <div class="align-center" style="padding-bottom:20px;">
+      <select id="{{ form.team.id_for_label }}" name="{{ form.team.html_name }}" class="form-control">
+        {% for team in teams %}
+        <option value="{{ team.id }}">{{ team.slug }}</option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <p>
+      <button type="submit" class="btn btn-default btn-login-{{ provider.key }}">
+        <span class="provider-logo {{ provider.key }}"></span> Link with {{ provider.name }}
+      </button>
+    </p>
+  </div>
+</form>
+{% endblock %}

--- a/src/sentry/templates/sentry/slack-linked-team.html
+++ b/src/sentry/templates/sentry/slack-linked-team.html
@@ -1,0 +1,19 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Team Linked" %} | {{ block.super }}{% endblock %}
+{% block wrapperclass %}narrow auth{% endblock %}
+
+{% block main %}
+  <div class="align-center">
+    <p>
+      {% trans "Your team has now been linked to the Slack channel. You will now receive issue alert notifications there!" %}
+    </p>
+    <p>
+      <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">
+        <span class="provider-logo slack"></span> Go back to Slack
+      </a>
+    </p>
+  </div>
+{% endblock %}

--- a/src/sentry/templates/sentry/slack-post-linked-team.html
+++ b/src/sentry/templates/sentry/slack-post-linked-team.html
@@ -2,13 +2,13 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Team Linked" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans heading_text %} | {{ block.super }}{% endblock %}
 {% block wrapperclass %}narrow auth{% endblock %}
 
 {% block main %}
   <div class="align-center">
     <p>
-      {% trans "Your team has now been linked to the Slack channel. You will now receive issue alert notifications there!" %}
+      {% trans body_text %}
     </p>
     <p>
       <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -287,3 +287,23 @@ class SlackCommandsLinkTeamTest(SlackCommandsTest):
         assert (
             f"The {self.team.slug} team has already been linked to a Slack channel." in data["text"]
         )
+
+    def test_error_page(self):
+        """Test that we successfully render an error page when bad form data is sent."""
+        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
+        linking_url = build_linking_url(
+            self.integration,
+            "UXXXXXXX1",
+            "CXXXXXXX9",
+            "general",
+            "http://example.slack.com/response_url",
+        )
+
+        resp = self.client.get(linking_url)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-link-team.html")
+
+        data = urlencode({"team": ["some", "garbage"]})
+        resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-link-team-error.html")

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -212,7 +212,9 @@ class SlackCommandsPostTest(SlackCommandsTest):
         attempts to link a team, we reject them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
         self.organization.flags.allow_joinleave = True
         user2 = self.create_user()
-        self.create_member(user=user2, role="member", organization=self.organization)
+        self.create_member(
+            teams=[self.team], user=user2, role="member", organization=self.organization
+        )
         self.login_as(user2)
         Identity.objects.create(
             external_id="UXXXXXXX2",

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -60,7 +60,30 @@ class SlackCommandsGetTest(SlackCommandsTest):
         self.get_error_response(status_code=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
-class SlackCommandsPostTest(SlackCommandsTest):
+class SlackCommandsHelpTest(SlackCommandsTest):
+    method = "post"
+
+    def test_invalid_signature(self):
+        # The `get_error_response` method doesn't use a signature.
+        self.get_error_response(status_code=status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_team(self):
+        self.get_slack_response({"text": ""}, status_code=status.HTTP_403_FORBIDDEN)
+
+    def test_missing_command(self):
+        response = self.get_slack_response({"text": "", "team_id": self.external_id})
+        assert_is_help_text(response)
+
+    def test_invalid_command(self):
+        response = self.get_slack_response({"text": "invalid command", "team_id": self.external_id})
+        assert_is_help_text(response, "invalid")
+
+    def test_help_command(self):
+        response = self.get_slack_response({"text": "help", "team_id": self.external_id})
+        assert_is_help_text(response)
+
+
+class SlackCommandsLinkTeamTest(SlackCommandsTest):
     method = "post"
 
     def setUp(self):
@@ -93,25 +116,6 @@ class SlackCommandsPostTest(SlackCommandsTest):
             external_name="general",
             external_id="CXXXXXXX9",
         )
-
-    def test_invalid_signature(self):
-        # The `get_error_response` method doesn't use a signature.
-        self.get_error_response(status_code=status.HTTP_400_BAD_REQUEST)
-
-    def test_missing_team(self):
-        self.get_slack_response({"text": ""}, status_code=status.HTTP_403_FORBIDDEN)
-
-    def test_missing_command(self):
-        response = self.get_slack_response({"text": "", "team_id": self.external_id})
-        assert_is_help_text(response)
-
-    def test_invalid_command(self):
-        response = self.get_slack_response({"text": "invalid command", "team_id": self.external_id})
-        assert_is_help_text(response, "invalid")
-
-    def test_help_command(self):
-        response = self.get_slack_response({"text": "help", "team_id": self.external_id})
-        assert_is_help_text(response)
 
     @responses.activate
     def test_link_team_command(self):

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -72,5 +72,26 @@ class SlackCommandsPostTest(SlackCommandsTest):
         assert_is_help_text(response)
 
     def test_link_team_command(self):
-        response = self.get_slack_response({"text": "link team", "team_id": self.external_id})
-        # add more stuff
+        """Test that we successfully link a team to a Slack channel"""
+        # response = self.get_slack_response({"text": "link team", "team_id": self.external_id})
+        pass
+
+    def test_link_team_identity_does_not_exist(self):
+        """Test that get_identity fails and we reply with the LINK_USER_MESSAGE"""
+        pass
+
+    def test_link_team_insufficient_role(self):
+        """Test that when a user whose role is insufficient and is not a member of the
+        team in question in a closed membership org attempts to link a team, we reject
+        them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
+        pass
+
+    def test_link_team_insufficient_role_open_membership(self):
+        """Test that when a user whose role is insufficient in an open membership organization
+        attempts to link a team, we reject them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
+        pass
+
+    def test_link_team_already_linked(self):
+        """Test that if a team has already been linked to a Slack channel when a user tries
+        to link them again, we reject the attempt and reply with the ALREADY_LINKED_MESSAGE"""
+        pass

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -70,3 +70,7 @@ class SlackCommandsPostTest(SlackCommandsTest):
     def test_help_command(self):
         response = self.get_slack_response({"text": "help", "team_id": self.external_id})
         assert_is_help_text(response)
+
+    def test_link_team_command(self):
+        response = self.get_slack_response({"text": "link team", "team_id": self.external_id})
+        # add more stuff

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -63,6 +63,37 @@ class SlackCommandsGetTest(SlackCommandsTest):
 class SlackCommandsPostTest(SlackCommandsTest):
     method = "post"
 
+    def setUp(self):
+        super().setUp()
+        self.idp = IdentityProvider.objects.create(type="slack", external_id="slack:1", config={})
+        self.login_as(self.user)
+        Identity.objects.create(
+            external_id="UXXXXXXX1",
+            idp=self.idp,
+            user=self.user,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
+        response = self.get_slack_response(
+            {"text": "link team", "team_id": self.external_id, "user_id": "UXXXXXXX1"}
+        )
+        self.data = json.loads(str(response.content.decode("utf-8")))
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            body='{"ok": true}',
+            status=200,
+            content_type="application/json",
+        )
+        self.external_actor = ExternalActor.objects.filter(
+            actor_id=self.team.actor_id,
+            organization=self.organization,
+            integration=self.integration,
+            provider=ExternalProviders.SLACK.value,
+            external_name="general",
+            external_id="CXXXXXXX9",
+        )
+
     def test_invalid_signature(self):
         # The `get_error_response` method doesn't use a signature.
         self.get_error_response(status_code=status.HTTP_400_BAD_REQUEST)
@@ -85,20 +116,149 @@ class SlackCommandsPostTest(SlackCommandsTest):
     @responses.activate
     def test_link_team_command(self):
         """Test that we successfully link a team to a Slack channel"""
-        self.login_as(self.user)
-        idp = IdentityProvider.objects.create(type="slack", external_id="slack:1", config={})
+        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
+        linking_url = build_linking_url(
+            self.integration,
+            "UXXXXXXX1",
+            "CXXXXXXX9",
+            "general",
+            "http://example.slack.com/response_url",
+        )
+
+        resp = self.client.get(linking_url)
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-link-team.html")
+
+        data = urlencode({"team": self.team.id})
+        resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-post-linked-team.html")
+
+        assert len(self.external_actor) == 1
+        assert self.external_actor[0].actor_id == self.team.actor_id
+
+        assert len(responses.calls) >= 1
+        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        assert (
+            f"The {self.team.slug} team will now receive issue alert notifications in the {self.external_actor[0].external_name} channel."
+            in data["text"]
+        )
+
+    def test_link_team_idp_does_not_exist(self):
+        """Test that get_identity fails if we cannot find a matching idp"""
+        self.get_slack_response(
+            {"text": "link team", "team_id": "slack:2", "user_id": "UA1J9RTE1"},
+            status_code=403,
+        )
+
+    def test_link_team_identity_does_not_exist(self):
+        """Test that get_identity fails if the user has no Identity and we reply with the LINK_USER_MESSAGE"""
+        user2 = self.create_user()
+        self.create_member(
+            teams=[self.team], user=user2, role="member", organization=self.organization
+        )
+        self.login_as(user2)
+        response = self.get_slack_response(
+            {"text": "link team", "team_id": self.external_id, "user_id": "UXXXXXXX2"}
+        )
+        data = json.loads(str(response.content.decode("utf-8")))
+        assert LINK_USER_MESSAGE in data["text"]
+
+    @responses.activate
+    def test_link_team_insufficient_role(self):
+        """Test that when a user whose role is insufficient and is a member of the
+        team in question in a closed membership org attempts to link a team, we reject
+        them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
+        user2 = self.create_user()
+        self.create_member(
+            teams=[self.team], user=user2, role="member", organization=self.organization
+        )
+        self.login_as(user2)
         Identity.objects.create(
-            external_id="UXXXXXXX1",
-            idp=idp,
-            user=self.user,
+            external_id="UXXXXXXX2",
+            idp=self.idp,
+            user=user2,
             status=IdentityStatus.VALID,
             scopes=[],
         )
-        response = self.get_slack_response(
-            {"text": "link team", "team_id": self.external_id, "user_id": "UXXXXXXX1"}
+        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
+        linking_url = build_linking_url(
+            self.integration,
+            "UXXXXXXX2",
+            "CXXXXXXX9",
+            "general",
+            "http://example.slack.com/response_url",
         )
-        data = json.loads(str(response.content.decode("utf-8")))
-        assert "Link your Sentry team to this Slack channel!" in data["text"]
+
+        resp = self.client.get(linking_url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-link-team.html")
+
+        data = urlencode({"team": self.team.id})
+        resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-post-linked-team.html")
+
+        assert len(self.external_actor) == 0
+
+        assert len(responses.calls) >= 1
+        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        assert "You must be an admin or higher" in data["text"]
+
+    @responses.activate
+    def test_link_team_insufficient_role_open_membership(self):
+        """Test that when a user whose role is insufficient in an open membership organization
+        attempts to link a team, we reject them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
+        self.organization.flags.allow_joinleave = True
+        user2 = self.create_user()
+        self.create_member(user=user2, role="member", organization=self.organization)
+        self.login_as(user2)
+        Identity.objects.create(
+            external_id="UXXXXXXX2",
+            idp=self.idp,
+            user=user2,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
+        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
+        linking_url = build_linking_url(
+            self.integration,
+            "UXXXXXXX2",
+            "CXXXXXXX9",
+            "general",
+            "http://example.slack.com/response_url",
+        )
+
+        resp = self.client.get(linking_url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-link-team.html")
+
+        data = urlencode({"team": self.team.id})
+        resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/slack-post-linked-team.html")
+
+        assert len(self.external_actor) == 0
+
+        assert len(responses.calls) >= 1
+        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
+        assert "You must be an admin or higher" in data["text"]
+
+    @responses.activate
+    def test_link_team_already_linked(self):
+        """Test that if a team has already been linked to a Slack channel when a user tries
+        to link them again, we reject the attempt and reply with the ALREADY_LINKED_MESSAGE"""
+        ExternalActor.objects.create(
+            actor_id=self.team.actor_id,
+            organization=self.organization,
+            integration=self.integration,
+            provider=ExternalProviders.SLACK.value,
+            external_name="general",
+            external_id="CXXXXXXX9",
+        )
+        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
         linking_url = build_linking_url(
             self.integration,
             "UXXXXXXX1",
@@ -112,65 +272,12 @@ class SlackCommandsPostTest(SlackCommandsTest):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/slack-link-team.html")
 
-        responses.add(
-            method=responses.POST,
-            url="https://slack.com/api/chat.postMessage",
-            body='{"ok": true}',
-            status=200,
-            content_type="application/json",
-        )
-
         data = urlencode({"team": self.team.id})
         resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/slack-post-linked-team.html")
-        external_actor = ExternalActor.objects.filter(
-            actor_id=self.team.actor_id,
-            organization=self.organization,
-            integration=self.integration,
-            provider=ExternalProviders.SLACK.value,
-            external_name="general",
-            external_id="CXXXXXXX9",
-        )
-        assert len(external_actor) == 1
-        assert external_actor[0].id == 1
-
         assert len(responses.calls) >= 1
         data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
         assert (
-            f"The {self.team.slug} team will now receive issue alert notifications in the {external_actor[0].external_name} channel."
-            in data["text"]
+            f"The {self.team.slug} team has already been linked to a Slack channel." in data["text"]
         )
-
-    def test_link_team_idp_does_not_exist(self):
-        """Test that get_identity fails if we cannot find a matching idp"""
-        IdentityProvider.objects.create(type="slack", external_id="slack:2", config={})
-        self.get_slack_response(
-            {"text": "link team", "team_id": self.external_id, "user_id": "UA1J9RTE1"},
-            status_code=404,
-        )
-
-    def test_link_team_identity_does_not_exist(self):
-        """Test that get_identity fails if the user has no Identity and we reply with the LINK_USER_MESSAGE"""
-        IdentityProvider.objects.create(type="slack", external_id="slack:1", config={})
-        response = self.get_slack_response(
-            {"text": "link team", "team_id": self.external_id, "user_id": "UXXXXXXX1"}
-        )
-        data = json.loads(str(response.content.decode("utf-8")))
-        assert LINK_USER_MESSAGE in data["text"]
-
-    def test_link_team_insufficient_role(self):
-        """Test that when a user whose role is insufficient and is not a member of the
-        team in question in a closed membership org attempts to link a team, we reject
-        them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
-        pass
-
-    def test_link_team_insufficient_role_open_membership(self):
-        """Test that when a user whose role is insufficient in an open membership organization
-        attempts to link a team, we reject them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
-        pass
-
-    def test_link_team_already_linked(self):
-        """Test that if a team has already been linked to a Slack channel when a user tries
-        to link them again, we reject the attempt and reply with the ALREADY_LINKED_MESSAGE"""
-        pass


### PR DESCRIPTION
Add the ability for a Sentry team to configure a Slack channel as the recipient of that team's project's issue alert notifications via the Slack slash command `/sentry link team`. For the time being all of a team's projects will be opted into "always" receiving issue alert notifications, but we are likely to expand this in the near future to allow more granular control (e.g. to turn off certain projects). Only a one to one relationship of team to Slack channel is supported. 

**Access**
The acting user must have the correct access level in order to complete the linking. If the user's identity is not linked, they will first need to do so (and are presented with a message letting them know how to do it). If the organization does not have open membership, the user must be a part of the relevant team and an admin or higher. If the organization does have open membership, the user must be an admin or higher.

**Flow**
The user types `/sentry link team` into the channel they wish to receive notifications in:
<img width="1053" alt="Screen Shot 2021-06-21 at 12 40 27 PM" src="https://user-images.githubusercontent.com/29959063/122818296-dd4d8980-d28d-11eb-9a47-252a32e7ea73.png">

When the user clicks this link they are taken to this page:
<img width="753" alt="Screen Shot 2021-06-21 at 12 41 36 PM" src="https://user-images.githubusercontent.com/29959063/122818435-0706b080-d28e-11eb-8078-fec170faff53.png">

After hitting submit they see this page:
(I know the sidebar looks bad, we have a [ticket](https://getsentry.atlassian.net/browse/API-1561) open for this)
<img width="754" alt="Screen Shot 2021-06-21 at 12 42 46 PM" src="https://user-images.githubusercontent.com/29959063/122818537-31586e00-d28e-11eb-85f4-e1af03bb439d.png">

The team receives confirmation in the relevant Slack channel that it's been completed successfully:
<img width="748" alt="Screen Shot 2021-06-21 at 12 44 29 PM" src="https://user-images.githubusercontent.com/29959063/122818747-6cf33800-d28e-11eb-820a-6c6d1d580290.png">