### PR TITLE
fix(templates): Bug issue template should use placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Steps to Reproduce
       description: How can we see what you're seeing? Specific is terrific.
-      value: |-
+      placeholder: |-
         1. foo
         2. bar
         3. baz


### PR DESCRIPTION
The bug issue template used `value` instead of `placeholder` for certain fields, leading to issue reports like getsentry/onpremise#1012. This PR fixes that.
