### PR TITLE
feat(ui): Add more platforms to release adoption chart

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -428,13 +428,15 @@ class ReleasesList extends AsyncView<Props, State> {
           const isMobileProject =
             selectedProject &&
             selectedProject.platform &&
-            ([
-              ...mobile,
-              ...desktop,
-              'java-android',
-              'cocoa-objc',
-              'cocoa-swift',
-            ] as string[]).includes(selectedProject.platform as string);
+            (
+              [
+                ...mobile,
+                ...desktop,
+                'java-android',
+                'cocoa-objc',
+                'cocoa-swift',
+              ] as string[]
+            ).includes(selectedProject.platform as string);
 
           return (
             <Fragment>

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -428,9 +428,13 @@ class ReleasesList extends AsyncView<Props, State> {
           const isMobileProject =
             selectedProject &&
             selectedProject.platform &&
-            ([...mobile, ...desktop] as string[]).includes(
-              selectedProject.platform as string
-            );
+            ([
+              ...mobile,
+              ...desktop,
+              'java-android',
+              'cocoa-objc',
+              'cocoa-swift',
+            ] as string[]).includes(selectedProject.platform as string);
 
           return (
             <Fragment>


### PR DESCRIPTION
I've noticed these legacy ones were not part of the mobile array anymore.