### PR TITLE
fix(cdc): Replicate only groupedmessage and groupassignee tables

### DIFF
--- a/config/cdc/configuration.yaml
+++ b/config/cdc/configuration.yaml
@@ -29,6 +29,7 @@ source:
                     include-xids: 'true'
                     include-timestamp: 'true'
                     include-message-header: 'true'
+                    add-tables: '*.sentry_groupasignee, *.sentry_groupedmessage'
 
 snapshot:
     source:


### PR DESCRIPTION
Snuba only requires groupedmessage and groupassignee table records
right now. Change the configuration of wal2json to only send records
of those 2 tables.