### PR TITLE
Revert "feat: Add tracing to Relay authentication endpoints"

### DIFF
--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -16,7 +16,6 @@ from sentry.api.serializers import serialize
 from sentry.models import Relay, RelayUsage
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
 from sentry.utils import json
-from sentry.web.decorators import transaction_start
 
 
 class RelayIdSerializer(serializers.Serializer):
@@ -37,7 +36,6 @@ class RelayRegisterChallengeEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
 
-    @transaction_start("RelayRegisterChallengeEndpoint")
     def post(self, request):
         """
         Requests to Register a Relay
@@ -114,7 +112,6 @@ class RelayRegisterResponseEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
 
-    @transaction_start("RelayRegisterResponseEndpoint")
     def post(self, request):
         """
         Registers a Relay


### PR DESCRIPTION
Reverts getsentry/sentry#26658


Tracing here may result in potential DB queries to `sentry_option` table, and we would like to avoid ANY database access for relay registration endpoints.