### PR TITLE
refs(semver): Move semver parsing code out of `ReleaseQuerySet`

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -27,7 +27,8 @@ from sentry.models import (
     ReleaseProject,
     ReleaseStatus,
 )
-from sentry.search.events.constants import OPERATOR_TO_DJANGO, SEMVER_ALIAS
+from sentry.search.events.constants import SEMVER_ALIAS
+from sentry.search.events.filter import parse_semver
 from sentry.signals import release_created
 from sentry.snuba.sessions import (
     STATS_PERIODS,
@@ -216,8 +217,7 @@ class OrganizationReleasesEndpoint(
                 if search_filter.key.name == SEMVER_ALIAS:
                     queryset = queryset.filter_by_semver(
                         organization.id,
-                        OPERATOR_TO_DJANGO[search_filter.operator],
-                        search_filter.value.raw_value,
+                        parse_semver(search_filter.value.raw_value, search_filter.operator),
                     )
 
         select_extra = {}

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -24,7 +24,6 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
-from sentry.exceptions import InvalidSearchQuery
 from sentry.models import CommitFileChange, GroupInboxRemoveAction, remove_group_from_inbox
 from sentry.signals import issue_resolved
 from sentry.utils import metrics
@@ -111,50 +110,6 @@ class SemverFilter:
     package: Optional[str] = None
 
 
-SEMVER_FAKE_PACKAGE = "__sentry_fake__"
-SEMVER_WILDCARDS = frozenset(["X", "*"])
-
-
-def convert_semver_to_filter(version, operator) -> Optional[SemverFilter]:
-    # TODO: This doesn't really belong in this module. Will move this elsewhere when
-    # refactoring `filter_by_semver` to accept a `SemverFilter`
-    version = version if "@" in version else f"{SEMVER_FAKE_PACKAGE}@{version}"
-    parsed = parse_release(version)
-    parsed_version = parsed.get("version_parsed")
-    if parsed_version:
-        # Convert `pre` to always be a string
-        prerelease = parsed_version["pre"] if parsed_version["pre"] else ""
-        semver_filter = SemverFilter(
-            operator,
-            [
-                parsed_version["major"],
-                parsed_version["minor"],
-                parsed_version["patch"],
-                parsed_version["revision"],
-                0 if prerelease else 1,
-                prerelease,
-            ],
-        )
-        if parsed["package"] and parsed["package"] != SEMVER_FAKE_PACKAGE:
-            semver_filter.package = parsed.package
-        return semver_filter
-    else:
-        # Try to parse as a wildcard match
-        package, version = version.split("@", 1)
-        version_parts = []
-        for part in version.split(".", 3):
-            if part in SEMVER_WILDCARDS:
-                break
-            try:
-                # We assume all ints for a wildcard match - not handling prerelease as
-                # part of these
-                version_parts.append(int(part))
-            except ValueError:
-                return
-
-        return SemverFilter("exact", version_parts)
-
-
 class ReleaseQuerySet(models.QuerySet):
     def annotate_prerelease_column(self):
         """
@@ -175,48 +130,39 @@ class ReleaseQuerySet(models.QuerySet):
         return self.filter(major__isnull=False)
 
     def filter_by_semver(
-        self, organization_id: int, operator: str, version: str
+        self, organization_id: int, semver_filter: SemverFilter
     ) -> models.QuerySet:
         """
-        Filter releases down based on semver syntax. version should be in format
-        `<package_name>@<version>` or `<version>`, where package_name is a string and
-        version is a version string matching semver format (https://semver.org/). We've
-        slightly extended this format to allow up to 4 integers. EG
-         - sentry@1.2.3.4
-         - sentry@1.2.3.4-alpha
-         - 1.2.3.4
-         - 1.2.3.4-alpha
-         - 1.*
-        """
-        # TODO: Will refactor this further so that we pass a `SemverFilter` instead of
-        # the version string
-        semver_filter = convert_semver_to_filter(version, operator)
-        if semver_filter:
-            # The version matches semver format, so we can use it for comparison
-            release_filter = Q(organization_id=organization_id)
-            if semver_filter.package:
-                release_filter &= Q(package=semver_filter.package)
+        Filters released based on a based `SemverFilter` instance.
+        `SemverFilter.version_parts` can contain up to 6 components, which should map
+        to the columns defined in `Release.SEMVER_COLS`. If fewer components are
+        included, then we will exclude later columns from the filter.
+        `SemverFilter.package` is optional, and if included we will filter the `package`
+        column using the provided value.
+        `SemverFilter.operator` should be a Django field filter.
 
-            filter_func = Func(
-                *[
-                    Value(part) if isinstance(part, str) else part
-                    for part in semver_filter.version_parts
-                ],
-                function="ROW",
+        Typically we build a `SemverFilter` via `sentry.search.events.filter.parse_semver`
+        """
+        release_filter = Q(organization_id=organization_id)
+        if semver_filter.package:
+            release_filter &= Q(package=semver_filter.package)
+
+        filter_func = Func(
+            *[
+                Value(part) if isinstance(part, str) else part
+                for part in semver_filter.version_parts
+            ],
+            function="ROW",
+        )
+        cols = self.model.SEMVER_COLS[: len(semver_filter.version_parts)]
+        return (
+            self.filter(release_filter)
+            .annotate_prerelease_column()
+            .annotate(
+                semver=Func(*[F(col) for col in cols], function="ROW", output_field=ArrayField())
             )
-            cols = self.model.SEMVER_COLS[: len(semver_filter.version_parts)]
-            return (
-                self.filter(release_filter)
-                .annotate_prerelease_column()
-                .annotate(
-                    semver=Func(
-                        *[F(col) for col in cols], function="ROW", output_field=ArrayField()
-                    )
-                )
-                .filter(**{f"semver__{semver_filter.operator}": filter_func})
-            )
-        else:
-            raise InvalidSearchQuery(f"Invalid format for semver query {version}")
+            .filter(**{f"semver__{semver_filter.operator}": filter_func})
+        )
 
 
 class ReleaseModelManager(models.Manager):
@@ -230,9 +176,9 @@ class ReleaseModelManager(models.Manager):
         return self.get_queryset().filter_to_semver()
 
     def filter_by_semver(
-        self, organization_id: int, operator: str, version: str
+        self, organization_id: int, semver_filter: SemverFilter
     ) -> models.QuerySet:
-        return self.get_queryset().filter_by_semver(organization_id, operator, version)
+        return self.get_queryset().filter_by_semver(organization_id, semver_filter)
 
     @staticmethod
     def _convert_build_code_to_build_number(build_code):

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -87,3 +87,5 @@ OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exac
 
 SEMVER_MAX_SEARCH_RELEASES = 1000
 SEMVER_EMPTY_RELEASE = "____SENTRY_EMPTY_RELEASE____"
+SEMVER_FAKE_PACKAGE = "__sentry_fake__"
+SEMVER_WILDCARDS = frozenset(["X", "*"])

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1,10 +1,9 @@
-import unittest
-
 import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.api.exceptions import InvalidRepository
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
     Commit,
     CommitAuthor,
@@ -18,7 +17,6 @@ from sentry.models import (
     GroupResolution,
     GroupStatus,
     Integration,
-    InvalidSearchQuery,
     OrganizationIntegration,
     Release,
     ReleaseCommit,
@@ -27,10 +25,9 @@ from sentry.models import (
     ReleaseProject,
     ReleaseProjectEnvironment,
     Repository,
-    SemverFilter,
     add_group_to_inbox,
-    convert_semver_to_filter,
 )
+from sentry.search.events.filter import parse_semver
 from sentry.testutils import SetRefsTestCase, TestCase
 from sentry.utils.compat.mock import patch
 from sentry.utils.strings import truncatechars
@@ -806,21 +803,21 @@ class SemverReleaseParseTestCase(TestCase):
 class ReleaseFilterBySemverTest(TestCase):
     def test_invalid_query(self):
         with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
-            Release.objects.filter_by_semver(self.organization.id, "gt", "1.2.hi")
+            Release.objects.filter_by_semver(self.organization.id, parse_semver("1.2.hi", ">"))
 
     def run_test(self, operator, version, expected_releases, organization_id=None):
         organization_id = organization_id if organization_id else self.organization.id
-        assert set(Release.objects.filter_by_semver(organization_id, operator, version)) == set(
-            expected_releases
-        )
+        assert set(
+            Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
+        ) == set(expected_releases)
 
     def test(self):
         release = self.create_release(version="test@1.2.3")
         release_2 = self.create_release(version="test@1.2.4")
-        self.run_test("gt", "1.2.3", [release_2])
-        self.run_test("gte", "1.2.4", [release_2])
-        self.run_test("lt", "1.2.4", [release])
-        self.run_test("lte", "1.2.3", [release])
+        self.run_test(">", "1.2.3", [release_2])
+        self.run_test(">=", "1.2.4", [release_2])
+        self.run_test("<", "1.2.4", [release])
+        self.run_test("<=", "1.2.3", [release])
 
     def test_prerelease(self):
         # Prerelease has weird sorting rules, where an empty string is higher priority
@@ -830,13 +827,13 @@ class ReleaseFilterBySemverTest(TestCase):
         release_2 = self.create_release(version="test@1.2.3")
         release_3 = self.create_release(version="test@1.2.4-alpha")
         release_4 = self.create_release(version="test@1.2.4")
-        self.run_test("gte", "1.2.3", [release_2, release_3, release_4])
+        self.run_test(">=", "1.2.3", [release_2, release_3, release_4])
         self.run_test(
-            "gte",
+            ">=",
             "1.2.3-beta",
             [release_1, release_2, release_3, release_4],
         )
-        self.run_test("lt", "1.2.3", [release_1, release])
+        self.run_test("<", "1.2.3", [release_1, release])
 
     def test_granularity(self):
         self.create_release(version="test@1.0.0.0")
@@ -845,14 +842,14 @@ class ReleaseFilterBySemverTest(TestCase):
         release_4 = self.create_release(version="test@1.2.3.4")
         release_5 = self.create_release(version="test@2.0.0.0")
         self.run_test(
-            "gt",
+            ">",
             "1",
             [release_2, release_3, release_4, release_5],
         )
-        self.run_test("gt", "1.2", [release_3, release_4, release_5])
-        self.run_test("gt", "1.2.3", [release_4, release_5])
-        self.run_test("gt", "1.2.3.4", [release_5])
-        self.run_test("gt", "2", [])
+        self.run_test(">", "1.2", [release_3, release_4, release_5])
+        self.run_test(">", "1.2.3", [release_4, release_5])
+        self.run_test(">", "1.2.3.4", [release_5])
+        self.run_test(">", "2", [])
 
     def test_wildcard(self):
         release_1 = self.create_release(version="test@1.0.0.0")
@@ -862,35 +859,11 @@ class ReleaseFilterBySemverTest(TestCase):
         release_5 = self.create_release(version="test@2.0.0.0")
 
         self.run_test(
-            "exact",
+            "=",
             "1.X",
             [release_1, release_2, release_3, release_4],
         )
-        self.run_test("exact", "1.2.*", [release_2, release_3, release_4])
-        self.run_test("exact", "1.2.3.*", [release_3, release_4])
-        self.run_test("exact", "1.2.3.4", [release_4])
-        self.run_test("exact", "2.*", [release_5])
-
-
-class ConvertSemverToFilterTest(unittest.TestCase):
-    def run_test(self, version: str, operator: str, expected: SemverFilter):
-        semver_filter = convert_semver_to_filter(version, operator)
-        assert semver_filter == expected
-
-    def test_invalid(self):
-        assert convert_semver_to_filter("1.hello", "gt") is None
-        assert convert_semver_to_filter("hello", "gt") is None
-
-    def test_normal(self):
-        self.run_test("1", "gt", SemverFilter("gt", [1, 0, 0, 0, 1, ""]))
-        self.run_test("1.2", "gt", SemverFilter("gt", [1, 2, 0, 0, 1, ""]))
-        self.run_test("1.2.3", "gt", SemverFilter("gt", [1, 2, 3, 0, 1, ""]))
-        self.run_test("1.2.3.4", "gt", SemverFilter("gt", [1, 2, 3, 4, 1, ""]))
-        self.run_test("1.2.3-hi", "gt", SemverFilter("gt", [1, 2, 3, 0, 0, "hi"]))
-        self.run_test("1.2.3-hi", "lt", SemverFilter("lt", [1, 2, 3, 0, 0, "hi"]))
-
-    def test_wildcard(self):
-        self.run_test("1.*", "exact", SemverFilter("exact", [1]))
-        self.run_test("1.2.*", "exact", SemverFilter("exact", [1, 2]))
-        self.run_test("1.2.3.*", "exact", SemverFilter("exact", [1, 2, 3]))
-        self.run_test("1.X", "exact", SemverFilter("exact", [1]))
+        self.run_test("=", "1.2.*", [release_2, release_3, release_4])
+        self.run_test("=", "1.2.3.*", [release_3, release_4])
+        self.run_test("=", "1.2.3.4", [release_4])
+        self.run_test("=", "2.*", [release_5])

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -8,9 +8,10 @@ from django.utils import timezone
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.models.release import SemverFilter
 from sentry.search.events.constants import SEMVER_ALIAS, SEMVER_EMPTY_RELEASE
 from sentry.search.events.fields import Function, FunctionArg, InvalidSearchQuery, with_default
-from sentry.search.events.filter import get_filter, parse_semver_search
+from sentry.search.events.filter import _semver_filter_converter, get_filter, parse_semver
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.snuba import OPERATOR_TO_FUNCTION
@@ -1432,20 +1433,20 @@ class FunctionTest(unittest.TestCase):
         assert fn.is_accessible(["fn"]) is True
 
 
-class ParseSemverSearchTest(TestCase):
+class SemverFilterConverterTest(TestCase):
     def test_invalid_params(self):
         key = "semver"
         filter = SearchFilter(SearchKey(key), ">", SearchValue("1.2.3"))
         with pytest.raises(ValueError, match="organization_id is a required param"):
-            parse_semver_search(filter, key, None)
+            _semver_filter_converter(filter, key, None)
         with pytest.raises(ValueError, match="organization_id is a required param"):
-            parse_semver_search(filter, key, {"something": 1})
+            _semver_filter_converter(filter, key, {"something": 1})
 
     def test_invalid_query(self):
         key = "semver"
         filter = SearchFilter(SearchKey(key), ">", SearchValue("1.2.hi"))
         with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
-            parse_semver_search(filter, key, {"organization_id": self.organization.id})
+            _semver_filter_converter(filter, key, {"organization_id": self.organization.id})
 
     def run_test(
         self, operator, version, expected_operator, expected_releases, organization_id=None
@@ -1453,7 +1454,7 @@ class ParseSemverSearchTest(TestCase):
         organization_id = organization_id if organization_id else self.organization.id
         key = "semver"
         filter = SearchFilter(SearchKey(key), operator, SearchValue(version))
-        assert parse_semver_search(filter, key, {"organization_id": organization_id}) == [
+        assert _semver_filter_converter(filter, key, {"organization_id": organization_id}) == [
             "release",
             expected_operator,
             expected_releases,
@@ -1553,3 +1554,29 @@ class ParseSemverSearchTest(TestCase):
         self.run_test("=", "1.2.3.*", "IN", [release_3.version, release_4.version])
         self.run_test("=", "1.2.3.4", "IN", [release_4.version])
         self.run_test("=", "2.*", "IN", [release_5.version])
+
+
+class ParseSemverTest(unittest.TestCase):
+    def run_test(self, version: str, operator: str, expected: SemverFilter):
+        semver_filter = parse_semver(version, operator)
+        assert semver_filter == expected
+
+    def test_invalid(self):
+        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+            parse_semver("1.hello", ">") is None
+        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+            parse_semver("hello", ">") is None
+
+    def test_normal(self):
+        self.run_test("1", ">", SemverFilter("gt", [1, 0, 0, 0, 1, ""]))
+        self.run_test("1.2", ">", SemverFilter("gt", [1, 2, 0, 0, 1, ""]))
+        self.run_test("1.2.3", ">", SemverFilter("gt", [1, 2, 3, 0, 1, ""]))
+        self.run_test("1.2.3.4", ">", SemverFilter("gt", [1, 2, 3, 4, 1, ""]))
+        self.run_test("1.2.3-hi", ">", SemverFilter("gt", [1, 2, 3, 0, 0, "hi"]))
+        self.run_test("1.2.3-hi", "<", SemverFilter("lt", [1, 2, 3, 0, 0, "hi"]))
+
+    def test_wildcard(self):
+        self.run_test("1.*", "=", SemverFilter("exact", [1]))
+        self.run_test("1.2.*", "=", SemverFilter("exact", [1, 2]))
+        self.run_test("1.2.3.*", "=", SemverFilter("exact", [1, 2, 3]))
+        self.run_test("1.X", "=", SemverFilter("exact", [1]))


### PR DESCRIPTION
The semver parsing code isn't really a concern of the `Release` model or any related
managers/querysets. This pr extracts it out to the search filter layer, and passes in a
`SemverFilter` to `filter_by_semver` instead.