### PR TITLE
feat(growth) : Adds query parameter to sign up page from Sandbox

### DIFF
--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -16,10 +16,11 @@ type Preferences = typeof PreferencesStore.prefs;
 export default function DemoHeader() {
   // if the user came from a SaaS org, we should send them back to upgrade when they leave the sandbox
   const saasOrgSlug = getCookie('saas_org_slug');
+  const email = localStorage.getItem('email');
   const getStartedText = saasOrgSlug ? t('Upgrade Now') : t('Sign Up for Free');
   const getStartedUrl = saasOrgSlug
     ? `https://sentry.io/settings/${saasOrgSlug}/billing/checkout/`
-    : 'https://sentry.io/signup/';
+    : `https://sentry.io/signup/?email=${email}`;
 
   const [collapsed, setCollapsed] = useState(PreferencesStore.prefs.collapsed);
 

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -17,10 +17,11 @@ export default function DemoHeader() {
   // if the user came from a SaaS org, we should send them back to upgrade when they leave the sandbox
   const saasOrgSlug = getCookie('saas_org_slug');
   const email = localStorage.getItem('email');
+  const queryParameter = email ? `?email=${email}` : '';
   const getStartedText = saasOrgSlug ? t('Upgrade Now') : t('Sign Up for Free');
   const getStartedUrl = saasOrgSlug
     ? `https://sentry.io/settings/${saasOrgSlug}/billing/checkout/`
-    : `https://sentry.io/signup/?email=${email}`;
+    : `https://sentry.io/signup/${queryParameter}`;
 
   const [collapsed, setCollapsed] = useState(PreferencesStore.prefs.collapsed);
 


### PR DESCRIPTION
This PR adds the query parameter to the sign up link from the Sandbox. Now, when clicking the "Sign up for free" button, the user's email (which was input when entering the sandbox) will be sent with the link allowing for the sign up page to automatically fill in their email for them. 