### PR TITLE
ref(sk-update): Add extra description

### DIFF
--- a/static/app/components/events/sdkUpdates/index.tsx
+++ b/static/app/components/events/sdkUpdates/index.tsx
@@ -1,7 +1,7 @@
 import Alert from 'app/components/alert';
 import EventDataSection from 'app/components/events/eventDataSection';
 import {IconUpgrade} from 'app/icons';
-import {tct} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {Event} from 'app/types/event';
 import getSdkUpdateSuggestion from 'app/utils/getSdkUpdateSuggestion';
 
@@ -24,7 +24,9 @@ const SdkUpdates = ({event}: Props) => {
 
       return (
         <Alert key={index} type="info" icon={<IconUpgrade />}>
-          {tct('We recommend you [suggestion]', {suggestion})}
+          {tct('We recommend you [suggestion] ', {suggestion})}
+          {sdkUpdate.type === 'updateSdk' &&
+            t('(All sentry packages should be updated and their versions should match)')}
         </Alert>
       );
     })

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import groupBy from 'lodash/groupBy';
 
+import Alert from 'app/components/alert';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
+import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Project, ProjectSdkUpdates, SDKUpdatesSuggestion} from 'app/types';
@@ -47,6 +49,9 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
         'Seems like your SDKs could use a refresh. We recommend updating these SDKs to make sure you’re getting all the data you need.'
       )}
     >
+      <StyledAlert type="warning" icon={<IconWarning />}>
+        {t('All sentry packages should be updated and their versions should match.')}
+      </StyledAlert>
       <UpdatesList>
         <Collapsible>
           {items.map(([projectId, updates]) => {
@@ -117,6 +122,11 @@ const SdkName = styled('div')`
 
 const SdkOutdatedVersion = styled('span')`
   color: ${p => p.theme.subText};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-top: ${space(2)};
+  margin-bottom: 0;
 `;
 
 export default withSdkUpdates(withProjects(BroadcastSdkUpdates));

--- a/static/app/components/sidebar/sidebarPanelItem.tsx
+++ b/static/app/components/sidebar/sidebarPanelItem.tsx
@@ -72,7 +72,7 @@ const Title = styled('div')<Pick<Props, 'hasSeen'>>`
 `;
 
 const Text = styled('div')`
-  margin-bottom: 5px;
+  margin-bottom: ${space(0.5)};
 
   &:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
Adds extra info in the `sdkUpdate` and `broadcasrSdkUpdate` components, warning the user that all sentry packages should also be updated and their versions should match:

![image](https://user-images.githubusercontent.com/29228205/123282969-3aa23e80-d50b-11eb-9a76-4498203a71d4.png)


closes: https://github.com/getsentry/sentry-javascript/issues/3223