### PR TITLE
fix: fix warnings in unescape_string part 2

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/mobile@2021-04-02.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/mobile@2021-04-02.txt
@@ -177,7 +177,7 @@ module:java.lang.reflect.* category=indirection
 module:java.lang.Class function:getMethod category=indirection
 module:androidx.work.impl.utils.ForceStopRunnable category=indirection
 
-family:native function:"*::\{dtor\}" category=dtor
+family:native function:"*::\\{dtor\\}" category=dtor
 family:native function:"destructor'" category=dtor
 
 family:native function:exit category=shutdown


### PR DESCRIPTION
Missed a spot in https://github.com/getsentry/sentry/pull/26900.

Not sure why, but makes CI here error: https://github.com/getsentry/sentry/pull/26930. It isn't during pytest, and when running locally it exits 0. Wasn't able to find any hits for like, "python warnings github actions".