### PR TITLE
feat(notifications): Team Notification Settings

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -92,8 +92,8 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
             tokens = tokenize_query(query)
             for key, value in tokens.items():
                 if key == "hasExternalTeams":
-                    hasExternalTeams = "true" in value
-                    if hasExternalTeams:
+                    has_external_teams = "true" in value
+                    if has_external_teams:
                         queryset = queryset.filter(
                             actor_id__in=ExternalActor.objects.filter(
                                 organization=organization

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.team import TeamWithProjectsSerializer
 from sentry.models import AuditLogEntryEvent, Team, TeamStatus
 from sentry.tasks.deletion import delete_team
 
@@ -40,9 +41,14 @@ class TeamDetailsEndpoint(TeamEndpoint):
         :pparam string organization_slug: the slug of the organization the
                                           team belongs to.
         :pparam string team_slug: the slug of the team to get.
+        :qparam bool full: if this is set to true then the team object will
+            include projects and external_teams. Set to 1 to enable.
         :auth: required
         """
-        context = serialize(team, request.user)
+        full = request.GET.get("full", False)
+        serializer = TeamWithProjectsSerializer() if full else TeamSerializer()
+
+        context = serialize(team, request.user, serializer)
         context["organization"] = serialize(team.organization, request.user)
 
         return Response(context)

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.team import TeamSerializer as TeamWithoutProjectsSerializer
 from sentry.api.serializers.models.team import TeamWithProjectsSerializer
 from sentry.models import AuditLogEntryEvent, Team, TeamStatus
 from sentry.tasks.deletion import delete_team
@@ -46,7 +47,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         :auth: required
         """
         full = request.GET.get("full", False)
-        serializer = TeamWithProjectsSerializer() if full else TeamSerializer()
+        serializer = TeamWithProjectsSerializer() if full else TeamWithoutProjectsSerializer()
 
         context = serialize(team, request.user, serializer)
         context["organization"] = serialize(team.organization, request.user)

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -210,7 +210,7 @@ class TeamSerializer(Serializer):  # type: ignore
 class TeamWithProjectsSerializer(TeamSerializer):
     """@deprecated Use `expand` instead."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(expand=["projects", "externalTeams"])
 
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -23,7 +23,6 @@ from sentry.models import (
     OrganizationAccessRequest,
     OrganizationMember,
     OrganizationMemberTeam,
-    ProjectStatus,
     ProjectTeam,
     Team,
     TeamAvatar,
@@ -88,6 +87,23 @@ def get_access_requests(item_list: Sequence[Team], user: User) -> AbstractSet[Te
 
 @register(Team)
 class TeamSerializer(Serializer):  # type: ignore
+    def __init__(
+        self, collapse: Optional[Sequence[str]] = None, expand: Optional[Sequence[str]] = None
+    ):
+        self.collapse = collapse
+        self.expand = expand
+
+    def _expand(self, key: str) -> bool:
+        if self.expand is None:
+            return False
+
+        return key in self.expand
+
+    def _collapse(self, key: str) -> bool:
+        if self.collapse is None:
+            return False
+        return key in self.collapse
+
     def get_attrs(
         self, item_list: Sequence[Team], user: User, **kwargs: Any
     ) -> MutableMapping[Team, MutableMapping[str, Any]]:
@@ -125,6 +141,34 @@ class TeamSerializer(Serializer):  # type: ignore
                 "avatar": avatars.get(team.id),
                 "member_count": member_totals.get(team.id, 0),
             }
+
+        if self._expand("projects"):
+            project_teams = ProjectTeam.objects.get_for_teams_with_org_cache(item_list)
+            projects = [pt.project for pt in project_teams]
+
+            projects_by_id = {
+                project.id: data for project, data in zip(projects, serialize(projects, user))
+            }
+
+            project_map = defaultdict(list)
+            for project_team in project_teams:
+                project_map[project_team.team_id].append(projects_by_id[project_team.project_id])
+
+            for team in item_list:
+                result[team]["projects"] = project_map[team.id]
+
+        if self._expand("externalTeams"):
+            actor_mapping = {team.actor_id: team for team in item_list}
+            external_actors = list(ExternalActor.objects.filter(actor_id__in=actor_mapping.keys()))
+
+            external_teams_map = defaultdict(list)
+            serialized_list = serialize(external_actors, user, key="team")
+            for serialized in serialized_list:
+                external_teams_map[serialized["teamId"]].append(serialized)
+
+            for team in item_list:
+                result[team]["externalTeams"] = external_teams_map[str(team.id)]
+
         return result
 
     def serialize(
@@ -137,7 +181,8 @@ class TeamSerializer(Serializer):  # type: ignore
             }
         else:
             avatar = {"avatarType": "letter_avatar", "avatarUuid": None}
-        return {
+
+        result = {
             "id": str(obj.id),
             "slug": obj.slug,
             "name": obj.name,
@@ -149,55 +194,24 @@ class TeamSerializer(Serializer):  # type: ignore
             "avatar": avatar,
         }
 
+        # Expandable attributes.
+        if self._expand("externalTeams"):
+            result["externalTeams"] = attrs["externalTeams"]
 
-class TeamWithProjectsSerializer(TeamSerializer):
-    def get_attrs(
-        self, item_list: Sequence[Team], user: Any, **kwargs: Any
-    ) -> MutableMapping[Team, MutableMapping[str, Any]]:
-        project_teams = list(
-            ProjectTeam.objects.filter(team__in=item_list, project__status=ProjectStatus.VISIBLE)
-            .order_by("project__name", "project__slug")
-            .select_related("project")
-        )
+        if self._expand("organization"):
+            result["organization"] = serialize(obj.organization, user)
 
-        actor_mapping = {team.actor_id: team for team in item_list}
-        external_actors = list(ExternalActor.objects.filter(actor_id__in=actor_mapping.keys()))
+        if self._expand("projects"):
+            result["projects"] = attrs["projects"]
 
-        # TODO(dcramer): we should query in bulk for ones we're missing here
-        orgs = {i.organization_id: i.organization for i in item_list}
-
-        for project_team in project_teams:
-            project_team.project.set_cached_field_value(
-                "organization", orgs[project_team.project.organization_id]
-            )
-
-        projects = [pt.project for pt in project_teams]
-        projects_by_id = {
-            project.id: data for project, data in zip(projects, serialize(projects, user))
-        }
-
-        project_map = defaultdict(list)
-        for project_team in project_teams:
-            project_map[project_team.team_id].append(projects_by_id[project_team.project_id])
-
-        external_teams_map = defaultdict(list)
-        serialized_list = serialize(external_actors, user, key="team")
-        for serialized in serialized_list:
-            external_teams_map[serialized["teamId"]].append(serialized)
-
-        result = super().get_attrs(item_list, user)
-        for team in item_list:
-            result[team]["projects"] = project_map[team.id]
-            result[team]["externalTeams"] = external_teams_map[str(team.id)]
         return result
 
-    def serialize(
-        self, obj: Team, attrs: Mapping[str, Any], user: Any, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
-        d = super().serialize(obj, attrs, user)
-        d["projects"] = attrs["projects"]
-        d["externalTeams"] = attrs["externalTeams"]
-        return d
+
+class TeamWithProjectsSerializer(TeamSerializer):
+    """@deprecated Use `expand` instead."""
+
+    def __init__(self):
+        super().__init__(expand=["projects", "externalTeams"])
 
 
 def get_scim_teams_members(

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 from uuid import uuid1
 
 import sentry_sdk

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import Sequence
+from typing import Sequence, TYPE_CHECKING
 from uuid import uuid1
 
 import sentry_sdk
@@ -32,8 +32,30 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.integrationdocs import integration_doc_exists
 from sentry.utils.retries import TimedRetryPolicy
 
+if TYPE_CHECKING:
+    from sentry.models import Team
+
 # TODO(dcramer): pull in enum library
 ProjectStatus = ObjectStatus
+
+
+class ProjectTeamManager(BaseManager):
+    def get_for_teams_with_org_cache(self, teams: Sequence["Team"]) -> Sequence["ProjectTeam"]:
+        project_teams = (
+            self.filter(team__in=teams, project__status=ProjectStatus.VISIBLE)
+            .order_by("project__name", "project__slug")
+            .select_related("project")
+        )
+
+        # TODO(dcramer): we should query in bulk for ones we're missing here
+        orgs = {i.organization_id: i.organization for i in teams}
+
+        for project_team in project_teams:
+            project_team.project.set_cached_field_value(
+                "organization", orgs[project_team.project.organization_id]
+            )
+
+        return project_teams
 
 
 class ProjectTeam(Model):
@@ -41,6 +63,8 @@ class ProjectTeam(Model):
 
     project = FlexibleForeignKey("sentry.Project")
     team = FlexibleForeignKey("sentry.Team")
+
+    objects = ProjectTeamManager()
 
     class Meta:
         app_label = "sentry"

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -60,7 +60,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         onResults: result => {
           // For organizations with >100 users, we want to make sure their
           // saved mapping gets populated in the results if it wouldn't have
-          // been in the inital 100 API results, which is why we add it here
+          // been in the initial 100 API results, which is why we add it here
           if (mapping && !result.find(({user}) => user.id === mapping.userId)) {
             result = [{id: mapping.userId, name: mapping.sentryName}, ...result];
           }
@@ -80,7 +80,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         onResults: result => {
           // For organizations with >100 teams, we want to make sure their
           // saved mapping gets populated in the results if it wouldn't have
-          // been in the inital 100 API results, which is why we add it here
+          // been in the initial 100 API results, which is why we add it here
           if (mapping && !result.find(({id}) => id === mapping.teamId)) {
             result = [{id: mapping.teamId, name: mapping.sentryName}, ...result];
           }

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -607,7 +607,7 @@ function routes() {
           />
           <Route
             path="settings/"
-            name="settings"
+            name="Settings"
             componentPromise={() =>
               import('app/views/settings/organizationTeams/teamSettings')
             }

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1326,7 +1326,7 @@ function routes() {
 
           {/*
         TODO(mark) Long term this /queries route should go away and /discover should be the
-        canoncial route for discover2. We have a redirect right now as /discover was for
+        canonical route for discover2. We have a redirect right now as /discover was for
         discover 1 and most of the application is linking to /discover/queries and not /discover
         */}
           <Redirect

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -598,6 +598,14 @@ function routes() {
             component={errorHandler(LazyLoad)}
           />
           <Route
+            path="notifications/"
+            name="Notifications"
+            componentPromise={() =>
+              import('app/views/settings/organizationTeams/teamNotifications')
+            }
+            component={errorHandler(LazyLoad)}
+          />
+          <Route
             path="projects/"
             name="Projects"
             componentPromise={() =>

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2186,6 +2186,7 @@ export type ExternalUser = {
   memberId: string;
   externalName: string;
   provider: string;
+  integrationId: string;
 };
 
 export type ExternalTeam = {
@@ -2193,4 +2194,5 @@ export type ExternalTeam = {
   teamId: string;
   externalName: string;
   provider: string;
+  integrationId: string;
 };

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -183,7 +183,7 @@ class Projects extends React.Component<Props, State> {
     this.setState({
       // placeholders for projects we need to fetch
       fetchedProjects: notInStore.map(slug => ({slug})),
-      // set initallyLoaded if any projects were fetched from store
+      // set initiallyLoaded if any projects were fetched from store
       initiallyLoaded: !!inStore.length,
       projectsFromStore,
     });

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -142,7 +142,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
           key={Actions.CUSTOMIZED_ALERTS}
           onClick={e => {
             // XXX(epurkhiser): The `e.preventDefault` here is needed to stop
-            // propegation of the click up to the label, causing it to focus
+            // propagation of the click up to the label, causing it to focus
             // the radio input and lose focus on the select.
             e.preventDefault();
             const alertSetting = Actions.CUSTOMIZED_ALERTS.toString();

--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -185,6 +185,16 @@ class TeamDetails extends React.Component<Props, State> {
       </ListLink>,
     ];
 
+    if (organization.features.includes('notification-platform')) {
+      navigationTabs.splice(
+        2,
+        0,
+        <ListLink key="x" to={`${routePrefix}notifications/`}>
+          {t('Notifications')}
+        </ListLink>
+      );
+    }
+
     return (
       <div>
         <SentryDocumentTitle title={t('Team Details')} orgSlug={params.orgId} />

--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -168,7 +168,21 @@ class TeamDetails extends React.Component<Props, State> {
       return <LoadingError onRetry={this.fetchData} />;
     }
 
-    const routePrefix = recreateRoute('', {routes, params, stepBack: -1}); // `/organizations/${orgId}/teams/${teamId}`;
+    // `/organizations/${orgId}/teams/${teamId}`;
+    const routePrefix = recreateRoute('', {routes, params, stepBack: -1});
+
+    const navigationTabs = [
+      <ListLink key={0} to={`${routePrefix}members/`}>
+        {t('Members')}
+      </ListLink>,
+      <ListLink key={1} to={`${routePrefix}projects/`}>
+        {t('Projects')}
+      </ListLink>,
+      <ListLink key={2} to={`${routePrefix}settings/`}>
+        {t('Settings')}
+      </ListLink>,
+    ];
+
     return (
       <div>
         <SentryDocumentTitle title={t('Team Details')} orgSlug={params.orgId} />
@@ -176,11 +190,7 @@ class TeamDetails extends React.Component<Props, State> {
           <IdBadge hideAvatar team={team} avatarSize={36} />
         </h3>
 
-        <NavTabs underlined>
-          <ListLink to={`${routePrefix}members/`}>{t('Members')}</ListLink>
-          <ListLink to={`${routePrefix}projects/`}>{t('Projects')}</ListLink>
-          <ListLink to={`${routePrefix}settings/`}>{t('Settings')}</ListLink>
-        </NavTabs>
+        <NavTabs underlined>{navigationTabs}</NavTabs>
 
         {React.isValidElement(children) &&
           React.cloneElement(children, {

--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -16,15 +16,17 @@ import NavTabs from 'app/components/navTabs';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t, tct} from 'app/locale';
 import TeamStore from 'app/stores/teamStore';
-import {Team} from 'app/types';
+import {Organization, Team} from 'app/types';
 import recreateRoute from 'app/utils/recreateRoute';
 import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
 import withTeams from 'app/utils/withTeams';
 
 type Props = {
   api: Client;
   teams: Team[];
   children: React.ReactNode;
+  organization: Organization;
 } & RouteComponentProps<{orgId: string; teamId: string}, {}>;
 
 type State = {
@@ -136,7 +138,7 @@ class TeamDetails extends React.Component<Props, State> {
   };
 
   render() {
-    const {params, routes, children} = this.props;
+    const {children, organization, params, routes} = this.props;
     const {team, loading, requesting, error} = this.state;
 
     if (loading) {
@@ -202,7 +204,7 @@ class TeamDetails extends React.Component<Props, State> {
   }
 }
 
-export default withApi(withTeams(TeamDetails));
+export default withApi(withOrganization(withTeams(TeamDetails)));
 
 const RequestAccessWrapper = styled('div')`
   display: flex;

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -72,7 +72,7 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
         <EmptyMessage>
           <div>{t('No External Teams have been linked yet.')}</div>
           <NotDisabledSubText>
-            Head over to Slack and type <code>/sentry</code> to get started.{' '}
+            Head over to Slack and type <code>/sentry link team</code> to get started.{' '}
             <a href="">Learn more</a>
           </NotDisabledSubText>
         </EmptyMessage>

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {Integration, LightWeightOrganization, Team} from 'app/types';
 import {toTitleCase} from 'app/utils';
 import withOrganization from 'app/utils/withOrganization';
@@ -76,8 +76,10 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
         <EmptyMessage>
           <div>{t('No External Teams have been linked yet.')}</div>
           <NotDisabledSubText>
-            Head over to Slack and type <code>/sentry link team</code> to get started.{' '}
-            <a href="">Learn more</a>
+            {tct('Head over to Slack and type [code] to get started. [link].', {
+              code: <code>/sentry link team</code>,
+              link: <a>{t('Learn more')}</a>,
+            })}
           </NotDisabledSubText>
         </EmptyMessage>
       );
@@ -98,8 +100,10 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
               {integrationsById[externalTeam.integrationId].name}
             </NotDisabledText>
             <NotDisabledSubText>
-              Unlink this channel in Slack with <code>/sentry unlink team</code>.{' '}
-              <a href="">Learn more</a>
+              {tct('Unlink this channel in Slack with [code]. [link].', {
+                code: <code>/sentry unlink team</code>,
+                link: <a>{t('Learn more')}</a>,
+              })}
             </NotDisabledSubText>
           </div>
         }

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -1,0 +1,108 @@
+import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
+
+import AsyncComponent from 'app/components/asyncComponent';
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {t} from 'app/locale';
+import {Integration, LightWeightOrganization, Team} from 'app/types';
+import {toTitleCase} from 'app/utils';
+import withOrganization from 'app/utils/withOrganization';
+import AsyncView from 'app/views/asyncView';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import TextField from 'app/views/settings/components/forms/textField';
+
+type Props = RouteComponentProps<{orgId: string; teamId: string}, {}> & {
+  organization: LightWeightOrganization;
+  team: Team;
+};
+
+type State = AsyncView['state'] & {
+  teamDetails: Team;
+  integrations: Integration[];
+};
+
+const NOTIFICATION_PROVIDERS = ['slack'];
+
+class TeamNotificationSettings extends AsyncView<Props, State> {
+  getTitle() {
+    return 'Team Notification Settings';
+  }
+
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {organization, team} = this.props;
+    return [
+      ['teamDetails', `/teams/${organization.slug}/${team.slug}/`, {query: {full: true}}],
+      [
+        'integrations',
+        `/organizations/${organization.slug}/integrations/`,
+        {query: {includeConfig: 0}},
+      ],
+    ];
+  }
+
+  renderBody() {
+    return (
+      <Panel>
+        <PanelHeader>{t('Notifications')}</PanelHeader>
+        <PanelBody>{this.renderPanelBody()}</PanelBody>
+      </Panel>
+    );
+  }
+
+  renderPanelBody() {
+    const {teamDetails, integrations} = this.state;
+
+    const notificationIntegrations = integrations.filter(integration =>
+      NOTIFICATION_PROVIDERS.includes(integration.provider.key)
+    );
+    if (!notificationIntegrations.length) {
+      return (
+        <EmptyMessage>
+          {t('No Notification Integrations have been installed yet.')}
+        </EmptyMessage>
+      );
+    }
+
+    const externalTeams = teamDetails.externalTeams.filter(externalTeam =>
+      NOTIFICATION_PROVIDERS.includes(externalTeam.provider)
+    );
+
+    if (!externalTeams.length) {
+      return <EmptyMessage>{t('No External Teams have been linked yet.')}</EmptyMessage>;
+    }
+
+    const integrationsById = Object.fromEntries(
+      notificationIntegrations.map(integration => [integration.id, integration])
+    );
+
+    return externalTeams.map(externalTeam => (
+      <TextField
+        disabled
+        key={externalTeam.id}
+        label={
+          <div>
+            <NotDisabledText>
+              {toTitleCase(externalTeam.provider)}:
+              {integrationsById[externalTeam.integrationId].name}
+            </NotDisabledText>
+            <NotDisabledSubText>
+              Unlink this channel in Slack with <code>/sentry unlink team</code>.{' '}
+              <a href="">Learn more</a>
+            </NotDisabledSubText>
+          </div>
+        }
+        name="externalName"
+        value={externalTeam.externalName}
+      />
+    ));
+  }
+}
+export default withOrganization(TeamNotificationSettings);
+
+const NotDisabledText = styled('div')`
+  color: ${p => p.theme.textColor};
+`;
+const NotDisabledSubText = styled('div')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeRelativeSmall};
+`;

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -68,7 +68,15 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
     );
 
     if (!externalTeams.length) {
-      return <EmptyMessage>{t('No External Teams have been linked yet.')}</EmptyMessage>;
+      return (
+        <EmptyMessage>
+          <div>{t('No External Teams have been linked yet.')}</div>
+          <NotDisabledSubText>
+            Head over to Slack and type <code>/sentry</code> to get started.{' '}
+            <a href="">Learn more</a>
+          </NotDisabledSubText>
+        </EmptyMessage>
+      );
     }
 
     const integrationsById = Object.fromEntries(

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -31,7 +31,11 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization, team} = this.props;
     return [
-      ['teamDetails', `/teams/${organization.slug}/${team.slug}/`, {query: {full: true}}],
+      [
+        'teamDetails',
+        `/teams/${organization.slug}/${team.slug}/`,
+        {query: {expand: ['externalTeams']}},
+      ],
       [
         'integrations',
         `/organizations/${organization.slug}/integrations/`,


### PR DESCRIPTION
This PR creates the Team Notification Settings Page to [match this spec](https://www.figma.com/file/48ATxgADirZkRz3qkV46e0/Handover%3A-Notifications?node-id=288%3A2425).
![Screen Shot 2021-07-08 at 2 54 30 PM](https://user-images.githubusercontent.com/31750075/124995598-6e499200-dffc-11eb-863b-fe3f5a6b74a4.png)
![Screen Shot 2021-07-08 at 3 05 39 PM](https://user-images.githubusercontent.com/31750075/124996605-11e77200-dffe-11eb-9938-a46a4cdae46e.png)
Its only job is to show a teams linked external identities, not add, update, or delete them.
