### PR TITLE
ref: Extract analytics from Pipeline into IntegrationPipeline

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -1,5 +1,7 @@
 __all__ = ["IntegrationPipeline"]
 
+from typing import Optional
+
 from django.db import IntegrityError
 from django.utils import timezone
 from django.utils.translation import ugettext as _
@@ -7,7 +9,7 @@ from django.utils.translation import ugettext as _
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
 from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration
-from sentry.pipeline import Pipeline
+from sentry.pipeline import Pipeline, PipelineAnalyticsEntry
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.web.helpers import render_to_response
 
@@ -32,6 +34,10 @@ def ensure_integration(key, data):
 class IntegrationPipeline(Pipeline):
     pipeline_name = "integration_pipeline"
     provider_manager = default_manager
+
+    def get_analytics_entry(self) -> Optional[PipelineAnalyticsEntry]:
+        pipeline_type = "reauth" if self.fetch_state("integration_id") else "install"
+        return PipelineAnalyticsEntry("integrations.pipeline_step", pipeline_type)
 
     def finish_pipeline(self):
         try:


### PR DESCRIPTION
Move analytics values that are specific to IntegrationPipeline into that class, in an override of a new method hook. It would have caused bogus analytics to be captured when new Pipeline subclasses are made.

Extracted from https://github.com/getsentry/sentry/pull/26883