### PR TITLE
feat(ci): Update `action-migrations` to track `main` branch

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -91,7 +91,7 @@ jobs:
           echo "::set-output name=added::$(git diff --diff-filter=A --name-only origin/master HEAD | grep 'src/sentry/migrations/')"
 
       - name: Generate SQL for migration
-        uses: getsentry/action-migrations@v1.0.7
+        uses: getsentry/action-migrations@main
         env:
           SENTRY_LOG_LEVEL: ERROR
         with:


### PR DESCRIPTION
Since this is an action we control, it is safe to track against `main` branch. This will fix an issue where python warnings writing to stderr will cause GHA to fail.