### PR TITLE
feat(backend): adds utility function for clearing flags on a model

### DIFF
--- a/src/sentry/utils/migrations.py
+++ b/src/sentry/utils/migrations.py
@@ -1,0 +1,14 @@
+from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+
+
+def clear_flag(Model, flag_name, flag_attr_name="flags"):
+    """
+    This function is used to clear an existing flag value for all items in a given model
+    """
+    for item in RangeQuerySetWrapperWithProgressBar(Model.objects.all()):
+        flags = getattr(item, flag_attr_name)
+        if flags[flag_name]:
+            # clear the flag
+            new_flag_value = flags & ~(getattr(Model, flag_attr_name)[flag_name])
+            setattr(item, flag_attr_name, new_flag_value)
+            item.save()

--- a/tests/sentry/utils/test_migrations.py
+++ b/tests/sentry/utils/test_migrations.py
@@ -1,0 +1,27 @@
+from sentry.models import Organization
+from sentry.testutils import TestCase
+from sentry.utils.migrations import clear_flag
+
+
+class ClearFlagTest(TestCase):
+    def test_simple(self):
+        org1 = self.create_organization(
+            flags=Organization.flags.enhanced_privacy | Organization.flags.early_adopter
+        )
+        org2 = self.create_organization(flags=Organization.flags.early_adopter)
+        org3 = self.create_organization(flags=0)
+
+        clear_flag(Organization, "early_adopter")
+
+        org1.refresh_from_db()
+        assert not org1.flags.early_adopter
+        assert org1.flags.enhanced_privacy
+        assert org1.flags._value == 2
+
+        org2.refresh_from_db()
+        assert not org2.flags.early_adopter
+        assert org2.flags._value == 0
+
+        org3.refresh_from_db()
+        assert not org3.flags.early_adopter
+        assert org3.flags._value == 0


### PR DESCRIPTION
This PR adds a utility function for clearing flags on an arbitrary model. This is used during migrations if we have an old flag that's no longer in use. Tests have been added.