### PR TITLE
feat(semver): Improve autocomplete results for semver

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -758,7 +758,7 @@ class SnubaTagStorage(TagStorage):
 
         if key == SEMVER_ALIAS:
             # If doing a search on semver, we want to hit postgres to query the releases
-            version = query
+            version = query if query else ""
             organization_id = Project.objects.filter(id=projects[0]).values_list(
                 "organization_id", flat=True
             )[0]
@@ -781,7 +781,7 @@ class SnubaTagStorage(TagStorage):
                     ),
                 ).annotate_prerelease_column()
             else:
-                include_package = "@" in version
+                include_package = not version or "@" in version
                 if not version:
                     version = "*"
                 elif version[-1] not in SEMVER_WILDCARDS | {"@"}:

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -764,6 +764,7 @@ class SnubaTagStorage(TagStorage):
             )[0]
 
             if version and "@" not in version and re.search(r"[^\d.\*]", version):
+                include_package = True
                 # Handle searching just on package
                 packages = (
                     Release.objects.filter(
@@ -780,6 +781,7 @@ class SnubaTagStorage(TagStorage):
                     ),
                 ).annotate_prerelease_column()
             else:
+                include_package = "@" in version
                 if not version:
                     version = "*"
                 elif version[-1] not in SEMVER_WILDCARDS | {"@"}:
@@ -802,8 +804,26 @@ class SnubaTagStorage(TagStorage):
             versions = versions.order_by(*Release.SEMVER_COLS, "package").values_list(
                 "version", flat=True
             )[:1000]
+
+            seen = set()
+            formatted_versions = []
+            # We want to format versions here in a way that makes sense for autocomplete. So we
+            # - Only include package if we think the user entered a package
+            # - Exclude build number, since it's not used as part of filtering
+            # When we don't include package, this can result in duplicate version numbers, so we
+            # also de-dupe here. This can result in less than 1000 versions returned, but we
+            # typically use very few values so this works ok.
+            for version in versions:
+                formatted_version = version if include_package else version.split("@", 1)[1]
+                formatted_version = formatted_version.split("+", 1)[0]
+                if formatted_version in seen:
+                    continue
+
+                seen.add(formatted_version)
+                formatted_versions.append(formatted_version)
+
             return SequencePaginator(
-                [(i, TagValue(key, v, None, None, None)) for i, v in enumerate(versions)]
+                [(i, TagValue(key, v, None, None, None)) for i, v in enumerate(formatted_versions)]
             )
 
         conditions = []

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -758,17 +758,17 @@ class SnubaTagStorage(TagStorage):
 
         if key == SEMVER_ALIAS:
             # If doing a search on semver, we want to hit postgres to query the releases
-            version = query if query else ""
+            query = query if query else ""
             organization_id = Project.objects.filter(id=projects[0]).values_list(
                 "organization_id", flat=True
             )[0]
 
-            if version and "@" not in version and re.search(r"[^\d.\*]", version):
+            if query and "@" not in query and re.search(r"[^\d.\*]", query):
                 include_package = True
                 # Handle searching just on package
                 packages = (
                     Release.objects.filter(
-                        organization_id=organization_id, package__startswith=version
+                        organization_id=organization_id, package__startswith=query
                     )
                     .values_list("package")
                     .distinct()
@@ -781,17 +781,17 @@ class SnubaTagStorage(TagStorage):
                     ),
                 ).annotate_prerelease_column()
             else:
-                include_package = not version or "@" in version
-                if not version:
-                    version = "*"
-                elif version[-1] not in SEMVER_WILDCARDS | {"@"}:
-                    if version[-1] != ".":
-                        version += "."
-                    version += "*"
+                include_package = not query or "@" in query
+                if not query:
+                    query = "*"
+                elif query[-1] not in SEMVER_WILDCARDS | {"@"}:
+                    if query[-1] != ".":
+                        query += "."
+                    query += "*"
 
                 versions = Release.objects.filter_by_semver(
                     organization_id,
-                    parse_semver(version, "="),
+                    parse_semver(query, "="),
                     project_ids=projects,
                 )
             if environments:

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.urls import reverse
 from exam import fixture
 
+from sentry.search.events.constants import SEMVER_ALIAS
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.samples import load_data
@@ -268,6 +269,16 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
         )
         self.run_test(
             "user.display", qs_params={"includeTransactions": "1", "query": "bar"}, expected=[]
+        )
+
+    def test_semver(self):
+        self.create_release(version="test@1.0.0.0")
+        self.create_release(version="test@2.0.0.0")
+        self.run_test(SEMVER_ALIAS, expected=[("test@1.0.0.0", None), ("test@2.0.0.0", None)])
+        self.run_test(SEMVER_ALIAS, query="1.", expected=[("1.0.0.0", None)])
+        self.run_test(SEMVER_ALIAS, query="test@1.", expected=[("test@1.0.0.0", None)])
+        self.run_test(
+            SEMVER_ALIAS, query="test", expected=[("test@1.0.0.0", None), ("test@2.0.0.0", None)]
         )
 
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -722,8 +722,30 @@ class GetTagValuePaginatorForProjectsSemverTest(TestCase, SnubaTestCase):
         self.create_release(version="z_test@1.0.0.0")
         self.create_release(version="z_test@2.0.0.0+456", additional_projects=[project_2])
 
-        self.run_test(None, ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4", "2.0.0.0"])
-        self.run_test("", ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4", "2.0.0.0"])
+        self.run_test(
+            None,
+            [
+                "test@1.0.0.0",
+                "z_test@1.0.0.0",
+                "test@1.2.0.0-alpha",
+                "test@1.2.3.0-beta",
+                "test@1.2.3.4",
+                "test2@2.0.0.0",
+                "z_test@2.0.0.0",
+            ],
+        )
+        self.run_test(
+            "",
+            [
+                "test@1.0.0.0",
+                "z_test@1.0.0.0",
+                "test@1.2.0.0-alpha",
+                "test@1.2.3.0-beta",
+                "test@1.2.3.4",
+                "test2@2.0.0.0",
+                "z_test@2.0.0.0",
+            ],
+        )
 
         # These should all be equivalent
         self.run_test("1", ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4"])
@@ -734,8 +756,8 @@ class GetTagValuePaginatorForProjectsSemverTest(TestCase, SnubaTestCase):
 
         self.run_test("1.2", ["1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4"])
 
-        self.run_test("", ["1.2.0.0-alpha", "2.0.0.0"], self.environment)
-        self.run_test("", ["1.2.3.0-beta", "1.2.3.4", "2.0.0.0"], env_2)
+        self.run_test("", ["test@1.2.0.0-alpha", "test2@2.0.0.0"], self.environment)
+        self.run_test("", ["test@1.2.3.0-beta", "test@1.2.3.4", "test2@2.0.0.0"], env_2)
         self.run_test("1", ["1.2.0.0-alpha"], self.environment)
         self.run_test("1", ["1.2.3.0-beta", "1.2.3.4"], env_2)
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -722,6 +722,7 @@ class GetTagValuePaginatorForProjectsSemverTest(TestCase, SnubaTestCase):
         self.create_release(version="z_test@1.0.0.0")
         self.create_release(version="z_test@2.0.0.0+456", additional_projects=[project_2])
 
+        self.run_test(None, ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4", "2.0.0.0"])
         self.run_test("", ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4", "2.0.0.0"])
 
         # These should all be equivalent


### PR DESCRIPTION
This changes the values we return from autocomplete. Given releases like

 - `sentry@1.2.3-alpha+123`
 - `sentry@1.2.3`
 - `sentry@1.2.4`

Input like `sen` would return

 - `sentry@1.2.3-alpha` (we exclude build number since it's not used for filtering)
 - `sentry@1.2.3`
 - `sentry@1.2.4`

Input like `1` or `1.2` would return
 - `1.2.3-alpha`
 - `1.2.3`
 - `1.2.4`