### PR TITLE
fix(releases): Sync crash free users/sessions sort with display

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -243,6 +243,10 @@ class ReleasesList extends AsyncView<Props, State> {
       sort = SortOption.SESSIONS_24_HOURS;
     else if (sort === SortOption.SESSIONS_24_HOURS && display === DisplayOption.USERS)
       sort = SortOption.USERS_24_HOURS;
+    else if (sort === SortOption.CRASH_FREE_USERS && display === DisplayOption.SESSIONS)
+      sort = SortOption.CRASH_FREE_SESSIONS;
+    else if (sort === SortOption.CRASH_FREE_SESSIONS && display === DisplayOption.USERS)
+      sort = SortOption.CRASH_FREE_USERS;
 
     router.push({
       ...location,

--- a/static/app/views/releases/list/releaseListSortOptions.tsx
+++ b/static/app/views/releases/list/releaseListSortOptions.tsx
@@ -23,10 +23,14 @@ function ReleaseListSortOptions({
     [SortOption.DATE]: t('Date Created'),
     [SortOption.SESSIONS]: t('Total Sessions'),
     ...(selectedDisplay === DisplayOption.USERS
-      ? {[SortOption.USERS_24_HOURS]: t('Active Users')}
-      : {[SortOption.SESSIONS_24_HOURS]: t('Active Sessions')}),
-    [SortOption.CRASH_FREE_USERS]: t('Crash Free Users'),
-    [SortOption.CRASH_FREE_SESSIONS]: t('Crash Free Sessions'),
+      ? {
+          [SortOption.USERS_24_HOURS]: t('Active Users'),
+          [SortOption.CRASH_FREE_USERS]: t('Crash Free Users'),
+        }
+      : {
+          [SortOption.SESSIONS_24_HOURS]: t('Active Sessions'),
+          [SortOption.CRASH_FREE_SESSIONS]: t('Crash Free Sessions'),
+        }),
   } as Record<SortOption, string>;
 
   if (organization.features.includes('semver')) {

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -185,7 +185,7 @@ describe('ReleasesList', function () {
     const sortByOptions = sortDropdown.find('DropdownItem span');
 
     const dateCreatedOption = sortByOptions.at(0);
-    expect(sortByOptions).toHaveLength(5);
+    expect(sortByOptions).toHaveLength(4);
     expect(dateCreatedOption.text()).toEqual('Date Created');
 
     const healthStatsControls = wrapper.find('CountColumn span').first();


### PR DESCRIPTION
This adds a display sync to the sort dropdown similarly to https://github.com/getsentry/sentry/pull/26804, switching between crash free users/sessions.

[WOR-1000](https://getsentry.atlassian.net/browse/WOR-1000)