### PR TITLE
bug(growth): Change threshold for crash rate for sessions on Demo Mode

### DIFF
--- a/src/sentry/demo/data_population.py
+++ b/src/sentry/demo/data_population.py
@@ -1260,7 +1260,7 @@ class DataPopulation:
             release_num = int(version.split(".")[-1])
             threshold = rate_by_release_num[release_num]
             outcome = random.random()
-            if outcome <= threshold:
+            if outcome > threshold:
                 if error_file:
                     local_event = copy.deepcopy(error)
                     local_event.update(
@@ -1333,8 +1333,8 @@ class DataPopulation:
             exited = random.choices([1, 2, 3, 4], k=1, weights=[10, 5, 3, 1])[0]
             outcome = random.random()
 
-            if outcome <= threshold:
-                crashed = int(random.uniform(1, 11))
+            if outcome > threshold:
+                crashed = int(random.uniform(1, 10))
             else:
                 crashed = 0
             current = {


### PR DESCRIPTION
This PR fixes a bug with the crash rates for sessions on Demo Mode. The thresholds were given in error rates before, but was switched to success rates while the conditional was not changed. The conditional now matches the success rates.