### PR TITLE
feat(release-files): Use disk cache for artifact index

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -400,7 +400,7 @@ def get_artifact_index(release, dist):
     elif result:
         index = json.loads(result)
     else:
-        index = read_artifact_index(release, dist)
+        index = read_artifact_index(release, dist, use_cache=True)
         cache_value = -1 if index is None else json.dumps(index)
         # Only cache for a short time to keep the manifest up-to-date
         cache.set(cache_key, cache_value, timeout=60)

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -253,14 +253,18 @@ class _ArtifactIndexGuard:
         self._ident = ReleaseFile.get_ident(ARTIFACT_INDEX_FILENAME, dist and dist.name)
         self._filter_args = filter_args  # Extra constraints on artifact index release file
 
-    def readable_data(self) -> Optional[dict]:
+    def readable_data(self, use_cache: bool) -> Optional[dict]:
         """Simple read, no synchronization necessary"""
         try:
             releasefile = self._releasefile_qs()[0]
         except IndexError:
             return None
         else:
-            with releasefile.file.getfile() as fp:
+            if use_cache:
+                fp = ReleaseFile.cache.getfile(releasefile)
+            else:
+                fp = releasefile.file.getfile()
+            with fp:
                 return json.load(fp)
 
     @contextmanager
@@ -340,11 +344,11 @@ class _ArtifactIndexGuard:
 
 
 def read_artifact_index(
-    release: Release, dist: Optional[Distribution], **filter_args
+    release: Release, dist: Optional[Distribution], use_cache: bool = False, **filter_args
 ) -> Optional[dict]:
     """Get index data"""
     guard = _ArtifactIndexGuard(release, dist, **filter_args)
-    return guard.readable_data()
+    return guard.readable_data(use_cache)
 
 
 def _compute_sha1(archive: ReleaseArchive, url: str) -> str:


### PR DESCRIPTION
During javascript processing, use the release file disk cache not only for release archives but also for the index file.

This should reduce the occurrence of https://getsentry.atlassian.net/browse/INGEST-116. 