### PR TITLE
fix(scim): Team Serializer Improvements

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -56,7 +56,9 @@ class TeamSerializer(serializers.Serializer):
 class OrganizationTeamsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationTeamsPermission,)
 
-    team_serializer = team_serializers.TeamSerializer
+    def team_serializer_for_post(self):
+        # allow child routes to supply own serializer, used in SCIM teams route
+        return team_serializers.TeamSerializer()
 
     def get(self, request, organization):
         """
@@ -187,7 +189,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
                 data=team.get_audit_log_data(),
             )
             return Response(
-                serialize(team, request.user, self.team_serializer()),
+                serialize(team, request.user, self.team_serializer_for_post()),
                 status=201,
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -113,7 +113,7 @@ class Serializer:
         """
         Convert an arbitrary python object `obj` to an object that only contains primitives.
 
-        :param obj: An item from `item_list` that was passes to `get_attrs`.
+        :param obj: An item from `item_list` that was passed to `get_attrs`.
         :param attrs: The object in `get_attrs` that corresponds to `obj`.
         :param user: The user who will be viewing the objects.
         :param kwargs: Any

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -225,15 +225,17 @@ class TeamSCIMSerializer(Serializer):  # type: ignore
     def get_attrs(
         self, item_list: Sequence[Team], user: Any, **kwargs: Any
     ) -> MutableMapping[Team, MutableMapping[str, Any]]:
-        result: MutableMapping[Team, MutableMapping[str, Any]] = {}
-        for team in item_list:
-            # return the members key with a None value if we aren't expanding
-            # because some SCIM specs say to set it to null
-            result[team] = {"members": None}
+
+        # return the members key with a None value if we aren't expanding
+        # because some SCIM specs say to set it to null
+        result: MutableMapping[Team, MutableMapping[str, Any]] = {
+            team: {"members": None} for team in item_list
+        }
 
         if "members" in self.expand:
             member_map = get_scim_teams_members(item_list)
             for team in item_list:
+                # if there are no members in the team, set to empty array
                 result[team]["members"] = member_map.get(team, [])
         return result
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -6,6 +6,7 @@ from typing import (
     Mapping,
     MutableMapping,
     MutableSequence,
+    Optional,
     Sequence,
     Set,
 )
@@ -217,8 +218,8 @@ def get_scim_teams_members(
 class TeamSCIMSerializer(Serializer):  # type: ignore
     def __init__(
         self,
-        expand=None,
-    ):
+        expand: Optional[Sequence[str]] = None,
+    ) -> None:
         self.expand = expand or []
 
     def get_attrs(

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -157,7 +157,6 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             omt.delete()
 
     def _rename_team_operation(self, request, new_name, team):
-        ##
         serializer = TeamSerializer(
             team,
             data={
@@ -229,6 +228,6 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         return super().delete(request, team)
 
     def put(self, request, organization, team):
-        # override parents put since we dont have puts
+        # override parent's put since we dont have puts
         # in SCIM Team routes
         return self.http_method_not_allowed(request)

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -189,15 +189,22 @@ class TeamWithProjectsSerializerTest(TestCase):
 
 
 class TeamSCIMSerializerTest(TestCase):
-    def test_simple(self):
+    def test_simple_with_members(self):
         user = self.create_user(username="foo")
+        user2 = self.create_user(username="bar")
         organization = self.create_organization(owner=user)
-        team = self.create_team(organization=organization, members=[user])
-        result = serialize(team, user, TeamSCIMSerializer())
+        team = self.create_team(organization=organization, members=[user, user2])
+        self.create_team(organization=organization, members=[user, user2])
+        # create a 2nd team to confirm we aren't duping data
+
+        result = serialize(team, user, TeamSCIMSerializer(expand=["members"]))
         assert result == {
             "displayName": team.slug,
             "id": str(team.id),
-            "members": [{"display": user.email, "value": str(team.member_set[0].id)}],
+            "members": [
+                {"display": user.email, "value": str(team.member_set[0].id)},
+                {"display": user2.email, "value": str(team.member_set[1].id)},
+            ],
             "meta": {"resourceType": "Group"},
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
         }
@@ -206,7 +213,7 @@ class TeamSCIMSerializerTest(TestCase):
         user = self.create_user(username="foo")
         organization = self.create_organization(owner=user)
         team = self.create_team(organization=organization, members=[user])
-        result = serialize(team, user, TeamSCIMSerializer(), exclude_members=True)
+        result = serialize(team, user, TeamSCIMSerializer())
         assert result == {
             "displayName": team.slug,
             "id": str(team.id),

--- a/tests/sentry/api/test_scim.py
+++ b/tests/sentry/api/test_scim.py
@@ -648,7 +648,7 @@ class SCIMGroupTests(APITestCase):
             "Resources": [
                 {
                     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-                    "id": self.team.id,
+                    "id": str(self.team.id),
                     "displayName": self.team.name,
                     "members": [
                         {"value": str(self.team.member_set[0].id), "display": "admin@localhost"}
@@ -671,7 +671,7 @@ class SCIMGroupTests(APITestCase):
             "Resources": [
                 {
                     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-                    "id": self.team.id,
+                    "id": str(self.team.id),
                     "displayName": self.team.name,
                     "members": None,
                     "meta": {"resourceType": "Group"},
@@ -796,7 +796,7 @@ class SCIMGroupTests(APITestCase):
         assert response.status_code == 200, response.content
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
-            "id": self.team.id,
+            "id": str(self.team.id),
             "displayName": "thenewname",
             "members": None,
             "meta": {"resourceType": "Group"},


### PR DESCRIPTION
- build member lists for teams in serializer.get_attr in order to not query members multiple times
- use RangeSetQuery in order to reduce memory usage
- Limit member lists to 10000. This should be a sane limit for now.

