### PR TITLE
feat(migrations): Add check for tables hints to migration executor

### DIFF
--- a/src/sentry/migrations/0001_squashed_0200_release_indices.py
+++ b/src/sentry/migrations/0001_squashed_0200_release_indices.py
@@ -4826,12 +4826,15 @@ class Migration(migrations.Migration):
             unique_together={("user", "application")},
         ),
         migrations.RunSQL(
+            hints={"tables": ["sentry_projectcounter"]},
             sql="\n        create or replace function sentry_increment_project_counter(\n                project bigint, delta int) returns int as $$\n            declare\n            new_val int;\n            begin\n            loop\n                update sentry_projectcounter set value = value + delta\n                where project_id = project\n                returning value into new_val;\n                if found then\n                return new_val;\n                end if;\n                begin\n                insert into sentry_projectcounter(project_id, value)\n                    values (project, delta)\n                    returning value into new_val;\n                return new_val;\n                exception when unique_violation then\n                end;\n            end loop;\n            end\n            $$ language plpgsql;\n        ",
         ),
         migrations.RunSQL(
+            hints={"tables": ["sentry_savedsearch"]},
             sql="\n        CREATE UNIQUE INDEX sentry_savedsearch_is_global_6793a2f9e1b59b95\n        ON sentry_savedsearch USING btree (is_global, name)\n        WHERE is_global\n        ",
         ),
         migrations.RunSQL(
+            hints={"tables": ["sentry_savedsearch"]},
             sql="\n        CREATE UNIQUE INDEX sentry_savedsearch_organization_id_313a24e907cdef99\n        ON sentry_savedsearch USING btree (organization_id, name, type)\n        WHERE (owner_id IS NULL);\n        ",
         ),
         migrations.CreateModel(
@@ -5852,6 +5855,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_eventattachment"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY "sentry_eventattachment_project_id_date_added_fi_f3b0597f_idx" ON "sentry_eventattachment" ("project_id", "date_added", "file_id");\n                    ',
                     reverse_sql='\n                        DROP INDEX CONCURRENTLY "sentry_eventattachment_project_id_date_added_fi_f3b0597f_idx";\n                        ',
                 ),
@@ -5869,14 +5873,17 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_alertrule"]},
                     sql="\n                    ALTER TABLE sentry_alertrule DROP CONSTRAINT IF EXISTS sentry_alertrule_organization_id_name_12c48b37_uniq;\n                    ",
                     reverse_sql="DO $$\n                    BEGIN\n                        BEGIN\n                            ALTER TABLE sentry_alertrule ADD CONSTRAINT sentry_alertrule_organization_id_name_12c48b37_uniq UNIQUE (organization_id, name);\n                        EXCEPTION\n                            WHEN duplicate_table THEN\n                        END;\n                    END $$;\n                    ",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_alertrule"]},
                     sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_alertrule_organization_id_name_12c48b37_uniq;\n                    ",
                     reverse_sql="\n                    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS sentry_alertrule_organization_id_name_12c48b37_uniq\n                    ON sentry_alertrule USING btree (organization_id, name);\n                    ",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_alertrule"]},
                     sql="\n                    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS sentry_alertrule_status_active\n                    ON sentry_alertrule USING btree (organization_id, name, status)\n                    WHERE status = 0;\n                    ",
                     reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_alertrule_status_active;\n                    ",
                 ),
@@ -5902,6 +5909,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_alertrule"]},
                     sql="\n                    ALTER TABLE sentry_alertrule DROP CONSTRAINT IF EXISTS sentry_alertrule_organization_id_382634eccd5f9371_uniq;\n                    ",
                     reverse_sql="DO $$\n                    BEGIN\n                        BEGIN\n                            ALTER TABLE sentry_alertrule ADD CONSTRAINT sentry_alertrule_organization_id_382634eccd5f9371_uniq UNIQUE (organization_id, name);\n                        EXCEPTION\n                            WHEN duplicate_table THEN\n                        END;\n                    END $$;\n                    ",
                 ),
@@ -6152,6 +6160,7 @@ class Migration(migrations.Migration):
             unique_together={("provider", "organization")},
         ),
         migrations.RunSQL(
+            hints={"tables": ["sentry_timeseriessnapshot"]},
             sql="ALTER TABLE sentry_timeseriessnapshot ALTER COLUMN values SET DATA TYPE float[] USING values::float[]",
         ),
         migrations.AddField(
@@ -6459,10 +6468,12 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_projectdsymfile"]},
                     sql='\n                    ALTER TABLE "sentry_projectdsymfile" ADD COLUMN "checksum" varchar(40) NULL;\n                    ',
                     reverse_sql='\n                        ALTER TABLE "sentry_projectdsymfile" DROP COLUMN "checksum";\n                        ',
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_projectdsymfile"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY "sentry_projectdsymfile_checksum_8fb028a8_idx" ON "sentry_projectdsymfile" ("checksum");\n                    ',
                     reverse_sql='\n                        DROP INDEX CONCURRENTLY "sentry_projectdsymfile_checksum_8fb028a8_idx";\n                        ',
                 ),
@@ -6561,6 +6572,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_release"]},
                     sql='\n                    ALTER TABLE "sentry_release" ADD COLUMN "status" integer NULL;\n                    ',
                     reverse_sql='\n                    ALTER TABLE "sentry_release" DROP COLUMN "status";\n                    ',
                 ),
@@ -6569,14 +6581,17 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_groupinbox"]},
                     sql='\n                    ALTER TABLE "sentry_groupinbox" ADD COLUMN "organization_id" bigint NULL;\n                    ALTER TABLE "sentry_groupinbox" ADD COLUMN "project_id" bigint NULL;\n                    ',
                     reverse_sql='\n                        ALTER TABLE "sentry_groupinbox" DROP COLUMN "organization_id";\n                        ALTER TABLE "sentry_groupinbox" DROP COLUMN "project_id";\n                        ',
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_groupinbox"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY "sentry_groupinbox_organization_id_7b67769a" ON "sentry_groupinbox" ("organization_id");\n                    ',
                     reverse_sql='\n                        DROP INDEX CONCURRENTLY "sentry_groupinbox_organization_id_7b67769a";\n                        ',
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_groupinbox"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY "sentry_groupinbox_project_id_ef8f034d" ON "sentry_groupinbox" ("project_id");\n                    ',
                     reverse_sql='\n                        DROP INDEX CONCURRENTLY "sentry_groupinbox_project_id_ef8f034d";\n                        ',
                 ),
@@ -6771,6 +6786,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_dashboard"]},
                     sql='\n                        ALTER TABLE "sentry_dashboard" DROP COLUMN "status";\n                        ',
                     reverse_sql='\n                        ALTER TABLE "sentry_dashboard" ADD COLUMN "status" int NOT NULL;\n                        ',
                 ),
@@ -6802,6 +6818,7 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.RunSQL(
+            hints={"tables": ["sentry_dashboardwidgetquery"]},
             sql="ALTER TABLE sentry_dashboardwidgetquery DROP COLUMN interval",
         ),
         migrations.AddField(
@@ -6868,6 +6885,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_groupinbox"]},
                     sql="\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS sentry_groupinbox_date_added_f113c11b\n                    ON sentry_groupinbox (date_added);\n                    ",
                     reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_groupinbox_date_added_f113c11b;\n                    ",
                 ),
@@ -7215,22 +7233,27 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_team"]},
                     sql='\n                    ALTER TABLE sentry_team ADD COLUMN "actor_id" bigint NULL;\n                    ALTER TABLE auth_user ADD COLUMN "actor_id" bigint NULL;\n                    ',
                     reverse_sql='\n                    ALTER TABLE sentry_team DROP COLUMN "actor_id";\n                    ALTER TABLE auth_user DROP COLUMN "actor_id";\n                    ',
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_team"]},
                     sql="\n                    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS sentry_team_actor_idx ON sentry_team (actor_id);\n                    ",
                     reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_team_actor_idx;\n                    ",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_team"]},
                     sql='\n                    ALTER TABLE sentry_team ADD CONSTRAINT "sentry_team_actor_idx_fk_sentry_actor_id" FOREIGN KEY ("actor_id") REFERENCES "sentry_actor" ("id") DEFERRABLE INITIALLY DEFERRED;\n                    ',
                     reverse_sql="\n                    ALTER TABLE sentry_team DROP CONSTRAINT IF EXISTS sentry_team_actor_idx_fk_sentry_actor_id;\n                    ",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["auth_user"]},
                     sql="\n                    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS auth_user_actor_idx ON auth_user (actor_id);\n                    ",
                     reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS auth_user_actor_idx;\n                    ",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["auth_user"]},
                     sql='\n                    ALTER TABLE auth_user ADD CONSTRAINT "auth_user_actor_idx_fk_sentry_actor_id" FOREIGN KEY ("actor_id") REFERENCES "sentry_actor" ("id") DEFERRABLE INITIALLY DEFERRED;\n                    ',
                     reverse_sql="\n                    ALTER TABLE sentry_team DROP CONSTRAINT IF EXISTS auth_user_actor_idx_fk_sentry_actor_id;\n                    ",
                 ),
@@ -7320,6 +7343,7 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.RunPython(
+            hints={"tables": ["sentry_savedsearch"]},
             code=add_my_issues_search,
             reverse_code=django.db.migrations.operations.special.RunPython.noop,
         ),
@@ -7356,6 +7380,7 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_notificationsetting"]},
                     sql='\n                        ALTER TABLE "sentry_notificationsetting" DROP COLUMN "target_identifier";\n                        ALTER TABLE "sentry_notificationsetting" DROP COLUMN "target_type";\n                        ',
                     reverse_sql='\n                        ALTER TABLE "sentry_notificationsetting" ADD COLUMN "target_identifier" bigint NULL;\n                        ALTER TABLE "sentry_notificationsetting" ADD COLUMN "target_type" int NULL;\n\n                        ',
                 ),
@@ -7433,10 +7458,12 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_externalactor"]},
                     sql='\n                    ALTER TABLE "sentry_externalactor" ALTER COLUMN "integration_id" SET DEFAULT 1;\n                    UPDATE "sentry_externalactor" SET "integration_id" = 1 where "integration_id" is NULL;\n                    ',
                     reverse_sql='\n                    ALTER TABLE "sentry_externalactor" ALTER COLUMN "integration_id" DROP DEFAULT;\n                    ',
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_externalactor"]},
                     sql='\n                    ALTER TABLE "sentry_externalactor" ALTER COLUMN "integration_id" SET NOT NULL;\n                    ALTER TABLE "sentry_externalactor" ALTER COLUMN "integration_id" DROP DEFAULT;\n                    ',
                     reverse_sql='\n                    ALTER TABLE "sentry_externalactor" ALTER COLUMN "integration_id" DROP NOT NULL;\n                    ',
                 ),
@@ -7486,10 +7513,12 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_grouprelease"]},
                     sql="\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS sentry_grouprelease_group_id_first_seen_53fc35ds\n                    ON sentry_grouprelease USING btree (group_id, first_seen);\n                    ",
                     reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_grouprelease_group_id_first_seen_53fc35ds;\n                    ",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_grouprelease"]},
                     sql="\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS sentry_grouprelease_group_id_last_seen_g8v2sk7c\n                    ON sentry_grouprelease USING btree (group_id, last_seen DESC);\n                    ",
                     reverse_sql="\n                    DROP INDEX CONCURRENTLY IF EXISTS sentry_grouprelease_group_id_last_seen_g8v2sk7c;\n                    ",
                 ),
@@ -7694,14 +7723,17 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_release"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_organization_id_major_mi_38715957_idx"\n                    ON "sentry_release" ("organization_id", "major" DESC, "minor" DESC, "patch" DESC, "revision" DESC);\n                    ',
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_organization_id_major_mi_38715957_idx",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_release"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_organization_id_build_code_f93815e5_idx" ON "sentry_release" ("organization_id", "build_code");\n                    ',
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_organization_id_build_code_f93815e5_idx",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_release"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_organization_id_build_number_e1646551_idx" ON "sentry_release" ("organization_id", "build_number");\n                    ',
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_organization_id_build_number_e1646551_idx",
                 ),
@@ -7720,10 +7752,12 @@ class Migration(migrations.Migration):
         migrations.SeparateDatabaseAndState(
             database_operations=[
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_release"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_organization_id_status_3c637259_idx" ON "sentry_release" ("organization_id", "status");\n                    ',
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_organization_id_status_3c637259_idx",
                 ),
                 migrations.RunSQL(
+                    hints={"tables": ["sentry_release"]},
                     sql='\n                    CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_organization_id_date_added_8ebd273a_idx" ON "sentry_release" ("organization_id", "date_added");\n                    ',
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_organization_id_date_added_8ebd273a_idx",
                 ),

--- a/src/sentry/migrations/0201_semver_package.py
+++ b/src/sentry/migrations/0201_semver_package.py
@@ -44,6 +44,7 @@ class Migration(migrations.Migration):
                     CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_organization_id_major_mi_38715957_idx"
                     ON "sentry_release" ("organization_id", "major" DESC, "minor" DESC, "patch" DESC, "revision" DESC);
                     """,
+                    hints={"tables": ["sentry_release"]},
                 ),
                 migrations.RunSQL(
                     """
@@ -61,6 +62,7 @@ class Migration(migrations.Migration):
                     prerelease DESC);
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_semver_idx",
+                    hints={"tables": ["sentry_release"]},
                 ),
                 migrations.RunSQL(
                     """
@@ -79,6 +81,7 @@ class Migration(migrations.Migration):
                     prerelease DESC);
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_semver_by_package_idx",
+                    hints={"tables": ["sentry_release"]},
                 ),
             ],
             state_operations=[

--- a/src/sentry/migrations/0202_org_slug_upper_idx.py
+++ b/src/sentry/migrations/0202_org_slug_upper_idx.py
@@ -35,5 +35,6 @@ class Migration(migrations.Migration):
             ON "sentry_organization" (UPPER(("slug"::text)));
             """,
             reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_organization_slug_upper_idx",
+            hints={"tables": ["sentry_organization"]},
         ),
     ]

--- a/src/sentry/migrations/0203_groupedmessage_status_index.py
+++ b/src/sentry/migrations/0203_groupedmessage_status_index.py
@@ -36,6 +36,7 @@ class Migration(migrations.Migration):
                     CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_groupedmessage_project_id_status_last_s_6b8195a7_idx" ON "sentry_groupedmessage" ("project_id", "status", "last_seen", "id");
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_groupedmessage_project_id_status_last_s_6b8195a7_idx",
+                    hints={"tables": ["sentry_groupedmessage"]},
                 ),
             ],
             state_operations=[

--- a/src/sentry/migrations/0205_semver_backfill.py
+++ b/src/sentry/migrations/0205_semver_backfill.py
@@ -110,5 +110,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(backfill_semver, migrations.RunPython.noop),
+        migrations.RunPython(
+            backfill_semver,
+            migrations.RunPython.noop,
+            hints={"tables": ["sentry_release"]},
+        ),
     ]

--- a/src/sentry/migrations/0207_release_adoption.py
+++ b/src/sentry/migrations/0207_release_adoption.py
@@ -38,6 +38,7 @@ class Migration(migrations.Migration):
                     reverse_sql="""
                     ALTER TABLE "sentry_release_project" DROP COLUMN "adopted";
                     """,
+                    hints={"tables": ["sentry_release_project"]},
                 ),
                 migrations.RunSQL(
                     """
@@ -46,6 +47,7 @@ class Migration(migrations.Migration):
                     reverse_sql="""
                     ALTER TABLE "sentry_release_project" DROP COLUMN "unadopted";
                     """,
+                    hints={"tables": ["sentry_release_project"]},
                 ),
                 migrations.RunSQL(
                     """
@@ -54,6 +56,7 @@ class Migration(migrations.Migration):
                     reverse_sql="""
                     ALTER TABLE "sentry_releaseprojectenvironment" DROP COLUMN "adopted";
                     """,
+                    hints={"tables": ["sentry_releaseprojectenvironment"]},
                 ),
                 migrations.RunSQL(
                     """
@@ -62,30 +65,35 @@ class Migration(migrations.Migration):
                     reverse_sql="""
                     ALTER TABLE "sentry_releaseprojectenvironment" DROP COLUMN "unadopted";
                     """,
+                    hints={"tables": ["sentry_releaseprojectenvironment"]},
                 ),
                 migrations.RunSQL(
                     """
                     CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_project_proj_id_adopted_4ce765fa" ON "sentry_release_project" ("project_id", "adopted");
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_project_proj_id_adopted_4ce765fa",
+                    hints={"tables": ["sentry_release_project"]},
                 ),
                 migrations.RunSQL(
                     """
                     CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_release_project_proj_id_unadopted_8h5g84ee" ON "sentry_release_project" ("project_id", "unadopted");
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_release_project_proj_id_unadopted_8h5g84ee",
+                    hints={"tables": ["sentry_release_project"]},
                 ),
                 migrations.RunSQL(
                     """
                     CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_releaseprojectenvironment_proj_id_env_id_adopted_j6h89s3" ON "sentry_releaseprojectenvironment" ("project_id", "adopted", "environment_id");
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_releaseprojectenvironment_proj_id_env_id_adopted_j6h89s3",
+                    hints={"tables": ["sentry_releaseprojectenvironment"]},
                 ),
                 migrations.RunSQL(
                     """
                     CREATE INDEX CONCURRENTLY IF NOT EXISTS "sentry_releaseprojectenvironment_proj_id_env_id_unadopted_kyh5m" ON "sentry_releaseprojectenvironment" ("project_id", "unadopted", "environment_id");
                     """,
                     reverse_sql="DROP INDEX CONCURRENTLY IF EXISTS sentry_releaseprojectenvironment_proj_id_env_id_unadopted_kyh5m",
+                    hints={"tables": ["sentry_releaseprojectenvironment"]},
                 ),
             ],
             state_operations=[

--- a/src/sentry/migrations/0210_backfill_project_transaction_thresholds.py
+++ b/src/sentry/migrations/0210_backfill_project_transaction_thresholds.py
@@ -70,5 +70,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(migrate_project_transaction_thresholds, migrations.RunPython.noop),
+        migrations.RunPython(
+            migrate_project_transaction_thresholds,
+            migrations.RunPython.noop,
+            hints={"tables": ["sentry_projecttransactionthreshold"]},
+        ),
     ]

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -17,7 +17,8 @@ class MissingDatabaseRoutingInfo(Exception):
 
 
 class SentryMigrationExecutor(MigrationExecutor):
-    def _check_db_routing(self, migration):
+    @staticmethod
+    def _check_db_routing(migration):
         """
         Make sure that operations in a given migration provide enough information
         for database router to select correct database connection/alias.

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -19,7 +19,7 @@ class MissingDatabaseRoutingInfo(Exception):
 class SentryMigrationExecutor(MigrationExecutor):
     def _check_db_routing(self, migration):
         """
-        Make sure that operations in given migration provide enough information
+        Make sure that operations in a given migration provide enough information
         for database router to select correct database connection/alias.
 
         We use either model or `tables` attribute in hints to select the database.

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -2,11 +2,58 @@ import logging
 import os
 
 from django.db.migrations.executor import MigrationExecutor
+from django.db.migrations.operations import RunPython, RunSQL, SeparateDatabaseAndState
+from django.db.migrations.operations.fields import FieldOperation
+from django.db.migrations.operations.models import ModelOperation
 
 logger = logging.getLogger(__name__)
 
 
+class MissingDatabaseRoutingInfo(Exception):
+    """
+    Raised when migration operation is missing information needed for selecting
+    correct database connection.
+    """
+
+
 class SentryMigrationExecutor(MigrationExecutor):
+    def _check_db_routing(self, migration):
+        """
+        Make sure that operations in given migration provide enough information
+        for database router to select correct database connection/alias.
+
+        We use either model or `tables` attribute in hints to select the database.
+        See: getsentry/db/router.py#L38-L53
+
+        - FieldOperation, ModelOperation operations are bound to a model
+        - RunSQL, RunPython need to provide hints['tables']
+        """
+
+        def _check_operations(operations):
+            failed_ops = []
+            for operation in operations:
+                if isinstance(operation, (FieldOperation, ModelOperation)):
+                    continue
+                elif isinstance(operation, (RunSQL, RunPython)):
+                    if operation.hints.get("tables"):
+                        continue
+                    else:
+                        failed_ops.append(operation)
+                elif isinstance(operation, SeparateDatabaseAndState):
+                    failed_ops.extend(_check_operations(operation.database_operations))
+                    continue
+            return failed_ops
+
+        failed_ops = _check_operations(migration.operations)
+        if failed_ops:
+            ops_msg = "\n".join(str(op) for op in failed_ops)
+            raise MissingDatabaseRoutingInfo(
+                f"Migration `{migration.name}` contains operation(s) that miss "
+                "`hints={'tables':..}` argument for correctly selecting "
+                "database connection/alias. "
+                f"\nOperations:\n{ops_msg}"
+            )
+
     def _check_fake(self, migration, fake):
         if (
             os.environ.get("MIGRATION_SKIP_DANGEROUS", "0") == "1"
@@ -19,9 +66,11 @@ class SentryMigrationExecutor(MigrationExecutor):
         return fake
 
     def apply_migration(self, state, migration, fake=False, fake_initial=False):
+        self._check_db_routing(migration)
         fake = self._check_fake(migration, fake)
         return super().apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
 
     def unapply_migration(self, state, migration, fake=False):
+        self._check_db_routing(migration)
         fake = self._check_fake(migration, fake)
         return super().unapply_migration(state, migration, fake=fake)

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -48,9 +48,9 @@ class SentryMigrationExecutor(MigrationExecutor):
         if failed_ops:
             ops_msg = "\n".join(str(op) for op in failed_ops)
             raise MissingDatabaseRoutingInfo(
-                f"Migration `{migration.name}` contains operation(s) that miss "
-                "`hints={'tables':..}` argument for correctly selecting "
-                "database connection/alias. "
+                f"Migration `{migration.app_label} {migration.name}` contains "
+                "operation(s) that miss `hints={'tables':..}` argument for "
+                "correctly selecting database connection/alias. "
                 f"\nOperations:\n{ops_msg}"
             )
 

--- a/src/sentry/new_migrations/monkey/executor.py
+++ b/src/sentry/new_migrations/monkey/executor.py
@@ -29,6 +29,9 @@ class SentryMigrationExecutor(MigrationExecutor):
         - RunSQL, RunPython need to provide hints['tables']
         """
 
+        if migration.app_label not in {"sentry", "getsentry"}:
+            return
+
         def _check_operations(operations):
             failed_ops = []
             for operation in operations:

--- a/tests/sentry/new_migrations/monkey/test_executor.py
+++ b/tests/sentry/new_migrations/monkey/test_executor.py
@@ -1,0 +1,162 @@
+import pytest
+from django.db import migrations, models
+
+from sentry.new_migrations.monkey.executor import (
+    MissingDatabaseRoutingInfo,
+    SentryMigrationExecutor,
+)
+from sentry.testutils import TestCase
+
+
+class SentryMigrationExecutorTest(TestCase):
+    def test_check_db_routing_pass(self):
+        class TestMigration(migrations.Migration):
+            operations = [
+                migrations.CreateModel(
+                    name="Test",
+                    fields=[
+                        (
+                            "id",
+                            models.IntegerField(serialize=False, primary_key=True),
+                        ),
+                        (
+                            "type",
+                            models.IntegerField(
+                                choices=[
+                                    (1, "set_resolved"),
+                                ]
+                            ),
+                        ),
+                    ],
+                    options={"db_table": "sentry_test"},
+                ),
+                migrations.AlterUniqueTogether(
+                    name="test", unique_together={("project_id", "key", "value")}
+                ),
+                migrations.AddField(
+                    model_name="release",
+                    name="projects",
+                    field=models.ManyToManyField(related_name="releases", to="sentry.Project"),
+                ),
+                migrations.RunSQL(
+                    "TEST SQL",
+                    hints={"tables": ["sentry_savedsearch"]},
+                ),
+                migrations.RunPython(
+                    migrations.RunPython.noop,
+                    migrations.RunPython.noop,
+                    hints={"tables": ["sentry_test"]},
+                ),
+            ]
+
+        SentryMigrationExecutor._check_db_routing(TestMigration(name="test", app_label="sentry"))
+
+        class TestMigration(migrations.Migration):
+            operations = [
+                migrations.SeparateDatabaseAndState(
+                    state_operations=[],
+                    database_operations=[
+                        migrations.CreateModel(
+                            name="Test",
+                            fields=[
+                                (
+                                    "id",
+                                    models.IntegerField(serialize=False, primary_key=True),
+                                ),
+                                (
+                                    "type",
+                                    models.IntegerField(
+                                        choices=[
+                                            (1, "set_resolved"),
+                                        ]
+                                    ),
+                                ),
+                            ],
+                            options={"db_table": "sentry_test"},
+                        ),
+                        migrations.AlterUniqueTogether(
+                            name="test", unique_together={("project_id", "key", "value")}
+                        ),
+                        migrations.AddField(
+                            model_name="release",
+                            name="projects",
+                            field=models.ManyToManyField(
+                                related_name="releases", to="sentry.Project"
+                            ),
+                        ),
+                        migrations.RunSQL(
+                            "TEST SQL",
+                            hints={"tables": ["sentry_savedsearch"]},
+                        ),
+                        migrations.RunPython(
+                            migrations.RunPython.noop,
+                            migrations.RunPython.noop,
+                            hints={"tables": ["sentry_test"]},
+                        ),
+                    ],
+                ),
+            ]
+
+        SentryMigrationExecutor._check_db_routing(TestMigration(name="test", app_label="sentry"))
+
+    def test_check_db_routing_missing_hints(self):
+        class TestMigration(migrations.Migration):
+            operations = [
+                migrations.SeparateDatabaseAndState(
+                    state_operations=[],
+                    database_operations=[
+                        migrations.AlterUniqueTogether(
+                            name="test", unique_together={("project_id", "key", "value")}
+                        ),
+                        migrations.AddField(
+                            model_name="release",
+                            name="projects",
+                            field=models.ManyToManyField(
+                                related_name="releases", to="sentry.Project"
+                            ),
+                        ),
+                        migrations.RunSQL("TEST SQL"),
+                        migrations.RunPython(
+                            migrations.RunPython.noop,
+                            migrations.RunPython.noop,
+                            hints={"tables": ["sentry_test"]},
+                        ),
+                    ],
+                ),
+            ]
+
+        with pytest.raises(MissingDatabaseRoutingInfo):
+            SentryMigrationExecutor._check_db_routing(
+                TestMigration(name="test", app_label="sentry")
+            )
+
+        class TestMigration(migrations.Migration):
+            operations = [
+                migrations.RunSQL("TEST SQL"),
+            ]
+
+        with pytest.raises(MissingDatabaseRoutingInfo):
+            SentryMigrationExecutor._check_db_routing(
+                TestMigration(name="test", app_label="getsentry")
+            )
+
+        class TestMigration(migrations.Migration):
+            operations = [
+                migrations.RunPython(
+                    migrations.RunPython.noop,
+                    migrations.RunPython.noop,
+                ),
+            ]
+
+        with pytest.raises(MissingDatabaseRoutingInfo):
+            SentryMigrationExecutor._check_db_routing(
+                TestMigration(name="test", app_label="getsentry")
+            )
+
+    def test_check_db_routing_dont_run_for_3rd_party(self):
+        class TestMigration(migrations.Migration):
+            operations = [
+                migrations.RunSQL("TEST SQL"),
+            ]
+
+        SentryMigrationExecutor._check_db_routing(TestMigration(name="test", app_label="auth"))


### PR DESCRIPTION
With multiple database setup we need to make sure that all migration operations carry enough info for the database router to correctly select database connection/alias. In [current getsentry implementation](https://github.com/getsentry/getsentry/blob/master/getsentry/db/router.py#L38-L53), we use the `hints['tables']` argument for operations that are not bound to model (RunSQL, RunPython).

This PR:
- introduces check for `hints['tables']` in migration operations of type RunSQL, RunPython to migrations executor
- updates old migrations to include `hints['tables']`
