### PR TITLE
fix(releases): Change release adoption tooltip date to interval

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -103,7 +103,7 @@ export const serverless = [
   'dotnet-awslambda',
 ] as const;
 
-const desktop = [
+export const desktop = [
   'apple-macos',
   'dotnet',
   'dotnet-winforms',

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2070,6 +2070,8 @@ export type SeriesApi = {
 };
 
 export type SessionApiResponse = SeriesApi & {
+  start: DateString;
+  end: DateString;
   query: string;
   intervals: string[];
   groups: {

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -17,7 +17,7 @@ import Pagination from 'app/components/pagination';
 import SearchBar from 'app/components/searchBar';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
-import {releaseHealth} from 'app/data/platformCategories';
+import {desktop, mobile, releaseHealth} from 'app/data/platformCategories';
 import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
@@ -25,6 +25,7 @@ import space from 'app/styles/space';
 import {
   GlobalSelection,
   Organization,
+  Project,
   Release,
   ReleaseStatus,
   SessionApiResponse,
@@ -173,6 +174,14 @@ class ReleasesList extends AsyncView<Props, State> {
       default:
         return StatusOption.ACTIVE;
     }
+  }
+
+  getSelectedProject(): Project | undefined {
+    const {selection, organization} = this.props;
+
+    const selectedProjectId =
+      selection.projects && selection.projects.length === 1 && selection.projects[0];
+    return organization.projects?.find(p => p.id === `${selectedProjectId}`);
   }
 
   async fetchSessionsExistence() {
@@ -325,16 +334,21 @@ class ReleasesList extends AsyncView<Props, State> {
   }
 
   renderHealthCta() {
-    const {selection, organization} = this.props;
+    const {organization} = this.props;
     const {hasSessions, releases} = this.state;
 
-    const selectedProjectId =
-      selection.projects && selection.projects.length === 1 && selection.projects[0];
-    const selectedProject = organization.projects?.find(
-      p => p.id === `${selectedProjectId}`
-    );
+    const selectedProject = this.getSelectedProject();
+    const isMobileProject =
+      selectedProject &&
+      selectedProject.platform &&
+      ([...mobile, ...desktop] as string[]).includes(selectedProject.platform as string);
 
-    if (!selectedProject || hasSessions !== false || !releases?.length) {
+    if (
+      !selectedProject ||
+      hasSessions !== false ||
+      !releases?.length ||
+      !isMobileProject
+    ) {
       return null;
     }
 
@@ -397,9 +411,15 @@ class ReleasesList extends AsyncView<Props, State> {
           const singleProjectSelected =
             selection.projects?.length === 1 &&
             selection.projects[0] !== ALL_ACCESS_PROJECTS;
+          const selectedProject = this.getSelectedProject();
+          const isMobileProject =
+            selectedProject &&
+            selectedProject.platform &&
+            ([...mobile, ...desktop] as string[]).includes(selectedProject.platform as string);
+
           return (
             <Fragment>
-              {singleProjectSelected && hasSessions && (
+              {singleProjectSelected && hasSessions && isMobileProject && (
                 <Feature features={['organizations:release-adoption-chart']}>
                   <ReleaseAdoptionChart
                     organization={organization}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -415,7 +415,9 @@ class ReleasesList extends AsyncView<Props, State> {
           const isMobileProject =
             selectedProject &&
             selectedProject.platform &&
-            ([...mobile, ...desktop] as string[]).includes(selectedProject.platform as string);
+            ([...mobile, ...desktop] as string[]).includes(
+              selectedProject.platform as string
+            );
 
           return (
             <Fragment>


### PR DESCRIPTION
This adds the exact interval each point in the release adoption chart represents to the tooltip. The 1d period for the chart (when 14d is selected) is different from the 1d period for the Active Users. The last point in the chart is different than the list. The shifted intervals in #26777 isn't going to work, so updated the tooltip to clear the confusion as much as I can.

Also limited the chart to mobile and desktop projects for now.

BEFORE:
![Screen Shot 2021-06-22 at 1 53 35 PM](https://user-images.githubusercontent.com/15015880/122997897-4eaa3c80-d361-11eb-830f-c53eb9246245.png)
![Screen Shot 2021-06-22 at 1 53 39 PM](https://user-images.githubusercontent.com/15015880/122997914-523dc380-d361-11eb-81cf-c876b9153a37.png)


AFTER:
![Screen Shot 2021-06-22 at 1 51 05 PM](https://user-images.githubusercontent.com/15015880/122997726-23bfe880-d361-11eb-82fe-07a76b1974cf.png)
![Screen Shot 2021-06-22 at 1 50 59 PM](https://user-images.githubusercontent.com/15015880/122997736-26224280-d361-11eb-84a1-8b2a0fba1009.png)
