### PR TITLE
feat(performance): Track analytics for project thresholds

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -7,6 +7,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import {PanelItem} from 'app/components/panels';
 import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import routeTitleGen from 'app/utils/routeTitle';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
@@ -123,6 +124,16 @@ class ProjectPerformance extends AsyncView<Props, State> {
           apiMethod="POST"
           apiEndpoint={endpoint}
           onSubmitSuccess={resp => {
+            const initial = this.initialData;
+            const changedThreshold = initial.metric === resp.metric;
+            trackAnalyticsEvent({
+              eventKey: 'project_transaction_threshold.changed',
+              eventName: 'Project Transaction Threshold: Changed',
+              organization_id: this.props.organization.id,
+              from: changedThreshold ? initial.threshold : initial.metric,
+              to: changedThreshold ? resp.threshold : resp.metric,
+              key: changedThreshold ? 'threshold' : 'metric',
+            });
             this.setState({threshold: resp});
           }}
         >

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -52,6 +52,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
 
   handleDelete = () => {
     const {orgId, projectId} = this.props.params;
+    const {organization} = this.props;
 
     this.setState({
       loading: true,
@@ -59,6 +60,13 @@ class ProjectPerformance extends AsyncView<Props, State> {
 
     this.api.request(`/projects/${orgId}/${projectId}/transaction-threshold/configure/`, {
       method: 'DELETE',
+      success: () => {
+        trackAnalyticsEvent({
+          eventKey: 'performance_views.project_transaction_threshold.clear',
+          eventName: 'Project Transaction Threshold: Cleared',
+          organization_id: organization.id,
+        });
+      },
       complete: () => this.fetchData(),
     });
   };
@@ -127,9 +135,9 @@ class ProjectPerformance extends AsyncView<Props, State> {
             const initial = this.initialData;
             const changedThreshold = initial.metric === resp.metric;
             trackAnalyticsEvent({
-              eventKey: 'project_transaction_threshold.changed',
+              eventKey: 'performance_views.project_transaction_threshold.change',
               eventName: 'Project Transaction Threshold: Changed',
-              organization_id: this.props.organization.id,
+              organization_id: organization.id,
               from: changedThreshold ? initial.threshold : initial.metric,
               to: changedThreshold ? resp.threshold : resp.metric,
               key: changedThreshold ? 'threshold' : 'metric',


### PR DESCRIPTION
Track analytics events when transaction thresholds are changed
or cleared.

reload PR: https://github.com/getsentry/reload/pull/210