### PR TITLE
fix(grouping-breakdown): Show entire stack instead of placeholder

### DIFF
--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -112,10 +112,10 @@ def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_p
     ]
 
     assert [e.title for e in events] == [
-        "bam | baz2 | bar2 | foo",
-        "baz | bar | foo",
-        "baz2 | bar2 | foo",
-        "bar3 | foo",
+        "foo | bar2 | baz2 | bam",
+        "foo | bar | baz",
+        "foo | bar2 | baz2",
+        "foo | bar3",
     ]
 
     assert len({e.group_id for e in events}) == 1
@@ -128,18 +128,18 @@ group: foo
 level 0*
 bab925683e73afdb4dc4047397a7b36b: foo (4)
 level 1
-64686dcd59e0cf97f34113e9d360541a: bar3 | foo (1)
-c8ef2dd3dedeed29b4b74b9c579eea1a: bar2 | foo (2)
-aa1c4037371150958f9ea22adb110bbc: bar | foo (1)
+64686dcd59e0cf97f34113e9d360541a: foo | bar3 (1)
+c8ef2dd3dedeed29b4b74b9c579eea1a: foo | bar2 (2)
+aa1c4037371150958f9ea22adb110bbc: foo | bar (1)
 level 2
-64686dcd59e0cf97f34113e9d360541a: bar3 | foo (1)
-8c0bbfebc194c7aa3e77e95436fd61e5: baz2 | bar2 | foo (2)
-b8d08a573c62ca8c84de14c12c0e19fe: baz | bar | foo (1)
+64686dcd59e0cf97f34113e9d360541a: foo | bar3 (1)
+8c0bbfebc194c7aa3e77e95436fd61e5: foo | bar2 | baz2 (2)
+b8d08a573c62ca8c84de14c12c0e19fe: foo | bar | baz (1)
 level 3
-64686dcd59e0cf97f34113e9d360541a: bar3 | foo (1)
-8c0bbfebc194c7aa3e77e95436fd61e5: baz2 | bar2 | foo (1)
-b8d08a573c62ca8c84de14c12c0e19fe: baz | bar | foo (1)
-b0505d7461a2e36c4a8235bb6c310a3b: bam | baz2 | bar2 | foo (1)\
+64686dcd59e0cf97f34113e9d360541a: foo | bar3 (1)
+8c0bbfebc194c7aa3e77e95436fd61e5: foo | bar2 | baz2 (1)
+b8d08a573c62ca8c84de14c12c0e19fe: foo | bar | baz (1)
+b0505d7461a2e36c4a8235bb6c310a3b: foo | bar2 | baz2 | bam (1)\
 """
     )
 
@@ -172,37 +172,37 @@ def test_upwards(default_project, store_stacktrace, reset_snuba, _render_all_pre
     assert (
         _render_all_previews(events[0].group)
         == """\
-group: baz | bar2 | foo
+group: foo | bar2 | baz
 level 0
 bab925683e73afdb4dc4047397a7b36b: foo (3)
 level 1
-c8ef2dd3dedeed29b4b74b9c579eea1a: bar2 | foo (1)
+c8ef2dd3dedeed29b4b74b9c579eea1a: foo | bar2 (1)
 level 2*
-7411b56aa6591edbdba71898d3a9f01c: baz | bar2 | foo (1)\
+7411b56aa6591edbdba71898d3a9f01c: foo | bar2 | baz (1)\
 """
     )
     assert (
         _render_all_previews(events[1].group)
         == """\
-group: baz | bar | foo
+group: foo | bar | baz
 level 0
 bab925683e73afdb4dc4047397a7b36b: foo (3)
 level 1
-aa1c4037371150958f9ea22adb110bbc: bar | foo (2)
+aa1c4037371150958f9ea22adb110bbc: foo | bar (2)
 level 2*
-b8d08a573c62ca8c84de14c12c0e19fe: baz | bar | foo (1)\
+b8d08a573c62ca8c84de14c12c0e19fe: foo | bar | baz (1)\
 """
     )
 
     assert (
         _render_all_previews(events[2].group)
         == """\
-group: bam | bar | foo
+group: foo | bar | bam
 level 0
 bab925683e73afdb4dc4047397a7b36b: foo (3)
 level 1
-aa1c4037371150958f9ea22adb110bbc: bar | foo (2)
+aa1c4037371150958f9ea22adb110bbc: foo | bar (2)
 level 2*
-97df6b60ec530c65ab227585143a087a: bam | bar | foo (1)\
+97df6b60ec530c65ab227585143a087a: foo | bar | bam (1)\
 """
     )

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.842808Z'
+created: '2021-06-30T16:44:01.142059Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "4c9aea199e5ed84c00a6d4d1bb7576c2"
-  tree_label: "actix_web::pipeline::ProcessResponse<T>::poll_io | log::__private_api_log | sentry::integrations::log::Logger::log"
+  tree_label: "sentry::integrations::log::Logger::log | log::__private_api_log | actix_web::pipeline::ProcessResponse<T>::poll_io"
   component:
     app-depth-2*
       exception*
@@ -53,7 +53,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "cb20e13a0ac481e2d961ddb5ec5b737c"
-  tree_label: "actix_web::pipeline::Pipeline<T>::poll_io | actix_web::pipeline::ProcessResponse<T>::poll_io | log::__private_api_log | sentry::integrations::log::Logger::log | sentry::hub::Hub::with_active"
+  tree_label: "sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | actix_web::pipeline::ProcessResponse<T>::poll_io | actix_web::pipeline::Pipeline<T>::poll_io"
   component:
     app-depth-3*
       exception*
@@ -94,7 +94,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "46035a02eac7b0ace4d4f740e8075d7f"
-  tree_label: "actix_web::server::h1::Http1Dispatcher<T>::parse | actix_web::pipeline::Pipeline<T>::poll_io | actix_web::pipeline::ProcessResponse<T>::poll_io | log::__private_api_log | sentry::integrations::log::Logger::log | sentry::hub::Hub::with_active | sentry::hub::Hub::with"
+  tree_label: "sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | actix_web::pipeline::ProcessResponse<T>::poll_io | actix_web::pipeline::Pipeline<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::parse"
   component:
     app-depth-4*
       exception*
@@ -147,7 +147,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "5e293439c562dbd9e43df32419d45b6a"
-  tree_label: "actix_web::server::h1::Http1Dispatcher<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::parse | actix_web::pipeline::Pipeline<T>::poll_io | actix_web::pipeline::ProcessResponse<T>::poll_io | log::__private_api_log | sentry::integrations::log::Logger::log | sentry::hub::Hub::with_active | sentry::hub::Hub::with | std::thread::local::LocalKey<T>::with"
+  tree_label: "std::thread::local::LocalKey<T>::with | sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | actix_web::pipeline::ProcessResponse<T>::poll_io | actix_web::pipeline::Pipeline<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::parse | actix_web::server::h1::Http1Dispatcher<T>::poll_io"
   component:
     app-depth-5*
       exception*
@@ -210,7 +210,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "3b6eaff1ca55deef09b01def1b407956"
-  tree_label: "<entire stacktrace>"
+  tree_label: "sentry::hub::Hub::with_active::{{closure}} | sentry::hub::Hub::with::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | actix_web::pipeline::ProcessResponse<T>::poll_io | actix_web::pipeline::Pipeline<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::parse | actix_web::server::h1::Http1Dispatcher<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::poll_handler | actix_web::server::h1::Http1Dispatcher<T>::poll | actix_web::server::channel::HttpChannel<T>::poll | actix_web::server::channel::HttpChannel<T>::poll | actix_net::service::map_err::MapErrFuture<T>::poll | actix_net::service::and_then::AndThenFuture<T>::poll | actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll | futures::future::either::Either<T>::poll | futures::future::either::Either<T>::poll | futures::future::chain::Chain<T>::poll | futures::future::then::Then<T>::poll | alloc::boxed::Box<T>::poll | futures::task_impl::Spawn<T>::poll_future_notify::{{closure}} | futures::task_impl::Spawn<T>::enter::{{closure}} | futures::task_impl::std::set | futures::task_impl::Spawn<T>::enter | futures::task_impl::Spawn<T>::poll_fn_notify | futures::task_impl::Spawn<T>::poll_future_notify | tokio_current_thread::scheduler::Scheduled<T>::tick | tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}} | tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}} | tokio_current_thread::CurrentRunner::set_spawn | tokio_current_thread::Borrow<T>::enter::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_current_thread::Borrow<T>::enter | tokio_current_thread::scheduler::Scheduler<T>::tick | tokio_current_thread::Entered<T>::tick | tokio_current_thread::Entered<T>::block_on | tokio::runtime::current_thread::runtime::Runtime::block_on::{{closure}} | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}} | tokio_executor::global::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_executor::global::with_default | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}} | tokio_timer::timer::handle::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_timer::timer::handle::with_default | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}} | tokio_timer::clock::clock::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_timer::clock::clock::with_default | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}} | tokio_reactor::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_reactor::with_default | tokio::runtime::current_thread::runtime::Runtime::enter | tokio::runtime::current_thread::runtime::Runtime::block_on | actix::arbiter::Arbiter::new_with_builder::{{closure}} | std::sys_common::backtrace::__rust_begin_short_backtrace | std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}} | std::panic::AssertUnwindSafe<T>::call_once | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::panicking::try | std::panic::catch_unwind | std::thread::Builder::spawn_unchecked::{{closure}} | alloc::boxed::FnBox<T>::call_box | std::sys::unix::thread::Thread::new::thread_start | __pthread_body | __pthread_start"
   component:
     app-depth-max*
       exception*
@@ -663,7 +663,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "3b6eaff1ca55deef09b01def1b407956"
-  tree_label: "<entire stacktrace>"
+  tree_label: "sentry::hub::Hub::with_active::{{closure}} | sentry::hub::Hub::with::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | actix_web::pipeline::ProcessResponse<T>::poll_io | actix_web::pipeline::Pipeline<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::parse | actix_web::server::h1::Http1Dispatcher<T>::poll_io | actix_web::server::h1::Http1Dispatcher<T>::poll_handler | actix_web::server::h1::Http1Dispatcher<T>::poll | actix_web::server::channel::HttpChannel<T>::poll | actix_web::server::channel::HttpChannel<T>::poll | actix_net::service::map_err::MapErrFuture<T>::poll | actix_net::service::and_then::AndThenFuture<T>::poll | actix_web::server::acceptor::ServerMessageAcceptorServiceFut<T>::poll | futures::future::either::Either<T>::poll | futures::future::either::Either<T>::poll | futures::future::chain::Chain<T>::poll | futures::future::then::Then<T>::poll | alloc::boxed::Box<T>::poll | futures::task_impl::Spawn<T>::poll_future_notify::{{closure}} | futures::task_impl::Spawn<T>::enter::{{closure}} | futures::task_impl::std::set | futures::task_impl::Spawn<T>::enter | futures::task_impl::Spawn<T>::poll_fn_notify | futures::task_impl::Spawn<T>::poll_future_notify | tokio_current_thread::scheduler::Scheduled<T>::tick | tokio_current_thread::scheduler::Scheduler<T>::tick::{{closure}} | tokio_current_thread::Borrow<T>::enter::{{closure}}::{{closure}} | tokio_current_thread::CurrentRunner::set_spawn | tokio_current_thread::Borrow<T>::enter::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_current_thread::Borrow<T>::enter | tokio_current_thread::scheduler::Scheduler<T>::tick | tokio_current_thread::Entered<T>::tick | tokio_current_thread::Entered<T>::block_on | tokio::runtime::current_thread::runtime::Runtime::block_on::{{closure}} | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}}::{{closure}} | tokio_executor::global::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_executor::global::with_default | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}}::{{closure}} | tokio_timer::timer::handle::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_timer::timer::handle::with_default | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}}::{{closure}} | tokio_timer::clock::clock::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_timer::clock::clock::with_default | tokio::runtime::current_thread::runtime::Runtime::enter::{{closure}} | tokio_reactor::with_default::{{closure}} | std::thread::local::LocalKey<T>::try_with | std::thread::local::LocalKey<T>::with | tokio_reactor::with_default | tokio::runtime::current_thread::runtime::Runtime::enter | tokio::runtime::current_thread::runtime::Runtime::block_on | actix::arbiter::Arbiter::new_with_builder::{{closure}} | std::sys_common::backtrace::__rust_begin_short_backtrace | std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}} | std::panic::AssertUnwindSafe<T>::call_once | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::panicking::try | std::panic::catch_unwind | std::thread::Builder::spawn_unchecked::{{closure}} | alloc::boxed::FnBox<T>::call_box | std::sys::unix::thread::Thread::new::thread_start | __pthread_body | __pthread_start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/android_anr.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-06-23T18:06:09.995148Z'
+created: '2021-06-30T16:44:01.690590Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
   hash: "65b492dd57da1268ca7868e104b2067d"
-  tree_label: "doFrame | doTraversal | onLayout"
+  tree_label: "onLayout | doTraversal | doFrame"
   component:
     app-depth-1*
       exception*
@@ -47,7 +47,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "81103d430ba24ccad51cdbf81de2297a"
-  tree_label: "<entire stacktrace>"
+  tree_label: "getChildAt | getUnfilteredChildAt | offsetPositionRecordsForInsert | offsetPositionsForAdd | consumeUpdatesInOnePass | processAdapterUpdatesAndSetAnimationFlags | dispatchLayoutStep1 | dispatchLayout | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | performLayout | performTraversals | doTraversal | run | run | doCallbacks | doFrame | run | handleCallback | dispatchMessage | loop | main | invoke | invoke | run | main"
   component:
     app-depth-max*
       exception*
@@ -831,7 +831,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "81103d430ba24ccad51cdbf81de2297a"
-  tree_label: "<entire stacktrace>"
+  tree_label: "getChildAt | getUnfilteredChildAt | offsetPositionRecordsForInsert | offsetPositionsForAdd | consumeUpdatesInOnePass | processAdapterUpdatesAndSetAnimationFlags | dispatchLayoutStep1 | dispatchLayout | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | setChildFrame | layoutVertical | onLayout | layout | layout | layoutChildren | onLayout | layout | layout | performLayout | performTraversals | doTraversal | run | run | doCallbacks | doFrame | run | handleCallback | dispatchMessage | loop | main | invoke | invoke | run | main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:08.982703Z'
+created: '2021-06-30T16:44:00.441129Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "228c649a3aa0901622c0a0e66ab0522c"
-  tree_label: "lambda_method | Get"
+  tree_label: "Get | lambda_method"
   component:
     app-depth-2*
       exception*
@@ -48,7 +48,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "1a74c747b5cea2b8c2ac2f5753a03116"
-  tree_label: "Execute | lambda_method | Get"
+  tree_label: "Get | lambda_method | Execute"
   component:
     app-depth-3*
       exception*
@@ -77,7 +77,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "14a57462092f01a0042382359f958006"
-  tree_label: "Execute | Execute | lambda_method | Get"
+  tree_label: "Get | lambda_method | Execute | Execute"
   component:
     app-depth-4*
       exception*
@@ -111,7 +111,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "8bd7d4553a8f5d58ad65bea951793080"
-  tree_label: "InvokeActionMethodAsync | Execute | Execute | lambda_method | Get"
+  tree_label: "Get | lambda_method | Execute | Execute | InvokeActionMethodAsync"
   component:
     app-depth-5*
       exception*
@@ -150,7 +150,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "4ccd0f1953483581ba360c7518f90332"
-  tree_label: "<entire stacktrace>"
+  tree_label: "Get | lambda_method | Execute | Execute | InvokeActionMethodAsync | Throw | HandleNonSuccessAndDebuggerNotification | InvokeNextActionFilterAsync | Throw | Rethrow | Next | InvokeInnerFilterAsync | Throw | HandleNonSuccessAndDebuggerNotification | InvokeNextResourceFilter | Throw | Rethrow | Next | InvokeFilterPipelineAsync | Throw | HandleNonSuccessAndDebuggerNotification | InvokeAsync | Throw | HandleNonSuccessAndDebuggerNotification | Invoke | Throw | HandleNonSuccessAndDebuggerNotification | Invoke | Throw | HandleNonSuccessAndDebuggerNotification | Invoke"
   component:
     app-depth-max*
       exception*
@@ -326,7 +326,7 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "4ccd0f1953483581ba360c7518f90332"
-  tree_label: "<entire stacktrace>"
+  tree_label: "Get | lambda_method | Execute | Execute | InvokeActionMethodAsync | Throw | HandleNonSuccessAndDebuggerNotification | InvokeNextActionFilterAsync | Throw | Rethrow | Next | InvokeInnerFilterAsync | Throw | HandleNonSuccessAndDebuggerNotification | InvokeNextResourceFilter | Throw | Rethrow | Next | InvokeFilterPipelineAsync | Throw | HandleNonSuccessAndDebuggerNotification | InvokeAsync | Throw | HandleNonSuccessAndDebuggerNotification | Invoke | Throw | HandleNonSuccessAndDebuggerNotification | Invoke | Throw | HandleNonSuccessAndDebuggerNotification | Invoke"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.368600Z'
+created: '2021-06-30T16:44:00.405354Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "ac1a85601e0656df67b159e882145099"
-  tree_label: "is_rate_limited | call_script | __call__"
+  tree_label: "__call__ | call_script | is_rate_limited"
   component:
     app-depth-2*
       exception*
@@ -65,7 +65,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "8538e8eb15b0b93e3355cf9d08268131"
-  tree_label: "is_rate_limited | is_rate_limited | call_script | __call__ | evalsha"
+  tree_label: "evalsha | __call__ | call_script | is_rate_limited | is_rate_limited"
   component:
     app-depth-3*
       exception*
@@ -122,7 +122,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "a4f739f3240d6c4fc5ed50428442abc1"
-  tree_label: "<lambda> | is_rate_limited | is_rate_limited | call_script | __call__ | evalsha | execute_command"
+  tree_label: "execute_command | evalsha | __call__ | call_script | is_rate_limited | is_rate_limited | <lambda>"
   component:
     app-depth-4*
       exception*
@@ -197,7 +197,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "acb23d293e6a73416ad00df1bb35d8a8"
-  tree_label: "safe_execute | <lambda> | is_rate_limited | is_rate_limited | call_script | __call__ | evalsha | execute_command | parse_response"
+  tree_label: "parse_response | execute_command | evalsha | __call__ | call_script | is_rate_limited | is_rate_limited | <lambda> | safe_execute"
   component:
     app-depth-5*
       exception*
@@ -290,7 +290,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "013d3477a774fe20c468dc8accd516f1"
-  tree_label: "<entire stacktrace>"
+  tree_label: "read_response | read_response | parse_response | execute_command | evalsha | __call__ | call_script | is_rate_limited | is_rate_limited | <lambda> | safe_execute"
   component:
     app-depth-max*
       exception*
@@ -408,7 +408,7 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "013d3477a774fe20c468dc8accd516f1"
-  tree_label: "<entire stacktrace>"
+  tree_label: "read_response | read_response | parse_response | execute_command | evalsha | __call__ | call_script | is_rate_limited | is_rate_limited | <lambda> | safe_execute"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.396888Z'
+created: '2021-06-30T16:44:00.537160Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: null
-  tree_label: "__init__ | _prefetch | __exit__"
+  tree_label: "__exit__ | _prefetch | __init__"
   component:
     app-depth-2 (custom fingerprint takes precedence)
       exception*
@@ -65,7 +65,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: null
-  tree_label: "_get_chunked_blob | __init__ | _prefetch | __exit__ | shutdown"
+  tree_label: "shutdown | __exit__ | _prefetch | __init__ | _get_chunked_blob"
   component:
     app-depth-3 (custom fingerprint takes precedence)
       exception*
@@ -122,7 +122,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: null
-  tree_label: "save_to | _get_chunked_blob | __init__ | _prefetch | __exit__ | shutdown | join"
+  tree_label: "join | shutdown | __exit__ | _prefetch | __init__ | _get_chunked_blob | save_to"
   component:
     app-depth-4 (custom fingerprint takes precedence)
       exception*
@@ -197,7 +197,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: null
-  tree_label: "_load_cachefiles_via_fs | save_to | _get_chunked_blob | __init__ | _prefetch | __exit__ | shutdown | join | wait"
+  tree_label: "wait | join | shutdown | __exit__ | _prefetch | __init__ | _get_chunked_blob | save_to | _load_cachefiles_via_fs"
   component:
     app-depth-5 (custom fingerprint takes precedence)
       exception*
@@ -290,7 +290,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: null
-  tree_label: "<entire stacktrace>"
+  tree_label: "soft_timeout_sighandler | wait | join | shutdown | __exit__ | _prefetch | __init__ | _get_chunked_blob | save_to | _load_cachefiles_via_fs | get_symcaches | __init__ | preprocess_step | process_stacktraces | _do_process_event | process_event | _wrapped"
   component:
     app-depth-max (custom fingerprint takes precedence)
       exception*
@@ -460,7 +460,7 @@ custom-fingerprint:
 --------------------------------------------------------------------------
 system:
   hash: null
-  tree_label: "<entire stacktrace>"
+  tree_label: "soft_timeout_sighandler | wait | join | shutdown | __exit__ | _prefetch | __init__ | _get_chunked_blob | save_to | _load_cachefiles_via_fs | get_symcaches | __init__ | preprocess_step | process_stacktraces | _do_process_event | process_event | _wrapped"
   component:
     system (custom fingerprint takes precedence)
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.852089Z'
+created: '2021-06-30T16:44:01.035037Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,12 +22,12 @@ app-depth-1:
     app-depth-1 (exception of app takes precedence)
       threads (exception of app takes precedence)
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
-            function*
-              "-[UIApplication sendAction:to:from:forEvent:]"
           frame*
             function*
               "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
 --------------------------------------------------------------------------
 app-depth-2:
   hash: null
@@ -35,18 +35,18 @@ app-depth-2:
     app-depth-2 (exception of app takes precedence)
       threads (exception of app takes precedence)
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
-            function*
-              "-[UIApplication sendAction:to:from:forEvent:]"
           frame*
             function*
-              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+              "GSEventRunModal"
           frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "__eventFetcherSourceCallback"
           frame*
             function*
-              "GSEventRunModal"
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
 --------------------------------------------------------------------------
 app-depth-3:
   hash: null
@@ -54,24 +54,24 @@ app-depth-3:
     app-depth-3 (exception of app takes precedence)
       threads (exception of app takes precedence)
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
-            function*
-              "-[UIApplication sendAction:to:from:forEvent:]"
           frame*
             function*
-              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
-            function*
-              "__eventFetcherSourceCallback"
-          frame*
-            function*
-              "GSEventRunModal"
+              "main"
           frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "UIApplicationMain"
           frame*
             function*
-              "main"
+              "GSEventRunModal"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
 --------------------------------------------------------------------------
 app-depth-max:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.600300Z'
+created: '2021-06-30T15:56:05.969550Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -19,7 +19,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "9509e122c6175606d52862fa4f64853c"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       exception*
@@ -34,7 +33,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "9509e122c6175606d52862fa4f64853c"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.161561Z'
+created: '2021-06-30T15:56:05.409452Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -19,7 +19,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "9509e122c6175606d52862fa4f64853c"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       exception*
@@ -34,7 +33,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "9509e122c6175606d52862fa4f64853c"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.716500Z'
+created: '2021-06-30T15:56:04.771739Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -29,7 +29,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "669cb6664e0f5fed38665da04e464f7e"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       chained-exception*
@@ -54,7 +53,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "669cb6664e0f5fed38665da04e464f7e"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       chained-exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.430232Z'
+created: '2021-06-30T16:44:00.436983Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -52,7 +52,6 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "26552f86ca2368e708afa1df6effc1c5"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       exception*
@@ -80,7 +79,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "26552f86ca2368e708afa1df6effc1c5"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_comput_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.559305Z'
+created: '2021-06-30T15:56:05.438308Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "526b64456c48836a46ec1a89544fd412"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "526b64456c48836a46ec1a89544fd412"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.027133Z'
+created: '2021-06-30T15:56:06.090147Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "45c0b0a8c777e7a7040d7c39233a08a5"
-  tree_label: "<entire stacktrace>"
+  tree_label: "jipJipManagementApplication"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "45c0b0a8c777e7a7040d7c39233a08a5"
-  tree_label: "<entire stacktrace>"
+  tree_label: "jipJipManagementApplication"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.151253Z'
+created: '2021-06-30T15:56:05.305422Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "353e05904b48bd3ae4fa9623934a70d0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "353e05904b48bd3ae4fa9623934a70d0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.242553Z'
+created: '2021-06-30T15:56:04.216970Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "be15ca3d511b96918e087c4f42503ca2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "jipJipManagementApplication"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "be15ca3d511b96918e087c4f42503ca2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "jipJipManagementApplication"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.903315Z'
+created: '2021-06-30T16:44:01.334146Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -40,7 +40,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "e04dce7550635e05dbd7f656102cf304"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test | test"
   component:
     app-depth-max*
       stacktrace*
@@ -66,7 +66,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "e04dce7550635e05dbd7f656102cf304"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test | test"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.798794Z'
+created: '2021-06-30T15:56:05.629338Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "098f6bcd4621d373cade4e832627b4f6"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "098f6bcd4621d373cade4e832627b4f6"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.759111Z'
+created: '2021-06-30T15:56:06.177286Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -19,7 +19,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test"
   component:
     app-depth-max*
       stacktrace*
@@ -33,7 +33,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.094903Z'
+created: '2021-06-30T15:56:03.972361Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -19,7 +19,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test"
   component:
     app-depth-max*
       stacktrace*
@@ -33,7 +33,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "64a0e0a34d99dce03a8c5a4c237a4b5a"
-  tree_label: "<entire stacktrace>"
+  tree_label: "test"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.937644Z'
+created: '2021-06-30T15:56:06.066751Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,7 +16,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "be7f1b8b4014de623c533a8218dba5bd"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -28,7 +27,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "be7f1b8b4014de623c533a8218dba5bd"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.059552Z'
+created: '2021-06-30T15:56:05.151048Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "53b9e9679a8ea25880376080b76f98ad"
-  tree_label: "<entire stacktrace>"
+  tree_label: "call"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "53b9e9679a8ea25880376080b76f98ad"
-  tree_label: "<entire stacktrace>"
+  tree_label: "call"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.916596Z'
+created: '2021-06-30T15:56:05.330352Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
-  tree_label: "<entire stacktrace>"
+  tree_label: "fn"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
-  tree_label: "<entire stacktrace>"
+  tree_label: "fn"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.865451Z'
+created: '2021-06-30T15:56:06.278675Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
-  tree_label: "<entire stacktrace>"
+  tree_label: "fn"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "538bdfd8d7bb2495d0d6429c3689a420"
-  tree_label: "<entire stacktrace>"
+  tree_label: "fn"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.212878Z'
+created: '2021-06-30T15:56:05.806451Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "dc3d511120ce04996b1eef3496516e5c"
-  tree_label: "<entire stacktrace>"
+  tree_label: "fn"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "dc3d511120ce04996b1eef3496516e5c"
-  tree_label: "<entire stacktrace>"
+  tree_label: "fn"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.118908Z'
+created: '2021-06-30T15:56:05.164772Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -19,7 +19,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "0cc175b9c0f1b6a831c399e269772661"
-  tree_label: "<entire stacktrace>"
+  tree_label: "a"
   component:
     app-depth-max*
       stacktrace*
@@ -33,7 +33,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "0cc175b9c0f1b6a831c399e269772661"
-  tree_label: "<entire stacktrace>"
+  tree_label: "a"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.021227Z'
+created: '2021-06-30T15:56:04.427442Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "30eb5001914d29dd8461898b5b8094fe"
-  tree_label: "<entire stacktrace>"
+  tree_label: "forEach"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "30eb5001914d29dd8461898b5b8094fe"
-  tree_label: "<entire stacktrace>"
+  tree_label: "forEach"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.654164Z'
+created: '2021-06-30T15:56:06.448432Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "07d1a8e5728b3c4c7aa8b8273fd0e753"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.102179Z'
+created: '2021-06-30T15:56:06.127096Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "09e0efcab18f545166318118ed4e0292"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "09e0efcab18f545166318118ed4e0292"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.804650Z'
+created: '2021-06-30T16:44:01.280812Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -34,7 +34,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "9bc326575875422d0d4ced3c35d9f916"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke | invoke"
   component:
     app-depth-max*
       stacktrace*
@@ -51,7 +51,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "9bc326575875422d0d4ced3c35d9f916"
-  tree_label: "<entire stacktrace>"
+  tree_label: "invoke | invoke"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.646744Z'
+created: '2021-06-30T15:56:04.651409Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "27eed4125fc13d42163ddb0b8f357b48"
-  tree_label: "<entire stacktrace>"
+  tree_label: "block"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "27eed4125fc13d42163ddb0b8f357b48"
-  tree_label: "<entire stacktrace>"
+  tree_label: "block"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.069655Z'
+created: '2021-06-30T15:56:06.062084Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "4067a71d7098866f87c746a57a77b2bb"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_foo_html_erb"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "4067a71d7098866f87c746a57a77b2bb"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_foo_html_erb"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.992202Z'
+created: '2021-06-30T15:56:04.570890Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "2f908c015ad77a50595512fcf65d344c"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -24,7 +23,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "2f908c015ad77a50595512fcf65d344c"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.057966Z'
+created: '2021-06-30T15:56:06.219041Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "2f908c015ad77a50595512fcf65d344c"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -24,7 +23,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "2f908c015ad77a50595512fcf65d344c"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_skips_symbol_if_unknown.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_skips_symbol_if_unknown.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.890598Z'
+created: '2021-06-30T15:56:06.311895Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "a972f399399f5566f39b14a7afdd24ff"
-  tree_label: "<entire stacktrace>"
+  tree_label: "main"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "a972f399399f5566f39b14a7afdd24ff"
-  tree_label: "<entire stacktrace>"
+  tree_label: "main"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:40.040273Z'
+created: '2021-06-30T15:56:05.836568Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "fb73cb54ced59b1c0c60d9bb40b7336b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "bar"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "fb73cb54ced59b1c0c60d9bb40b7336b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "bar"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_function_over_lineno.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_function_over_lineno.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.678299Z'
+created: '2021-06-30T15:56:04.714642Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "fb73cb54ced59b1c0c60d9bb40b7336b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "bar"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "fb73cb54ced59b1c0c60d9bb40b7336b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "bar"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.659337Z'
+created: '2021-06-30T15:56:05.898376Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,7 +16,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -28,7 +27,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_symbol_instead_of_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_uses_symbol_instead_of_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.617675Z'
+created: '2021-06-30T15:56:06.409809Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "23db4a9e73800923f345d2b868993345"
-  tree_label: "<entire stacktrace>"
+  tree_label: "int main()"
   component:
     app-depth-max*
       stacktrace*
@@ -29,7 +29,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "23db4a9e73800923f345d2b868993345"
-  tree_label: "<entire stacktrace>"
+  tree_label: "int main()"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.167806Z'
+created: '2021-06-30T15:56:04.495165Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "1effb24729ae4c43efa36b460511136a"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -24,7 +23,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "1effb24729ae4c43efa36b460511136a"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_125_event_126.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:09.071026Z'
+created: '2021-06-30T16:44:00.770925Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "05526eb3e37b799f775acd2a31b13dd1"
+  hash: "b7de92d39e823772baa9a88863c07cab"
   tree_label: "dlopen | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
             package (ignored because function takes precedence)
               "libdyld.dylib"
-          frame*
-            function*
-              "stripped_application_code"
         type (ignored because exception is synthetic (detected via exception type))
           "EXC_BAD_ACCESS / 0x00000032"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "3da34e8c72dbcd4a490ac36eb7130638"
-  tree_label: "<entire stacktrace>"
+  tree_label: "ImageLoaderMachOCompressed::rebase | ImageLoader::recursiveRebase | ImageLoader::link | dyld::link | dlopen_internal | dlopen | _CFBundleDlfcnLoadBundle | _CFBundleLoadExecutableAndReturnError | CFBundleGetFunctionPointerForName | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | MZ::`anonymous namespace'::lambda::operator() | std::__1::__invoke<T> | std::__1::__invoke_void_return_wrapper<T>::__call<T> | std::__1::__function::__alloc_func<T>::operator() | std::__1::__function::__func<T>::operator() | std::__1::__function::__value_func<T>::operator() | std::__1::function<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start | start"
   component:
     app-depth-max*
       exception*
@@ -187,7 +187,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "3da34e8c72dbcd4a490ac36eb7130638"
-  tree_label: "<entire stacktrace>"
+  tree_label: "ImageLoaderMachOCompressed::rebase | ImageLoader::recursiveRebase | ImageLoader::link | dyld::link | dlopen_internal | dlopen | _CFBundleDlfcnLoadBundle | _CFBundleLoadExecutableAndReturnError | CFBundleGetFunctionPointerForName | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | MZ::`anonymous namespace'::lambda::operator() | std::__1::__invoke<T> | std::__1::__invoke_void_return_wrapper<T>::__call<T> | std::__1::__function::__alloc_func<T>::operator() | std::__1::__function::__func<T>::operator() | std::__1::__function::__value_func<T>::operator() | std::__1::function<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start | start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2021-06-23T18:06:11.174758Z'
+created: '2021-06-30T16:44:00.022517Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "1028091c5d80feac9a1542ab321d1fe7"
+  hash: "4d4c43d1d793f5a308704e28502a515f"
   tree_label: "RtlFreeHeap | RtlFreeHeap | destructor'"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
-            function*
-              "RtlFreeHeap"
-            package (ignored because function takes precedence)
-              "ntdll.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
-            function*
-              "RtlFreeHeap"
-            package (ignored because function takes precedence)
-              "ntdll.dll"
           frame*
             function*
               "destructor'"
             package (ignored because function takes precedence)
               "winhttp.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+            function*
+              "RtlFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+            function*
+              "RtlFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
         type (ignored because exception is synthetic (detected via exception type))
           "EXCEPTION_ACCESS_VIOLATION_WRITE"
         value (ignored because stacktrace takes precedence)
@@ -32,7 +32,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "6b9106347534a0018fe5f3d9993b3bb5"
-  tree_label: "<entire stacktrace>"
+  tree_label: "RtlpOptimizeWaitOnAddressWaitList | RtlpWaitOnAddress | RtlpWaitOnCriticalSection | RtlpEnterCriticalSectionContended | RtlEnterCriticalSection | RtlpFreeHeap | RtlpFreeHeapInternal | RtlFreeHeap | RtlpFreeUserBlockToHeap | RtlpFreeUserBlock | memset | RtlFreeHeap | destructor' | HTTP_USER_REQUEST::~HTTP_USER_REQUEST | destructor' | HTTP_BASE_OBJECT::Dereference | HTTP_USER_REQUEST::OnSendRequest | WEBIO_REQUEST::OnIoComplete | HTTP_ASYNC_OVERLAPPED::OnWorkItem | HTTP_THREAD_POOL::_StaticWorkItemCallback | TppWorkpExecuteCallback | TppWorkerThread | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     app-depth-max*
       exception*
@@ -164,7 +164,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "6b9106347534a0018fe5f3d9993b3bb5"
-  tree_label: "<entire stacktrace>"
+  tree_label: "RtlpOptimizeWaitOnAddressWaitList | RtlpWaitOnAddress | RtlpWaitOnCriticalSection | RtlpEnterCriticalSectionContended | RtlEnterCriticalSection | RtlpFreeHeap | RtlpFreeHeapInternal | RtlFreeHeap | RtlpFreeUserBlockToHeap | RtlpFreeUserBlock | memset | RtlFreeHeap | destructor' | HTTP_USER_REQUEST::~HTTP_USER_REQUEST | destructor' | HTTP_BASE_OBJECT::Dereference | HTTP_USER_REQUEST::OnSendRequest | WEBIO_REQUEST::OnIoComplete | HTTP_ASYNC_OVERLAPPED::OnWorkItem | HTTP_THREAD_POOL::_StaticWorkItemCallback | TppWorkpExecuteCallback | TppWorkerThread | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.237733Z'
+created: '2021-06-30T16:43:59.085474Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -59,7 +59,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "2c1bbd635b64d5adccdb64a620044075"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T> | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | _dispatch_client_callout | _dispatch_root_queue_drain | _dispatch_worker_thread2 | _pthread_wqthread | start_wqthread | _dispatch_root_queues_init_once"
   component:
     app-depth-max*
       exception*
@@ -171,7 +171,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "2c1bbd635b64d5adccdb64a620044075"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_INTERNAL34b3029b::`anonymous namespace'::Convert4444_8uTo4444_32f<T> | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | _dispatch_client_callout | _dispatch_root_queue_drain | _dispatch_worker_thread2 | _pthread_wqthread | start_wqthread | _dispatch_root_queues_init_once"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2021-06-23T18:06:11.013886Z'
+created: '2021-06-30T16:44:00.961274Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "345122a1d95a95b106bdda3c8d0b19c8"
+  hash: "c20e97250c9dbf61615dff51c4bcc286"
   tree_label: "abort | gldCreateDevice | glDeleteTextures_Exec"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
-            function*
-              "gldCreateDevice"
-            package (ignored because function takes precedence)
-              "geforcegldriver"
           frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "glDeleteTextures_Exec"
             package (ignored because function takes precedence)
               "glengine"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            function*
+              "gldCreateDevice"
+            package (ignored because function takes precedence)
+              "geforcegldriver"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -32,7 +32,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "9c336f632f6764c0f082a6a66edbf22d"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gldCreateDevice | gpusSubmitDataBuffers | gldUpdateDispatch | gldUpdateDispatch | gleUnbindTextureObject | gleUnbindDeleteHashNamesAndObjects | glDeleteTextures_Exec | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::`anonymous namespace'::thread_proxy | _pthread_start | thread_start | boost::thread::start_thread_noexcept"
   component:
     app-depth-max*
       exception*
@@ -152,7 +152,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "9c336f632f6764c0f082a6a66edbf22d"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gldCreateDevice | gpusSubmitDataBuffers | gldUpdateDispatch | gldUpdateDispatch | gleUnbindTextureObject | gleUnbindDeleteHashNamesAndObjects | glDeleteTextures_Exec | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::`anonymous namespace'::thread_proxy | _pthread_start | thread_start | boost::thread::start_thread_noexcept"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
@@ -1,40 +1,35 @@
 ---
-created: '2021-06-23T18:06:10.936010Z'
+created: '2021-06-30T16:44:00.723051Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "a66d08de7cceeb31e6eb389b94ea6690"
+  hash: "d0c847d9bc45ca8c26389be94bd21878"
   tree_label: "std::terminate | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame*
-            function*
-              "stripped_application_code"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 app-depth-2:
-  hash: "f43890f57d10433d20cc751da38b314b"
+  hash: "93142e733eede833a5cf69b302f43941"
   tree_label: "std::terminate | stripped_application_code | std::__1::allocator_traits<T>::destroy<T> | stripped_application_code"
   component:
     app-depth-2*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "std::terminate"
-            package (ignored because function takes precedence)
-              "libc++abi.dylib"
           frame*
             function*
               "stripped_application_code"
@@ -46,6 +41,11 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -53,7 +53,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "a3681449b8f66e38697bba72bab32569"
-  tree_label: "<entire stacktrace>"
+  tree_label: "libsystem_kernel.dylib | __abort | abort | abort_message | default_terminate_handler | std::__terminate | std::terminate | std::__1::thread::~thread | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::__1::pair<T>::~pair | std::__1::pair<T>::~pair | std::__1::allocator_traits<T>::__destroy<T> | std::__1::allocator_traits<T>::destroy<T> | std::__1::__tree<T>::destroy | std::__1::__tree<T>::~__tree | std::__1::__tree<T>::~__tree | std::__1::map<T>::~map | std::__1::map<T>::~map | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | libdispatch.dylib | libdispatch.dylib | libdispatch.dylib | _pthread_wqthread | start_wqthread | libdispatch.dylib"
   component:
     app-depth-max*
       exception*
@@ -222,7 +222,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "a3681449b8f66e38697bba72bab32569"
-  tree_label: "<entire stacktrace>"
+  tree_label: "libsystem_kernel.dylib | __abort | abort | abort_message | default_terminate_handler | std::__terminate | std::terminate | std::__1::thread::~thread | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::__1::pair<T>::~pair | std::__1::pair<T>::~pair | std::__1::allocator_traits<T>::__destroy<T> | std::__1::allocator_traits<T>::destroy<T> | std::__1::__tree<T>::destroy | std::__1::__tree<T>::~__tree | std::__1::__tree<T>::~__tree | std::__1::map<T>::~map | std::__1::map<T>::~map | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | libdispatch.dylib | libdispatch.dylib | libdispatch.dylib | _pthread_wqthread | start_wqthread | libdispatch.dylib"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
@@ -1,40 +1,35 @@
 ---
-created: '2021-06-23T18:06:11.910392Z'
+created: '2021-06-30T16:44:00.381203Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "a66d08de7cceeb31e6eb389b94ea6690"
+  hash: "d0c847d9bc45ca8c26389be94bd21878"
   tree_label: "std::terminate | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame*
-            function*
-              "stripped_application_code"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
           "Fatal Error: <hex> / <hex>"
 --------------------------------------------------------------------------
 app-depth-2:
-  hash: "f43890f57d10433d20cc751da38b314b"
+  hash: "93142e733eede833a5cf69b302f43941"
   tree_label: "std::terminate | stripped_application_code | std::__1::allocator_traits<T>::destroy<T> | stripped_application_code"
   component:
     app-depth-2*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "std::terminate"
-            package (ignored because function takes precedence)
-              "libc++abi.dylib"
           frame*
             function*
               "stripped_application_code"
@@ -46,6 +41,11 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -53,7 +53,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "a3681449b8f66e38697bba72bab32569"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | abort_message | demangling_terminate_handler | std::__terminate | std::terminate | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::__1::pair<T>::~pair | std::__1::pair<T>::~pair | std::__1::allocator_traits<T>::__destroy<T> | std::__1::allocator_traits<T>::destroy<T> | std::__1::__tree<T>::destroy | std::__1::__tree<T>::destroy | std::__1::__tree<T>::~__tree | std::__1::__tree<T>::~__tree | std::__1::map<T>::~map | std::__1::map<T>::~map | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | _dispatch_client_callout | _dispatch_root_queue_drain | _dispatch_worker_thread2 | _pthread_wqthread | start_wqthread | _dispatch_root_queues_init_once"
   component:
     app-depth-max*
       exception*
@@ -235,7 +235,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "a3681449b8f66e38697bba72bab32569"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | abort_message | demangling_terminate_handler | std::__terminate | std::terminate | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::__1::pair<T>::~pair | std::__1::pair<T>::~pair | std::__1::allocator_traits<T>::__destroy<T> | std::__1::allocator_traits<T>::destroy<T> | std::__1::__tree<T>::destroy | std::__1::__tree<T>::destroy | std::__1::__tree<T>::~__tree | std::__1::__tree<T>::~__tree | std::__1::map<T>::~map | std::__1::map<T>::~map | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | _dispatch_client_callout | _dispatch_root_queue_drain | _dispatch_worker_thread2 | _pthread_wqthread | start_wqthread | _dispatch_root_queues_init_once"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-17T08:41:29.485762Z'
+created: '2021-06-30T16:44:01.257730Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__dynamic_cast | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | _pthread_start | thread_start | stripped_application_code"
   component:
     app-depth-max*
       exception*
@@ -86,7 +86,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__dynamic_cast | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | _pthread_start | thread_start | stripped_application_code"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-17T08:41:28.731631Z'
+created: '2021-06-30T16:44:00.779321Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "libc++abi.dylib | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | libsystem_pthread.dylib | libsystem_pthread.dylib | libsystem_pthread.dylib | stripped_application_code"
   component:
     app-depth-max*
       exception*
@@ -83,7 +83,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "libc++abi.dylib | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | libsystem_pthread.dylib | libsystem_pthread.dylib | libsystem_pthread.dylib | stripped_application_code"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
@@ -1,28 +1,28 @@
 ---
-created: '2021-06-23T18:06:12.095745Z'
+created: '2021-06-30T16:44:00.943761Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "83c2aa527052d0ca889ed70770032dd8"
+  hash: "f594e5549c122b83e267719d16333d98"
   tree_label: "abort | dlopen | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame*
             function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
             package (ignored because function takes precedence)
               "libdyld.dylib"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
-              "stripped_application_code"
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -30,7 +30,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "8be5979a334287a1b47457228f1d4612"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | __report_load.cold.1 | __report_load | dyld | dyld | dyld | dyld | dyld | dyld | dyld | dlopen_internal | dlopen | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | CALLING_SOME_+initialize_METHOD | initializeNonMetaClass | initializeAndMaybeRelock | lookUpImpOrForward | _objc_msgSend_uncached | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | MZ::`anonymous namespace'::lambda::operator() | std::__1::__invoke<T> | std::__1::__invoke_void_return_wrapper<T>::__call<T> | std::__1::__function::__alloc_func<T>::operator() | std::__1::__function::__func<T>::operator() | std::__1::__function::__value_func<T>::operator() | std::__1::function<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start | start"
   component:
     app-depth-max*
       exception*
@@ -261,7 +261,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | __report_load.cold.1 | __report_load | dyld | dyld | dyld | dyld | dyld | dyld | dyld | dlopen_internal | dlopen | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | CALLING_SOME_+initialize_METHOD | initializeNonMetaClass | initializeAndMaybeRelock | lookUpImpOrForward | _objc_msgSend_uncached | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | MZ::`anonymous namespace'::lambda::operator() | std::__1::__invoke<T> | std::__1::__invoke_void_return_wrapper<T>::__call<T> | std::__1::__function::__alloc_func<T>::operator() | std::__1::__function::__func<T>::operator() | std::__1::__function::__value_func<T>::operator() | std::__1::function<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start | start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
@@ -1,28 +1,28 @@
 ---
-created: '2021-06-23T18:06:12.198128Z'
+created: '2021-06-30T16:44:01.334862Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "83c2aa527052d0ca889ed70770032dd8"
+  hash: "f594e5549c122b83e267719d16333d98"
   tree_label: "abort | dlopen | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame*
             function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:load +sentinel +prefix))
             function*
               "dlopen"
             package (ignored because function takes precedence)
               "libdyld.dylib"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
-              "stripped_application_code"
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -30,7 +30,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "8be5979a334287a1b47457228f1d4612"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | __report_load | ImageLoaderMachO::doModInitFunctions | ImageLoaderMachO::doInitialization | ImageLoader::recursiveInitialization | ImageLoader::processInitializers | ImageLoader::runInitializers | dyld::runInitializers | dlopen_internal | dlopen | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | CALLING_SOME_+initialize_METHOD | initializeNonMetaClass | initializeAndMaybeRelock | lookUpImpOrForward | _objc_msgSend_uncached | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | MZ::`anonymous namespace'::lambda::operator() | std::__1::__invoke<T> | std::__1::__invoke_void_return_wrapper<T>::__call<T> | std::__1::__function::__alloc_func<T>::operator() | std::__1::__function::__func<T>::operator() | std::__1::__function::__value_func<T>::operator() | std::__1::function<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start"
   component:
     app-depth-max*
       exception*
@@ -260,7 +260,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "8be5979a334287a1b47457228f1d4612"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | __abort | abort | __report_load | ImageLoaderMachO::doModInitFunctions | ImageLoaderMachO::doInitialization | ImageLoader::recursiveInitialization | ImageLoader::processInitializers | ImageLoader::runInitializers | dyld::runInitializers | dlopen_internal | dlopen | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | CALLING_SOME_+initialize_METHOD | initializeNonMetaClass | initializeAndMaybeRelock | lookUpImpOrForward | _objc_msgSend_uncached | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | MZ::`anonymous namespace'::lambda::operator() | std::__1::__invoke<T> | std::__1::__invoke_void_return_wrapper<T>::__call<T> | std::__1::__function::__alloc_func<T>::operator() | std::__1::__function::__func<T>::operator() | std::__1::__function::__value_func<T>::operator() | std::__1::function<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2021-06-23T18:06:09.554796Z'
+created: '2021-06-30T16:44:00.207087Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "ec536565582e9952c456c552200e7885"
+  hash: "6aaea3702ff04eef387e90d3080f0659"
   tree_label: "abort | gpusSubmitDataBuffers | CGLFlushDrawable"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
-            function*
-              "gpusSubmitDataBuffers"
-            package (ignored because function takes precedence)
-              "libgpusupportmercury.dylib"
           frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLFlushDrawable"
             package (ignored because function takes precedence)
               "opengl"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -32,7 +32,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "7e64037e487c78ce0439f750a2ef503f"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | gldFlushObject | gliSetInteger | CGLDescribeRenderer | CGLTexImageIOSurface2D | stripped_application_code | stripped_application_code | -[_NSOpenGLViewBackingLayer display] | CA::Layer::display_if_needed | CA::Context::commit_transaction | CA::Transaction::commit | _NSTryRunModal | NSRunAlertPanel | stripped_application_code | stripped_application_code | stripped_application_code | _sigtramp | stripped_application_code | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | SwapFlush | gldPresentFramebufferData | glSwap_Exec | CGLFlushDrawable | -[NSOpenGLContext flushBuffer] | stripped_application_code | -[_NSOpenGLViewBackingLayer display] | -[NSView displayIfNeeded] | stripped_application_code | __NSThreadPerformPerform | __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ | __CFRunLoopDoSource0 | __CFRunLoopDoSources0 | __CFRunLoopRun | CFRunLoopRunSpecific | RunCurrentEventLoopInMode | ReceiveNextEventCommon | _BlockUntilNextEventMatchingListInModeWithFilter | _DPSNextEvent | -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] | -[NSApplication run] | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start"
   component:
     app-depth-max*
       exception*
@@ -316,7 +316,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "7e64037e487c78ce0439f750a2ef503f"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | gldFlushObject | gliSetInteger | CGLDescribeRenderer | CGLTexImageIOSurface2D | stripped_application_code | stripped_application_code | -[_NSOpenGLViewBackingLayer display] | CA::Layer::display_if_needed | CA::Context::commit_transaction | CA::Transaction::commit | _NSTryRunModal | NSRunAlertPanel | stripped_application_code | stripped_application_code | stripped_application_code | _sigtramp | stripped_application_code | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | SwapFlush | gldPresentFramebufferData | glSwap_Exec | CGLFlushDrawable | -[NSOpenGLContext flushBuffer] | stripped_application_code | -[_NSOpenGLViewBackingLayer display] | -[NSView displayIfNeeded] | stripped_application_code | __NSThreadPerformPerform | __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ | __CFRunLoopDoSource0 | __CFRunLoopDoSources0 | __CFRunLoopRun | CFRunLoopRunSpecific | RunCurrentEventLoopInMode | ReceiveNextEventCommon | _BlockUntilNextEventMatchingListInModeWithFilter | _DPSNextEvent | -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] | -[NSApplication run] | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-17T08:41:27.725745Z'
+created: '2021-06-30T16:43:59.298091Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_pthread_testcancel | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | _pthread_body | _pthread_start | thread_start | stripped_application_code"
   component:
     app-depth-max*
       exception*
@@ -70,7 +70,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "aeed765d29d1a60cb094f66d2cd8efb2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_pthread_testcancel | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | _pthread_body | _pthread_start | thread_start | stripped_application_code"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:09.678791Z'
+created: '2021-06-30T16:43:59.703871Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "989aaa994181faf8b1df77c0d7e0d85f"
+  hash: "578743178fb72882e3c4d60b1c30d225"
   tree_label: "abort | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame*
-            function*
-              "stripped_application_code"
         type (ignored because exception is synthetic)
           "0x40000015 / 0x00000001"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "28f1b76e3bcdfa5e5e1671e6a919a506"
-  tree_label: "<entire stacktrace>"
+  tree_label: "crashpad::`anonymous namespace'::HandleAbortSignal | raise | abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | RtlpTpWorkCallback | TppWorkerThread | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     app-depth-max*
       exception*
@@ -163,7 +163,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "28f1b76e3bcdfa5e5e1671e6a919a506"
-  tree_label: "<entire stacktrace>"
+  tree_label: "crashpad::`anonymous namespace'::HandleAbortSignal | raise | abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | RtlpTpWorkCallback | TppWorkerThread | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:09.439847Z'
+created: '2021-06-30T16:43:59.762089Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "989aaa994181faf8b1df77c0d7e0d85f"
+  hash: "578743178fb72882e3c4d60b1c30d225"
   tree_label: "abort | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame*
-            function*
-              "stripped_application_code"
         type (ignored because exception is synthetic)
           "0x40000015 / 0x00000001"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "8a62fbea1511325fb930366d547f0afa"
-  tree_label: "<entire stacktrace>"
+  tree_label: "crashpad::`anonymous namespace'::HandleAbortSignal | raise | abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::_Tree<T>::_Emplace | std::_Tree<T>::insert<T> | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | RtlpTpWorkCallback | TppWorkerThread | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     app-depth-max*
       exception*
@@ -163,7 +163,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "8a62fbea1511325fb930366d547f0afa"
-  tree_label: "<entire stacktrace>"
+  tree_label: "crashpad::`anonymous namespace'::HandleAbortSignal | raise | abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::_Tree<T>::_Emplace | std::_Tree<T>::insert<T> | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | RtlpTpWorkCallback | TppWorkerThread | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:08.946164Z'
+created: '2021-06-30T16:44:00.302554Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "af9d758f026c55155ef957140783a1b0"
+  hash: "2d19dfc08a0a1656533e4dc4cc4c7b40"
   tree_label: "raise | stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
           frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame*
-            function*
-              "stripped_application_code"
         type (ignored because exception is synthetic)
           "0x40000015 / 0x00000001"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "e964d1e7cfec1ffbfe73559e02f9ac1b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "crashpad::`anonymous namespace'::HandleAbortSignal | raise | abort | _purecall | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | UserCallWinProcCheckWow | DispatchMessageWorker | stripped_application_code | std::_Func_class<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::basic_string<T>::_Reallocate_for | std::basic_string<T>::assign | std::basic_string<T>::assign | std::basic_string<T>::{ctor} | wWinMain | invoke_main | stripped_application_code | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     app-depth-max*
       exception*
@@ -186,7 +186,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "e964d1e7cfec1ffbfe73559e02f9ac1b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "crashpad::`anonymous namespace'::HandleAbortSignal | raise | abort | _purecall | stripped_application_code | stripped_application_code | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | boost::function0<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | UserCallWinProcCheckWow | DispatchMessageWorker | stripped_application_code | std::_Func_class<T>::operator() | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | std::basic_string<T>::_Reallocate_for | std::basic_string<T>::assign | std::basic_string<T>::assign | std::basic_string<T>::{ctor} | wWinMain | invoke_main | stripped_application_code | BaseThreadInitThunk | RtlUserThreadStart"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.199179Z'
+created: '2021-06-30T16:44:02.387657Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -51,7 +51,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "4342cbc52b434588d500b518441bb830"
-  tree_label: "bind | bind0"
+  tree_label: "bind0 | bind"
   component:
     app-depth-2*
       chained-exception*
@@ -118,7 +118,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "797355840aa68b9aeb7416a2267456dd"
-  tree_label: "bind | bind | bind0"
+  tree_label: "bind0 | bind | bind"
   component:
     app-depth-3*
       chained-exception*
@@ -206,7 +206,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "b5cb31481ea65dffcf2f5ba853a8ae37"
-  tree_label: "bind | bind | bind | bind0"
+  tree_label: "bind0 | bind | bind | bind"
   component:
     app-depth-4*
       chained-exception*
@@ -315,7 +315,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "b4abb2ff030b1ad52cbcc34a0be98d77"
-  tree_label: "bind | bind | bind | bind | bind0"
+  tree_label: "bind0 | bind | bind | bind | bind"
   component:
     app-depth-5*
       chained-exception*
@@ -445,7 +445,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "8924849495809d42431719c2b9ab65c8"
-  tree_label: "<entire stacktrace>"
+  tree_label: "bind0 | bind | bind | bind | bind | bind | start | start | startInternal | start | addConnector | addPreviouslyRemovedConnectors | start | startEmbeddedServletContainer | finishRefresh | refresh | refresh | refresh | refreshContext | run | run | run | main"
   component:
     app-depth-max*
       chained-exception*
@@ -841,7 +841,7 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "8924849495809d42431719c2b9ab65c8"
-  tree_label: "<entire stacktrace>"
+  tree_label: "bind0 | bind | bind | bind | bind | bind | start | start | startInternal | start | addConnector | addPreviouslyRemovedConnectors | start | startEmbeddedServletContainer | finishRefresh | refresh | refresh | refresh | refreshContext | run | run | run | main"
   component:
     system*
       chained-exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.358991Z'
+created: '2021-06-30T16:43:59.513294Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "59ef3cab7ba66f62b79d29aa80090c5c"
-  tree_label: "invoke0 | home"
+  tree_label: "home | invoke0"
   component:
     app-depth-2*
       exception*
@@ -50,7 +50,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "1415060f2c35db944c439d52c620310b"
-  tree_label: "invoke | invoke0 | home"
+  tree_label: "home | invoke0 | invoke"
   component:
     app-depth-3*
       exception*
@@ -83,7 +83,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "fceae19423f2f5c139821d29c433ba4c"
-  tree_label: "invoke | invoke | invoke0 | home"
+  tree_label: "home | invoke0 | invoke | invoke"
   component:
     app-depth-4*
       exception*
@@ -123,7 +123,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "90de1f0caf1150bfdc92d957fdbb1fea"
-  tree_label: "doInvoke | invoke | invoke | invoke0 | home"
+  tree_label: "home | invoke0 | invoke | invoke | doInvoke"
   component:
     app-depth-5*
       exception*
@@ -170,7 +170,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "12f3d3df2e7804af98f4b56c602d17b0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "home | invoke0 | invoke | invoke | invoke | doInvoke | invokeForRequest | invokeAndHandle | invokeHandlerMethod | handleInternal | handle | doDispatch | doService | processRequest | doGet | service | service | service | internalDoFilter | doFilter | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | invoke | invoke | invoke | invoke | invoke | invoke | service | service | process | process | doRun | run | runWorker | run | run | run"
   component:
     app-depth-max*
       exception*
@@ -574,7 +574,7 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "12f3d3df2e7804af98f4b56c602d17b0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "home | invoke0 | invoke | invoke | invoke | doInvoke | invokeForRequest | invokeAndHandle | invokeHandlerMethod | handleInternal | handle | doDispatch | doService | processRequest | doGet | service | service | service | internalDoFilter | doFilter | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | doFilterInternal | doFilter | internalDoFilter | doFilter | invoke | invoke | invoke | invoke | invoke | invoke | service | service | process | process | doRun | run | runWorker | run | run | run"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:12.233655Z'
+created: '2021-06-30T16:44:01.425332Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "dec9099448c6b933bd8f19a81eaca1bd"
-  tree_label: "sentryWrapped | callCallback"
+  tree_label: "callCallback | sentryWrapped"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "aaae5958b3c09511bd5201fdfc436667"
-  tree_label: "invokeGuardedCallbackDev | sentryWrapped | callCallback"
+  tree_label: "callCallback | sentryWrapped | invokeGuardedCallbackDev"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "b32646fc84b4b6b67d079fbc0618820e"
-  tree_label: "invokeGuardedCallback | invokeGuardedCallbackDev | sentryWrapped | callCallback"
+  tree_label: "callCallback | sentryWrapped | invokeGuardedCallbackDev | invokeGuardedCallback"
   component:
     app-depth-4*
       exception*
@@ -103,7 +103,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "a179ca629ea4296d1a975c061b84da97"
-  tree_label: "replayUnitOfWork | invokeGuardedCallback | invokeGuardedCallbackDev | sentryWrapped | callCallback"
+  tree_label: "callCallback | sentryWrapped | invokeGuardedCallbackDev | invokeGuardedCallback | replayUnitOfWork"
   component:
     app-depth-5*
       exception*
@@ -140,7 +140,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c0f3f7d6deb17aec9d07259ac684fad0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "callCallback | sentryWrapped | invokeGuardedCallbackDev | invokeGuardedCallback | replayUnitOfWork | renderRoot | performWorkOnRoot | performWork | performSyncWork | interactiveUpdates$1 | interactiveUpdates | dispatchInteractiveEvent"
   component:
     app-depth-max*
       exception*
@@ -212,7 +212,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c0f3f7d6deb17aec9d07259ac684fad0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "callCallback | sentryWrapped | invokeGuardedCallbackDev | invokeGuardedCallback | replayUnitOfWork | renderRoot | performWorkOnRoot | performWork | performSyncWork | interactiveUpdates$1 | interactiveUpdates | dispatchInteractiveEvent"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.621956Z'
+created: '2021-06-30T16:43:59.489212Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "78acc30fe8d8e2064308f28393383e51"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "ec9def2a5325597f5b348f141b83b261"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "01b5dfbc3a7cf58591f53b2da01832da"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-4*
       exception*
@@ -101,7 +101,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "4b0afdab89c9fdf5c0ddcfa2098bd6e8"
-  tree_label: "test | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test"
   component:
     app-depth-5*
       exception*
@@ -136,7 +136,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     app-depth-max*
       exception*
@@ -194,7 +194,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.314363Z'
+created: '2021-06-30T16:44:00.562806Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "78acc30fe8d8e2064308f28393383e51"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "ec9def2a5325597f5b348f141b83b261"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "01b5dfbc3a7cf58591f53b2da01832da"
-  tree_label: "Anonymous function | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function"
   component:
     app-depth-4*
       exception*
@@ -103,7 +103,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "4b0afdab89c9fdf5c0ddcfa2098bd6e8"
-  tree_label: "test | Anonymous function | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function | test"
   component:
     app-depth-5*
       exception*
@@ -140,7 +140,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function | map | test | eval code | aha | testMethod | Anonymous function"
   component:
     app-depth-max*
       exception*
@@ -202,7 +202,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function | map | test | eval code | aha | testMethod | Anonymous function"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.602991Z'
+created: '2021-06-30T16:44:00.392467Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "78acc30fe8d8e2064308f28393383e51"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "ec9def2a5325597f5b348f141b83b261"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "01b5dfbc3a7cf58591f53b2da01832da"
-  tree_label: "test/< | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test/<"
   component:
     app-depth-4*
       exception*
@@ -103,7 +103,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "4b0afdab89c9fdf5c0ddcfa2098bd6e8"
-  tree_label: "test | test/< | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test/< | test"
   component:
     app-depth-5*
       exception*
@@ -140,7 +140,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | test/< | test | eval | aha | testMethod"
   component:
     app-depth-max*
       exception*
@@ -195,7 +195,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | test/< | test | eval | aha | testMethod"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.114714Z'
+created: '2021-06-30T16:44:02.090340Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "73facb3a45e918c97815e79d62fc43b7"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -50,7 +50,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "c10618815cb9d15b0e81ed312a98e876"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -83,7 +83,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4f469a97e68ee14eaa6d2415d0dce221"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-4*
       exception*
@@ -121,7 +121,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "39d673f040bd575e7fcc952ca42d7a86"
-  tree_label: "test | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test"
   component:
     app-depth-5*
       exception*
@@ -166,7 +166,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     app-depth-max*
       exception*
@@ -242,7 +242,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.090417Z'
+created: '2021-06-30T16:44:00.819695Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "73facb3a45e918c97815e79d62fc43b7"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -50,7 +50,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "c10618815cb9d15b0e81ed312a98e876"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -83,7 +83,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4f469a97e68ee14eaa6d2415d0dce221"
-  tree_label: "Anonymous function | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function"
   component:
     app-depth-4*
       exception*
@@ -123,7 +123,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "39d673f040bd575e7fcc952ca42d7a86"
-  tree_label: "test | Anonymous function | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function | test"
   component:
     app-depth-5*
       exception*
@@ -170,7 +170,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function | map | test | eval code | aha | testMethod | Anonymous function"
   component:
     app-depth-max*
       exception*
@@ -250,7 +250,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | Anonymous function | map | test | eval code | aha | testMethod | Anonymous function"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.434128Z'
+created: '2021-06-30T16:44:00.372623Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "73facb3a45e918c97815e79d62fc43b7"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -50,7 +50,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "c10618815cb9d15b0e81ed312a98e876"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -83,7 +83,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4f469a97e68ee14eaa6d2415d0dce221"
-  tree_label: "test/< | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test/<"
   component:
     app-depth-4*
       exception*
@@ -123,7 +123,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "39d673f040bd575e7fcc952ca42d7a86"
-  tree_label: "test | test/< | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test/< | test"
   component:
     app-depth-5*
       exception*
@@ -170,7 +170,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | test/< | test | eval | aha | testMethod"
   component:
     app-depth-max*
       exception*
@@ -243,7 +243,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | callAnotherThing | callback | test/< | test | eval | aha | testMethod"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.267734Z'
+created: '2021-06-30T16:43:59.189482Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "73facb3a45e918c97815e79d62fc43b7"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -50,7 +50,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "c10618815cb9d15b0e81ed312a98e876"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -83,7 +83,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4f469a97e68ee14eaa6d2415d0dce221"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-4*
       exception*
@@ -121,7 +121,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "39d673f040bd575e7fcc952ca42d7a86"
-  tree_label: "test | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test"
   component:
     app-depth-5*
       exception*
@@ -166,7 +166,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     app-depth-max*
       exception*
@@ -245,7 +245,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "b2602ad455472dede8e4c340d8a7eaba"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.263998Z'
+created: '2021-06-30T16:44:00.021631Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "78acc30fe8d8e2064308f28393383e51"
-  tree_label: "callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "ec9def2a5325597f5b348f141b83b261"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "01b5dfbc3a7cf58591f53b2da01832da"
-  tree_label: "callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback"
   component:
     app-depth-4*
       exception*
@@ -101,7 +101,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "4b0afdab89c9fdf5c0ddcfa2098bd6e8"
-  tree_label: "test | callback | callAnotherThing | aha"
+  tree_label: "aha | callAnotherThing | callback | test"
   component:
     app-depth-5*
       exception*
@@ -136,7 +136,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     app-depth-max*
       exception*
@@ -199,7 +199,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c63e8727af1a8fe75872b6a762797113"
-  tree_label: "<entire stacktrace>"
+  tree_label: "aha | aha | callAnotherThing | callback | map | test | eval | aha | testMethod"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.295057Z'
+created: '2021-06-30T16:44:00.498967Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -140,7 +140,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "782153e53117c0f58035c28b745f1150"
-  tree_label: "Xg | rh"
+  tree_label: "rh | Xg"
   component:
     app-depth-5*
       exception*
@@ -197,7 +197,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "d5456487ea8dccfe96c1968b19870978"
-  tree_label: "<entire stacktrace>"
+  tree_label: "rh | Xg | Yg | If | this | this"
   component:
     app-depth-max*
       exception*
@@ -371,7 +371,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "d5456487ea8dccfe96c1968b19870978"
-  tree_label: "<entire stacktrace>"
+  tree_label: "rh | Xg | Yg | If | this | this"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:12.395763Z'
+created: '2021-06-30T16:44:00.684522Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -140,7 +140,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "10d59ebf3acfdfe7057e631360f3937a"
-  tree_label: "Xg | ih"
+  tree_label: "ih | Xg"
   component:
     app-depth-5*
       exception*
@@ -197,7 +197,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
-  tree_label: "<entire stacktrace>"
+  tree_label: "ih | Xg | Yg | tag | enqueueSetState | setState | promiseReactionJob"
   component:
     app-depth-max*
       exception*
@@ -340,7 +340,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
-  tree_label: "<entire stacktrace>"
+  tree_label: "ih | Xg | Yg | tag | enqueueSetState | setState | promiseReactionJob"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.567759Z'
+created: '2021-06-30T16:44:00.867870Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "20f4e11e2c90a75e1d5c9147523669b1"
-  tree_label: "Illuminate\Routing\Route::runCallable | Illuminate\Routing\RouteFileRegistrar::{closure}"
+  tree_label: "Illuminate\Routing\RouteFileRegistrar::{closure} | Illuminate\Routing\Route::runCallable"
   component:
     app-depth-2*
       exception*
@@ -50,7 +50,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "412af8b5b341a73f526e2f9a6d4761b8"
-  tree_label: "Illuminate\Routing\Route::run | Illuminate\Routing\Route::runCallable | Illuminate\Routing\RouteFileRegistrar::{closure}"
+  tree_label: "Illuminate\Routing\RouteFileRegistrar::{closure} | Illuminate\Routing\Route::runCallable | Illuminate\Routing\Route::run"
   component:
     app-depth-3*
       exception*
@@ -83,7 +83,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "287d1bc162651ea2b799796d9b1c0da8"
-  tree_label: "Illuminate\Routing\Router::Illuminate\Routing\{closure} | Illuminate\Routing\Route::run | Illuminate\Routing\Route::runCallable | Illuminate\Routing\RouteFileRegistrar::{closure}"
+  tree_label: "Illuminate\Routing\RouteFileRegistrar::{closure} | Illuminate\Routing\Route::runCallable | Illuminate\Routing\Route::run | Illuminate\Routing\Router::Illuminate\Routing\{closure}"
   component:
     app-depth-4*
       exception*
@@ -123,7 +123,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "0eb1d26aa9a5022cec623d0ddf53173f"
-  tree_label: "Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Routing\Router::Illuminate\Routing\{closure} | Illuminate\Routing\Route::run | Illuminate\Routing\Route::runCallable | Illuminate\Routing\RouteFileRegistrar::{closure}"
+  tree_label: "Illuminate\Routing\RouteFileRegistrar::{closure} | Illuminate\Routing\Route::runCallable | Illuminate\Routing\Route::run | Illuminate\Routing\Router::Illuminate\Routing\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure}"
   component:
     app-depth-5*
       exception*
@@ -170,7 +170,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "107ed03036d901157372f260bc3df446"
-  tree_label: "<entire stacktrace>"
+  tree_label: "Illuminate\Routing\RouteFileRegistrar::{closure} | Illuminate\Routing\Route::runCallable | Illuminate\Routing\Route::run | Illuminate\Routing\Router::Illuminate\Routing\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Routing\Middleware\SubstituteBindings::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\View\Middleware\ShareErrorsFromSession::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Session\Middleware\StartSession::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Cookie\Middleware\EncryptCookies::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Pipeline\Pipeline::then | Illuminate\Routing\Router::runRouteWithinStack | Illuminate\Routing\Router::runRoute | Illuminate\Routing\Router::dispatchToRoute | Illuminate\Routing\Router::dispatch | Illuminate\Foundation\Http\Kernel::Illuminate\Foundation\Http\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Fideloper\Proxy\TrustProxies::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\TransformsRequest::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\TransformsRequest::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\ValidatePostSize::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Pipeline\Pipeline::then | Illuminate\Foundation\Http\Kernel::sendRequestThroughRouter | Illuminate\Foundation\Http\Kernel::handle | require_once"
   component:
     app-depth-max*
       exception*
@@ -530,7 +530,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "107ed03036d901157372f260bc3df446"
-  tree_label: "<entire stacktrace>"
+  tree_label: "Illuminate\Routing\RouteFileRegistrar::{closure} | Illuminate\Routing\Route::runCallable | Illuminate\Routing\Route::run | Illuminate\Routing\Router::Illuminate\Routing\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Routing\Middleware\SubstituteBindings::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\View\Middleware\ShareErrorsFromSession::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Session\Middleware\StartSession::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Cookie\Middleware\EncryptCookies::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Pipeline\Pipeline::then | Illuminate\Routing\Router::runRouteWithinStack | Illuminate\Routing\Router::runRoute | Illuminate\Routing\Router::dispatchToRoute | Illuminate\Routing\Router::dispatch | Illuminate\Foundation\Http\Kernel::Illuminate\Foundation\Http\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Fideloper\Proxy\TrustProxies::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\TransformsRequest::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\TransformsRequest::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\ValidatePostSize::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::handle | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | Illuminate\Routing\Pipeline::Illuminate\Routing\{closure} | Illuminate\Pipeline\Pipeline::then | Illuminate\Foundation\Http\Kernel::sendRequestThroughRouter | Illuminate\Foundation\Http\Kernel::handle | require_once"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.469146Z'
+created: '2021-06-30T16:44:00.576747Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -45,7 +45,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "63c67781779781d9b0a442a5b2bdb976"
-  tree_label: "run | Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure}"
+  tree_label: "Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | run"
   component:
     app-depth-3*
       exception*
@@ -76,7 +76,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "63c67781779781d9b0a442a5b2bdb976"
-  tree_label: "<entire stacktrace>"
+  tree_label: "Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | run"
   component:
     app-depth-max*
       exception*
@@ -107,7 +107,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "63c67781779781d9b0a442a5b2bdb976"
-  tree_label: "<entire stacktrace>"
+  tree_label: "Illuminate\Pipeline\Pipeline::Illuminate\Pipeline\{closure} | run"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
@@ -1,28 +1,28 @@
 ---
-created: '2021-06-23T18:06:10.071705Z'
+created: '2021-06-30T16:44:01.946666Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "54990400a84ec9035d4608470ba05b48"
+  hash: "df30c081c8ab27eecf8395e0a0ab0e5d"
   tree_label: "abort | amdradeonx5000gldriver | glTexSubImage2D"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
-            package* (used as fallback because function name is not available)
-              "amdradeonx5000gldriver"
           frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "glTexSubImage2D"
             package (ignored because function takes precedence)
               "libgl.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "amdradeonx5000gldriver"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -30,7 +30,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "0a16eff3ac6acb7f1b7926d65019e155"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | amdradeonx5000gldriver | gpusSubmitDataBuffers | amdradeonx5000gldriver | gleTextureImagePut | glTexSubImage2D_Exec | glTexSubImage2D | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ | __CFRunLoopDoSource0 | __CFRunLoopDoSources0 | __CFRunLoopRun | CFRunLoopRunSpecific | -[NSRunLoop(NSRunLoop) runMode:beforeDate:] | code | code | code | code | code | code | code | code | code | code | code | code | code | start"
   component:
     app-depth-max*
       exception*
@@ -219,7 +219,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "0a16eff3ac6acb7f1b7926d65019e155"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | amdradeonx5000gldriver | gpusSubmitDataBuffers | amdradeonx5000gldriver | gleTextureImagePut | glTexSubImage2D_Exec | glTexSubImage2D | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | code | __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ | __CFRunLoopDoSource0 | __CFRunLoopDoSources0 | __CFRunLoopRun | CFRunLoopRunSpecific | -[NSRunLoop(NSRunLoop) runMode:beforeDate:] | code | code | code | code | code | code | code | code | code | code | code | code | code | start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2021-06-23T18:06:10.721390Z'
+created: '2021-06-30T16:44:01.423340Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "3e7b3825275e7ca0fbfe8cd9a857ee01"
+  hash: "407bfa003f7687a0ef24e66384725f7c"
   tree_label: "abort | gpusSubmitDataBuffers | CGLTexImageIOSurface2D"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
-            function*
-              "gpusSubmitDataBuffers"
-            package (ignored because function takes precedence)
-              "libgpusupportmercury.dylib"
           frame* (marked as sentinel frame by stack trace rule (category:gl +sentinel))
             function*
               "CGLTexImageIOSurface2D"
             package (ignored because function takes precedence)
               "opengl"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            function*
+              "gpusSubmitDataBuffers"
+            package (ignored because function takes precedence)
+              "libgpusupportmercury.dylib"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -32,7 +32,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "36be6e0b6123ef6ecfbef62f5cb88406"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | gldFlushObject | gliSetInteger | CGLDescribeRenderer | CGLTexImageIOSurface2D | code | code | -[_NSOpenGLViewBackingLayer display] | CA::Layer::display_if_needed | CA::Context::commit_transaction | CA::Transaction::commit | _NSTryRunModal | NSRunAlertPanel | code | code | code | _sigtramp | corefoundation | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | gldFlushObject | gliSetInteger | CGLDescribeRenderer | CGLTexImageIOSurface2D | code | code | -[_NSOpenGLViewBackingLayer display] | -[NSView displayIfNeeded] | code | __NSThreadPerformPerform | corefoundation | corefoundation | corefoundation | corefoundation | corefoundation | RunCurrentEventLoopInMode | ReceiveNextEventCommon | _BlockUntilNextEventMatchingListInModeWithFilter | _DPSNextEvent | -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] | -[NSApplication run] | code | code | code | code | code | code | start | start"
   component:
     app-depth-max*
       exception*
@@ -309,7 +309,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "36be6e0b6123ef6ecfbef62f5cb88406"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__pthread_kill | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | gldFlushObject | gliSetInteger | CGLDescribeRenderer | CGLTexImageIOSurface2D | code | code | -[_NSOpenGLViewBackingLayer display] | CA::Layer::display_if_needed | CA::Context::commit_transaction | CA::Transaction::commit | _NSTryRunModal | NSRunAlertPanel | code | code | code | _sigtramp | corefoundation | abort | gpusGenerateCrashLog.cold.1 | gpusGenerateCrashLog | gpusKillClientExt | gpusSubmitDataBuffers | IntelCommandBuffer::getNew | intelSubmitCommands | gldFlushObject | gliSetInteger | CGLDescribeRenderer | CGLTexImageIOSurface2D | code | code | -[_NSOpenGLViewBackingLayer display] | -[NSView displayIfNeeded] | code | __NSThreadPerformPerform | corefoundation | corefoundation | corefoundation | corefoundation | corefoundation | RunCurrentEventLoopInMode | ReceiveNextEventCommon | _BlockUntilNextEventMatchingListInModeWithFilter | _DPSNextEvent | -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] | -[NSApplication run] | code | code | code | code | code | code | start | start"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:12.282621Z'
+created: '2021-06-30T16:44:00.307247Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "f1434ba679e6b1155a535a19738c3be2"
-  tree_label: "e | wrapTimeFunction/<"
+  tree_label: "wrapTimeFunction/< | e"
   component:
     app-depth-2*
       exception*
@@ -52,7 +52,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "27b19d035e291a5a750f2d39f0658220"
-  tree_label: "componentPromise | e | wrapTimeFunction/<"
+  tree_label: "wrapTimeFunction/< | e | componentPromise"
   component:
     app-depth-3*
       exception*
@@ -89,7 +89,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "256fdadc22b3abffcf4ec847e43615d3"
-  tree_label: "e/< | componentPromise | e | wrapTimeFunction/<"
+  tree_label: "wrapTimeFunction/< | e | componentPromise | e/<"
   component:
     app-depth-4*
       exception*
@@ -135,7 +135,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "09767cbb939dfda38a031f6ce40e6ee0"
-  tree_label: "W | e/< | componentPromise | e | wrapTimeFunction/<"
+  tree_label: "wrapTimeFunction/< | e | componentPromise | e/< | W"
   component:
     app-depth-5*
       exception*
@@ -190,7 +190,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "dcfcd48a02c100bbe4023cbc783054f0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "wrapTimeFunction/< | e | componentPromise | e/< | W | _invoke</< | g/</t[e] | n | c | exports/</< | L | exports/< | e/</a</< | e/< | W | _invoke</< | g/</t[e] | n | b | i | S/< | M"
   component:
     app-depth-max*
       exception*
@@ -398,7 +398,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "dcfcd48a02c100bbe4023cbc783054f0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "wrapTimeFunction/< | e | componentPromise | e/< | W | _invoke</< | g/</t[e] | n | c | exports/</< | L | exports/< | e/</a</< | e/< | W | _invoke</< | g/</t[e] | n | b | i | S/< | M"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.453638Z'
+created: '2021-06-30T16:44:00.454084Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
-  tree_label: "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated | Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+  tree_label: "Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     app-depth-2*
       exception*
@@ -38,7 +38,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "<lambda>::operator() | Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     app-depth-max*
       exception*
@@ -59,7 +59,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "<lambda>::operator() | Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash1.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:11.779208Z'
+created: '2021-06-30T16:44:01.202779Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "664bc3a4dacc3a650b5f327d04cc9931"
+  hash: "e0b1ea961231b18c64222df5f9dd6062"
   tree_label: "nvwgf2umx.dll | CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
-            package* (used as fallback because function name is not available)
-              "nvwgf2umx.dll"
           frame*
             function*
               "CD3D11LayeredChild<T>::LUCBeginLayerDestruction"
             package (ignored because function takes precedence)
               "d3d11.dll"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
         type (ignored because exception is synthetic (detected via exception type))
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "dace415c7739d08199fdcba4a694e255"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nvwgf2umx.dll | OpenAdapter10 | NDXGI::CDevice::DestroyDriverInstance | CContext::LUCBeginLayerDestruction | CD3D11LayeredChild<T>::LUCBeginLayerDestruction | destructor' | CUseCountedObject<T>::UCDestroy"
   component:
     app-depth-max*
       exception*
@@ -70,7 +70,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "dace415c7739d08199fdcba4a694e255"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nvwgf2umx.dll | OpenAdapter10 | NDXGI::CDevice::DestroyDriverInstance | CContext::LUCBeginLayerDestruction | CD3D11LayeredChild<T>::LUCBeginLayerDestruction | destructor' | CUseCountedObject<T>::UCDestroy"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-17T08:41:27.912069Z'
+created: '2021-06-30T16:44:02.184600Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c85e23e804b52ea4b9f290ba838e77a0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nvwgf2umx.dll | nvwgf2umx.dll | OpenAdapter10 | NDXGI::CDevice::DestroyDriverInstance | CContext::LUCBeginLayerDestruction | CUseCountedObject<T>::UCDestroy"
   component:
     app-depth-max*
       exception*
@@ -60,7 +60,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c85e23e804b52ea4b9f290ba838e77a0"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nvwgf2umx.dll | nvwgf2umx.dll | OpenAdapter10 | NDXGI::CDevice::DestroyDriverInstance | CContext::LUCBeginLayerDestruction | CUseCountedObject<T>::UCDestroy"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_driver_crash3.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:10.783983Z'
+created: '2021-06-30T16:44:00.148291Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "55bd75031734b940f930d7b67078663c"
+  hash: "99c9ddaf52b5ae7eebc8965606c28328"
   tree_label: "nvwgf2umx.dll | NOutermost::CDeviceChild::LUCBeginLayerDestruction"
   component:
     app-depth-1*
       exception*
         stacktrace*
-          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
-            package* (used as fallback because function name is not available)
-              "nvwgf2umx.dll"
           frame*
             function*
               "NOutermost::CDeviceChild::LUCBeginLayerDestruction"
             package (ignored because function takes precedence)
               "d3d11.dll"
+          frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
+            package* (used as fallback because function name is not available)
+              "nvwgf2umx.dll"
         type (ignored because exception is synthetic (detected via exception type))
           "EXCEPTION_ACCESS_VIOLATION_READ"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "f7257ec144c61a9da89b30a65eaa616e"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nvwgf2umx.dll | OpenAdapter12 | nvwgf2umx.dll | NDXGI::CDevice::DestroyDriverInstance | CContext::LUCBeginLayerDestruction | NOutermost::CDeviceChild::LUCBeginLayerDestruction | destructor' | CUseCountedObject<T>::UCDestroy"
   component:
     app-depth-max*
       exception*
@@ -73,7 +73,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "f7257ec144c61a9da89b30a65eaa616e"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nvwgf2umx.dll | OpenAdapter12 | nvwgf2umx.dll | NDXGI::CDevice::DestroyDriverInstance | CContext::LUCBeginLayerDestruction | NOutermost::CDeviceChild::LUCBeginLayerDestruction | destructor' | CUseCountedObject<T>::UCDestroy"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.861575Z'
+created: '2021-06-30T16:44:01.229928Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "8f4c7709e4af98d3c47ce3519690e6d9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "<lambda>::operator() | Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     app-depth-max*
       exception*
@@ -41,7 +41,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "8f4c7709e4af98d3c47ce3519690e6d9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "<lambda>::operator() | Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2021-06-23T18:06:11.235317Z'
+created: '2021-06-30T16:44:00.268599Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "bfa38798962f4c0a56cb787726d4a3be"
+  hash: "3ff01ce959249abecc6bc8a8f1432b0b"
   tree_label: "malloc_zone_malloc | application_frame"
   component:
     app-depth-1*
       exception*
         stacktrace*
+          frame*
+            function*
+              "application_frame"
           frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
             function*
               "malloc_zone_malloc"
             package (ignored because function takes precedence)
               "libsystem_malloc.dylib"
-          frame*
-            function*
-              "application_frame"
         type (ignored because exception is synthetic (detected via exception type))
           "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
         value (ignored because stacktrace takes precedence)
@@ -25,7 +25,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "3ff01ce959249abecc6bc8a8f1432b0b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nanov2_allocate_from_block.cold.1 | nanov2_allocate_from_block | nanov2_allocate | nanov2_malloc | malloc_zone_malloc | application_frame"
   component:
     app-depth-max*
       exception*
@@ -65,7 +65,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "3ff01ce959249abecc6bc8a8f1432b0b"
-  tree_label: "<entire stacktrace>"
+  tree_label: "nanov2_allocate_from_block.cold.1 | nanov2_allocate_from_block | nanov2_allocate | nanov2_malloc | malloc_zone_malloc | application_frame"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.063674Z'
+created: '2021-06-30T16:44:01.137819Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "8cd9c779e1522f718e9270004d2029ed"
-  tree_label: "log_demo::main | log::__private_api_log | sentry::integrations::log::Logger::log"
+  tree_label: "sentry::integrations::log::Logger::log | log::__private_api_log | log_demo::main"
   component:
     app-depth-2*
       exception*
@@ -47,7 +47,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "833d4f5b442ef5432a634e68338ee495"
-  tree_label: "std::panicking::try::do_call | log_demo::main | log::__private_api_log | sentry::integrations::log::Logger::log | sentry::hub::Hub::with_active"
+  tree_label: "sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | log_demo::main | std::panicking::try::do_call"
   component:
     app-depth-3*
       exception*
@@ -82,7 +82,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "05b386226c903021d3797c9800e3ef5d"
-  tree_label: "___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log | sentry::integrations::log::Logger::log | sentry::hub::Hub::with_active | sentry::hub::Hub::with"
+  tree_label: "sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic"
   component:
     app-depth-4*
       exception*
@@ -125,7 +125,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "5c76070b3447d5bdd0f418005d190395"
-  tree_label: "std::rt::lang_start | ___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log | sentry::integrations::log::Logger::log | sentry::hub::Hub::with_active | sentry::hub::Hub::with | sentry::hub::Hub::with_active::{{closure}}"
+  tree_label: "sentry::hub::Hub::with_active::{{closure}} | sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start"
   component:
     app-depth-5*
       exception*
@@ -178,7 +178,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "a12f03cf6be0c16305a3c6c5c69538e8"
-  tree_label: "<entire stacktrace>"
+  tree_label: "something | sentry | sentry::hub::Hub::with_active::{{closure}} | sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | std::rt::lang_start | _main"
   component:
     app-depth-max*
       exception*
@@ -254,7 +254,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "a12f03cf6be0c16305a3c6c5c69538e8"
-  tree_label: "<entire stacktrace>"
+  tree_label: "something | sentry | sentry::hub::Hub::with_active::{{closure}} | sentry::hub::Hub::with | sentry::hub::Hub::with_active | sentry::integrations::log::Logger::log | log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | std::rt::lang_start | _main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.572992Z'
+created: '2021-06-30T16:44:00.280927Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -20,7 +20,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
-  tree_label: "Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated | Scaleform::GFx::AS3::IMEManager::DispatchEvent"
+  tree_label: "Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     app-depth-2*
       exception*
@@ -38,7 +38,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "<lambda>::operator() | Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     app-depth-max*
       exception*
@@ -59,7 +59,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "9b78cced1eefcd0c655a0a3d8ce2cdd2"
-  tree_label: "<entire stacktrace>"
+  tree_label: "<lambda>::operator() | Scaleform::GFx::AS3::IMEManager::DispatchEvent | Scaleform::GFx::IME::GImeNamesManagerVista::OnActivated"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:12.310719Z'
+created: '2021-06-30T16:44:00.409631Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "8e1e6add5d343d84489b957df999f941"
-  tree_label: "`anonymous namespace'::start | `anonymous namespace'::crash"
+  tree_label: "`anonymous namespace'::crash | `anonymous namespace'::start"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "3df8bc242dfdc7460b42fa529422630f"
-  tree_label: "main | `anonymous namespace'::start | `anonymous namespace'::crash"
+  tree_label: "`anonymous namespace'::crash | `anonymous namespace'::start | main"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "3df8bc242dfdc7460b42fa529422630f"
-  tree_label: "<entire stacktrace>"
+  tree_label: "`anonymous namespace'::crash | `anonymous namespace'::start | main | invoke_main | __scrt_common_main_seh"
   component:
     app-depth-max*
       exception*
@@ -108,7 +108,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "3df8bc242dfdc7460b42fa529422630f"
-  tree_label: "<entire stacktrace>"
+  tree_label: "`anonymous namespace'::crash | `anonymous namespace'::start | main | invoke_main | __scrt_common_main_seh"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.497124Z'
+created: '2021-06-30T16:44:00.670220Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -30,7 +30,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "ecaeb0c00f2962b1e3e3f40313787711"
-  tree_label: "`anonymous namespace'::crash | `anonymous namespace'::something::nested::Foo<T>::crash"
+  tree_label: "`anonymous namespace'::something::nested::Foo<T>::crash | `anonymous namespace'::crash"
   component:
     app-depth-2*
       exception*
@@ -56,7 +56,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "d64904dcba276f8cad4f718cda9d8690"
-  tree_label: "`anonymous namespace'::start | `anonymous namespace'::crash | `anonymous namespace'::something::nested::Foo<T>::crash"
+  tree_label: "`anonymous namespace'::something::nested::Foo<T>::crash | `anonymous namespace'::crash | `anonymous namespace'::start"
   component:
     app-depth-3*
       exception*
@@ -89,7 +89,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "a07df792479c5ba46fc056236749b796"
-  tree_label: "main | `anonymous namespace'::start | `anonymous namespace'::crash | `anonymous namespace'::something::nested::Foo<T>::crash"
+  tree_label: "`anonymous namespace'::something::nested::Foo<T>::crash | `anonymous namespace'::crash | `anonymous namespace'::start | main"
   component:
     app-depth-4*
       exception*
@@ -129,7 +129,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "a07df792479c5ba46fc056236749b796"
-  tree_label: "<entire stacktrace>"
+  tree_label: "`anonymous namespace'::something::nested::Foo<T>::crash | `anonymous namespace'::crash | `anonymous namespace'::start | main"
   component:
     app-depth-max*
       exception*
@@ -169,7 +169,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "a07df792479c5ba46fc056236749b796"
-  tree_label: "<entire stacktrace>"
+  tree_label: "`anonymous namespace'::something::nested::Foo<T>::crash | `anonymous namespace'::crash | `anonymous namespace'::start | main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.741095Z'
+created: '2021-06-30T16:44:01.507032Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "d5ccedb70f6a8e9203070b7239258834"
-  tree_label: "captureException | eventFromException"
+  tree_label: "eventFromException | captureException"
   component:
     app-depth-2*
       exception*
@@ -52,7 +52,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "c35317b0e34b5148a5be409a656af7ff"
-  tree_label: "invokeClient | captureException | eventFromException"
+  tree_label: "eventFromException | captureException | invokeClient"
   component:
     app-depth-3*
       exception*
@@ -89,7 +89,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "0824915a9819f48054d20b6003199d87"
-  tree_label: "captureException | invokeClient | captureException | eventFromException"
+  tree_label: "eventFromException | captureException | invokeClient | captureException"
   component:
     app-depth-4*
       exception*
@@ -135,7 +135,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "20741a4530d240adb9910aefac03e4b1"
-  tree_label: "<anonymous> | captureException | invokeClient | captureException | eventFromException"
+  tree_label: "eventFromException | captureException | invokeClient | captureException | <anonymous>"
   component:
     app-depth-5*
       exception*
@@ -190,7 +190,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "252dc79eb5653bf822e2684d90734cb8"
-  tree_label: "<entire stacktrace>"
+  tree_label: "eventFromException | captureException | invokeClient | captureException | <anonymous> | finalReturnValue | <anonymous> | mockConstructor [as captureException] | <anonymous> | withScope"
   component:
     app-depth-max*
       exception*
@@ -288,7 +288,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "252dc79eb5653bf822e2684d90734cb8"
-  tree_label: "<entire stacktrace>"
+  tree_label: "eventFromException | captureException | invokeClient | captureException | <anonymous> | finalReturnValue | <anonymous> | mockConstructor [as captureException] | <anonymous> | withScope"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.893782Z'
+created: '2021-06-30T15:56:05.841050Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -29,7 +29,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "669cb6664e0f5fed38665da04e464f7e"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       chained-exception*
@@ -54,7 +53,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "669cb6664e0f5fed38665da04e464f7e"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       chained-exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.977109Z'
+created: '2021-06-30T16:44:00.604115Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "a5af2577d4caca8f983657c5d1919e14"
-  tree_label: "post | handle | __getitem__"
+  tree_label: "__getitem__ | handle | post"
   component:
     app-depth-2*
       exception*
@@ -65,7 +65,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "a5af2577d4caca8f983657c5d1919e14"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__getitem__ | handle | post | dispatch | dispatch | bound_func | wrapped_view | _wrapper | view | get_response"
   component:
     app-depth-max*
       exception*
@@ -167,7 +167,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "a5af2577d4caca8f983657c5d1919e14"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__getitem__ | handle | post | dispatch | dispatch | bound_func | wrapped_view | _wrapper | view | get_response"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.590793Z'
+created: '2021-06-30T16:44:00.937839Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "fffce8f5341aba04611ac9a2e2b69aec"
-  tree_label: "view | _wrapper"
+  tree_label: "_wrapper | view"
   component:
     app-depth-2*
       exception*
@@ -56,7 +56,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "90888e813b09fa25061af2883c0fb9bd"
-  tree_label: "get_response | view | _wrapper"
+  tree_label: "_wrapper | view | get_response"
   component:
     app-depth-3*
       exception*
@@ -95,7 +95,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "90888e813b09fa25061af2883c0fb9bd"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__getitem__ | handle | post | dispatch | dispatch | bound_func | wrapped_view | _wrapper | view | get_response"
   component:
     app-depth-max*
       exception*
@@ -197,7 +197,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "90888e813b09fa25061af2883c0fb9bd"
-  tree_label: "<entire stacktrace>"
+  tree_label: "__getitem__ | handle | post | dispatch | dispatch | bound_func | wrapped_view | _wrapper | view | get_response"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.413996Z'
+created: '2021-06-30T16:44:00.591611Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "133db3f366b1327dab4e661f66dfb961"
-  tree_label: "safe_execute | send_notification | raise_for_status"
+  tree_label: "raise_for_status | send_notification | safe_execute"
   component:
     app-depth-2*
       exception*
@@ -65,7 +65,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "133db3f366b1327dab4e661f66dfb961"
-  tree_label: "<entire stacktrace>"
+  tree_label: "raise_for_status | send_notification | safe_execute"
   component:
     app-depth-max*
       exception*
@@ -111,7 +111,7 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "133db3f366b1327dab4e661f66dfb961"
-  tree_label: "<entire stacktrace>"
+  tree_label: "raise_for_status | send_notification | safe_execute"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.210312Z'
+created: '2021-06-30T16:44:00.160397Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -195,7 +195,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
-  tree_label: "<entire stacktrace>"
+  tree_label: "[native code] forEach"
   component:
     app-depth-max*
       exception*
@@ -399,7 +399,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
-  tree_label: "<entire stacktrace>"
+  tree_label: "[native code] forEach"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:08.998539Z'
+created: '2021-06-30T16:44:00.514192Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,6 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "1df786c8c266506e1acb6669c8df5154"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -39,7 +38,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "1df786c8c266506e1acb6669c8df5154"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.621038Z'
+created: '2021-06-30T16:44:00.689171Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -19,7 +19,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "9840fdc749627fbfacae7e58f325326a"
-  tree_label: "recurFunc | throwError"
+  tree_label: "throwError | recurFunc"
   component:
     app-depth-2*
       stacktrace*
@@ -40,7 +40,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "e40eae807d6005ad95f045fcccaeb0a4"
-  tree_label: "recurFunc | recurFunc | throwError"
+  tree_label: "throwError | recurFunc | recurFunc"
   component:
     app-depth-3*
       stacktrace*
@@ -68,7 +68,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "3fb69ce71efee7c559762478ce1981bc"
-  tree_label: "normalFunc | recurFunc | recurFunc | throwError"
+  tree_label: "throwError | recurFunc | recurFunc | normalFunc"
   component:
     app-depth-4*
       stacktrace*
@@ -103,7 +103,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "894c3489e2ade384dc107bca6829d134"
-  tree_label: "main | normalFunc | recurFunc | recurFunc | throwError"
+  tree_label: "throwError | recurFunc | recurFunc | normalFunc | main"
   component:
     app-depth-5*
       stacktrace*
@@ -145,7 +145,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "894c3489e2ade384dc107bca6829d134"
-  tree_label: "<entire stacktrace>"
+  tree_label: "throwError | recurFunc | recurFunc | recurFunc | recurFunc | normalFunc | main"
   component:
     app-depth-max*
       stacktrace*
@@ -201,7 +201,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "894c3489e2ade384dc107bca6829d134"
-  tree_label: "<entire stacktrace>"
+  tree_label: "throwError | recurFunc | recurFunc | recurFunc | recurFunc | normalFunc | main"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.342444Z'
+created: '2021-06-30T16:44:00.633646Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,6 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "659ad79e2e70c822d30a53d7d889529e"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -39,7 +38,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.389832Z'
+created: '2021-06-30T15:56:05.663599Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,7 +14,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -24,7 +23,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "acbd18db4cc2f85cedef654fccc4a4d8"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.344715Z'
+created: '2021-06-30T16:44:00.323231Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "a6b93019b02cf028eda2609bd65d9fad"
-  tree_label: "std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call"
   component:
     app-depth-2*
       exception*
@@ -49,7 +49,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "4eb99802a070500823c05725287f0b24"
-  tree_label: "___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic"
   component:
     app-depth-3*
       exception*
@@ -79,7 +79,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4a4627b56f14924321050658c1b863ec"
-  tree_label: "std::rt::lang_start_internal | ___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal"
   component:
     app-depth-4*
       exception*
@@ -114,7 +114,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
-  tree_label: "_main | std::rt::lang_start_internal | ___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     app-depth-5*
       exception*
@@ -152,7 +152,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     app-depth-max*
       exception*
@@ -195,7 +195,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:38.945592Z'
+created: '2021-06-30T15:56:05.808197Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -16,7 +16,6 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -28,7 +27,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "cd2a9fd0cdaa8cd55ed22b101fc65882"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:12.248400Z'
+created: '2021-06-30T16:44:01.478202Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,6 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "659ad79e2e70c822d30a53d7d889529e"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -39,7 +38,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.182599Z'
+created: '2021-06-30T16:43:58.879479Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -17,7 +17,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "c5da56c71b31f34c5880d734cbc8f5bb"
-  tree_label: "c | _createDocumentViewModel"
+  tree_label: "_createDocumentViewModel | c"
   component:
     app-depth-2*
       stacktrace*
@@ -34,7 +34,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c5da56c71b31f34c5880d734cbc8f5bb"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_createDocumentViewModel | c"
   component:
     app-depth-max*
       stacktrace*
@@ -54,7 +54,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c5da56c71b31f34c5880d734cbc8f5bb"
-  tree_label: "<entire stacktrace>"
+  tree_label: "_createDocumentViewModel | c"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.924824Z'
+created: '2021-06-30T16:44:00.586407Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     app-depth-max*
       exception*
@@ -65,7 +65,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "eb87c1031dba55b67df86fb9fff59dc6"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:10.853564Z'
+created: '2021-06-30T16:44:00.405936Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "a6b93019b02cf028eda2609bd65d9fad"
-  tree_label: "std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call"
   component:
     app-depth-2*
       exception*
@@ -49,7 +49,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "4eb99802a070500823c05725287f0b24"
-  tree_label: "___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic"
   component:
     app-depth-3*
       exception*
@@ -79,7 +79,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4a4627b56f14924321050658c1b863ec"
-  tree_label: "std::rt::lang_start_internal | ___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal"
   component:
     app-depth-4*
       exception*
@@ -114,7 +114,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
-  tree_label: "_main | std::rt::lang_start_internal | ___rust_maybe_catch_panic | std::panicking::try::do_call | log_demo::main | log::__private_api_log"
+  tree_label: "log::__private_api_log | log_demo::main | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     app-depth-5*
       exception*
@@ -152,7 +152,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     app-depth-max*
       exception*
@@ -195,7 +195,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "cb57cfc73cc622c2ac1386c9ea531fb9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.600098Z'
+created: '2021-06-30T16:44:00.643235Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "f3257035573aef17e8643504abed74e6"
-  tree_label: "std::panicking::try::do_call | log_demo::main"
+  tree_label: "log_demo::main | std::panicking::try::do_call"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "dd291e7b08c871b74afbf4434db70dd3"
-  tree_label: "std::rt::lang_start_internal | std::panicking::try::do_call | log_demo::main"
+  tree_label: "log_demo::main | std::panicking::try::do_call | std::rt::lang_start_internal"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "0817e4e604fbe88c4534eff166df1db9"
-  tree_label: "_main | std::rt::lang_start_internal | std::panicking::try::do_call | log_demo::main"
+  tree_label: "log_demo::main | std::panicking::try::do_call | std::rt::lang_start_internal | _main"
   component:
     app-depth-4*
       exception*
@@ -101,7 +101,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "0817e4e604fbe88c4534eff166df1db9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     app-depth-max*
       exception*
@@ -144,7 +144,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "0817e4e604fbe88c4534eff166df1db9"
-  tree_label: "<entire stacktrace>"
+  tree_label: "log::__private_api_log | log_demo::main | std::rt::lang_start::{{closure}} | std::panicking::try::do_call | ___rust_maybe_catch_panic | std::rt::lang_start_internal | _main"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:11.927262Z'
+created: '2021-06-30T16:44:00.456639Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -26,7 +26,6 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "659ad79e2e70c822d30a53d7d889529e"
-  tree_label: "<entire stacktrace>"
   component:
     app-depth-max*
       stacktrace*
@@ -69,7 +68,6 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "659ad79e2e70c822d30a53d7d889529e"
-  tree_label: "<entire stacktrace>"
   component:
     system*
       stacktrace*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T18:04:39.887775Z'
+created: '2021-06-30T15:56:06.020809Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "1a11687556cf74559f0ae90b1c87e2fd"
-  tree_label: "<entire stacktrace>"
+  tree_label: "main"
   component:
     app-depth-max*
       threads*
@@ -31,7 +31,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "1a11687556cf74559f0ae90b1c87e2fd"
-  tree_label: "<entire stacktrace>"
+  tree_label: "main"
   component:
     system*
       threads*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-06-23T18:06:09.376908Z'
+created: '2021-06-30T16:43:59.562014Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -22,7 +22,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "2ec04cf0cdd511a30492d2ef0a2e8f57"
-  tree_label: "UnityEngine.Events.InvokableCall.Invoke () | SampleScript.ThrowNull ()"
+  tree_label: "SampleScript.ThrowNull () | UnityEngine.Events.InvokableCall.Invoke ()"
   component:
     app-depth-2*
       exception*
@@ -44,7 +44,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "cc2160edfd340d734321a9bf33eb91e3"
-  tree_label: "UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.Events.InvokableCall.Invoke () | SampleScript.ThrowNull ()"
+  tree_label: "SampleScript.ThrowNull () | UnityEngine.Events.InvokableCall.Invoke () | UnityEngine.Events.UnityEvent.Invoke ()"
   component:
     app-depth-3*
       exception*
@@ -71,7 +71,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "8b1f3b176a539129232c8cc8d94be95c"
-  tree_label: "UnityEngine.UI.Button.Press () | UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.Events.InvokableCall.Invoke () | SampleScript.ThrowNull ()"
+  tree_label: "SampleScript.ThrowNull () | UnityEngine.Events.InvokableCall.Invoke () | UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.UI.Button.Press ()"
   component:
     app-depth-4*
       exception*
@@ -103,7 +103,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "b7a54608ccd4adaa5b40fe92c155d3e0"
-  tree_label: "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) | UnityEngine.UI.Button.Press () | UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.Events.InvokableCall.Invoke () | SampleScript.ThrowNull ()"
+  tree_label: "SampleScript.ThrowNull () | UnityEngine.Events.InvokableCall.Invoke () | UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.UI.Button.Press () | UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
   component:
     app-depth-5*
       exception*
@@ -140,7 +140,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
-  tree_label: "<entire stacktrace>"
+  tree_label: "SampleScript.ThrowNull () | UnityEngine.Events.InvokableCall.Invoke () | UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.UI.Button.Press () | UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) | UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) | UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) | UnityEngine.EventSystems.EventSystem:Update()"
   component:
     app-depth-max*
       exception*
@@ -192,7 +192,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
-  tree_label: "<entire stacktrace>"
+  tree_label: "SampleScript.ThrowNull () | UnityEngine.Events.InvokableCall.Invoke () | UnityEngine.Events.UnityEvent.Invoke () | UnityEngine.UI.Button.Press () | UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) | UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) | UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) | UnityEngine.EventSystems.EventSystem:Update()"
   component:
     system*
       exception*


### PR DESCRIPTION
Fix two issues:

* In group titles, showing `<entire stacktrace>` instead of the
  actual stackframes is nondescriptive on the last layer. We now really
  do render the entire stacktrace into tree_labels. There is a concern
  with how this blows up event size due to all tree labels being
  persisted in `hierarchical_tree_labels`, however I hope that
  eventually we will be able to get rid of that property in favor of
  generating titles more dynamically. At least for now it compresses
  well.

* In group titles the order of frames was reversed if the fallback tree
  is being built. Fix that by restoring frame order to be the same as in
  the event (in non-fallback mode), and unconditionally flipping the label.

Fix [INGEST-122]
Fix [INGEST-119]

[INGEST-122]: https://getsentry.atlassian.net/browse/INGEST-122

[INGEST-119]: https://getsentry.atlassian.net/browse/INGEST-119