### PR TITLE
fix(releases): Add optional high fidelity range parameter to sessions intervals

### DIFF
--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -106,6 +106,7 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
             groupBy: ['release'],
             field: [sessionDisplayToField(activeDisplay)],
             query: location.query.query ? `release:${location.query.query}` : undefined,
+            highFidelityRange: true,
           },
         },
       ],


### PR DESCRIPTION
This adds a query parameter to sessions request in order to make the interval alignments same as the releases list. Happens rarely but when you select Sort By: Active Users in the releases page the sorting is done by data from the last 24 hours, where as the chart/sessions request uses 24h intervals midnight utc-midnight utc and sometimes the top item on the list is different from the top item on the chart on the last point. Users expect the order to be the same on that point in the chart with the list because they both have a 1d interval but they were looking at different intervals.

See for context: [WOR-978](https://getsentry.atlassian.net/browse/WOR-978)