### PR TITLE
feat(semver): Support equality match for semver filters

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -83,6 +83,6 @@ OPERATOR_NEGATION_MAP = {
     ">=": "<",
     "IN": "NOT IN",
 }
-OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt"}
+OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
 
 SEMVER_MAX_SEARCH_RELEASES = 1000

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1466,6 +1466,7 @@ class ParseSemverSearchTest(TestCase):
         self.run_test(">=", "1.2.4", "IN", [release_2.version])
         self.run_test("<", "1.2.4", "IN", [release.version])
         self.run_test("<=", "1.2.3", "IN", [release.version])
+        self.run_test("=", "1.2.4", "IN", [release_2.version])
 
     def test_invert_query(self):
         # Tests that flipping the query works and uses a NOT IN. Test all operators to


### PR DESCRIPTION
This adds support for semver queries like `sentry.semver:1.2.4`, which makes an exact match.