### PR TITLE
fix(ui): Semver project filter

### DIFF
--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -153,7 +153,7 @@ class ProjectDetail extends AsyncView<Props, State> {
       organization.slug,
       key,
       search,
-      [projectId],
+      projectId ? [projectId] : null,
       location.query
     );
   };

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -300,7 +300,7 @@ class ReleasesList extends AsyncView<Props, State> {
       organization.slug,
       key,
       search,
-      [projectId],
+      projectId ? [projectId] : null,
       location.query
     );
   };


### PR DESCRIPTION
Adding a `projectId` existence condition to semver filter, otherwise `/api/0/organizations/sentry/tags/sentry.semver/values/?query=3.&project=` might be called, which causes `400 Invalid project parameter. Values must be numbers.`