### PR TITLE
feat(semver): Handle semver lookups in `ProjectTagKeyValuesEndpoint`

### DIFF
--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -439,15 +439,16 @@ def parse_semver(version, operator) -> Optional[SemverFilter]:
         # Try to parse as a wildcard match
         package, version = version.split("@", 1)
         version_parts = []
-        for part in version.split(".", 3):
-            if part in SEMVER_WILDCARDS:
-                break
-            try:
-                # We assume all ints for a wildcard match - not handling prerelease as
-                # part of these
-                version_parts.append(int(part))
-            except ValueError:
-                raise InvalidSearchQuery(f"Invalid format for semver query {version}")
+        if version:
+            for part in version.split(".", 3):
+                if part in SEMVER_WILDCARDS:
+                    break
+                try:
+                    # We assume all ints for a wildcard match - not handling prerelease as
+                    # part of these
+                    version_parts.append(int(part))
+                except ValueError:
+                    raise InvalidSearchQuery(f"Invalid format for semver query {version}")
 
         package = package if package and package != SEMVER_FAKE_PACKAGE else None
         return SemverFilter("exact", version_parts, package)

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1,4 +1,5 @@
 import functools
+import re
 from collections import Iterable, OrderedDict, defaultdict
 
 from dateutil.parser import parse as parse_datetime
@@ -7,9 +8,15 @@ from pytz import UTC
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
 from sentry.api.utils import default_start_end_dates
-from sentry.models import Project, ReleaseProjectEnvironment
-from sentry.search.events.constants import PROJECT_ALIAS, USER_DISPLAY_ALIAS
+from sentry.models import Project, Release, ReleaseProjectEnvironment
+from sentry.search.events.constants import (
+    PROJECT_ALIAS,
+    SEMVER_ALIAS,
+    SEMVER_WILDCARDS,
+    USER_DISPLAY_ALIAS,
+)
 from sentry.search.events.fields import FIELD_ALIASES
+from sentry.search.events.filter import parse_semver
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagStorage
@@ -741,6 +748,46 @@ class SnubaTagStorage(TagStorage):
                         ),
                     ),
                 ]
+            )
+
+        if key == SEMVER_ALIAS:
+            # If doing a search on semver, we want to hit postgres to query the releases
+            version = query
+            if not version:
+                version = "*"
+            elif version[-1] not in SEMVER_WILDCARDS | {"@"}:
+                suffix = ""
+                if version[-1] != ".":
+                    suffix += "."
+                suffix += "*"
+                version += suffix
+            organization_id = Project.objects.filter(id=projects[0]).values_list(
+                "organization_id", flat=True
+            )[0]
+            if version[:-2] and "@" not in version and re.search(r"[^\d.]", version[:-2]):
+                # Handle searching just on package
+                packages = (
+                    Release.objects.filter(
+                        organization_id=organization_id, package__startswith=version[:-2]
+                    )
+                    .values_list("package")
+                    .distinct()
+                )
+                versions = Release.objects.filter(
+                    organization_id=organization_id, package__in=packages
+                ).annotate_prerelease_column()
+            else:
+                versions = Release.objects.filter_by_semver(
+                    organization_id, parse_semver(version, "=")
+                )
+            if environments:
+                versions = versions.filter(releaseenvironment__environment_id__in=environments)
+
+            versions = versions.order_by(*Release.SEMVER_COLS, "package").values_list(
+                "version", flat=True
+            )[:1000]
+            return SequencePaginator(
+                [(i, TagValue(key, v, None, None, None)) for i, v in enumerate(versions)]
             )
 
         conditions = []

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -3,9 +3,10 @@ import os
 import random
 import warnings
 from binascii import hexlify
+from datetime import datetime
 from hashlib import sha1
 from importlib import import_module
-from typing import Any
+from typing import Any, Optional, Sequence
 from uuid import uuid4
 
 import petname
@@ -63,6 +64,7 @@ from sentry.models import (
     ProjectDebugFile,
     Release,
     ReleaseCommit,
+    ReleaseEnvironment,
     ReleaseFile,
     Repository,
     RepositoryProjectPathConfig,
@@ -356,7 +358,14 @@ class Factories:
         return project.key_set.get_or_create()[0]
 
     @staticmethod
-    def create_release(project, user=None, version=None, date_added=None, additional_projects=None):
+    def create_release(
+        project: Project,
+        user: Optional[User] = None,
+        version: Optional[str] = None,
+        date_added: Optional[datetime] = None,
+        additional_projects: Optional[Sequence[Project]] = None,
+        environments: Optional[Sequence[Environment]] = None,
+    ):
         if version is None:
             version = force_text(hexlify(os.urandom(20)))
 
@@ -373,6 +382,11 @@ class Factories:
         release.add_project(project)
         for additional_project in additional_projects:
             release.add_project(additional_project)
+
+        for environment in environments or []:
+            ReleaseEnvironment.objects.create(
+                organization=project.organization, release=release, environment=environment
+            )
 
         Activity.objects.create(
             type=Activity.RELEASE,

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -4,6 +4,7 @@ import pytest
 from django.utils import timezone
 
 from sentry.models import Environment, EventUser, Release, ReleaseProjectEnvironment
+from sentry.search.events.constants import SEMVER_ALIAS
 from sentry.tagstore.exceptions import (
     GroupTagKeyNotFound,
     GroupTagValueNotFound,
@@ -11,6 +12,7 @@ from sentry.tagstore.exceptions import (
     TagValueNotFound,
 )
 from sentry.tagstore.snuba.backend import SnubaTagStorage
+from sentry.tagstore.types import TagValue
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format
 
@@ -681,3 +683,65 @@ class TagStorageTest(TestCase, SnubaTestCase):
             )
             == {}
         )
+
+
+class GetTagValuePaginatorForProjectsSemverTest(TestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.ts = SnubaTagStorage()
+
+    def run_test(self, query, expected_releases, enviroment=None):
+        assert list(
+            self.ts.get_tag_value_paginator(
+                self.project.id,
+                enviroment.id if enviroment else enviroment,
+                SEMVER_ALIAS,
+                query=query,
+            ).get_result(10)
+        ) == [
+            TagValue(
+                key=SEMVER_ALIAS,
+                value=r.version,
+                times_seen=None,
+                first_seen=None,
+                last_seen=None,
+            )
+            for r in expected_releases
+        ]
+
+    def test_semver(self):
+        env_2 = self.create_environment()
+        release_1 = self.create_release(version="test@1.0.0.0")
+        release_2 = self.create_release(version="test@1.2.0.0", environments=[self.environment])
+        release_3 = self.create_release(version="test@1.2.3.0", environments=[env_2])
+        release_4 = self.create_release(version="test@1.2.3.4", environments=[env_2])
+        release_5 = self.create_release(
+            version="test2@2.0.0.0", environments=[self.environment, env_2]
+        )
+        release_6 = self.create_release(version="z_test@1.0.0.0")
+        release_7 = self.create_release(version="z_test@2.0.0.0")
+
+        self.run_test(
+            "", [release_1, release_6, release_2, release_3, release_4, release_5, release_7]
+        )
+
+        # These should all be equivalent
+        self.run_test("1", [release_1, release_6, release_2, release_3, release_4])
+        self.run_test("1.", [release_1, release_6, release_2, release_3, release_4])
+        self.run_test("1.*", [release_1, release_6, release_2, release_3, release_4])
+
+        self.run_test("1.2", [release_2, release_3, release_4])
+
+        self.run_test("", [release_2, release_5], self.environment)
+        self.run_test("", [release_3, release_4, release_5], env_2)
+        self.run_test("1", [release_2], self.environment)
+        self.run_test("1", [release_3, release_4], env_2)
+
+        # Test packages handling
+        self.run_test("test", [release_1, release_2, release_3, release_4, release_5])
+        self.run_test("test2", [release_5])
+        self.run_test("z", [release_6, release_7])
+
+        self.run_test("test@", [release_1, release_2, release_3, release_4])
+        self.run_test("test@*", [release_1, release_2, release_3, release_4])
+        self.run_test("test@1.2", [release_2, release_3, release_4])


### PR DESCRIPTION
This should allow us to handle typeahead for semver in search boxes.