### PR TITLE
chore(deps): Bump react-date-range from 1.1.3 -> 1.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,6 @@ updates:
       - dependency-name: "less-loader"
       - dependency-name: "marked"
       - dependency-name: "mini-css-extract-plugin"
-      - dependency-name: "react-date-range"
       - dependency-name: "react-lazyload"
       - dependency-name: "react-popper"
       - dependency-name: "react-refresh"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "query-string": "7.0.1",
     "react": "17.0.2",
     "react-autosize-textarea": "7.1.0",
-    "react-date-range": "^1.1.3",
+    "react-date-range": "^1.3.0",
     "react-document-title": "2.0.3",
     "react-dom": "17.0.2",
     "react-keydown": "^1.9.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12538,10 +12538,10 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.2.2.tgz#0a69d0648db47e51359d343854d83d250a742243"
   integrity sha512-Xdb1Rl6lZ5SMdNBH59eE0lGqR1g2LVD8IgPlw0WeMDrOC65lYI8fgMEwj/0dDpVRVMh5qp73ciISDst/t2O2iQ==
 
-react-date-range@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-date-range/-/react-date-range-1.1.3.tgz#8b3bb18066dcac6609b1e8df655c720ffd273d4f"
-  integrity sha512-Q0+80JaEw3O2J50Lf1dcwWfqkzu3SaCZUTgtVEG9kIHy1h1x8XTNrumX08hKz+M//wg7NOymaTzP1RPBYoLpmw==
+react-date-range@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-date-range/-/react-date-range-1.3.0.tgz#109be685873372c3da975b1cf175d33980ce5c4a"
+  integrity sha512-ximAsbdf28tT7jMRLenSUeMacZ+s3opgvlUKbXIg7qvpehVfjlcYfQ3MF1C59rUghk44yckPsCxqPm0l8Lb+KA==
   dependencies:
     classnames "^2.2.6"
     prop-types "^15.7.2"


### PR DESCRIPTION
Changelog here https://github.com/hypeserver/react-date-range/blob/master/CHANGELOG.md

Looks like basically just two new features.