### PR TITLE
fix(warnings): remove unused deprecated Project.callsign

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -200,17 +200,10 @@ class Project(Model, PendingDeletionMixin):
         return projectoptions.update_rev_for_option(self)
 
     @property
-    def callsign(self):
-        warnings.warn(
-            "Project.callsign is deprecated. Use Group.get_short_id() instead.", DeprecationWarning
-        )
-        return self.slug.upper()
-
-    @property
     def color(self):
         if self.forced_color is not None:
-            return "#%s" % self.forced_color
-        return get_hashed_color(self.callsign or self.slug)
+            return f"#{self.forced_color}"
+        return get_hashed_color(self.slug.upper())
 
     @property
     def member_set(self):


### PR DESCRIPTION
This is one of the classes of warnings I'm seeing in production logs. The goal is to reduce incoming future events from #26796 when I land that.

It seems to be completely unused otherwise both in sentry and getsentry, so just inlining it.