### PR TITLE
feat(org-stats): added filtered to chartData

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -34,6 +34,7 @@ const COLOR_ATTACHMENTS = Color(commonTheme.dataCategory.attachments)
   .string();
 const COLOR_DROPPED = commonTheme.red300;
 const COLOR_PROJECTED = commonTheme.gray100;
+const COLOR_FILTERED = commonTheme.pink100;
 
 export const CHART_OPTIONS_DATACATEGORY: SelectValue<DataCategory>[] = [
   {
@@ -75,6 +76,7 @@ export enum SeriesTypes {
   ACCEPTED = 'Accepted',
   DROPPED = 'Dropped',
   PROJECTED = 'Projected',
+  FILTERED = 'Filtered',
 }
 
 type DefaultProps = {
@@ -140,6 +142,7 @@ export type ChartStats = {
   accepted: NonNullable<EChartOption.SeriesBar['data']>;
   dropped: NonNullable<EChartOption.SeriesBar['data']>;
   projected: NonNullable<EChartOption.SeriesBar['data']>;
+  filtered: NonNullable<EChartOption.SeriesBar['data']>;
 };
 
 export class UsageChart extends React.Component<Props, State> {
@@ -151,6 +154,7 @@ export class UsageChart extends React.Component<Props, State> {
         accepted: [],
         dropped: [],
         projected: [],
+        filtered: [],
       };
       const isCumulative = transform === ChartDataTransform.CUMULATIVE;
 
@@ -201,14 +205,14 @@ export class UsageChart extends React.Component<Props, State> {
     const {dataCategory} = this.props;
 
     if (dataCategory === DataCategory.ERRORS) {
-      return [COLOR_ERRORS, COLOR_DROPPED, COLOR_PROJECTED];
+      return [COLOR_ERRORS, COLOR_DROPPED, COLOR_PROJECTED, COLOR_FILTERED];
     }
 
     if (dataCategory === DataCategory.ATTACHMENTS) {
-      return [COLOR_ATTACHMENTS, COLOR_DROPPED, COLOR_PROJECTED];
+      return [COLOR_ATTACHMENTS, COLOR_DROPPED, COLOR_PROJECTED, COLOR_FILTERED];
     }
 
-    return [COLOR_TRANSACTIONS, COLOR_DROPPED, COLOR_PROJECTED];
+    return [COLOR_TRANSACTIONS, COLOR_DROPPED, COLOR_PROJECTED, COLOR_FILTERED];
   }
 
   get chartMetadata(): {
@@ -324,6 +328,13 @@ export class UsageChart extends React.Component<Props, State> {
         stack: 'usage',
         legendHoverLink: false,
       }),
+      barSeries({
+        name: SeriesTypes.FILTERED,
+        data: chartData.filtered as any, // TODO(ts)
+        barMinHeight: 1,
+        stack: 'usage',
+        legendHoverLink: false,
+      }),
     ];
 
     // Additional series passed by parent component
@@ -351,6 +362,12 @@ export class UsageChart extends React.Component<Props, State> {
     if (chartData.projected.length > 0) {
       legend.push({
         name: SeriesTypes.PROJECTED,
+      });
+    }
+
+    if (chartData.filtered.length > 0) {
+      legend.push({
+        name: SeriesTypes.FILTERED,
       });
     }
 

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -205,14 +205,14 @@ export class UsageChart extends React.Component<Props, State> {
     const {dataCategory} = this.props;
 
     if (dataCategory === DataCategory.ERRORS) {
-      return [COLOR_ERRORS, COLOR_DROPPED, COLOR_PROJECTED, COLOR_FILTERED];
+      return [COLOR_ERRORS, COLOR_FILTERED, COLOR_DROPPED, COLOR_PROJECTED];
     }
 
     if (dataCategory === DataCategory.ATTACHMENTS) {
-      return [COLOR_ATTACHMENTS, COLOR_DROPPED, COLOR_PROJECTED, COLOR_FILTERED];
+      return [COLOR_ATTACHMENTS, COLOR_FILTERED, COLOR_DROPPED, COLOR_PROJECTED];
     }
 
-    return [COLOR_TRANSACTIONS, COLOR_DROPPED, COLOR_PROJECTED, COLOR_FILTERED];
+    return [COLOR_TRANSACTIONS, COLOR_FILTERED, COLOR_DROPPED, COLOR_PROJECTED];
   }
 
   get chartMetadata(): {
@@ -316,6 +316,13 @@ export class UsageChart extends React.Component<Props, State> {
         legendHoverLink: false,
       }),
       barSeries({
+        name: SeriesTypes.FILTERED,
+        data: chartData.filtered as any, // TODO(ts)
+        barMinHeight: 1,
+        stack: 'usage',
+        legendHoverLink: false,
+      }),
+      barSeries({
         name: SeriesTypes.DROPPED,
         data: chartData.dropped as any, // TODO(ts)
         stack: 'usage',
@@ -324,13 +331,6 @@ export class UsageChart extends React.Component<Props, State> {
       barSeries({
         name: SeriesTypes.PROJECTED,
         data: chartData.projected as any, // TODO(ts)
-        barMinHeight: 1,
-        stack: 'usage',
-        legendHoverLink: false,
-      }),
-      barSeries({
-        name: SeriesTypes.FILTERED,
-        data: chartData.filtered as any, // TODO(ts)
         barMinHeight: 1,
         stack: 'usage',
         legendHoverLink: false,
@@ -353,6 +353,12 @@ export class UsageChart extends React.Component<Props, State> {
       },
     ];
 
+    if (chartData.filtered && chartData.filtered.length > 0) {
+      legend.push({
+        name: SeriesTypes.FILTERED,
+      });
+    }
+
     if (chartData.dropped.length > 0) {
       legend.push({
         name: SeriesTypes.DROPPED,
@@ -364,13 +370,6 @@ export class UsageChart extends React.Component<Props, State> {
         name: SeriesTypes.PROJECTED,
       });
     }
-
-    if (chartData.filtered && chartData.filtered.length > 0) {
-      legend.push({
-        name: SeriesTypes.FILTERED,
-      });
-    }
-
     return legend;
   }
 

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -142,7 +142,7 @@ export type ChartStats = {
   accepted: NonNullable<EChartOption.SeriesBar['data']>;
   dropped: NonNullable<EChartOption.SeriesBar['data']>;
   projected: NonNullable<EChartOption.SeriesBar['data']>;
-  filtered: NonNullable<EChartOption.SeriesBar['data']>;
+  filtered?: NonNullable<EChartOption.SeriesBar['data']>;
 };
 
 export class UsageChart extends React.Component<Props, State> {
@@ -365,7 +365,7 @@ export class UsageChart extends React.Component<Props, State> {
       });
     }
 
-    if (chartData.filtered.length > 0) {
+    if (chartData.filtered && chartData.filtered.length > 0) {
       legend.push({
         name: SeriesTypes.FILTERED,
       });

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -293,13 +293,13 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
             dataCategory,
             getFormatUsageOptions(dataCategory)
           ),
-          dropped: formatUsageWithUnits(
-            count[Outcome.DROPPED],
+          filtered: formatUsageWithUnits(
+            count[Outcome.FILTERED],
             dataCategory,
             getFormatUsageOptions(dataCategory)
           ),
-          filtered: formatUsageWithUnits(
-            count[Outcome.FILTERED],
+          dropped: formatUsageWithUnits(
+            count[Outcome.DROPPED],
             dataCategory,
             getFormatUsageOptions(dataCategory)
           ),

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -278,7 +278,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         // Chart Data
         chartStats.accepted.push({value: [stat.date, stat.accepted]} as any);
         chartStats.dropped.push({value: [stat.date, stat.dropped.total]} as any);
-        chartStats.filtered.push({value: [stat.date, stat.filtered]} as any);
+        chartStats.filtered?.push({value: [stat.date, stat.filtered]} as any);
       });
 
       return {

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -214,6 +214,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
       accepted: [],
       dropped: [],
       projected: [],
+      filtered: [],
     };
 
     if (!orgStats) {
@@ -277,6 +278,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         // Chart Data
         chartStats.accepted.push({value: [stat.date, stat.accepted]} as any);
         chartStats.dropped.push({value: [stat.date, stat.dropped.total]} as any);
+        chartStats.filtered.push({value: [stat.date, stat.filtered]} as any);
       });
 
       return {


### PR DESCRIPTION
Added filtered in chartStats of org-stats page.

TODO: wait for megan and john to confirm color for filtered bar

before: 
![image](https://user-images.githubusercontent.com/22259802/124822204-9b833b00-df3d-11eb-8e52-5003cc764829.png)


after:
![image](https://user-images.githubusercontent.com/22259802/124822123-83abb700-df3d-11eb-8d1b-84b23e011a2e.png)
![image](https://user-images.githubusercontent.com/22259802/124822149-88706b00-df3d-11eb-9f7c-1dbd5eed6059.png)

ticket: https://getsentry.atlassian.net/browse/ER-715
