### PR TITLE
fix(notifications): Clean up link_team

### DIFF
--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -28,6 +28,8 @@ from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
 ALLOWED_METHODS = ["GET", "POST"]
+ALLOWED_ROLES = ["admin", "manager", "owner"]
+
 INSUFFICIENT_ROLE_TITLE = "Insufficient role"
 INSUFFICIENT_ROLE_MESSAGE = "You must be an admin or higher to link teams."
 ALREADY_LINKED_TITLE = "Already linked"
@@ -158,9 +160,9 @@ class SlackLinkTeamView(BaseView):  # type: ignore
 
         identity = self.get_identity(request, integration, params["slack_id"])
         org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
-        allowed_roles = ["admin", "manager", "owner"]
+
         if not (
-            org_member.role in allowed_roles
+            org_member.role in ALLOWED_ROLES
             and (organization.flags.allow_joinleave or team in org_member.teams.all())
         ):
             return send_slack_message(


### PR DESCRIPTION
This PR refactors `link_team.py` and fixes two bugs:
 - the `get_identity()` function was returning responses but not sending them to the user
 - a `render_error_body()` call was missing the `request` parameter.