### PR TITLE
feat(backend): adds get_prompt_activities

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -48,7 +48,7 @@ prompt_config = PromptsConfig(DEFAULT_PROMPTS)
 
 
 @request_cache
-def check_prompt_activities(organization_ids, features):
+def get_prompt_activities(organization_ids, features):
     return PromptsActivity.objects.filter(
         organization_id__in=organization_ids, feature__in=features
     )

--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -1,3 +1,6 @@
+from sentry.models import PromptsActivity
+from sentry.utils.request_cache import request_cache
+
 DEFAULT_PROMPTS = {
     "releases": {"required_fields": ["organization_id", "project_id"]},
     "suspect_commits": {"required_fields": ["organization_id", "project_id"]},
@@ -42,3 +45,10 @@ class PromptsConfig:
 
 
 prompt_config = PromptsConfig(DEFAULT_PROMPTS)
+
+
+@request_cache
+def check_prompt_activities(organization_ids, features):
+    return PromptsActivity.objects.filter(
+        organization_id__in=organization_ids, feature__in=features
+    )


### PR DESCRIPTION
Adding a utility function for checking prompt activities that I'm gonna use: https://github.com/getsentry/getsentry/pull/5870