### PR TITLE
build(webpack): Change webpack output paths

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -392,8 +392,8 @@ let appConfig = {
     path: distPath,
     publicPath: '',
     filename: '[name].[contenthash].js',
-    chunkFilename: '[name].[contenthash].js',
-    sourceMapFilename: '[name].js.map',
+    chunkFilename: 'chunks/[name].[contenthash].js',
+    sourceMapFilename: 'sourcemaps/[name].[contenthash].js.map',
   },
   optimization: {
     chunkIds: 'named',


### PR DESCRIPTION
Output webpack chunks and source maps to respective child directories. This will allow us to better differentiate entries from chunks from source maps. We currently have all of these files in a single directory and will make upcoming changes regarding frontend-only deploys a bit more difficult.