### PR TITLE
perf(ingest): Add metric to record normalized per-message batch flush time

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -144,7 +144,7 @@ class IngestConsumerWorker(AbstractBatchWorker):
                     results[future].callback(future)
 
                 metrics.timing(
-                    "ingest_consumer.process_other_messages_batch_normalized",
+                    "ingest_consumer.process_other_messages_batch.normalized",
                     (time.monotonic() - other_messages_flush_start) / len(other_messages),
                 )
 


### PR DESCRIPTION
Similar to the metrics already present in the batching Kafka consumer for the abstract batch worker, this enables us to see the throughput impact of this specific block as concurrency is applied.