### PR TITLE
fix(arithmetic): Handle opening a stack with equations

### DIFF
--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -20,6 +20,7 @@ import {
   Field,
   FIELDS,
   getAggregateAlias,
+  isAggregateEquation,
   isEquation,
   isMeasurement,
   isSpanOperationBreakdownField,
@@ -250,7 +251,9 @@ export function getExpandedResults(
       // if expanding the function failed
       column === null ||
       // the new column is already present
-      fieldSet.has(column.field)
+      fieldSet.has(column.field) ||
+      // Skip aggregate equations, their functions will already be added so we just want to remove it
+      isAggregateEquation(field.field)
     ) {
       return null;
     }

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -472,6 +472,34 @@ describe('getExpandedResults()', function () {
     expect(result.query).toEqual('some_tag:value');
   });
 
+  it('removes equations on aggregates', () => {
+    const view = new EventView({
+      ...state,
+      fields: [{field: 'count()'}, {field: 'equation|count() / 2'}],
+    });
+    const result = getExpandedResults(view, {});
+    expect(result.fields).toEqual([
+      {
+        field: 'id',
+        width: -1,
+      },
+    ]);
+  });
+
+  it('keeps equations without aggregates', () => {
+    const view = new EventView({
+      ...state,
+      fields: [{field: 'count()'}, {field: 'equation|transaction.duration / 2'}],
+    });
+    const result = getExpandedResults(view, {});
+    expect(result.fields).toEqual([
+      {
+        field: 'equation|transaction.duration / 2',
+        width: -1,
+      },
+    ]);
+  });
+
   it('applies array value conditions from event data', () => {
     const view = new EventView({
       ...state,

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -475,7 +475,11 @@ describe('getExpandedResults()', function () {
   it('removes equations on aggregates', () => {
     const view = new EventView({
       ...state,
-      fields: [{field: 'count()'}, {field: 'equation|count() / 2'}],
+      fields: [
+        {field: 'count()'},
+        {field: 'equation|count() / 2'},
+        {field: 'equation|(count() - count()) + 5'},
+      ],
     });
     const result = getExpandedResults(view, {});
     expect(result.fields).toEqual([


### PR DESCRIPTION
- Because equations weren't being removed an error that the field is no
  longer selected was happening whenever you would open a stack in
  discover