### PR TITLE
fix(perf): Change tags page badge to alpha

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -275,7 +275,7 @@ class TransactionHeader extends React.Component<Props> {
                 onClick={this.trackTagsTabClick}
               >
                 {t('Tags')}
-                <FeatureBadge type="beta" noTooltip />
+                <FeatureBadge type="alpha" noTooltip />
               </ListLink>
             </Feature>
             <Feature features={['organizations:performance-events-page']}>


### PR DESCRIPTION
### Summary
Switched it to beta, but it should be alpha.