### PR TITLE
chore(deps): Bump papaparse from 5.2.0 -> 5.3.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,6 @@ updates:
       - dependency-name: "less-loader"
       - dependency-name: "marked"
       - dependency-name: "mini-css-extract-plugin"
-      - dependency-name: "papaparse"
       - dependency-name: "react-date-range"
       - dependency-name: "react-lazyload"
       - dependency-name: "react-popper"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mobx-react": "~7.2.0",
     "moment": "2.29.1",
     "moment-timezone": "0.5.33",
-    "papaparse": "^5.2.0",
+    "papaparse": "^5.3.1",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
     "platformicons": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11126,10 +11126,10 @@ pako@^1.0.11:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
-papaparse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.2.0.tgz#97976a1b135c46612773029153dc64995caa3b7b"
-  integrity sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA==
+papaparse@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.1.tgz#770b7a9124d821d4b2132132b7bd7dce7194b5b1"
+  integrity sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==
 
 param-case@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Changelog isn't great so here's the compare https://github.com/mholt/PapaParse/compare/5.2.0...5.3.1

Looks like a small fix to their date parsing and an option to sanitize csvs for excel https://github.com/mholt/PapaParse/issues/793