### PR TITLE
fix(ui): dark mode fixes for issue details page

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -66,21 +66,21 @@ export const GroupingValue = styled('code')<{valueType: string}>`
   font-size: ${p => p.theme.fontSizeSmall};
   padding: 0 ${space(0.25)};
   background: rgba(112, 163, 214, 0.1);
-  color: #4e3fb4;
+  color: ${p => p.theme.textColor};
 
   ${({valueType}) =>
     (valueType === 'function' || valueType === 'symbol') &&
     `
     font-weight: bold;
-    color: #2c58a8;
+    color: ${p => p.theme.textColor};
   `}
 `;
 
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
-  color: ${p => (p.isContributing ? null : p.theme.gray200)};
+  color: ${p => (p.isContributing ? null : p.theme.textColor)};
 
   ${GroupingValue}, button {
-    opacity: ${p => (p.isContributing ? 1 : 0.6)};
+    opacity: 1;
   }
 `;
 

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -86,6 +86,7 @@ class GroupingComponentFrames extends React.Component<Props, State> {
 
 const ToggleCollapse = styled(Button)`
   margin: ${space(0.5)} 0;
+  color: ${p => p.theme.linkColor};
 `;
 
 export default GroupingComponentFrames;

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -285,7 +285,7 @@ const ContributingToggle = styled(ButtonBar)`
 `;
 
 const GroupingTree = styled('div')`
-  color: #2f2936;
+  color: ${p => p.theme.textColor};
 `;
 
 const TextWithQuestionTooltip = styled('div')`

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -188,6 +188,7 @@ export const GroupingConfigItem = styled('span')<{
 
 const VariantDivider = styled('hr')`
   padding-top: ${space(1)};
+  border-top: 1px solid ${p => p.theme.border};
 `;
 
 export default withOrganization(EventGroupingInfo);

--- a/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -45,13 +45,14 @@ const Wrapper = styled('div')`
 
 const ContextDataWrapper = styled('div')`
   padding: ${space(1)};
-  background: #f7f8f9;
+  background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   max-height: 100%;
   height: 100%;
   overflow: hidden;
 
   pre {
+    background: ${p => p.theme.backgroundSecondary};
     margin: 0;
     padding: 0;
     overflow: hidden;


### PR DESCRIPTION
Fixing a few bugs in dark mode for the issue details page.

### Before 

![CleanShot 2021-06-28 at 13 11 27](https://user-images.githubusercontent.com/1900676/123697954-61fe5180-d812-11eb-8c35-e9913c7e10b3.png)

### After 

![CleanShot 2021-06-28 at 13 11 20](https://user-images.githubusercontent.com/1900676/123697966-662a6f00-d812-11eb-8e7a-ace0a11d57a7.png)

---

### Before
![CleanShot 2021-06-28 at 13 11 55](https://user-images.githubusercontent.com/1900676/123698001-74788b00-d812-11eb-958f-10e28e5bd12e.png)

### After
![CleanShot 2021-06-28 at 13 11 05](https://user-images.githubusercontent.com/1900676/123698012-780c1200-d812-11eb-9442-45abf513109a.png)

