### PR TITLE
feat(semver): Add semver filtering to organization release endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -27,6 +27,7 @@ from sentry.models import (
     ReleaseProject,
     ReleaseStatus,
 )
+from sentry.search.events.constants import OPERATOR_TO_DJANGO, SEMVER_ALIAS
 from sentry.signals import release_created
 from sentry.snuba.sessions import (
     STATS_PERIODS,
@@ -211,6 +212,13 @@ class OrganizationReleasesEndpoint(
                         query_q |= Q(version__icontains="%s+%s" % suffix_match.groups())
 
                     queryset = queryset.filter(query_q)
+
+                if search_filter.key.name == SEMVER_ALIAS:
+                    queryset = queryset.filter_by_semver(
+                        organization.id,
+                        OPERATOR_TO_DJANGO[search_filter.operator],
+                        search_filter.value.raw_value,
+                    )
 
         select_extra = {}
 

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -162,7 +162,7 @@ class ReleaseQuerySet(models.QuerySet):
             )
 
             return (
-                Release.objects.filter(release_filter)
+                self.filter(release_filter)
                 .annotate_prerelease_column()
                 .annotate(
                     semver=Func(

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -27,6 +27,7 @@ from sentry.models import (
     Repository,
 )
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
+from sentry.search.events.constants import SEMVER_ALIAS
 from sentry.testutils import APITestCase, ReleaseCommitPatchTest, SetRefsTestCase, TestCase
 from sentry.utils.compat.mock import patch
 
@@ -246,6 +247,24 @@ class OrganizationReleaseListTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["version"] == release.version
+
+    def test_semver_filter(self):
+        self.login_as(user=self.user)
+
+        release_1 = self.create_release(version="test@1.2.4")
+        release_2 = self.create_release(version="test@1.2.3")
+        self.create_release(version="some.release")
+
+        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>1.2.3")
+        assert [r["version"] for r in response.data] == [release_1.version]
+
+        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3")
+        assert [r["version"] for r in response.data] == [release_2.version, release_1.version]
+
+        response = self.get_valid_response(
+            self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3", sort="semver"
+        )
+        assert [r["version"] for r in response.data] == [release_1.version, release_2.version]
 
     def test_project_permissions(self):
         user = self.create_user(is_staff=False, is_superuser=False)


### PR DESCRIPTION
This adds in the ability to use semver syntax in the organization release endpoint. Also fixes a bug
in `filter_by_semver` where we were creating a new `QuerySet` rather than building off of the
existing one.