### PR TITLE
feat(identity): IdentityProvider dual-write to new columns

### DIFF
--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -3,6 +3,7 @@ import logging
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
+from django.db.models.signals import pre_save
 from django.utils import timezone
 
 from sentry.db.models import (
@@ -51,6 +52,19 @@ class IdentityProvider(Model):
         from sentry.identity import get
 
         return get(self.type)
+
+
+def handle_identity_provider_pre_save(instance, **kwargs):
+    instance.provider = instance.type
+    instance.provider_id = instance.external_id
+
+
+pre_save.connect(
+    handle_identity_provider_pre_save,
+    sender="sentry.IdentityProvider",
+    dispatch_uid="handle_identity_provider_pre_save",
+    weak=False,
+)
 
 
 class Identity(Model):


### PR DESCRIPTION
This is a series of PR to merge `IdentityProvider` and `AuthProvider` into 1 model/table. 

At the moment, they will need to go through COPS to disconnect their Google identities from their Sentry account. This will make it easier for users to manage their external identities from Slack/MS Teams/Okta/Google/etc. 

Part 1: IdentityProvider add new columns (#26930)
Part 2: IdentityProvider dual-write to columns (#26931) ← Here
Part 3: AuthProvider dual-write to 2 tables (#26932)