### PR TITLE
fix(discover): Do not replace on null value

### DIFF
--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -404,5 +404,5 @@ function formatQuery(query: string) {
 function escapeTagValue(value: string) {
   // astericks (*) is used for wildcard searches
   // back slaches (\) is used to escape other characters
-  return value.replace(/([\*\\])/g, '\\$1');
+  return value ? value.replace(/([\*\\])/g, '\\$1') : value;
 }


### PR DESCRIPTION
Not certain why but there can be nulls here. Adding a check to make sure it
doesn't error.