### PR TITLE
fix(ui): SentryApp was not fully exported

### DIFF
--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -55,7 +55,7 @@ const SentryApp = {
   getModalPortal: require('app/utils/getModalPortal').default,
 };
 
-Object.keys(globals).forEach(name => (window[name] = globals[name]));
 globals.SentryApp = SentryApp;
+Object.keys(globals).forEach(name => (window[name] = globals[name]));
 
 export default globals;


### PR DESCRIPTION
Because of the order of operations, we were not exporting the correct `SentryApp` referenced to `window.SentryApp`. It was incorrectly assigning an empty object to `window.SentryApp`, instead of the local `SentryApp`.