### PR TITLE
feat(codeowners): Display alert with code owner errors

### DIFF
--- a/docs-ui/components/alert.stories.js
+++ b/docs-ui/components/alert.stories.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'app/components/alert';

--- a/docs-ui/components/alert.stories.js
+++ b/docs-ui/components/alert.stories.js
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import Alert from 'app/components/alert';
 import ExternalLink from 'app/components/links/externalLink';
-import {IconCheckmark, IconInfo, IconNot, IconWarning} from 'app/icons';
+import {IconCheckmark, IconInfo, IconLightning, IconNot, IconWarning} from 'app/icons';
 import space from 'app/styles/space';
 
 export default {
@@ -94,6 +94,48 @@ System.parameters = {
     description: {
       story:
         'System-level alert messages that appear at the top of the viewport, or embedded in a panel',
+    },
+  },
+};
+
+export const Expandable = () => {
+  return (
+    <Grid>
+      <Alert
+        type="info"
+        icon={<IconInfo size="md" />}
+        expand={[<div key="1">Here is some details</div>]}
+      >
+        Expandable Alert
+      </Alert>
+
+      <Alert
+        type="success"
+        icon={<IconCheckmark size="md" />}
+        expand={[<div key="1">Here is some details</div>]}
+        expandIcon={<IconLightning size="md" />}
+      >
+        Expandable Alert with Custom Expand Icon
+      </Alert>
+
+      <Alert
+        type="warning"
+        icon={<IconWarning size="md" />}
+        expand={[<div key="1">Here is some details</div>]}
+        expandIcon={<IconCheckmark size="md" />}
+        onExpandIconClick={() => {}}
+      >
+        Expandable Alert with Custom Expand Icon behaviour
+      </Alert>
+    </Grid>
+  );
+};
+
+Expandable.storyName = 'Expandable';
+Expandable.parameters = {
+  docs: {
+    description: {
+      story: 'Expand with details',
     },
   },
 };

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -38,9 +38,8 @@ def validate_association(
         sentry_items = [item.external_name for item in associations]
 
     diff = [str(item) for item in raw_items if item not in sentry_items]
-    unique_diff = list(dict.fromkeys(diff).keys())
 
-    return unique_diff if len(unique_diff) else []
+    return list(dict.fromkeys(diff).keys())
 
 
 class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -205,7 +205,7 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectC
                     project_codeowners,
                     request.user,
                     serializer=projectcodeowners_serializers.ProjectCodeOwnersSerializer(
-                        expand=["ownershipSyntax"]
+                        expand=["ownershipSyntax", "errors"]
                     ),
                 ),
                 status=status.HTTP_201_CREATED,

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -41,11 +41,6 @@ def validate_association(
     unique_diff = list(dict.fromkeys(diff).keys())
 
     return unique_diff if len(unique_diff) else []
-    #     return [
-    #         f'The following {type} do not have an association in Sentry: {", ".join(unique_diff)}.'
-    #     ]
-
-    # return []
 
 
 class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -30,16 +30,14 @@ def validate_association(
     associations: Sequence[Union[UserEmail, ExternalActor]],
     type: str,
 ) -> Sequence[str]:
+    raw_items_set = {str(item) for item in raw_items}
     if type == "emails":
         # associations are UserEmail objects
-        sentry_items = [item.email for item in associations]
+        sentry_items = {item.email for item in associations}
     else:
         # associations are ExternalActor objects
-        sentry_items = [item.external_name for item in associations]
-
-    diff = [str(item) for item in raw_items if item not in sentry_items]
-
-    return list(dict.fromkeys(diff).keys())
+        sentry_items = {item.external_name for item in associations}
+    return list(raw_items_set.difference(sentry_items))
 
 
 class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
@@ -169,7 +167,6 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectC
         :pparam string project_slug: the slug of the project to get.
         :param string raw: the raw CODEOWNERS text
         :param string codeMappingId: id of the RepositoryProjectPathConfig object
-        :param boolean (optional) ignoreMissing: if true, ignore errors for unassociated owners
         :auth: required
         """
         if not self.has_feature(request, project):

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -61,6 +61,8 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
         if not attrs.get("raw", "").strip():
             return attrs
 
+        # Ignore association errors and continue parsing CODEOWNERS for valid lines.
+        # Allow users to incrementally fix association errors; for CODEOWNERS with many external mappings.
         associations, _ = ProjectCodeOwners.validate_codeowners_associations(
             attrs, self.context["project"]
         )

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -9,6 +9,7 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.endpoints.project_ownership import ProjectOwnershipMixin
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models import projectcodeowners as projectcodeowners_serializers
 from sentry.models import ProjectCodeOwners
 
 from .project_codeowners import ProjectCodeOwnerSerializer, ProjectCodeOwnersMixin
@@ -67,7 +68,16 @@ class ProjectCodeOwnersDetailsEndpoint(
                 codeowners_id=updated_codeowners.id,
             )
             self.track_response_code("update", status.HTTP_200_OK)
-            return Response(serialize(updated_codeowners, request.user), status=status.HTTP_200_OK)
+            return Response(
+                serialize(
+                    updated_codeowners,
+                    request.user,
+                    serializer=projectcodeowners_serializers.ProjectCodeOwnersSerializer(
+                        expand=["ownershipSyntax", "errors"]
+                    ),
+                ),
+                status=status.HTTP_200_OK,
+            )
 
         self.track_response_code("update", status.HTTP_400_BAD_REQUEST)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -15,7 +15,7 @@ class ProjectOwnershipSerializer(serializers.Serializer):
     autoAssignment = serializers.BooleanField()
 
     def validate(self, attrs):
-        if not attrs.get("raw", "").strip():
+        if "raw" not in attrs:
             return attrs
         try:
             rules = parse_rules(attrs["raw"])

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -52,4 +52,9 @@ class ProjectCodeOwnersSerializer(Serializer):
         if "ownershipSyntax" in self.expand:
             data["ownershipSyntax"] = convert_schema_to_rules_text(obj.schema)
 
+        if "errors" in self.expand:
+            # _, errors = validate_codeowners_associations(obj, obj.project)
+            _, errors = ProjectCodeOwners.validate_codeowners_associations(obj, obj.project)
+            data["errors"] = errors
+
         return data

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -53,8 +53,7 @@ class ProjectCodeOwnersSerializer(Serializer):
             data["ownershipSyntax"] = convert_schema_to_rules_text(obj.schema)
 
         if "errors" in self.expand:
-            # _, errors = validate_codeowners_associations(obj, obj.project)
-            _, errors = ProjectCodeOwners.validate_codeowners_associations(obj, obj.project)
+            _, errors = ProjectCodeOwners.validate_codeowners_associations(data, obj.project)
             data["errors"] = errors
 
         return data

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -61,7 +61,7 @@ class ProjectCodeOwners(DefaultFieldsModel):
         from sentry.ownership.grammar import parse_code_owners
 
         # Get list of team/user names from CODEOWNERS file
-        team_names, usernames, emails = parse_code_owners(getattr(attrs, "raw", ""))
+        team_names, usernames, emails = parse_code_owners(attrs["raw"])
 
         # Check if there exists Sentry users with the emails listed in CODEOWNERS
         user_emails = UserEmail.objects.filter(
@@ -93,7 +93,7 @@ class ProjectCodeOwners(DefaultFieldsModel):
                 else:
                     teams_without_access.append(f"#{team.slug}")
 
-        emails_dict = {email: email for email in emails}
+        emails_dict = {item.email: item.email for item in user_emails}
         associations = {**users_dict, **teams_dict, **emails_dict}
 
         errors = {

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -33,7 +33,7 @@ class ProjectCodeOwners(DefaultFieldsModel):
 
     @classmethod
     def get_cache_key(self, project_id):
-        return f"projectcodewoners_project_id:1:{project_id}"
+        return f"projectcodeowners_project_id:1:{project_id}"
 
     @classmethod
     def get_codeowners_cached(self, project_id):

--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import {useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
+import {IconChevron} from 'app/icons';
 import space from 'app/styles/space';
 import {Theme} from 'app/utils/theme';
 
@@ -10,6 +11,9 @@ type Props = {
   type?: keyof Theme['alert'];
   icon?: React.ReactNode;
   system?: boolean;
+  expand?: React.ReactNode[];
+  expandIcon?: React.ReactNode;
+  onExpandIconClick?: () => void;
 };
 
 type AlertProps = Omit<React.HTMLProps<HTMLDivElement>, keyof Props> & Props;
@@ -60,6 +64,7 @@ const getSystemAlertColorStyles = ({
 
 const alertStyles = ({theme, type = DEFAULT_TYPE, system}: Props & {theme: Theme}) => css`
   display: flex;
+  flex-direction: column;
   margin: 0 0 ${space(3)};
   padding: ${space(1.5)} ${space(2)};
   font-size: 15px;
@@ -79,24 +84,67 @@ const alertStyles = ({theme, type = DEFAULT_TYPE, system}: Props & {theme: Theme
 
 const StyledTextBlock = styled('span')`
   line-height: 1.5;
-  flex-grow: 1;
   position: relative;
-  margin: auto;
 `;
 
+const MessageContainer = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(${space(4)}, 1fr) 30fr 1fr;
+  width: 100%;
+`;
+
+const ExpandContainer = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(${space(4)}, 1fr) 30fr 1fr;
+  grid-template-areas: '. details details';
+  padding: ${space(1.5)} 0;
+`;
+const DetailsContainer = styled('div')`
+  grid-area: details;
+`;
+
+const ExpandIcon = styled(props => (
+  <IconWrapper {...props}>{<IconChevron size="md" />}</IconWrapper>
+))`
+  transform: ${props => (props.isExpanded ? 'rotate(0deg)' : 'rotate(180deg)')};
+  cursor: pointer;
+  justify-self: flex-end;
+`;
 const Alert = styled(
   ({
     type,
     icon,
     children,
     className,
+    expand,
+    expandIcon,
+    onExpandIconClick,
     system: _system, // don't forward to `div`
     ...props
   }: AlertProps) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const showExpand = expand && expand.length;
+    const showExpandItems = showExpand && isExpanded;
+    const handleOnExpandIconClick = onExpandIconClick ? onExpandIconClick : setIsExpanded;
+
     return (
       <div className={classNames(type ? `ref-${type}` : '', className)} {...props}>
-        {icon && <IconWrapper>{icon}</IconWrapper>}
-        <StyledTextBlock>{children}</StyledTextBlock>
+        <MessageContainer>
+          {icon && <IconWrapper>{icon}</IconWrapper>}
+          <StyledTextBlock>{children}</StyledTextBlock>
+          {showExpand &&
+            (expandIcon || (
+              <ExpandIcon
+                onClick={() => handleOnExpandIconClick(!isExpanded)}
+                isExpanded={isExpanded}
+              />
+            ))}
+        </MessageContainer>
+        {showExpandItems && (
+          <ExpandContainer>
+            <DetailsContainer>{(expand || []).map(item => item)}</DetailsContainer>
+          </ExpandContainer>
+        )}
       </div>
     );
   }

--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -85,11 +85,11 @@ const alertStyles = ({theme, type = DEFAULT_TYPE, system}: Props & {theme: Theme
 const StyledTextBlock = styled('span')`
   line-height: 1.5;
   position: relative;
+  margin-right: auto;
 `;
 
 const MessageContainer = styled('div')`
-  display: grid;
-  grid-template-columns: minmax(${space(4)}, 1fr) 30fr 1fr;
+  display: flex;
   width: 100%;
 `;
 
@@ -132,13 +132,11 @@ const Alert = styled(
         <MessageContainer>
           {icon && <IconWrapper>{icon}</IconWrapper>}
           <StyledTextBlock>{children}</StyledTextBlock>
-          {showExpand &&
-            (expandIcon || (
-              <ExpandIcon
-                onClick={() => handleOnExpandIconClick(!isExpanded)}
-                isExpanded={isExpanded}
-              />
-            ))}
+          {showExpand && (
+            <div onClick={() => handleOnExpandIconClick(!isExpanded)}>
+              {expandIcon || <ExpandIcon isExpanded={isExpanded} />}
+            </div>
+          )}
         </MessageContainer>
         {showExpandItems && (
           <ExpandContainer>

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2135,7 +2135,13 @@ export type CodeOwners = {
   dateCreated: string;
   dateUpdated: string;
   provider: 'github' | 'gitlab';
-  codeMapping?: RepositoryProjectPathConfig[];
+  codeMapping?: RepositoryProjectPathConfig;
+  errors: {
+    missing_external_teams: string[];
+    missing_external_users: string[];
+    missing_user_emails: string[];
+    teams_without_access: string[];
+  };
 };
 
 export type KeyValueListData = {

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -17,7 +17,7 @@ import {
 } from 'app/components/performance/waterfall/rowDetails';
 import {generateIssueEventTarget} from 'app/components/quickTrace/utils';
 import {PAGE_URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {IconAnchor, IconChevron, IconWarning} from 'app/icons';
+import {IconAnchor, IconWarning} from 'app/icons';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
@@ -37,22 +37,9 @@ type Props = {
   scrollToHash: (hash: string) => void;
 };
 
-type State = {
-  errorsOpened: boolean;
-};
-
-class TransactionDetail extends Component<Props, State> {
-  state: State = {
-    errorsOpened: false,
-  };
-
-  toggleErrors = () => {
-    this.setState(({errorsOpened}) => ({errorsOpened: !errorsOpened}));
-  };
-
+class TransactionDetail extends Component<Props> {
   renderTransactionErrors() {
     const {organization, transaction} = this.props;
-    const {errorsOpened} = this.state;
     const {errors} = transaction;
 
     if (errors.length === 0) {
@@ -60,32 +47,29 @@ class TransactionDetail extends Component<Props, State> {
     }
 
     return (
-      <Alert system type="error" icon={<IconWarning size="md" />}>
+      <Alert
+        system
+        type="error"
+        icon={<IconWarning size="md" />}
+        expand={errors.map(error => (
+          <ErrorMessageContent key={error.event_id}>
+            <ErrorDot level={error.level} />
+            <ErrorLevel>{error.level}</ErrorLevel>
+            <ErrorTitle>
+              <Link to={generateIssueEventTarget(error, organization)}>
+                {error.title}
+              </Link>
+            </ErrorTitle>
+          </ErrorMessageContent>
+        ))}
+      >
         <ErrorMessageTitle>
           {tn(
             'An error event occurred in this transaction.',
             '%s error events occurred in this transaction.',
             errors.length
           )}
-          <Toggle priority="link" onClick={this.toggleErrors}>
-            <IconChevron direction={errorsOpened ? 'up' : 'down'} />
-          </Toggle>
         </ErrorMessageTitle>
-        {errorsOpened && (
-          <ErrorMessageContent>
-            {errors.map(error => (
-              <Fragment key={error.event_id}>
-                <ErrorDot level={error.level} />
-                <ErrorLevel>{error.level}</ErrorLevel>
-                <ErrorTitle>
-                  <Link to={generateIssueEventTarget(error, organization)}>
-                    {error.title}
-                  </Link>
-                </ErrorTitle>
-              </Fragment>
-            ))}
-          </ErrorMessageContent>
-        )}
       </Alert>
     );
   }
@@ -274,14 +258,6 @@ const StyledButton = styled(Button)`
   position: absolute;
   top: ${space(0.75)};
   right: ${space(0.5)};
-`;
-
-const Toggle = styled(Button)`
-  font-weight: bold;
-  color: ${p => p.theme.subText};
-  :hover {
-    color: ${p => p.theme.textColor};
-  }
 `;
 
 export default TransactionDetail;

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -107,14 +107,7 @@ class AddCodeOwnerModal extends Component<Props, State> {
         if (err.responseJSON.raw) {
           this.setState({error: true, errorJSON: err.responseJSON, isLoading: false});
         } else {
-          addErrorMessage(
-            t(
-              Object.entries(err.responseJSON)
-                .map(([_, value]) => value)
-                .flat()
-                .join(' ')
-            )
-          );
+          addErrorMessage(t(Object.values(err.responseJSON).flat().join(' ')));
         }
       }
     }

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -335,4 +335,6 @@ const ErrorMessageContainer = styled('div')`
 const ErrorCtaContainer = styled('div')`
   grid-area: cta;
   justify-self: flex-end;
+  text-align: right;
+  line-height: 1.5;
 `;

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -80,11 +80,14 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         }
         with self.feature({"organizations:integrations-codeowners": True}):
             response = self.client.put(self.url, data)
-        assert response.status_code == 400
-        assert response.data == {
-            "raw": [
-                "The following usernames do not have an association in Sentry: @AnotherUser.\nThe following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
-            ]
+        assert response.status_code == 200
+        assert response.data["id"] == str(self.codeowners.id)
+        assert response.data["codeMappingId"] == str(self.code_mapping.id)
+        assert response.data["errors"] == {
+            "missing_external_teams": ["@getsentry/frontend", "@getsentry/docs"],
+            "missing_external_users": ["@AnotherUser"],
+            "missing_user_emails": [],
+            "teams_without_access": [],
         }
 
     def test_invalid_code_mapping_id_update(self):

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -83,12 +83,12 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert response.status_code == 200
         assert response.data["id"] == str(self.codeowners.id)
         assert response.data["codeMappingId"] == str(self.code_mapping.id)
-        assert response.data["errors"] == {
+        assert {
             "missing_external_teams": ["@getsentry/frontend", "@getsentry/docs"],
             "missing_external_users": ["@AnotherUser"],
             "missing_user_emails": [],
             "teams_without_access": [],
-        }
+        }.items() <= response.data["errors"].items()
 
     def test_invalid_code_mapping_id_update(self):
         with self.feature({"organizations:integrations-codeowners": True}):

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -83,12 +83,12 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert response.status_code == 200
         assert response.data["id"] == str(self.codeowners.id)
         assert response.data["codeMappingId"] == str(self.code_mapping.id)
-        assert {
-            "missing_external_teams": ["@getsentry/frontend", "@getsentry/docs"],
-            "missing_external_users": ["@AnotherUser"],
-            "missing_user_emails": [],
-            "teams_without_access": [],
-        }.items() <= response.data["errors"].items()
+
+        errors = response.data["errors"]
+        assert set(errors["missing_external_teams"]) == {"@getsentry/frontend", "@getsentry/docs"}
+        assert set(errors["missing_external_users"]) == {"@AnotherUser"}
+        assert errors["missing_user_emails"] == []
+        assert errors["teams_without_access"] == []
 
     def test_invalid_code_mapping_id_update(self):
         with self.feature({"organizations:integrations-codeowners": True}):


### PR DESCRIPTION
# Objective:

We should allow users to successfully upload CodeOwners, even if not all External Teams/Users have been mapped. For large orgs, atleast some external actors will be mapped and they can get some value from the feature.
Then when users view the page, we should show a warning that there are errors associated with their Code Owners.

# UI
<img width="1438" alt="Screen Shot 2021-07-06 at 2 44 06 AM" src="https://user-images.githubusercontent.com/10491193/124581592-177a6780-de06-11eb-93ce-9074def2cffc.png">
<img width="1440" alt="Screen Shot 2021-07-06 at 2 43 55 AM" src="https://user-images.githubusercontent.com/10491193/124581630-1ea17580-de06-11eb-8072-f1d263e8b36f.png">
