### PR TITLE
ref(search): Simplify tokenizeSearch API surface

### DIFF
--- a/static/app/components/deployBadge.tsx
+++ b/static/app/components/deployBadge.tsx
@@ -3,7 +3,7 @@ import Tag from 'app/components/tag';
 import {IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import {Deploy} from 'app/types';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 
 type Props = {
   deploy: Deploy;
@@ -39,7 +39,7 @@ const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) =>
         query: {
           project: projectId ?? null,
           environment: deploy.environment,
-          query: stringifyQueryObject(new QueryResults([`release:${version!}`])),
+          query: new QueryResults([`release:${version!}`]).formatString(),
         },
       }}
     >

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -17,7 +17,7 @@ import {Sort} from 'app/utils/discover/fields';
 import BaselineQuery from 'app/utils/performance/baseline/baselineQuery';
 import {TrendsEventsDiscoverQuery} from 'app/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {Actions} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 import {decodeColumnOrder} from 'app/views/eventsV2/utils';
@@ -140,7 +140,7 @@ class TransactionsList extends React.Component<Props> {
     if (selected.query) {
       const query = tokenizeSearch(sortedEventView.query);
       selected.query.forEach(item => query.setTagValues(item[0], [item[1]]));
-      sortedEventView.query = stringifyQueryObject(query);
+      sortedEventView.query = query.formatString();
     }
 
     return sortedEventView;
@@ -314,7 +314,7 @@ class TransactionsList extends React.Component<Props> {
     if (selected.query) {
       const query = tokenizeSearch(sortedEventView.query);
       selected.query.forEach(item => query.setTagValues(item[0], [item[1]]));
-      sortedEventView.query = stringifyQueryObject(query);
+      sortedEventView.query = query.formatString();
     }
     const cursor = decodeScalar(location.query?.[cursorName]);
 

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -13,7 +13,7 @@ import {
   TraceError,
 } from 'app/utils/performance/quickTrace/types';
 import {getTraceTimeRangeFromEvent} from 'app/utils/performance/quickTrace/utils';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {getTransactionDetailsUrl} from 'app/views/performance/utils';
 
@@ -119,7 +119,7 @@ export function generateMultiTransactionsTarget(
     name: `${groupType} Transactions of Event ID ${currentEvent.id}`,
     fields: ['transaction', 'project', 'trace.span', 'transaction.duration', 'timestamp'],
     orderby: '-timestamp',
-    query: stringifyQueryObject(queryResults),
+    query: queryResults.formatString(),
     projects: [...new Set(events.map(child => child.project_id))],
     version: 2,
     start,

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -23,7 +23,7 @@ import {
 import {decodeColumnOrder} from 'app/views/eventsV2/utils';
 
 import {statsPeriodToDays} from '../dates';
-import {QueryResults, stringifyQueryObject, tokenizeSearch} from '../tokenizeSearch';
+import {QueryResults, tokenizeSearch} from '../tokenizeSearch';
 
 import {getSortField} from './fieldRenderers';
 import {
@@ -1253,7 +1253,7 @@ class EventView {
     Object.entries(this.additionalConditions.tagValues).forEach(([tag, tagValues]) => {
       conditions.addTagValues(tag, tagValues);
     });
-    return stringifyQueryObject(conditions);
+    return conditions.formatString();
   }
 }
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -296,13 +296,6 @@ export function tokenizeSearch(query: string) {
 }
 
 /**
- * Convert a QueryResults object back to a query string
- */
-export function stringifyQueryObject(results: QueryResults) {
-  return results.formatString();
-}
-
-/**
  * Splits search strings into tokens for parsing by tokenizeSearch.
  *
  * Should stay in sync with src.sentry.search.utils:split_query_into_tokens

--- a/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
@@ -10,7 +10,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
 import {GlobalSelection, Organization, Project, SessionApiResponse} from 'app/types';
 import {Series} from 'app/types/echarts';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 import {getInterval} from 'app/views/releases/detail/overview/chart/utils';
 import {roundDuration} from 'app/views/releases/utils';
 
@@ -109,7 +109,7 @@ function StatsRequest({
           .filter(tag => !!tag);
 
         if (!!tagsWithDoubleQuotes.length) {
-          query.query = stringifyQueryObject(new QueryResults(tagsWithDoubleQuotes));
+          query.query = new QueryResults(tagsWithDoubleQuotes).formatString();
         }
       }
 

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -32,7 +32,7 @@ import {
 } from 'app/utils/discover/fields';
 import {DisplayModes, TOP_N} from 'app/utils/discover/types';
 import {eventDetailsRouteWithEventView, generateEventSlug} from 'app/utils/discover/urls';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
@@ -418,7 +418,7 @@ class TableView extends React.Component<TableViewProps> {
           updateQuery(query, action, column, value);
         }
       }
-      nextView.query = stringifyQueryObject(query);
+      nextView.query = query.formatString();
 
       browserHistory.push(nextView.getResultsViewUrlTarget(organization.slug));
     };

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -28,7 +28,7 @@ import {
 } from 'app/utils/discover/fields';
 import {getTitle} from 'app/utils/events';
 import localStorage from 'app/utils/localStorage';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 import {FieldValue, FieldValueKind, TableColumn} from './table/types';
 import {ALL_VIEWS, TRANSACTION_VIEWS, WEB_VITALS_VIEWS} from './data';
@@ -416,7 +416,7 @@ function generateExpandedConditions(
     parsedQuery.setTagValues(key, [value]);
   }
 
-  return stringifyQueryObject(parsedQuery);
+  return parsedQuery.formatString();
 }
 
 type FieldGeneratorOpts = {

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -20,11 +20,7 @@ import {GlobalSelection, Organization, Project} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {
-  QueryResults,
-  stringifyQueryObject,
-  tokenizeSearch,
-} from 'app/utils/tokenizeSearch';
+import {QueryResults, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -166,7 +162,7 @@ class PerformanceContent extends Component<Props, State> {
         `<${DEFAULT_MAX_DURATION}`,
       ]);
     }
-    newQuery.query = stringifyQueryObject(modifiedConditions);
+    newQuery.query = modifiedConditions.formatString();
 
     browserHistory.push({
       pathname: getPerformanceTrendsUrl(organization),

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -5,7 +5,7 @@ import {t} from 'app/locale';
 import {LightWeightOrganization, NewQuery, SelectValue} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from './landing/utils';
 import {
@@ -363,7 +363,7 @@ function generateGenericPerformanceEventView(
     conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
     conditions.query = [];
   }
-  savedQuery.query = stringifyQueryObject(conditions);
+  savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions.addTagValues('event.type', ['transaction']);
@@ -432,7 +432,7 @@ function generateBackendPerformanceEventView(
     conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
     conditions.query = [];
   }
-  savedQuery.query = stringifyQueryObject(conditions);
+  savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions.addTagValues('event.type', ['transaction']);
@@ -499,7 +499,7 @@ function generateFrontendPageloadPerformanceEventView(
     conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
     conditions.query = [];
   }
-  savedQuery.query = stringifyQueryObject(conditions);
+  savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions
@@ -568,7 +568,7 @@ function generateFrontendOtherPerformanceEventView(
     conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
     conditions.query = [];
   }
-  savedQuery.query = stringifyQueryObject(conditions);
+  savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions
@@ -646,7 +646,7 @@ export function generatePerformanceVitalDetailView(
     conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
     conditions.query = [];
   }
-  savedQuery.query = stringifyQueryObject(conditions);
+  savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions

--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -16,7 +16,7 @@ import EventView from 'app/utils/discover/eventView';
 import {generateAggregateFields} from 'app/utils/discover/fields';
 import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withTeams from 'app/utils/withTeams';
 
 import Charts from '../charts/index';
@@ -61,7 +61,7 @@ class LandingContent extends Component<Props, State> {
     const parsed = tokenizeSearch(query);
     parsed.query = [];
 
-    return stringifyQueryObject(parsed);
+    return parsed.formatString();
   }
 
   handleLandingDisplayChange = (field: string) => {
@@ -94,7 +94,7 @@ class LandingContent extends Component<Props, State> {
       pathname: location.pathname,
       query: {
         ...newQuery,
-        query: stringifyQueryObject(searchConditions),
+        query: searchConditions.formatString(),
         landingDisplay: field,
       },
     });

--- a/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
+++ b/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
@@ -8,7 +8,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 
 import _Footer from '../../charts/footer';
@@ -40,7 +40,7 @@ function DoubleAxisDisplay(props: Props) {
       `>=${Math.round(minValue)}`,
       `<${Math.round(maxValue)}`,
     ]);
-    const query = stringifyQueryObject(conditions);
+    const query = conditions.formatString();
 
     trackAnalyticsEvent({
       eventKey: 'performance_views.landingv2.display.filter_change',

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -17,7 +17,7 @@ import DiscoverQuery, {TableData, TableDataRow} from 'app/utils/discover/discove
 import EventView, {EventData, isFieldSortable} from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'app/utils/discover/fields';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -101,7 +101,7 @@ class Table extends React.Component<Props, State> {
         query: {
           ...location.query,
           cursor: undefined,
-          query: stringifyQueryObject(searchConditions),
+          query: searchConditions.formatString(),
         },
       });
     };

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -25,7 +25,7 @@ import {
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
@@ -133,7 +133,7 @@ class SummaryContent extends React.Component<Props, State> {
         query: {
           ...location.query,
           cursor: undefined,
-          query: stringifyQueryObject(searchConditions),
+          query: searchConditions.formatString(),
         },
       });
     };

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -24,7 +24,7 @@ import {
 } from 'app/utils/discover/fields';
 import {removeHistogramQueryStrings} from 'app/utils/performance/histogram';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -323,7 +323,7 @@ function generateSummaryEventView(
       version: 2,
       name: transactionName,
       fields,
-      query: stringifyQueryObject(conditions),
+      query: conditions.formatString(),
       projects: [],
     },
     location

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -16,7 +16,7 @@ import {OrganizationSummary} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {TRACING_FIELDS} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 type Props = {
   organization: OrganizationSummary;
@@ -68,7 +68,7 @@ class RelatedIssues extends Component<Props> {
       path: `/organizations/${organization.slug}/issues/`,
       queryParams: {
         ...queryParams,
-        query: stringifyQueryObject(currentFilter),
+        query: currentFilter.formatString(),
       },
     };
   }

--- a/static/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -14,7 +14,7 @@ import {t} from 'app/locale';
 import {LightWeightOrganization} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {getTermHelp, PERFORMANCE_TERM} from 'app/views/performance/data';
 
 type Props = {
@@ -76,7 +76,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
                 query: {
                   ...location.query,
                   cursor: undefined,
-                  query: stringifyQueryObject(query),
+                  query: query.formatString(),
                 },
               });
             },

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -24,7 +24,7 @@ import SegmentExplorerQuery, {
   TableDataRow,
 } from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -281,7 +281,7 @@ class _TagExplorer extends React.Component<Props> {
 
     conditions.addTagValues(tagKey, [tagValue]);
 
-    const query = stringifyQueryObject(conditions);
+    const query = conditions.formatString();
     browserHistory.push({
       pathname: location.pathname,
       query: {
@@ -316,7 +316,7 @@ class _TagExplorer extends React.Component<Props> {
         query: {
           ...location.query,
           [TAGS_CURSOR_NAME]: undefined,
-          query: stringifyQueryObject(searchConditions),
+          query: searchConditions.formatString(),
         },
       });
     };

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -18,7 +18,7 @@ import {Organization, Project} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -78,7 +78,7 @@ class EventsPageContent extends React.Component<Props, State> {
         query: {
           ...location.query,
           cursor: undefined,
-          query: stringifyQueryObject(searchConditions),
+          query: searchConditions.formatString(),
         },
       });
     };

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -16,7 +16,7 @@ import {
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -165,7 +165,7 @@ function generateEventsEventView(
       version: 2,
       name: transactionName,
       fields,
-      query: stringifyQueryObject(conditions),
+      query: conditions.formatString(),
       projects: [],
       orderby: '-timestamp',
     },

--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -13,7 +13,7 @@ import {PageContent} from 'app/styles/organization';
 import {GlobalSelection, Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -147,7 +147,7 @@ function generateTagsEventView(
       version: 2,
       name: transactionName,
       fields: ['transaction.duration'],
-      query: stringifyQueryObject(conditions),
+      query: conditions.formatString(),
       projects: [],
     },
     location

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -21,7 +21,7 @@ import {
   TableDataRow,
 } from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -170,7 +170,7 @@ export class TagValueTable extends Component<Props, State> {
 
     conditions.addTagValues(tagKey, [tagValue]);
 
-    const query = stringifyQueryObject(conditions);
+    const query = conditions.formatString();
     browserHistory.push({
       pathname: location.pathname,
       query: {
@@ -199,7 +199,7 @@ export class TagValueTable extends Component<Props, State> {
         query: {
           ...location.query,
           [TAGS_CURSOR_NAME]: undefined,
-          query: stringifyQueryObject(searchConditions),
+          query: searchConditions.formatString(),
         },
       });
     };

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
@@ -15,7 +15,7 @@ import EventView from 'app/utils/discover/eventView';
 import {isAggregateField, WebVital} from 'app/utils/discover/fields';
 import {WEB_VITAL_DETAILS} from 'app/utils/performance/vitals/constants';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -169,7 +169,7 @@ function generateRumEventView(
           vital => `count_at_least(${vital}, ${WEB_VITAL_DETAILS[vital].poorThreshold})`
         ),
       ],
-      query: stringifyQueryObject(conditions),
+      query: conditions.formatString(),
       projects: [],
     },
     location

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -24,7 +24,7 @@ import {computeBuckets, formatHistogramData} from 'app/utils/performance/histogr
 import {Vital} from 'app/utils/performance/vitals/types';
 import {VitalData} from 'app/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {Theme} from 'app/utils/theme';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 import {VitalBar} from '../../landing/vitalsCards';
 import {
@@ -176,7 +176,7 @@ class VitalCard extends Component<Props, State> {
         query.addTagValues(column, [`<=${max}`]);
       }
     }
-    newEventView.query = stringifyQueryObject(query);
+    newEventView.query = query.formatString();
 
     return (
       <CardSummary>

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -26,7 +26,7 @@ import {AvatarProject, Organization, Project} from 'app/types';
 import {formatPercentage, getDuration} from 'app/utils/formatters';
 import TrendsDiscoverQuery from 'app/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -165,7 +165,7 @@ function handleFilterTransaction(location: Location, transaction: string) {
 
   conditions.addTagValues('!transaction', [transaction]);
 
-  const query = stringifyQueryObject(conditions);
+  const query = conditions.formatString();
 
   browserHistory.push({
     pathname: location.pathname,
@@ -194,7 +194,7 @@ function handleFilterDuration(location: Location, value: number, symbol: FilterS
 
   conditions.addTagValues(durationTag, [`${symbol}${value}`]);
 
-  const query = stringifyQueryObject(conditions);
+  const query = conditions.formatString();
 
   browserHistory.push({
     pathname: location.pathname,

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -18,7 +18,7 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {generateAggregateFields} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import {getPerformanceLandingUrl, getTransactionSearchQuery} from '../utils';
@@ -153,7 +153,7 @@ class TrendsContent extends React.Component<Props, State> {
     conditions.removeTag('tpm()');
     conditions.removeTag('confidence()');
     conditions.removeTag('transaction.duration');
-    newQuery.query = stringifyQueryObject(conditions);
+    newQuery.query = conditions.formatString();
     return {
       pathname: getPerformanceLandingUrl(this.props.organization),
       query: newQuery,
@@ -324,7 +324,7 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
       conditions.setTagValues(trendParameter.column, ['>0', `<${DEFAULT_MAX_DURATION}`]);
     }
 
-    const query = stringifyQueryObject(conditions);
+    const query = conditions.formatString();
     eventView.query = query;
 
     browserHistory.push({

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -24,7 +24,7 @@ import VitalsDetailsTableQuery, {
   TableData,
   TableDataRow,
 } from 'app/utils/performance/vitals/vitalsDetailsTableQuery';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -118,7 +118,7 @@ class Table extends React.Component<Props, State> {
         query: {
           ...location.query,
           cursor: undefined,
-          query: stringifyQueryObject(searchConditions),
+          query: searchConditions.formatString(),
         },
       });
     };
@@ -178,7 +178,7 @@ class Table extends React.Component<Props, State> {
       const summaryView = eventView.clone();
       const conditions = tokenizeSearch(summaryConditions);
       conditions.addTagValues('has', [`${vitalName}`]);
-      summaryView.query = stringifyQueryObject(conditions);
+      summaryView.query = conditions.formatString();
 
       const target = transactionSummaryRouteWithQuery({
         orgSlug: organization.slug,

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -22,7 +22,7 @@ import {generateQueryWithTag} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
 import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import withTeams from 'app/utils/withTeams';
 
@@ -56,7 +56,7 @@ function getSummaryConditions(query: string) {
   const parsed = tokenizeSearch(query);
   parsed.query = [];
 
-  return stringifyQueryObject(parsed);
+  return parsed.formatString();
 }
 
 class VitalDetailContent extends React.Component<Props, State> {

--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -10,7 +10,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {DEFAULT_MAX_DURATION} from 'app/views/performance/trends/utils';
 import {
   getPerformanceLandingUrl,
@@ -37,7 +37,7 @@ function ProjectQuickLinks({organization, project, location}: Props) {
       query: {
         project: project?.id,
         cursor: undefined,
-        query: stringifyQueryObject(conditions),
+        query: conditions.formatString(),
       },
     };
   }

--- a/static/app/views/releases/detail/overview/chart/utils.tsx
+++ b/static/app/views/releases/detail/overview/chart/utils.tsx
@@ -11,7 +11,7 @@ import EventView from 'app/utils/discover/eventView';
 import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
 import {formatVersion} from 'app/utils/formatters';
 import {WEB_VITAL_DETAILS} from 'app/utils/performance/vitals/constants';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 import {getCrashFreePercent} from 'app/views/releases/utils';
 import {sessionTerm} from 'app/views/releases/utils/sessionTerm';
 
@@ -86,11 +86,9 @@ export function getReleaseEventView(
       );
       return EventView.fromSavedQuery({
         ...baseQuery,
-        query: stringifyQueryObject(
-          new QueryResults(
-            ['event.type:transaction', releaseFilter, ...statusFilters].filter(Boolean)
-          )
-        ),
+        query: new QueryResults(
+          ['event.type:transaction', releaseFilter, ...statusFilters].filter(Boolean)
+        ).formatString(),
       });
     case YAxis.COUNT_VITAL:
     case YAxis.COUNT_DURATION:
@@ -101,32 +99,31 @@ export function getReleaseEventView(
           : WEB_VITAL_DETAILS[vitalType].poorThreshold;
       return EventView.fromSavedQuery({
         ...baseQuery,
-        query: stringifyQueryObject(
-          new QueryResults(
-            [
-              'event.type:transaction',
-              releaseFilter,
-              threshold ? `${column}:>${threshold}` : '',
-            ].filter(Boolean)
-          )
-        ),
+        query: new QueryResults(
+          [
+            'event.type:transaction',
+            releaseFilter,
+            threshold ? `${column}:>${threshold}` : '',
+          ].filter(Boolean)
+        ).formatString(),
       });
     case YAxis.EVENTS:
       const eventTypeFilter =
         eventType === EventType.ALL ? '' : `event.type:${eventType}`;
       return EventView.fromSavedQuery({
         ...baseQuery,
-        query: stringifyQueryObject(
-          new QueryResults([releaseFilter, eventTypeFilter].filter(Boolean))
-        ),
+        query: new QueryResults(
+          [releaseFilter, eventTypeFilter].filter(Boolean)
+        ).formatString(),
       });
     default:
       return EventView.fromSavedQuery({
         ...baseQuery,
         fields: ['issue', 'title', 'count()', 'count_unique(user)', 'project'],
-        query: stringifyQueryObject(
-          new QueryResults([`release:${version}`, '!event.type:transaction'])
-        ),
+        query: new QueryResults([
+          `release:${version}`,
+          '!event.type:transaction',
+        ]).formatString(),
         orderby: '-count',
       });
   }

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -17,7 +17,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection} from 'app/types';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 import {IssueSortOptions} from 'app/views/issueList/utils';
 
 import EmptyState from '../emptyState';
@@ -89,7 +89,7 @@ class Issues extends Component<Props, State> {
         ...queryParams,
         limit: undefined,
         cursor: undefined,
-        query: stringifyQueryObject(query),
+        query: query.formatString(),
       },
     };
   }
@@ -111,7 +111,7 @@ class Issues extends Component<Props, State> {
           path: `/organizations/${orgId}/issues/`,
           queryParams: {
             ...queryParams,
-            query: stringifyQueryObject(new QueryResults([`release:${version}`])),
+            query: new QueryResults([`release:${version}`]).formatString(),
           },
         };
       case IssuesType.RESOLVED:
@@ -124,9 +124,10 @@ class Issues extends Component<Props, State> {
           path: `/organizations/${orgId}/issues/`,
           queryParams: {
             ...queryParams,
-            query: stringifyQueryObject(
-              new QueryResults([`release:${version}`, 'error.handled:0'])
-            ),
+            query: new QueryResults([
+              `release:${version}`,
+              'error.handled:0',
+            ]).formatString(),
           },
         };
       case IssuesType.NEW:
@@ -135,7 +136,7 @@ class Issues extends Component<Props, State> {
           path: `/organizations/${orgId}/issues/`,
           queryParams: {
             ...queryParams,
-            query: stringifyQueryObject(new QueryResults([`first-release:${version}`])),
+            query: new QueryResults([`first-release:${version}`]).formatString(),
           },
         };
     }

--- a/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -16,7 +16,7 @@ import {Series} from 'app/types/echarts';
 import {defined} from 'app/utils';
 import {WebVital} from 'app/utils/discover/fields';
 import {getExactDuration} from 'app/utils/formatters';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 
 import {displayCrashFreePercent, roundDuration} from '../../utils';
 
@@ -108,7 +108,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
     const {version, organization, location, selection, defaultStatsPeriod} = this.props;
 
     return {
-      query: stringifyQueryObject(new QueryResults([`release:"${version}"`])),
+      query: new QueryResults([`release:"${version}"`]).formatString(),
       interval: getInterval(selection.datetime, {
         highFidelity: organization.features.includes('minute-resolution-sessions'),
       }),
@@ -202,7 +202,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
           ...this.baseQueryParams,
           field: 'sum(session)',
           groupBy: 'session.status',
-          query: stringifyQueryObject(new QueryResults([`!release:"${version}"`])),
+          query: new QueryResults([`!release:"${version}"`]).formatString(),
         },
       }),
     ]);
@@ -251,7 +251,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
           ...this.baseQueryParams,
           field: 'count_unique(user)',
           groupBy: 'session.status',
-          query: stringifyQueryObject(new QueryResults([`!release:"${version}"`])),
+          query: new QueryResults([`!release:"${version}"`]).formatString(),
         },
       }),
     ]);
@@ -300,7 +300,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
           ...this.baseQueryParams,
           field: ['sum(session)', 'count_unique(user)'],
           groupBy: 'session.status',
-          query: stringifyQueryObject(new QueryResults([`!release:"${version}"`])),
+          query: new QueryResults([`!release:"${version}"`]).formatString(),
         },
       }),
     ]);
@@ -370,7 +370,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         query: {
           ...this.baseQueryParams,
           field: 'p50(session.duration)',
-          query: stringifyQueryObject(new QueryResults([`!release:"${version}"`])),
+          query: new QueryResults([`!release:"${version}"`]).formatString(),
         },
       }),
     ]);

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -13,7 +13,7 @@ import {
 } from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 
 export type CommitsByRepository = {
   [key: string]: Commit[];
@@ -117,9 +117,11 @@ export function getReleaseEventView(
     version: 2,
     name: `${t('Release Apdex')}`,
     fields: [apdexField],
-    query: stringifyQueryObject(
-      new QueryResults([`release:${version}`, 'event.type:transaction', 'count():>0'])
-    ),
+    query: new QueryResults([
+      `release:${version}`,
+      'event.type:transaction',
+      'count():>0',
+    ]).formatString(),
     range: period,
     environment: environments,
     projects,

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -2,7 +2,7 @@ import round from 'lodash/round';
 
 import {tn} from 'app/locale';
 import {Release, ReleaseStatus} from 'app/types';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 import {IssueSortOptions} from 'app/views/issueList/utils';
 
 import {DisplayOption} from '../list/utils';
@@ -56,7 +56,7 @@ export const getReleaseNewIssuesUrl = (
       statsPeriod: undefined,
       start: undefined,
       end: undefined,
-      query: stringifyQueryObject(new QueryResults([`firstRelease:${version}`])),
+      query: new QueryResults([`firstRelease:${version}`]).formatString(),
       sort: IssueSortOptions.FREQ,
     },
   };
@@ -71,9 +71,10 @@ export const getReleaseUnhandledIssuesUrl = (
     pathname: `/organizations/${orgSlug}/issues/`,
     query: {
       project: projectId,
-      query: stringifyQueryObject(
-        new QueryResults([`release:${version}`, 'error.unhandled:true'])
-      ),
+      query: new QueryResults([
+        `release:${version}`,
+        'error.unhandled:true',
+      ]).formatString(),
       sort: IssueSortOptions.FREQ,
     },
   };

--- a/static/app/views/releases/utils/releaseHealthRequest.tsx
+++ b/static/app/views/releases/utils/releaseHealthRequest.tsx
@@ -24,7 +24,7 @@ import {
   SessionApiResponse,
 } from 'app/types';
 import {defined, percent} from 'app/utils';
-import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {QueryResults} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 
 import {DisplayOption} from '../list/utils';
@@ -142,18 +142,16 @@ class ReleaseHealthRequest extends React.Component<Props, State> {
     const {location, selection, defaultStatsPeriod, releases} = this.props;
 
     return {
-      query: stringifyQueryObject(
-        new QueryResults(
-          releases.reduce((acc, release, index, allReleases) => {
-            acc.push(`release:"${release}"`);
-            if (index < allReleases.length - 1) {
-              acc.push('OR');
-            }
+      query: new QueryResults(
+        releases.reduce((acc, release, index, allReleases) => {
+          acc.push(`release:"${release}"`);
+          if (index < allReleases.length - 1) {
+            acc.push('OR');
+          }
 
-            return acc;
-          }, [] as string[])
-        )
-      ),
+          return acc;
+        }, [] as string[])
+      ).formatString(),
       interval: getInterval(selection.datetime),
       ...getParams(pick(location.query, Object.values(URL_PARAM)), {
         defaultStatsPeriod,

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -6,7 +6,7 @@ import Switch from 'app/components/switchButton';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {MemberRole} from 'app/types';
-import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 type Props = {
   className?: string;
@@ -56,7 +56,7 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
 
     const newSearch = search.copy();
     newSearch.setTagValues('role', [...roleList]);
-    onChange(stringifyQueryObject(newSearch));
+    onChange(newSearch.formatString());
   };
 
   const handleBoolFilter = (key: keyof Filters) => (value: boolean | null) => {
@@ -66,7 +66,7 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
       newQueryObject.setTagValues(key, [Boolean(value).toString()]);
     }
 
-    onChange(stringifyQueryObject(newQueryObject));
+    onChange(newQueryObject.formatString());
   };
 
   return (

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -1,9 +1,4 @@
-import {
-  QueryResults,
-  stringifyQueryObject,
-  tokenizeSearch,
-  TokenType,
-} from 'app/utils/tokenizeSearch';
+import {QueryResults, tokenizeSearch, TokenType} from 'app/utils/tokenizeSearch';
 
 describe('utils/tokenizeSearch', function () {
   describe('tokenizeSearch()', function () {
@@ -379,7 +374,7 @@ describe('utils/tokenizeSearch', function () {
     });
   });
 
-  describe('stringifyQueryObject()', function () {
+  describe('QueryResults.formatString', function () {
     const cases = [
       {
         name: 'should convert a basic object to a query string',
@@ -485,7 +480,7 @@ describe('utils/tokenizeSearch', function () {
     ];
 
     for (const {name, string, object} of cases) {
-      it(name, () => expect(stringifyQueryObject(object)).toEqual(string));
+      it(name, () => expect(object.formatString()).toEqual(string));
     }
   });
 });


### PR DESCRIPTION
Removes the stringifyQueryObject and juse calls `formatString` on the query object instead.