### PR TITLE
fix(warnings): make some naive datetimes aware

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from django.db.models import DateTimeField, IntegerField, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce
+from django.utils.timezone import make_aware
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -110,7 +111,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             )
 
         if "date_triggered" in sort_key:
-            far_past_date = Value(datetime.min, output_field=DateTimeField())
+            far_past_date = Value(make_aware(datetime.min), output_field=DateTimeField())
             alert_rules = alert_rules.annotate(
                 date_triggered=Coalesce(
                     Subquery(

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -1,3 +1,4 @@
+from dateutil.parser import parse as parse_date
 from django.db.models import Q
 from rest_framework import status
 from rest_framework.response import Response
@@ -17,6 +18,7 @@ from sentry.incidents.models import (
     IncidentStatus,
 )
 from sentry.snuba.dataset import Dataset
+from sentry.utils.dates import ensure_aware
 
 from .utils import parse_team_params
 
@@ -63,11 +65,13 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         query_start = request.GET.get("start")
         if query_start is not None:
             # exclude incidents closed before the window
+            query_start = ensure_aware(parse_date(query_start))
             incidents = incidents.exclude(date_closed__lt=query_start)
 
         query_end = request.GET.get("end")
         if query_end is not None:
             # exclude incidents started after the window
+            query_end = ensure_aware(parse_date(query_end))
             incidents = incidents.exclude(date_started__gt=query_end)
 
         query_status = request.GET.get("status")

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -6,6 +6,7 @@ import pytz
 from dateutil.parser import parse
 from django.db import connections
 from django.http.request import HttpRequest
+from django.utils.timezone import is_aware, make_aware
 
 from sentry import quotas
 from sentry.constants import MAX_ROLLUP_POINTS
@@ -13,6 +14,15 @@ from sentry.constants import MAX_ROLLUP_POINTS
 DATE_TRUNC_GROUPERS = {"date": "day", "hour": "hour", "minute": "minute"}
 
 epoch = datetime(1970, 1, 1, tzinfo=pytz.utc)
+
+
+def ensure_aware(value: datetime) -> datetime:
+    """
+    Ensures the datetime is an aware datetime.
+    """
+    if is_aware(value):
+        return value
+    return make_aware(value)
 
 
 def to_timestamp(value: datetime) -> float:

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime, timedelta
-from typing import Any, Mapping, Optional, Tuple, Union
+from typing import Any, Mapping, Optional, Tuple, Union, cast
 
 import pytz
 from dateutil.parser import parse
@@ -22,7 +22,7 @@ def ensure_aware(value: datetime) -> datetime:
     """
     if is_aware(value):
         return value
-    return make_aware(value)
+    return cast(datetime, make_aware(value))
 
 
 def to_timestamp(value: datetime) -> float:


### PR DESCRIPTION
All datetime objects we give to Django should be timezone-aware since we set USE_TZ = True. These have been identified so far from sending warnings to Sentry from a staging deployment of https://github.com/getsentry/sentry/pull/26796. Probably more will be identified once I go full production. I can see others in k8s logs, but it's quite hard to identify where fixes need to be done without proper stacktraces + variable values that Sentry reporting gets me.

Fixes SENTRY-QZD.
Fixes SENTRY-QZF.
Fixes SENTRY-QZG.

