### PR TITLE
ref(search): Remove punctuation from invalid token reasons

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -591,7 +591,7 @@ class TokenConverter {
 
     if (this.keyValidation.isDuration(keyName)) {
       return {
-        reason: t('Invalid duration. Expected number followed by duration unit suffix.'),
+        reason: t('Invalid duration. Expected number followed by duration unit suffix'),
         expectedType: [FilterType.Duration],
       };
     }
@@ -599,7 +599,7 @@ class TokenConverter {
     if (this.keyValidation.isDate(keyName)) {
       return {
         reason: t(
-          'Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).',
+          'Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now})',
           new Date().toISOString()
         ),
         expectedType: [FilterType.Date, FilterType.SpecificDate, FilterType.RelativeDate],
@@ -616,7 +616,7 @@ class TokenConverter {
     if (this.keyValidation.isNumeric(keyName)) {
       return {
         reason: t(
-          'Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).'
+          'Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)'
         ),
         expectedType: [FilterType.Numeric, FilterType.NumericIn],
       };
@@ -630,11 +630,11 @@ class TokenConverter {
    */
   checkInvalidTextValue = (value: TextFilter['value']) => {
     if (!value.quoted && /(^|[^\\])"/.test(value.value)) {
-      return {reason: t('Quotes must enclose text or be escaped.')};
+      return {reason: t('Quotes must enclose text or be escaped')};
     }
 
     if (!value.quoted && value.value === '') {
-      return {reason: t('Filter must have a value.')};
+      return {reason: t('Filter must have a value')};
     }
 
     return null;

--- a/tests/fixtures/search-syntax/empty_filter_value.json
+++ b/tests/fixtures/search-syntax/empty_filter_value.json
@@ -20,7 +20,7 @@
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "invalid": {"reason": "Filter must have a value."},
+        "invalid": {"reason": "Filter must have a value"},
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
         "value": {"type": "valueText", "value": "", "quoted": false}

--- a/tests/fixtures/search-syntax/invalid_date_formats.json
+++ b/tests/fixtures/search-syntax/invalid_date_formats.json
@@ -7,7 +7,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now})",
           "expectedType": ["date", "specificDate", "relativeDate"]
         },
         "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
@@ -25,7 +25,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now})",
           "expectedType": ["date", "specificDate", "relativeDate"]
         },
         "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
@@ -43,7 +43,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now}).",
+          "reason": "Invalid date format. Expected +/-duration (e.g. +1h) or ISO 8601-like (e.g. {now})",
           "expectedType": ["date", "specificDate", "relativeDate"]
         },
         "key": {"type": "keySimple", "value": "first_seen", "quoted": false},

--- a/tests/fixtures/search-syntax/invalid_duration_filter.json
+++ b/tests/fixtures/search-syntax/invalid_duration_filter.json
@@ -7,7 +7,7 @@
         "negated": false,
         "operator": "",
         "invalid": {
-          "reason": "Invalid duration. Expected number followed by duration unit suffix.",
+          "reason": "Invalid duration. Expected number followed by duration unit suffix",
           "expectedType": ["duration"]
         },
         "key": {"quoted": false, "type": "keySimple", "value": "transaction.duration"},

--- a/tests/fixtures/search-syntax/invalid_numeric_fields.json
+++ b/tests/fixtures/search-syntax/invalid_numeric_fields.json
@@ -7,7 +7,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)",
           "expectedType": ["numeric", "numericIn"]
         },
         "key": {"type": "keySimple", "value": "project.id", "quoted": false},
@@ -25,7 +25,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)",
           "expectedType": ["numeric", "numericIn"]
         },
         "key": {"type": "keySimple", "value": "issue.id", "quoted": false},
@@ -43,7 +43,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid duration. Expected number followed by duration unit suffix.",
+          "reason": "Invalid duration. Expected number followed by duration unit suffix",
           "expectedType": ["duration"]
         },
         "key": {"type": "keySimple", "value": "transaction.duration", "quoted": false},

--- a/tests/fixtures/search-syntax/invalid_numeric_shorthand.json
+++ b/tests/fixtures/search-syntax/invalid_numeric_shorthand.json
@@ -7,7 +7,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k).",
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)",
           "expectedType": ["numeric", "numericIn"]
         },
         "key": {"type": "keySimple", "value": "stack.colno", "quoted": false},

--- a/tests/fixtures/search-syntax/trailing_quote_value.json
+++ b/tests/fixtures/search-syntax/trailing_quote_value.json
@@ -7,7 +7,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Quotes must enclose text or be escaped."
+          "reason": "Quotes must enclose text or be escaped"
         },
         "key": {"type": "keySimple", "value": "device.family", "quoted": false},
         "operator": "",
@@ -24,7 +24,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Quotes must enclose text or be escaped."
+          "reason": "Quotes must enclose text or be escaped"
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
@@ -41,7 +41,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Quotes must enclose text or be escaped."
+          "reason": "Quotes must enclose text or be escaped"
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",
@@ -67,7 +67,7 @@
         "filter": "text",
         "negated": false,
         "invalid": {
-          "reason": "Quotes must enclose text or be escaped."
+          "reason": "Quotes must enclose text or be escaped"
         },
         "key": {"type": "keySimple", "value": "url", "quoted": false},
         "operator": "",


### PR DESCRIPTION
These show up in tooltips where the punctuation looks a little weird