### PR TITLE
feat(notification platform): Unlink a team in Slack

### DIFF
--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -6,6 +6,7 @@ from .endpoints.event import SlackEventEndpoint
 from .views.link_identity import SlackLinkIdentityView
 from .views.link_team import SlackLinkTeamView
 from .views.unlink_identity import SlackUnlinkIdentityView
+from .views.unlink_team import SlackUnlinkTeamView
 
 urlpatterns = [
     url(r"^action/$", SlackActionEndpoint.as_view()),
@@ -25,5 +26,10 @@ urlpatterns = [
         r"^link-team/(?P<signed_params>[^\/]+)/$",
         SlackLinkTeamView.as_view(),
         name="sentry-integration-slack-link-team",
+    ),
+    url(
+        r"^unlink-team/(?P<signed_params>[^\/]+)/$",
+        SlackUnlinkTeamView.as_view(),
+        name="sentry-integration-slack-unlink-team",
     ),
 ]

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -4,16 +4,25 @@ from typing import List, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.core.exceptions import ValidationError
-from django.http import Http404
+from django.http import Http404, HttpResponse
+from rest_framework.request import Request
 
 from sentry.constants import ObjectStatus
-from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration, Organization
+from sentry.models import (
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    Organization,
+    OrganizationMember,
+)
 from sentry.shared_integrations.exceptions import (
     ApiError,
     DuplicateDisplayNameError,
     IntegrationError,
 )
 from sentry.utils import json
+from sentry.web.helpers import render_to_response
 
 from .client import SlackClient
 
@@ -23,6 +32,7 @@ MEMBER_PREFIX = "@"
 CHANNEL_PREFIX = "#"
 strip_channel_chars = "".join([MEMBER_PREFIX, CHANNEL_PREFIX])
 SLACK_DEFAULT_TIMEOUT = 10
+ALLOWED_ROLES = ["admin", "manager", "owner"]
 
 
 def get_integration_type(integration: Integration):
@@ -298,3 +308,67 @@ def get_identities_by_user(idp, users):
         status=IdentityStatus.VALID,
     )
     return {identity.user: identity for identity in identity_models}
+
+
+def get_org_member_by_slack_id(request, integration, organization, slack_id):
+    try:
+        idp = IdentityProvider.objects.get(type="slack", external_id=integration.external_id)
+    except IdentityProvider.DoesNotExist:
+        logger.error("slack.action.invalid-team-id", extra={"slack_id": integration.external_id})
+        return render_error_page(request, body_text="HTTP 403: Invalid team ID")
+
+    try:
+        identity = Identity.objects.select_related("user").get(idp=idp, external_id=slack_id)
+    except Identity.DoesNotExist:
+        logger.error("slack.action.missing-identity", extra={"slack_id": integration.external_id})
+        return render_error_page(request, body_text="HTTP 403: User identity does not exist")
+
+    return OrganizationMember.objects.get(user=identity.user, organization=organization)
+
+
+def is_valid_role(org_member, team, organization):
+    return org_member.role in ALLOWED_ROLES and (
+        organization.flags.allow_joinleave or team in org_member.teams.all()
+    )
+
+
+def render_error_page(request: Request, body_text: str) -> HttpResponse:
+    return render_to_response(
+        "sentry/integrations/slack-link-team-error.html",
+        request=request,
+        context={"body_text": body_text},
+    )
+
+
+def send_slack_message(
+    integration: Integration,
+    channel_id: str,
+    heading: str,
+    text: str,
+    request: Request,
+) -> HttpResponse:
+    client = SlackClient()
+    token = integration.metadata.get("user_access_token") or integration.metadata["access_token"]
+    payload = {
+        "token": token,
+        "channel": channel_id,
+        "text": text,
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        client.post("/chat.postMessage", headers=headers, data=payload, json=True)
+    except ApiError as e:
+        message = str(e)
+        if message != "Expired url":
+            logger.error("slack.link-notify.response-error", extra={"error": message})
+    else:
+        return render_to_response(
+            "sentry/integrations/slack-post-linked-team.html",
+            request=request,
+            context={
+                "heading_text": heading,
+                "body_text": text,
+                "channel_id": channel_id,
+                "team_id": integration.external_id,
+            },
+        )

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -340,11 +340,12 @@ def render_error_page(request: Request, body_text: str) -> HttpResponse:
     )
 
 
-def send_slack_message(
+def send_confirmation(
     integration: Integration,
     channel_id: str,
     heading: str,
     text: str,
+    template: str,
     request: Request,
 ) -> HttpResponse:
     client = SlackClient()
@@ -354,16 +355,17 @@ def send_slack_message(
         "channel": channel_id,
         "text": text,
     }
+
     headers = {"Authorization": f"Bearer {token}"}
     try:
         client.post("/chat.postMessage", headers=headers, data=payload, json=True)
     except ApiError as e:
         message = str(e)
         if message != "Expired url":
-            logger.error("slack.link-notify.response-error", extra={"error": message})
+            logger.error("slack.slash-notify.response-error", extra={"error": message})
     else:
         return render_to_response(
-            "sentry/integrations/slack-post-linked-team.html",
+            template,
             request=request,
             context={
                 "heading_text": heading,

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -8,14 +8,7 @@ from django.http import Http404, HttpResponse
 from rest_framework.request import Request
 
 from sentry.constants import ObjectStatus
-from sentry.models import (
-    Identity,
-    IdentityProvider,
-    IdentityStatus,
-    Integration,
-    Organization,
-    OrganizationMember,
-)
+from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration, Organization
 from sentry.shared_integrations.exceptions import (
     ApiError,
     DuplicateDisplayNameError,
@@ -308,22 +301,6 @@ def get_identities_by_user(idp, users):
         status=IdentityStatus.VALID,
     )
     return {identity.user: identity for identity in identity_models}
-
-
-def get_org_member_by_slack_id(request, integration, organization, slack_id):
-    try:
-        idp = IdentityProvider.objects.get(type="slack", external_id=integration.external_id)
-    except IdentityProvider.DoesNotExist:
-        logger.error("slack.action.invalid-team-id", extra={"slack_id": integration.external_id})
-        return render_error_page(request, body_text="HTTP 403: Invalid team ID")
-
-    try:
-        identity = Identity.objects.select_related("user").get(idp=idp, external_id=slack_id)
-    except Identity.DoesNotExist:
-        logger.error("slack.action.missing-identity", extra={"slack_id": integration.external_id})
-        return render_error_page(request, body_text="HTTP 403: User identity does not exist")
-
-    return OrganizationMember.objects.get(user=identity.user, organization=organization)
 
 
 def is_valid_role(org_member, team, organization):

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -11,7 +11,7 @@ from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 
-from ..utils import get_org_member_by_slack_id, is_valid_role, render_error_page, send_slack_message
+from ..utils import get_org_member_by_slack_id, is_valid_role, render_error_page, send_confirmation
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
@@ -90,11 +90,12 @@ class SlackLinkTeamView(BaseView):  # type: ignore
         )
 
         if not is_valid_role(org_member, team, organization):
-            return send_slack_message(
+            return send_confirmation(
                 integration,
                 channel_id,
                 INSUFFICIENT_ROLE_TITLE,
                 INSUFFICIENT_ROLE_MESSAGE,
+                "sentry/integrations/slack-post-linked-team.html",
                 request,
             )
         external_team, created = ExternalActor.objects.get_or_create(
@@ -109,11 +110,12 @@ class SlackLinkTeamView(BaseView):  # type: ignore
         )
 
         if not created:
-            return send_slack_message(
+            return send_confirmation(
                 integration,
                 channel_id,
                 ALREADY_LINKED_TITLE,
                 ALREADY_LINKED_MESSAGE.format(slug=team.slug),
+                "sentry/integrations/slack-post-linked-team.html",
                 request,
             )
 
@@ -124,10 +126,11 @@ class SlackLinkTeamView(BaseView):  # type: ignore
             NotificationSettingOptionValues.ALWAYS,
             team=team,
         )
-        return send_slack_message(
+        return send_confirmation(
             integration,
             channel_id,
             SUCCESS_LINKED_TITLE,
             SUCCESS_LINKED_MESSAGE.format(slug=team.slug, channel_name=channel_name),
+            "sentry/integrations/slack-post-linked-team.html",
             request,
         )

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -4,14 +4,22 @@ from django import forms
 from django.http import HttpResponse
 from rest_framework.request import Request
 
-from sentry.models import ExternalActor, Integration, NotificationSetting, Team
+from sentry.models import (
+    ExternalActor,
+    Identity,
+    IdentityProvider,
+    Integration,
+    NotificationSetting,
+    OrganizationMember,
+    Team,
+)
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 
-from ..utils import get_org_member_by_slack_id, is_valid_role, render_error_page, send_confirmation
+from ..utils import is_valid_role, logger, render_error_page, send_confirmation
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
@@ -85,9 +93,25 @@ class SlackLinkTeamView(BaseView):  # type: ignore
         except Team.DoesNotExist:
             return render_error_page(request, body_text="HTTP 404: Team does not exist")
 
-        org_member = get_org_member_by_slack_id(
-            request, integration, organization, params["slack_id"]
-        )
+        try:
+            idp = IdentityProvider.objects.get(type="slack", external_id=integration.external_id)
+        except IdentityProvider.DoesNotExist:
+            logger.error(
+                "slack.action.invalid-team-id", extra={"slack_id": integration.external_id}
+            )
+            return render_error_page(request, body_text="HTTP 403: Invalid team ID")
+
+        try:
+            identity = Identity.objects.select_related("user").get(
+                idp=idp, external_id=params["slack_id"]
+            )
+        except Identity.DoesNotExist:
+            logger.error(
+                "slack.action.missing-identity", extra={"slack_id": integration.external_id}
+            )
+            return render_error_page(request, body_text="HTTP 403: User identity does not exist")
+
+        org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
 
         if not is_valid_role(org_member, team, organization):
             return send_confirmation(

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -1,0 +1,113 @@
+from django.db import IntegrityError
+from django.http import Http404
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.models import ExternalActor, Integration, NotificationSetting, Team
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.shared_integrations.exceptions import ApiError
+from sentry.types.integrations import ExternalProviders
+from sentry.utils.signing import unsign
+from sentry.web.decorators import transaction_start
+from sentry.web.frontend.base import BaseView
+from sentry.web.helpers import render_to_response
+
+from ..client import SlackClient
+from ..utils import get_identity, logger
+from . import build_linking_url as base_build_linking_url
+from . import never_cache
+
+SUCCESS_UNLINKED_MESSAGE = (
+    "This channel will no longer receive issue alert notifications for the {team} team."
+)
+
+
+def build_team_unlinking_url(
+    integration: Integration,
+    organization_id: str,
+    slack_id: str,
+    channel_id: str,
+    channel_name: str,
+    response_url: str,
+) -> str:
+    return base_build_linking_url(
+        "sentry-integration-slack-unlink-team",
+        integration_id=integration.id,
+        organization_id=organization_id,
+        slack_id=slack_id,
+        channel_name=channel_name,
+        channel_id=channel_id,
+        response_url=response_url,
+    )
+
+
+class SlackUnlinkTeamView(BaseView):  # type: ignore
+    @transaction_start("SlackUnlinkIdentityView")
+    @never_cache
+    def handle(self, request: Request, signed_params: str) -> Response:
+        params = unsign(signed_params)
+
+        organization, integration, idp = get_identity(
+            request.user, params["organization_id"], params["integration_id"]
+        )
+        channel_name = params["channel_name"]
+        channel_id = params["channel_id"]
+
+        try:
+            external_team = ExternalActor.objects.get(
+                organization=organization,
+                integration=integration,
+                provider=ExternalProviders.SLACK.value,
+                external_name=channel_name,
+                external_id=channel_id,
+            )
+        except IntegrityError as e:
+            logger.error("slack.team.unlink.integrity-error", extra=e)
+            raise Http404
+
+        team = Team.objects.get(actor=external_team.actor)
+        if request.method != "POST":
+            return render_to_response(
+                "sentry/integrations/slack-unlink-team.html",
+                request=request,
+                context={
+                    "team": team,
+                    "channel_name": channel_name,
+                    "provider": integration.get_provider(),
+                },
+            )
+
+        external_team.delete()
+
+        # Turn off notifications for all of a team's projects.
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            team=team,
+        )
+
+        payload = {
+            "replace_original": False,
+            "response_type": "ephemeral",
+            "text": SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),
+        }
+
+        client = SlackClient()
+        try:
+            client.post(params["response_url"], data=payload, json=True)
+        except ApiError as e:
+            message = str(e)
+            # If the user took their time to unlink their team, we may no
+            # longer be able to respond, and we're not guaranteed able to post into
+            # the channel. Ignore Expired url errors.
+            #
+            # XXX(epurkhiser): Yes the error string has a space in it.
+            if message != "Expired url":
+                logger.error("slack.unlink-notify.response-error", extra={"error": message})
+
+        return render_to_response(
+            "sentry/integrations/slack-unlinked-team.html",
+            request=request,
+            context={"channel_name": channel_name, "team": team},
+        )

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -4,7 +4,6 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.models import ExternalActor, Integration, NotificationSetting, Team
-from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
@@ -97,14 +96,7 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
             )
 
         external_team.delete()
-
-        # Turn off notifications for all of a team's projects.
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            team=team,
-        )
+        NotificationSetting.objects.remove_for_team(team, ExternalProviders.SLACK)
 
         return send_confirmation(
             integration,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -171,10 +171,13 @@ class NotificationsManager(BaseManager):  # type: ignore
         self._filter(target_ids=[user.actor_id], type=type).delete()
 
     def remove_for_team(
-        self, team: "Team", type: Optional[NotificationSettingTypes] = None
+        self,
+        team: "Team",
+        provider: ExternalProviders,
+        type: Optional[NotificationSettingTypes] = None,
     ) -> None:
         """Bulk delete all Notification Settings for a TEAM, optionally by type."""
-        self._filter(target_ids=[team.actor_id], type=type).delete()
+        self._filter(target_ids=[team.actor_id], provider=provider, type=type).delete()
 
     def remove_for_project(
         self, project: "Project", type: Optional[NotificationSettingTypes] = None

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -173,8 +173,8 @@ class NotificationsManager(BaseManager):  # type: ignore
     def remove_for_team(
         self,
         team: "Team",
-        provider: ExternalProviders,
         type: Optional[NotificationSettingTypes] = None,
+        provider: Optional[ExternalProviders] = None,
     ) -> None:
         """Bulk delete all Notification Settings for a TEAM, optionally by type."""
         self._filter(target_ids=[team.actor_id], provider=provider, type=type).delete()

--- a/src/sentry/templates/sentry/integrations/slack-unlink-team.html
+++ b/src/sentry/templates/sentry/integrations/slack-unlink-team.html
@@ -1,0 +1,29 @@
+{% extends "sentry/bases/auth.html" %}
+
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% load sentry_assets %}
+
+{% block title %}{% trans "Unlink Team" %} | {{ block.super }}{% endblock %}
+
+{% block auth_main %}
+<form class="form-stacked" action="" method="post">
+  {% csrf_token %}
+
+  <div class="align-center">
+    <img src="{% asset_url "sentry" "images/logos/default-organization-logo.png" %}" class="org-avatar">
+
+    <h3>{{ team }}</h3>
+  </div>
+
+  <div class="align-center">
+    <p>Confirm that you'd like to unlink the <b>#{{ team.slug }}</b> team from the Slack <b>#{{ channel_name }}</b> channel.</p>
+
+    <p>
+      <button type="submit" class="btn btn-default btn-login-{{ provider.key }}">
+        <span class="provider-logo {{ provider.key }}"></span> Unlink from {{ provider.name }}
+      </button>
+    </p>
+  </div>
+</form>
+{% endblock %}

--- a/src/sentry/templates/sentry/integrations/slack-unlinked-team.html
+++ b/src/sentry/templates/sentry/integrations/slack-unlinked-team.html
@@ -1,0 +1,19 @@
+{% extends "sentry/bases/modal.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Team Unlinked" %} | {{ block.super }}{% endblock %}
+{% block wrapperclass %}narrow auth{% endblock %}
+
+{% block main %}
+  <div class="align-center">
+    <p>
+      <b>#{{ channel_name }}</b> will no longer receive issue alert notifications for the <b>#{{ team.slug }}</b> team.
+    </p>
+    <p>
+      <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">
+        <span class="provider-logo slack"></span> Go back to Slack
+      </a>
+    </p>
+  </div>
+{% endblock %}

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -31,7 +31,7 @@ from sentry.models import (
     Integration,
     NotificationSetting,
 )
-from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
+from sentry.notifications.types import NotificationScopeType
 from sentry.testutils import APITestCase, TestCase
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -523,8 +523,7 @@ class SlackCommandsUnlinkTeamTest(SlackCommandsTest):
         team_settings = NotificationSetting.objects.filter(
             scope_type=NotificationScopeType.TEAM.value, target=self.team.actor.id
         )
-        assert len(team_settings) == 1
-        assert team_settings[0].value == NotificationSettingOptionValues.NEVER.value
+        assert len(team_settings) == 0
 
     def test_unlink_no_team(self):
         """Test for when a user attempts to remove a link between a Slack channel and a Sentry team that does not exist"""


### PR DESCRIPTION
If a Sentry team has already been linked to a Slack channel (see previous PR [here](https://github.com/getsentry/sentry/pull/26750)) they may want to unlink it, and can do so by using the Slack command `/sentry unlink team`.  This uses the same access and flow as `/sentry link team`.

<img width="711" alt="Screen Shot 2021-07-02 at 2 58 20 PM" src="https://user-images.githubusercontent.com/29959063/124332263-f2f06800-db45-11eb-90e3-fc59a301fc07.png">

<img width="733" alt="Screen Shot 2021-07-01 at 3 44 56 PM" src="https://user-images.githubusercontent.com/29959063/124332095-7f4e5b00-db45-11eb-8c33-d912c2c9b4d6.png">
<img width="716" alt="Screen Shot 2021-07-01 at 3 50 25 PM" src="https://user-images.githubusercontent.com/29959063/124332101-81b0b500-db45-11eb-9d1b-4be2896e634b.png">

<img width="733" alt="Screen Shot 2021-07-02 at 2 58 31 PM" src="https://user-images.githubusercontent.com/29959063/124332273-f8e64900-db45-11eb-873b-3adf6483b2a0.png">
