### PR TITLE
fix(grouping): Add exception type to hierarchical title

### DIFF
--- a/src/sentry/api/endpoints/grouping_level_new_issues.py
+++ b/src/sentry/api/endpoints/grouping_level_new_issues.py
@@ -11,8 +11,8 @@ from sentry.api.endpoints.group_hashes_split import _get_group_filters
 from sentry.api.endpoints.grouping_levels import LevelsOverview, check_feature, get_levels_overview
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, serialize
+from sentry.event_manager import get_event_type
 from sentry.eventstore.models import Event
-from sentry.eventtypes.error import format_title_from_tree_label
 from sentry.models import Group
 from sentry.utils import snuba
 from sentry.utils.safe import get_path
@@ -205,10 +205,12 @@ def _process_snuba_results(query_res, group: Group, id: int, user):
             tree_label = get_path(event_data, "hierarchical_tree_labels", id)
 
             # Rough approximation of what happens with Group title
-            response_item["title"] = (
-                tree_label and format_title_from_tree_label(tree_label) or event.title
-            )
-            response_item["metadata"] = {"current_tree_label": tree_label}
+            event_type = get_event_type(event.data)
+            metadata = dict(event.get_event_metadata())
+            metadata["current_tree_label"] = tree_label
+            title = event_type.get_title(metadata)
+            response_item["title"] = title or event.title
+            response_item["metadata"] = metadata
 
         response.append(response_item)
 

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -77,8 +77,4 @@ class DefaultEvent(BaseEvent):
         else:
             title = "<unlabeled event>"
 
-        return {"message_title": title}
-
-    def compute_title(self, metadata):
-        title: Optional[str] = metadata.get("message_title")
-        return compute_title_with_tree_label(title, metadata)
+        return {"title": title}

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -384,6 +384,7 @@ export type EventMetadata = {
   function?: string;
   stripped_crash?: boolean;
   current_tree_label?: string[];
+  finest_tree_label?: string[];
 };
 
 export type EventAttachment = {

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -1,4 +1,4 @@
-import {BaseGroup, GroupTombstone, Organization} from 'app/types';
+import {BaseGroup, EventMetadata, GroupTombstone, Organization} from 'app/types';
 import {Event} from 'app/types/event';
 import {isNativePlatform} from 'app/utils/platform';
 
@@ -31,6 +31,25 @@ export function getMessage(
   }
 }
 
+function formatTreeLabel(treeLabel: string[]) {
+  return treeLabel.join(' | ');
+}
+
+function computeTitleWithTreeLabel(title: string | undefined, metadata: EventMetadata) {
+  const treeLabel = metadata.current_tree_label || metadata.finest_tree_label;
+  const formattedTreeLabel = treeLabel ? formatTreeLabel(treeLabel) : null;
+
+  if (!title) {
+    return formattedTreeLabel || metadata.function || '<unknown>';
+  }
+
+  if (formattedTreeLabel) {
+    title += ' | ' + formattedTreeLabel;
+  }
+
+  return title;
+}
+
 /**
  * Get the location from an event.
  */
@@ -61,13 +80,7 @@ export function getTitle(
 
   if (type === 'error') {
     result.subtitle = culprit;
-    if (metadata.current_tree_label) {
-      result.title = metadata.current_tree_label.join(' | ');
-    } else if (metadata.type) {
-      result.title = metadata.type;
-    } else {
-      result.title = metadata.function || '<unknown>';
-    }
+    result.title = computeTitleWithTreeLabel(metadata.type, metadata);
   } else if (type === 'csp') {
     result.title = metadata.directive || '';
     result.subtitle = metadata.uri || '';

--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -213,13 +213,12 @@ level 2*
 @pytest.mark.django_db
 @pytest.mark.snuba
 def test_default_events(default_project, store_stacktrace, reset_snuba, _render_all_previews):
-
+    # Would like to add tree labels to default event titles as well,
+    # But leave as is for now.
     event = store_stacktrace(["bar", "foo"], interface="threads", type="default")
-    # Could use tree label only instead of "unlabeled event", but let's not
-    # touch this right now
-    assert event.title == "<unlabeled event> | foo | bar"
+    assert event.title == "<unlabeled event>"
 
     event = store_stacktrace(
         ["bar", "foo"], interface="threads", type="default", extra_event_data={"message": "hello"}
     )
-    assert event.title == "hello | foo | bar"
+    assert event.title == "hello"

--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -23,14 +23,14 @@ def store_stacktrace(default_project, factories):
 
     timestamp = time.time() - 3600
 
-    def inner(functions):
+    def inner(functions, interface="exception", type="error", extra_event_data=None):
         nonlocal timestamp
 
         timestamp += 1
 
         event = {
             "timestamp": timestamp,
-            "exception": {
+            interface: {
                 "values": [
                     {
                         "type": "ZeroDivisionError",
@@ -38,6 +38,8 @@ def store_stacktrace(default_project, factories):
                     }
                 ]
             },
+            "type": type,
+            **(extra_event_data or {}),
         }
 
         return factories.store_event(data=event, project_id=default_project.id)
@@ -112,10 +114,10 @@ def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_p
     ]
 
     assert [e.title for e in events] == [
-        "foo | bar2 | baz2 | bam",
-        "foo | bar | baz",
-        "foo | bar2 | baz2",
-        "foo | bar3",
+        "ZeroDivisionError | foo | bar2 | baz2 | bam",
+        "ZeroDivisionError | foo | bar | baz",
+        "ZeroDivisionError | foo | bar2 | baz2",
+        "ZeroDivisionError | foo | bar3",
     ]
 
     assert len({e.group_id for e in events}) == 1
@@ -124,22 +126,22 @@ def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_p
     assert (
         _render_all_previews(group)
         == """\
-group: foo
+group: ZeroDivisionError | foo
 level 0*
-bab925683e73afdb4dc4047397a7b36b: foo (4)
+bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (4)
 level 1
-64686dcd59e0cf97f34113e9d360541a: foo | bar3 (1)
-c8ef2dd3dedeed29b4b74b9c579eea1a: foo | bar2 (2)
-aa1c4037371150958f9ea22adb110bbc: foo | bar (1)
+64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
+c8ef2dd3dedeed29b4b74b9c579eea1a: ZeroDivisionError | foo | bar2 (2)
+aa1c4037371150958f9ea22adb110bbc: ZeroDivisionError | foo | bar (1)
 level 2
-64686dcd59e0cf97f34113e9d360541a: foo | bar3 (1)
-8c0bbfebc194c7aa3e77e95436fd61e5: foo | bar2 | baz2 (2)
-b8d08a573c62ca8c84de14c12c0e19fe: foo | bar | baz (1)
+64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
+8c0bbfebc194c7aa3e77e95436fd61e5: ZeroDivisionError | foo | bar2 | baz2 (2)
+b8d08a573c62ca8c84de14c12c0e19fe: ZeroDivisionError | foo | bar | baz (1)
 level 3
-64686dcd59e0cf97f34113e9d360541a: foo | bar3 (1)
-8c0bbfebc194c7aa3e77e95436fd61e5: foo | bar2 | baz2 (1)
-b8d08a573c62ca8c84de14c12c0e19fe: foo | bar | baz (1)
-b0505d7461a2e36c4a8235bb6c310a3b: foo | bar2 | baz2 | bam (1)\
+64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
+8c0bbfebc194c7aa3e77e95436fd61e5: ZeroDivisionError | foo | bar2 | baz2 (1)
+b8d08a573c62ca8c84de14c12c0e19fe: ZeroDivisionError | foo | bar | baz (1)
+b0505d7461a2e36c4a8235bb6c310a3b: ZeroDivisionError | foo | bar2 | baz2 | bam (1)\
 """
     )
 
@@ -172,37 +174,52 @@ def test_upwards(default_project, store_stacktrace, reset_snuba, _render_all_pre
     assert (
         _render_all_previews(events[0].group)
         == """\
-group: foo | bar2 | baz
+group: ZeroDivisionError | foo | bar2 | baz
 level 0
-bab925683e73afdb4dc4047397a7b36b: foo (3)
+bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
-c8ef2dd3dedeed29b4b74b9c579eea1a: foo | bar2 (1)
+c8ef2dd3dedeed29b4b74b9c579eea1a: ZeroDivisionError | foo | bar2 (1)
 level 2*
-7411b56aa6591edbdba71898d3a9f01c: foo | bar2 | baz (1)\
+7411b56aa6591edbdba71898d3a9f01c: ZeroDivisionError | foo | bar2 | baz (1)\
 """
     )
     assert (
         _render_all_previews(events[1].group)
         == """\
-group: foo | bar | baz
+group: ZeroDivisionError | foo | bar | baz
 level 0
-bab925683e73afdb4dc4047397a7b36b: foo (3)
+bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
-aa1c4037371150958f9ea22adb110bbc: foo | bar (2)
+aa1c4037371150958f9ea22adb110bbc: ZeroDivisionError | foo | bar (2)
 level 2*
-b8d08a573c62ca8c84de14c12c0e19fe: foo | bar | baz (1)\
+b8d08a573c62ca8c84de14c12c0e19fe: ZeroDivisionError | foo | bar | baz (1)\
 """
     )
 
     assert (
         _render_all_previews(events[2].group)
         == """\
-group: foo | bar | bam
+group: ZeroDivisionError | foo | bar | bam
 level 0
-bab925683e73afdb4dc4047397a7b36b: foo (3)
+bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
-aa1c4037371150958f9ea22adb110bbc: foo | bar (2)
+aa1c4037371150958f9ea22adb110bbc: ZeroDivisionError | foo | bar (2)
 level 2*
-97df6b60ec530c65ab227585143a087a: foo | bar | bam (1)\
+97df6b60ec530c65ab227585143a087a: ZeroDivisionError | foo | bar | bam (1)\
 """
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.snuba
+def test_default_events(default_project, store_stacktrace, reset_snuba, _render_all_previews):
+
+    event = store_stacktrace(["bar", "foo"], interface="threads", type="default")
+    # Could use tree label only instead of "unlabeled event", but let's not
+    # touch this right now
+    assert event.title == "<unlabeled event> | foo | bar"
+
+    event = store_stacktrace(
+        ["bar", "foo"], interface="threads", type="default", extra_event_data={"message": "hello"}
+    )
+    assert event.title == "hello | foo | bar"

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -1,6 +1,6 @@
 import pytest
 
-from sentry.eventtypes.error import format_title_from_tree_label
+from sentry.eventtypes.base import format_title_from_tree_label
 from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.configurations import CONFIGURATIONS


### PR DESCRIPTION
For non-synthetic exceptions, prefix tree labels with the original title.

See https://github.com/getsentry/sentry/pull/26740