### PR TITLE
ref(webpack): Replace file-loader with asset type

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "downsample": "1.4.0",
     "echarts": "4.7.0",
     "echarts-for-react": "2.0.16",
-    "file-loader": "^6.2.0",
     "focus-trap": "^6.5.1",
     "focus-visible": "^5.2.0",
     "fork-ts-checker-webpack-plugin": "^6.2.12",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,16 +252,7 @@ let appConfig = {
       },
       {
         test: /\.(woff|woff2|ttf|eot|svg|png|gif|ico|jpg|mp4)($|\?)/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              // This needs to be `false` because of platformicons package
-              esModule: false,
-              name: '[folder]/[name].[contenthash:6].[ext]',
-            },
-          },
-        ],
+        type: 'asset',
       },
     ],
     noParse: [
@@ -395,6 +386,7 @@ let appConfig = {
     filename: '[name].[contenthash].js',
     chunkFilename: 'chunks/[name].[contenthash].js',
     sourceMapFilename: 'sourcemaps/[name].[contenthash].js.map',
+    assetModuleFilename: 'assets/[name].[contenthash].[ext]',
   },
   optimization: {
     chunkIds: 'named',


### PR DESCRIPTION
As suggested by [0], the webpack file-loader is deprecated and should be replaced with one of the 'asset' module type [1].

This uses the generic `asset` type, which will automatically inline the asset if it is small enough, as determined by webpack.

[0]: https://v4.webpack.js.org/loaders/file-loader
[1]: https://webpack.js.org/guides/asset-modules/

Billy We can probably wait until your stuff is all good before merging something like this.