### PR TITLE
py38(django 2.0): disallow RemovedInDjango20Warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,9 @@ filterwarnings = [
     # This is just to prevent pytest from exiting if pytest-xdist isn't installed.
     "ignore:Unknown config option.*looponfailroots:pytest.PytestConfigWarning",
 
-    # The following warning filters should be kept in sync with
-    # sentry.utils.pytest.sentry, and sentry.runner.settings.
-    # TODO(joshuarli): Address these as a prerequisite to testing on Django 2.1.
-    "ignore::django.utils.deprecation.RemovedInDjango20Warning",
+    # TODO(joshuarli): Enable this and address all after Django 2.0 lands.
     "ignore::django.utils.deprecation.RemovedInDjango21Warning",
+
     # DeprecationWarnings from Python 3.6's sre_parse are just so painful,
     # and I haven't found a way to ignore it specifically from a module.
     # This one in particular is from the "cookies" packages as depended

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import click
 
@@ -88,19 +89,14 @@ def configure(ctx, py, yaml, skip_service_validation=False):
     if __installed:
         return
 
-    import warnings
-
     # Make sure that our warnings are always displayed.
     warnings.filterwarnings("default", "", Warning, r"^sentry")
 
-    # This should be kept in-sync with sentry.utils.pytest.sentry,
-    # and pytest warningfilters in pyproject.toml.
-    # See pyproject.toml for explanations.
-    from django.utils.deprecation import RemovedInDjango20Warning, RemovedInDjango21Warning
+    from django.utils.deprecation import RemovedInDjango21Warning
 
-    warnings.filterwarnings(action="ignore", category=RemovedInDjango20Warning)
+    # While we're on Django 1.9, we only care about RemovedInDjango20Warning.
+    # TODO(joshuarli): Remove this after RemovedInDjango21Warnings are fixed in testing.
     warnings.filterwarnings(action="ignore", category=RemovedInDjango21Warning)
-    warnings.filterwarnings(action="ignore", category=DeprecationWarning)
 
     # Add in additional mimetypes that are useful for our static files
     # which aren't common in default system registries

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -15,16 +15,7 @@ TEST_ROOT = os.path.normpath(
 def pytest_configure(config):
     import warnings
 
-    from django.utils.deprecation import RemovedInDjango20Warning, RemovedInDjango21Warning
-
-    # These warnings should be kept in sync with sentry.runner.settings,
-    # and pytest warningfilters in pyproject.toml.
-    # See pyproject.toml for explanations.
-    warnings.filterwarnings(action="ignore", category=RemovedInDjango20Warning)
-    warnings.filterwarnings(action="ignore", category=RemovedInDjango21Warning)
-    warnings.filterwarnings(action="ignore", category=DeprecationWarning)
-
-    # These warnings are for pytest only.
+    # This is just to filter out an obvious warning before the pytest session starts.
     warnings.filterwarnings(
         action="ignore",
         message=r".*sentry.digests.backends.dummy.DummyBackend.*",


### PR DESCRIPTION
Now that all of these are fixed as far as the test suite is concerned, make them fatal in pytest.
