### PR TITLE
fix(org-auth): changed text for SAML2 auth

### DIFF
--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -85,7 +85,7 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
     }
 
     if (providerName === 'Google') {
-      return 'Google(OAuth)';
+      return 'Google (OAuth)';
     }
 
     return providerName;

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -81,12 +81,14 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
 
   const GetProviderDescription = providerName => {
     if (providerName === 'SAML2') {
-      return 'with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
-    } else if (providerName === 'Google') {
-      return 'Google(OAuth)';
-    } else {
-      return providerName;
+      return 'your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
     }
+
+    if (providerName === 'Google') {
+      return 'Google(OAuth)';
+    }
+
+    return providerName;
   };
 
   return (

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -79,7 +79,7 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
 
   const featureProps = hookName ? {hookName} : {};
 
-  const GetProviderDescription = providerName => {
+  const getProviderDescription = providerName => {
     if (providerName === 'SAML2') {
       return 'your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
     }
@@ -120,7 +120,7 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
               <ProviderDescription>
                 {t(
                   'Enable your organization to sign in with %s.',
-                  GetProviderDescription(provider.name)
+                  getProviderDescription(provider.name)
                 )}
               </ProviderDescription>
             </div>

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -105,9 +105,17 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
             />
             <div>
               <ProviderName>{provider.name}</ProviderName>
-              <ProviderDescription>
-                {t('Enable your organization to sign in with %s.', provider.name)}
-              </ProviderDescription>
+              {provider.name === 'SAML2' ? (
+                <ProviderDescription>
+                  {t(
+                    'Enable your organization to sign in with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager.'
+                  )}
+                </ProviderDescription>
+              ) : (
+                <ProviderDescription>
+                  {t('Enable your organization to sign in with %s.', provider.name)}
+                </ProviderDescription>
+              )}
             </div>
           </ProviderInfo>
 

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -79,15 +79,15 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
 
   const featureProps = hookName ? {hookName} : {};
 
-  function GetProviderDescription(p: string) {
-    if (p === 'SAML2') {
+  const GetProviderDescription = providerName => {
+    if (providerName === 'SAML2') {
       return 'with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
-    } else if (p === 'Google') {
+    } else if (providerName === 'Google') {
       return 'Google(OAuth)';
     } else {
-      return p;
+      return providerName;
     }
-  }
+  };
 
   return (
     <Feature

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -79,6 +79,16 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
 
   const featureProps = hookName ? {hookName} : {};
 
+  function GetProviderDescription(p: string) {
+    if (p === 'SAML2') {
+      return 'with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
+    } else if (p === 'Google') {
+      return 'Google(Auth)';
+    } else {
+      return p;
+    }
+  }
+
   return (
     <Feature
       {...featureProps}
@@ -105,17 +115,12 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
             />
             <div>
               <ProviderName>{provider.name}</ProviderName>
-              {provider.name === 'SAML2' ? (
-                <ProviderDescription>
-                  {t(
-                    'Enable your organization to sign in with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager.'
-                  )}
-                </ProviderDescription>
-              ) : (
-                <ProviderDescription>
-                  {t('Enable your organization to sign in with %s.', provider.name)}
-                </ProviderDescription>
-              )}
+              <ProviderDescription>
+                {t(
+                  'Enable your organization to sign in with %s.',
+                  GetProviderDescription(provider.name)
+                )}
+              </ProviderDescription>
             </div>
           </ProviderInfo>
 

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -83,7 +83,7 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
     if (p === 'SAML2') {
       return 'with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
     } else if (p === 'Google') {
-      return 'Google(Auth)';
+      return 'Google(OAuth)';
     } else {
       return p;
     }

--- a/static/app/views/settings/organizationAuth/providerItem.tsx
+++ b/static/app/views/settings/organizationAuth/providerItem.tsx
@@ -81,11 +81,13 @@ const ProviderItem = ({provider, active, onConfigure}: Props) => {
 
   const getProviderDescription = providerName => {
     if (providerName === 'SAML2') {
-      return 'your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager';
+      return t(
+        'your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager'
+      );
     }
 
     if (providerName === 'Google') {
-      return 'Google (OAuth)';
+      return t('Google (OAuth)');
     }
 
     return providerName;


### PR DESCRIPTION
Changed the description for SAML2 to "Enable your organization to sign in with your preferred SAML2 compliant provider like Ping Identity, Google SAML, Keycloak, or VMware Identity Manager."

Before:
![image](https://user-images.githubusercontent.com/22259802/123676250-b1904d80-d811-11eb-8f17-bbe0a5270045.png)


After:
![image](https://user-images.githubusercontent.com/22259802/123697138-8d8d3600-d82a-11eb-8eb9-2d937a68f678.png)
https://getsentry.atlassian.net/browse/ER-679