### PR TITLE
fix(ui): reduced size of important tags

### DIFF
--- a/static/app/components/events/contextSummary/contextSummary.tsx
+++ b/static/app/components/events/contextSummary/contextSummary.tsx
@@ -98,13 +98,9 @@ class ContextSummary extends React.Component<Props> {
 export default ContextSummary;
 
 const Wrapper = styled('div')`
-  border-top: 1px solid ${p => p.theme.innerBorder};
-
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    display: grid;
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(0, auto);
-    grid-gap: ${space(4)};
-    padding: 25px ${space(4)} 25px 40px;
+    display: flex;
+    gap: ${space(3)};
+    margin-bottom: ${space(2)};
   }
 `;

--- a/static/app/components/events/contextSummary/contextSummaryUser.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryUser.tsx
@@ -97,7 +97,7 @@ const ContextSummaryUser = ({data}: Props) => {
   const icon = userTitle ? (
     <UserAvatar
       user={user as AvatarUser}
-      size={30}
+      size={32}
       className="context-item-icon"
       gravatar={false}
     />

--- a/static/app/components/events/contextSummary/contextSummaryUser.tsx
+++ b/static/app/components/events/contextSummary/contextSummaryUser.tsx
@@ -97,7 +97,7 @@ const ContextSummaryUser = ({data}: Props) => {
   const icon = userTitle ? (
     <UserAvatar
       user={user as AvatarUser}
-      size={48}
+      size={30}
       className="context-item-icon"
       gravatar={false}
     />

--- a/static/app/components/events/contextSummary/item.tsx
+++ b/static/app/components/events/contextSummary/item.tsx
@@ -29,7 +29,7 @@ const Details = styled('div')`
 
 const Wrapper = styled('div')`
   border-top: 1px solid ${p => p.theme.innerBorder};
-  padding: ${space(2)} 0 0 40px;
+  padding: 4px 0 4px 40px;
   display: flex;
   margin-right: ${space(3)};
   align-items: center;
@@ -37,6 +37,6 @@ const Wrapper = styled('div')`
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     border: 0;
-    padding: ${space(0.5)} 0px 0px 40px;
+    padding: 0px 0px 0px 42px;
   }
 `;

--- a/static/app/components/events/contextSummary/item.tsx
+++ b/static/app/components/events/contextSummary/item.tsx
@@ -20,6 +20,9 @@ const Item = ({children, icon, className}: Props) => (
 export default Item;
 
 const Details = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   max-width: 100%;
   min-height: 48px;
 `;

--- a/static/app/components/events/contextSummary/item.tsx
+++ b/static/app/components/events/contextSummary/item.tsx
@@ -26,15 +26,14 @@ const Details = styled('div')`
 
 const Wrapper = styled('div')`
   border-top: 1px solid ${p => p.theme.innerBorder};
-  padding: ${space(2)} 0 ${space(2)} 64px;
+  padding: ${space(2)} 0 0 40px;
   display: flex;
+  margin-right: ${space(3)};
   align-items: center;
   position: relative;
-  min-height: 67px;
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     border: 0;
-    padding: ${space(0.5)} 0px 0px 64px;
-    min-height: 48px;
+    padding: ${space(0.5)} 0px 0px 40px;
   }
 `;

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -132,7 +132,7 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  margin-bottom: ${space(2)};
+  margin-bottom: ${space(1)};
 
   > * {
     margin-bottom: ${space(0.5)};

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -373,9 +373,9 @@ class EventEntries extends Component<Props, State> {
             includeBorder={!hasErrors}
           />
         )}
-        <StyledEventDataSection title={t('Tags')} type="tags">
-          {hasContext && <EventContextSummary event={event} />}
-          {showTagSummary && (
+        {showTagSummary && (
+          <StyledEventDataSection title={t('Tags')} type="tags">
+            {hasContext && <EventContextSummary event={event} />}
             <EventTags
               event={event}
               organization={organization as Organization}
@@ -383,8 +383,8 @@ class EventEntries extends Component<Props, State> {
               location={location}
               hasQueryFeature={hasQueryFeature}
             />
-          )}
-        </StyledEventDataSection>
+          </StyledEventDataSection>
+        )}
         {this.renderEntries(event)}
         {hasContext && <EventContexts group={group} event={event} />}
         {event && !objectIsEmpty(event.context) && <EventExtraData event={event} />}

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -373,16 +373,18 @@ class EventEntries extends Component<Props, State> {
             includeBorder={!hasErrors}
           />
         )}
-        {hasContext && showTagSummary && <EventContextSummary event={event} />}
-        {showTagSummary && (
-          <EventTags
-            event={event}
-            organization={organization as Organization}
-            projectId={project.slug}
-            location={location}
-            hasQueryFeature={hasQueryFeature}
-          />
-        )}
+        <StyledEventDataSection title={t('Tags')} type="tags">
+          {hasContext && <EventContextSummary event={event} />}
+          {showTagSummary && (
+            <EventTags
+              event={event}
+              organization={organization as Organization}
+              projectId={project.slug}
+              location={location}
+              hasQueryFeature={hasQueryFeature}
+            />
+          )}
+        </StyledEventDataSection>
         {this.renderEntries(event)}
         {hasContext && <EventContexts group={group} event={event} />}
         {event && !objectIsEmpty(event.context) && <EventExtraData event={event} />}
@@ -453,6 +455,10 @@ const StyledEventUserFeedback = styled(EventUserFeedback)<StyledEventUserFeedbac
   border: 0;
   ${p => (p.includeBorder ? `border-top: 1px solid ${p.theme.innerBorder};` : '')}
   margin: 0;
+`;
+
+const StyledEventDataSection = styled(EventDataSection)`
+  margin-bottom: ${space(2)};
 `;
 
 // TODO(ts): any required due to our use of SharedViewOrganization

--- a/static/app/components/events/eventTags/eventTags.tsx
+++ b/static/app/components/events/eventTags/eventTags.tsx
@@ -1,11 +1,7 @@
-import styled from '@emotion/styled';
 import {Location} from 'history';
 import isEmpty from 'lodash/isEmpty';
 
-import EventDataSection from 'app/components/events/eventDataSection';
 import Pills from 'app/components/pills';
-import {t} from 'app/locale';
-import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {Event} from 'app/types/event';
 import {defined, generateQueryWithTag} from 'app/utils';
@@ -36,29 +32,21 @@ const EventTags = ({
   const releasesPath = `/organizations/${orgSlug}/releases/`;
 
   return (
-    <StyledEventDataSection title={t('Tags')} type="tags">
-      <Pills>
-        {tags.map((tag, index) => (
-          <EventTagsPill
-            key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
-            tag={tag}
-            projectId={projectId}
-            organization={organization}
-            query={generateQueryWithTag(location.query, tag)}
-            streamPath={streamPath}
-            releasesPath={releasesPath}
-            hasQueryFeature={hasQueryFeature}
-          />
-        ))}
-      </Pills>
-    </StyledEventDataSection>
+    <Pills>
+      {tags.map((tag, index) => (
+        <EventTagsPill
+          key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
+          tag={tag}
+          projectId={projectId}
+          organization={organization}
+          query={generateQueryWithTag(location.query, tag)}
+          streamPath={streamPath}
+          releasesPath={releasesPath}
+          hasQueryFeature={hasQueryFeature}
+        />
+      ))}
+    </Pills>
   );
 };
 
 export default EventTags;
-
-const StyledEventDataSection = styled(EventDataSection)`
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    margin-bottom: ${space(3)};
-  }
-`;

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -161,14 +161,12 @@
     .context-item-icon {
       position: absolute;
       left: 0;
-      top: 50%;
-      transform: translateY(-50%);
-      width: 30px;
-      height: 30px;
+      width: 36px;
+      height: 36px;
       background-repeat: no-repeat;
-      background-position: center;
+      background-position: center 2px;
       background-image: url(~sentry-logos/logo-unknown.svg);
-      background-size: 30px 30px;
+      background-size: 30px 32px; // magic number here because some logos are slightly cut off when at 32 x 32
     }
 
     &:first-child {
@@ -277,6 +275,7 @@
     &.watchos {
       .context-item-icon {
         background-image: url(~sentry-logos/logo-apple.svg);
+        background-position: center 0;
       }
     }
 
@@ -1402,12 +1401,7 @@ ul.crumbs {
     flex-direction: column;
     margin-top: 0;
     padding: 0;
-
-    .context-item {
-      .context-item-icon {
-        top: 9px;
-      }
-    }
+    margin-bottom: 20px;
   }
 
   .context {

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -161,28 +161,25 @@
     .context-item-icon {
       position: absolute;
       left: 0;
-      top: 0;
-      width: 48px;
-      height: 48px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 30px;
+      height: 30px;
       background-repeat: no-repeat;
       background-position: center;
       background-image: url(~sentry-logos/logo-unknown.svg);
-      background-size: 48px 48px;
+      background-size: 30px 30px;
     }
 
     &:first-child {
       border: 0;
     }
 
-    h3,
-    p {
-      margin: 0 0 4px;
-    }
-
     h3 {
       .truncate;
       font-size: 16px;
       line-height: 1.2;
+      margin-bottom: 0;
     }
 
     p {
@@ -280,13 +277,11 @@
     &.watchos {
       .context-item-icon {
         background-image: url(~sentry-logos/logo-apple.svg);
-        top: -2px;
       }
     }
 
     &.android .context-item-icon {
       background-image: url(~sentry-logos/logo-android.svg);
-      top: -1px;
     }
 
     &.windows .context-item-icon {


### PR DESCRIPTION
Tags take up a lot of room so I'm reducing the size of the important tags and moving them into the same section as the pills.

## Before

<img width="951" alt="CleanShot 2021-06-22 at 17 23 02@2x" src="https://user-images.githubusercontent.com/1900676/123016009-88d60700-d37e-11eb-8cfc-4eed62c40071.png">

## After 

<img width="929" alt="CleanShot 2021-06-22 at 17 22 27@2x" src="https://user-images.githubusercontent.com/1900676/123016022-8d022480-d37e-11eb-8cf8-487bb690cef0.png">
