### PR TITLE
chore: Remove `__core__` completely.

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -87,8 +87,15 @@ def __model_class_prepared(sender, **kwargs):
     if not issubclass(sender, BaseModel):
         return
 
-    if not hasattr(sender, "__core__") and not hasattr(sender, "__include_in_export__"):
-        raise ValueError(f"{sender!r} model has not defined __core__ or __include_in_export__")
+    if not hasattr(sender, "__include_in_export__"):
+        raise ValueError(
+            f"{sender!r} model has not defined __include_in_export__. This is used to determine "
+            f"which models we export from sentry as part of our migration workflow: \n"
+            f"https://docs.sentry.io/product/sentry-basics/guides/migration/#3-export-your-data.\n"
+            f"This should be True for core, low volume models used to configure Sentry. Things like "
+            f"Organization, Project  and related settings. It should be False for high volume models "
+            f"like Group."
+        )
 
 
 signals.pre_save.connect(__model_pre_save)

--- a/src/sentry/runner/commands/backup.py
+++ b/src/sentry/runner/commands/backup.py
@@ -135,7 +135,7 @@ def export(dest, silent, indent, exclude):
         # Collate the objects to be serialized.
         for model in sort_dependencies():
             if (
-                not getattr(model, "__include_in_export__", getattr(model, "__core__", True))
+                not getattr(model, "__include_in_export__", True)
                 or model.__name__.lower() in exclude
                 or model._meta.proxy
             ):


### PR DESCRIPTION
Now that we've updated all models to use `__include_in_export__`, we can remove code than handles
`__core__`. Also adds more detail to the error message.