### PR TITLE
ref(github): Use signed urls for external installs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1795,6 +1795,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
     "sentry.integrations.bitbucket_server.BitbucketServerIntegrationProvider",
     "sentry.integrations.slack.SlackIntegrationProvider",
     "sentry.integrations.github.GitHubIntegrationProvider",
+    "sentry.integrations.github.GitHubExtensionIntegrationProvider",
     "sentry.integrations.github_enterprise.GitHubEnterpriseIntegrationProvider",
     "sentry.integrations.gitlab.GitlabIntegrationProvider",
     "sentry.integrations.jira.JiraIntegrationProvider",

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -552,3 +552,6 @@ ALERTS_MEMBER_WRITE_DEFAULT = True
 
 # Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
 DataCategory = sentry_relay.DataCategory
+
+# 24 hours to finish integration installation
+INSTALL_EXPIRATION_TIME = 60 * 60 * 24

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -51,3 +51,18 @@ class GitHubIdentityProvider(OAuth2Provider):
             "scopes": [],  # GitHub apps do not have user scopes
             "data": self.get_oauth_data(data),
         }
+
+
+class GitHubExtensionIdentityProvider(GitHubIdentityProvider):
+    """
+    Functions exactly the same as ``GitHubIdentityProvider``.
+
+    This class is necessary because of how Integration Pipelines look up
+    sibling/dependent classes using ``key``.
+
+    The IntegrationProvider for the Github Extension is slightly different from
+    the Github version, so it requires a new class. Hence, the Identity portion
+    also requires a new class; this one.
+    """
+
+    key = "github-extension"

--- a/src/sentry/integrations/github/github_extension_installation.py
+++ b/src/sentry/integrations/github/github_extension_installation.py
@@ -1,7 +1,8 @@
 from sentry.constants import INSTALL_EXPIRATION_TIME
 from sentry.utils.signing import unsign
-
-from .integration_extension_configuration import IntegrationExtensionConfigurationView
+from sentry.web.frontend.integration_extension_configuration import (
+    IntegrationExtensionConfigurationView,
+)
 
 
 class GithubExtensionConfigurationView(IntegrationExtensionConfigurationView):

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         name="sentry-extensions-github-search",
     ),
     url(
-        r"^configure/(?P<signed_params>[^\/]+)/$",
+        r"^configure/$",
         GithubExtensionConfigurationView.as_view(),
         name="github-integration-installation",
     ),

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -1,6 +1,8 @@
 from django.conf.urls import url
 
-from sentry.web.frontend.github_extension_installation import GithubExtensionConfigurationView
+from sentry.integrations.github.github_extension_installation import (
+    GithubExtensionConfigurationView,
+)
 
 from .search import GitHubSearchEndpoint
 from .webhook import GitHubIntegrationsWebhookEndpoint

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url
 
+from sentry.web.frontend.github_extension_installation import GithubExtensionConfigurationView
+
 from .search import GitHubSearchEndpoint
 from .webhook import GitHubIntegrationsWebhookEndpoint
 
@@ -9,5 +11,10 @@ urlpatterns = [
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",
         GitHubSearchEndpoint.as_view(),
         name="sentry-extensions-github-search",
+    ),
+    url(
+        r"^extensions/external-install/$",
+        GithubExtensionConfigurationView.as_view(),
+        name="integration-installation",
     ),
 ]

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -13,8 +13,8 @@ urlpatterns = [
         name="sentry-extensions-github-search",
     ),
     url(
-        r"^extensions/external-install/$",
+        r"^configure/$",
         GithubExtensionConfigurationView.as_view(),
-        name="integration-installation",
+        name="github-integration-installation",
     ),
 ]

--- a/src/sentry/integrations/github/urls.py
+++ b/src/sentry/integrations/github/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         name="sentry-extensions-github-search",
     ),
     url(
-        r"^configure/$",
+        r"^configure/(?P<signed_params>[^\/]+)/$",
         GithubExtensionConfigurationView.as_view(),
         name="github-integration-installation",
     ),

--- a/src/sentry/integrations/jira/extension_configuration.py
+++ b/src/sentry/integrations/jira/extension_configuration.py
@@ -1,11 +1,9 @@
+from sentry.constants import INSTALL_EXPIRATION_TIME
 from sentry.utils import json
 from sentry.utils.signing import unsign
 from sentry.web.frontend.integration_extension_configuration import (
     IntegrationExtensionConfigurationView,
 )
-
-# 24 hours to finish installation
-INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
 class JiraExtensionConfigurationView(IntegrationExtensionConfigurationView):

--- a/src/sentry/testutils/asserts.py
+++ b/src/sentry/testutils/asserts.py
@@ -37,3 +37,7 @@ def assert_status_code(response, minimum: int, maximum: Optional[int] = None):
     # Omit max to assert status_code == minimum.
     maximum = maximum or minimum + 1
     assert minimum <= response.status_code < maximum, (response.status_code, response.content)
+
+
+def assert_dialog_success(response):
+    assert b"window.opener.postMessage(" in response.content

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -752,9 +752,6 @@ class IntegrationTestCase(TestCase):
         self.pipeline.initialize()
         self.save_session()
 
-    def assertDialogSuccess(self, resp):
-        assert b"window.opener.postMessage(" in resp.content
-
 
 @pytest.mark.snuba
 @requires_snuba

--- a/src/sentry/web/frontend/github_extension_installation.py
+++ b/src/sentry/web/frontend/github_extension_installation.py
@@ -1,0 +1,24 @@
+from sentry.utils.signing import unsign
+
+from .integration_extension_configuration import IntegrationExtensionConfigurationView
+
+# 24 hours to finish installation
+INSTALL_EXPIRATION_TIME = 60 * 60 * 24
+
+
+class GithubExtensionConfigurationView(IntegrationExtensionConfigurationView):
+    provider = "github"
+    external_provider_key = "github"
+
+    def map_params_to_state(self, params):
+        # decode the signed params and add them to whatever params we have
+        params = params.copy()
+        signed_params = params["signed_params"]
+        del params["signed_params"]
+        params.update(
+            unsign(
+                signed_params,
+                max_age=INSTALL_EXPIRATION_TIME,
+            )
+        )
+        return params

--- a/src/sentry/web/frontend/github_extension_installation.py
+++ b/src/sentry/web/frontend/github_extension_installation.py
@@ -1,9 +1,7 @@
+from sentry.constants import INSTALL_EXPIRATION_TIME
 from sentry.utils.signing import unsign
 
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
-
-# 24 hours to finish installation
-INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
 class GithubExtensionConfigurationView(IntegrationExtensionConfigurationView):

--- a/src/sentry/web/frontend/github_extension_installation.py
+++ b/src/sentry/web/frontend/github_extension_installation.py
@@ -6,7 +6,7 @@ from .integration_extension_configuration import IntegrationExtensionConfigurati
 
 class GithubExtensionConfigurationView(IntegrationExtensionConfigurationView):
     provider = "github"
-    external_provider_key = "github"
+    external_provider_key = "github-extension"
 
     def map_params_to_state(self, params):
         # decode the signed params and add them to whatever params we have

--- a/src/sentry/web/frontend/msteams_extension_configuration.py
+++ b/src/sentry/web/frontend/msteams_extension_configuration.py
@@ -1,9 +1,7 @@
+from sentry.constants import INSTALL_EXPIRATION_TIME
 from sentry.utils.signing import unsign
 
 from .integration_extension_configuration import IntegrationExtensionConfigurationView
-
-# 24 hours to finish installation
-INSTALL_EXPIRATION_TIME = 60 * 60 * 24
 
 
 class MsTeamsExtensionConfigurationView(IntegrationExtensionConfigurationView):

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -46,7 +46,7 @@ class PipelineAdvancerView(BaseView):
                 provider_id=provider_id,
             )
             return self.redirect(
-                reverse("integration-installation", kwargs={"signed_params": signed_params})
+                reverse("github-integration-installation", kwargs={"signed_params": signed_params})
             )
 
         if pipeline is None or not pipeline.is_valid():

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -36,25 +36,17 @@ class PipelineAdvancerView(BaseView):
             if pipeline:
                 break
 
-        # print("=" * 100)
-        # print("In pipeline advancer")
-        # print(f"provider_id: {provider_id}")
-        # print(f"setup_action: {request.GET.get('setup_action')}")
-        # print(f"pipeline: {pipeline}")
-
         if (
             provider_id in FORWARD_INSTALL_FOR
             and request.GET.get("setup_action") == "install"
             and pipeline is None
         ):
-            # print("Github breakout happening")
             signed_params = sign(
                 installation_id=request.GET.get("installation_id"),
                 provider_id=provider_id,
             )
-            # print(f"This is the signed_params: {signed_params}")
             return self.redirect(
-                reverse("github-integration-installation", kwargs={"signed_params": signed_params})
+                f"{reverse('github-integration-installation')}/?signed_params={signed_params}"
             )
 
         if pipeline is None or not pipeline.is_valid():

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -36,6 +36,7 @@ class PipelineAdvancerView(BaseView):
             if pipeline:
                 break
 
+        # For github -> sentry installs, we will sign the url before continuing.
         if (
             provider_id in FORWARD_INSTALL_FOR
             and request.GET.get("setup_action") == "install"

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 
@@ -40,9 +41,12 @@ class PipelineAdvancerView(BaseView):
             and request.GET.get("setup_action") == "install"
             and pipeline is None
         ):
-            installation_id = request.GET.get("installation_id")
+            signed_params = sign(
+                installation_id=request.GET.get("installation_id"),
+                provider_id=provider_id,
+            )
             return self.redirect(
-                reverse("integration-installation", args=[provider_id, installation_id])
+                reverse("integration-installation", kwargs={"signed_params": signed_params})
             )
 
         if pipeline is None or not pipeline.is_valid():

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -21,7 +21,7 @@ FORWARD_INSTALL_FOR = ["github"]
 
 
 class PipelineAdvancerView(BaseView):
-    """Gets the current pipeline from the request and executes the current step."""
+    """Gets the current pipeline from the req   uest and executes the current step."""
 
     auth_required = False
 
@@ -47,7 +47,7 @@ class PipelineAdvancerView(BaseView):
                 provider_id=provider_id,
             )
             return self.redirect(
-                f"{reverse('github-integration-installation')}/?signed_params={signed_params}"
+                f"{reverse('github-integration-installation')}?signed_params={signed_params}"
             )
 
         if pipeline is None or not pipeline.is_valid():

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -36,15 +36,23 @@ class PipelineAdvancerView(BaseView):
             if pipeline:
                 break
 
+        # print("=" * 100)
+        # print("In pipeline advancer")
+        # print(f"provider_id: {provider_id}")
+        # print(f"setup_action: {request.GET.get('setup_action')}")
+        # print(f"pipeline: {pipeline}")
+
         if (
             provider_id in FORWARD_INSTALL_FOR
             and request.GET.get("setup_action") == "install"
             and pipeline is None
         ):
+            # print("Github breakout happening")
             signed_params = sign(
                 installation_id=request.GET.get("installation_id"),
                 provider_id=provider_id,
             )
+            # print(f"This is the signed_params: {signed_params}")
             return self.redirect(
                 reverse("github-integration-installation", kwargs={"signed_params": signed_params})
             )

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -440,11 +440,6 @@ urlpatterns += [
             ]
         ),
     ),
-    url(
-        r"^extensions/external-install/(?P<provider_id>\w+)/(?P<installation_id>\w+)/$",
-        react_page_view,
-        name="integration-installation",
-    ),
     # Organizations
     url(r"^(?P<organization_slug>[\w_-]+)/$", react_page_view, name="sentry-organization-home"),
     url(

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -754,11 +754,6 @@ function routes() {
           componentPromise={() => import('app/views/acceptProjectTransfer')}
           component={errorHandler(LazyLoad)}
         />
-        <Route
-          path="/extensions/external-install/:integrationSlug/:installationId"
-          componentPromise={() => import('app/views/integrationOrganizationLink')}
-          component={errorHandler(LazyLoad)}
-        />
 
         <Route
           path="/extensions/:integrationSlug/link/"

--- a/static/app/views/integrationOrganizationLink.tsx
+++ b/static/app/views/integrationOrganizationLink.tsx
@@ -21,11 +21,10 @@ import {
 } from 'app/utils/integrationUtil';
 import {singleLineRenderer} from 'app/utils/marked';
 import AsyncView from 'app/views/asyncView';
-import AddIntegration from 'app/views/organizationIntegrations/addIntegration';
 import Field from 'app/views/settings/components/forms/field';
 
 // installationId present for Github flow
-type Props = RouteComponentProps<{integrationSlug: string; installationId?: string}, {}>;
+type Props = RouteComponentProps<{integrationSlug: string}, {}>;
 
 type State = AsyncView['state'] & {
   selectedOrgSlug?: string;
@@ -147,7 +146,6 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
   };
 
   renderAddButton() {
-    const {installationId} = this.props.params;
     const {organization, provider} = this.state;
     // should never happen but we need this check for TS
     if (!provider || !organization) {
@@ -177,29 +175,15 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
         features={featuresComponents}
       >
         {({disabled}) => (
-          <AddIntegration
-            provider={provider}
-            onInstall={this.onInstallWithInstallationId}
-            organization={organization}
-          >
-            {addIntegrationWithInstallationId => (
-              <ButtonWrapper>
-                <Button
-                  priority="primary"
-                  disabled={!this.hasAccess() || disabled}
-                  onClick={() =>
-                    installationId
-                      ? addIntegrationWithInstallationId({
-                          installation_id: installationId,
-                        })
-                      : this.finishInstallation()
-                  }
-                >
-                  {t('Install %s', provider.name)}
-                </Button>
-              </ButtonWrapper>
-            )}
-          </AddIntegration>
+          <ButtonWrapper>
+            <Button
+              priority="primary"
+              disabled={!this.hasAccess() || disabled}
+              onClick={() => this.finishInstallation()}
+            >
+              {t('Install %s', provider.name)}
+            </Button>
+          </ButtonWrapper>
         )}
       </IntegrationDirectoryFeatures>
     );

--- a/tests/sentry/integrations/custom_scm/test_integration.py
+++ b/tests/sentry/integrations/custom_scm/test_integration.py
@@ -1,6 +1,6 @@
 from sentry.integrations.custom_scm import CustomSCMIntegrationProvider
 from sentry.models import Integration, OrganizationIntegration, Repository
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 
 
 class CustomSCMIntegrationTest(IntegrationTestCase):
@@ -18,7 +18,7 @@ class CustomSCMIntegrationTest(IntegrationTestCase):
         resp = self.client.post(self.init_path, data=self.config)
         assert resp.status_code == 200
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
     def test_basic_flow(self):
         self.assert_setup_flow()

--- a/tests/sentry/integrations/github/test_extension_conifguration.py
+++ b/tests/sentry/integrations/github/test_extension_conifguration.py
@@ -1,0 +1,14 @@
+from sentry.integrations.github.github_extension_installation import (
+    GithubExtensionConfigurationView,
+)
+from sentry.testutils import TestCase
+from sentry.utils.signing import sign
+
+
+class GithubExtensionInstallationTest(TestCase):
+    def test_map_params_to_state(self):
+        config_view = GithubExtensionConfigurationView()
+        data = dict(install_id=1, provider="github")
+        signed_data = sign(**data)
+        params = {"signed_params": signed_data}
+        assert data == config_view.map_params_to_state(params)

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -10,7 +10,7 @@ from sentry.models import (
     Integration,
     OrganizationIntegration,
 )
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 from sentry.utils.compat.mock import patch
 
 
@@ -123,7 +123,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
         auth_header = responses.calls[2].request.headers["Authorization"]
         assert auth_header == "Bearer jwt_token_1"
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
     @responses.activate
     def test_basic_flow(self):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -11,7 +11,7 @@ from sentry.models import (
     OrganizationIntegration,
     Repository,
 )
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 from sentry.utils.compat.mock import Mock, patch
 
 
@@ -97,7 +97,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         assert resp.status_code == 200
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
     @responses.activate
     @patch("sentry.integrations.gitlab.integration.sha1_text")

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -4,7 +4,7 @@ import responses
 
 from sentry.integrations.msteams import MsTeamsIntegrationProvider
 from sentry.models import Integration, OrganizationIntegration
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 from sentry.utils.compat.mock import patch
 from sentry.utils.signing import sign
 
@@ -58,7 +58,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
             )
 
             assert resp.status_code == 200
-            self.assertDialogSuccess(resp)
+            assert_dialog_success(resp)
 
             integration = Integration.objects.get(provider=self.provider.key)
 

--- a/tests/sentry/integrations/pagerduty/test_integration.py
+++ b/tests/sentry/integrations/pagerduty/test_integration.py
@@ -7,7 +7,7 @@ from sentry import options
 from sentry.integrations.pagerduty.integration import PagerDutyIntegrationProvider
 from sentry.models import Integration, OrganizationIntegration, PagerDutyService
 from sentry.shared_integrations.exceptions import IntegrationError
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 from sentry.utils import json
 
 
@@ -62,7 +62,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
             "{}?{}".format(self.setup_path, urlencode({"config": json.dumps(config)}))
         )
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
         return resp
 
     def assert_add_service_flow(self, integration):
@@ -91,7 +91,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
             "{}?{}".format(self.setup_path, urlencode({"config": json.dumps(config)}))
         )
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
         return resp
 
     @responses.activate

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -12,7 +12,7 @@ from sentry.models import (
     Integration,
     OrganizationIntegration,
 )
-from sentry.testutils import APITestCase, IntegrationTestCase, TestCase
+from sentry.testutils import APITestCase, IntegrationTestCase, TestCase, assert_dialog_success
 
 
 class SlackIntegrationTest(IntegrationTestCase):
@@ -95,7 +95,7 @@ class SlackIntegrationTest(IntegrationTestCase):
         assert req_params["client_secret"] == [expected_client_secret]
 
         assert resp.status_code == 200
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
     @responses.activate
     def test_bot_flow(self):

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -9,7 +9,7 @@ from sentry.models import (
 )
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 from sentry.utils.compat.mock import patch
 
 
@@ -48,7 +48,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.state.data = data
         resp = self.pipeline.finish_pipeline()
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         integration = Integration.objects.get(
             provider=self.provider.key, external_id=self.external_id
@@ -71,7 +71,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.state.data = data
         resp = self.pipeline.finish_pipeline()
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         # Creates the Integration using ``integration_key`` instead of ``key``
         assert Integration.objects.filter(
@@ -85,7 +85,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.state.data = {"expect_exists": True, "external_id": self.external_id}
         resp = self.pipeline.finish_pipeline()
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
         integration = Integration.objects.get(
             provider=self.provider.key, external_id=self.external_id
         )
@@ -109,7 +109,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         }
         resp = self.pipeline.finish_pipeline()
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
         integration = Integration.objects.get(
             provider=self.provider.key, external_id=self.external_id
         )
@@ -140,7 +140,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.state.data = data
         resp = self.pipeline.finish_pipeline()
 
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         integration = Integration.objects.get(
             provider=self.provider.key, external_id=self.external_id
@@ -180,7 +180,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
         }
 
         resp = self.pipeline.finish_pipeline()
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         org_integration = OrganizationIntegration.objects.get(
             organization_id=self.organization.id, integration_id=integration.id
@@ -221,7 +221,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
             },
         }
         resp = self.pipeline.finish_pipeline()
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         org_integration = OrganizationIntegration.objects.get(
             organization_id=self.organization.id, integration_id=integration.id
@@ -262,7 +262,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
             },
         }
         resp = self.pipeline.finish_pipeline()
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         org_integrations = OrganizationIntegration.objects.filter(integration_id=integration.id)
         identity = Identity.objects.get(idp_id=identity_provider.id, external_id="new_external_id")
@@ -294,7 +294,7 @@ class FinishPipelineTestCase(IntegrationTestCase):
             },
         }
         resp = self.pipeline.finish_pipeline()
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
         assert OrganizationIntegration.objects.filter(
             integration_id=integration.id, organization=self.organization.id
         ).exists()

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -13,7 +13,7 @@ from sentry.models import (
     SentryAppInstallation,
     SentryAppInstallationForProvider,
 )
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 from sentry.utils import json
 
 
@@ -73,7 +73,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         assert req_params["client_secret"] == ["vercel-client-secret"]
 
         assert resp.status_code == 200
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         integration = Integration.objects.get(provider=self.provider.key)
 

--- a/tests/sentry/web/frontend/test_integration_setup.py
+++ b/tests/sentry/web/frontend/test_integration_setup.py
@@ -1,6 +1,6 @@
 from sentry.integrations.example import ExampleIntegrationProvider, ExampleSetupView
 from sentry.models import Integration, OrganizationIntegration
-from sentry.testutils import IntegrationTestCase
+from sentry.testutils import IntegrationTestCase, assert_dialog_success
 
 
 class ExampleIntegrationTest(IntegrationTestCase):
@@ -13,7 +13,7 @@ class ExampleIntegrationTest(IntegrationTestCase):
 
         resp = self.client.post(self.setup_path, {"name": "test"})
         assert resp.status_code == 200
-        self.assertDialogSuccess(resp)
+        assert_dialog_success(resp)
 
         integration = Integration.objects.get(provider=self.provider.key)
         assert integration.external_id == "test"


### PR DESCRIPTION
Github -> Sentry integration installs now use signed urls.
Some other QoL improvements
- External github installs now redirect back to github once install is complete
- Added a constant for signed URL expiration

More work is needed as URL signing is done every time, instead of once.

Fixes API-1953