### PR TITLE
feat(workflow): Change adoption calculation

### DIFF
--- a/src/sentry/tasks/releasemonitor.py
+++ b/src/sentry/tasks/releasemonitor.py
@@ -12,7 +12,6 @@ from sentry.models import Release, ReleaseProjectEnvironment
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics, snuba
 
-REQUIRED_ADOPTION_PERCENT = 0.1
 CHUNK_SIZE = 1000
 MAX_SECONDS = 60
 
@@ -153,7 +152,7 @@ def process_projects_with_sessions(org_id, project_ids):
             for environment in totals[project_id]:
                 total_releases = len(totals[project_id][environment]["releases"])
                 for release in totals[project_id][environment]["releases"]:
-                    threshold = 1 / total_releases
+                    threshold = 0.1 / total_releases
                     if (
                         totals[project_id][environment]["releases"][release]
                         / totals[project_id][environment]["total_sessions"]

--- a/tests/sentry/tasks/test_releasemonitor.py
+++ b/tests/sentry/tasks/test_releasemonitor.py
@@ -261,7 +261,7 @@ class TestReleaseMonitor(TestCase, SnubaTestCase):
         self.bulk_store_sessions(
             [
                 self.session_dict(i, self.project1.id, self.release2.version, self.environment.name)
-                for i in range(11)
+                for i in range(20)
             ]
         )
         now = timezone.now()


### PR DESCRIPTION
This PR changes the adoption calculation threshold from a fixed 10% to (100 / # of releases in the last 6 hours with sessions)%. Importantly, it also now performs step 3 separately after summing session counts across SnQL query pages. This is so we can sum the sessions of a release on a per project and environment basis, and have a total count of releases.