### PR TITLE
feat(ui): AST-aware autocomplete

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -9,6 +9,7 @@ import {
 } from 'app/utils/discover/fields';
 
 import grammar from './grammar.pegjs';
+import {getKeyName} from './utils';
 
 type TextFn = () => string;
 type LocationFn = () => LocationRange;
@@ -292,26 +293,6 @@ type TextFilter = FilterMap[FilterType.Text];
  */
 type FilterResult = FilterMap[FilterType];
 
-/**
- * Utility to get the string name of any type of key.
- */
-export const getKeyName = (
-  key: ReturnType<
-    TokenConverter['tokenKeySimple' | 'tokenKeyExplicitTag' | 'tokenKeyAggregate']
-  >
-) => {
-  switch (key.type) {
-    case Token.KeySimple:
-      return key.value;
-    case Token.KeyExplicitTag:
-      return key.key.value;
-    case Token.KeyAggregate:
-      return key.name.value;
-    default:
-      return '';
-  }
-};
-
 type TokenConverterOpts = {
   text: TextFn;
   location: LocationFn;
@@ -321,7 +302,7 @@ type TokenConverterOpts = {
 /**
  * Used to construct token results via the token grammar
  */
-class TokenConverter {
+export class TokenConverter {
   text: TextFn;
   location: LocationFn;
   config: SearchConfig;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -106,8 +106,13 @@ const allOperators = [
 
 const basicOperators = [TermOperator.Default, TermOperator.NotEqual] as const;
 
+/**
+ * Map of certain filter types to other filter types with applicable operators
+ * e.g. SpecificDate can use the operators from Date to become a Date filter.
+ */
 export const interchangeableFilterOperators = {
   [FilterType.SpecificDate]: [FilterType.Date],
+  [FilterType.Date]: [FilterType.SpecificDate],
 };
 
 const textKeys = [Token.KeySimple, Token.KeyExplicitTag] as const;
@@ -290,7 +295,7 @@ type FilterResult = FilterMap[FilterType];
 /**
  * Utility to get the string name of any type of key.
  */
-const getKeyName = (
+export const getKeyName = (
   key: ReturnType<
     TokenConverter['tokenKeySimple' | 'tokenKeyExplicitTag' | 'tokenKeyAggregate']
   >

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -744,8 +744,8 @@ const defaultConfig: SearchConfig = {
   dateKeys: new Set([
     'start',
     'end',
-    'firstSeen',
-    'lastSeen',
+    'first_seen',
+    'last_seen',
     'time',
     'event.timestamp',
     'timestamp',

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -104,6 +104,12 @@ const allOperators = [
   TermOperator.NotEqual,
 ] as const;
 
+const basicOperators = [TermOperator.Default, TermOperator.NotEqual] as const;
+
+export const interchangeableFilterOperators = {
+  [FilterType.SpecificDate]: [FilterType.Date],
+};
+
 const textKeys = [Token.KeySimple, Token.KeyExplicitTag] as const;
 
 const numberUnits = {
@@ -123,7 +129,7 @@ const numberUnits = {
 export const filterTypeConfig = {
   [FilterType.Text]: {
     validKeys: textKeys,
-    validOps: [],
+    validOps: basicOperators,
     validValues: [Token.ValueText],
     canNegate: true,
   },
@@ -171,7 +177,7 @@ export const filterTypeConfig = {
   },
   [FilterType.Boolean]: {
     validKeys: [Token.KeySimple],
-    validOps: [],
+    validOps: basicOperators,
     validValues: [Token.ValueBoolean],
     canNegate: true,
   },
@@ -207,13 +213,13 @@ export const filterTypeConfig = {
   },
   [FilterType.Has]: {
     validKeys: [Token.KeySimple],
-    validOps: [],
+    validOps: basicOperators,
     validValues: [],
     canNegate: true,
   },
   [FilterType.Is]: {
     validKeys: [Token.KeySimple],
-    validOps: [],
+    validOps: basicOperators,
     validValues: [Token.ValueText],
     canNegate: true,
   },
@@ -738,9 +744,10 @@ const defaultConfig: SearchConfig = {
   dateKeys: new Set([
     'start',
     'end',
-    'first_seen',
-    'last_seen',
+    'firstSeen',
+    'lastSeen',
     'time',
+    'event.timestamp',
     'timestamp',
     'timestamp.to_hour',
     'timestamp.to_day',

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -55,21 +55,29 @@ export function treeTransformer(
   return tree.map(nodeVisitor);
 }
 
+type GetKeyNameOpts = {
+  aggregateWithArgs?: boolean;
+};
+
 /**
  * Utility to get the string name of any type of key.
  */
 export const getKeyName = (
   key: ReturnType<
     TokenConverter['tokenKeySimple' | 'tokenKeyExplicitTag' | 'tokenKeyAggregate']
-  >
+  >,
+  options?: GetKeyNameOpts
 ) => {
+  const {aggregateWithArgs} = options ?? {};
   switch (key.type) {
     case Token.KeySimple:
       return key.value;
     case Token.KeyExplicitTag:
       return key.key.value;
     case Token.KeyAggregate:
-      return key.name.value;
+      return aggregateWithArgs
+        ? `${key.name.value}(${key.args ? key.args.text : ''})`
+        : key.name.value;
     default:
       return '';
   }

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -1,3 +1,5 @@
+import {LocationRange} from 'pegjs';
+
 import {Token, TokenConverter, TokenResult} from './parser';
 
 /**
@@ -56,6 +58,9 @@ export function treeTransformer(
 }
 
 type GetKeyNameOpts = {
+  /**
+   * Include arguments in aggregate key names
+   */
   aggregateWithArgs?: boolean;
 };
 
@@ -66,9 +71,9 @@ export const getKeyName = (
   key: ReturnType<
     TokenConverter['tokenKeySimple' | 'tokenKeyExplicitTag' | 'tokenKeyAggregate']
   >,
-  options?: GetKeyNameOpts
+  options: GetKeyNameOpts = {}
 ) => {
-  const {aggregateWithArgs} = options ?? {};
+  const {aggregateWithArgs} = options;
   switch (key.type) {
     case Token.KeySimple:
       return key.value;
@@ -82,3 +87,7 @@ export const getKeyName = (
       return '';
   }
 };
+
+export function isWithinToken(node: {location: LocationRange}, position: number) {
+  return position >= node.location.start.offset && position <= node.location.end.offset;
+}

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -1,4 +1,4 @@
-import {Token, TokenResult} from './parser';
+import {Token, TokenConverter, TokenResult} from './parser';
 
 /**
  * Utility function to visit every Token node within an AST tree and apply
@@ -54,3 +54,23 @@ export function treeTransformer(
 
   return tree.map(nodeVisitor);
 }
+
+/**
+ * Utility to get the string name of any type of key.
+ */
+export const getKeyName = (
+  key: ReturnType<
+    TokenConverter['tokenKeySimple' | 'tokenKeyExplicitTag' | 'tokenKeyAggregate']
+  >
+) => {
+  switch (key.type) {
+    case Token.KeySimple:
+      return key.value;
+    case Token.KeyExplicitTag:
+      return key.key.value;
+    case Token.KeyAggregate:
+      return key.name.value;
+    default:
+      return '';
+  }
+};

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -13,13 +13,13 @@ import ButtonBar from 'app/components/buttonBar';
 import DropdownLink from 'app/components/dropdownLink';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {
-  getKeyName,
   ParseResult,
   parseSearch,
   TermOperator,
   Token,
 } from 'app/components/searchSyntax/parser';
 import HighlightQuery from 'app/components/searchSyntax/renderer';
+import {getKeyName} from 'app/components/searchSyntax/utils';
 import {
   DEFAULT_DEBOUNCE_DURATION,
   MAX_AUTOCOMPLETE_RELEASES,
@@ -869,7 +869,10 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     const cursorToken = this.getCursorToken(parsedQuery, cursor);
-    if (cursorToken && cursorToken.type === Token.Filter) {
+    if (!cursorToken) {
+      return;
+    }
+    if (cursorToken.type === Token.Filter) {
       const tagName = getKeyName(cursorToken.key);
       // check if we are on the tag, value, or operator
       if (isWithinToken(cursorToken.value, cursor)) {
@@ -897,7 +900,7 @@ class SmartSearchBar extends React.Component<Props, State> {
         const tagGroup: AutocompleteGroup = {
           searchItems: tagKeys,
           recentSearchItems: recentSearches ?? [],
-          tagName: node.text,
+          tagName,
           type: 'tag-key' as ItemType,
         };
         const autocompleteGroups = [tagGroup];
@@ -919,7 +922,7 @@ class SmartSearchBar extends React.Component<Props, State> {
       return;
     }
 
-    if (cursorToken && cursorToken.type === Token.FreeText) {
+    if (cursorToken.type === Token.FreeText) {
       const tagKeys = this.getTagKeys(cursorToken.text);
       const recentSearches = await this.getRecentSearches();
 
@@ -1048,7 +1051,7 @@ class SmartSearchBar extends React.Component<Props, State> {
     type: ItemType
   ) {
     const {hasRecentSearches, maxSearchItems, maxQueryLength} = this.props;
-    const query = this.state.query;
+    const {query} = this.state;
 
     const queryCharsLeft =
       maxQueryLength && query ? maxQueryLength - query.length : undefined;
@@ -1188,7 +1191,7 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     const cursor = this.getCursorPosition();
-    const query = this.state.query;
+    const {query} = this.state;
 
     const {organization} = this.props;
     if (organization.features.includes('search-syntax-highlight')) {

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -919,18 +919,10 @@ class SmartSearchBar extends React.Component<Props, State> {
       this.blurTimeout = undefined;
     }
 
-    const {organization} = this.props;
     const cursor = this.getCursorPosition();
-    let AST: ParseResult | null = null;
-    if (organization.features.includes('search-syntax-highlight')) {
-      try {
-        AST = parseSearch(this.state.query);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.log(err);
-      }
-    }
-    if (AST) {
+    const {organization} = this.props;
+    const AST = this.state.parsedQuery;
+    if (AST && organization.features.includes('search-syntax-highlight')) {
       const filterNode = this.getCursorToken(AST, cursor);
       if (filterNode && filterNode.type === Token.Filter) {
         // check if we are on the tag, value, or operator
@@ -1163,23 +1155,14 @@ class SmartSearchBar extends React.Component<Props, State> {
     const query = this.state.query;
 
     const {organization} = this.props;
-    let AST: ParseResult | null = null;
-    if (organization.features.includes('search-syntax-highlight')) {
-      try {
-        AST = parseSearch(this.state.query);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.log(err);
-      }
-    }
-    if (AST) {
+    const AST = this.state.parsedQuery;
+    if (AST && organization.features.includes('search-syntax-highlight')) {
       const filterNode = this.getCursorToken(AST, cursor);
       if (filterNode && filterNode.type === Token.Filter) {
         let clauseStart: null | number = null;
         let clauseEnd: null | number = null;
         let replaceToken = replaceText;
         if (item.type === 'tag-operator') {
-          // this is an operator
           const valueLocation = filterNode.value.location;
           clauseStart = filterNode.location.start.offset;
           clauseEnd = valueLocation.start.offset;
@@ -1191,12 +1174,13 @@ class SmartSearchBar extends React.Component<Props, State> {
         } else if (this.withinTokenLocation(filterNode.value, cursor)) {
           const location = filterNode.value.location;
           const keyLocation = filterNode.key.location;
+          // Include everything after the ':'
           clauseStart = keyLocation.end.offset + 1;
           clauseEnd = location.end.offset;
         } else if (this.withinTokenLocation(filterNode.key, cursor)) {
-          // If the token is a key, then trim off the end to avoid duplicate ':'
           const location = filterNode.key.location;
           clauseStart = location.start.offset;
+          // If the token is a key, then trim off the end to avoid duplicate ':'
           clauseEnd = location.end.offset + 1;
         }
         if (clauseStart !== null && clauseEnd !== null) {

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -769,6 +769,18 @@ class SmartSearchBar extends React.Component<Props, State> {
     return [];
   };
 
+  async generateTagAutocompleteGroup(tagName: string): Promise<AutocompleteGroup> {
+    const tagKeys = this.getTagKeys(tagName);
+    const recentSearches = await this.getRecentSearches();
+
+    return {
+      searchItems: tagKeys,
+      recentSearchItems: recentSearches ?? [],
+      tagName,
+      type: 'tag-key' as ItemType,
+    };
+  }
+
   generateValueAutocompleteGroup = async (
     tagName: string,
     query: string
@@ -918,16 +930,7 @@ class SmartSearchBar extends React.Component<Props, State> {
 
       if (isWithinToken(cursorToken.key, cursor)) {
         const node = cursorToken.key;
-        const tagKeys = this.getTagKeys(tagName);
-        const recentSearches = await this.getRecentSearches();
-
-        const tagGroup: AutocompleteGroup = {
-          searchItems: tagKeys,
-          recentSearchItems: recentSearches ?? [],
-          tagName,
-          type: 'tag-key' as ItemType,
-        };
-        const autocompleteGroups = [tagGroup];
+        const autocompleteGroups = [await this.generateTagAutocompleteGroup(tagName)];
         // show operator group if at end of key
         if (cursor === node.location.end.offset) {
           const opGroup = this.generateOpAutocompleteGroup(
@@ -948,16 +951,9 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     if (cursorToken.type === Token.FreeText) {
-      const tagKeys = this.getTagKeys(cursorToken.text);
-      const recentSearches = await this.getRecentSearches();
-
-      const tagGroup: AutocompleteGroup = {
-        searchItems: tagKeys,
-        recentSearchItems: recentSearches ?? [],
-        tagName: cursorToken.text,
-        type: 'tag-key' as ItemType,
-      };
-      const autocompleteGroups = [tagGroup];
+      const autocompleteGroups = [
+        await this.generateTagAutocompleteGroup(cursorToken.text),
+      ];
       this.setState({searchTerm: cursorToken.text});
       this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
       return;

--- a/static/app/components/smartSearchBar/types.tsx
+++ b/static/app/components/smartSearchBar/types.tsx
@@ -2,6 +2,7 @@ export type ItemType =
   | 'default'
   | 'tag-key'
   | 'tag-value'
+  | 'tag-operator'
   | 'first-release'
   | 'invalid-tag'
   | 'recent-search';

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -1,5 +1,3 @@
-import {LocationRange} from 'pegjs';
-
 import {
   filterTypeConfig,
   interchangeableFilterOperators,
@@ -234,8 +232,4 @@ export function getValidOps(
   );
 
   return [...validOps];
-}
-
-export function isWithinToken(node: {location: LocationRange}, position: number) {
-  return position >= node.location.start.offset && position <= node.location.end.offset;
 }

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -51,6 +51,10 @@ function getTitleForType(type: ItemType) {
     return t('Common Search Terms');
   }
 
+  if (type === 'tag-operator') {
+    return t('Operator Helpers');
+  }
+
   return t('Tags');
 }
 

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -1,3 +1,4 @@
+import {TermOperator} from 'app/components/searchSyntax/parser';
 import {IconClock, IconStar, IconTag, IconToggle, IconUser} from 'app/icons';
 import {t} from 'app/locale';
 
@@ -163,4 +164,44 @@ export function filterSearchGroupsByIndex(items: SearchGroup[], index: number) {
   });
 
   return foundSearchItem;
+}
+
+export function generateOperatorEntryMap(tag: string) {
+  return {
+    [TermOperator.Default]: {
+      type: 'tag-operator' as ItemType,
+      value: ':',
+      desc: t(`${tag}:[value] is equal to`),
+    },
+    [TermOperator.GreaterThanEqual]: {
+      type: 'tag-operator' as ItemType,
+      value: ':>=',
+      desc: t(`${tag}:>=[value] is greater than or equal to`),
+    },
+    [TermOperator.LessThanEqual]: {
+      type: 'tag-operator' as ItemType,
+      value: ':<=',
+      desc: t(`${tag}:<=[value] is less than or equal to`),
+    },
+    [TermOperator.GreaterThan]: {
+      type: 'tag-operator' as ItemType,
+      value: ':>',
+      desc: t(`${tag}:>[value] is greater than`),
+    },
+    [TermOperator.LessThan]: {
+      type: 'tag-operator' as ItemType,
+      value: ':<',
+      desc: t(`${tag}:<[value] is less than`),
+    },
+    [TermOperator.Equal]: {
+      type: 'tag-operator' as ItemType,
+      value: ':=',
+      desc: t(`${tag}:=[value] is equal to`),
+    },
+    [TermOperator.NotEqual]: {
+      type: 'tag-operator' as ItemType,
+      value: '!:',
+      desc: t(`!${tag}:[value] is not equal to`),
+    },
+  };
 }

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -237,6 +237,7 @@ describe('EventsV2 > Results', function () {
     search.simulate('change', {target: {value: 'geo:canada'}}).simulate('submit', {
       preventDefault() {},
     });
+    await tick();
 
     // cursor query string should be omitted from the query string
     expect(initialData.router.push).toHaveBeenCalledWith({


### PR DESCRIPTION
Basic autocomplete (with operators) using the AST

![Kapture 2021-06-21 at 17 51 10](https://user-images.githubusercontent.com/9372512/122845791-4bf40c80-d2b9-11eb-89e3-0c8ba18497a9.gif)

Uses the AST provided in https://github.com/getsentry/sentry/pull/26982 and traverses it to find the token that the user is on. Presents tag/operator/value autocomplete entries accordingly and replaces the appropriate text using the AST's location data.