### PR TITLE
fix(performance): Escape tag values when adding to query

### DIFF
--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -129,10 +129,13 @@ export class QueryResults {
 
   addTagValues(tag: string, tagValues: string[]) {
     for (const t of tagValues) {
+      // Tag values that we insert through the UI can contain special characters
+      // that need to escaped. User entered filters should not be escaped.
+      const escaped = escapeTagValue(t);
       this.tagValues[tag] = Array.isArray(this.tagValues[tag])
-        ? [...this.tagValues[tag], t]
-        : [t];
-      const token: Token = {type: TokenType.TAG, key: tag, value: t};
+        ? [...this.tagValues[tag], escaped]
+        : [escaped];
+      const token: Token = {type: TokenType.TAG, key: tag, value: escaped};
       this.tokens.push(token);
     }
     return this;
@@ -391,4 +394,15 @@ function removeSurroundingQuotes(text: string) {
  */
 function formatQuery(query: string) {
   return query.replace(/^["\(]+|["\)]+$/g, '');
+}
+
+/**
+ * Some characters have special meaning in a tag value. So when they
+ * are directly added as a tag value, we have to escape them to mean
+ * the literal.
+ */
+function escapeTagValue(value: string) {
+  // astericks (*) is used for wildcard searches
+  // back slaches (\) is used to escape other characters
+  return value.replace(/([\*\\])/g, '\\$1');
 }

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -85,7 +85,7 @@ export class QueryResults {
       if (tokenState === TokenType.QUERY && token.length) {
         this.addQuery(token);
       } else if (tokenState === TokenType.TAG) {
-        this.addStringTag(token);
+        this.addStringTag(token, false);
       }
 
       if (trailingParen !== '') {
@@ -121,17 +121,17 @@ export class QueryResults {
     return formattedTokens.join(' ').trim();
   }
 
-  addStringTag(value: string) {
+  addStringTag(value: string, shouldEscape = true) {
     const [key, tag] = formatTag(value);
-    this.addTagValues(key, [tag]);
+    this.addTagValues(key, [tag], shouldEscape);
     return this;
   }
 
-  addTagValues(tag: string, tagValues: string[]) {
+  addTagValues(tag: string, tagValues: string[], shouldEscape = true) {
     for (const t of tagValues) {
       // Tag values that we insert through the UI can contain special characters
       // that need to escaped. User entered filters should not be escaped.
-      const escaped = escapeTagValue(t);
+      const escaped = shouldEscape ? escapeTagValue(t) : t;
       this.tagValues[tag] = Array.isArray(this.tagValues[tag])
         ? [...this.tagValues[tag], escaped]
         : [escaped];
@@ -141,9 +141,9 @@ export class QueryResults {
     return this;
   }
 
-  setTagValues(tag: string, tagValues: string[]) {
+  setTagValues(tag: string, tagValues: string[], shouldEscape = true) {
     this.removeTag(tag);
-    this.addTagValues(tag, tagValues);
+    this.addTagValues(tag, tagValues, shouldEscape);
     return this;
   }
 

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -360,7 +360,8 @@ function generateGenericPerformanceEventView(
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.query.length > 0) {
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
+    // the query here is a user entered condition, no need to escape it
+    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
     conditions.query = [];
   }
   savedQuery.query = conditions.formatString();
@@ -429,7 +430,8 @@ function generateBackendPerformanceEventView(
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.query.length > 0) {
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
+    // the query here is a user entered condition, no need to escape it
+    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
     conditions.query = [];
   }
   savedQuery.query = conditions.formatString();
@@ -496,7 +498,8 @@ function generateFrontendPageloadPerformanceEventView(
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.query.length > 0) {
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
+    // the query here is a user entered condition, no need to escape it
+    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
     conditions.query = [];
   }
   savedQuery.query = conditions.formatString();
@@ -565,7 +568,8 @@ function generateFrontendOtherPerformanceEventView(
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.query.length > 0) {
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
+    // the query here is a user entered condition, no need to escape it
+    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
     conditions.query = [];
   }
   savedQuery.query = conditions.formatString();
@@ -643,7 +647,8 @@ export function generatePerformanceVitalDetailView(
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.query.length > 0) {
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`]);
+    // the query here is a user entered condition, no need to escape it
+    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
     conditions.query = [];
   }
   savedQuery.query = conditions.formatString();

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -218,8 +218,13 @@ describe('utils/tokenizeSearch', function () {
       results.addTagValues('d', ['d']);
       expect(results.formatString()).toEqual('a:a b:b c:c1 c:c2 d:d');
 
+      results.addTagValues('e', ['e1*e2\\e3']);
+      expect(results.formatString()).toEqual('a:a b:b c:c1 c:c2 d:d e:"e1\\*e2\\\\e3"');
+
       results.addStringTag('d:d2');
-      expect(results.formatString()).toEqual('a:a b:b c:c1 c:c2 d:d d:d2');
+      expect(results.formatString()).toEqual(
+        'a:a b:b c:c1 c:c2 d:d e:"e1\\*e2\\\\e3" d:d2'
+      );
     });
 
     it('add text searches to query object', function () {


### PR DESCRIPTION
Tag values that are added to the query through the UI may contain special
characters like astericks and slashes that need to be escaped. This ensures that
when adding them to the query, they are correctly escaped.