### PR TITLE
feat(mobile-vitals): Add mobile vitals to discover and dashboards

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -126,8 +126,9 @@ class SearchBar extends React.PureComponent<SearchBarProps> {
   }
 
   render() {
+    const {organization} = this.props;
     return (
-      <Measurements>
+      <Measurements organization={organization}>
         {({measurements}) => {
           const tags = this.getTagList(measurements);
           return (

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -374,7 +374,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               />
             </Field>
           </DoubleFieldWrapper>
-          <Measurements>
+          <Measurements organization={organization}>
             {({measurements}) => {
               const measurementKeys = Object.values(measurements).map(({key}) => key);
               const amendedFieldOptions = fieldOptions(measurementKeys);

--- a/static/app/utils/measurements/measurements.tsx
+++ b/static/app/utils/measurements/measurements.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 
-import {WEB_VITAL_DETAILS} from 'app/utils/performance/vitals/constants';
+import {Organization} from 'app/types';
+import {MobileVital, WebVital} from 'app/utils/discover/fields';
+import {
+  MOBILE_VITAL_DETAILS,
+  WEB_VITAL_DETAILS,
+} from 'app/utils/performance/vitals/constants';
+import {Vital} from 'app/utils/performance/vitals/types';
 
 type Measurement = {
   name: string;
@@ -9,32 +15,39 @@ type Measurement = {
 
 type MeasurementCollection = Record<string, Measurement>;
 
-const MEASUREMENTS: MeasurementCollection = Object.fromEntries(
-  Object.entries(WEB_VITAL_DETAILS).map(([key, value]) => {
-    const newValue: Measurement = {
-      name: value.name,
-      key,
-    };
-    return [key, newValue];
-  })
-);
+type VitalType = WebVital | MobileVital;
+
+function measurementsFromDetails(
+  details: Partial<Record<VitalType, Vital>>
+): MeasurementCollection {
+  return Object.fromEntries(
+    Object.entries(details).map(([key, value]) => {
+      const newValue: Measurement = {
+        name: value.name,
+        key,
+      };
+      return [key, newValue];
+    })
+  );
+}
+
+const MOBILE_MEASUREMENTS = measurementsFromDetails(MOBILE_VITAL_DETAILS);
+const WEB_MEASUREMENTS = measurementsFromDetails(WEB_VITAL_DETAILS);
 
 type ChildrenProps = {
   measurements: MeasurementCollection;
 };
 
 type Props = {
+  organization: Organization;
   children: (props: ChildrenProps) => React.ReactNode;
 };
 
-function Measurements(props: Props) {
-  return (
-    <React.Fragment>
-      {props.children({
-        measurements: MEASUREMENTS,
-      })}
-    </React.Fragment>
-  );
+function Measurements({organization, children}: Props) {
+  const measurements = organization.features.includes('performance-mobile-vitals')
+    ? {...WEB_MEASUREMENTS, ...MOBILE_MEASUREMENTS}
+    : WEB_MEASUREMENTS;
+  return <React.Fragment>{children({measurements})}</React.Fragment>;
 }
 
 export default Measurements;

--- a/static/app/utils/performance/vitals/constants.tsx
+++ b/static/app/utils/performance/vitals/constants.tsx
@@ -1,5 +1,5 @@
 import {t} from 'app/locale';
-import {measurementType, WebVital} from 'app/utils/discover/fields';
+import {measurementType, MobileVital, WebVital} from 'app/utils/discover/fields';
 import {Vital} from 'app/utils/performance/vitals/types';
 
 export const WEB_VITAL_DETAILS: Record<WebVital, Vital> = {
@@ -72,5 +72,28 @@ export const WEB_VITAL_DETAILS: Record<WebVital, Vital> = {
     ),
     poorThreshold: 600,
     type: measurementType(WebVital.RequestTime),
+  },
+};
+
+export const MOBILE_VITAL_DETAILS: Record<MobileVital, Vital> = {
+  [MobileVital.AppStartCold]: {
+    slug: 'app_start_cold',
+    name: t('App Start Cold'),
+    acronym: 'COLD START',
+    description: t(
+      'Cold start is a measure of the application start up time from scratch.'
+    ),
+    poorThreshold: 4000,
+    type: measurementType(MobileVital.AppStartCold),
+  },
+  [MobileVital.AppStartWarm]: {
+    slug: 'app_start_warm',
+    name: t('App Start Warm'),
+    acronym: 'WARM START',
+    description: t(
+      'Warm start is a measure of the application start up time while still in memory.'
+    ),
+    poorThreshold: 3000,
+    type: measurementType(MobileVital.AppStartWarm),
   },
 };

--- a/static/app/views/dashboardsV2/widget/eventWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/eventWidget/index.tsx
@@ -279,7 +279,7 @@ class EventWidget extends AsyncView<Props, State> {
                 errors={widgetErrors?.queries}
               />
             </BuildStep>
-            <Measurements>
+            <Measurements organization={organization}>
               {({measurements}) => {
                 const measurementKeys = Object.values(measurements).map(({key}) => key);
                 const amendedFieldOptions = fieldOptions(measurementKeys);

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -150,7 +150,7 @@ class Table extends PureComponent<TableProps, TableState> {
   };
 
   render() {
-    const {eventView, tags} = this.props;
+    const {eventView, organization, tags} = this.props;
     const {pageLinks, tableData, isLoading, error} = this.state;
     const tagKeys = Object.values(tags).map(({key}) => key);
 
@@ -160,7 +160,7 @@ class Table extends PureComponent<TableProps, TableState> {
 
     return (
       <Container>
-        <Measurements>
+        <Measurements organization={organization}>
           {({measurements}) => {
             const measurementKeys = Object.values(measurements).map(({key}) => key);
 


### PR DESCRIPTION
This adds support for mobile vitals in discover and dashboards.