### PR TITLE
feat(mobile-vitals): Add mobile frame vitals to discover

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -490,7 +490,7 @@ function hasFailedThreshold(marks: Measurements): boolean {
 
   return records.some(record => {
     const value = marks[record.slug];
-    if (typeof value === 'number') {
+    if (typeof value === 'number' && typeof record.poorThreshold === 'number') {
       return value >= record.poorThreshold;
     }
     return false;

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -628,6 +628,9 @@ export enum WebVital {
 export enum MobileVital {
   AppStartCold = 'measurements.app_start_cold',
   AppStartWarm = 'measurements.app_start_warm',
+  FramesTotal = 'measurements.frames_total',
+  FramesSlow = 'measurements.frames_slow',
+  FramesFrozen = 'measurements.frames_frozen',
 }
 
 const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
@@ -640,6 +643,9 @@ const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
   [WebVital.RequestTime]: 'duration',
   [MobileVital.AppStartCold]: 'duration',
   [MobileVital.AppStartWarm]: 'duration',
+  [MobileVital.FramesTotal]: 'number',
+  [MobileVital.FramesSlow]: 'number',
+  [MobileVital.FramesFrozen]: 'number',
 };
 
 // This list contains fields/functions that are available with performance-view feature.

--- a/static/app/utils/performance/vitals/constants.tsx
+++ b/static/app/utils/performance/vitals/constants.tsx
@@ -79,21 +79,41 @@ export const MOBILE_VITAL_DETAILS: Record<MobileVital, Vital> = {
   [MobileVital.AppStartCold]: {
     slug: 'app_start_cold',
     name: t('App Start Cold'),
-    acronym: 'COLD START',
     description: t(
       'Cold start is a measure of the application start up time from scratch.'
     ),
-    poorThreshold: 4000,
     type: measurementType(MobileVital.AppStartCold),
   },
   [MobileVital.AppStartWarm]: {
     slug: 'app_start_warm',
     name: t('App Start Warm'),
-    acronym: 'WARM START',
     description: t(
       'Warm start is a measure of the application start up time while still in memory.'
     ),
-    poorThreshold: 3000,
     type: measurementType(MobileVital.AppStartWarm),
+  },
+  [MobileVital.FramesTotal]: {
+    slug: 'frames_total',
+    name: t('Total Frames'),
+    description: t(
+      'Total frames is a count of the number of frames recorded within a transaction.'
+    ),
+    type: measurementType(MobileVital.FramesTotal),
+  },
+  [MobileVital.FramesSlow]: {
+    slug: 'frames_slow',
+    name: t('Slow Frames'),
+    description: t(
+      'Slow frames is a count of the number of slow frames recorded within a transaction.'
+    ),
+    type: measurementType(MobileVital.FramesSlow),
+  },
+  [MobileVital.FramesFrozen]: {
+    slug: 'frames_frozen',
+    name: t('Frozen Frames'),
+    description: t(
+      'Frozen frames is a count of the number of frozen frames recorded within a transaction.'
+    ),
+    type: measurementType(MobileVital.FramesFrozen),
   },
 };

--- a/static/app/utils/performance/vitals/types.tsx
+++ b/static/app/utils/performance/vitals/types.tsx
@@ -3,9 +3,9 @@ import {ColumnType, WebVital} from 'app/utils/discover/fields';
 export type Vital = {
   slug: string;
   name: string;
-  acronym: string;
+  acronym?: string;
   description: string;
-  poorThreshold: number;
+  poorThreshold?: number;
   type: ColumnType;
 };
 


### PR DESCRIPTION
This adds the following mobile vitals to discover.
- measurements.frames_total
- measurements.frames_slow
- measurements.frames_frozen