### PR TITLE
build(ui): Disable typescript errors from interrupting dev server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -326,6 +326,7 @@ let appConfig = {
     ...(SHOULD_FORK_TS
       ? [
           new ForkTsCheckerWebpackPlugin({
+            logger: {devServer: false},
             typescript: {
               configFile: path.resolve(__dirname, './config/tsconfig.build.json'),
               configOverwrite: {


### PR DESCRIPTION
Currently, if you have a typescript error it displays full screen and stops development. This could even be an unused import or variable. 

This is annoying when refactoring, the errors will still log to console.