### PR TITLE
feat(events-tab): tweak CTA from open to view

### DIFF
--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -113,7 +113,7 @@ type Props = {
    */
   handleOpenInDiscoverClick?: (e: React.MouseEvent<Element>) => void;
   /**
-   * The callback for when Open All Events is clicked.
+   * The callback for when View All Events is clicked.
    */
   handleOpenAllEventsClick?: (e: React.MouseEvent<Element>) => void;
   /**
@@ -226,7 +226,7 @@ class TransactionsList extends React.Component<Props> {
                 size="small"
                 data-test-id="transaction-events-open"
               >
-                {t('Open All Events')}
+                {t('View All Events')}
               </Button>
             </GuideAnchor>
           ) : (

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -234,7 +234,7 @@ class VitalCard extends Component<Props, State> {
                 })}
               onClick={this.trackOpenAllEventsClicked}
             >
-              {t('Open All Events')}
+              {t('View All Events')}
             </Button>
           ) : (
             <DiscoverButton

--- a/tests/js/spec/components/discover/transactionsList.spec.jsx
+++ b/tests/js/spec/components/discover/transactionsList.spec.jsx
@@ -403,7 +403,7 @@ describe('TransactionsList', function () {
       });
     });
 
-    it('renders Open All Events button when provided with handler', async function () {
+    it('renders View All Events button when provided with handler', async function () {
       wrapper = mountWithTheme(
         <TransactionsList
           api={api}
@@ -422,7 +422,7 @@ describe('TransactionsList', function () {
       wrapper.update();
 
       expect(wrapper.find('Button').last().find('span').children().html()).toEqual(
-        'Open All Events'
+        'View All Events'
       );
     });
   });


### PR DESCRIPTION
Keeping it consistent with other "View All Events" buttons in the app. No rush.

**Before:**
![Screen Shot 2021-07-08 at 8 48 38 AM](https://user-images.githubusercontent.com/4830259/124952856-6e7c6a00-dfc9-11eb-9e28-ea846a0658e5.png)

**After:**
![Screen Shot 2021-07-08 at 8 48 46 AM](https://user-images.githubusercontent.com/4830259/124952871-71775a80-dfc9-11eb-9537-b6a95be7efd5.png)