### PR TITLE
fix(performance): Atomic txn cannot wrap try/except

### DIFF
--- a/src/sentry/api/endpoints/project_transaction_threshold.py
+++ b/src/sentry/api/endpoints/project_transaction_threshold.py
@@ -78,8 +78,8 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
 
         data = serializer.validated_data
 
-        with transaction.atomic():
-            try:
+        try:
+            with transaction.atomic():
                 project_threshold = ProjectTransactionThreshold.objects.get(
                     project=project,
                     organization=project.organization,
@@ -89,9 +89,10 @@ class ProjectTransactionThresholdEndpoint(ProjectEndpoint):
                 project_threshold.edited_by = request.user
                 project_threshold.save()
 
-                created = False
+            created = False
 
-            except ProjectTransactionThreshold.DoesNotExist:
+        except ProjectTransactionThreshold.DoesNotExist:
+            with transaction.atomic():
                 project_threshold = ProjectTransactionThreshold.objects.create(
                     project=project,
                     organization=project.organization,


### PR DESCRIPTION
`transaction.atomic` cannot wrap a try/except block
because if an exception is handled before exiting
an atomic block, it may cause unexpected behaviour.