### PR TITLE
fix(reprocessing2): Do not get stuck when event is unprocessable

### DIFF
--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -40,6 +40,7 @@ def reprocess_group(
     from sentry.reprocessing2 import (
         CannotReprocess,
         logger,
+        mark_event_reprocessed,
         reprocess_event,
         start_group_reprocessing,
     )
@@ -96,13 +97,19 @@ def reprocess_group(
 
                     continue
 
+            # In case of errors while kicking off reprocessing, mark the event
+            # as reprocessed such that progressbar advances and the
+            # finish_reprocessing task is still correctly spawned.
+            mark_event_reprocessed(group_id=group_id, project_id=project_id)
+
+        # In case of errors while kicking off reprocessing or if max_events has
+        # been exceeded, do the default action.
+
         if remaining_events_min_datetime is None or remaining_events_min_datetime > event.datetime:
             remaining_events_min_datetime = event.datetime
         if remaining_events_max_datetime is None or remaining_events_max_datetime < event.datetime:
             remaining_events_max_datetime = event.datetime
 
-        # In case of errors while kicking of reprocessing or if max_events has
-        # been exceeded, do the default action.
         remaining_event_ids.append(event.event_id)
 
     # len(remaining_event_ids) is upper-bounded by GROUP_REPROCESSING_CHUNK_SIZE
@@ -149,6 +156,9 @@ def handle_remaining_events(
     See doccomment in sentry.reprocessing2.
     """
 
+    from sentry import buffer
+    from sentry.models.group import Group
+
     assert remaining_events in ("delete", "keep")
 
     if remaining_events == "delete":
@@ -173,6 +183,8 @@ def handle_remaining_events(
             from_timestamp=from_timestamp,
             to_timestamp=to_timestamp,
         )
+
+        buffer.incr(Group, {"times_seen": len(event_ids)}, {"id": new_group_id})
     else:
         raise ValueError(f"Invalid value for remaining_events: {remaining_events}")
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -8,7 +8,15 @@ from sentry import eventstore
 from sentry.attachments import attachment_cache
 from sentry.event_manager import EventManager
 from sentry.eventstore.processing import event_processing_store
-from sentry.models import Activity, EventAttachment, File, Group, GroupAssignee, UserReport
+from sentry.models import (
+    Activity,
+    EventAttachment,
+    File,
+    Group,
+    GroupAssignee,
+    GroupRedirect,
+    UserReport,
+)
 from sentry.plugins.base.v2 import Plugin2
 from sentry.reprocessing2 import is_group_finished
 from sentry.tasks.reprocessing2 import reprocess_group
@@ -348,23 +356,39 @@ def test_attachments_and_userfeedback(
 
 @pytest.mark.django_db
 @pytest.mark.snuba
+@pytest.mark.parametrize("remaining_events", ["keep", "delete"])
 def test_nodestore_missing(
-    default_project,
-    reset_snuba,
-    process_and_save,
-    burst_task_runner,
-    monkeypatch,
+    default_project, reset_snuba, process_and_save, burst_task_runner, monkeypatch, remaining_events
 ):
-    event_id = process_and_save({"message": "hello world"})
+    logs = []
+    monkeypatch.setattr("sentry.reprocessing2.logger.error", logs.append)
+
+    event_id = process_and_save({"message": "hello world", "platform": "python"})
     event = eventstore.get_event_by_id(default_project.id, event_id)
+    old_group = event.group
 
     with burst_task_runner() as burst:
-        reprocess_group(default_project.id, event.group_id, max_events=1)
+        reprocess_group(
+            default_project.id, event.group_id, max_events=1, remaining_events=remaining_events
+        )
 
     burst(max_jobs=100)
 
-    new_event = eventstore.get_event_by_id(default_project.id, event_id)
-    assert not new_event.data.get("errors")
-    assert new_event.group_id != event.group_id
-
     assert is_group_finished(event.group_id)
+
+    new_event = eventstore.get_event_by_id(default_project.id, event_id)
+
+    if remaining_events == "delete":
+        assert new_event is None
+    else:
+        assert not new_event.data.get("errors")
+        assert new_event.group_id != event.group_id
+
+        assert new_event.group.times_seen == 1
+
+        assert not Group.objects.filter(id=old_group.id).exists()
+        assert (
+            GroupRedirect.objects.get(previous_group_id=old_group.id).group_id == new_event.group_id
+        )
+
+    assert logs == ["reprocessing2.reprocessing_nodestore.not_found"]


### PR DESCRIPTION
We have logic in place to deal with events that cannot be reprocessed
(treat them like remaining events), however that logic is entirely
broken, and the test that is supposed to test for the exact behavior was
broken too.

First, the logic. It did correctly emit Snuba replacements such that the
event is correctly moved into the new group. However, there was
absolutely no code for moving the progressbar. That's why it got stuck.

Second, the test. It did spawn a reprocessing task, but assumed that
simply because the event did not contain a stacktrace, it would be
unprocessable. Unfortunately the event contained platform=native, which
seems to be enough for the processing pipeline to actually create
nodestore backups and drag the event through symbolicator. Therefore the
test simply ran a full reprocessing that actually spawned
symbolicate_event, but that just did nothing because there's no
stacktrace.

Fix the test to assert for specific log messages, and add a call to
mark_event_reprocessed. Also in order to get correct times_seen the
structure had to be changed a little bit because that was broken too.

Additionally first_seen/last_seen are broken but we'll save that for
another day as people are unlikely to notice. Perhaps one day we can
refactor this such that it shares logic with unmerge for updating
group metadata.

Fix [INGEST-96]

[INGEST-96]: https://getsentry.atlassian.net/browse/INGEST-96