### PR TITLE
fix(ui): Use sentry-loader from django static assets

### DIFF
--- a/src/sentry/templates/sentry/base-react.html
+++ b/src/sentry/templates/sentry/base-react.html
@@ -9,7 +9,7 @@
       <div class="loading-mask"></div>
 
       <div class="loading-indicator">
-        <img src="{% manifest_asset_url 'sentry' 'images/sentry-loader.svg' %}" />
+        <img src="{% asset_url 'sentry' 'images/sentry-loader.svg' %}" />
       </div>
 
       <div class="loading-message">


### PR DESCRIPTION
With the change from file-loader to the webpack asset module type, the
sentry-loader is likely being inlined in the webpack build. There's no
reason we can't use the django static image here.