### PR TITLE
fix(arithmetic): Handle the case where field.field is null

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -304,7 +304,7 @@ class EventView {
     let equations = 0;
     const sortKeys = fields
       .map(field => {
-        if (isEquation(field.field)) {
+        if (field.field && isEquation(field.field)) {
           const sortKey = getSortKeyFromField(
             {field: `equation[${equations}]`},
             undefined


### PR DESCRIPTION
- Fixes JAVASCRIPT-24WK
- This seems to happen when a field is cleared via the URL, but wasn't
  able to reproduce it, figured adding a check is better to be safe