### PR TITLE
fix(arithmetic): Don't intepret bracketed equations as aggregates

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -682,9 +682,9 @@ export function getMeasurementSlug(field: string): string | null {
   return null;
 }
 
-const AGGREGATE_PATTERN = /^([^\(]+)\((.*)?\)$/;
+const AGGREGATE_PATTERN = /^(\w+)\((.*)?\)$/g;
 // Identical to AGGREGATE_PATTERN, but without the $ for newline, or ^ for start of line
-const AGGREGATE_BASE = /([^\(]+)\((.*)?\)/g;
+const AGGREGATE_BASE = /(\w+)\((.*)?\)/g;
 
 export function getAggregateArg(field: string): string | null {
   // only returns the first argument if field is an aggregate

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -682,7 +682,7 @@ export function getMeasurementSlug(field: string): string | null {
   return null;
 }
 
-const AGGREGATE_PATTERN = /^(\w+)\((.*)?\)$/g;
+const AGGREGATE_PATTERN = /^(\w+)\((.*)?\)$/;
 // Identical to AGGREGATE_PATTERN, but without the $ for newline, or ^ for start of line
 const AGGREGATE_BASE = /(\w+)\((.*)?\)/g;
 

--- a/tests/js/spec/utils/discover/fields.spec.jsx
+++ b/tests/js/spec/utils/discover/fields.spec.jsx
@@ -5,6 +5,7 @@ import {
   fieldAlignment,
   generateAggregateFields,
   getAggregateAlias,
+  isAggregateEquation,
   isAggregateField,
   isMeasurement,
   measurementType,
@@ -136,6 +137,23 @@ describe('isAggregateField', function () {
     expect(isAggregateField('thing(')).toBe(false);
     expect(isAggregateField('unique_count(user)')).toBe(true);
     expect(isAggregateField('unique_count(foo.bar.is-Enterprise_42)')).toBe(true);
+  });
+});
+
+describe('isAggregateEquation', function () {
+  it('detects functions', function () {
+    expect(isAggregateEquation('equation|5 + count()')).toBe(true);
+    expect(
+      isAggregateEquation('equation|percentile(transaction.duration, 0.55) / count()')
+    ).toBe(true);
+    expect(isAggregateEquation('equation|(5 + 5) + (count() - 2)')).toBe(true);
+  });
+
+  it('detects lack of functions', function () {
+    expect(isAggregateEquation('equation|5 + 5')).toBe(false);
+    expect(isAggregateEquation('equation|(5 + 5)')).toBe(false);
+    expect(isAggregateEquation('equation|5 + (thing - other_thing)')).toBe(false);
+    expect(isAggregateEquation('equation|5+(thing-other_thing)')).toBe(false);
   });
 });
 


### PR DESCRIPTION
- The current regex interprets equations with brackets as equations,
  which means something like `(5 + 5)` looks like an aggregate when it
  really isn't
- This fixes that by checking the character before the `(` is a valid
  character for a function