### PR TITLE
feat(ui): Add release comparison chart

### DIFF
--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2089,6 +2089,13 @@ export enum SessionField {
   USERS = 'count_unique(user)',
 }
 
+export enum ReleaseComparisonChartType {
+  CRASH_FREE_USERS = 'crashFreeUsers',
+  CRASH_FREE_SESSIONS = 'crashFreeSessions',
+  SESSION_COUNT = 'sessionCount',
+  USER_COUNT = 'userCount',
+}
+
 export enum HealthStatsPeriodOption {
   AUTO = 'auto',
   TWENTY_FOUR_HOURS = '24h',

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -1,3 +1,5 @@
+import compact from 'lodash/compact';
+
 import {
   DateTimeObject,
   getDiffInMinutes,
@@ -41,29 +43,33 @@ export function getCrashFreeSeries(
   intervals: SessionApiResponse['intervals'] = [],
   field: SessionField
 ): SeriesDataUnit[] {
-  return intervals.map((interval, i) => {
-    const intervalTotalSessions = groups.reduce(
-      (acc, group) => acc + group.series[field][i],
-      0
-    );
+  return compact(
+    intervals.map((interval, i) => {
+      const intervalTotalSessions = groups.reduce(
+        (acc, group) => acc + group.series[field][i],
+        0
+      );
 
-    const intervalCrashedSessions =
-      groups.find(group => group.by['session.status'] === 'crashed')?.series[field][i] ??
-      0;
+      const intervalCrashedSessions =
+        groups.find(group => group.by['session.status'] === 'crashed')?.series[field][
+          i
+        ] ?? 0;
 
-    const crashedSessionsPercent = percent(
-      intervalCrashedSessions,
-      intervalTotalSessions
-    );
+      const crashedSessionsPercent = percent(
+        intervalCrashedSessions,
+        intervalTotalSessions
+      );
 
-    return {
-      name: interval,
-      value:
-        intervalTotalSessions === 0
-          ? (null as any)
-          : getCrashFreePercent(100 - crashedSessionsPercent),
-    };
-  });
+      if (intervalTotalSessions === 0) {
+        return null;
+      }
+
+      return {
+        name: interval,
+        value: getCrashFreePercent(100 - crashedSessionsPercent),
+      };
+    })
+  );
 }
 
 type GetSessionsIntervalOptions = {

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -1,5 +1,9 @@
-// import moment from 'moment';
-
+import {
+  DateTimeObject,
+  getDiffInMinutes,
+  ONE_WEEK,
+  TWO_WEEKS,
+} from 'app/components/charts/utils';
 import {SessionApiResponse, SessionField} from 'app/types';
 import {SeriesDataUnit} from 'app/types/echarts';
 import {defined, percent} from 'app/utils';
@@ -60,4 +64,33 @@ export function getCrashFreeSeries(
           : getCrashFreePercent(100 - crashedSessionsPercent),
     };
   });
+}
+
+type GetSessionsIntervalOptions = {
+  highFidelity?: boolean;
+};
+
+export function getSessionsInterval(
+  datetimeObj: DateTimeObject,
+  {highFidelity}: GetSessionsIntervalOptions = {}
+) {
+  const diffInMinutes = getDiffInMinutes(datetimeObj);
+
+  if (diffInMinutes > TWO_WEEKS) {
+    return '1d';
+  }
+  if (diffInMinutes > ONE_WEEK) {
+    return '6h';
+  }
+
+  // limit on backend for sub-hour session resolution is set to six hours
+  if (highFidelity && diffInMinutes < 360) {
+    if (diffInMinutes <= 30) {
+      return '1m';
+    }
+
+    return '5m';
+  }
+
+  return '1h';
 }

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -422,7 +422,7 @@ class ReleaseOverview extends AsyncView<Props> {
               version={version}
               releaseBounds={releaseBounds}
             >
-              {({thisRelease, allReleases}) => (
+              {({thisRelease, allReleases, loading, reloading, errored}) => (
                 <Body>
                   <Main>
                     {isReleaseArchived(release) && (
@@ -467,6 +467,9 @@ class ReleaseOverview extends AsyncView<Props> {
                               allSessions={allReleases}
                               platform={project.platform}
                               location={location}
+                              loading={loading}
+                              reloading={reloading}
+                              errored={errored}
                             />
                           </Fragment>
                         ) : (

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -441,6 +441,7 @@ class ReleaseOverview extends AsyncView<Props> {
                               end={end ?? null}
                               utc={utc ?? null}
                               onUpdate={this.handleDateChange}
+                              showAbsolute={false}
                               relativeOptions={{
                                 [RELEASE_PERIOD_KEY]: (
                                   <Fragment>
@@ -464,6 +465,7 @@ class ReleaseOverview extends AsyncView<Props> {
                             <ReleaseComparisonChart
                               releaseSessions={thisRelease}
                               allSessions={allReleases}
+                              platform={project.platform}
                             />
                           </Fragment>
                         ) : (

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -466,6 +466,7 @@ class ReleaseOverview extends AsyncView<Props> {
                               releaseSessions={thisRelease}
                               allSessions={allReleases}
                               platform={project.platform}
+                              location={location}
                             />
                           </Fragment>
                         ) : (

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -177,6 +177,7 @@ function ReleaseComparisonChart({
           series: [
             {
               seriesName: t('This Release'),
+              connectNulls: true,
               data: getCrashFreeSeries(
                 releaseSessions?.groups,
                 releaseSessions?.intervals,
@@ -200,6 +201,7 @@ function ReleaseComparisonChart({
           series: [
             {
               seriesName: t('This Release'),
+              connectNulls: true,
               data: getCrashFreeSeries(
                 releaseSessions?.groups,
                 releaseSessions?.intervals,

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -1,5 +1,7 @@
-import {Fragment, useState} from 'react';
+import {Fragment} from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 import round from 'lodash/round';
 
 import {ChartContainer} from 'app/components/charts/styles';
@@ -14,6 +16,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {ReleaseComparisonChartType, SessionApiResponse, SessionField} from 'app/types';
 import {defined, percent} from 'app/utils';
+import {decodeScalar} from 'app/utils/queryString';
 import {getCount, getCrashFreeRate, getCrashFreeSeries} from 'app/utils/sessions';
 import {Color} from 'app/utils/theme';
 import {displayCrashFreePercent} from 'app/views/releases/utils';
@@ -39,12 +42,19 @@ type Props = {
   releaseSessions: SessionApiResponse | null;
   allSessions: SessionApiResponse | null;
   platform: PlatformKey;
+  location: Location;
 };
 
-function ReleaseComparisonChart({releaseSessions, allSessions, platform}: Props) {
-  const [activeChart, setActiveChart] = useState(
+function ReleaseComparisonChart({
+  releaseSessions,
+  allSessions,
+  platform,
+  location,
+}: Props) {
+  const activeChart = decodeScalar(
+    location.query.chart,
     ReleaseComparisonChartType.CRASH_FREE_SESSIONS
-  );
+  ) as ReleaseComparisonChartType;
 
   const releaseCrashFreeSessions = getCrashFreeRate(
     releaseSessions?.groups,
@@ -235,6 +245,16 @@ function ReleaseComparisonChart({releaseSessions, allSessions, platform}: Props)
     }
   }
 
+  function handleChartChange(chartType: ReleaseComparisonChartType) {
+    browserHistory.push({
+      ...location,
+      query: {
+        ...location.query,
+        chart: chartType,
+      },
+    });
+  }
+
   const {series, previousSeries} = getSeries(activeChart);
 
   return (
@@ -275,7 +295,7 @@ function ReleaseComparisonChart({releaseSessions, allSessions, platform}: Props)
                       id={type}
                       disabled={false}
                       checked={type === activeChart}
-                      onChange={() => setActiveChart(type)}
+                      onChange={() => handleChartChange(type)}
                     />
                     {releaseComparisonChartLabels[type]}
                   </ChartToggle>

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import {withTheme} from '@emotion/react';
+
+import AreaChart from 'app/components/charts/areaChart';
+import LineChart from 'app/components/charts/lineChart';
+import StackedAreaChart from 'app/components/charts/stackedAreaChart';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
+import {PlatformKey} from 'app/data/platformCategories';
+import {ReleaseComparisonChartType} from 'app/types';
+import {Series} from 'app/types/echarts';
+import {defined} from 'app/utils';
+import {Theme} from 'app/utils/theme';
+import {displayCrashFreePercent} from 'app/views/releases/utils';
+
+import {
+  getSessionTermDescription,
+  SessionTerm,
+  sessionTerm,
+} from '../../../utils/sessionTerm';
+import {releaseComparisonChartHelp, releaseComparisonChartLabels} from '../../utils';
+
+type Props = {
+  theme: Theme;
+  series: Series[];
+  previousSeries: Series[];
+  chartType: ReleaseComparisonChartType;
+  platform: PlatformKey;
+};
+
+class SessionsChart extends React.Component<Props> {
+  formatTooltipValue = (value: string | number | null) => {
+    const {chartType} = this.props;
+    if (value === null) {
+      return '\u2015';
+    }
+
+    switch (chartType) {
+      case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:
+      case ReleaseComparisonChartType.CRASH_FREE_USERS:
+        return defined(value) ? `${value}%` : '\u2015';
+      case ReleaseComparisonChartType.SESSION_COUNT:
+      case ReleaseComparisonChartType.USER_COUNT:
+      default:
+        return typeof value === 'number' ? value.toLocaleString() : value;
+    }
+  };
+
+  configureYAxis() {
+    const {theme, chartType} = this.props;
+    switch (chartType) {
+      case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:
+      case ReleaseComparisonChartType.CRASH_FREE_USERS:
+        return {
+          max: 100,
+          scale: true,
+          axisLabel: {
+            formatter: (value: number) => displayCrashFreePercent(value),
+            color: theme.chartLabel,
+          },
+        };
+      case ReleaseComparisonChartType.SESSION_COUNT:
+      case ReleaseComparisonChartType.USER_COUNT:
+      default:
+        return undefined;
+    }
+  }
+
+  getChart():
+    | React.ComponentType<StackedAreaChart['props']>
+    | React.ComponentType<AreaChart['props']>
+    | React.ComponentType<LineChart['props']> {
+    const {chartType} = this.props;
+    switch (chartType) {
+      case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:
+      case ReleaseComparisonChartType.CRASH_FREE_USERS:
+      default:
+        return AreaChart;
+      case ReleaseComparisonChartType.SESSION_COUNT:
+      case ReleaseComparisonChartType.USER_COUNT:
+        return StackedAreaChart;
+    }
+  }
+
+  getLegendTooltipDescription(serieName: string) {
+    const {platform} = this.props;
+
+    switch (serieName) {
+      case sessionTerm.crashed:
+        return getSessionTermDescription(SessionTerm.CRASHED, platform);
+      case sessionTerm.abnormal:
+        return getSessionTermDescription(SessionTerm.ABNORMAL, platform);
+      case sessionTerm.errored:
+        return getSessionTermDescription(SessionTerm.ERRORED, platform);
+      case sessionTerm.healthy:
+        return getSessionTermDescription(SessionTerm.HEALTHY, platform);
+      case sessionTerm['crash-free-users']:
+        return getSessionTermDescription(SessionTerm.CRASH_FREE_USERS, platform);
+      case sessionTerm['crash-free-sessions']:
+        return getSessionTermDescription(SessionTerm.CRASH_FREE_SESSIONS, platform);
+      default:
+        return '';
+    }
+  }
+
+  render() {
+    const {series, previousSeries, chartType} = this.props;
+
+    const Chart = this.getChart();
+
+    const legend = {
+      right: 10,
+      top: 0,
+      tooltip: {
+        show: true,
+        // TODO(ts) tooltip.formatter has incorrect types in echarts 4
+        formatter: (params: any): string => {
+          const seriesNameDesc = this.getLegendTooltipDescription(params.name ?? '');
+
+          if (!seriesNameDesc) {
+            return '';
+          }
+
+          return ['<div class="tooltip-description">', seriesNameDesc, '</div>'].join('');
+        },
+      },
+    };
+
+    return (
+      <React.Fragment>
+        <HeaderTitleLegend>
+          {releaseComparisonChartLabels[chartType]}
+          {releaseComparisonChartHelp[chartType] && (
+            <QuestionTooltip
+              size="sm"
+              position="top"
+              title={releaseComparisonChartHelp[chartType]}
+            />
+          )}
+        </HeaderTitleLegend>
+
+        <Chart
+          legend={legend}
+          series={series}
+          previousPeriod={previousSeries}
+          isGroupedByDate
+          seriesOptions={{
+            showSymbol: false,
+          }}
+          grid={{
+            left: '10px',
+            right: '10px',
+            top: '40px',
+            bottom: '0px',
+          }}
+          yAxis={this.configureYAxis()}
+          tooltip={{valueFormatter: this.formatTooltipValue}}
+          transformSinglePointToBar
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+export default withTheme(SessionsChart);

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {withTheme} from '@emotion/react';
 
 import AreaChart from 'app/components/charts/areaChart';
-import LineChart from 'app/components/charts/lineChart';
 import StackedAreaChart from 'app/components/charts/stackedAreaChart';
 import {HeaderTitleLegend} from 'app/components/charts/styles';
 import QuestionTooltip from 'app/components/questionTooltip';
@@ -63,8 +62,7 @@ class SessionsChart extends React.Component<Props> {
 
   getChart():
     | React.ComponentType<StackedAreaChart['props']>
-    | React.ComponentType<AreaChart['props']>
-    | React.ComponentType<LineChart['props']> {
+    | React.ComponentType<AreaChart['props']> {
     const {chartType} = this.props;
     switch (chartType) {
       case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:
@@ -106,9 +104,6 @@ class SessionsChart extends React.Component<Props> {
           previousPeriod={previousSeries}
           isGroupedByDate
           showTimeInTooltip
-          seriesOptions={{
-            showSymbol: false,
-          }}
           grid={{
             left: '10px',
             right: '10px',

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
@@ -105,6 +105,7 @@ class SessionsChart extends React.Component<Props> {
           series={series}
           previousPeriod={previousSeries}
           isGroupedByDate
+          showTimeInTooltip
           seriesOptions={{
             showSymbol: false,
           }}

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
@@ -13,11 +13,6 @@ import {defined} from 'app/utils';
 import {Theme} from 'app/utils/theme';
 import {displayCrashFreePercent} from 'app/views/releases/utils';
 
-import {
-  getSessionTermDescription,
-  SessionTerm,
-  sessionTerm,
-} from '../../../utils/sessionTerm';
 import {releaseComparisonChartHelp, releaseComparisonChartLabels} from '../../utils';
 
 type Props = {
@@ -82,27 +77,6 @@ class SessionsChart extends React.Component<Props> {
     }
   }
 
-  getLegendTooltipDescription(serieName: string) {
-    const {platform} = this.props;
-
-    switch (serieName) {
-      case sessionTerm.crashed:
-        return getSessionTermDescription(SessionTerm.CRASHED, platform);
-      case sessionTerm.abnormal:
-        return getSessionTermDescription(SessionTerm.ABNORMAL, platform);
-      case sessionTerm.errored:
-        return getSessionTermDescription(SessionTerm.ERRORED, platform);
-      case sessionTerm.healthy:
-        return getSessionTermDescription(SessionTerm.HEALTHY, platform);
-      case sessionTerm['crash-free-users']:
-        return getSessionTermDescription(SessionTerm.CRASH_FREE_USERS, platform);
-      case sessionTerm['crash-free-sessions']:
-        return getSessionTermDescription(SessionTerm.CRASH_FREE_SESSIONS, platform);
-      default:
-        return '';
-    }
-  }
-
   render() {
     const {series, previousSeries, chartType} = this.props;
 
@@ -111,19 +85,6 @@ class SessionsChart extends React.Component<Props> {
     const legend = {
       right: 10,
       top: 0,
-      tooltip: {
-        show: true,
-        // TODO(ts) tooltip.formatter has incorrect types in echarts 4
-        formatter: (params: any): string => {
-          const seriesNameDesc = this.getLegendTooltipDescription(params.name ?? '');
-
-          if (!seriesNameDesc) {
-            return '';
-          }
-
-          return ['<div class="tooltip-description">', seriesNameDesc, '</div>'].join('');
-        },
-      },
     };
 
     return (

--- a/static/app/views/releases/detail/overview/releaseDetailsRequest.tsx
+++ b/static/app/views/releases/detail/overview/releaseDetailsRequest.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
@@ -11,11 +10,6 @@ import {Organization, SessionApiResponse} from 'app/types';
 import withApi from 'app/utils/withApi';
 
 import {getReleaseParams, ReleaseBounds} from '../../utils';
-
-function omitIgnoredProps(props: Props) {
-  // TODO(release-comparison): pick the right props
-  return omit(props, ['api', 'organization', 'children', 'location']);
-}
 
 export function reduceTimeSeriesGroups(
   acc: number[],
@@ -65,11 +59,12 @@ class ReleaseDetailsRequest extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (isEqual(omitIgnoredProps(prevProps), omitIgnoredProps(this.props))) {
-      return;
+    if (
+      prevProps.version !== this.props.version ||
+      !isEqual(prevProps.location, this.props.location)
+    ) {
+      this.fetchData();
     }
-
-    this.fetchData();
   }
 
   get path() {

--- a/static/app/views/releases/detail/overview/releaseDetailsRequest.tsx
+++ b/static/app/views/releases/detail/overview/releaseDetailsRequest.tsx
@@ -14,6 +14,7 @@ import {getReleaseParams, ReleaseBounds} from '../../utils';
 
 export type ReleaseHealthRequestRenderProps = {
   loading: boolean;
+  reloading: boolean;
   errored: boolean;
   thisRelease: SessionApiResponse | null;
   allReleases: SessionApiResponse | null;
@@ -30,7 +31,7 @@ type Props = {
 };
 
 type State = {
-  loading: boolean;
+  reloading: boolean;
   errored: boolean;
   thisRelease: SessionApiResponse | null;
   allReleases: SessionApiResponse | null;
@@ -38,7 +39,7 @@ type State = {
 
 class ReleaseDetailsRequest extends React.Component<Props, State> {
   state: State = {
-    loading: false,
+    reloading: false,
     errored: false,
     thisRelease: null,
     allReleases: null,
@@ -96,10 +97,10 @@ class ReleaseDetailsRequest extends React.Component<Props, State> {
     }
 
     api.clear();
-    this.setState({
-      loading: true,
+    this.setState(state => ({
+      reloading: state.thisRelease !== null && state.allReleases !== null,
       errored: false,
-    });
+    }));
 
     const promises = [this.fetchThisRelease(), this.fetchAllReleases()];
 
@@ -107,17 +108,15 @@ class ReleaseDetailsRequest extends React.Component<Props, State> {
       const [thisRelease, allReleases] = await Promise.all(promises);
 
       this.setState({
-        loading: false,
+        reloading: false,
         thisRelease,
         allReleases,
       });
     } catch (error) {
       addErrorMessage(error.responseJSON?.detail ?? t('Error loading health data'));
       this.setState({
-        loading: false,
+        reloading: false,
         errored: true,
-        thisRelease: null,
-        allReleases: null,
       });
     }
   };
@@ -146,11 +145,14 @@ class ReleaseDetailsRequest extends React.Component<Props, State> {
   }
 
   render() {
-    const {loading, errored, thisRelease, allReleases} = this.state;
+    const {reloading, errored, thisRelease, allReleases} = this.state;
     const {children} = this.props;
+
+    const loading = thisRelease === null && allReleases === null;
 
     return children({
       loading,
+      reloading,
       errored,
       thisRelease,
       allReleases,

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -9,11 +9,14 @@ import {
   FilesByRepository,
   GlobalSelection,
   LightWeightOrganization,
+  ReleaseComparisonChartType,
   Repository,
 } from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
 import {QueryResults} from 'app/utils/tokenizeSearch';
+
+import {commonTermsDescription, SessionTerm} from '../utils/sessionTerm';
 
 export type CommitsByRepository = {
   [key: string]: Commit[];
@@ -131,3 +134,21 @@ export function getReleaseEventView(
 
   return EventView.fromSavedQuery(discoverQuery);
 }
+
+export const releaseComparisonChartLabels = {
+  [ReleaseComparisonChartType.CRASH_FREE_SESSIONS]: t('Crash Free Sessions'),
+  [ReleaseComparisonChartType.CRASH_FREE_USERS]: t('Crash Free Users'),
+  [ReleaseComparisonChartType.SESSION_COUNT]: t('Session Count'),
+  [ReleaseComparisonChartType.USER_COUNT]: t('User Count'),
+};
+
+export const releaseComparisonChartHelp = {
+  [ReleaseComparisonChartType.CRASH_FREE_SESSIONS]:
+    commonTermsDescription[SessionTerm.CRASH_FREE_SESSIONS],
+  [ReleaseComparisonChartType.CRASH_FREE_USERS]:
+    commonTermsDescription[SessionTerm.CRASH_FREE_USERS],
+  [ReleaseComparisonChartType.SESSION_COUNT]: t(
+    'The number of sessions in a given period.'
+  ),
+  [ReleaseComparisonChartType.USER_COUNT]: t('The number of users in a given period.'),
+};

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -99,14 +99,11 @@ export function releaseDisplayLabel(displayOption: DisplayOption, count?: number
 export type ReleaseBounds = {releaseStart?: string | null; releaseEnd?: string | null};
 
 export function getReleaseBounds(release?: Release): ReleaseBounds {
-  const {firstEvent, lastEvent, currentProjectMeta, dateCreated} = release || {};
-  const {sessionsLowerBound, sessionsUpperBound} = currentProjectMeta || {};
+  const {lastEvent, currentProjectMeta, dateCreated} = release || {};
+  const {sessionsUpperBound} = currentProjectMeta || {};
 
   return {
-    releaseStart:
-      (moment(sessionsLowerBound).isBefore(firstEvent)
-        ? sessionsLowerBound
-        : firstEvent) ?? dateCreated,
+    releaseStart: dateCreated,
     releaseEnd:
       (moment(sessionsUpperBound).isAfter(lastEvent) ? sessionsUpperBound : lastEvent) ??
       moment().utc().format(),


### PR DESCRIPTION
Adding release comparison charts:
- crash free users
- crash free sessions
- users breakdown
- sessions breakdown

This is still feature flagged.

![Screenshot 2021-07-01 at 16 48 54](https://user-images.githubusercontent.com/9060071/124144485-5027e300-da8c-11eb-8f68-7eb9b806d6a0.png)
