### PR TITLE
Revert "feat: report all warnings to sentry (#26796)"

### DIFF
--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import warnings
 
@@ -80,22 +79,6 @@ def discover_configs():
     )
 
 
-_warning_logger = logging.getLogger("sentry.warnings")
-
-
-# This is set to warnings.showwarning to intercept all warnings and report them to Sentry.
-# The python SDK doesn't have a warnings integration at the time of writing,
-# and capture_message is very limited, so we just log an error here since LOGGING setting
-# is already configured to send error logs to the SDK's EventHandler.
-def _showwarning(message, category, filename, lineno, file=None, line=None):
-    _warning_logger.error(
-        warnings.formatwarning(message, category, filename, lineno),
-        # Warnings aren't exceptions, but we specify exc_info=True
-        # regardless because we want a proper stacktrace in the event.
-        exc_info=True,
-    )
-
-
 def configure(ctx, py, yaml, skip_service_validation=False):
     """
     Given the two different config files, set up the environment.
@@ -105,8 +88,6 @@ def configure(ctx, py, yaml, skip_service_validation=False):
     global __installed
     if __installed:
         return
-
-    warnings.showwarning = _showwarning
 
     # Make sure that our warnings are always displayed.
     warnings.filterwarnings("default", "", Warning, r"^sentry")

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -280,9 +280,6 @@ def configure_sdk():
             DjangoAtomicIntegration(),
             DjangoIntegration(),
             CeleryIntegration(),
-            # The logging integration is disabled because we have more specific
-            # configuration in the LOGGING setting that sends stuff over to the
-            # sentry_sdk.integrations.logging.EventHandler.
             LoggingIntegration(event_level=None),
             RustInfoIntegration(),
             RedisIntegration(),


### PR DESCRIPTION
This reverts commit d9de3cf4ac29fd3a0eed06a1af01077a5f20f3a3.

Despite my best effort to resolve most of the warnings I saw there seems to still be quite a few warnings. Just gonna revert this for now and work on the new issues.

Also, should find a way to ignore all warnings coming from dependencies. Otherwise it'll be way too noisy.

Got some good BytesWarnings to look at which was my main goal from all of this.