### PR TITLE
fix(semver): Fix bug in semver snuba related searches when we find no related releases.

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -86,3 +86,4 @@ OPERATOR_NEGATION_MAP = {
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
 
 SEMVER_MAX_SEARCH_RELEASES = 1000
+SEMVER_EMPTY_RELEASE = "____SENTRY_EMPTY_RELEASE____"

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -34,6 +34,7 @@ from sentry.search.events.constants import (
     PROJECT_NAME_ALIAS,
     RELEASE_ALIAS,
     SEMVER_ALIAS,
+    SEMVER_EMPTY_RELEASE,
     SEMVER_MAX_SEARCH_RELEASES,
     TEAM_KEY_TRANSACTION_ALIAS,
     USER_DISPLAY_ALIAS,
@@ -390,6 +391,10 @@ def parse_semver_search(
             # Do a negative search instead
             final_operator = "NOT IN"
             versions = exclude_versions
+
+    if not versions:
+        # XXX: Just return a filter that will return no results if we have no versions
+        versions = [SEMVER_EMPTY_RELEASE]
 
     return ["release", final_operator, versions]
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -269,6 +269,9 @@ class OrganizationReleaseListTest(APITestCase):
         )
         assert [r["version"] for r in response.data] == [release_1.version, release_2.version]
 
+        response = self.get_valid_response(self.organization.slug, query=f"{SEMVER_ALIAS}:2.2.1")
+        assert [r["version"] for r in response.data] == []
+
     def test_project_permissions(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.create_organization()

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
-from sentry.search.events.constants import SEMVER_ALIAS
+from sentry.search.events.constants import SEMVER_ALIAS, SEMVER_EMPTY_RELEASE
 from sentry.search.events.fields import Function, FunctionArg, InvalidSearchQuery, with_default
 from sentry.search.events.filter import get_filter, parse_semver_search
 from sentry.testutils.cases import TestCase
@@ -1460,7 +1460,7 @@ class ParseSemverSearchTest(TestCase):
         ]
 
     def test_empty(self):
-        self.run_test(">", "1.2.3", "IN", [])
+        self.run_test(">", "1.2.3", "IN", [SEMVER_EMPTY_RELEASE])
 
     def test(self):
         release = self.create_release(version="test@1.2.3")
@@ -1534,7 +1534,7 @@ class ParseSemverSearchTest(TestCase):
         self.run_test(">", "1.2", "IN", [release_3.version, release_4.version, release_5.version])
         self.run_test(">", "1.2.3", "IN", [release_4.version, release_5.version])
         self.run_test(">", "1.2.3.4", "IN", [release_5.version])
-        self.run_test(">", "2", "IN", [])
+        self.run_test(">", "2", "IN", [SEMVER_EMPTY_RELEASE])
 
     def test_wildcard(self):
         release_1 = self.create_release(version="test@1.0.0.0")

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1459,6 +1459,9 @@ class ParseSemverSearchTest(TestCase):
             expected_releases,
         ]
 
+    def test_empty(self):
+        self.run_test(">", "1.2.3", "IN", [])
+
     def test(self):
         release = self.create_release(version="test@1.2.3")
         release_2 = self.create_release(version="test@1.2.4")

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1196,6 +1196,10 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert [int(r["id"]) for r in response.json()] == [release_1_g_1, release_1_g_2]
 
+        response = self.get_response(sort_by="date", limit=10, query=f"{SEMVER_ALIAS}:<1.0")
+        assert response.status_code == 200, response.content
+        assert [int(r["id"]) for r in response.json()] == []
+
     def test_aggregate_stats_regression_test(self):
         self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
We'd get an error if a semver search returned no versions when making a snuba search (issues,
discover, etc). To work around this, if we find no versions then just insert a dummy release.

Alternatively, we could just raise an `InvalidSearchQuery("No releases found for this query")`.
This stops us making a pointless query to snuba, maybe that's preferable?