### PR TITLE
feat(performance): Renaming Transaction Events tab filter label and removed option for clarity

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -260,7 +260,7 @@ const Search = (props: Props) => {
       />
       <LatencyDropdown>
         <DropdownControl
-          buttonProps={{prefix: t('Display')}}
+          buttonProps={{prefix: t('Percentile')}}
           label={eventsFilterOptions[eventsDisplayFilterName].label}
         >
           {Object.entries(eventsFilterOptions).map(([name, filter]) => {

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -180,27 +180,23 @@ class TransactionEvents extends Component<Props, State> {
     const percentileColumns: QueryFieldValue[] = [
       {
         kind: 'function',
-        function: ['p100', '', undefined, undefined],
+        function: ['p100', '', undefined],
       },
       {
         kind: 'function',
-        function: ['p99', '', undefined, undefined],
+        function: ['p99', '', undefined],
       },
       {
         kind: 'function',
-        function: ['p95', '', undefined, undefined],
+        function: ['p95', '', undefined],
       },
       {
         kind: 'function',
-        function: ['p75', '', undefined, undefined],
+        function: ['p75', '', undefined],
       },
       {
         kind: 'function',
-        function: ['p50', '', undefined, undefined],
-      },
-      {
-        kind: 'function',
-        function: ['avg', 'transaction.duration', undefined, undefined],
+        function: ['p50', '', undefined],
       },
     ];
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -180,23 +180,23 @@ class TransactionEvents extends Component<Props, State> {
     const percentileColumns: QueryFieldValue[] = [
       {
         kind: 'function',
-        function: ['p100', '', undefined],
+        function: ['p100', '', undefined, undefined],
       },
       {
         kind: 'function',
-        function: ['p99', '', undefined],
+        function: ['p99', '', undefined, undefined],
       },
       {
         kind: 'function',
-        function: ['p95', '', undefined],
+        function: ['p95', '', undefined, undefined],
       },
       {
         kind: 'function',
-        function: ['p75', '', undefined],
+        function: ['p75', '', undefined, undefined],
       },
       {
         kind: 'function',
-        function: ['p50', '', undefined],
+        function: ['p50', '', undefined, undefined],
       },
     ];
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/utils.tsx
@@ -12,7 +12,6 @@ export enum EventsDisplayFilterName {
   p95 = 'p95',
   p99 = 'p99',
   p100 = 'p100',
-  avg_transaction_duration = 'avg_transaction_duration',
 }
 
 export type EventsDisplayFilter = {
@@ -34,9 +33,9 @@ export function getEventsFilterOptions(
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter,
   percentileValues?: EventsFilterPercentileValues
 ): EventsFilterOptions {
-  const {p99, p95, p75, p50, avg_transaction_duration} = percentileValues
+  const {p99, p95, p75, p50} = percentileValues
     ? percentileValues
-    : {p99: 0, p95: 0, p75: 0, p50: 0, avg_transaction_duration: 0};
+    : {p99: 0, p95: 0, p75: 0, p50: 0};
   return {
     [EventsDisplayFilterName.p50]: {
       name: EventsDisplayFilterName.p50,
@@ -77,17 +76,6 @@ export function getEventsFilterOptions(
     [EventsDisplayFilterName.p100]: {
       name: EventsDisplayFilterName.p100,
       label: t('p100'),
-    },
-    [EventsDisplayFilterName.avg_transaction_duration]: {
-      name: EventsDisplayFilterName.avg_transaction_duration,
-      query: avg_transaction_duration
-        ? [['transaction.duration', `<=${avg_transaction_duration.toFixed(0)}`]]
-        : undefined,
-      sort: {
-        kind: 'desc',
-        field: filterToField(spanOperationBreakdownFilter) || 'transaction.duration',
-      },
-      label: t('average'),
     },
   };
 }

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -74,7 +74,6 @@ describe('Performance > TransactionSummary', function () {
               p95: 7273.6,
               p75: 3639.5,
               p50: 755.5,
-              avg_transaction_duration: 2122.1,
             },
           ],
           meta: {
@@ -83,7 +82,6 @@ describe('Performance > TransactionSummary', function () {
             p95: 'duration',
             p75: 'duration',
             p50: 'duration',
-            avg_transaction_duration: 'duration',
           },
         },
       },


### PR DESCRIPTION
Renamed display label to percentile and removed average option
![image](https://user-images.githubusercontent.com/83961295/124664616-b5f3e080-de79-11eb-97f9-560f920d1322.png)
