### PR TITLE
ref(sdk-updates): Update copy + design

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -399,9 +399,7 @@ class EventEntries extends Component<Props, State> {
           />
         )}
         {event?.sdk && !objectIsEmpty(event.sdk) && <EventSdk sdk={event.sdk} />}
-        {!isShare && event?.sdkUpdates && event.sdkUpdates.length > 0 && (
-          <EventSdkUpdates event={{sdkUpdates: event.sdkUpdates, ...event}} />
-        )}
+        {!isShare && <EventSdkUpdates event={event} />}
         {!isShare && event?.groupID && (
           <EventGroupingInfo
             projectId={project.slug}

--- a/static/app/components/events/sdkUpdates/sdkAlert.tsx
+++ b/static/app/components/events/sdkUpdates/sdkAlert.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+
+import SidebarPanelActions from 'app/actions/sidebarPanelActions';
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
+import {SidebarPanelKey} from 'app/components/sidebar/types';
+import {IconUpgrade} from 'app/icons';
+import {t} from 'app/locale';
+import {SdkSuggestionType} from 'app/types';
+
+const actionDescription = {
+  [SdkSuggestionType.UPDATE_SDK]: t('Update SDK'),
+  [SdkSuggestionType.CHANGE_SDK]: t('Migrate SDK'),
+  [SdkSuggestionType.ENABLE_INTEGRATION]: t('Enable Integration'),
+};
+
+type Props = {
+  type: SdkSuggestionType;
+  suggestion: React.ReactNode;
+  withGoToBroadcastAction?: boolean;
+};
+
+function SdkAlert({type, suggestion, withGoToBroadcastAction}: Props) {
+  return (
+    <Alert type="info" icon={<IconUpgrade />}>
+      {withGoToBroadcastAction ? (
+        <AlertContent>
+          {suggestion}
+          <StyledButton
+            priority="link"
+            onClick={() => {
+              SidebarPanelActions.activatePanel(SidebarPanelKey.Broadcasts);
+            }}
+          >
+            {actionDescription[type]}
+          </StyledButton>
+        </AlertContent>
+      ) : (
+        suggestion
+      )}
+    </Alert>
+  );
+}
+
+export default SdkAlert;
+
+const AlertContent = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    justify-content: space-between;
+  }
+`;
+
+const StyledButton = styled(Button)`
+  /* this is needed to be aligned with the alert icon
+   * which currently has a height of 22px. */
+  height: 22px;
+`;

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -26,6 +26,18 @@ const flattenSuggestions = (list: ProjectSdkUpdates[]) =>
     []
   );
 
+const commonUpdateMessage = t(
+  'We recommend updating the following SDKs to make sure you’re getting all the data you need.'
+);
+
+const javascriptUpdateMessage = t(
+  'All instalations of javascript must be updated to the same version. Otherwise, there will be problems getting the correct data.'
+);
+
+const ravenUpdateMessage = t(
+  'All instalations of raven are out date and must be migrated to the new Sentry SDKs.'
+);
+
 const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
   if (!sdkUpdates) {
     return null;
@@ -39,14 +51,46 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
   // Group SDK updates by project
   const items = Object.entries(groupBy(sdkUpdates, 'projectId'));
 
+  function getUpdateMessage() {
+    const hasRavenSDkUpdate = !!sdkUpdates?.find(sdkUpdate =>
+      sdkUpdate.sdkName.includes('raven')
+    );
+
+    const hasJavascriptSDkUpdate = !!sdkUpdates?.find(sdkUpdate =>
+      sdkUpdate.sdkName.includes('javascript')
+    );
+
+    if (hasRavenSDkUpdate && hasJavascriptSDkUpdate) {
+      return (
+        <UpdateMessage>
+          <p>{commonUpdateMessage}</p>
+          <p>{ravenUpdateMessage}</p>
+          <p>{javascriptUpdateMessage}</p>
+        </UpdateMessage>
+      );
+    }
+
+    if (hasRavenSDkUpdate) {
+      <UpdateMessage>
+        <p>{commonUpdateMessage}</p>
+        <p>{ravenUpdateMessage}</p>
+      </UpdateMessage>;
+    }
+
+    if (hasJavascriptSDkUpdate) {
+      return (
+        <UpdateMessage>
+          <p>{commonUpdateMessage}</p>
+          <p>{javascriptUpdateMessage}</p>
+        </UpdateMessage>
+      );
+    }
+
+    return commonUpdateMessage;
+  }
+
   return (
-    <SidebarPanelItem
-      hasSeen
-      title={t('Update your SDKs')}
-      message={t(
-        'We recommend updating the following SDKs to make sure you’re getting all the data you need.'
-      )}
-    >
+    <SidebarPanelItem hasSeen title={t('Update your SDKs')} message={getUpdateMessage()}>
       <UpdatesList>
         <Collapsible>
           {items.map(([projectId, updates]) => {
@@ -76,7 +120,7 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
                               suggestion,
                               shortStyle: true,
                               capitalized: true,
-                            })}
+                            }) ?? null}
                           </ListItem>
                         ))}
                       </List>
@@ -119,6 +163,14 @@ const SdkName = styled('div')`
 
 const SdkOutdatedVersion = styled('span')`
   color: ${p => p.theme.subText};
+`;
+
+const UpdateMessage = styled('div')`
+  && {
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
 `;
 
 export default withSdkUpdates(withProjects(BroadcastSdkUpdates));

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -401,15 +401,21 @@ export type EventAttachment = {
 
 export type EntryData = Record<string, any | Array<any>>;
 
+export enum SdkSuggestionType {
+  UPDATE_SDK = 'updateSdk',
+  CHANGE_SDK = 'changeSdk',
+  ENABLE_INTEGRATION = 'enableIntegration',
+}
+
 type EnableIntegrationSuggestion = {
-  type: 'enableIntegration';
+  type: SdkSuggestionType.ENABLE_INTEGRATION;
   integrationName: string;
   enables: Array<SDKUpdatesSuggestion>;
   integrationUrl?: string | null;
 };
 
 export type UpdateSdkSuggestion = {
-  type: 'updateSdk';
+  type: SdkSuggestionType.UPDATE_SDK;
   sdkName: string;
   newSdkVersion: string;
   enables: Array<SDKUpdatesSuggestion>;
@@ -417,7 +423,7 @@ export type UpdateSdkSuggestion = {
 };
 
 type ChangeSdkSuggestion = {
-  type: 'changeSdk';
+  type: SdkSuggestionType.CHANGE_SDK;
   newSdkName: string;
   enables: Array<SDKUpdatesSuggestion>;
   sdkUrl?: string | null;


### PR DESCRIPTION
Adds an extra message to the `sdks update alerts`, warning the users that:

- all sentry `javascript` packages should also be updated and their versions should match. -  it will only be displayed if there is at least one javascript sdk update

- `raven` installations are out of date and must be migrated  - it will only be displayed if there is at least one raven sdk update

This alert is being added based on the feedback received in the PR https://github.com/getsentry/sentry-javascript/issues/3223

**Previews:**

![image](https://user-images.githubusercontent.com/29228205/124287450-4f588500-db50-11eb-8b87-92a45e0722f7.png)


![image](https://user-images.githubusercontent.com/29228205/124287218-0e607080-db50-11eb-8504-eefe80fd1cfb.png)


<img width="366" alt="Screenshot 2021-07-02 at 15 36 12" src="https://user-images.githubusercontent.com/29228205/124282849-909a6600-db4b-11eb-8019-89490dc1fb38.png">
