### PR TITLE
feat(search): Frontend search now describes expected filter types

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -221,16 +221,52 @@ export const filterTypeConfig = {
 
 type FilterTypeConfig = typeof filterTypeConfig;
 
+/**
+ * Object representing an invalid filter state
+ */
+type InvalidFilter = {
+  /**
+   * The message indicating why the filter is invalid
+   */
+  reason: string;
+  /**
+   * In the case where a filter is invalid, we may be expecting a different
+   * type for this filter based on the key. This can be useful to hint to the
+   * user what values they should be providing.
+   *
+   * This may be multiple filter types.
+   */
+  expectedType?: FilterType[];
+};
+
 type FilterMap = {
   [F in keyof FilterTypeConfig]: {
     type: Token.Filter;
+    /**
+     * The filter type being represented
+     */
     filter: F;
-    config: FilterTypeConfig[F];
+    /**
+     * The key of the filter
+     */
     key: KVConverter<FilterTypeConfig[F]['validKeys'][number]>;
+    /**
+     * The value of the filter
+     */
     value: KVConverter<FilterTypeConfig[F]['validValues'][number]>;
+    /**
+     * The operator applied to the filter
+     */
     operator: FilterTypeConfig[F]['validOps'][number];
+    /**
+     * Indicates if the filter has been negated
+     */
     negated: FilterTypeConfig[F]['canNegate'] extends true ? boolean : false;
-    invalidReason: string | null;
+    /**
+     * When a filter is marked as 'invalid' a reason is given. If the filter is
+     * not invalid this will always be null
+     */
+    invalid: InvalidFilter | null;
   };
 };
 
@@ -315,7 +351,7 @@ class TokenConverter {
     });
 
   tokenFilter = <T extends FilterType>(
-    type: T,
+    filter: T,
     key: FilterMap[T]['key'],
     value: FilterMap[T]['value'],
     operator: FilterMap[T]['operator'] | undefined,
@@ -323,13 +359,12 @@ class TokenConverter {
   ) =>
     this.makeToken({
       type: Token.Filter,
-      filter: type,
-      config: filterTypeConfig[type],
-      negated,
+      filter,
       key,
-      operator: operator ?? TermOperator.Default,
       value,
-      invalidReason: this.checkInvalidFilter(type, key, value),
+      negated,
+      operator: operator ?? TermOperator.Default,
+      invalid: this.checkInvalidFilter(filter, key, value),
     } as FilterResult);
 
   tokenFreeText = (value: string, quoted: boolean) =>
@@ -523,56 +558,83 @@ class TokenConverter {
   predicateTextOperator = (key: TextFilter['key']) =>
     this.config.textOperatorKeys.has(getKeyName(key));
 
+  /**
+   * Checks a filter against some non-grammar validation rules
+   */
   checkInvalidFilter = <T extends FilterType>(
-    type: T,
+    filter: T,
     key: FilterMap[T]['key'],
     value: FilterMap[T]['value']
-  ) =>
-    type !== FilterType.Text
-      ? null
-      : this.checkInvalidTextFilter(
-          key as TextFilter['key'],
-          value as TextFilter['value']
-        );
+  ) => {
+    // Only text filters may currently be invalid, since the text filter is the
+    // "fall through" filter that will match when other filter predicates fail.
+    if (filter !== FilterType.Text) {
+      return null;
+    }
+
+    return this.checkInvalidTextFilter(
+      key as TextFilter['key'],
+      value as TextFilter['value']
+    );
+  };
 
   /**
-   * Validates that a text filter is not using a non-text key.
+   * Validates text filters which may have failed predication
    */
   checkInvalidTextFilter = (key: TextFilter['key'], value: TextFilter['value']) => {
-    // Explicit tag keys are always treated as text filters
+    // Explicit tag keys will always be treated as text filters
     if (key.type === Token.KeyExplicitTag) {
-      return null;
+      return this.checkInvalidTextValue(value);
     }
 
     const keyName = getKeyName(key);
 
     if (this.keyValidation.isDuration(keyName)) {
-      return t('Invalid duration. Expected number followed by duration unit suffix.');
+      return {
+        reason: t('Invalid duration. Expected number followed by duration unit suffix.'),
+        expectedType: [FilterType.Duration],
+      };
     }
 
     if (this.keyValidation.isDate(keyName)) {
-      return t(
-        'Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).',
-        new Date().toISOString()
-      );
+      return {
+        reason: t(
+          'Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).',
+          new Date().toISOString()
+        ),
+        expectedType: [FilterType.Date, FilterType.SpecificDate, FilterType.RelativeDate],
+      };
     }
 
     if (this.keyValidation.isBoolean(keyName)) {
-      return t('Invalid boolean. Expected true, 1, false, or 0.');
+      return {
+        reason: t('Invalid boolean. Expected true, 1, false, or 0.'),
+        expectedType: [FilterType.Boolean],
+      };
     }
 
     if (this.keyValidation.isNumeric(keyName)) {
-      return t(
-        'Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).'
-      );
+      return {
+        reason: t(
+          'Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).'
+        ),
+        expectedType: [FilterType.Numeric, FilterType.NumericIn],
+      };
     }
 
+    return this.checkInvalidTextValue(value);
+  };
+
+  /**
+   * Validates the value of a text filter
+   */
+  checkInvalidTextValue = (value: TextFilter['value']) => {
     if (!value.quoted && /(^|[^\\])"/.test(value.value)) {
-      return t('Quotes must enclose text or be escaped.');
+      return {reason: t('Quotes must enclose text or be escaped.')};
     }
 
     if (!value.quoted && value.value === '') {
-      return t('Filter must have a value.');
+      return {reason: t('Filter must have a value.')};
     }
 
     return null;

--- a/tests/fixtures/search-syntax/empty_filter_value.json
+++ b/tests/fixtures/search-syntax/empty_filter_value.json
@@ -20,7 +20,7 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Filter must have a value.",
+        "invalid": {"reason": "Filter must have a value."},
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "", "quoted": false}

--- a/tests/fixtures/search-syntax/invalid_boolean_filter.json
+++ b/tests/fixtures/search-syntax/invalid_boolean_filter.json
@@ -6,7 +6,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid boolean. Expected true, 1, false, or 0.",
+        "invalid": {
+          "reason": "Invalid boolean. Expected true, 1, false, or 0.",
+          "expectedType": ["boolean"]
+        },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "lol", "quoted": false}
@@ -21,7 +24,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid boolean. Expected true, 1, false, or 0.",
+        "invalid": {
+          "reason": "Invalid boolean. Expected true, 1, false, or 0.",
+          "expectedType": ["boolean"]
+        },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "123", "quoted": false}
@@ -36,7 +42,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid boolean. Expected true, 1, false, or 0.",
+        "invalid": {
+          "reason": "Invalid boolean. Expected true, 1, false, or 0.",
+          "expectedType": ["boolean"]
+        },
         "key": {"type": "keySimple", "value": "stack.in_app", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": ">true", "quoted": false}

--- a/tests/fixtures/search-syntax/invalid_date_formats.json
+++ b/tests/fixtures/search-syntax/invalid_date_formats.json
@@ -6,7 +6,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+        "invalid": {
+          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+          "expectedType": ["date", "specificDate", "relativeDate"]
+        },
         "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "hello", "quoted": false}
@@ -21,7 +24,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+        "invalid": {
+          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+          "expectedType": ["date", "specificDate", "relativeDate"]
+        },
         "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "123", "quoted": false}
@@ -36,7 +42,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+        "invalid": {
+          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+          "expectedType": ["date", "specificDate", "relativeDate"]
+        },
         "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "2018-01-01T00:01ZZ", "quoted": false}

--- a/tests/fixtures/search-syntax/invalid_duration_filter.json
+++ b/tests/fixtures/search-syntax/invalid_duration_filter.json
@@ -6,7 +6,10 @@
         "filter": "text",
         "negated": false,
         "operator": "",
-        "invalidReason": "Invalid duration. Expected number followed by duration unit suffix.",
+        "invalid": {
+          "reason": "Invalid duration. Expected number followed by duration unit suffix.",
+          "expectedType": ["duration"]
+        },
         "key": {"quoted": false, "type": "keySimple", "value": "transaction.duration"},
         "type": "filter",
         "value": {"quoted": false, "type": "valueText", "value": ">..500s"}

--- a/tests/fixtures/search-syntax/invalid_numeric_fields.json
+++ b/tests/fixtures/search-syntax/invalid_numeric_fields.json
@@ -6,7 +6,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+        "invalid": {
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+          "expectedType": ["numeric", "numericIn"]
+        },
         "key": {"type": "keySimple", "value": "project.id", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "one", "quoted": false}
@@ -21,7 +24,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+        "invalid": {
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+          "expectedType": ["numeric", "numericIn"]
+        },
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "two", "quoted": false}
@@ -36,7 +42,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid duration. Expected number followed by duration unit suffix.",
+        "invalid": {
+          "reason": "Invalid duration. Expected number followed by duration unit suffix.",
+          "expectedType": ["duration"]
+        },
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": ">hotdog", "quoted": false}

--- a/tests/fixtures/search-syntax/invalid_numeric_shorthand.json
+++ b/tests/fixtures/search-syntax/invalid_numeric_shorthand.json
@@ -6,7 +6,10 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+        "invalid": {
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+          "expectedType": ["numeric", "numericIn"]
+        },
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": ">3s", "quoted": false}

--- a/tests/fixtures/search-syntax/trailing_quote_value.json
+++ b/tests/fixtures/search-syntax/trailing_quote_value.json
@@ -6,7 +6,9 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Quotes must enclose text or be escaped.",
+        "invalid": {
+          "reason": "Quotes must enclose text or be escaped."
+        },
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "\"test", "quoted": false}
@@ -21,7 +23,9 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Quotes must enclose text or be escaped.",
+        "invalid": {
+          "reason": "Quotes must enclose text or be escaped."
+        },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "test\"", "quoted": false}
@@ -36,7 +40,9 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Quotes must enclose text or be escaped.",
+        "invalid": {
+          "reason": "Quotes must enclose text or be escaped."
+        },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "\"test", "quoted": false}
@@ -60,7 +66,9 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalidReason": "Quotes must enclose text or be escaped.",
+        "invalid": {
+          "reason": "Quotes must enclose text or be escaped."
+        },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "te\"st", "quoted": false}

--- a/tests/js/spec/components/searchSyntax/parser.spec.tsx
+++ b/tests/js/spec/components/searchSyntax/parser.spec.tsx
@@ -38,9 +38,9 @@ const normalizeResult = (tokens: TokenResult<Token>[]) =>
     // @ts-ignore
     delete token.config;
 
-    if (token.type === Token.Filter && token.invalidReason === null) {
+    if (token.type === Token.Filter && token.invalid === null) {
       // @ts-ignore
-      delete token.invalidReason;
+      delete token.invalid;
     }
 
     if (token.type === Token.ValueIso8601Date) {

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -63,10 +63,10 @@ def result_transformer(result):
             return None
 
         if token["type"] == "filter":
-            # Filters with an invalidReason raises to signal to the test runner
-            # that we should expect this exception
-            if token.get("invalidReason"):
-                raise InvalidSearchQuery(token["invalidReason"])
+            # Filters with an invalid reason raises to signal to the test
+            # runner that we should expect this exception
+            if token.get("invalid"):
+                raise InvalidSearchQuery(token["invalid"]["reason"])
 
             # Transform the operator to match for list values
             if token["value"]["type"] in ["valueTextList", "valueNumberList"]:


### PR DESCRIPTION
When a filter is invalid it is valuable to offer a hint as to the type the filter should be. It now provides a `expectedType` as part of the new invalid object. This list describes what type of filter it _should_ represent for the key.