### PR TITLE
feat(ui): Add adoption stage labels as tags to releases list

### DIFF
--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -11,6 +11,7 @@ import ProjectBadge from 'app/components/idBadge/projectBadge';
 import NotAvailable from 'app/components/notAvailable';
 import {PanelItem} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
+import Tag from 'app/components/tag';
 import Tooltip from 'app/components/tooltip';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -28,6 +29,21 @@ import {DisplayOption} from '../utils';
 
 import Header from './header';
 import ProjectLink from './projectLink';
+
+const ADOPTION_STAGE_LABELS = {
+  not_adopted: {
+    name: t('Low Adoption'),
+    type: 'warning',
+  },
+  adopted: {
+    name: t('High Adoption'),
+    type: 'success',
+  },
+  replaced: {
+    name: t('Replaced'),
+    type: 'default',
+  },
+};
 
 type Props = {
   projects: Array<ReleaseProject>;
@@ -52,11 +68,6 @@ const Content = ({
   isTopRelease,
   getHealthData,
 }: Props) => {
-  const adoption_map = {
-    not_adopted: 'Not Adopted',
-    adopted: 'Adopted',
-    replaced: 'Replaced',
-  };
   const hasAdoptionStages: boolean = adoptionStages !== undefined;
   return (
     <Fragment>
@@ -72,7 +83,7 @@ const Content = ({
               {t('Adoption')}
             </GuideAnchor>
           </AdoptionColumn>
-          {adoptionStages && <Column>{t('Status')}</Column>}
+          {adoptionStages && <Column>{t('Adoption Stage')}</Column>}
           <CrashFreeRateColumn>{t('Crash Free Rate')}</CrashFreeRateColumn>
           <CountColumn>
             <span>{t('Count')}</span>
@@ -162,7 +173,21 @@ const Content = ({
                   {adoptionStages && (
                     <Column>
                       {adoptionStages[project.slug] ? (
-                        adoption_map[adoptionStages[project.slug].stage]
+                        isTopRelease ? (
+                          <Tag type="highlight">{t('Latest')}</Tag>
+                        ) : (
+                          <Tag
+                            type={
+                              ADOPTION_STAGE_LABELS[adoptionStages[project.slug].stage]
+                                .type
+                            }
+                          >
+                            {
+                              ADOPTION_STAGE_LABELS[adoptionStages[project.slug].stage]
+                                .name
+                            }
+                          </Tag>
+                        )
                       ) : (
                         <NotAvailable />
                       )}

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -43,6 +43,10 @@ const ADOPTION_STAGE_LABELS = {
     name: t('Replaced'),
     type: 'default',
   },
+  latest: {
+    name: t('Latest'),
+    type: 'highlight',
+  },
 };
 
 type Props = {
@@ -145,6 +149,10 @@ const Content = ({
               timeSeries?.[0].data.length > 7 &&
               timeSeries[0].data.some(item => item.value > 0);
 
+            const adoptionStage =
+              adoptionStages &&
+              (isTopRelease ? 'latest' : adoptionStages[project.slug].stage);
+
             return (
               <ProjectRow key={`${releaseVersion}-${slug}-health`}>
                 <Layout hasAdoptionStages={hasAdoptionStages}>
@@ -173,21 +181,9 @@ const Content = ({
                   {adoptionStages && (
                     <Column>
                       {adoptionStages[project.slug] ? (
-                        isTopRelease ? (
-                          <Tag type="highlight">{t('Latest')}</Tag>
-                        ) : (
-                          <Tag
-                            type={
-                              ADOPTION_STAGE_LABELS[adoptionStages[project.slug].stage]
-                                .type
-                            }
-                          >
-                            {
-                              ADOPTION_STAGE_LABELS[adoptionStages[project.slug].stage]
-                                .name
-                            }
-                          </Tag>
-                        )
+                        <Tag type={ADOPTION_STAGE_LABELS[adoptionStage].type}>
+                          {ADOPTION_STAGE_LABELS[adoptionStage].name}
+                        </Tag>
                       ) : (
                         <NotAvailable />
                       )}

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -43,10 +43,6 @@ const ADOPTION_STAGE_LABELS = {
     name: t('Replaced'),
     type: 'default',
   },
-  latest: {
-    name: t('Latest'),
-    type: 'highlight',
-  },
 };
 
 type Props = {
@@ -149,9 +145,7 @@ const Content = ({
               timeSeries?.[0].data.length > 7 &&
               timeSeries[0].data.some(item => item.value > 0);
 
-            const adoptionStage =
-              adoptionStages &&
-              (isTopRelease ? 'latest' : adoptionStages[project.slug].stage);
+            const adoptionStage = adoptionStages && adoptionStages[project.slug].stage;
 
             return (
               <ProjectRow key={`${releaseVersion}-${slug}-health`}>


### PR DESCRIPTION
This updates the release adoption stage label column based on new designs, converted to tags.

Before:
![Screen Shot 2021-07-06 at 11 15 04 AM](https://user-images.githubusercontent.com/15015880/124647919-6d253300-de4b-11eb-8f8c-cfd3e84ce4e5.png)

After:
![Screen Shot 2021-07-06 at 11 11 19 AM](https://user-images.githubusercontent.com/15015880/124647550-f5570880-de4a-11eb-8a0d-e50eb5d77fc0.png)

[Design](https://www.figma.com/file/2Eaeky9nOHusjw0ySfjZsq/Release-Comparison?node-id=225%3A14501)
Jira: [WOR-1012](https://getsentry.atlassian.net/browse/WOR-1012)