### PR TITLE
feat(ui): Fix MenuTarget overflow by inlining icons

### DIFF
--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -70,9 +70,29 @@ type MenuItemProps = {
 
 type Props = MenuItemProps & Omit<React.HTMLProps<HTMLLIElement>, keyof MenuItemProps>;
 
-class MenuItem extends React.Component<Props> {
-  handleClick = (e: React.MouseEvent): void => {
-    const {onSelect, disabled, eventKey, allowDefaultEvent, stopPropagation} = this.props;
+const MenuItem = ({
+  header,
+  icon,
+  divider,
+  isActive,
+  noAnchor,
+  className,
+  children,
+  ...props
+}: Props) => {
+  const {
+    to,
+    href,
+    title,
+    withBorder,
+    disabled,
+    onSelect,
+    eventKey,
+    allowDefaultEvent,
+    stopPropagation,
+  } = props;
+
+  const handleClick = (e: React.MouseEvent): void => {
     if (disabled) {
       return;
     }
@@ -87,11 +107,9 @@ class MenuItem extends React.Component<Props> {
     }
   };
 
-  renderAnchor = (): React.ReactNode => {
-    const {to, href, title, withBorder, disabled, isActive, children} = this.props;
-
+  const renderAnchor = (): React.ReactNode => {
     const linkProps = {
-      onClick: this.handleClick,
+      onClick: handleClick,
       tabIndex: -1,
       isActive,
       disabled,
@@ -101,6 +119,7 @@ class MenuItem extends React.Component<Props> {
     if (to) {
       return (
         <MenuLink to={to} {...linkProps} title={title}>
+          {icon && <MenuIcon>{icon}</MenuIcon>}
           {children}
         </MenuLink>
       );
@@ -109,6 +128,7 @@ class MenuItem extends React.Component<Props> {
     if (href) {
       return (
         <MenuAnchor {...linkProps} href={href}>
+          {icon && <MenuIcon>{icon}</MenuIcon>}
           {children}
         </MenuAnchor>
       );
@@ -116,40 +136,35 @@ class MenuItem extends React.Component<Props> {
 
     return (
       <MenuTarget role="button" {...linkProps} title={title}>
-        {this.props.children}
+        {icon && <MenuIcon>{icon}</MenuIcon>}
+        {children}
       </MenuTarget>
     );
   };
 
-  render() {
-    const {header, icon, divider, isActive, noAnchor, className, children, ...props} =
-      this.props;
-
-    let renderChildren: React.ReactNode | null = null;
-    if (noAnchor) {
-      renderChildren = children;
-    } else if (header) {
-      renderChildren = children;
-    } else if (!divider) {
-      renderChildren = this.renderAnchor();
-    }
-
-    return (
-      <MenuListItem
-        className={className}
-        role="presentation"
-        isActive={isActive}
-        divider={divider}
-        noAnchor={noAnchor}
-        header={header}
-        {...omit(props, ['href', 'title', 'onSelect', 'eventKey', 'to', 'as'])}
-      >
-        {icon}
-        {renderChildren}
-      </MenuListItem>
-    );
+  let renderChildren: React.ReactNode | null = null;
+  if (noAnchor) {
+    renderChildren = children;
+  } else if (header) {
+    renderChildren = children;
+  } else if (!divider) {
+    renderChildren = renderAnchor();
   }
-}
+
+  return (
+    <MenuListItem
+      className={className}
+      role="presentation"
+      isActive={isActive}
+      divider={divider}
+      noAnchor={noAnchor}
+      header={header}
+      {...omit(props, ['href', 'title', 'onSelect', 'eventKey', 'to', 'as'])}
+    >
+      {renderChildren}
+    </MenuListItem>
+  );
+};
 
 type MenuListItemProps = {
   header?: boolean;
@@ -252,11 +267,14 @@ const MenuListItem = styled('li')<MenuListItemProps>`
 
 const MenuTarget = styled('span')<MenuListItemProps>`
   ${getListItemStyles}
-  display: grid;
+  display: flex;
   align-items: center;
-  grid-auto-columns: max-content;
-  grid-gap: ${space(1)};
-  grid-auto-flow: column;
+`;
+
+const MenuIcon = styled('div')`
+  display: flex;
+  align-items: center;
+  margin-right: ${space(1)};
 `;
 
 const MenuLink = styled(Link, {shouldForwardProp})<MenuListItemProps>`

--- a/static/app/components/smartSearchBar/actions.tsx
+++ b/static/app/components/smartSearchBar/actions.tsx
@@ -99,8 +99,12 @@ export function makePinSearchAction({pinnedSearch, sort}: PinSearchActionOpts) {
     const pinTooltip = !!pinnedSearch ? t('Unpin this search') : t('Pin this search');
 
     return menuItemVariant ? (
-      <MenuItem withBorder data-test-id="pin-icon" onClick={onTogglePinnedSearch}>
-        <IconPin isSolid={!!pinnedSearch} size="xs" />
+      <MenuItem
+        withBorder
+        data-test-id="pin-icon"
+        icon={<IconPin isSolid={!!pinnedSearch} size="xs" />}
+        onClick={onTogglePinnedSearch}
+      >
         {!!pinnedSearch ? t('Unpin Search') : t('Pin Search')}
       </MenuItem>
     ) : (
@@ -140,8 +144,7 @@ export function makeSaveSearchAction({sort}: SaveSearchActionOpts) {
     return (
       <Access organization={organization} access={['org:write']}>
         {menuItemVariant ? (
-          <MenuItem withBorder onClick={onClick}>
-            <IconAdd size="xs" />
+          <MenuItem withBorder icon={<IconAdd size="xs" />} onClick={onClick}>
             {t('Create Saved Search')}
           </MenuItem>
         ) : (
@@ -170,8 +173,7 @@ type SearchBuilderActionOpts = {
 export function makeSearchBuilderAction({onSidebarToggle}: SearchBuilderActionOpts) {
   const SearchBuilderAction = ({menuItemVariant}: ActionProps) =>
     menuItemVariant ? (
-      <MenuItem withBorder onClick={onSidebarToggle}>
-        <IconSliders size="xs" />
+      <MenuItem withBorder icon={<IconSliders size="xs" />} onClick={onSidebarToggle}>
         {t('Toggle sidebar')}
       </MenuItem>
     ) : (


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/1421724/123913962-b3523200-d933-11eb-915c-829cd53b28fb.png)

after
![image](https://user-images.githubusercontent.com/1421724/123913981-b816e600-d933-11eb-957a-a5cde39a8e0b.png)

this stays the same (with icons)
![image](https://user-images.githubusercontent.com/1421724/123914005-c238e480-d933-11eb-886f-739f8e92a9a8.png)
