### PR TITLE
chore(deps): Bump sprintf-js from 1.0.2 -> 1.1.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,6 +71,5 @@ updates:
       - dependency-name: "rrweb"
       - dependency-name: "rrweb-player"
       - dependency-name: "size-limit"
-      - dependency-name: "sprintf-js"
       - dependency-name: "terser-webpack-plugin"
       - dependency-name: "u2f-api"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "regenerator-runtime": "^0.13.3",
     "rrweb-player": "^0.4.6",
     "scroll-to-element": "^2.0.0",
-    "sprintf-js": "1.0.3",
+    "sprintf-js": "1.1.2",
     "style-loader": "^3.0.0",
     "tslib": "^2.3.0",
     "typescript": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13895,7 +13895,12 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-sprintf-js@1.0.3, sprintf-js@~1.0.2:
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
+
+sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=


### PR DESCRIPTION
The changelog is pretty bad for this one, so here's the compare view https://github.com/alexei/sprintf.js/compare/1.0.3...1.1.2

Reading through the commits it looks like all benign changes. But we'll see if tests are OK and if any visual snapshots take issue. I'll also click around a bit in the preview build.