### PR TITLE
feat(ui): Add markers to release chart

### DIFF
--- a/static/app/types/echarts.tsx
+++ b/static/app/types/echarts.tsx
@@ -21,6 +21,7 @@ export type Series = {
   lineStyle?: EChartOption.LineStyle;
   stack?: string; // https://echarts.apache.org/en/option.html#series-line.stack
   z?: number; // https://echarts.apache.org/en/option.html#series-line.z
+  markLine?: EChartOption.SeriesLine['markLine'];
 };
 
 export type ReactEchartsRef = ReactEchartsCore & {

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -1469,7 +1469,14 @@ type ReleaseData = {
     firstReleaseVersion: string | null;
     lastReleaseVersion: string | null;
   };
-  adoptionStages?: {};
+  adoptionStages?: Record<
+    'string',
+    {
+      stage: string | null;
+      adopted: string | null;
+      unadopted: string | null;
+    }
+  >;
 };
 
 type BaseRelease = {

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -463,6 +463,7 @@ class ReleaseOverview extends AsyncView<Props> {
                               defaultPeriod={RELEASE_PERIOD_KEY}
                             />
                             <ReleaseComparisonChart
+                              release={release}
                               releaseSessions={thisRelease}
                               allSessions={allReleases}
                               platform={project.platform}
@@ -470,6 +471,7 @@ class ReleaseOverview extends AsyncView<Props> {
                               loading={loading}
                               reloading={reloading}
                               errored={errored}
+                              project={project}
                             />
                           </Fragment>
                         ) : (

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/sessionsChart.tsx
@@ -83,6 +83,10 @@ class SessionsChart extends React.Component<Props> {
     const legend = {
       right: 10,
       top: 0,
+      // do not show adoption markers in the legend
+      data: [...series, ...previousSeries]
+        .filter(s => !s.markLine)
+        .map(s => s.seriesName),
     };
 
     return (

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -1,6 +1,7 @@
 import {Location} from 'history';
 import pick from 'lodash/pick';
 
+import MarkLine from 'app/components/charts/components/markLine';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
 import {
@@ -14,6 +15,7 @@ import {
 } from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
+import {Theme} from 'app/utils/theme';
 import {QueryResults} from 'app/utils/tokenizeSearch';
 
 import {commonTermsDescription, SessionTerm} from '../utils/sessionTerm';
@@ -152,3 +154,26 @@ export const releaseComparisonChartHelp = {
   ),
   [ReleaseComparisonChartType.USER_COUNT]: t('The number of users in a given period.'),
 };
+
+export function generateReleaseMarkLine(title: string, position: number, theme: Theme) {
+  return {
+    seriesName: title,
+    type: 'line',
+    data: [],
+    markLine: MarkLine({
+      silent: true,
+      lineStyle: {color: theme.gray300, type: 'solid'},
+      label: {
+        position: 'insideEndBottom',
+        formatter: title,
+        font: 'Rubik',
+        fontSize: 11,
+      } as any, // TODO(ts): weird echart types,
+      data: [
+        {
+          xAxis: position,
+        },
+      ] as any, // TODO(ts): weird echart types
+    }),
+  };
+}

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -38,7 +38,7 @@ type Props = {
   showPlaceholders: boolean;
   isTopRelease: boolean;
   getHealthData: ReleaseHealthRequestRenderProps['getHealthData'];
-  adoptionStages?: Record<string, {stage: string; unadopted: string; adopted: string}>;
+  adoptionStages?: Release['adoptionStages'];
 };
 
 const Content = ({


### PR DESCRIPTION
Adding 3 markers to the release details chart:
- release created
- release adopted
- release unadopted

![image](https://user-images.githubusercontent.com/9060071/124442126-b2c6fa80-dd7c-11eb-9cc5-f18a436ee9a0.png)
