### PR TITLE
deps(js): Bump query-string

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,7 +71,6 @@ updates:
       - dependency-name: "mobx-react"
       - dependency-name: "papaparse"
       - dependency-name: "prettier"
-      - dependency-name: "query-string"
       - dependency-name: "react-date-range"
       - dependency-name: "react-lazyload"
       - dependency-name: "react-mentions"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "process": "^0.11.10",
     "prop-types": "^15.6.0",
     "qrcode.react": "^1.0.1",
-    "query-string": "7.0.0",
+    "query-string": "7.0.1",
     "react": "17.0.2",
     "react-autosize-textarea": "7.1.0",
     "react-date-range": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11990,10 +11990,10 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-query-string@7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.0.tgz#aaad2c8d5c6a6d0c6afada877fecbd56af79e609"
-  integrity sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==
+query-string@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
+  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
   dependencies:
     decode-uri-component "^0.2.0"
     filter-obj "^1.1.0"


### PR DESCRIPTION
It is a very uninteresting patch https://github.com/sindresorhus/query-string/releases/tag/v7.0.1