### PR TITLE
feat(spans): Embed span trees of transactions that are direct children

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -11,6 +11,7 @@ import {
   DividerContainer,
   DividerLine,
   DividerLineGhostContainer,
+  EmbeddedTransactionBadge,
   ErrorBadge,
 } from 'app/components/performance/waterfall/rowDivider';
 import {
@@ -714,6 +715,15 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     return errors?.length ? <ErrorBadge /> : null;
   }
 
+  renderEmbeddedTransactionsBadge(
+    transactions: QuickTraceEvent[] | null
+  ): React.ReactNode {
+    if (transactions && transactions.length === 1) {
+      return <EmbeddedTransactionBadge expanded />;
+    }
+    return null;
+  }
+
   renderWarningText({warningText}: {warningText?: string} = {}) {
     if (!warningText) {
       return null;
@@ -730,10 +740,12 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     scrollbarManagerChildrenProps,
     dividerHandlerChildrenProps,
     errors,
+    transactions,
   }: {
     dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps;
     scrollbarManagerChildrenProps: ScrollbarManager.ScrollbarManagerChildrenProps;
     errors: TraceError[] | null;
+    transactions: QuickTraceEvent[] | null;
   }) {
     const {span, spanBarColour, spanBarHatch, spanNumber} = this.props;
     const startTimestamp: number = span.start_timestamp;
@@ -763,6 +775,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         <DividerContainer>
           {this.renderDivider(dividerHandlerChildrenProps)}
           {this.renderErrorBadge(errors)}
+          {this.renderEmbeddedTransactionsBadge(transactions)}
         </DividerContainer>
         <RowCell
           data-type="span-row-cell"
@@ -853,6 +866,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
                           dividerHandlerChildrenProps,
                           scrollbarManagerChildrenProps,
                           errors,
+                          transactions,
                         })
                       }
                     </DividerHandlerManager.Consumer>

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -877,14 +877,14 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       case 'loading_embedded_transactions': {
         return (
           <MessageRow>
-            <span>{t('Loading transaction')}</span>
+            <span>{t('Loading embedded transaction')}</span>
           </MessageRow>
         );
       }
       case 'error_fetching_embedded_transactions': {
         return (
           <MessageRow>
-            <span>{t('Error loading transaction')}</span>
+            <span>{t('Error loading embedded transaction')}</span>
           </MessageRow>
         );
       }

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -39,6 +39,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 import {defined} from 'app/utils';
+import {generateEventSlug} from 'app/utils/discover/urls';
 import * as QuickTraceContext from 'app/utils/performance/quickTrace/quickTraceContext';
 import {QuickTraceContextChildrenProps} from 'app/utils/performance/quickTrace/quickTraceContext';
 import {QuickTraceEvent, TraceError} from 'app/utils/performance/quickTrace/types';
@@ -104,6 +105,10 @@ type SpanBarProps = {
   isRoot?: boolean;
   toggleSpanTree: () => void;
   isCurrentSpanFilteredOut: boolean;
+  showEmbeddedChildren: boolean;
+  toggleEmbeddedChildren:
+    | ((props: {orgSlug: string; eventSlug: string}) => void)
+    | undefined;
 };
 
 type SpanBarState = {
@@ -718,8 +723,26 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
   renderEmbeddedTransactionsBadge(
     transactions: QuickTraceEvent[] | null
   ): React.ReactNode {
+    const {toggleEmbeddedChildren, organization} = this.props;
+
     if (transactions && transactions.length === 1) {
-      return <EmbeddedTransactionBadge expanded />;
+      const transaction = transactions[0];
+      return (
+        <EmbeddedTransactionBadge
+          expanded={!!this.props.showEmbeddedChildren}
+          onClick={() => {
+            if (toggleEmbeddedChildren) {
+              toggleEmbeddedChildren({
+                orgSlug: organization.slug,
+                eventSlug: generateEventSlug({
+                  id: transaction.event_id,
+                  project: transaction.project_slug,
+                }),
+              });
+            }
+          }}
+        />
+      );
     }
     return null;
   }

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -725,6 +725,10 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
   ): React.ReactNode {
     const {toggleEmbeddedChildren, organization} = this.props;
 
+    if (!organization.features.includes('unified-span-view')) {
+      return null;
+    }
+
     if (transactions && transactions.length === 1) {
       const transaction = transactions[0];
       return (

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -151,7 +151,7 @@ class SpanTree extends React.Component<PropType> {
 
     const {spanTree, numOfSpansOutOfViewAbove, numOfFilteredSpansAbove} = spans.reduce(
       (acc: AccType, payload: EnhancedProcessedSpanType, index) => {
-        const {span, type} = payload;
+        const {type} = payload;
 
         switch (payload.type) {
           case 'filtered_out': {
@@ -179,6 +179,17 @@ class SpanTree extends React.Component<PropType> {
           });
           acc.spanTree.push(infoMessage);
         }
+
+        if (payload.type === 'loading_embedded_transactions') {
+          acc.spanTree.push(
+            <MessageRow key={`loading-transaction-${index}`}>
+              <span>{t('Loading transaction')}</span>
+            </MessageRow>
+          );
+          return acc;
+        }
+
+        const {span} = payload;
 
         const key = getSpanID(span, `span-${index}`);
 
@@ -211,6 +222,8 @@ class SpanTree extends React.Component<PropType> {
             isLast={isLast}
             isRoot={isRoot}
             isCurrentSpanFilteredOut={false}
+            showEmbeddedChildren={payload.showEmbeddedChildren}
+            toggleEmbeddedChildren={payload.toggleEmbeddedChildren}
           />
         );
 

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -180,15 +180,6 @@ class SpanTree extends React.Component<PropType> {
           acc.spanTree.push(infoMessage);
         }
 
-        if (payload.type === 'loading_embedded_transactions') {
-          acc.spanTree.push(
-            <MessageRow key={`loading-transaction-${index}`}>
-              <span>{t('Loading transaction')}</span>
-            </MessageRow>
-          );
-          return acc;
-        }
-
         const {span} = payload;
 
         const key = getSpanID(span, `span-${index}`);
@@ -224,6 +215,7 @@ class SpanTree extends React.Component<PropType> {
             isCurrentSpanFilteredOut={false}
             showEmbeddedChildren={payload.showEmbeddedChildren}
             toggleEmbeddedChildren={payload.toggleEmbeddedChildren}
+            fetchEmbeddedChildrenState={payload.fetchEmbeddedChildrenState}
           />
         );
 

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -340,10 +340,7 @@ class SpanTreeModel {
           this.embeddedChildren = [];
           this.fetchEmbeddedChildrenState = 'error_fetching_embedded_transactions';
         })
-      )
-      .finally(() => {
-        this.fetchEmbeddedChildrenState = 'idle';
-      });
+      );
   }
 }
 

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -299,8 +299,10 @@ class SpanTreeModel {
     this.showEmbeddedChildren = !this.showEmbeddedChildren;
 
     if (this.showEmbeddedChildren && this.embeddedChildren.length === 0) {
-      this.fetchEmbeddedTransactions(props);
+      return this.fetchEmbeddedTransactions(props);
     }
+
+    return Promise.resolve(undefined);
   };
 
   fetchEmbeddedTransactions({orgSlug, eventSlug}: {orgSlug: string; eventSlug: string}) {
@@ -308,7 +310,7 @@ class SpanTreeModel {
 
     this.loadingEmbeddedChildren = true;
 
-    this.api
+    return this.api
       .requestPromise(url, {
         method: 'GET',
         query: {},

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -193,8 +193,6 @@ class SpanTreeModel {
       ? continuingTreeDepths
       : [...continuingTreeDepths, treeDepthEntry];
 
-    const lastIndex = this.children.length - 1;
-
     const parentSpanID = getSpanID(this.span);
     const childSpanGroup = new Set(spanGroups);
     childSpanGroup.add(parentSpanID);
@@ -202,6 +200,8 @@ class SpanTreeModel {
     const descendantsSource = this.showEmbeddedChildren
       ? [...this.embeddedChildren, ...this.children]
       : this.children;
+
+    const lastIndex = descendantsSource.length - 1;
 
     const {descendants} = descendantsSource.reduce(
       (

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -308,7 +308,7 @@ class SpanTreeModel {
   };
 
   fetchEmbeddedTransactions({orgSlug, eventSlug}: {orgSlug: string; eventSlug: string}) {
-    const url = `/organizations/${orgSlug}/eventsxxx/${eventSlug}/`;
+    const url = `/organizations/${orgSlug}/events/${eventSlug}/`;
 
     this.fetchEmbeddedChildrenState = 'loading_embedded_transactions';
 
@@ -333,6 +333,7 @@ class SpanTreeModel {
           );
 
           this.embeddedChildren = [parsedRootSpan];
+          this.fetchEmbeddedChildrenState = 'idle';
         })
       )
       .catch(

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -49,6 +49,10 @@ type CommonEnhancedProcessedSpanType = {
   treeDepth: number;
   isLastSibling: boolean;
   continuingTreeDepths: Array<TreeDepthType>;
+  showEmbeddedChildren: boolean;
+  toggleEmbeddedChildren:
+    | ((props: {orgSlug: string; eventSlug: string}) => void)
+    | undefined;
 };
 
 // ProcessedSpanType with additional information
@@ -72,6 +76,9 @@ export type EnhancedProcessedSpanType =
   | {
       type: 'out_of_view';
       span: SpanType;
+    }
+  | {
+      type: 'loading_embedded_transactions';
     };
 
 export type SpanEntry = {

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -44,11 +44,17 @@ export type SpanType = RawSpanType | OrphanSpanType;
 // and as well as pseudo-spans (e.g. gap spans)
 export type ProcessedSpanType = SpanType | GapSpanType;
 
+export type FetchEmbeddedChildrenState =
+  | 'idle'
+  | 'loading_embedded_transactions'
+  | 'error_fetching_embedded_transactions';
+
 type CommonEnhancedProcessedSpanType = {
   numOfSpanChildren: number;
   treeDepth: number;
   isLastSibling: boolean;
   continuingTreeDepths: Array<TreeDepthType>;
+  fetchEmbeddedChildrenState: FetchEmbeddedChildrenState;
   showEmbeddedChildren: boolean;
   toggleEmbeddedChildren:
     | ((props: {orgSlug: string; eventSlug: string}) => void)
@@ -76,9 +82,6 @@ export type EnhancedProcessedSpanType =
   | {
       type: 'out_of_view';
       span: SpanType;
-    }
-  | {
-      type: 'loading_embedded_transactions';
     };
 
 export type SpanEntry = {

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -2,6 +2,7 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import {action, computed, makeObservable, observable} from 'mobx';
 
+import {Client} from 'app/api';
 import {EventTransaction} from 'app/types/event';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 
@@ -18,6 +19,8 @@ import {
 import {boundsGenerator, generateRootSpan, getSpanID, parseTrace} from './utils';
 
 class WaterfallModel {
+  api: Client = new Client();
+
   // readonly state
   event: Readonly<EventTransaction>;
   rootSpan: SpanTreeModel;
@@ -35,7 +38,12 @@ class WaterfallModel {
 
     this.parsedTrace = parseTrace(event);
     const rootSpan = generateRootSpan(this.parsedTrace);
-    this.rootSpan = new SpanTreeModel(rootSpan, this.parsedTrace.childSpans, true);
+    this.rootSpan = new SpanTreeModel(
+      rootSpan,
+      this.parsedTrace.childSpans,
+      this.api,
+      true
+    );
 
     this.indexSearch(this.parsedTrace, rootSpan);
 

--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -72,9 +72,22 @@ export function ErrorBadge() {
   );
 }
 
-export function EmbeddedTransactionBadge({expanded}: {expanded: boolean}) {
+export function EmbeddedTransactionBadge({
+  expanded,
+  onClick,
+}: {
+  expanded: boolean;
+  onClick: () => void;
+}) {
   return (
-    <BadgeBorder borderColor="gray500">
+    <BadgeBorder
+      borderColor="gray500"
+      onClick={event => {
+        event.stopPropagation();
+        event.preventDefault();
+        onClick();
+      }}
+    >
       {expanded ? (
         <IconCollapse color="gray500" size="xs" />
       ) : (

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -188,8 +188,7 @@ describe('SpanTreeModel', () => {
 
     const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans, api);
 
-    expect(spanTreeModel.showEmbeddedChildren).toBe(false);
-    expect(spanTreeModel.loadingEmbeddedChildren).toBe(false);
+    expect(spanTreeModel.fetchEmbeddedChildrenState).toBe('idle');
 
     const fullWaterfall: EnhancedProcessedSpanType[] = [
       {
@@ -211,6 +210,7 @@ describe('SpanTreeModel', () => {
         continuingTreeDepths: [],
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
+        fetchEmbeddedChildrenState: 'idle',
       },
       {
         type: 'span',
@@ -238,6 +238,7 @@ describe('SpanTreeModel', () => {
         continuingTreeDepths: [],
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
+        fetchEmbeddedChildrenState: 'idle',
       },
       {
         type: 'span',
@@ -265,6 +266,7 @@ describe('SpanTreeModel', () => {
         continuingTreeDepths: [],
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
+        fetchEmbeddedChildrenState: 'idle',
       },
       {
         type: 'span',
@@ -288,6 +290,7 @@ describe('SpanTreeModel', () => {
         continuingTreeDepths: [],
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
+        fetchEmbeddedChildrenState: 'idle',
       },
     ];
 
@@ -319,13 +322,13 @@ describe('SpanTreeModel', () => {
       orgSlug: 'sentry',
       eventSlug: 'project:19c403a10af34db2b7d93ad669bb51ed',
     });
-
-    expect(spanTreeModel.showEmbeddedChildren).toBe(true);
-    expect(spanTreeModel.loadingEmbeddedChildren).toBe(true);
+    expect(spanTreeModel.fetchEmbeddedChildrenState).toBe(
+      'loading_embedded_transactions'
+    );
 
     await promise;
 
-    expect(spanTreeModel.loadingEmbeddedChildren).toBe(false);
+    expect(spanTreeModel.fetchEmbeddedChildrenState).toBe('idle');
 
     spans = spanTreeModel.getSpansList({
       operationNameFilters: {
@@ -367,6 +370,7 @@ describe('SpanTreeModel', () => {
         continuingTreeDepths: [],
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
+        fetchEmbeddedChildrenState: 'idle',
       },
       {
         type: 'span',
@@ -387,6 +391,7 @@ describe('SpanTreeModel', () => {
         continuingTreeDepths: [1],
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
+        fetchEmbeddedChildrenState: 'idle',
       }
     );
 

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -1,8 +1,11 @@
+import {Client} from 'app/api';
 import SpanTreeModel from 'app/components/events/interfaces/spans/spanTreeModel';
 import {generateRootSpan, parseTrace} from 'app/components/events/interfaces/spans/utils';
 import {EntryType, EventTransaction} from 'app/types/event';
 
 describe('SpanTreeModel', () => {
+  const api: Client = new Client();
+
   const event = {
     id: '2b658a829a21496b87fd1f14a61abf65',
     eventID: '2b658a829a21496b87fd1f14a61abf65',
@@ -82,7 +85,7 @@ describe('SpanTreeModel', () => {
     const parsedTrace = parseTrace(event);
     const rootSpan = generateRootSpan(parsedTrace);
 
-    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans);
+    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans, api);
 
     expect(spanTreeModel.children).toHaveLength(2);
   });
@@ -120,7 +123,7 @@ describe('SpanTreeModel', () => {
     const parsedTrace = parseTrace(event2);
     const rootSpan = generateRootSpan(parsedTrace);
 
-    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans);
+    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans, api);
     expect(spanTreeModel.children).toHaveLength(1);
   });
 
@@ -128,7 +131,7 @@ describe('SpanTreeModel', () => {
     const parsedTrace = parseTrace(event);
     const rootSpan = generateRootSpan(parsedTrace);
 
-    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans);
+    const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans, api);
 
     expect(Object.fromEntries(spanTreeModel.operationNameCounts)).toMatchObject({
       http: 2,

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -2,6 +2,7 @@ import {ActiveFilter, noFilter} from 'app/components/events/interfaces/spans/fil
 import {EnhancedProcessedSpanType} from 'app/components/events/interfaces/spans/types';
 import WaterfallModel from 'app/components/events/interfaces/spans/waterfallModel';
 import {EntryType, EventTransaction} from 'app/types/event';
+import {assert} from 'app/types/utils';
 
 describe('WaterfallModel', () => {
   const event = {
@@ -111,6 +112,8 @@ describe('WaterfallModel', () => {
       treeDepth: 0,
       isLastSibling: true,
       continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
     },
     {
       type: 'span',
@@ -130,6 +133,8 @@ describe('WaterfallModel', () => {
       treeDepth: 1,
       isLastSibling: false,
       continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
     },
     {
       type: 'gap',
@@ -144,6 +149,8 @@ describe('WaterfallModel', () => {
       treeDepth: 1,
       isLastSibling: false,
       continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: undefined,
     },
     {
       type: 'span',
@@ -163,6 +170,8 @@ describe('WaterfallModel', () => {
       treeDepth: 1,
       isLastSibling: false,
       continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
     },
     {
       type: 'span',
@@ -184,6 +193,8 @@ describe('WaterfallModel', () => {
       treeDepth: 2,
       isLastSibling: true,
       continuingTreeDepths: [1],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
     },
     {
       type: 'gap',
@@ -198,6 +209,8 @@ describe('WaterfallModel', () => {
       treeDepth: 1,
       isLastSibling: false,
       continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: undefined,
     },
     {
       type: 'span',
@@ -219,6 +232,8 @@ describe('WaterfallModel', () => {
       treeDepth: 1,
       isLastSibling: true,
       continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
     },
   ];
 
@@ -353,11 +368,13 @@ describe('WaterfallModel', () => {
 
     const expected = [...fullWaterfall];
 
+    assert(fullWaterfall[1].type !== 'loading_embedded_transactions');
     expected[1] = {
       type: 'out_of_view',
       span: fullWaterfall[1].span,
     } as EnhancedProcessedSpanType;
 
+    assert(fullWaterfall[4].type !== 'loading_embedded_transactions');
     expected[4] = {
       type: 'out_of_view',
       span: fullWaterfall[4].span,
@@ -372,6 +389,8 @@ describe('WaterfallModel', () => {
       viewEnd: 0.65,
     });
 
+    assert(fullWaterfall[0].type !== 'loading_embedded_transactions');
+    assert(fullWaterfall[6].type !== 'loading_embedded_transactions');
     expect(spans).toEqual([
       {
         type: 'filtered_out',

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -2,7 +2,6 @@ import {ActiveFilter, noFilter} from 'app/components/events/interfaces/spans/fil
 import {EnhancedProcessedSpanType} from 'app/components/events/interfaces/spans/types';
 import WaterfallModel from 'app/components/events/interfaces/spans/waterfallModel';
 import {EntryType, EventTransaction} from 'app/types/event';
-import {assert} from 'app/types/utils';
 
 describe('WaterfallModel', () => {
   const event = {

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -375,13 +375,11 @@ describe('WaterfallModel', () => {
 
     const expected = [...fullWaterfall];
 
-    assert(fullWaterfall[1].type !== 'loading_embedded_transactions');
     expected[1] = {
       type: 'out_of_view',
       span: fullWaterfall[1].span,
     } as EnhancedProcessedSpanType;
 
-    assert(fullWaterfall[4].type !== 'loading_embedded_transactions');
     expected[4] = {
       type: 'out_of_view',
       span: fullWaterfall[4].span,
@@ -396,8 +394,6 @@ describe('WaterfallModel', () => {
       viewEnd: 0.65,
     });
 
-    assert(fullWaterfall[0].type !== 'loading_embedded_transactions');
-    assert(fullWaterfall[6].type !== 'loading_embedded_transactions');
     expect(spans).toEqual([
       {
         type: 'filtered_out',

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -114,6 +114,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
     },
     {
       type: 'span',
@@ -135,6 +136,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
     },
     {
       type: 'gap',
@@ -151,6 +153,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: undefined,
+      fetchEmbeddedChildrenState: 'idle',
     },
     {
       type: 'span',
@@ -172,6 +175,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
     },
     {
       type: 'span',
@@ -195,6 +199,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [1],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
     },
     {
       type: 'gap',
@@ -211,6 +216,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: undefined,
+      fetchEmbeddedChildrenState: 'idle',
     },
     {
       type: 'span',
@@ -234,6 +240,7 @@ describe('WaterfallModel', () => {
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
     },
   ];
 


### PR DESCRIPTION
Using the information provided by the trace navigation feature, we can identify transactions that are direct children to the current transaction, and embed their span trees into the current span view.

For example, this enables customers to be able to see backend transactions inline with the frontend spans.

This product feature will be gated behind the `organizations:unified-span-view` feature flag.

Functionality that appears to be missing will be added in follow-up pull-requests. 

https://user-images.githubusercontent.com/139499/123486805-bfa85900-d5da-11eb-8cd0-0b37242a0d5e.mp4

