### PR TITLE
refs: Add basic support for using `__include_in_export__` instead of `__core__`

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -87,8 +87,8 @@ def __model_class_prepared(sender, **kwargs):
     if not issubclass(sender, BaseModel):
         return
 
-    if not hasattr(sender, "__core__"):
-        raise ValueError(f"{sender!r} model has not defined __core__")
+    if not hasattr(sender, "__core__") and not hasattr(sender, "__include_in_export__"):
+        raise ValueError(f"{sender!r} model has not defined __core__ or __include_in_export__")
 
 
 signals.pre_save.connect(__model_pre_save)

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -135,7 +135,7 @@ def export(dest, silent, indent, exclude):
         # Collate the objects to be serialized.
         for model in sort_dependencies():
             if (
-                not getattr(model, "__core__", True)
+                not getattr(model, "__include_in_export__", getattr(model, "__core__", True))
                 or model.__name__.lower() in exclude
                 or model._meta.proxy
             ):


### PR DESCRIPTION
We want to rename `__core__` to `__include_in_export__` so that it's more explicit. This pr adds in
support so that either `__core__` or `__include_in_export__` can be used.