### PR TITLE
feat(grouping): Ability to render grouping information inline with stacktrace

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -8,7 +8,7 @@ from sentry.utils.strings import strip, truncatechars
 
 
 def format_title_from_tree_label(tree_label):
-    return " | ".join(tree_label)
+    return " | ".join(filter(bool, (x.get("function") or x.get("package") for x in tree_label)))
 
 
 def compute_title_with_tree_label(title: Optional[str], metadata: dict):

--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -79,6 +79,12 @@ def _compute_tree_label(components: Iterable[GroupingComponent]):
 
     for frame in components:
         if frame.tree_label:
+            tree_label = dict(frame.tree_label)
+            if frame.is_sentinel_frame:
+                tree_label["is_sentinel"] = True
+            if frame.is_prefix_frame:
+                tree_label["is_prefix"] = True
+
             tree_label.append(frame.tree_label)
 
     # We assume all components are always sorted in the way frames appear in

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -267,7 +267,7 @@ def get_function_component(
             )
 
     if function_component.values and context["hierarchical_grouping"]:
-        function_component.update(tree_label=function_component.values[0])
+        function_component.update(tree_label={"function": function_component.values[0]})
 
     return function_component
 
@@ -346,7 +346,7 @@ def frame(frame, event, context, **meta):
                 )
 
             if package_component.values and context["hierarchical_grouping"]:
-                package_component.update(tree_label=package_component.values[0])
+                package_component.update(tree_label={"package": package_component.values[0]})
 
             values.append(package_component)
 
@@ -384,6 +384,9 @@ def frame(frame, event, context, **meta):
 
     if context["is_recursion"]:
         rv.update(contributes=False, hint="ignored due to recursion")
+
+    if rv.tree_label:
+        rv.tree_label = {"datapath": frame.datapath, **rv.tree_label}
 
     return {context["variant"]: rv}
 

--- a/src/sentry/interfaces/breadcrumbs.py
+++ b/src/sentry/interfaces/breadcrumbs.py
@@ -26,13 +26,13 @@ class Breadcrumbs(Interface):
     score = 800
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         values = []
         for index, crumb in enumerate(get_path(data, "values", filter=True, default=())):
             # TODO(ja): Handle already invalid and None breadcrumbs
             values.append(cls.normalize_crumb(crumb))
 
-        return cls(values=values)
+        return super().to_python({"values": values}, **kwargs)
 
     def to_json(self):
         return prune_empty_keys(

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -144,14 +144,15 @@ class Contexts(Interface):
     score = 800
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         rv = {}
         for alias, value in data.items():
             # XXX(markus): The `None`-case should be handled in the UI and
             # other consumers of this interface
             if value is not None:
                 rv[alias] = cls.normalize_context(alias, value)
-        return cls(**rv)
+
+        return super().to_python(rv, **kwargs)
 
     @classmethod
     def normalize_context(cls, alias, data):

--- a/src/sentry/interfaces/debug_meta.py
+++ b/src/sentry/interfaces/debug_meta.py
@@ -23,11 +23,14 @@ class DebugMeta(Interface):
     external_type = "debugmeta"
 
     @classmethod
-    def to_python(cls, data):
-        return cls(
-            images=data.get("images", None) or [],
-            sdk_info=data.get("sdk_info"),
-            is_debug_build=data.get("is_debug_build"),
+    def to_python(cls, data, **kwargs):
+        return super().to_python(
+            {
+                "images": data.get("images", None) or [],
+                "sdk_info": data.get("sdk_info"),
+                "is_debug_build": data.get("is_debug_build"),
+            },
+            **kwargs,
         )
 
     def to_json(self):

--- a/src/sentry/interfaces/geo.py
+++ b/src/sentry/interfaces/geo.py
@@ -15,11 +15,11 @@ class Geo(Interface):
     """
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         data = {
             "country_code": data.get("country_code"),
             "city": data.get("city"),
             "region": data.get("region"),
         }
 
-        return cls(**data)
+        return super().to_python(data, **kwargs)

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -113,7 +113,7 @@ class Http(Interface):
     FORM_TYPE = "application/x-www-form-urlencoded"
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         data.setdefault("query_string", [])
         for key in (
             "method",
@@ -126,7 +126,8 @@ class Http(Interface):
             "inferred_content_type",
         ):
             data.setdefault(key, None)
-        return cls(**data)
+
+        return super().to_python(data, **kwargs)
 
     def to_json(self):
         return prune_empty_keys(

--- a/src/sentry/interfaces/message.py
+++ b/src/sentry/interfaces/message.py
@@ -36,10 +36,11 @@ class Message(Interface):
     external_type = "message"
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         for key in ("message", "formatted", "params"):
             data.setdefault(key, None)
-        return cls(**data)
+
+        return super().to_python(data, **kwargs)
 
     def to_json(self):
         return prune_empty_keys(

--- a/src/sentry/interfaces/sdk.py
+++ b/src/sentry/interfaces/sdk.py
@@ -22,11 +22,11 @@ class Sdk(Interface):
     """
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         for key in ("name", "version", "integrations", "packages"):
             data.setdefault(key, None)
 
-        return cls(**data)
+        return super().to_python(data, **kwargs)
 
     def to_json(self):
         return prune_empty_keys(

--- a/src/sentry/interfaces/security.py
+++ b/src/sentry/interfaces/security.py
@@ -165,12 +165,12 @@ class Csp(SecurityReport):
     title = "CSP Report"
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         data.setdefault("document_uri", None)
         data.setdefault("violated_directive", None)
         data.setdefault("blocked_uri", None)
         data.setdefault("effective_directive", None)
-        return cls(**data)
+        return super().to_python(data, **kwargs)
 
     def to_string(self, is_public=False, **kwargs):
         return json.dumps({"csp-report": self.get_api_context()}, indent=2)

--- a/src/sentry/interfaces/spans.py
+++ b/src/sentry/interfaces/spans.py
@@ -40,10 +40,11 @@ class Span(Interface):
     """
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         for key in SPAN_KEYS:
             data.setdefault(key, None)
-        return cls(**data)
+
+        return super().to_python(data, **kwargs)
 
 
 class Spans(Interface):
@@ -56,9 +57,9 @@ class Spans(Interface):
     path = "spans"
 
     @classmethod
-    def to_python(cls, data):
-        spans = [Span.to_python(span) for span in data]
-        return cls(spans=spans)
+    def to_python(cls, data, **kwargs):
+        spans = [Span.to_python_subpath(data, [i], **kwargs) for i, span in enumerate(data)]
+        return super().to_python({"spans": spans}, **kwargs)
 
     def __iter__(self):
         return iter(self.spans)

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -237,6 +237,9 @@ class Frame(Interface):
         if self.data and "symbolicator_status" in self.data:
             data["symbolicatorStatus"] = self.data["symbolicator_status"]
 
+        if self.datapath:
+            data["datapath"] = self.datapath
+
         return data
 
     def get_meta_context(self, meta, is_public=False, platform=None):

--- a/src/sentry/interfaces/template.py
+++ b/src/sentry/interfaces/template.py
@@ -32,7 +32,7 @@ class Template(Interface):
     score = 1100
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         for key in (
             "abs_path",
             "filename",
@@ -42,7 +42,8 @@ class Template(Interface):
             "post_context",
         ):
             data.setdefault(key, None)
-        return cls(**data)
+
+        return super().to_python(data, **kwargs)
 
     def to_string(self, event, is_public=False, **kwargs):
         context = get_context(

--- a/src/sentry/interfaces/threads.py
+++ b/src/sentry/interfaces/threads.py
@@ -1,17 +1,18 @@
 from sentry.interfaces.base import Interface
 from sentry.interfaces.stacktrace import Stacktrace
 from sentry.utils.json import prune_empty_keys
-from sentry.utils.safe import trim
+from sentry.utils.safe import get_path, trim
 
 __all__ = ("Threads",)
 
 
-def get_stacktrace(value, raw=False):
+def get_stacktrace(value, path, **kwargs):
     # Special case: if the thread has no frames we set the
     # stacktrace to none.  Otherwise this will fail really
     # badly.
-    if value and value.get("frames"):
-        return Stacktrace.to_python(value, raw=raw)
+    subvalue = get_path(value, *path)
+    if subvalue and subvalue.get("frames"):
+        return Stacktrace.to_python_subpath(value, path, **kwargs)
 
 
 class Threads(Interface):
@@ -19,18 +20,20 @@ class Threads(Interface):
     grouping_variants = ["system", "app"]
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         threads = []
 
-        for thread in data.get("values") or ():
+        for i, thread in enumerate(data.get("values") or ()):
             if thread is None:
                 # XXX(markus): We should handle this in the UI and other
                 # consumers of this interface
                 continue
             threads.append(
                 {
-                    "stacktrace": get_stacktrace(thread.get("stacktrace")),
-                    "raw_stacktrace": get_stacktrace(thread.get("raw_stacktrace"), raw=True),
+                    "stacktrace": get_stacktrace(data, ["values", i, "stacktrace"], **kwargs),
+                    "raw_stacktrace": get_stacktrace(
+                        data, ["values", i, "raw_stacktrace"], **kwargs
+                    ),
                     "id": trim(thread.get("id"), 40),
                     "crashed": bool(thread.get("crashed")),
                     "current": bool(thread.get("current")),
@@ -38,7 +41,7 @@ class Threads(Interface):
                 }
             )
 
-        return cls(values=threads)
+        return super().to_python({"values": threads}, **kwargs)
 
     def to_json(self):
         def export_thread(data):

--- a/src/sentry/interfaces/user.py
+++ b/src/sentry/interfaces/user.py
@@ -29,13 +29,14 @@ class User(Interface):
     display_score = 2020
 
     @classmethod
-    def to_python(cls, data):
+    def to_python(cls, data, **kwargs):
         data = data.copy()
         for key in ("id", "email", "username", "ip_address", "name", "geo", "data"):
             data.setdefault(key, None)
         if data["geo"] is not None:
-            data["geo"] = Geo.to_python(data["geo"])
-        return cls(**data)
+            data["geo"] = Geo.to_python_subpath(data, ["geo"], **kwargs)
+
+        return super().to_python(data, **kwargs)
 
     def to_json(self):
         return prune_empty_keys(

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -371,6 +371,12 @@ export type Team = {
 
 export type TeamWithProjects = Team & {projects: Project[]};
 
+export type TreeLabelComponent = {
+  function?: string;
+  package?: string;
+  datapath?: (string | number)[];
+};
+
 // This type is incomplete
 export type EventMetadata = {
   value?: string;
@@ -383,8 +389,8 @@ export type EventMetadata = {
   origin?: string;
   function?: string;
   stripped_crash?: boolean;
-  current_tree_label?: string[];
-  finest_tree_label?: string[];
+  current_tree_label?: TreeLabelComponent[];
+  finest_tree_label?: object[];
 };
 
 export type EventAttachment = {

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -1,4 +1,10 @@
-import {BaseGroup, EventMetadata, GroupTombstone, Organization} from 'app/types';
+import {
+  BaseGroup,
+  EventMetadata,
+  GroupTombstone,
+  Organization,
+  TreeLabelComponent,
+} from 'app/types';
 import {Event} from 'app/types/event';
 import {isNativePlatform} from 'app/utils/platform';
 
@@ -31,8 +37,11 @@ export function getMessage(
   }
 }
 
-function formatTreeLabel(treeLabel: string[]) {
-  return treeLabel.join(' | ');
+function formatTreeLabel(treeLabel: TreeLabelComponent[]) {
+  return treeLabel
+    .map(part => part && (part.function || part.package))
+    .filter(part => part)
+    .join(' | ');
 }
 
 function computeTitleWithTreeLabel(title: string | undefined, metadata: EventMetadata) {


### PR DESCRIPTION
Fix [INGEST-91]

## Original problem statement

<details>
<summary>

*Full document at https://www.notion.so/sentry/Stack-trace-rendering-API-5a1019dfd1df4839a15391274d64b65f*

</summary>

For [INGEST-74] we want to change which frames we show by default when showing a stacktrace for a group. Right now we only show in-app frames by default, but sometimes out-of-app frames that we also group by are more relevant to summarizing what the issue is about.

The purpose of this document is to figure out an API and implementation for determining which frame (interfaces) were involved in grouping the event into the current issue. We currently have only `in_app` as marker that the UI uses, but now also want the following flags:

1. Is this frame considered for grouping in principle ("`+/-group` in any variant")? (we want to show those + app-frames by default)
    - why? sentinel frame or prefix frame? (we may want to show this sometime)
2. Is this frame used for grouping right now? ("is the currently applied grouping variant hashing that frame") (we want to mark those frames in UI)
3. nice to have: expose all kinds of component data, such as grouping hints, output of function mangling etc (we may want to show this sometime in the future, not planned)

This should be future-proof for when regrouping lands, such that when the grouping level is changed the frames that are *currently* being grouped by (point 2) are updated.

</details>

## Proposal

<details>
<summary>

*full document at https://www.notion.so/sentry/API-proposal-1-164de09aaf904babae916f13540ef48c*

</summary>

We don't touch frame data and don't add any additional frame components. Instead, tree labels now look like this:

```tsx
// top-level event property
metadata: {
  culprit: ...,
  location: ...,
  finest_tree_label: [
    {function: "foo", package: "libfoo", "datapath": ["exception", "values", 0, "stacktrace", "frames", 1]},
    ...
  ]
}

// loaded from .../issues/123/
metadata: {
  culprit: ...,
  location: ...,
  current_tree_label: [
    {function: "foo", package: "libfoo", "datapath": ["exception", "values", 0, "stacktrace", "frames", 1]},
    ...
  ]
}
```

TypeScript definition of array item:

```tsx
// array item is currently a string, treat as if it is {"function": ...}
string | {
  function?: string, // those are all optional in the frame component itself
  package?: string,
  datapath?: string[],
  is_sentinel?: bool, // if false, it is omitted
  is_prefix?: bool // if false, it is omitted
}
```

API serializer of a `frame` will gain a new attribute `datapath`:

```tsx
{
  absPath: "/usr/bin/bar",
  datapath: ["exception", "values", 0, ...]
}
```

Changes in frontend include:

- In issue details, stacktrace preview, and event details (discover), pass down event (or just event metadata) into frame component
- In issue details and stacktrace preview, also pass down *group* metadata into frame component

The frame component now has `finest_tree_label?` and `current_tree_label?`, and can implement all logic:

- A frame is being grouped by on the max level if `finest_tree_label` contains the frame's datapath
- A frame is *currently* being grouped by if `current_tree_label` contains the frame's datapath
- Top sentinel frame = first tree label item with `is_sentinel=true`.

We solve multiple problems with this:

- Due to architectural artifacts in grouping, it's hard to really mutate the event after producing grouping components. Information as to whether a frame is being grouped cannot just be written back into the event.
    - tree_labels already have to "flow" through the system correctly and have to be updated whenever grouping level changes
- In a similar manner, writing a frame identifier back into the frame is also expensive. We cannot do it in `get_grouping_variants` (as per above) and we would not want to do it in `normalize_stacktraces_for_grouping` as it would mean we compute identifiers for all threads, blowing up minidump events further.
- We have stories in the pipeline that talk about showing package information in addition to function information in group titles. Since this information is now structured in tree labels we now have done most of the backend work there as well

## Limiting storage

This proposal adds a lot of data to the persisted event. While [the original problem statement] concerned itself a lot with storage, this is now done on purpose because new product requirements may pop up to convey more information in the group title.

At a later point we can:

- Remove `hierarchical_tree_labels` property from persisted event
- If we know we never want to use `is_sentinel` in the title, we can remove it before saving the event, and load the full tree labels via grouping debug information.
    - Generally this approach is very flexible for moving properties around between the persisted event and on-the-fly computation.

[INGEST-91]: https://getsentry.atlassian.net/browse/INGEST-91
[INGEST-74]: https://getsentry.atlassian.net/browse/INGEST-74

</details>