### PR TITLE
fix(discover): Do not replace on non string values

### DIFF
--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -402,7 +402,10 @@ function formatQuery(query: string) {
  * the literal.
  */
 function escapeTagValue(value: string) {
+  // TODO(txiao): The types here are definitely wrong.
+  // Need to dig deeper to see where exactly it's wrong.
+  //
   // astericks (*) is used for wildcard searches
   // back slaches (\) is used to escape other characters
-  return value ? value.replace(/([\*\\])/g, '\\$1') : value;
+  return typeof value === 'string' ? value.replace(/([\*\\])/g, '\\$1') : value;
 }


### PR DESCRIPTION
The types here are actually wrong and there are non string values being passed
here like nulls and numbers. This adds a check to avoid these type errors but
still need to fix the actual typing here so it doesn't happen again.