### PR TITLE
fix(org-stats): added no project error message to frontend project table

### DIFF
--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -3,16 +3,20 @@ import styled from '@emotion/styled';
 
 import ErrorPanel from 'app/components/charts/errorPanel';
 import IdBadge from 'app/components/idBadge';
+import ExternalLink from 'app/components/links/externalLink';
 import Link from 'app/components/links/link';
 import {SettingsIconLink} from 'app/components/organizations/headerItem';
 import {Panel} from 'app/components/panels';
 import PanelTable from 'app/components/panels/panelTable';
 import {IconSettings, IconWarning} from 'app/icons';
+import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {DataCategory, Project} from 'app/types';
 import theme from 'app/utils/theme';
 
 import {formatUsageWithUnits} from '../utils';
+
+const DOCS_URL = 'https://docs.sentry.io/product/accounts/membership/#restricting-access';
 
 type Props = {
   isLoading?: boolean;
@@ -45,6 +49,26 @@ class UsageTable extends React.Component<Props> {
       useUnitScaling: dataCategory === DataCategory.ATTACHMENTS,
     };
   }
+
+  getErrorMessage = errorMessage => {
+    if (errorMessage.projectStats.responseJSON.detail === 'No projects available') {
+      return (
+        <ErrorMessages>
+          <Title>
+            {t(
+              "You don't have access to any projects, or your organization has no projects."
+            )}
+          </Title>
+          <Description>
+            {tct('Learn more about [link:Project Access]', {
+              link: <ExternalLink href={DOCS_URL} />,
+            })}
+          </Description>
+        </ErrorMessages>
+      );
+    }
+    return null;
+  };
 
   renderTableRow(stat: TableStat & {project: Project}) {
     const {dataCategory} = this.props;
@@ -87,11 +111,8 @@ class UsageTable extends React.Component<Props> {
       return (
         <Panel>
           <ErrorPanel height="256px">
-            <IconWarning color="gray300" size="lg" />
-            <ErrorMessages>
-              {errors &&
-                Object.keys(errors).map(k => <span key={k}>{errors[k]?.message}</span>)}
-            </ErrorMessages>
+            <IconWarning color="gray300" size="48" />
+            {this.getErrorMessage(errors)}
           </ErrorPanel>
         </Panel>
       );
@@ -142,4 +163,16 @@ const ErrorMessages = styled('div')`
 
   margin-top: ${space(1)};
   font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const Title = styled('strong')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  margin-bottom: ${space(1)};
+`;
+
+const Description = styled('span')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  display: block;
+  margin: 0;
+  text-align: center;
 `;

--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -10,9 +10,9 @@ import {Panel} from 'app/components/panels';
 import PanelTable from 'app/components/panels/panelTable';
 import {IconSettings, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
-import space from 'app/styles/space';
 import {DataCategory, Project} from 'app/types';
 import theme from 'app/utils/theme';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 import {formatUsageWithUnits} from '../utils';
 
@@ -53,21 +53,18 @@ class UsageTable extends React.Component<Props> {
   getErrorMessage = errorMessage => {
     if (errorMessage.projectStats.responseJSON.detail === 'No projects available') {
       return (
-        <ErrorMessages>
-          <Title>
-            {t(
-              "You don't have access to any projects, or your organization has no projects."
-            )}
-          </Title>
-          <Description>
-            {tct('Learn more about [link:Project Access]', {
-              link: <ExternalLink href={DOCS_URL} />,
-            })}
-          </Description>
-        </ErrorMessages>
+        <EmptyMessage
+          icon={<IconWarning color="gray300" size="48" />}
+          title={t(
+            "You don't have access to any projects, or your organization has no projects."
+          )}
+          description={tct('Learn more about [link:Project Access]', {
+            link: <ExternalLink href={DOCS_URL} />,
+          })}
+        />
       );
     }
-    return null;
+    return <IconWarning color="gray300" size="48" />;
   };
 
   renderTableRow(stat: TableStat & {project: Project}) {
@@ -110,10 +107,7 @@ class UsageTable extends React.Component<Props> {
     if (isError) {
       return (
         <Panel>
-          <ErrorPanel height="256px">
-            <IconWarning color="gray300" size="48" />
-            {this.getErrorMessage(errors)}
-          </ErrorPanel>
+          <ErrorPanel height="256px">{this.getErrorMessage(errors)}</ErrorPanel>
         </Panel>
       );
     }
@@ -155,24 +149,4 @@ const StyledIdBadge = styled(IdBadge)`
   overflow: hidden;
   white-space: nowrap;
   flex-shrink: 1;
-`;
-
-const ErrorMessages = styled('div')`
-  display: flex;
-  flex-direction: column;
-
-  margin-top: ${space(1)};
-  font-size: ${p => p.theme.fontSizeSmall};
-`;
-
-const Title = styled('strong')`
-  font-size: ${p => p.theme.fontSizeExtraLarge};
-  margin-bottom: ${space(1)};
-`;
-
-const Description = styled('span')`
-  font-size: ${p => p.theme.fontSizeLarge};
-  display: block;
-  margin: 0;
-  text-align: center;
 `;

--- a/tests/js/spec/views/organizationStats/index.spec.jsx
+++ b/tests/js/spec/views/organizationStats/index.spec.jsx
@@ -135,6 +135,30 @@ describe('OrganizationStats', function () {
     expect(wrapper.find('IconWarning')).toHaveLength(2);
   });
 
+  it('renders with error when user has no access to projects', async function () {
+    MockApiClient.addMockResponse({
+      url: statsUrl,
+      statusCode: 400,
+      body: {
+        detail: 'No projects available',
+      },
+    });
+
+    const wrapper = mountWithTheme(
+      <OrganizationStats organization={organization} />,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.text()).toContain('Organization Usage Stats');
+
+    expect(wrapper.find('UsageTable')).toHaveLength(1);
+    expect(wrapper.find('IconWarning')).toHaveLength(2);
+    expect(wrapper.find('UsageTable').text()).toContain('no projects');
+  });
+
   it('passes state from router down to components', async function () {
     const wrapper = mountWithTheme(
       <OrganizationStats


### PR DESCRIPTION
if the endpoint returns a 400 with "No projects available" as the error message, display the error on the projects table. 

Before:
![image](https://user-images.githubusercontent.com/22259802/123989158-9ef35100-d996-11eb-870c-df92d059dfb9.png)


After:
![image](https://user-images.githubusercontent.com/22259802/124038555-4be9c000-d9cf-11eb-9c47-2e1286ea5bc4.png)


Ticket: https://getsentry.atlassian.net/browse/ER-714