### PR TITLE
fix(grouping): Clear memoized interfaces after stack trace normalization

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -71,7 +71,6 @@ from sentry.reprocessing2 import (
     save_unprocessed_event,
 )
 from sentry.signals import first_event_received, first_transaction_received, issue_unresolved
-from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache_key_for_event
@@ -1630,9 +1629,7 @@ def _calculate_event_grouping(project, event, grouping_config) -> CalculatedHash
 
     with metrics.timer("event_manager.normalize_stacktraces_for_grouping"):
         with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):
-            normalize_stacktraces_for_grouping(
-                event.data.data, load_grouping_config(grouping_config)
-            )
+            event.normalize_stacktraces_for_grouping(load_grouping_config(grouping_config))
 
     with metrics.timer("event_manager.apply_server_fingerprinting"):
         # The active grouping config was put into the event in the

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -449,7 +449,7 @@ class Event:
         normalize_stacktraces_for_grouping(self.data, grouping_config)
 
         # We have modified event data, so any cached interfaces have to be reset:
-        vars(self).pop("interfaces", None)
+        self.__dict__.pop("interfaces", None)
 
     def get_grouping_variants(self, force_config=None, normalize_stacktraces=False):
         """

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1495,11 +1495,16 @@ class EventManagerTest(TestCase):
         )
 
     def test_category_match_in_app(self):
+        """
+        Regression test to ensure that grouping in-app enhancements work in
+        principle.
+        """
         from sentry.grouping.enhancer import Enhancements
 
         enhancement = Enhancements.from_config_string(
             """
             function:foo category=bar
+            function:foo2 category=bar
             category:bar -app
             """,
         )
@@ -1516,6 +1521,7 @@ class EventManagerTest(TestCase):
                                     "function": "foo",
                                     "in_app": True,
                                 },
+                                {"function": "bar"},
                             ]
                         },
                     }
@@ -1532,7 +1538,41 @@ class EventManagerTest(TestCase):
         event1 = manager.save(1)
         assert event1.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
 
+        event = make_event(
+            platform="native",
+            exception={
+                "values": [
+                    {
+                        "type": "Hello",
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "function": "foo2",
+                                    "in_app": True,
+                                },
+                                {"function": "bar"},
+                            ]
+                        },
+                    }
+                ]
+            },
+        )
+
+        manager = EventManager(event)
+        manager.normalize()
+        manager.get_data()["grouping_config"] = {
+            "enhancements": enhancement.dumps(),
+            "id": "mobile:2021-02-12",
+        }
+        event2 = manager.save(1)
+        assert event2.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
+        assert event1.group_id == event2.group_id
+
     def test_category_match_group(self):
+        """
+        Regression test to ensure categories are applied consistently and don't
+        produce hash mismatches.
+        """
         from sentry.grouping.enhancer import Enhancements
 
         enhancement = Enhancements.from_config_string(

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -244,6 +244,10 @@ class EventTest(TestCase):
         assert not event_from_nodestore.group
 
     def test_grouping_reset(self):
+        """
+        Regression test against a specific mutability bug involving grouping,
+        stacktrace normalization and memoized interfaces
+        """
         event_data = {
             "exception": {
                 "values": [


### PR DESCRIPTION
Previously, grouping enhancements would use a memoized version of the frame data, so any modifications made in `normalize_stacktraces_for_grouping` were not considered by the enhancer.

The impact of this bug is basically that `+app/-app` stack trace rules are not considered during grouping at all, only in the grouping debug view. It also has similarly catastrophic effects on hierarchical grouping where all categorization is basically unapplied.