### PR TITLE
feat: Use unversioned frontend asset paths

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -64,15 +64,11 @@ jobs:
           name: jest-html
           path: .artifacts/visual-snapshots/jest
 
-      - name: Get CSS filename
-        id: css-manifest
-        run: echo "::set-output name=sentrycss::$(jq -r '.["sentry.css"]' src/sentry/static/sentry/dist/manifest.json)"
-
       - name: Create Images from HTML
         uses: getsentry/action-html-to-image@main
         with:
           base-path: .artifacts/visual-snapshots/jest
-          css-path: src/sentry/static/sentry/dist/${{ steps.css-manifest.outputs.sentrycss }}
+          css-path: src/sentry/static/sentry/dist/sentry.css
 
       - name: Save snapshots
         if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -68,7 +68,7 @@ jobs:
         uses: getsentry/action-html-to-image@main
         with:
           base-path: .artifacts/visual-snapshots/jest
-          css-path: src/sentry/static/sentry/dist/sentry.css
+          css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
 
       - name: Save snapshots
         if: always()

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,6 @@
 import os
 import sys
 
-dist_path = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "src", "sentry", "static", "sentry", "dist")
-)
-manifest_path = os.path.join(dist_path, "manifest.json")
 pytest_plugins = ["sentry.utils.pytest"]
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -16,24 +12,3 @@ def pytest_configure(config):
     # XXX(dcramer): Kombu throws a warning due to transaction.commit_manually
     # being used
     warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
-
-    # Create an empty webpack manifest file - otherwise tests will crash if it does not exist
-    os.makedirs(dist_path, exist_ok=True)
-
-    # Only create manifest if it doesn't exist
-    # (e.g. acceptance tests will have an actual manifest from webpack)
-    if os.path.exists(manifest_path):
-        return
-
-    with open(manifest_path, "w+") as fp:
-        fp.write("{}")
-
-
-def pytest_unconfigure():
-    if not os.path.exists(manifest_path):
-        return
-
-    # Clean up manifest file if contents are empty
-    with open(manifest_path) as f:
-        if f.read() == "{}":
-            os.remove(manifest_path)

--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
     "u2f-api": "1.0.10",
     "webpack": "5.41.1",
     "webpack-cli": "4.7.2",
-    "webpack-manifest-plugin": "^3.1.1",
     "webpack-remove-empty-scripts": "^0.7.1",
     "wink-jaro-distance": "^2.0.0",
     "zxcvbn": "^4.4.2"

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -9,7 +9,6 @@ croniter==0.3.37
 dataclasses==0.8; python_version <= '3.6'
 datadog==0.29.3
 django-crispy-forms==1.7.2
-django-manifest-loader==1.0.0
 django-picklefield==1.0.0
 Django==1.11.29
 djangorestframework==3.11.2

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -327,7 +327,6 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "crispy_forms",
     "rest_framework",
-    "manifest_loader",
     "sentry",
     "sentry.analytics",
     "sentry.incidents.apps.Config",
@@ -367,15 +366,12 @@ STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned
 # as we configure webpack to include file content based hash in the filename
-STATIC_MANIFEST_URL = "/_static/dist/"
+STATIC_UNVERSIONED_URL = "/_static/dist/"
 
-# The webpack output directory, used by django-manifest-loader
+# The webpack output directory
 STATICFILES_DIRS = [
     os.path.join(STATIC_ROOT, "sentry", "dist"),
 ]
-
-# django-manifest-loader settings
-MANIFEST_LOADER = {"cache": True}
 
 # various middleware will use this to identify resources which should not access
 # cookies

--- a/src/sentry/middleware/user.py
+++ b/src/sentry/middleware/user.py
@@ -7,6 +7,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 class UserActiveMiddleware(MiddlewareMixin):
     disallowed_paths = (
+        "sentry.web.frontend.generic.unversioned_static_media",
         "sentry.web.frontend.generic.static_media",
         "sentry.web.frontend.organization_avatar",
         "sentry.web.frontend.project_avatar",

--- a/src/sentry/templates/sentry/base-react.html
+++ b/src/sentry/templates/sentry/base-react.html
@@ -9,7 +9,7 @@
       <div class="loading-mask"></div>
 
       <div class="loading-indicator">
-        <img src="{% manifest_asset_url 'sentry' 'images/sentry-loader.svg' %}" />
+        <img src="{% asset_url 'sentry' 'images/sentry-loader.svg' %}" />
       </div>
 
       <div class="loading-message">

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -1,2 +1,1 @@
 {% extends "sentry/base-react.html" %}
-{% load sentry_assets %}

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% manifest_asset_url "sentry" "pipeline.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "pipeline.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% unversioned_asset_url "sentry" "pipeline.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "entrypoints/pipeline.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% unversioned_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
+  <link href="{% unversioned_asset_url "sentry" "entrypoints/sentry.css" %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -53,11 +53,11 @@
   {% endscript %}
 
   {% block scripts %}
-  {% unversioned_asset_url "sentry" "runtime.js" as asset_url %}
+  {% unversioned_asset_url "sentry" "entrypoints/runtime.js" as asset_url %}
   {% script src=asset_url %}{% endscript %}
 
   {% block scripts_main_entrypoint %}
-    {% unversioned_asset_url "sentry" "app.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "entrypoints/app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% manifest_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
+  <link href="{% unversioned_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -53,11 +53,11 @@
   {% endscript %}
 
   {% block scripts %}
-  {% manifest_asset_url "sentry" "runtime.js" as asset_url %}
+  {% unversioned_asset_url "sentry" "runtime.js" as asset_url %}
   {% script src=asset_url %}{% endscript %}
 
   {% block scripts_main_entrypoint %}
-    {% manifest_asset_url "sentry" "app.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -5,13 +5,13 @@ from django.conf import settings
 from django.template.base import token_kwargs
 
 from sentry import options
-from sentry.utils.assets import get_asset_url, get_manifest_url
+from sentry.utils.assets import get_asset_url, get_unversioned_asset_url
 from sentry.utils.http import absolute_uri
 
 register = template.Library()
 
 register.simple_tag(get_asset_url, name="asset_url")
-register.simple_tag(get_manifest_url, name="manifest_asset_url")
+register.simple_tag(get_unversioned_asset_url, name="unversioned_asset_url")
 
 
 @register.simple_tag

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -108,36 +108,6 @@ class BaseTestCase(Fixtures, Exam):
 
     @classmethod
     @contextmanager
-    def static_asset_manifest(cls, manifest_data):
-        dist_path = "src/sentry/static/sentry/dist"
-        manifest_path = f"{dist_path}/manifest.json"
-
-        with open(manifest_path, "w") as manifest_fp:
-            json.dump(manifest_data, manifest_fp)
-
-        files = []
-        for file_path in manifest_data.values():
-            full_path = f"{dist_path}/{file_path}"
-            # make directories in case they don't exist
-            # (e.g. dist path should exist, but subdirs won't)
-            os.makedirs(os.path.dirname(full_path), exist_ok=True)
-            open(full_path, "a").close()
-            files.append(full_path)
-
-        try:
-            yield {"manifest": manifest_data, "files": files}
-        finally:
-            with open(manifest_path, "w") as manifest_fp:
-                # Instead of unlinking, preserve an empty manifest file so that other tests that
-                # may or may not load static assets, do not fail
-                manifest_fp.write("{}")
-
-            # Remove any files created from the test manifest
-            for filepath in files:
-                os.unlink(filepath)
-
-    @classmethod
-    @contextmanager
     def capture_on_commit_callbacks(cls, using=DEFAULT_DB_ALIAS, execute=False):
         """
         Context manager to capture transaction.on_commit() callbacks.

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,29 +1,18 @@
 from django.conf import settings
-from manifest_loader.utils import _get_manifest, _load_from_manifest
 
 
-def get_manifest_obj():
+def get_unversioned_asset_url(module, key):
     """
-    Returns the webpack asset manifest as a dict of <file key, hashed file name>
-
-    The `manifest_loader` library caches this (if `cache` settings is set)
-    """
-    return _get_manifest()
-
-
-def get_manifest_url(module, key):
-    """
-    Returns an asset URL that is produced by webpack. Uses webpack's manifest to map
-    `key` to the asset produced by webpack. Required if using file contents based hashing for filenames.
+    Returns an asset URL that is unversioned. These assets should have a
+    `Cache-Control: no-cache` so that clients must validate with the origin
+    server before using their locally cached asset.
 
     Example:
-      {% manifest_asset_url 'sentry' 'sentry.css' %}
-      =>  "/_static/dist/sentry/sentry.filehash123.css"
+      {% unversioned_asset_url 'sentry' 'sentry.css' %}
+      =>  "/_static/dist/sentry/sentry.css"
     """
-    manifest_obj = get_manifest_obj()
-    manifest_value = _load_from_manifest(manifest_obj, key=key)
 
-    return "{}/{}/{}".format(settings.STATIC_MANIFEST_URL.rstrip("/"), module, manifest_value)
+    return "{}/{}/{}".format(settings.STATIC_UNVERSIONED_URL.rstrip("/"), module, key.lstrip("/"))
 
 
 def get_asset_url(module, path):
@@ -31,7 +20,7 @@ def get_asset_url(module, path):
     Returns a versioned asset URL (located within Sentry's static files).
 
     Example:
-      {% asset_url 'sentry' 'images/sentry.png' %}
-      =>  "/_static/74d127b78dc7daf2c51f/sentry/sentry.png"
+    {% asset_url 'sentry' 'images/sentry.png' %}
+    =>  "/_static/74d127b78dc7daf2c51f/sentry/sentry.png"
     """
     return "{}/{}/{}".format(settings.STATIC_URL.rstrip("/"), module, path.lstrip("/"))

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -12,7 +12,7 @@ from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
-from sentry.utils.assets import get_manifest_url
+from sentry.utils.assets import get_unversioned_asset_url
 from sentry.utils.email import is_smtp_enabled
 from sentry.utils.support import get_support_mail
 
@@ -146,7 +146,7 @@ def get_client_config(request=None):
         "urlPrefix": options.get("system.url-prefix"),
         "version": version_info,
         "features": enabled_features,
-        "distPrefix": get_manifest_url("sentry", ""),
+        "distPrefix": get_unversioned_asset_url("sentry", ""),
         "needsUpgrade": needs_upgrade,
         "dsn": public_dsn,
         "dsn_requests": _get_dsn_requests(),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -96,8 +96,8 @@ urlpatterns += [
     # a filecontent-based hash in its filenames so that it can be cached long term
     url(
         r"^_static/dist/(?P<module>[^/]+)/(?P<path>.*)$",
-        generic.static_media_with_manifest,
-        name="sentry-webpack-media",
+        generic.unversioned_static_media,
+        name="sentry-unversioned-media",
     ),
     # The static version is either a 10 digit timestamp, a sha1, or md5 hash
     url(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -290,7 +290,7 @@ let appConfig = {
     new MiniCssExtractPlugin({
       // We want the sentry css file to be unversioned for frontend-only deploys
       // We will cache using `Cache-Control` headers
-      filename: '[name].css',
+      filename: 'entrypoints/[name].css',
     }),
 
     /**
@@ -382,7 +382,7 @@ let appConfig = {
   output: {
     path: distPath,
     publicPath: '',
-    filename: '[name].js',
+    filename: 'entrypoints/[name].js',
     chunkFilename: 'chunks/[name].[contenthash].js',
     sourceMapFilename: 'sourcemaps/[name].[contenthash].js.map',
     assetModuleFilename: 'assets/[name].[contenthash][ext]',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const path = require('path');
 
 const {CleanWebpackPlugin} = require('clean-webpack-plugin'); // installed via npm
-const {WebpackManifestPlugin} = require('webpack-manifest-plugin');
 const webpack = require('webpack');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -266,8 +265,6 @@ let appConfig = {
   plugins: [
     new CleanWebpackPlugin(),
 
-    new WebpackManifestPlugin({}),
-
     // Do not bundle moment's locale files as we will lazy load them using
     // dynamic imports in the application code
     new webpack.IgnorePlugin({
@@ -291,7 +288,9 @@ let appConfig = {
      * Extract CSS into separate files.
      */
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash:6].css',
+      // We want the sentry css file to be unversioned for frontend-only deploys
+      // We will cache using `Cache-Control` headers
+      filename: '[name].css',
     }),
 
     /**
@@ -383,7 +382,7 @@ let appConfig = {
   output: {
     path: distPath,
     publicPath: '',
-    filename: '[name].[contenthash].js',
+    filename: '[name].js',
     chunkFilename: 'chunks/[name].[contenthash].js',
     sourceMapFilename: 'sourcemaps/[name].[contenthash].js.map',
     assetModuleFilename: 'assets/[name].[contenthash][ext]',
@@ -474,9 +473,6 @@ if (
         '/api/{1..9}*({0..9})/**': relayAddress,
         '/api/0/relays/outcomes/': relayAddress,
         '!/_static/dist/sentry/**': backendAddress,
-      },
-      writeToDisk: filePath => {
-        return /manifest\.json/.test(filePath);
       },
     };
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -247,7 +247,16 @@ let appConfig = {
       {
         test: /\.less$/,
         include: [staticPrefix],
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'less-loader'],
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: 'auto',
+            },
+          },
+          'css-loader',
+          'less-loader',
+        ],
       },
       {
         test: /\.(woff|woff2|ttf|eot|svg|png|gif|ico|jpg|mp4)($|\?)/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15597,14 +15597,6 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-manifest-plugin@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.1.tgz#d4c57ef70e0641f754dd005cb5ba7ca5601ac9d3"
-  integrity sha512-r3vL8BBNVtyeNbaFwDQoOWqBd0Gp/Tbzo8Q3YGZDV+IG77gsB9VZry5XKKbfFNFHSmwW+f1z4/w2XPt6wBZJYg==
-  dependencies:
-    tapable "^2.0.0"
-    webpack-sources "^2.2.0"
-
 webpack-merge@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
@@ -15626,7 +15618,7 @@ webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^2.2.0, webpack-sources@^2.3.0:
+webpack-sources@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
   integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==


### PR DESCRIPTION
This reverts commit 32284922606b6b03d0dd551df458fd5f53c4ac5b.

This builds on top of https://github.com/getsentry/sentry/pull/25744 where we refactored our JS entry points to be lightweight and to use dynamic imports (via webpack) to load the rest of the JS application.

This PR will now remove the need for the backend to be updated in order to release a new frontend. This will allow us to have frontend-only deploys which should complete much faster than a full deploy. We accomplish this by removing the webpack manifest plugin introduced in https://github.com/getsentry/sentry/pull/25234, where we previously were versioning by a release string in the asset path. These unversioned asset files will be served using a [`Cache-Control: no-cache`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#cacheability) header which tells clients that they need to check against the origin server to see if the asset has changed, if it has not, they can use their cached copy. These unversioned files will end up changing quite frequently with every release, but they should be relatively small. They contain the webpack runtime that allows us to load the rest of our application bundles, which are versioned by a hash of their contents. These versioned chunks will have a long-term `max-age` for caching as the hash in the file name will serve to cache bust.

Note: this was reverted in https://github.com/getsentry/sentry/pull/25994 as it broke production due to our CDN having cached an old asset due to a cache misconfiguration during development. This was also not caught in staging because we needed to change the asset paths for staging deploys to avoid clobbering production assets.