### PR TITLE
feat(ms-teams): Handle expired links

### DIFF
--- a/src/sentry/templates/sentry/integrations/msteams-expired-link.html
+++ b/src/sentry/templates/sentry/integrations/msteams-expired-link.html
@@ -1,0 +1,14 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Microsoft Teams Expired Link" %} | {{ block.super }}{% endblock %}
+{% block wrapperclass %}narrow auth{% endblock %}
+
+{% block main %}
+  <div class="align-center">
+    <p>
+      {% trans "Your link has expired. Please retry again." %}
+    </p>
+  </div>
+{% endblock %}

--- a/src/sentry/templates/sentry/integrations/msteams-expired-link.html
+++ b/src/sentry/templates/sentry/integrations/msteams-expired-link.html
@@ -8,7 +8,8 @@
 {% block main %}
   <div class="align-center">
     <p>
-      {% trans "Your link has expired. Please retry again." %}
+      {% trans "Your link is expired. Please try re-linking your identity again by interacting with a Sentry notification in Microsoft Teams.
+      " %}
     </p>
   </div>
 {% endblock %}


### PR DESCRIPTION
Objective:
Fixes [SENTRY-K8M](https://sentry.io/organizations/sentry/issues/2106159015/?project=1&referrer=slack)

Currently, if a user tries to link their identity with an expired link, we just return the Internal Server Error page. This PR adds a template that we can return for this error case, so that the user can retry the linking process.

UI
Before:
![Screen Shot 2021-06-28 at 4 11 26 PM](https://user-images.githubusercontent.com/10491193/123714646-9599a580-d82b-11eb-8b7d-7446118265b4.png)

After:
![Screen Shot 2021-06-28 at 4 11 41 PM](https://user-images.githubusercontent.com/10491193/123714694-ac3ffc80-d82b-11eb-9855-8adcf8e4598b.png)
