### PR TITLE
fix(copy): alert copy for issue details page

### DIFF
--- a/static/app/components/events/errors.tsx
+++ b/static/app/components/events/errors.tsx
@@ -142,8 +142,8 @@ class Errors extends Component<Props, State> {
           <StyledIconWarning />
           <span data-test-id="errors-banner-summary-info">
             {tn(
-              'There was %s error encountered while processing this event',
-              'There were %s errors encountered while processing this event',
+              'There was %s problem processing this event',
+              'There were %s problems processing this event',
               errors.length
             )}
           </span>

--- a/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
@@ -86,7 +86,7 @@ describe('GroupEventEntries', function () {
       const {bannerSummaryInfoText, errorItem} = await renderComponent(event, errors);
 
       expect(bannerSummaryInfoText).toEqual(
-        `There were ${errors.length} errors encountered while processing this event`
+        `There were ${errors.length} problems processing this event`
       );
       expect(errorItem.length).toBe(2);
       expect(errorItem.at(0).props().error).toEqual(errors[0]);
@@ -113,7 +113,7 @@ describe('GroupEventEntries', function () {
         const {errorItem, bannerSummaryInfoText} = await renderComponent(newEvent);
 
         expect(bannerSummaryInfoText).toEqual(
-          'There was 1 error encountered while processing this event'
+          'There was 1 problem processing this event'
         );
 
         expect(errorItem.length).toBe(1);
@@ -148,7 +148,7 @@ describe('GroupEventEntries', function () {
         const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
 
         expect(bannerSummaryInfoText).toEqual(
-          'There was 1 error encountered while processing this event'
+          'There was 1 problem processing this event'
         );
 
         expect(errorItem.length).toBe(1);
@@ -202,7 +202,7 @@ describe('GroupEventEntries', function () {
           const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
 
           expect(bannerSummaryInfoText).toEqual(
-            'There was 1 error encountered while processing this event'
+            'There was 1 problem processing this event'
           );
 
           expect(errorItem.length).toBe(1);
@@ -276,7 +276,7 @@ describe('GroupEventEntries', function () {
           const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
 
           expect(bannerSummaryInfoText).toEqual(
-            'There was 1 error encountered while processing this event'
+            'There was 1 problem processing this event'
           );
 
           expect(errorItem.length).toBe(1);


### PR DESCRIPTION
### Before
Confusing, weird use of "error" considering that issues are mostly made up of error events.

![CleanShot 2021-06-29 at 11 58 47](https://user-images.githubusercontent.com/1900676/123852812-9553e580-d8d1-11eb-9538-ce539f862392.png)

### After
Using the word "problem" instead so as to avoid confusion.

![CleanShot 2021-06-29 at 11 58 22](https://user-images.githubusercontent.com/1900676/123852935-b9afc200-d8d1-11eb-94ad-e80384d2ce25.png)
