### PR TITLE
fix(aws-lambda): Handle env variables size limit exceeded

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -24,6 +24,7 @@ SUPPORTED_RUNTIMES = [
 INVALID_LAYER_TEXT = "Invalid existing layer %s"
 MISSING_ROLE_TEXT = "Invalid role associated with the lambda function"
 TOO_MANY_REQUESTS_TEXT = "Something went wrong! Please enable function manually after installation"
+ENV_VARS_LIMIT_TEXT = "Environment variables size limit of 4KB was exceeded"
 
 DEFAULT_NUM_RETRIES = 3
 
@@ -338,6 +339,21 @@ def get_missing_role_error(err_message):
     return err_message == missing_role_err
 
 
+def get_exceeded_env_vars_limit_error(err_message):
+    """
+    Check to see if an error matches the env vars limit text
+    :param err_message: error string
+    :return boolean value if the error matches the env vars limit text
+    """
+    env_vars_limit_error = (
+        "An error occurred (InvalidParameterValueException) when calling "
+        "the UpdateFunctionConfiguration operation: Lambda was unable to configure "
+        "your environment variables because the environment variables you "
+        "have provided exceeded the 4KB limit."
+    )
+    return env_vars_limit_error in err_message
+
+
 def get_sentry_err_message(err_message):
     """
     Check to see if an error matches a custom error and customizes the error
@@ -352,6 +368,8 @@ def get_sentry_err_message(err_message):
         return True, MISSING_ROLE_TEXT
     if get_too_many_requests_error_message(err_message):
         return True, TOO_MANY_REQUESTS_TEXT
+    if get_exceeded_env_vars_limit_error(err_message):
+        return True, ENV_VARS_LIMIT_TEXT
     return False, err_message
 
 

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -455,3 +455,67 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
         mock_react_view.assert_called_with(
             ANY, "awsLambdaFailureDetails", {"lambdaFunctionFailures": failures, "successCount": 0}
         )
+
+    @patch("sentry.integrations.aws_lambda.integration.get_supported_functions")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch.object(PipelineView, "render_react_view", return_value=HttpResponse())
+    def test_lambda_setup_layer_env_vars_limit_exceeded_exception(
+        self, mock_react_view, mock_gen_aws_client, mock_get_supported_functions
+    ):
+        class MockException(Exception):
+            pass
+
+        env_vars_size_limit_err = (
+            "An error occurred (InvalidParameterValueException) when calling the "
+            "UpdateFunctionConfiguration operation: Lambda was unable to configure "
+            "your environment variables because the environment variables you have "
+            "provided exceeded the 4KB limit. String measured: {'MESSAGE':'This is production "
+            "environment','TARGET_ENV' :'pre-production','IS_SERVERLESS':'true','STAGE':'pre-prod'"
+        )
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+        mock_client.update_function_configuration = MagicMock(
+            side_effect=Exception(env_vars_size_limit_err)
+        )
+        mock_client.describe_account = MagicMock(return_value={"Account": {"Name": "my_name"}})
+        mock_client.exceptions = MagicMock()
+        mock_client.exceptions.ResourceConflictException = MockException
+
+        mock_get_supported_functions.return_value = [
+            {
+                "FunctionName": "lambdaB",
+                "Runtime": "nodejs10.x",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaB",
+            },
+        ]
+
+        aws_external_id = "12-323"
+        self.pipeline.state.step_index = 2
+        self.pipeline.state.data = {
+            "region": region,
+            "account_number": account_number,
+            "aws_external_id": aws_external_id,
+            "project_id": self.projectA.id,
+        }
+
+        resp = self.client.post(
+            self.setup_path,
+            {"lambdaB": True},
+            format="json",
+            HTTP_ACCEPT="application/json",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+
+        assert resp.status_code == 200
+        assert not Integration.objects.filter(provider=self.provider.key).exists()
+
+        failures = [
+            {
+                "name": "lambdaB",
+                "error": "Environment variables size limit of 4KB was exceeded",
+            }
+        ]
+
+        mock_react_view.assert_called_with(
+            ANY, "awsLambdaFailureDetails", {"lambdaFunctionFailures": failures, "successCount": 0}
+        )


### PR DESCRIPTION
This PR:
- Replace `Unknown Error` shown to user when trying to enable sentry on a function where environment variable size limit of 4kb is exceeded