### PR TITLE
ref(whats-new): Add extra javascript update info

### DIFF
--- a/static/app/components/events/sdkUpdates/index.tsx
+++ b/static/app/components/events/sdkUpdates/index.tsx
@@ -26,7 +26,10 @@ const SdkUpdates = ({event}: Props) => {
         <Alert key={index} type="info" icon={<IconUpgrade />}>
           {tct('We recommend you [suggestion] ', {suggestion})}
           {sdkUpdate.type === 'updateSdk' &&
-            t('(All sentry packages should be updated and their versions should match)')}
+            sdkUpdate.sdkName.startsWith('sentry.javascript') &&
+            t(
+              '(Make sure all sentry.javascript.* packages are updated and their versions match)'
+            )}
         </Alert>
       );
     })

--- a/static/app/components/events/sdkUpdates/index.tsx
+++ b/static/app/components/events/sdkUpdates/index.tsx
@@ -1,7 +1,10 @@
+import styled from '@emotion/styled';
+
 import Alert from 'app/components/alert';
 import EventDataSection from 'app/components/events/eventDataSection';
 import {IconUpgrade} from 'app/icons';
 import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
 import {Event} from 'app/types/event';
 import getSdkUpdateSuggestion from 'app/utils/getSdkUpdateSuggestion';
 
@@ -22,14 +25,20 @@ const SdkUpdates = ({event}: Props) => {
         return null;
       }
 
+      const isSdkJavascript =
+        sdkUpdate.type === 'updateSdk' &&
+        sdkUpdate.sdkName.startsWith('sentry.javascript');
+
       return (
         <Alert key={index} type="info" icon={<IconUpgrade />}>
-          {tct('We recommend you [suggestion] ', {suggestion})}
-          {sdkUpdate.type === 'updateSdk' &&
-            sdkUpdate.sdkName.startsWith('sentry.javascript') &&
-            t(
-              '(Make sure all sentry.javascript.* packages are updated and their versions match)'
-            )}
+          {tct('We recommend you [suggestion]', {suggestion})}
+          {isSdkJavascript && (
+            <JavascriptInfo>
+              {t(
+                'Make sure all sentry.javascript.* packages are updated and their versions match'
+              )}
+            </JavascriptInfo>
+          )}
         </Alert>
       );
     })
@@ -47,3 +56,8 @@ const SdkUpdates = ({event}: Props) => {
 };
 
 export default SdkUpdates;
+
+const JavascriptInfo = styled('div')`
+  margin-top: ${space(1)};
+  text-decoration: underline;
+`;

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -88,6 +88,7 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
                               },
                               suggestion,
                               shortStyle: true,
+                              capitalized: true,
                             })}
                           </ListItem>
                         ))}

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 import groupBy from 'lodash/groupBy';
 
+import Alert from 'app/components/alert';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
+import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Project, ProjectSdkUpdates, SDKUpdatesSuggestion} from 'app/types';
@@ -39,6 +41,10 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
   // Group SDK updates by project
   const items = Object.entries(groupBy(sdkUpdates, 'projectId'));
 
+  const haveSdkUpdatesJavascriptPackage = sdkUpdates.find(sdkUpdate =>
+    sdkUpdate.sdkName.startsWith('sentry.javascript')
+  );
+
   return (
     <SidebarPanelItem
       hasSeen
@@ -47,6 +53,13 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
         'We recommend updating the following SDKs to make sure you’re getting all the data you need.'
       )}
     >
+      {haveSdkUpdatesJavascriptPackage && (
+        <StyledAlert type="warning" icon={<IconWarning />}>
+          {t(
+            'Make sure all sentry.javascript.* packages are updated and their versions match'
+          )}
+        </StyledAlert>
+      )}
       <UpdatesList>
         <Collapsible>
           {items.map(([projectId, updates]) => {
@@ -118,6 +131,11 @@ const SdkName = styled('div')`
 
 const SdkOutdatedVersion = styled('span')`
   color: ${p => p.theme.subText};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-top: ${space(2)};
+  margin-bottom: 0;
 `;
 
 export default withSdkUpdates(withProjects(BroadcastSdkUpdates));

--- a/static/app/utils/getSdkUpdateSuggestion.tsx
+++ b/static/app/utils/getSdkUpdateSuggestion.tsx
@@ -10,24 +10,35 @@ type Props = {
   sdk: Event['sdk'];
   suggestion: NonNullable<Event['sdkUpdates']>[0];
   shortStyle?: boolean;
+  capitalized?: boolean;
 };
 
-function getSdkUpdateSuggestion({sdk, suggestion, shortStyle = false}: Props) {
+function getSdkUpdateSuggestion({
+  sdk,
+  suggestion,
+  shortStyle = false,
+  capitalized = false,
+}: Props) {
   const getTitleData = () => {
     switch (suggestion.type) {
-      case 'updateSdk':
+      case 'updateSdk': {
+        const updateWord = capitalized ? t('Update') : t('update');
         return {
           href: suggestion?.sdkUrl,
           content: sdk
             ? shortStyle
-              ? t('Update to @v%s', suggestion.newSdkVersion)
-              : t(
-                  'Update your SDK from @v%s to @v%s',
-                  sdk.version,
-                  suggestion.newSdkVersion
-                )
-            : t('Update your SDK version'),
+              ? tct('[updateWord] to @v[new-sdk-version]', {
+                  updateWord,
+                  ['new-sdk-version']: suggestion.newSdkVersion,
+                })
+              : tct('[updateWord] your SDK from @v[sdk-version] to @v[new-sdk-version]', {
+                  updateWord,
+                  ['sdk-version']: sdk.version,
+                  ['new-sdk-version']: suggestion.newSdkVersion,
+                })
+            : tct('[updateWord] your SDK version', {updateWord}),
         };
+      }
       case 'changeSdk':
         return {
           href: suggestion?.sdkUrl,


### PR DESCRIPTION
Adds an extra message to the `sdks update alerts`, warning the users that all sentry `javascript` packages should also be updated and their versions should match.

This alert is being added based on the feedback received in the PR https://github.com/getsentry/sentry-javascript/issues/3223

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/124132448-20271280-da81-11eb-85d2-ad3af59f1344.png)


![image](https://user-images.githubusercontent.com/29228205/124157167-c3375680-da98-11eb-8c3a-dd1863fb0a5e.png)


Fixed minor copy issue introduced in the PR: https://github.com/getsentry/sentry/pull/27046

**Before:**

![image](https://user-images.githubusercontent.com/29228205/124157656-4b1d6080-da99-11eb-9245-724ba06083a5.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/124157705-5a9ca980-da99-11eb-8772-69a6a425ec02.png)
