### PR TITLE
Files tables transactions using correct database routing

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -3,7 +3,7 @@ import posixpath
 import re
 
 import jsonschema
-from django.db import transaction
+from django.db import router, transaction
 from django.db.models import Q
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework.response import Response
@@ -461,7 +461,7 @@ class SourceMapsEndpoint(ProjectEndpoint):
         archive_name = request.GET.get("name")
 
         if archive_name:
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(ReleaseFile)):
                 release = Release.objects.get(
                     organization_id=project.organization_id, projects=project, version=archive_name
                 )

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -3,7 +3,7 @@ import posixpath
 import re
 
 import jsonschema
-from django.db import router, transaction
+from django.db import router
 from django.db.models import Q
 from django.http import Http404, HttpResponse, StreamingHttpResponse
 from rest_framework.response import Response
@@ -18,6 +18,7 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.constants import DEBUG_FILES_ROLE_DEFAULT, KNOWN_DIF_FORMATS
 from sentry.models import (
+    File,
     FileBlobOwner,
     OrganizationMember,
     ProjectDebugFile,
@@ -33,6 +34,7 @@ from sentry.tasks.assemble import (
     set_assemble_status,
 )
 from sentry.utils import json
+from sentry.utils.db import atomic_transaction
 
 logger = logging.getLogger("sentry.api")
 ERR_FILE_EXISTS = "A file matching this debug identifier already exists"
@@ -204,7 +206,7 @@ class DebugFilesEndpoint(ProjectEndpoint):
         """
 
         if request.GET.get("id") and (request.access.has_scope("project:write")):
-            with transaction.atomic():
+            with atomic_transaction(using=router.db_for_write(File)):
                 debug_file = (
                     ProjectDebugFile.objects.filter(id=request.GET.get("id"), project_id=project.id)
                     .select_related("file")
@@ -461,7 +463,7 @@ class SourceMapsEndpoint(ProjectEndpoint):
         archive_name = request.GET.get("name")
 
         if archive_name:
-            with transaction.atomic(using=router.db_for_write(ReleaseFile)):
+            with atomic_transaction(using=router.db_for_write(ReleaseFile)):
                 release = Release.objects.get(
                     organization_id=project.organization_id, projects=project, version=archive_name
                 )

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -2,7 +2,7 @@ import logging
 import re
 from typing import List, Optional, Tuple
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils.functional import cached_property
 from rest_framework.response import Response
@@ -144,7 +144,7 @@ class ReleaseFilesMixin:
         file.putfile(fileobj, logger=logger)
 
         try:
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(ReleaseFile)):
                 releasefile = ReleaseFile.objects.create(
                     organization_id=release.organization_id,
                     release_id=release.id,

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from celery.exceptions import MaxRetriesExceededError
 from celery.task import current
 from django.core.files.base import ContentFile
-from django.db import IntegrityError, router, transaction
+from django.db import IntegrityError, router
 from django.utils import timezone
 
 from sentry.models import (
@@ -254,29 +254,40 @@ def process_discover(processor, limit, offset):
     return processor.handle_fields(raw_data_unicode)
 
 
-@transaction.atomic()
+class ExportDataFileTooBig(Exception):
+    pass
+
+
 def store_export_chunk_as_blob(data_export, bytes_written, fileobj, blob_size=DEFAULT_BLOB_SIZE):
-    # adapted from `putfile` in  `src/sentry/models/file.py`
-    bytes_offset = 0
-    while True:
-        contents = fileobj.read(blob_size)
-        if not contents:
-            return bytes_offset
+    try:
+        with atomic_transaction(
+            using=(
+                router.db_for_write(FileBlob),
+                router.db_for_write(ExportedDataBlob),
+            )
+        ):
+            # adapted from `putfile` in  `src/sentry/models/file.py`
+            bytes_offset = 0
+            while True:
+                contents = fileobj.read(blob_size)
+                if not contents:
+                    return bytes_offset
 
-        blob_fileobj = ContentFile(contents)
-        blob = FileBlob.from_file(blob_fileobj, logger=logger)
-        ExportedDataBlob.objects.get_or_create(
-            data_export=data_export, blob_id=blob.id, offset=bytes_written + bytes_offset
-        )
+                blob_fileobj = ContentFile(contents)
+                blob = FileBlob.from_file(blob_fileobj, logger=logger)
+                ExportedDataBlob.objects.get_or_create(
+                    data_export=data_export, blob_id=blob.id, offset=bytes_written + bytes_offset
+                )
 
-        bytes_offset += blob.size
+                bytes_offset += blob.size
 
-        # there is a maximum file size allowed, so we need to make sure we don't exceed it
-        # NOTE: there seems to be issues with downloading files larger than 1 GB on slower
-        # networks, limit the export to 1 GB for now to improve reliability
-        if bytes_written + bytes_offset >= min(MAX_FILE_SIZE, 2 ** 30):
-            transaction.set_rollback(True)
-            return 0
+                # there is a maximum file size allowed, so we need to make sure we don't exceed it
+                # NOTE: there seems to be issues with downloading files larger than 1 GB on slower
+                # networks, limit the export to 1 GB for now to improve reliability
+                if bytes_written + bytes_offset >= min(MAX_FILE_SIZE, 2 ** 30):
+                    raise ExportDataFileTooBig()
+    except ExportDataFileTooBig:
+        return 0
 
 
 @instrumented_task(name="sentry.data_export.tasks.merge_blobs", queue="data_export", acks_late=True)

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -310,11 +310,11 @@ def merge_export_blobs(data_export_id, **kwargs):
         # adapted from `putfile` in  `src/sentry/models/file.py`
         try:
             with atomic_transaction(
-                using={
+                using=(
                     router.db_for_write(File),
                     router.db_for_write(FileBlobIndex),
                     router.db_for_write(ExportedData),
-                }
+                )
             ):
                 file = File.objects.create(
                     name=data_export.file_name,

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router
 from django.utils import timezone
 
 from sentry import eventstore
 from sentry.models import EventUser, UserReport
 from sentry.signals import user_feedback_received
+from sentry.utils.db import atomic_transaction
 
 
 class Conflict(Exception):
@@ -41,7 +42,7 @@ def save_userreport(project, report, start_time=None):
         report["group_id"] = event.group_id
 
     try:
-        with transaction.atomic():
+        with atomic_transaction(using=router.db_for_write(UserReport)):
             report_instance = UserReport.objects.create(**report)
 
     except IntegrityError:

--- a/src/sentry/models/avatar.py
+++ b/src/sentry/models/avatar.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 from uuid import uuid4
 
-from django.db import models, transaction
+from django.db import models, router, transaction
 from django.utils.encoding import force_bytes
 from PIL import Image
 
@@ -82,7 +82,7 @@ class AvatarBase(Model):
         from sentry.models import File
 
         if avatar:
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(File)):
                 photo = File.objects.create(name=filename, type=cls.FILE_TYPE)
                 # XXX: Avatar may come in as a string instance in python2
                 # if it's not wrapped in BytesIO.
@@ -92,7 +92,7 @@ class AvatarBase(Model):
         else:
             photo = None
 
-        with transaction.atomic():
+        with transaction.atomic(using=router.db_for_write(cls)):
             instance, created = cls.objects.get_or_create(**relation)
             file = instance.get_file()
             if file and photo:

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -420,7 +420,8 @@ class File(Model):
         contents.
         """
         tf = tempfile.NamedTemporaryFile()
-        with transaction.atomic():
+        assert router.db_for_write(FileBlob) == router.db_for_write(FileBlobIndex)
+        with transaction.atomic(using=router.db_for_write(FileBlob)):
             file_blobs = FileBlob.objects.filter(id__in=file_blob_ids).all()
 
             # Ensure blobs are in the order and duplication as provided

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -6,7 +6,7 @@ from time import time
 from typing import List, Mapping, Optional, Sequence, Union
 
 import sentry_sdk
-from django.db import IntegrityError, models, router, transaction
+from django.db import IntegrityError, models, router
 from django.db.models import Case, F, Func, Q, Subquery, Sum, Value, When
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -25,10 +25,17 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.exceptions import InvalidSearchQuery
-from sentry.models import CommitFileChange, GroupInboxRemoveAction, remove_group_from_inbox
+from sentry.models import (
+    Activity,
+    CommitFileChange,
+    GroupInbox,
+    GroupInboxRemoveAction,
+    remove_group_from_inbox,
+)
 from sentry.signals import issue_resolved
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import md5_text
 from sentry.utils.numbers import validate_bigint
 from sentry.utils.retries import TimedRetryPolicy
@@ -540,7 +547,7 @@ class Release(Model):
                 metric_tags["created"] = "false"
             else:
                 try:
-                    with transaction.atomic():
+                    with atomic_transaction(using=router.db_for_write(cls)):
                         release = cls.objects.create(
                             organization_id=project.organization_id,
                             version=version,
@@ -615,12 +622,12 @@ class Release(Model):
                 else:
                     update_kwargs = {"release_id": to_release.id}
                 try:
-                    with transaction.atomic(using=router.db_for_write(model)):
+                    with atomic_transaction(using=router.db_for_write(model)):
                         model.objects.filter(release_id=release.id).update(**update_kwargs)
                 except IntegrityError:
                     for item in model.objects.filter(release_id=release.id):
                         try:
-                            with transaction.atomic(using=router.db_for_write(model)):
+                            with atomic_transaction(using=router.db_for_write(model)):
                                 model.objects.filter(id=item.id).update(**update_kwargs)
                         except IntegrityError:
                             item.delete()
@@ -657,7 +664,7 @@ class Release(Model):
         from sentry.models import Project
 
         try:
-            with transaction.atomic():
+            with atomic_transaction(using=router.db_for_write(ReleaseProject)):
                 ReleaseProject.objects.create(project=project, release=self)
                 if not project.flags.has_releases:
                     project.flags.has_releases = True
@@ -777,7 +784,15 @@ class Release(Model):
             raise ReleaseCommitError
         with TimedRetryPolicy(10)(lock.acquire):
             start = time()
-            with transaction.atomic():
+            with atomic_transaction(
+                using=(
+                    router.db_for_write(type(self)),
+                    router.db_for_write(ReleaseCommit),
+                    router.db_for_write(Repository),
+                    router.db_for_write(CommitAuthor),
+                    router.db_for_write(Commit),
+                )
+            ):
                 # TODO(dcramer): would be good to optimize the logic to avoid these
                 # deletes but not overly important
                 ReleaseCommit.objects.filter(release=self).delete()
@@ -854,7 +869,7 @@ class Release(Model):
                     patch_set = data.get("patch_set") or []
                     for patched_file in patch_set:
                         try:
-                            with transaction.atomic():
+                            with atomic_transaction(using=router.db_for_write(CommitFileChange)):
                                 CommitFileChange.objects.create(
                                     organization_id=self.organization.id,
                                     commit=commit,
@@ -865,7 +880,7 @@ class Release(Model):
                             pass
 
                     try:
-                        with transaction.atomic():
+                        with atomic_transaction(using=router.db_for_write(ReleaseCommit)):
                             ReleaseCommit.objects.create(
                                 organization_id=self.organization_id,
                                 release=self,
@@ -897,7 +912,7 @@ class Release(Model):
         # fill any missing ReleaseHeadCommit entries
         for repo_id, commit_id in head_commit_by_repo.items():
             try:
-                with transaction.atomic():
+                with atomic_transaction(using=router.db_for_write(ReleaseHeadCommit)):
                     ReleaseHeadCommit.objects.create(
                         organization_id=self.organization_id,
                         release_id=self.id,
@@ -969,7 +984,15 @@ class Release(Model):
                     user_by_author[author] = None
             actor = user_by_author[author]
 
-            with transaction.atomic():
+            with atomic_transaction(
+                using=(
+                    router.db_for_write(GroupResolution),
+                    router.db_for_write(Group),
+                    # inside the remove_group_from_inbox
+                    router.db_for_write(GroupInbox),
+                    router.db_for_write(Activity),
+                )
+            ):
                 GroupResolution.objects.create_or_update(
                     group_id=group_id,
                     values={

--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -10,7 +10,7 @@ from typing import IO, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 from django.core.files.base import File as FileObj
-from django.db import models, router, transaction
+from django.db import models, router
 
 from sentry import options
 from sentry.db.models import (
@@ -25,6 +25,7 @@ from sentry.models.distribution import Distribution
 from sentry.models.file import File
 from sentry.models.release import Release
 from sentry.utils import json, metrics
+from sentry.utils.db import atomic_transaction
 from sentry.utils.hashlib import sha1_text
 from sentry.utils.zip import safe_extract_zip
 
@@ -283,8 +284,12 @@ class _ArtifactIndexGuard:
     @contextmanager
     def writable_data(self, create: bool, initial_artifact_count=None):
         """Context manager for editable artifact index"""
-        assert router.db_for_write(ReleaseFile) == router.db_for_write(File)
-        with transaction.atomic(using=router.db_for_write(ReleaseFile)):
+        with atomic_transaction(
+            using=(
+                router.db_for_write(ReleaseFile),
+                router.db_for_write(File),
+            )
+        ):
             created = False
             if create:
                 releasefile, created = self._get_or_create_releasefile(initial_artifact_count)

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 from os import path
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, router, transaction
 
 from sentry import options
 from sentry.api.serializers import serialize
@@ -183,7 +183,7 @@ def _upsert_release_file(
         release_file = ReleaseFile.objects.get(**key_fields)
     except ReleaseFile.DoesNotExist:
         try:
-            with transaction.atomic():
+            with transaction.atomic(using=router.db_for_write(ReleaseFile)):
                 release_file = ReleaseFile.objects.create(
                     file=file, **dict(key_fields, **additional_fields)
                 )

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 from os import path
 
-from django.db import IntegrityError, router, transaction
+from django.db import IntegrityError, router
 
 from sentry import options
 from sentry.api.serializers import serialize
@@ -12,6 +12,7 @@ from sentry.models import File, Organization, Release, ReleaseFile
 from sentry.models.releasefile import ReleaseArchive, update_artifact_index
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
+from sentry.utils.db import atomic_transaction
 from sentry.utils.files import get_max_file_size
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
@@ -183,7 +184,7 @@ def _upsert_release_file(
         release_file = ReleaseFile.objects.get(**key_fields)
     except ReleaseFile.DoesNotExist:
         try:
-            with transaction.atomic(using=router.db_for_write(ReleaseFile)):
+            with atomic_transaction(using=router.db_for_write(ReleaseFile)):
                 release_file = ReleaseFile.objects.create(
                     file=file, **dict(key_fields, **additional_fields)
                 )

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -12,14 +12,15 @@ def atomic_transaction(using, savepoint=True):
     Usage:
 
     >>> atomic_transaction(using=router.db_for_write(File))
-    >>> atomic_transaction(using={router.db_for_write(Release), router.db_for_write(ReleaseFile)})
+    >>> atomic_transaction(using=(router.db_for_write(Release), router.db_for_write(ReleaseFile)))
 
     """
     if isinstance(using, str):
         return transaction.atomic(using=using, savepoint=savepoint)
 
     stack = ExitStack()
-    for db in set(using):
+    # dict.fromkeys -> deduplicate while preserving order
+    for db in dict.fromkeys(using):
         stack.enter_context(transaction.atomic(using=db, savepoint=savepoint))
     return stack
 

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -1,4 +1,5 @@
 from contextlib import ExitStack
+from typing import Sequence, Union
 
 import sentry_sdk
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
@@ -6,7 +7,9 @@ from django.db.models.fields.related_descriptors import ReverseOneToOneDescripto
 from sentry_sdk.integrations import Integration
 
 
-def atomic_transaction(using, savepoint=True):
+def atomic_transaction(
+    using: Union[str, Sequence[str]], savepoint: bool = True
+) -> Union[transaction.Atomic, ExitStack]:
     """
     Open transaction to one or multiple databases.
 

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -1,4 +1,5 @@
 from contextlib import ExitStack
+
 import sentry_sdk
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
 from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor


### PR DESCRIPTION
Used this monkey patch ~ https://github.com/getsentry/sentry/pull/27128/commits/58960df9edc3c5f19b5bce8e897a90eb69ab9617 ~ to find places where we mutate file tables within transactions and added the `using` argument with database connection alias from database router.

I think we probably want to review all use of `transaction.atomic` and make sure `using` is provided also placing some check in place to ensure that going forward.