### PR TITLE
chore(deps): Bump @sentry/rrweb

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
       # We ignore everything that hasn't yet been upgrade, this way we will
       # only get the _freshest_ of new packages to consider upgrading
       - dependency-name: "@sentry/release-parser"
-      - dependency-name: "@sentry/rrweb"
       - dependency-name: "@size-limit/preset-small-lib"
       - dependency-name: "@types/echarts"
       - dependency-name: "@types/jquery"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@sentry/integrations": "6.7.2",
     "@sentry/react": "6.7.2",
     "@sentry/release-parser": "^1.1.4",
-    "@sentry/rrweb": "^0.1.1",
+    "@sentry/rrweb": "^0.3.1",
     "@sentry/tracing": "6.7.2",
     "@sentry/utils": "6.7.2",
     "@testing-library/jest-dom": "^5.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,10 +1908,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.1.4.tgz#f7612af1c01caf4163290582077cd6e936f33b7f"
   integrity sha512-zJ9kpSGSvu4txyzAkRlSkYKcVnKeqLG/VF1yXyM6ZH9uTyFiHJBAQi20Z5LgEJIOmpZtE1bRRjHB8XeaDViKYA==
 
-"@sentry/rrweb@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.1.1.tgz#1e2ef7381d5c5725ea3bf3ac20987d50eee83dd1"
-  integrity sha512-bFzZ+NVaGFpkmBvSHsvM/Pc/wiy7UeP/ICofkY2iY5PwiRHpZCX5hLrLYA7o921VR847EKZB44fQYWZC1YFB1Q==
+"@sentry/rrweb@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@sentry/rrweb/-/rrweb-0.3.1.tgz#a0f7496e086a30679d7af227d62ab76cfd5ed934"
+  integrity sha512-AJIy2yqjtgpcow3L1gyxxr6x+rqLN9HXMlsNNmLeUKlPBxaSMP47lM6aexI3V+XkKnRmOW05H21cLimyuM+59Q==
 
 "@sentry/tracing@6.7.2":
   version "6.7.2"


### PR DESCRIPTION
https://github.com/getsentry/sentry-rrweb/compare/v0.1.1...v0.3.1

1. Lots of configuration for craft, which makes up the 3.0 and 3.1 versions

2. The major change is https://github.com/getsentry/sentry-rrweb/pull/14. Which fixes an issue when sentry hasn't been initalized yet.