### PR TITLE
fix(migration): Find and use existing index names

### DIFF
--- a/src/sentry/migrations/0216_cdc_setup_replication_index.py
+++ b/src/sentry/migrations/0216_cdc_setup_replication_index.py
@@ -3,6 +3,57 @@
 from django.db import migrations
 
 
+def set_replication_identity(schema_editor, model, column_names):
+    cursor = schema_editor.connection.cursor()
+    # This gets the current list of constraint names on the model based on the provided parameters.
+    # We are specifically looking for matching column names and unique indexes since replication
+    # identities only work on unique constraints
+    unique_constraint_names = schema_editor._constraint_names(model, column_names, unique=True)
+
+    if not unique_constraint_names:
+        # Create a unique index since there is no unique index on the columns we want.
+        index = schema_editor._create_index_name(model, column_names, "_uniq")
+        cursor.execute(
+            f'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {schema_editor.quote_name(index)} ON {schema_editor.quote_name(model._meta.db_table)} ({", ".join(schema_editor.quote_name(col) for col in column_names)});'
+        )
+    else:
+        # There should ideally be only one. But even if there are more, lets use the first one
+        index = unique_constraint_names[0]
+
+    cursor.execute(
+        f"ALTER TABLE {schema_editor.quote_name(model._meta.db_table)} REPLICA IDENTITY USING INDEX {schema_editor.quote_name(index)}"
+    )
+    cursor.close()
+
+
+def reset_replication_identity(schema_editor, model):
+    cursor = schema_editor.connection.cursor()
+    cursor.execute(
+        f"ALTER TABLE {schema_editor.quote_name(model._meta.db_table)} REPLICA IDENTITY DEFAULT"
+    )
+    cursor.close()
+
+
+def set_groupassignee_replication_identity(apps, schema_editor):
+    group_assignee_model = apps.get_model("sentry", "GroupAssignee")
+    set_replication_identity(schema_editor, group_assignee_model, ["project_id", "group_id"])
+
+
+def reset_groupassignee_replication_identity(apps, schema_editor):
+    group_assignee_model = apps.get_model("sentry", "GroupAssignee")
+    reset_replication_identity(schema_editor, group_assignee_model)
+
+
+def set_groupedmessage_replication_identity(apps, schema_editor):
+    group_model = apps.get_model("sentry", "Group")
+    set_replication_identity(schema_editor, group_model, ["project_id", "id"])
+
+
+def reset_groupedmessage_replication_identity(apps, schema_editor):
+    group_model = apps.get_model("sentry", "Group")
+    reset_replication_identity(schema_editor, group_model)
+
+
 class Migration(migrations.Migration):
     # This flag is used to mark that a migration shouldn't be automatically run in
     # production. We set this to True for operations that we think are risky and want
@@ -31,24 +82,28 @@ class Migration(migrations.Migration):
     operations = [
         migrations.SeparateDatabaseAndState(
             database_operations=[
-                migrations.RunSQL(
-                    """
-                    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "sentry_groupedmessage_project_id_id_515aaa7e_uniq" ON "sentry_groupedmessage" ("project_id", "id");
-                    """,
-                    reverse_sql="""
-                    DROP INDEX CONCURRENTLY IF EXISTS sentry_groupedmessage_project_id_id_515aaa7e_uniq;
-                    """,
-                    hints={"tables": ["sentry_groupedmessage"]},
+                migrations.RunPython(
+                    code=set_groupassignee_replication_identity,
+                    reverse_code=reset_groupassignee_replication_identity,
+                    atomic=False,
+                    hints={"tables": ["sentry_groupasignee"]},
+                )
+            ],
+            state_operations=[
+                migrations.AlterUniqueTogether(
+                    name="groupassignee",
+                    unique_together={("project", "group")},
                 ),
-                migrations.RunSQL(
-                    """
-                    ALTER TABLE "sentry_groupedmessage" ADD CONSTRAINT "sentry_groupedmessage_project_id_id_515aaa7e_uniq" UNIQUE USING INDEX "sentry_groupedmessage_project_id_id_515aaa7e_uniq";
-                    """,
-                    reverse_sql="""
-                    ALTER TABLE "sentry_groupedmessage" DROP CONSTRAINT IF EXISTS "sentry_groupedmessage_project_id_id_515aaa7e_uniq";
-                    """,
+            ],
+        ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    code=set_groupedmessage_replication_identity,
+                    reverse_code=reset_groupedmessage_replication_identity,
+                    atomic=False,
                     hints={"tables": ["sentry_groupedmessage"]},
-                ),
+                )
             ],
             state_operations=[
                 migrations.AlterUniqueTogether(
@@ -56,25 +111,5 @@ class Migration(migrations.Migration):
                     unique_together={("project", "id"), ("project", "short_id")},
                 ),
             ],
-        ),
-        migrations.RunSQL(
-            sql="""
-            ALTER TABLE sentry_groupasignee REPLICA IDENTITY USING INDEX
-            sentry_groupasignee_project_id_group_id_fbf4364e_uniq
-            """,
-            reverse_sql="""
-            ALTER TABLE sentry_groupasignee REPLICA IDENTITY DEFAULT
-            """,
-            hints={"tables": ["sentry_groupasignee"]},
-        ),
-        migrations.RunSQL(
-            sql="""
-            ALTER TABLE sentry_groupedmessage REPLICA IDENTITY USING INDEX
-            sentry_groupedmessage_project_id_id_515aaa7e_uniq
-            """,
-            reverse_sql="""
-            ALTER TABLE sentry_groupedmessage REPLICA IDENTITY DEFAULT
-            """,
-            hints={"tables": ["sentry_groupedmessage"]},
         ),
     ]


### PR DESCRIPTION
The current migration assumes that index with the names provided exist.
The problem with this approach is that south and django have different
schemes for creating index names. Since this migration was originally
part of south migrations and this PR is trying to resotre it, its
possible that the index names for the given constraint might be
different. The change is to get the index name based on the columns
we want and then use it in the REPLICATION IDENTITY statement. It also
takes care of cases where there might not be a unique index at all. In
those cases we create a unique index and then use it.