### PR TITLE
feat(ui): Fetch adoption markers on release details

### DIFF
--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -115,6 +115,7 @@ class ReleasesDetail extends AsyncView<Props, State> {
         basePath,
         {
           query: {
+            adoptionStages: 1,
             ...getParams(pick(location.query, [...Object.values(URL_PARAM)]), {
               defaultStatsPeriod,
             }),


### PR DESCRIPTION
We can start fetching data for markers introduced here: https://github.com/getsentry/sentry/pull/27126