### PR TITLE
fix(ForkTsCheckerWebpackPlugin): Update config to not report errors to devServer

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -332,6 +332,7 @@ let appConfig = {
                 compilerOptions: {incremental: true},
               },
             },
+            logger: {devServer: false},
           }),
         ]
       : []),


### PR DESCRIPTION
After updating library `ForkTsCheckerWebpackPlugin` to version `6.2.12`, the developer experience has decreased, as the `webpack` no longer compiles with eslint errors.

This PR fixes the issue by disabling devServer in the plugin config.

https://github.com/TypeStrong/fork-ts-checker-webpack-plugin#options

> If `devServer` is set to false, errors will not be reported to Webpack Dev Server.