### PR TITLE
build(ui): Enable incremental builds for fork-ts-checker

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -362,6 +362,9 @@ let appConfig = {
           new ForkTsCheckerWebpackPlugin({
             typescript: {
               configFile: path.resolve(__dirname, './config/tsconfig.build.json'),
+              configOverwrite: {
+                compilerOptions: {incremental: true},
+              },
             },
           }),
         ]


### PR DESCRIPTION
the biggest improvement seems to be the 2nd run of the `yarn dev-ui` command.
both cold starts are about this slow
```
Create Watch Compiler Host:  0.00 s
I/O Read:                    1.11 s
Parse:                       3.35 s
ResolveModule:               3.71 s
ResolveTypeReference:        0.08 s
Program:                     8.87 s
Bind:                        1.73 s
Check:                      50.50 s
Semantic Diagnostics:       51.03 s
I/O Write:                   0.00 s
Emit:                        0.06 s
Create Watch Program:       62.57 s
Queued Tasks:                0.00 s
```

but with incremental the 2nd run becomes
```
Create Watch Compiler Host:  0.00 s
I/O Read:                    0.49 s
Parse:                       3.80 s
ResolveModule:               4.19 s
ResolveTypeReference:        0.09 s
Program:                     9.27 s
Bind:                        1.96 s
Semantic Diagnostics:        0.01 s
I/O Write:                   0.00 s
Emit:                        0.09 s
Create Watch Program:       12.31 s
Queued Tasks:                0.00 s
```