### PR TITLE
feat(workflow): Use PanelTable empty state on alerts lists

### DIFF
--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -351,6 +351,7 @@ const StyledPanelTable = styled(PanelTable)<{hasAlertList: boolean}>`
 
   grid-template-columns: auto 1.5fr 1fr 1fr ${p => (!p.hasAlertList ? '1fr' : '')} 1fr auto;
   white-space: nowrap;
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const EmptyStateAction = styled('p')`

--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import flatten from 'lodash/flatten';
@@ -10,10 +10,10 @@ import ExternalLink from 'app/components/links/externalLink';
 import Link from 'app/components/links/link';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import Pagination from 'app/components/pagination';
-import {PanelTable, PanelTableHeader} from 'app/components/panels';
+import {PanelTable} from 'app/components/panels';
 import SearchBar from 'app/components/searchBar';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
-import {IconArrow, IconCheckmark} from 'app/icons';
+import {IconArrow} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization, Project, Team} from 'app/types';
@@ -66,28 +66,6 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
         },
       ],
     ];
-  }
-
-  tryRenderEmpty() {
-    const {ruleList} = this.state;
-    if (ruleList && ruleList.length > 0) {
-      return null;
-    }
-
-    return (
-      <Fragment>
-        <IconWrapper>
-          <IconCheckmark isCircled size="48" />
-        </IconWrapper>
-
-        <Title>{t('No alert rules exist for these projects.')}</Title>
-        <Description>
-          {tct('Learn more about [link:Alerts]', {
-            link: <ExternalLink href={DOCS_URL} />,
-          })}
-        </Description>
-      </Fragment>
-    );
   }
 
   handleChangeFilter = (_sectionId: string, activeFilters: Set<string>) => {
@@ -186,6 +164,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     );
 
     const userTeams = new Set(teams.filter(({isMember}) => isMember).map(({id}) => id));
+
     return (
       <StyledLayoutBody>
         <Layout.Main fullWidth>
@@ -257,7 +236,14 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
             ]}
             isLoading={loading}
             isEmpty={ruleList?.length === 0}
-            emptyMessage={this.tryRenderEmpty()}
+            emptyMessage={t('No alert rules found for the current query.')}
+            emptyAction={
+              <EmptyStateAction>
+                {tct('Learn more about [link:Alerts]', {
+                  link: <ExternalLink href={DOCS_URL} />,
+                })}
+              </EmptyStateAction>
+            }
             hasAlertList={hasAlertList}
           >
             <Projects orgId={orgId} slugs={Array.from(allProjectsFromIncidents)}>
@@ -363,35 +349,10 @@ const StyledPanelTable = styled(PanelTable)<{hasAlertList: boolean}>`
     overflow: initial;
   }
 
-  ${PanelTableHeader} {
-    padding: ${space(2)};
-    line-height: normal;
-  }
-  font-size: ${p => p.theme.fontSizeMedium};
   grid-template-columns: auto 1.5fr 1fr 1fr ${p => (!p.hasAlertList ? '1fr' : '')} 1fr auto;
-  margin-bottom: 0;
   white-space: nowrap;
-  ${p =>
-    p.emptyMessage &&
-    `svg:not([data-test-id='icon-check-mark']) {
-    display: none;`}
-  & > * {
-    padding: ${p => (p.hasAlertList ? `${space(2)} ${space(2)}` : space(2))};
-  }
 `;
 
-const IconWrapper = styled('span')`
-  color: ${p => p.theme.gray200};
-  display: block;
-`;
-
-const Title = styled('strong')`
-  font-size: ${p => p.theme.fontSizeExtraLarge};
-  margin-bottom: ${space(1)};
-`;
-
-const Description = styled('span')`
+const EmptyStateAction = styled('p')`
   font-size: ${p => p.theme.fontSizeLarge};
-  display: block;
-  margin: 0;
 `;

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -197,7 +197,7 @@ describe('IncidentsList', function () {
     wrapper.update();
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain('No incidents exist for the current query.');
+    expect(wrapper.text()).toContain('No incidents exist for the current query');
   });
 
   it('filters by opened issues', async function () {

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -99,7 +99,7 @@ describe('OrganizationRuleList', () => {
     expect(rulesMock).toHaveBeenCalledTimes(0);
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain('No alert rules exist for these projects');
+    expect(wrapper.text()).toContain('No alert rules found for the current query');
   });
 
   it('sorts by date created', async () => {


### PR DESCRIPTION
Fixes a bug introduced in #26807 that displayed the empty state incorrectly
![image](https://user-images.githubusercontent.com/1400464/124324899-93d82680-db38-11eb-8093-b58b63086872.png)

Now they're using the PanelTable error message w/ the magnifying glass 

alert rules
![image](https://user-images.githubusercontent.com/1400464/124325023-d1d54a80-db38-11eb-97f9-a6bd086cef0b.png)

history
![image](https://user-images.githubusercontent.com/1400464/124325060-e31e5700-db38-11eb-98b9-59a596a93db0.png)

