### PR TITLE
fix(ui): Stop sidebar nav item icons from shrinking

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -243,6 +243,7 @@ const SidebarItemIcon = styled('span')`
   height: 22px;
   font-size: 20px;
   align-items: center;
+  flex-shrink: 0;
 
   svg {
     display: block;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/122991683-2bc85a00-d35a-11eb-822a-a7473ff2d097.png)

vs before it looked like

![image](https://user-images.githubusercontent.com/1421724/122991721-3551c200-d35a-11eb-9af8-be2b704744b4.png)
