### PR TITLE
feat(onpremise): Support custom CA roots in Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -110,6 +110,10 @@ RUN sentry help | sed '1,/Commands:/d' | awk '{print $1}' >  /sentry-commands.tx
 COPY ./docker/sentry.conf.py ./docker/config.yml $SENTRY_CONF/
 COPY ./docker/docker-entrypoint.sh /
 
+ENV DEFAULT_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV REQUESTS_CA_BUNDLE=$DEFAULT_CA_BUNDLE \
+    GRPC_DEFAULT_SSL_ROOTS_FILE_PATH_ENV_VAR=$DEFAULT_CA_BUNDLE
+
 EXPOSE 9000
 VOLUME /data
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ "$(ls -A /usr/local/share/ca-certificates/)" ]; then
+  update-ca-certificates
+fi
+
 # first check if we're passing flags, if so
 # prepend with sentry
 if [ "${1:0:1}" = '-' ]; then

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -3,7 +3,10 @@
 set -e
 
 if [ "$(ls -A /usr/local/share/ca-certificates/)" ]; then
+  echo "Found custom ca certificates, loading ..."
   update-ca-certificates
+else
+  echo "No custom ca certificates, skipping ..."
 fi
 
 # first check if we're passing flags, if so


### PR DESCRIPTION
Trigger updating the system CA roots if there are local certificates,
and add env vars to override some bundled CA roots.

Result of poking and prodding from getsentry/sentry#26851
~~Required for getsentry/onpremise#1015~~