### PR TITLE
feat(deps): Upgrade `MiniCssExtractPlugin` webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "less-loader": "^10.0.0",
     "lodash": "^4.17.19",
     "marked": "0.7.0",
-    "mini-css-extract-plugin": "^1.3.9",
+    "mini-css-extract-plugin": "^2.0.0",
     "mobx": "^6.3.2",
     "mobx-react": "~7.2.0",
     "moment": "2.29.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10619,14 +10619,12 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
   integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
-mini-css-extract-plugin@^1.3.9:
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-1.3.9.tgz#47a32132b0fd97a119acd530e8421e8f6ab16d5e"
-  integrity sha512-Ac4s+xhVbqlyhXS5J/Vh/QXUz3ycXlCqoCPpg0vdfhsIBH9eg/It/9L1r1XhSCH737M1lqcWnMuWL13zcygn5A==
+mini-css-extract-plugin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-2.0.0.tgz#e3492a2dcd218a6103e4dec5e3a88b55157012ea"
+  integrity sha512-LzJaninAMkfVAUDldZ4lUidAeS8GD0w8tSUbZLscYXWmdTOjYuEoiIhwKvwHX6+42D2cRAl35pA9DHtvAv71JQ==
   dependencies:
-    loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-    webpack-sources "^1.1.0"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[View Changelog here](https://github.com/webpack-contrib/mini-css-extract-plugin/releases)

This allows us to move our CSS file to a subdirectory and still have it load assets with `url()` using relative paths. For frontend deploys we were planning on moving the CSS to a different output path, so this upgrade is quite timely.