### PR TITLE
fix(performance): Improved operation duration tooltip visual appearance

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -7,8 +7,7 @@ import SortLink from 'app/components/gridEditable/sortLink';
 import Link from 'app/components/links/link';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import PanelTable from 'app/components/panels/panelTable';
-import Tooltip from 'app/components/tooltip';
-import {IconQuestion} from 'app/icons';
+import QuestionTooltip from 'app/components/questionTooltip';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -77,13 +76,13 @@ class TransactionsTable extends React.PureComponent<Props> {
                   title === t('operation duration') ? (
                     <React.Fragment>
                       {title}
-                      <Tooltip
+                      <StyledIconQuestion
+                        size="xs"
+                        position="top"
                         title={t(
-                          'Span durations are summed over the course of an entire transaction. Any overlapping spans are only counted once.'
+                          `Span durations are summed over the course of an entire transaction. Any overlapping spans are only counted once.`
                         )}
-                      >
-                        <StyledIconQuestion size="xs" color="gray400" />
-                      </Tooltip>
+                      />
                     </React.Fragment>
                   ) : (
                     title
@@ -296,9 +295,9 @@ const BodyCellContainer = styled('div')`
   ${overflowEllipsis};
 `;
 
-const StyledIconQuestion = styled(IconQuestion)`
+const StyledIconQuestion = styled(QuestionTooltip)`
   position: relative;
-  top: 2px;
+  top: 1px;
   left: 4px;
 `;
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -7,8 +7,8 @@ import GridEditable, {COL_WIDTH_UNDEFINED, GridColumn} from 'app/components/grid
 import SortLink from 'app/components/gridEditable/sortLink';
 import Link from 'app/components/links/link';
 import Pagination from 'app/components/pagination';
+import QuestionTooltip from 'app/components/questionTooltip';
 import Tooltip from 'app/components/tooltip';
-import {IconQuestion} from 'app/icons';
 import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
@@ -56,13 +56,13 @@ class OperationTitle extends React.Component<TitleProps> {
     return (
       <div onClick={onClick}>
         <span>{t('operation duration')}</span>
-        <Tooltip
+        <StyledIconQuestion
+          size="xs"
+          position="top"
           title={t(
-            'Span durations are summed over the course of an entire transaction. Any overlapping spans are only counted once.'
+            `Span durations are summed over the course of an entire transaction. Any overlapping spans are only counted once.`
           )}
-        >
-          <StyledIconQuestion size="xs" color="gray400" />
-        </Tooltip>
+        />
       </div>
     );
   }
@@ -333,9 +333,9 @@ class EventsTable extends React.Component<Props, State> {
   }
 }
 
-const StyledIconQuestion = styled(IconQuestion)`
+const StyledIconQuestion = styled(QuestionTooltip)`
   position: relative;
-  top: 2px;
+  top: 1px;
   left: 4px;
 `;
 


### PR DESCRIPTION
Improved operation duration tooltip to be more consistent across themes and visual consistency against other tooltips.
Question mark tooltip should now match the existing tooltip in the transaction summary chart, colour now matches theme better, and overflow issues are also fixed.
![image](https://user-images.githubusercontent.com/83961295/124777039-eab17780-df0d-11eb-9682-1d33976789ac.png)
