### PR TITLE
ref(snql) Revert dry run changes once fix is tested

### DIFF
--- a/src/sentry/utils/snql.py
+++ b/src/sentry/utils/snql.py
@@ -61,12 +61,6 @@ dryrun_check = ReferrerCheck(
         "eventstore.",
         "search_sample",
         "testing.test",
-        "discover",
-        "outcomes.",
-        "sessions.",
-        "incidents.",
-        "tsdb-modelid:",
-        "api.",
     ],
     by_entity={},
 )
@@ -81,7 +75,7 @@ snql_check = ReferrerCheck(
         "tsdb-modelid:100",
     },
     allowlist=set(),
-    prefixes=[],
+    prefixes=["discover", "outcomes.", "sessions.", "incidents.", "tsdb-modelid:", "api."],
     by_entity={},
     is_dryrun=False,
 )


### PR DESCRIPTION
There is a fix for a bug in snuba sdk 0.0.19 that requires this fix (https://github.com/getsentry/snuba/pull/1970) in Snuba as well. In order to avoid bugs, I switched all of SnQL traffic to dry run mode. Once the above snuba PR is merged and confirmed, this can be merged to move traffic back to SnQL.