### PR TITLE
fix(notifications): Slack "ok" Logging

### DIFF
--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -34,16 +34,16 @@ class SlackClient(ApiClient):
         # If Slack gives us back a 200 we still want to check the 'ok' param
         if resp:
             content_type = resp.headers["content-type"]
-            if content_type == "application/json":
+            if content_type == "text/html":
+                is_ok = str(resp.content) == "ok"
+                # If there is an error, Slack just makes the error the entire response.
+                error_option = resp.content
+
+            else:
+                # The content-type should be "application/json" at this point but we don't check.
                 response = resp.json()
                 is_ok = response.get("ok")
                 error_option = response.get("error")
-
-            else:
-                # The content-type should be "text/html" at this point but we don't check.
-                is_ok = str(resp.content) == "ok"
-                # If there is an error, slack just makes the error the entire response.
-                error_option = resp.content
 
             span.set_tag("ok", is_ok)
 


### PR DESCRIPTION
A [recent change](https://github.com/getsentry/sentry/pull/26901) broke [this datadog graph](https://app.datadoghq.com/s/FH6-Y3/qw8-462-wjy).

![Screen Shot 2021-07-07 at 4 15 47 PM](https://user-images.githubusercontent.com/31750075/124839948-ad191280-df3e-11eb-99d7-cdcaa51f2bbc.png)

My guess is that the Content-Type of JSON slack responses is not `"application/json"`. This PR assumes that anything that is not HTML can be interpreted as JSON.