### PR TITLE
fix(sessions): Format session time bounds to be in ISO

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -607,6 +607,10 @@ def get_release_sessions_time_bounds(project_id, release, org_id, environments=N
         Dictionary with two keys "sessions_lower_bound" and "sessions_upper_bound" that
     correspond to when the first session occurred and when the last session occurred respectively
     """
+
+    def iso_format_snuba_datetime(date):
+        return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S+00:00").isoformat()[:19] + "Z"
+
     release_sessions_time_bounds = {
         "sessions_lower_bound": None,
         "sessions_upper_bound": None,
@@ -641,9 +645,10 @@ def get_release_sessions_time_bounds(project_id, release, org_id, environments=N
         # P.S. To avoid confusion the `0` timestamp which is '1970-01-01 00:00:00'
         # is rendered as '0000-00-00 00:00:00' in clickhouse shell
         if set(rv.values()) != {formatted_unix_start_time}:
+
             release_sessions_time_bounds = {
-                "sessions_lower_bound": rv["first_session_started"],
-                "sessions_upper_bound": rv["last_session_started"],
+                "sessions_lower_bound": iso_format_snuba_datetime(rv["first_session_started"]),
+                "sessions_upper_bound": iso_format_snuba_datetime(rv["last_session_started"]),
             }
     return release_sessions_time_bounds
 

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -506,11 +506,15 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             }
         )
 
-        expected_formatted_lower_bound = format_timestamp(
-            datetime.utcfromtimestamp(self.session_started - 3600 * 2).replace(minute=0)
+        expected_formatted_lower_bound = (
+            datetime.utcfromtimestamp(self.session_started - 3600 * 2)
+            .replace(minute=0)
+            .isoformat()[:19]
+            + "Z"
         )
-        expected_formatted_upper_bound = format_timestamp(
-            datetime.utcfromtimestamp(self.session_started).replace(minute=0)
+
+        expected_formatted_upper_bound = (
+            datetime.utcfromtimestamp(self.session_started).replace(minute=0).isoformat()[:19] + "Z"
         )
 
         # Test for self.session_release


### PR DESCRIPTION
This PR changes the formatting of datetime objects representing session time bounds to follow ISO format like in `firstEvent` and `lastEvent`

example:
![image](https://user-images.githubusercontent.com/10855986/122891228-a5554d80-d344-11eb-872b-18e8f25ac37c.png)
