### PR TITLE
feat(semver): Add support for wildcard matching

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -236,7 +236,7 @@ class OrganizationReleasesEndpoint(
             queryset = queryset.filter(build_number__isnull=False).order_by("-build_number")
             paginator_kwargs["order_by"] = "-build_number"
         elif sort == "semver":
-            order_by = [f"-{col}" for col in Release.SEMVER_SORT_COLS]
+            order_by = [f"-{col}" for col in Release.SEMVER_COLS]
             queryset = queryset.annotate_prerelease_column().filter_to_semver().order_by(*order_by)
             paginator_kwargs["order_by"] = order_by
         elif sort in self.SESSION_SORTS:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1,8 +1,9 @@
 import itertools
 import logging
 import re
+from dataclasses import dataclass
 from time import time
-from typing import List, Mapping
+from typing import List, Mapping, Optional, Sequence, Union
 
 import sentry_sdk
 from django.db import IntegrityError, models, transaction
@@ -103,9 +104,58 @@ class ReleaseStatus:
             raise ValueError(repr(value))
 
 
-class ReleaseQuerySet(models.QuerySet):
-    SEMVER_FAKE_PACKAGE = "__sentry_fake__"
+@dataclass
+class SemverFilter:
+    operator: str
+    version_parts: Sequence[Union[int, str]]
+    package: Optional[str] = None
 
+
+SEMVER_FAKE_PACKAGE = "__sentry_fake__"
+SEMVER_WILDCARDS = frozenset(["X", "*"])
+
+
+def convert_semver_to_filter(version, operator) -> Optional[SemverFilter]:
+    # TODO: This doesn't really belong in this module. Will move this elsewhere when
+    # refactoring `filter_by_semver` to accept a `SemverFilter`
+    version = version if "@" in version else f"{SEMVER_FAKE_PACKAGE}@{version}"
+    parsed = parse_release(version)
+    parsed_version = parsed.get("version_parsed")
+    if parsed_version:
+        # Convert `pre` to always be a string
+        prerelease = parsed_version["pre"] if parsed_version["pre"] else ""
+        semver_filter = SemverFilter(
+            operator,
+            [
+                parsed_version["major"],
+                parsed_version["minor"],
+                parsed_version["patch"],
+                parsed_version["revision"],
+                0 if prerelease else 1,
+                prerelease,
+            ],
+        )
+        if parsed["package"] and parsed["package"] != SEMVER_FAKE_PACKAGE:
+            semver_filter.package = parsed.package
+        return semver_filter
+    else:
+        # Try to parse as a wildcard match
+        package, version = version.split("@", 1)
+        version_parts = []
+        for part in version.split(".", 3):
+            if part in SEMVER_WILDCARDS:
+                break
+            try:
+                # We assume all ints for a wildcard match - not handling prerelease as
+                # part of these
+                version_parts.append(int(part))
+            except ValueError:
+                return
+
+        return SemverFilter("exact", version_parts)
+
+
+class ReleaseQuerySet(models.QuerySet):
     def annotate_prerelease_column(self):
         """
         Adds a `prerelease_case` column to the queryset which is used to properly sort
@@ -136,51 +186,36 @@ class ReleaseQuerySet(models.QuerySet):
          - sentry@1.2.3.4-alpha
          - 1.2.3.4
          - 1.2.3.4-alpha
+         - 1.*
         """
-        # TODO: Probably move the parsing logic into a separate function once we start
-        # to handle wildcards
-        # Our semver parser expects a package at the start of the version, so just add a
-        # dummy one here if not already provided.
-        version = version if "@" in version else f"{self.SEMVER_FAKE_PACKAGE}@{version}"
-        parsed = parse_release(version)
-        parsed_version = parsed.get("version_parsed")
-        if parsed_version:
+        # TODO: Will refactor this further so that we pass a `SemverFilter` instead of
+        # the version string
+        semver_filter = convert_semver_to_filter(version, operator)
+        if semver_filter:
             # The version matches semver format, so we can use it for comparison
             release_filter = Q(organization_id=organization_id)
-            if parsed["package"] and parsed["package"] != self.SEMVER_FAKE_PACKAGE:
-                release_filter &= Q(package=parsed["package"])
-            # Convert `pre` to always be a string
-            prerelease = parsed_version["pre"] if parsed_version["pre"] else ""
+            if semver_filter.package:
+                release_filter &= Q(package=semver_filter.package)
+
             filter_func = Func(
-                parsed_version["major"],
-                parsed_version["minor"],
-                parsed_version["patch"],
-                parsed_version["revision"],
-                0 if prerelease else 1,
-                Value(prerelease),
+                *[
+                    Value(part) if isinstance(part, str) else part
+                    for part in semver_filter.version_parts
+                ],
                 function="ROW",
             )
-
+            cols = self.model.SEMVER_COLS[: len(semver_filter.version_parts)]
             return (
                 self.filter(release_filter)
                 .annotate_prerelease_column()
                 .annotate(
                     semver=Func(
-                        F("major"),
-                        F("minor"),
-                        F("patch"),
-                        F("revision"),
-                        F("prerelease_case"),
-                        F("prerelease"),
-                        function="ROW",
-                        output_field=ArrayField(),
-                    ),
+                        *[F(col) for col in cols], function="ROW", output_field=ArrayField()
+                    )
                 )
-                .filter(**{f"semver__{operator}": filter_func})
+                .filter(**{f"semver__{semver_filter.operator}": filter_func})
             )
         else:
-            # TODO: We want to parse partial strings like 1.*, etc. For now, we'll just
-            # handle the basic case and fail otherwise
             raise InvalidSearchQuery(f"Invalid format for semver query {version}")
 
 
@@ -363,7 +398,7 @@ class Release(Model):
 
     __repr__ = sane_repr("organization_id", "version")
 
-    SEMVER_SORT_COLS = ["major", "minor", "patch", "revision", "prerelease_case", "prerelease"]
+    SEMVER_COLS = ["major", "minor", "patch", "revision", "prerelease_case", "prerelease"]
 
     def __eq__(self, other):
         """Make sure that specialized releases are only comparable to the same

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -353,13 +353,14 @@ def parse_semver_search(
         raise ValueError("organization_id is a required param")
 
     organization_id: int = params["organization_id"]
-    version: str = search_filter.value.value
+    # We explicitly use `raw_value` here to avoid converting wildcards to shell values
+    version: str = search_filter.value.raw_value
     operator: str = search_filter.operator
 
     # Note that we sort this such that if we end up fetching more than
     # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to
     # the passed filter.
-    order_by = Release.SEMVER_SORT_COLS
+    order_by = Release.SEMVER_COLS
     if operator.startswith("<"):
         order_by = list(map(_flip_field_sort, order_by))
     qs = (

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -261,6 +261,9 @@ class OrganizationReleaseListTest(APITestCase):
         response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3")
         assert [r["version"] for r in response.data] == [release_2.version, release_1.version]
 
+        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:1.2.*")
+        assert [r["version"] for r in response.data] == [release_2.version, release_1.version]
+
         response = self.get_valid_response(
             self.organization.slug, query=f"{SEMVER_ALIAS}:>=1.2.3", sort="semver"
         )

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1443,7 +1443,7 @@ class ParseSemverSearchTest(TestCase):
 
     def test_invalid_query(self):
         key = "semver"
-        filter = SearchFilter(SearchKey(key), ">", SearchValue("1.2.*"))
+        filter = SearchFilter(SearchKey(key), ">", SearchValue("1.2.hi"))
         with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
             parse_semver_search(filter, key, {"organization_id": self.organization.id})
 
@@ -1532,3 +1532,21 @@ class ParseSemverSearchTest(TestCase):
         self.run_test(">", "1.2.3", "IN", [release_4.version, release_5.version])
         self.run_test(">", "1.2.3.4", "IN", [release_5.version])
         self.run_test(">", "2", "IN", [])
+
+    def test_wildcard(self):
+        release_1 = self.create_release(version="test@1.0.0.0")
+        release_2 = self.create_release(version="test@1.2.0.0")
+        release_3 = self.create_release(version="test@1.2.3.0")
+        release_4 = self.create_release(version="test@1.2.3.4")
+        release_5 = self.create_release(version="test@2.0.0.0")
+
+        self.run_test(
+            "=",
+            "1.X",
+            "IN",
+            [release_1.version, release_2.version, release_3.version, release_4.version],
+        )
+        self.run_test("=", "1.2.*", "IN", [release_2.version, release_3.version, release_4.version])
+        self.run_test("=", "1.2.3.*", "IN", [release_3.version, release_4.version])
+        self.run_test("=", "1.2.3.4", "IN", [release_4.version])
+        self.run_test("=", "2.*", "IN", [release_5.version])


### PR DESCRIPTION
This adds support for wildcard matching when performing a semver search. This can look like:
 - `<key>:1.2.*`
 - `<key>:sentry@1.2.*`
 - `<key>:1.2.X`
 - `<key>:1.*`
 - etc

I've split the parsing logic out from `filter_by_semver`. I want to take this a step further and
have `filter_by_semver` not be aware of parsing at all, and just pass a `SemverFilter` to it
directly, but will handle that refactor separately.