### PR TITLE
feat(scim): Add SCIM to Generic SAML2 Provider

### DIFF
--- a/src/sentry/auth/providers/saml2/activedirectory/provider.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/provider.py
@@ -1,6 +1,5 @@
 from sentry.auth.providers.saml2.generic.provider import GenericSAML2Provider
-from sentry.auth.providers.saml2.provider import SCIMMixin
 
 
-class ActiveDirectorySAML2Provider(SCIMMixin, GenericSAML2Provider):
+class ActiveDirectorySAML2Provider(GenericSAML2Provider):
     name = "Active Directory"

--- a/src/sentry/auth/providers/saml2/generic/provider.py
+++ b/src/sentry/auth/providers/saml2/generic/provider.py
@@ -1,9 +1,9 @@
-from sentry.auth.providers.saml2.provider import SAML2Provider
+from sentry.auth.providers.saml2.provider import SAML2Provider, SCIMMixin
 
 from .views import MapAttributes, SAML2ConfigureView, SelectIdP
 
 
-class GenericSAML2Provider(SAML2Provider):
+class GenericSAML2Provider(SCIMMixin, SAML2Provider):
     name = "SAML2"
 
     def get_configure_view(self):

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -211,7 +211,14 @@ class Attributes:
     LAST_NAME = "last_name"
 
 
-class SAML2Provider(Provider):
+class SCIMMixin:
+    def can_use_scim(self, organization, user):
+        if features.has("organizations:sso-scim", organization, actor=user):
+            return True
+        return False
+
+
+class SAML2Provider(SCIMMixin, Provider):
     """
     Base SAML2 Authentication provider. SAML style authentication plugins
     should implement this.
@@ -321,13 +328,6 @@ class SAML2Provider(Provider):
     def refresh_identity(self, auth_identity):
         # Nothing to refresh
         return
-
-
-class SCIMMixin:
-    def can_use_scim(self, organization, user):
-        if features.has("organizations:sso-scim", organization, actor=user):
-            return True
-        return False
 
 
 def build_saml_config(provider_config, org):

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -211,14 +211,7 @@ class Attributes:
     LAST_NAME = "last_name"
 
 
-class SCIMMixin:
-    def can_use_scim(self, organization, user):
-        if features.has("organizations:sso-scim", organization, actor=user):
-            return True
-        return False
-
-
-class SAML2Provider(SCIMMixin, Provider):
+class SAML2Provider(Provider):
     """
     Base SAML2 Authentication provider. SAML style authentication plugins
     should implement this.
@@ -328,6 +321,13 @@ class SAML2Provider(SCIMMixin, Provider):
     def refresh_identity(self, auth_identity):
         # Nothing to refresh
         return
+
+
+class SCIMMixin:
+    def can_use_scim(self, organization, user):
+        if features.has("organizations:sso-scim", organization, actor=user):
+            return True
+        return False
 
 
 def build_saml_config(provider_config, org):


### PR DESCRIPTION
Generic SAML2 providers should have SCIM capabilities in addition to Okta and Azure.