### PR TITLE
Create file tables without db constraint on fks

### DIFF
--- a/src/sentry/migrations/0001_initial.py
+++ b/src/sentry/migrations/0001_initial.py
@@ -2289,6 +2289,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -2578,6 +2579,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -2650,7 +2652,9 @@ class Migration(migrations.Migration):
                 (
                     "project",
                     sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        to="sentry.Project", null=True
+                        to="sentry.Project",
+                        null=True,
+                        db_constraint=False,
                     ),
                 ),
             ],
@@ -3132,17 +3136,21 @@ class Migration(migrations.Migration):
                 (
                     "dist",
                     sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        to="sentry.Distribution", null=True
+                        to="sentry.Distribution", null=True, db_constraint=False
                     ),
                 ),
                 ("file", sentry.db.models.fields.foreignkey.FlexibleForeignKey(to="sentry.File")),
                 (
                     "organization",
-                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(to="sentry.Organization"),
+                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                        to="sentry.Organization", db_constraint=False
+                    ),
                 ),
                 (
                     "release",
-                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(to="sentry.Release"),
+                    sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                        to="sentry.Release", db_constraint=False
+                    ),
                 ),
             ],
             options={"db_table": "sentry_releasefile"},
@@ -3544,6 +3552,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -3839,6 +3848,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -3873,6 +3883,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -4441,7 +4452,9 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="fileblobowner",
             name="organization",
-            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(to="sentry.Organization"),
+            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                to="sentry.Organization", db_constraint=False
+            ),
         ),
         migrations.AddField(
             model_name="file",
@@ -4499,7 +4512,9 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="eventattachment",
             name="file",
-            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(to="sentry.File"),
+            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                to="sentry.File", db_constraint=False
+            ),
         ),
         migrations.AlterUniqueTogether(name="event", unique_together={("project_id", "event_id")}),
         migrations.AlterIndexTogether(name="event", index_together={("group_id", "datetime")}),

--- a/src/sentry/migrations/0001_squashed_0200_release_indices.py
+++ b/src/sentry/migrations/0001_squashed_0200_release_indices.py
@@ -2237,6 +2237,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -2507,6 +2508,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -2571,13 +2573,17 @@ class Migration(migrations.Migration):
                 (
                     "file",
                     sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="sentry.File"
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="sentry.File",
                     ),
                 ),
                 (
                     "project",
                     sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        null=True, on_delete=django.db.models.deletion.CASCADE, to="sentry.Project"
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="sentry.Project",
+                        db_constraint=False,
                     ),
                 ),
             ],
@@ -3104,6 +3110,7 @@ class Migration(migrations.Migration):
                         null=True,
                         on_delete=django.db.models.deletion.CASCADE,
                         to="sentry.Distribution",
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -3115,13 +3122,17 @@ class Migration(migrations.Migration):
                 (
                     "organization",
                     sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="sentry.Organization"
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="sentry.Organization",
+                        db_constraint=False,
                     ),
                 ),
                 (
                     "release",
                     sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="sentry.Release"
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="sentry.Release",
+                        db_constraint=False,
                     ),
                 ),
             ],
@@ -3564,6 +3575,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -3777,6 +3789,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -3811,6 +3824,7 @@ class Migration(migrations.Migration):
                         on_delete=django.db.models.deletion.SET_NULL,
                         to="sentry.File",
                         unique=True,
+                        db_constraint=False,
                     ),
                 ),
                 (
@@ -4330,7 +4344,9 @@ class Migration(migrations.Migration):
             model_name="fileblobowner",
             name="organization",
             field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                on_delete=django.db.models.deletion.CASCADE, to="sentry.Organization"
+                on_delete=django.db.models.deletion.CASCADE,
+                to="sentry.Organization",
+                db_constraint=False,
             ),
         ),
         migrations.AddField(
@@ -4389,7 +4405,9 @@ class Migration(migrations.Migration):
             model_name="eventattachment",
             name="file",
             field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
-                on_delete=django.db.models.deletion.CASCADE, to="sentry.File"
+                on_delete=django.db.models.deletion.CASCADE,
+                to="sentry.File",
+                db_constraint=False,
             ),
         ),
         migrations.AddField(


### PR DESCRIPTION
To not break multi-database setup for getsentry in dev and test we need to create these foreign keys without database constraints.

https://github.com/getsentry/getsentry/pull/5884 moves multiple tables to a non-default (`files`) database connection (`secondary` in dev/test) therefore we need to create those tables already without db constraint.