### PR TITLE
feat(docs): add display description flag

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -22,6 +22,7 @@
     {
       "name": "Teams",
       "description": "Endpoints for teams",
+      "x-display-description": false,
       "externalDocs": {
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/teams/&template=api_error_template.md"
@@ -30,6 +31,7 @@
     {
       "name": "Organizations",
       "description": "Endpoints for organizations",
+      "x-display-description": false,
       "externalDocs": {
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/organizations/&template=api_error_template.md"
@@ -38,6 +40,7 @@
     {
       "name": "Projects",
       "description": "Endpoints for projects",
+      "x-display-description": false,
       "externalDocs": {
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/projects/&template=api_error_template.md"
@@ -47,6 +50,7 @@
       "name": "Events",
       "x-sidebar-name": "Events & Issues",
       "description": "Endpoints for events and issues",
+      "x-display-description": false,
       "externalDocs": {
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/events/&template=api_error_template.md"
@@ -55,6 +59,7 @@
     {
       "name": "Releases",
       "description": "Endpoints for releases",
+      "x-display-description": false,
       "externalDocs": {
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/releases/&template=api_error_template.md"
@@ -64,6 +69,7 @@
       "name": "Integration",
       "x-sidebar-name": "Integration Platform",
       "description": "Endpoints for the integration platform",
+      "x-display-description": false,
       "externalDocs": {
         "description": "Found an error? Let us know.",
         "url": "https://github.com/getsentry/sentry-docs/issues/new/?title=API%20Documentation%20Error:%20/api/integration-platform/&template=api_error_template.md"


### PR DESCRIPTION
adds a field to hide or display the top level api description -- this controls whether or not to render the "description" field on the top level api page ([eg](https://docs.sentry.io/api/events/)) . This will be used in an upcoming PR in the docs repo where we will conditionally display it. None of the existing APIs will have a description, but the one for SCIM will (forthcoming).