### PR TITLE
fix(tests): refresh snuba_query from db

### DIFF
--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -147,6 +147,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             )
 
         self.alert_rule.name = "what"
+        self.alert_rule.snuba_query.refresh_from_db()
         assert resp.data == serialize(self.alert_rule)
         assert resp.data["name"] == "what"
 
@@ -416,6 +417,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
                 self.organization.slug, self.project.slug, alert_rule.id, **test_params
             )
 
+        alert_rule.snuba_query.refresh_from_db()
         assert resp.data == serialize(alert_rule, self.user)
         assert (
             resp.data["owner"] == self.user.actor.get_actor_identifier()


### PR DESCRIPTION
I wasn't able to track down what changed in Django 2.0 in a reasonable amount of time, but need additional `refresh_from_db` calls for these tests which otherwise fail on 2.0. h/t @wedamija