### PR TITLE
feat(releases): Change sort by active users to sessions according display

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -143,6 +143,8 @@ class ReleasesList extends AsyncView<Props, State> {
         return SortOption.SESSIONS;
       case SortOption.USERS_24_HOURS:
         return SortOption.USERS_24_HOURS;
+      case SortOption.SESSIONS_24_HOURS:
+        return SortOption.SESSIONS_24_HOURS;
       case SortOption.BUILD:
         return SortOption.BUILD;
       case SortOption.SEMVER:
@@ -236,9 +238,15 @@ class ReleasesList extends AsyncView<Props, State> {
   handleDisplay = (display: string) => {
     const {location, router} = this.props;
 
+    let sort = location.query.sort;
+    if (sort === SortOption.USERS_24_HOURS && display === DisplayOption.SESSIONS)
+      sort = SortOption.SESSIONS_24_HOURS;
+    else if (sort === SortOption.SESSIONS_24_HOURS && display === DisplayOption.USERS)
+      sort = SortOption.USERS_24_HOURS;
+
     router.push({
       ...location,
-      query: {...location.query, cursor: undefined, display},
+      query: {...location.query, cursor: undefined, display, sort},
     });
   };
 
@@ -293,6 +301,16 @@ class ReleasesList extends AsyncView<Props, State> {
       return (
         <EmptyStateWarning small>
           {t('There are no releases with active user data (users in the last 24 hours).')}
+        </EmptyStateWarning>
+      );
+    }
+
+    if (activeSort === SortOption.SESSIONS_24_HOURS) {
+      return (
+        <EmptyStateWarning small>
+          {t(
+            'There are no releases with active session data (sessions in the last 24 hours).'
+          )}
         </EmptyStateWarning>
       );
     }
@@ -490,6 +508,7 @@ class ReleasesList extends AsyncView<Props, State> {
               />
               <ReleaseListSortOptions
                 selected={activeSort}
+                selectedDisplay={activeDisplay}
                 onSelect={this.handleSortBy}
                 organization={organization}
               />

--- a/static/app/views/releases/list/releaseListSortOptions.tsx
+++ b/static/app/views/releases/list/releaseListSortOptions.tsx
@@ -4,19 +4,27 @@ import {t} from 'app/locale';
 import {Organization} from 'app/types';
 
 import ReleaseListDropdown from './releaseListDropdown';
-import {SortOption} from './utils';
+import {DisplayOption, SortOption} from './utils';
 
 type Props = {
   selected: SortOption;
+  selectedDisplay: DisplayOption;
   onSelect: (key: string) => void;
   organization: Organization;
 };
 
-function ReleaseListSortOptions({selected, onSelect, organization}: Props) {
+function ReleaseListSortOptions({
+  selected,
+  selectedDisplay,
+  onSelect,
+  organization,
+}: Props) {
   const sortOptions = {
     [SortOption.DATE]: t('Date Created'),
     [SortOption.SESSIONS]: t('Total Sessions'),
-    [SortOption.USERS_24_HOURS]: t('Active Users'),
+    ...(selectedDisplay === DisplayOption.USERS
+      ? {[SortOption.USERS_24_HOURS]: t('Active Users')}
+      : {[SortOption.SESSIONS_24_HOURS]: t('Active Sessions')}),
     [SortOption.CRASH_FREE_USERS]: t('Crash Free Users'),
     [SortOption.CRASH_FREE_SESSIONS]: t('Crash Free Sessions'),
   } as Record<SortOption, string>;

--- a/static/app/views/releases/list/utils.tsx
+++ b/static/app/views/releases/list/utils.tsx
@@ -2,6 +2,7 @@ export enum SortOption {
   CRASH_FREE_USERS = 'crash_free_users',
   CRASH_FREE_SESSIONS = 'crash_free_sessions',
   USERS_24_HOURS = 'users_24h',
+  SESSIONS_24_HOURS = 'sessions_24h',
   SESSIONS = 'sessions',
   DATE = 'date',
   BUILD = 'build',

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -133,6 +133,15 @@ describe('ReleasesList', function () {
       'There are no releases with active user data (users in the last 24 hours).'
     );
 
+    location = {query: {sort: SortOption.SESSIONS_24_HOURS, statsPeriod: '7d'}};
+    wrapper = mountWithTheme(
+      <ReleasesList {...props} location={location} />,
+      routerContext
+    );
+    expect(wrapper.find('EmptyMessage').text()).toEqual(
+      'There are no releases with active session data (sessions in the last 24 hours).'
+    );
+
     location = {query: {sort: SortOption.BUILD}};
     wrapper = mountWithTheme(
       <ReleasesList {...props} location={location} />,


### PR DESCRIPTION
This adds the `Active Sessions` release page sort dropdown option, similar to `Active Users`, the query parameter for it is `sessions_24h` and it already exists in the api. Tied the `Sort: Active Users` to `Display: Users` and `Sort: Active Sessions` to `Display: Sessions`.

Resolves: [WOR-994](https://getsentry.atlassian.net/browse/WOR-994)

Demo:
https://user-images.githubusercontent.com/15015880/123014519-4bbc4580-d37b-11eb-938e-e7d377386ea1.mp4

