### PR TITLE
fix(breadcrumb): Crumb tree expand issue

### DIFF
--- a/static/app/components/contextData/index.tsx
+++ b/static/app/components/contextData/index.tsx
@@ -22,7 +22,6 @@ type Props = React.HTMLAttributes<HTMLPreElement> & {
   maxDefaultDepth?: number;
   meta?: Meta;
   jsonConsts?: boolean;
-  className?: string;
 };
 
 type State = {
@@ -166,12 +165,11 @@ class ContextData extends React.Component<Props, State> {
       withAnnotatedText: _withAnnotatedText,
       meta: _meta,
       children,
-      className,
       ...other
     } = this.props;
 
     return (
-      <pre {...other} className={className}>
+      <pre {...other}>
         {this.renderValue(data)}
         {children}
       </pre>

--- a/static/app/components/contextData/index.tsx
+++ b/static/app/components/contextData/index.tsx
@@ -17,12 +17,12 @@ type Value = null | string | boolean | number | {[key: string]: Value} | Value[]
 
 type Props = React.HTMLAttributes<HTMLPreElement> & {
   data: Value;
-  onToggle?: () => void;
   preserveQuotes?: boolean;
   withAnnotatedText?: boolean;
   maxDefaultDepth?: number;
   meta?: Meta;
   jsonConsts?: boolean;
+  className?: string;
 };
 
 type State = {
@@ -43,7 +43,6 @@ class ContextData extends React.Component<Props, State> {
       withAnnotatedText,
       jsonConsts,
       maxDefaultDepth,
-      onToggle,
     } = this.props;
     const maxDepth = maxDefaultDepth ?? 2;
 
@@ -118,11 +117,7 @@ class ContextData extends React.Component<Props, State> {
         return (
           <span className="val-array">
             <span className="val-array-marker">{'['}</span>
-            <Toggle
-              highUp={depth <= maxDepth}
-              wrapClassName="val-array-items"
-              onClick={onToggle}
-            >
+            <Toggle highUp={depth <= maxDepth} wrapClassName="val-array-items">
               {children}
             </Toggle>
             <span className="val-array-marker">{']'}</span>
@@ -154,11 +149,7 @@ class ContextData extends React.Component<Props, State> {
       return (
         <span className="val-dict">
           <span className="val-dict-marker">{'{'}</span>
-          <Toggle
-            highUp={depth <= maxDepth - 1}
-            onClick={onToggle}
-            wrapClassName="val-dict-items"
-          >
+          <Toggle highUp={depth <= maxDepth - 1} wrapClassName="val-dict-items">
             {children}
           </Toggle>
           <span className="val-dict-marker">{'}'}</span>
@@ -175,11 +166,12 @@ class ContextData extends React.Component<Props, State> {
       withAnnotatedText: _withAnnotatedText,
       meta: _meta,
       children,
+      className,
       ...other
     } = this.props;
 
     return (
-      <pre {...other}>
+      <pre {...other} className={className}>
         {this.renderValue(data)}
         {children}
       </pre>

--- a/static/app/components/contextData/toggle.tsx
+++ b/static/app/components/contextData/toggle.tsx
@@ -7,10 +7,9 @@ type Props = {
   highUp: boolean;
   wrapClassName: string;
   children: React.ReactNode;
-  onClick?: () => void;
 };
 
-function Toggle({highUp, wrapClassName, onClick, children}: Props) {
+function Toggle({highUp, wrapClassName, children}: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
 
   if (Children.count(children) === 0) {
@@ -29,7 +28,6 @@ function Toggle({highUp, wrapClassName, onClick, children}: Props) {
         isExpanded={isExpanded}
         onClick={evt => {
           setIsExpanded(!isExpanded);
-          onClick?.();
           evt.preventDefault();
         }}
       >

--- a/static/app/components/events/interfaces/breadcrumbs/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/default.tsx
@@ -15,11 +15,10 @@ type Props = {
   breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
   event: Event;
   orgId: string | null;
-  onToggle: () => void;
 };
 
-const Default = ({breadcrumb, event, orgId, searchTerm, onToggle}: Props) => (
-  <Summary kvData={breadcrumb.data} onToggle={onToggle}>
+const Default = ({breadcrumb, event, orgId, searchTerm}: Props) => (
+  <Summary kvData={breadcrumb.data}>
     {breadcrumb?.message && (
       <AnnotatedText
         value={

--- a/static/app/components/events/interfaces/breadcrumbs/data/exception.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/exception.tsx
@@ -11,15 +11,14 @@ import Summary from './summary';
 type Props = {
   searchTerm: string;
   breadcrumb: BreadcrumbTypeDefault;
-  onToggle: () => void;
 };
 
-const Exception = ({breadcrumb, searchTerm, onToggle}: Props) => {
+const Exception = ({breadcrumb, searchTerm}: Props) => {
   const {data} = breadcrumb;
   const dataValue = data?.value;
 
   return (
-    <Summary kvData={omit(data, ['type', 'value'])} onToggle={onToggle}>
+    <Summary kvData={omit(data, ['type', 'value'])}>
       {data?.type && (
         <AnnotatedText
           value={

--- a/static/app/components/events/interfaces/breadcrumbs/data/http.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/http.tsx
@@ -13,10 +13,9 @@ import Summary from './summary';
 type Props = {
   searchTerm: string;
   breadcrumb: BreadcrumbTypeHTTP;
-  onToggle: () => void;
 };
 
-const Http = ({breadcrumb, searchTerm, onToggle}: Props) => {
+const Http = ({breadcrumb, searchTerm}: Props) => {
   const {data} = breadcrumb;
 
   const renderUrl = (url: any) => {
@@ -41,7 +40,7 @@ const Http = ({breadcrumb, searchTerm, onToggle}: Props) => {
   const statusCode = data?.status_code;
 
   return (
-    <Summary kvData={omit(data, ['method', 'url', 'status_code'])} onToggle={onToggle}>
+    <Summary kvData={omit(data, ['method', 'url', 'status_code'])}>
       {data?.method && (
         <AnnotatedText
           value={

--- a/static/app/components/events/interfaces/breadcrumbs/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/index.tsx
@@ -10,21 +10,18 @@ type Props = {
   breadcrumb: Breadcrumb;
   event: Event;
   orgId: string | null;
-  onToggle: () => void;
 };
 
-const Data = ({breadcrumb, event, orgId, searchTerm, onToggle}: Props) => {
+const Data = ({breadcrumb, event, orgId, searchTerm}: Props) => {
   if (breadcrumb.type === BreadcrumbType.HTTP) {
-    return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} onToggle={onToggle} />;
+    return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} />;
   }
 
   if (
     breadcrumb.type === BreadcrumbType.WARNING ||
     breadcrumb.type === BreadcrumbType.ERROR
   ) {
-    return (
-      <Exception breadcrumb={breadcrumb} searchTerm={searchTerm} onToggle={onToggle} />
-    );
+    return <Exception breadcrumb={breadcrumb} searchTerm={searchTerm} />;
   }
 
   return (
@@ -33,7 +30,6 @@ const Data = ({breadcrumb, event, orgId, searchTerm, onToggle}: Props) => {
       orgId={orgId}
       breadcrumb={breadcrumb}
       searchTerm={searchTerm}
-      onToggle={onToggle}
     />
   );
 };

--- a/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -49,6 +49,8 @@ const ContextDataWrapper = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   max-height: 100%;
   height: 100%;
+  overflow: hidden;
+
   pre {
     margin: 0;
     padding: 0;

--- a/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -1,43 +1,64 @@
 import styled from '@emotion/styled';
 
 import ContextData from 'app/components/contextData';
+import space from 'app/styles/space';
 
 type Props = {
   children: React.ReactNode;
-  onToggle: () => void;
   kvData?: Record<string, any>;
 };
 
-function Summary({kvData, children, onToggle}: Props) {
-  function renderKvData() {
-    if (!kvData || !Object.keys(kvData).length) {
+function Summary({kvData, children}: Props) {
+  if (!kvData || !Object.keys(kvData).length) {
+    if (!children) {
       return null;
     }
 
-    return <ContextData data={kvData} onToggle={onToggle} withAnnotatedText />;
+    return (
+      <Wrapper>
+        <StyledCode>{children}</StyledCode>
+      </Wrapper>
+    );
   }
 
   return (
-    <StyledPre>
-      <StyledCode>{children}</StyledCode>
-      {renderKvData()}
-    </StyledPre>
+    <Wrapper withBackground>
+      <ContextData data={kvData} withAnnotatedText>
+        {children ? <StyledCode>{children}</StyledCode> : null}
+      </ContextData>
+    </Wrapper>
   );
 }
 
 export default Summary;
 
-const StyledPre = styled('pre')`
-  padding: 0;
-  background: none;
-  box-sizing: border-box;
-  white-space: pre-wrap;
+const Wrapper = styled('div')<{withBackground?: boolean}>`
+  max-height: 100%;
+  height: 100%;
   word-break: break-all;
-  margin: 0;
+  word-wrap: break-word;
   font-size: ${p => p.theme.fontSizeSmall};
+  ${p =>
+    p.withBackground &&
+    `
+      padding: ${space(1)};
+      background: #f7f8f9;
+      border-radius: ${p.theme.borderRadius};
+    `}
+
+  pre {
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    overflow-y: auto;
+    max-height: 100%;
+  }
 `;
 
 const StyledCode = styled('code')`
-  white-space: pre-wrap;
   line-height: 26px;
+  color: inherit;
+  font-size: inherit;
+  white-space: pre-wrap;
+  background: none;
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -22,30 +22,33 @@ function Summary({kvData, children}: Props) {
   }
 
   return (
-    <Wrapper withBackground>
-      <ContextData data={kvData} withAnnotatedText>
-        {children ? <StyledCode>{children}</StyledCode> : null}
-      </ContextData>
+    <Wrapper>
+      {children && <StyledCode>{children}</StyledCode>}
+      <ContextDataWrapper>
+        <ContextData data={kvData} withAnnotatedText />
+      </ContextDataWrapper>
     </Wrapper>
   );
 }
 
 export default Summary;
 
-const Wrapper = styled('div')<{withBackground?: boolean}>`
+const Wrapper = styled('div')`
   max-height: 100%;
   height: 100%;
   word-break: break-all;
-  word-wrap: break-word;
   font-size: ${p => p.theme.fontSizeSmall};
-  ${p =>
-    p.withBackground &&
-    `
-      padding: ${space(1)};
-      background: #f7f8f9;
-      border-radius: ${p.theme.borderRadius};
-    `}
+  font-family: ${p => p.theme.text.familyMono};
+  display: grid;
+  grid-gap: ${space(0.5)};
+`;
 
+const ContextDataWrapper = styled('div')`
+  padding: ${space(1)};
+  background: #f7f8f9;
+  border-radius: ${p => p.theme.borderRadius};
+  max-height: 100%;
+  height: 100%;
   pre {
     margin: 0;
     padding: 0;
@@ -61,4 +64,5 @@ const StyledCode = styled('code')`
   font-size: inherit;
   white-space: pre-wrap;
   background: none;
+  padding: 0;
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/list.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/list.tsx
@@ -86,7 +86,7 @@ class ListContainer extends React.Component<Props, State> {
         relativeTime={relativeTime}
         displayRelativeTime={displayRelativeTime}
         isLastItem={isLastItem}
-        height={height ? Number(height) : undefined}
+        height={height ? String(height) : undefined}
       />
     );
   }

--- a/static/app/components/events/interfaces/breadcrumbs/list.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/list.tsx
@@ -71,7 +71,11 @@ class ListContainer extends React.Component<Props, State> {
     this.setState({scrollbarSize: size});
   };
 
-  renderBody(breadcrumb: BreadcrumbsWithDetails[0], isLastItem = false) {
+  renderBody(
+    breadcrumb: BreadcrumbsWithDetails[0],
+    height: string | number | undefined,
+    isLastItem = false
+  ) {
     const {event, orgId, searchTerm, relativeTime, displayRelativeTime} = this.props;
     return (
       <ListBody
@@ -82,6 +86,7 @@ class ListContainer extends React.Component<Props, State> {
         relativeTime={relativeTime}
         displayRelativeTime={displayRelativeTime}
         isLastItem={isLastItem}
+        height={height ? Number(height) : undefined}
       />
     );
   }
@@ -90,6 +95,7 @@ class ListContainer extends React.Component<Props, State> {
     const {breadcrumbs} = this.props;
     const breadcrumb = breadcrumbs[index];
     const isLastItem = breadcrumbs[breadcrumbs.length - 1].id === breadcrumb.id;
+    const {height} = style;
     return (
       <CellMeasurer
         cache={cache}
@@ -101,11 +107,11 @@ class ListContainer extends React.Component<Props, State> {
         {({measure}) =>
           isLastItem ? (
             <Row style={style} onLoad={measure} data-test-id="last-crumb">
-              {this.renderBody(breadcrumb, isLastItem)}
+              {this.renderBody(breadcrumb, height, isLastItem)}
             </Row>
           ) : (
             <Row style={style} onLoad={measure}>
-              {this.renderBody(breadcrumb)}
+              {this.renderBody(breadcrumb, height)}
             </Row>
           )
         }

--- a/static/app/components/events/interfaces/breadcrumbs/list.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/list.tsx
@@ -22,10 +22,7 @@ type Props = {
   onSwitchTimeFormat: () => void;
   breadcrumbs: BreadcrumbsWithDetails;
   relativeTime: string;
-} & Omit<
-  React.ComponentProps<typeof ListBody>,
-  'breadcrumb' | 'isLastItem' | 'column' | 'onToggle'
->;
+} & Omit<React.ComponentProps<typeof ListBody>, 'breadcrumb' | 'isLastItem' | 'column'>;
 
 const cache = new CellMeasurerCache({
   fixedWidth: true,
@@ -85,7 +82,6 @@ class ListContainer extends React.Component<Props, State> {
         relativeTime={relativeTime}
         displayRelativeTime={displayRelativeTime}
         isLastItem={isLastItem}
-        onToggle={this.updateGrid}
       />
     );
   }

--- a/static/app/components/events/interfaces/breadcrumbs/listBody.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/listBody.tsx
@@ -21,6 +21,7 @@ type Props = {
   isLastItem: boolean;
   relativeTime: string;
   displayRelativeTime: boolean;
+  height?: number;
 };
 
 const ListBody = memo(
@@ -32,6 +33,7 @@ const ListBody = memo(
     displayRelativeTime,
     searchTerm,
     isLastItem,
+    height,
   }: Props) => {
     const hasError = breadcrumb.type === BreadcrumbType.ERROR;
 
@@ -45,7 +47,7 @@ const ListBody = memo(
         <GridCellCategory hasError={hasError} isLastItem={isLastItem}>
           <Category category={breadcrumb?.category} searchTerm={searchTerm} />
         </GridCellCategory>
-        <GridCell hasError={hasError} isLastItem={isLastItem}>
+        <GridCell hasError={hasError} isLastItem={isLastItem} height={height}>
           <Data
             event={event}
             orgId={orgId}

--- a/static/app/components/events/interfaces/breadcrumbs/listBody.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/listBody.tsx
@@ -21,7 +21,7 @@ type Props = {
   isLastItem: boolean;
   relativeTime: string;
   displayRelativeTime: boolean;
-  height?: number;
+  height?: string;
 };
 
 const ListBody = memo(

--- a/static/app/components/events/interfaces/breadcrumbs/listBody.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/listBody.tsx
@@ -21,7 +21,6 @@ type Props = {
   isLastItem: boolean;
   relativeTime: string;
   displayRelativeTime: boolean;
-  onToggle: () => void;
 };
 
 const ListBody = memo(
@@ -33,7 +32,6 @@ const ListBody = memo(
     displayRelativeTime,
     searchTerm,
     isLastItem,
-    onToggle,
   }: Props) => {
     const hasError = breadcrumb.type === BreadcrumbType.ERROR;
 
@@ -53,7 +51,6 @@ const ListBody = memo(
             orgId={orgId}
             breadcrumb={breadcrumb}
             searchTerm={searchTerm}
-            onToggle={onToggle}
           />
         </GridCell>
         <GridCell hasError={hasError} isLastItem={isLastItem}>

--- a/static/app/components/events/interfaces/breadcrumbs/styles.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/styles.tsx
@@ -32,7 +32,7 @@ const IconWrapper = styled('div', {
 const GridCell = styled('div')<{
   hasError?: boolean;
   isLastItem?: boolean;
-  height?: number;
+  height?: string;
 }>`
   height: ${p => (p.height ? `${p.height}px` : '100%')};
   position: relative;

--- a/static/app/components/events/interfaces/breadcrumbs/styles.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/styles.tsx
@@ -33,6 +33,7 @@ const GridCell = styled('div')<{
   hasError?: boolean;
   isLastItem?: boolean;
 }>`
+  overflow: hidden;
   height: 100%;
   position: relative;
   white-space: pre-wrap;

--- a/static/app/components/events/interfaces/breadcrumbs/styles.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/styles.tsx
@@ -32,9 +32,9 @@ const IconWrapper = styled('div', {
 const GridCell = styled('div')<{
   hasError?: boolean;
   isLastItem?: boolean;
+  height?: number;
 }>`
-  overflow: hidden;
-  height: 100%;
+  height: ${p => (p.height ? `${p.height}px` : '100%')};
   position: relative;
   white-space: pre-wrap;
   word-break: break-all;

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/httpRenderer.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/httpRenderer.spec.tsx
@@ -4,14 +4,11 @@ import HttpRenderer from 'app/components/events/interfaces/breadcrumbs/data/http
 import {BreadcrumbLevelType, BreadcrumbType} from 'app/types/breadcrumbs';
 
 describe('HttpRenderer', () => {
-  const handleToggle = jest.fn();
-
   describe('render', () => {
     it('should work', () => {
       const httpRendererWrapper = mountWithTheme(
         <HttpRenderer
           searchTerm=""
-          onToggle={handleToggle}
           breadcrumb={{
             type: BreadcrumbType.HTTP,
             level: BreadcrumbLevelType.INFO,
@@ -47,7 +44,6 @@ describe('HttpRenderer', () => {
       const httpRendererWrapper = mountWithTheme(
         <HttpRenderer
           searchTerm=""
-          onToggle={handleToggle}
           breadcrumb={{
             category: 'xhr',
             type: BreadcrumbType.HTTP,
@@ -65,7 +61,6 @@ describe('HttpRenderer', () => {
       const httpRendererWrapper = mountWithTheme(
         <HttpRenderer
           searchTerm=""
-          onToggle={handleToggle}
           breadcrumb={{
             category: 'xhr',
             type: BreadcrumbType.HTTP,


### PR DESCRIPTION
**Issue:**
After expanding nested data on breadcrumbs and scrolling through the data, the data is automatically collapsed again. This happens because we are using a virtual list.

**Solution:** 
The ContextData component (tree component) will now display a vertical scroll bar when the content overflows. This solution is still not ideal, so I will discuss with the design team a better solution for this problem, which could be, for example, a modal.

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/122954835-1108dc00-d380-11eb-8c90-15685e358bdf.png)

closes: https://getsentry.atlassian.net/browse/ISSUE-1235