### PR TITLE
fix: Show tree_label for correct exception in chain

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -24,7 +24,7 @@ def _calculate_contributes(values):
     return False
 
 
-def _calculate_tree_label(values):
+def calculate_tree_label(values):
     for value in values or ():
         if isinstance(value, GroupingComponent) and value.contributes and value.tree_label:
             return value.tree_label
@@ -132,7 +132,7 @@ class GroupingComponent:
             if contributes is None:
                 contributes = _calculate_contributes(values)
             if tree_label is None:
-                tree_label = _calculate_tree_label(values)
+                tree_label = calculate_tree_label(values)
             self.values = values
         if contributes is not None:
             if contributes_to_similarity is None:

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, Dict, List
 
-from sentry.grouping.component import GroupingComponent
+from sentry.grouping.component import GroupingComponent, calculate_tree_label
 from sentry.grouping.strategies.base import call_with_variants, strategy
 from sentry.grouping.strategies.hierarchical import get_stacktrace_hierarchy
 from sentry.grouping.strategies.message import trim_message_for_grouping
@@ -640,7 +640,11 @@ def chained_exception(chained_exception, context, **meta):
     rv = {}
 
     for name, component_list in by_name.items():
-        rv[name] = GroupingComponent(id="chained-exception", values=component_list)
+        rv[name] = GroupingComponent(
+            id="chained-exception",
+            values=component_list,
+            tree_label=calculate_tree_label(reversed(component_list)),
+        )
 
     return rv
 

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/java_chained.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-06-30T16:44:02.387657Z'
+created: '2021-07-08T11:25:50.125928Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
   hash: "e37a6991567f96367fac9ba5c34f1d68"
-  tree_label: "bind0"
+  tree_label: "main"
   component:
     app-depth-1*
       chained-exception*
@@ -51,7 +51,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "4342cbc52b434588d500b518441bb830"
-  tree_label: "bind0 | bind"
+  tree_label: "run | main"
   component:
     app-depth-2*
       chained-exception*
@@ -118,7 +118,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "797355840aa68b9aeb7416a2267456dd"
-  tree_label: "bind0 | bind | bind"
+  tree_label: "run | run | main"
   component:
     app-depth-3*
       chained-exception*
@@ -206,7 +206,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "b5cb31481ea65dffcf2f5ba853a8ae37"
-  tree_label: "bind0 | bind | bind | bind"
+  tree_label: "run | run | run | main"
   component:
     app-depth-4*
       chained-exception*
@@ -315,7 +315,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-5:
   hash: "b4abb2ff030b1ad52cbcc34a0be98d77"
-  tree_label: "bind0 | bind | bind | bind | bind"
+  tree_label: "refreshContext | run | run | run | main"
   component:
     app-depth-5*
       chained-exception*
@@ -445,7 +445,7 @@ app-depth-5:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "8924849495809d42431719c2b9ab65c8"
-  tree_label: "bind0 | bind | bind | bind | bind | bind | start | start | startInternal | start | addConnector | addPreviouslyRemovedConnectors | start | startEmbeddedServletContainer | finishRefresh | refresh | refresh | refresh | refreshContext | run | run | run | main"
+  tree_label: "start | addConnector | addPreviouslyRemovedConnectors | start | startEmbeddedServletContainer | finishRefresh | refresh | refresh | refresh | refreshContext | run | run | run | main"
   component:
     app-depth-max*
       chained-exception*
@@ -841,7 +841,7 @@ default:
 --------------------------------------------------------------------------
 system:
   hash: "8924849495809d42431719c2b9ab65c8"
-  tree_label: "bind0 | bind | bind | bind | bind | bind | start | start | startInternal | start | addConnector | addPreviouslyRemovedConnectors | start | startEmbeddedServletContainer | finishRefresh | refresh | refresh | refresh | refreshContext | run | run | run | main"
+  tree_label: "start | addConnector | addPreviouslyRemovedConnectors | start | startEmbeddedServletContainer | finishRefresh | refresh | refresh | refresh | refreshContext | run | run | run | main"
   component:
     system*
       chained-exception*


### PR DESCRIPTION
In eventtypes/error.py we compute the tree_label from the last exception, not the first.