### PR TITLE
fix(performance): Transaction Events tab dark mode text

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -255,7 +255,6 @@ const MenuItemContent = styled('div')`
   justify-content: flex-start;
   align-items: center;
   width: 100%;
-  color: ${p => p.theme.gray500};
 `;
 
 const RadioLabel = styled('label')`


### PR DESCRIPTION
Fixed dark mode text in transaction events tab to appear correctly by removing hard coded css color value (which was unneeded).

Before:
![image](https://user-images.githubusercontent.com/83961295/124507153-34c61c00-dd9b-11eb-8cbd-73b0db197357.png)

After:
![image](https://user-images.githubusercontent.com/83961295/124507275-7656c700-dd9b-11eb-8dec-cbdd3824155e.png)

And for light mode:
![image](https://user-images.githubusercontent.com/83961295/124507236-65a65100-dd9b-11eb-9b4d-c632faf78416.png)
