### PR TITLE
feat(semver): Introduce parser for release search and refactor how we create `SearchConfig`.

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -396,7 +396,7 @@ class SearchConfig:
 
     @classmethod
     def create_from(cls, search_config: "SearchConfig", **overrides):
-        config = SearchConfig(**asdict(search_config))
+        config = cls(**asdict(search_config))
         for key, val in overrides.items():
             setattr(config, key, val)
         return config

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1,6 +1,6 @@
 import re
 from collections import namedtuple
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any, List, Mapping, NamedTuple, Sequence, Set, Tuple, Union
 
@@ -387,6 +387,20 @@ class SearchConfig:
     # Enables boolean filtering (AND / OR)
     allow_boolean = True
 
+    # Allows us to specify an allowlist of keys we will accept for this search.
+    # If empty, allow all keys.
+    allowed_keys: Set[str] = field(default_factory=set)
+
+    # Which key we should return any free text under
+    free_text_key = "message"
+
+    @classmethod
+    def create_from(cls, search_config: "SearchConfig", **overrides):
+        config = SearchConfig(**asdict(search_config))
+        for key, val in overrides.items():
+            setattr(config, key, val)
+        return config
+
 
 class SearchVisitor(NodeVisitor):
     unwrapped_exceptions = (InvalidSearchQuery,)
@@ -446,13 +460,13 @@ class SearchVisitor(NodeVisitor):
     def visit_free_text(self, node, children):
         if not children[0]:
             return None
-        return SearchFilter(SearchKey("message"), "=", SearchValue(children[0]))
+        return SearchFilter(SearchKey(self.config.free_text_key), "=", SearchValue(children[0]))
 
     def visit_paren_group(self, node, children):
         if not self.config.allow_boolean:
             # It's possible to have a valid search that includes parens, so we
             # can't just error out when we find a paren expression.
-            return SearchFilter(SearchKey("message"), "=", SearchValue(node.text))
+            return SearchFilter(SearchKey(self.config.free_text_key), "=", SearchValue(node.text))
 
         children = remove_space(remove_optional_nodes(flatten(children)))
         children = flatten(children[1])
@@ -817,6 +831,8 @@ class SearchVisitor(NodeVisitor):
 
     def visit_search_key(self, node, children):
         key = children[0]
+        if self.config.allowed_keys and key not in self.config.allowed_keys:
+            raise InvalidSearchQuery("Invalid key for this search")
         return SearchKey(self.key_mappings_lookup.get(key, key))
 
     def visit_text_key(self, node, children):
@@ -970,7 +986,7 @@ default_config = SearchConfig(
 )
 
 
-def parse_search_query(query, config=None, params=None):
+def parse_search_query(query, config=None, params=None) -> Sequence[SearchFilter]:
     if config is None:
         config = default_config
 

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -1,4 +1,3 @@
-from dataclasses import asdict
 from functools import partial
 from typing import List, Union
 
@@ -27,28 +26,28 @@ for status_key, status_value in STATUS_QUERY_CHOICES.items():
     is_filter_translation[status_key] = ("status", status_value)
 
 
-issue_search_config = SearchConfig(**asdict(default_config))
-issue_search_config.allow_boolean = False
-issue_search_config.is_filter_translation = is_filter_translation
-issue_search_config.numeric_keys |= {"times_seen"}
-issue_search_config.date_keys |= {"active_at", "date"}
-issue_search_config.key_mappings = {
-    "assigned_to": ["assigned"],
-    "bookmarked_by": ["bookmarks"],
-    "subscribed_by": ["subscribed"],
-    "assigned_or_suggested": ["assigned_or_suggested"],
-    "first_release": ["first-release", "firstRelease"],
-    "first_seen": ["age", "firstSeen"],
-    "last_seen": ["lastSeen"],
-    "active_at": ["activeSince"],
-    # TODO: Special case this in the backends, since they currently rely
-    # on date_from and date_to explicitly
-    "date": ["event.timestamp"],
-    "times_seen": ["timesSeen"],
-    "sentry:dist": ["dist"],
-}
-
-
+issue_search_config = SearchConfig.create_from(
+    default_config,
+    allow_boolean=False,
+    is_filter_translation=is_filter_translation,
+    numeric_keys=default_config.numeric_keys | {"times_seen"},
+    date_keys=default_config.date_keys | {"active_at", "date"},
+    key_mappings={
+        "assigned_to": ["assigned"],
+        "bookmarked_by": ["bookmarks"],
+        "subscribed_by": ["subscribed"],
+        "assigned_or_suggested": ["assigned_or_suggested"],
+        "first_release": ["first-release", "firstRelease"],
+        "first_seen": ["age", "firstSeen"],
+        "last_seen": ["lastSeen"],
+        "active_at": ["activeSince"],
+        # TODO: Special case this in the backends, since they currently rely
+        # on date_from and date_to explicitly
+        "date": ["event.timestamp"],
+        "times_seen": ["timesSeen"],
+        "sentry:dist": ["dist"],
+    },
+)
 parse_search_query = partial(base_parse_query, config=issue_search_config)
 
 

--- a/src/sentry/api/release_search.py
+++ b/src/sentry/api/release_search.py
@@ -1,0 +1,14 @@
+from functools import partial
+
+from sentry.api.event_search import SearchConfig, default_config, parse_search_query
+from sentry.search.events.constants import SEMVER_ALIAS
+
+RELEASE_FREE_TEXT_KEY = "release"
+
+release_search_config = SearchConfig.create_from(
+    default_config,
+    allowed_keys={SEMVER_ALIAS},
+    allow_boolean=False,
+    free_text_key=RELEASE_FREE_TEXT_KEY,
+)
+parse_search_query = partial(parse_search_query, config=release_search_config)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -3,6 +3,7 @@ import os
 import unittest
 from datetime import timedelta
 
+import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -363,6 +364,23 @@ class ParseSearchQueryBackendTest(unittest.TestCase):
         # quoted key
         assert parse_search_query('!has:"hi:there"') == [
             SearchFilter(key=SearchKey(name="hi:there"), operator="=", value=SearchValue(""))
+        ]
+
+    def test_allowed_keys(self):
+        config = SearchConfig(allowed_keys=["good_key"])
+
+        assert parse_search_query("good_key:123 bad_key:123 text") == [
+            SearchFilter(key=SearchKey(name="good_key"), operator="=", value=SearchValue("123")),
+            SearchFilter(key=SearchKey(name="bad_key"), operator="=", value=SearchValue("123")),
+            SearchFilter(key=SearchKey(name="message"), operator="=", value=SearchValue("text")),
+        ]
+
+        with pytest.raises(InvalidSearchQuery, match="Invalid key for this search"):
+            assert parse_search_query("good_key:123 bad_key:123 text", config=config)
+
+        assert parse_search_query("good_key:123 text") == [
+            SearchFilter(key=SearchKey(name="good_key"), operator="=", value=SearchValue("123")),
+            SearchFilter(key=SearchKey(name="message"), operator="=", value=SearchValue("text")),
         ]
 
     def test_invalid_aggregate_column_with_duration_filter(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -378,7 +378,7 @@ class ParseSearchQueryBackendTest(unittest.TestCase):
         with pytest.raises(InvalidSearchQuery, match="Invalid key for this search"):
             assert parse_search_query("good_key:123 bad_key:123 text", config=config)
 
-        assert parse_search_query("good_key:123 text") == [
+        assert parse_search_query("good_key:123 text", config=config) == [
             SearchFilter(key=SearchKey(name="good_key"), operator="=", value=SearchValue("123")),
             SearchFilter(key=SearchKey(name="message"), operator="=", value=SearchValue("text")),
         ]

--- a/tests/sentry/api/test_release_search.py
+++ b/tests/sentry/api/test_release_search.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+
+import pytest
+
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.api.release_search import RELEASE_FREE_TEXT_KEY, parse_search_query
+from sentry.exceptions import InvalidSearchQuery
+from sentry.search.events.constants import SEMVER_ALIAS
+
+
+class ParseSearchQueryTest(TestCase):
+    def test_invalid_key(self):
+        with pytest.raises(InvalidSearchQuery, match="Invalid key for this search"):
+            parse_search_query("bad_key:>1.2.3")
+
+    def test_semver(self):
+        assert parse_search_query(f"{SEMVER_ALIAS}:>1.2.3") == [
+            SearchFilter(key=SearchKey(name=SEMVER_ALIAS), operator=">", value=SearchValue("1.2.3"))
+        ]
+        assert parse_search_query(f"{SEMVER_ALIAS}:>1.2.3 1.2.*") == [
+            SearchFilter(
+                key=SearchKey(name=SEMVER_ALIAS), operator=">", value=SearchValue("1.2.3")
+            ),
+            SearchFilter(
+                key=SearchKey(name=RELEASE_FREE_TEXT_KEY), operator="=", value=SearchValue("1.2.*")
+            ),
+        ]


### PR DESCRIPTION
We need a new parser for release search. It shares a lot of logic with the event and issue search
parsers, but we need to be able to:
 - restrict the keys we actually allow
 - rename the free text key to something that makes sense for releases

I've updated the parsers to have this functionality in their configs. Also added
`SearchConfig.create_from` to allow easier overriding of search config values from the base values.

We start using the new parser in `organization_releases.py`, but we don't support semver there yet.
Will do so in an upcoming pr.