### PR TITLE
fix(appconnect): Correct parsing builds form API

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -174,13 +174,17 @@ def get_build_info(
             try:
                 related_appstore_version = get_related(build, "appStoreVersion")
                 related_prerelease_version = get_related(build, "preReleaseVersion")
-                related_version = related_appstore_version or related_prerelease_version
-                if not related_version:
-                    logger.error("Missing related version for AppStoreConnect `build`")
-                    continue
-                platform = related_version["attributes"]["platform"]
-                version = related_version["attributes"]["version"]
+
+                if related_appstore_version:
+                    version = related_appstore_version["attributes"]["versionString"]
+                    platform = related_appstore_version["attributes"]["platform"]
+                elif related_prerelease_version:
+                    version = related_prerelease_version["attributes"]["version"]
+                    platform = related_prerelease_version["attributes"]["platform"]
+                else:
+                    raise KeyError("missing related version")
                 build_number = build["attributes"]["version"]
+
                 result.append(
                     {"platform": platform, "version": version, "build_number": build_number}
                 )

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections import namedtuple
-from typing import Any, Dict, Generator, List, Mapping, Optional
+from typing import Any, Dict, Generator, List, Mapping, Optional, Union
 
 import jwt
 from requests import Session
@@ -118,9 +118,6 @@ def get_build_info(
        in starship documentation
     build_number: str - the version of the build (e.g. '101'), looks like the build number
     """
-
-    result = []
-
     # https://developer.apple.com/documentation/appstoreconnectapi/list_builds
     url = (
         f"v1/builds?filter[app]={app_id}"
@@ -141,42 +138,56 @@ def get_build_info(
         "&filter[expired]=false"
     )
     pages = _get_appstore_info_paged(session, credentials, url)
+    result = []
 
     for page in pages:
+
+        # Collect the related data sent in this page so we can look it up by (type, id).
         included_relations = {}
-        for included in safe.get_path(page, "included", default=[]):
-            type = safe.get_path(included, "type")
-            id = safe.get_path(included, "id")
-            if type is not None and id is not None:
-                included_relations[(type, id)] = included
+        for relation in page["included"]:
+            rel_type = relation["type"]
+            rel_id = relation["id"]
+            included_relations[(rel_type, rel_id)] = relation
 
-        def get_related(relation: JSONData) -> JSONData:
-            type = safe.get_path(relation, "data", "type")
-            id = safe.get_path(relation, "data", "id")
-            if type is None or id is None:
+        def get_related(data: JSONData, relation: str) -> Union[None, JSONData]:
+            """Returns related data by looking it up in all the related data included in the page.
+
+            This first looks up the related object in the data provided under the
+            `relationships` key.  Then it uses the `type` and `id` of this key to look up
+            the actual data in `included_relations` which is an index of all related data
+            returned with the page.
+
+            If the `relation` does not exist in `data` then `None` is returned.
+            """
+            rel_ptr_data = safe.get_path(data, "relationships", relation, "data")
+            if rel_ptr_data is None:
+                # The query asks for both the appStoreVersion and preReleaseVersion
+                # relations to be included.  However for each build there is only one of
+                # these that will have the data with type and id, the other will have None
+                # for data.
                 return None
-            return included_relations.get((type, id))
+            rel_type = rel_ptr_data["type"]
+            rel_id = rel_ptr_data["id"]
+            return included_relations[(rel_type, rel_id)]
 
-        for build in safe.get_path(page, "data", default=[]):
-            related_appstore_version = get_related(
-                safe.get_path(build, "relationships", "appStoreVersion")
-            )
-            related_prerelease_version = get_related(
-                safe.get_path(build, "relationships", "preReleaseVersion")
-            )
-            related_version = related_appstore_version or related_prerelease_version
-            if not related_version:
-                logger.error("Missing related version for AppStoreConnect `build`")
-                continue
-            platform = safe.get_path(related_version, "attributes", "platform")
-            version = safe.get_path(related_version, "attributes", "versionString")
-            build_number = safe.get_path(build, "attributes", "version")
-            if platform is not None and version is not None and build_number is not None:
+        for build in page["data"]:
+            try:
+                related_appstore_version = get_related(build, "appStoreVersion")
+                related_prerelease_version = get_related(build, "preReleaseVersion")
+                related_version = related_appstore_version or related_prerelease_version
+                if not related_version:
+                    logger.error("Missing related version for AppStoreConnect `build`")
+                    continue
+                platform = related_version["attributes"]["platform"]
+                version = related_version["attributes"]["version"]
+                build_number = build["attributes"]["version"]
                 result.append(
                     {"platform": platform, "version": version, "build_number": build_number}
                 )
-            else:
-                logger.error("Malformed AppStoreConnect `builds` data")
+            except Exception:
+                logger.error(
+                    "Failed to process AppStoreConnect build from API: %s", build, exc_info=True
+                )
 
     return result
 

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -162,9 +162,9 @@ def get_build_info(
             rel_ptr_data = safe.get_path(data, "relationships", relation, "data")
             if rel_ptr_data is None:
                 # The query asks for both the appStoreVersion and preReleaseVersion
-                # relations to be included.  However for each build there is only one of
-                # these that will have the data with type and id, the other will have None
-                # for data.
+                # relations to be included.  However for each build there could be only one
+                # of these that will have the data with type and id, the other will have
+                # None for data.
                 return None
             rel_type = rel_ptr_data["type"]
             rel_id = rel_ptr_data["id"]
@@ -175,12 +175,17 @@ def get_build_info(
                 related_appstore_version = get_related(build, "appStoreVersion")
                 related_prerelease_version = get_related(build, "preReleaseVersion")
 
-                if related_appstore_version:
-                    version = related_appstore_version["attributes"]["versionString"]
-                    platform = related_appstore_version["attributes"]["platform"]
-                elif related_prerelease_version:
+                # Normally release versions also have a matching prerelease version, the
+                # platform and version number for them should be identical.  Nevertheless
+                # because we would likely see the build first with a prerelease version
+                # before it also has a release version we prefer to stick with that one if
+                # it is available.
+                if related_prerelease_version:
                     version = related_prerelease_version["attributes"]["version"]
                     platform = related_prerelease_version["attributes"]["platform"]
+                elif related_appstore_version:
+                    version = related_appstore_version["attributes"]["versionString"]
+                    platform = related_appstore_version["attributes"]["platform"]
                 else:
                     raise KeyError("missing related version")
                 build_number = build["attributes"]["version"]


### PR DESCRIPTION
The last refactor here broke the fetching of build info because it was
accessing the build number from an attribute which did not exist.

Also re-write this so that these errors are easier to debug and errors
result in more fatal exceptions which are reported to the internal
sentry.  It still tries to process all the items in a single page however,
which means if there is an actual coding error we get an issue with
lots of events (depending on the number of builds).  On the other
hand if there are errors on processing the page-level elements then
the entire task fails and no attempt is made to process the next page.

@Swatinem next time please test locally 😉 
(yes, there is a desperate lack of tests for these things.  a debt we will have to pay at some point because otherwise things like this will keep breaking production)