### PR TITLE
fix(perf): Add empty state for tag page when no tags exist

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -100,23 +100,23 @@ const InnerContent = (
   const {eventView: _eventView, location, organization, tableData} = props;
   const eventView = _eventView.clone();
 
-  if (!tableData) {
-    return null;
-  }
-
-  const tagOptions = getTagKeyOptions(tableData);
+  const tagOptions = tableData ? getTagKeyOptions(tableData) : null;
+  const suspectTags = tagOptions ? tagOptions.suspectTags : [];
+  const otherTags = tagOptions ? tagOptions.otherTags : [];
 
   const decodedTagKey = decodeSelectedTagKey(location);
 
-  const allTags = [...tagOptions.suspectTags, ...tagOptions.otherTags];
+  const allTags = [...suspectTags, ...otherTags];
   const decodedTagFromOptions = decodedTagKey
     ? allTags.find(tag => tag === decodedTagKey)
     : undefined;
 
-  const defaultTag = tagOptions.suspectTags.length
-    ? tagOptions.suspectTags[0]
-    : tagOptions.otherTags.length
-    ? tagOptions.otherTags[0]
+  const defaultTag = tagOptions
+    ? tagOptions.suspectTags.length
+      ? tagOptions.suspectTags[0]
+      : tagOptions.otherTags.length
+      ? tagOptions.otherTags[0]
+      : ''
     : '';
 
   const initialTag = decodedTagFromOptions ?? defaultTag;
@@ -129,7 +129,7 @@ const InnerContent = (
       tagKey,
     });
 
-    browserHistory.push({
+    browserHistory.replace({
       pathname: location.pathname,
       query: queryParams,
     });
@@ -137,10 +137,10 @@ const InnerContent = (
   };
 
   useEffect(() => {
-    if (!decodedTagFromOptions) {
+    if (!decodedTagFromOptions && initialTag) {
       changeTagSelected(initialTag);
     }
-  }, [decodedTagFromOptions]);
+  }, [decodedTagFromOptions, initialTag]);
 
   const handleSearch = (query: string) => {
     const queryParams = getParams({
@@ -166,8 +166,8 @@ const InnerContent = (
   return (
     <ReversedLayoutBody>
       <TagsSideBar
-        suspectTags={tagOptions.suspectTags}
-        otherTags={tagOptions.otherTags}
+        suspectTags={suspectTags}
+        otherTags={otherTags}
         tagSelected={tagSelected}
         changeTag={changeTag}
       />
@@ -196,52 +196,53 @@ const TagsSideBar = (props: {
   const {suspectTags, otherTags, changeTag, tagSelected} = props;
   return (
     <StyledSide>
+      <StyledSectionHeading>
+        {t('Suspect Tags')}
+        <QuestionTooltip
+          position="top"
+          title={t('Suspect tags are tags that often correspond to slower transaction')}
+          size="sm"
+        />
+      </StyledSectionHeading>
       {suspectTags.length ? (
-        <React.Fragment>
-          <StyledSectionHeading>
-            {t('Suspect Tags')}
-            <QuestionTooltip
-              position="top"
-              title={t(
-                'Suspect tags are tags that often correspond to slower transaction'
-              )}
-              size="sm"
+        suspectTags.map(tag => (
+          <RadioLabel key={tag}>
+            <Radio
+              aria-label={tag}
+              checked={tagSelected === tag}
+              onChange={() => changeTag(tag)}
             />
-          </StyledSectionHeading>
-          {suspectTags.map(tag => (
-            <RadioLabel key={tag}>
-              <Radio
-                aria-label={tag}
-                checked={tagSelected === tag}
-                onChange={() => changeTag(tag)}
-              />
-              <SidebarTagValue className="truncate">{tag}</SidebarTagValue>
-            </RadioLabel>
-          ))}
+            <SidebarTagValue className="truncate">{tag}</SidebarTagValue>
+          </RadioLabel>
+        ))
+      ) : (
+        <div>{t('No tags detected.')}</div>
+      )}
 
-          <SidebarSpacer />
-        </React.Fragment>
-      ) : null}
+      <SidebarSpacer />
+      <StyledSectionHeading>
+        {t('Other Tags')}
+        <QuestionTooltip
+          position="top"
+          title={t('Other common tags for this transaction')}
+          size="sm"
+        />
+      </StyledSectionHeading>
+
       {otherTags.length ? (
-        <StyledSectionHeading>
-          {t('Other Tags')}
-          <QuestionTooltip
-            position="top"
-            title={t('Other common tags for this transaction')}
-            size="sm"
-          />
-        </StyledSectionHeading>
-      ) : null}
-      {otherTags.map(tag => (
-        <RadioLabel key={tag}>
-          <Radio
-            aria-label={tag}
-            checked={tagSelected === tag}
-            onChange={() => changeTag(tag)}
-          />
-          <SidebarTagValue className="truncate">{tag}</SidebarTagValue>
-        </RadioLabel>
-      ))}
+        otherTags.map(tag => (
+          <RadioLabel key={tag}>
+            <Radio
+              aria-label={tag}
+              checked={tagSelected === tag}
+              onChange={() => changeTag(tag)}
+            />
+            <SidebarTagValue className="truncate">{tag}</SidebarTagValue>
+          </RadioLabel>
+        ))
+      ) : (
+        <div>{t('No tags detected.')}</div>
+      )}
     </StyledSide>
   );
 };

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
@@ -32,9 +32,6 @@ const TagsDisplay = (props: Props) => {
     projects,
     eventView
   );
-  if (!tagKey) {
-    return null;
-  }
   return (
     <React.Fragment>
       <TagKeyHistogramQuery

--- a/tests/js/spec/views/performance/transactionTags/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.jsx
@@ -143,7 +143,7 @@ describe('Performance > Transaction Tags', function () {
     // Table is loaded.
     expect(wrapper.find('GridEditable')).toHaveLength(1);
 
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(browserHistory.replace).toHaveBeenCalledWith({
       query: {
         project: 1,
         statsPeriod: '14d',


### PR DESCRIPTION
### Summary
Fixes tag page to show empty results still when no tag keys exist for your query.

### Screenshots
<img width="963" alt="Screen Shot 2021-07-08 at 1 01 33 PM" src="https://user-images.githubusercontent.com/6111995/124962459-a648d900-dfec-11eb-8547-d9da914b3c5b.png">
