### PR TITLE
fix(search): set word-break: break-word to mimic textarea

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1186,6 +1186,7 @@ const Highlight = styled('div')`
   bottom: 0;
   user-select: none;
   white-space: pre-wrap;
+  word-break: break-word;
   line-height: 25px;
   font-size: ${p => p.theme.fontSizeSmall};
   font-family: ${p => p.theme.text.familyMono};


### PR DESCRIPTION
Fixes stuff like this 
![image](https://user-images.githubusercontent.com/1421724/124331192-c1769d00-db43-11eb-84f8-8e45f4d4632f.png)
