### PR TITLE
fix(notifications): Use `get_email_addresses` to get project specific email addresses

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Sequence, Set, Tuple
 
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
@@ -14,7 +15,7 @@ from sentry.incidents.models import (
 from sentry.models.notificationsetting import NotificationSetting
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
-from sentry.utils.email import MessageBuilder
+from sentry.utils.email import MessageBuilder, get_email_addresses
 from sentry.utils.http import absolute_uri
 
 
@@ -53,28 +54,25 @@ class DefaultActionHandler(ActionHandler):
     [AlertRuleTriggerAction.TargetType.USER, AlertRuleTriggerAction.TargetType.TEAM],
 )
 class EmailActionHandler(ActionHandler):
-    def get_targets(self):
+    def _get_targets(self) -> Set[int]:
         target = self.action.target
         if not target:
-            return []
-        targets = []
-        if self.action.target_type in (
-            AlertRuleTriggerAction.TargetType.USER.value,
-            AlertRuleTriggerAction.TargetType.TEAM.value,
-        ):
-            if self.action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
-                targets = [(target.id, target.email)]
-            elif self.action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
-                users = NotificationSetting.objects.filter_to_subscribed_users(
-                    self.project,
-                    {member.user for member in target.member_set},
-                )[ExternalProviders.EMAIL]
-                targets = [(user.id, user.email) for user in users]
-        # TODO: We need some sort of verification system to make sure we're not being
-        # used as an email relay.
-        # elif self.action.target_type == AlertRuleTriggerAction.TargetType.SPECIFIC.value:
-        #     emails = [target]
-        return targets
+            return set()
+
+        if self.action.target_type == AlertRuleTriggerAction.TargetType.USER.value:
+            return {target.id}
+
+        elif self.action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
+            users = NotificationSetting.objects.filter_to_subscribed_users(
+                self.project,
+                {member.user for member in target.member_set},
+            )[ExternalProviders.EMAIL]
+            return {user.id for user in users}
+
+        return set()
+
+    def get_targets(self) -> Sequence[Tuple[int, str]]:
+        return list(get_email_addresses(self._get_targets(), project=self.project).items())
 
     def fire(self, metric_value):
         self.email_users(TriggerStatus.ACTIVE)
@@ -82,7 +80,7 @@ class EmailActionHandler(ActionHandler):
     def resolve(self, metric_value):
         self.email_users(TriggerStatus.RESOLVED)
 
-    def email_users(self, status):
+    def email_users(self, status: TriggerStatus) -> None:
         email_context = generate_incident_trigger_email_context(
             self.project, self.incident, self.action.alert_rule_trigger, status
         )

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -24,7 +24,7 @@ from sentry.incidents.models import (
     IncidentStatusMethod,
     TriggerStatus,
 )
-from sentry.models import Integration, NotificationSetting, PagerDutyService
+from sentry.models import Integration, NotificationSetting, PagerDutyService, UserOption
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
@@ -97,6 +97,42 @@ class EmailActionHandlerGetTargetsTest(TestCase):
         )
         handler = EmailActionHandler(action, self.incident, self.project)
         assert set(handler.get_targets()) == {(new_user.id, new_user.email)}
+
+    def test_user_email_routing(self):
+        new_email = "marcos@sentry.io"
+        UserOption.objects.create(
+            user=self.user, project=self.project, key="mail:email", value=new_email
+        )
+
+        action = self.create_alert_rule_trigger_action(
+            target_type=AlertRuleTriggerAction.TargetType.USER,
+            target_identifier=str(self.user.id),
+        )
+        handler = EmailActionHandler(action, self.incident, self.project)
+
+        assert handler.get_targets() == [(self.user.id, new_email)]
+
+    def test_team_email_routing(self):
+        new_user = self.create_user()
+
+        new_email = "marcos@sentry.io"
+        UserOption.objects.create(
+            user=self.user, project=self.project, key="mail:email", value=new_email
+        )
+        UserOption.objects.create(
+            user=new_user, project=self.project, key="mail:email", value=new_email
+        )
+
+        self.create_team_membership(team=self.team, user=new_user)
+        action = self.create_alert_rule_trigger_action(
+            target_type=AlertRuleTriggerAction.TargetType.TEAM,
+            target_identifier=str(self.team.id),
+        )
+        handler = EmailActionHandler(action, self.incident, self.project)
+        assert set(handler.get_targets()) == {
+            (self.user.id, new_user),
+            (new_user.id, new_user),
+        }
 
 
 @freeze_time()

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -130,8 +130,8 @@ class EmailActionHandlerGetTargetsTest(TestCase):
         )
         handler = EmailActionHandler(action, self.incident, self.project)
         assert set(handler.get_targets()) == {
-            (self.user.id, new_user),
-            (new_user.id, new_user),
+            (self.user.id, new_email),
+            (new_user.id, new_email),
         }
 
 


### PR DESCRIPTION
When a user sets up an "email" AlertRuleTriggerAction in  Metric Alert, they choose either a "user" or "team" target. In both cases we're only sending to the email address at `user.email` or `[user.email for user in team.users]`. This does not respect the user's Email Routing preferences that say which project should send messages to which email address. 

This PR uses the email helper `get_email_addresses` to do the DB lookups to get the correct emails.

Fixes [ISSUE-1060](https://getsentry.atlassian.net/browse/ISSUE-1060).