### PR TITLE
chore(trends): rename display to percentile

### DIFF
--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -240,7 +240,7 @@ class TrendsContent extends React.Component<Props, State> {
                 />
                 <TrendsDropdown>
                   <DropdownControl
-                    buttonProps={{prefix: t('Display')}}
+                    buttonProps={{prefix: t('Percentile')}}
                     label={currentTrendFunction.label}
                   >
                     {TRENDS_FUNCTIONS.map(({label, field}) => (


### PR DESCRIPTION
Make consistent with All Events tab

**Before:**
![Screen Shot 2021-07-07 at 6 21 33 PM](https://user-images.githubusercontent.com/4830259/124847651-2e2cd580-df50-11eb-985b-d484eff83b13.png)

**After:**
![Screen Shot 2021-07-07 at 6 21 03 PM](https://user-images.githubusercontent.com/4830259/124847619-1b1a0580-df50-11eb-834e-de1875135782.png)
