### PR TITLE
ref(images-loaded): Move reprocess alert to be above cand. table

### DIFF
--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -317,6 +317,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
         </Header>
         <Body>
           <Content>
+            <GeneralInfo image={image} />
             {hasReprocessWarning && (
               <AlertLink
                 priority="warning"
@@ -329,7 +330,6 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
                 )}
               </AlertLink>
             )}
-            <GeneralInfo image={image} />
             <Candidates
               imageStatus={status}
               candidates={candidates}


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/29228205/123433980-4c97e600-d5cc-11eb-83a8-719cf4cca3c7.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/123433920-3d189d00-d5cc-11eb-860b-e0baa9327103.png)
