### PR TITLE
feat(grouping): Fewer sentinels

### DIFF
--- a/src/sentry/grouping/enhancer/enhancement-configs/mobile@2021-04-02.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/mobile@2021-04-02.txt
@@ -92,6 +92,7 @@ family:native package:IOKit category=system
 family:native package:QuartzCore category=system
 family:native package:IOMobileFramebuffer category=system
 family:native package:libobjc* category=system
+family:native package:libsystem* category=system
 family:native package:/system/** category=system
 family:native package:/vendor/** category=system
 module:dalvik.system.* category=system
@@ -160,10 +161,8 @@ module:java.util.concurrent.ThreadPoolExecutor* function:runWorker category=thre
 module:android.os.* function:call category=threadbase
 module:android.app.ActivityThread function:main category=threadbase
 
-family:native package:"/usr/lib/system/libsystem_malloc.dylib" category=malloc
+family:native package:"*libsystem_malloc.dylib" category=malloc
 family:native function:malloc category=malloc
-family:native function:malloc_report category=oom
-family:native function:malloc_vreport category=oom
 family:native function:malloc_base category=malloc
 family:native function:RtlpAllocateHeapInternal category=malloc
 family:native function:std::*::allocator_traits* category=malloc
@@ -217,7 +216,7 @@ family:native package:AGXGLDriver category=driver
 family:native function:RtlFreeHeap category=free
 family:native function:RtlFreeUnicodeString category=free
 family:native function:std::_Deallocate category=free
-family:native category:system function:free category=free
+family:native function:free category=free
 
 family:native package:C:/Windows/SYSTEM32/OPENGL32.dll category=gl
 family:native package:/System/Library/Frameworks/OpenGL.framework/** category=gl
@@ -251,8 +250,8 @@ family:native function:pthread_mutex_lock category=lock
 
 # Semi-interesting frames
 category:driver +sentinel +prefix
-category:free +sentinel +prefix
-category:malloc +sentinel +prefix
+category:free +prefix
+category:malloc +prefix
 category:lock +sentinel +prefix
 category:load +sentinel +prefix
 category:gl +sentinel
@@ -275,7 +274,7 @@ category:driver | [ category:driver ] category=internals
 
 # abort() and exception raising is technically the culprit for crashes, but not
 # the thing we want to show.
-category:throw +sentinel +prefix ^-group
+category:throw +prefix ^-group
 
 # On Windows, _purecall internally aborts when the function pointer is invalid.
 # We want to treat this the same as a segfault happening before calling

--- a/src/sentry/grouping/enhancer/enhancement-configs/mobile@2021-04-02.txt
+++ b/src/sentry/grouping/enhancer/enhancement-configs/mobile@2021-04-02.txt
@@ -161,7 +161,7 @@ module:java.util.concurrent.ThreadPoolExecutor* function:runWorker category=thre
 module:android.os.* function:call category=threadbase
 module:android.app.ActivityThread function:main category=threadbase
 
-family:native package:"*libsystem_malloc.dylib" category=malloc
+family:native package:"**/libsystem_malloc.dylib" category=malloc
 family:native function:malloc category=malloc
 family:native function:malloc_base category=malloc
 family:native function:RtlpAllocateHeapInternal category=malloc

--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -98,6 +98,13 @@ def _build_fallback_tree(main_variant, components, frames, inverted_hierarchy):
 
     if blaming_frame_idx is None:
         for idx, (component, frame) in enumerate(zip(components, frames)):
+            if component.contributes and not component.is_prefix_frame:
+                blaming_frame_idx = idx
+                if inverted_hierarchy:
+                    break
+
+    if blaming_frame_idx is None:
+        for idx, (component, frame) in enumerate(zip(components, frames)):
             if component.contributes:
                 blaming_frame_idx = idx
                 if inverted_hierarchy:

--- a/tests/sentry/grouping/categorization_inputs/malloc-sentinel.json
+++ b/tests/sentry/grouping/categorization_inputs/malloc-sentinel.json
@@ -1,0 +1,190 @@
+{
+    "platform": "cocoa",
+    "exception": {
+        "values": [
+            {
+                "type": "SIGABRT",
+                "value": "<redacted>",
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "_pthread_start",
+                            "symbol": "_pthread_start",
+                            "package": "libsystem_pthread.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "std::__1::basic_string<T>::~basic_string",
+                            "raw_function": "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::~basic_string()",
+                            "symbol": "_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev",
+                            "package": "libc++.1.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "free",
+                            "symbol": "free",
+                            "package": "libsystem_malloc.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "malloc_report",
+                            "symbol": "malloc_report",
+                            "package": "libsystem_malloc.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "malloc_vreport",
+                            "symbol": "malloc_vreport",
+                            "package": "libsystem_malloc.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "abort",
+                            "symbol": "abort",
+                            "package": "libsystem_c.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "pthread_kill",
+                            "symbol": "pthread_kill",
+                            "package": "libsystem_pthread.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "__pthread_kill",
+                            "symbol": "__pthread_kill",
+                            "package": "libsystem_kernel.dylib",
+                            "in_app": false
+                        }
+                    ]
+                },
+                "thread_id": 6,
+                "mechanism": {
+                    "type": "signal",
+                    "handled": false,
+                    "meta": {
+                        "signal": {
+                            "number": 6,
+                            "code": 0,
+                            "name": "SIGABRT"
+                        },
+                        "mach_exception": {
+                            "exception": 10,
+                            "code": 0,
+                            "subcode": 0,
+                            "name": "EXC_CRASH"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/sentry/grouping/categorization_inputs/malloc-sentinel.json
+++ b/tests/sentry/grouping/categorization_inputs/malloc-sentinel.json
@@ -1,190 +1,113 @@
 {
-    "platform": "cocoa",
-    "exception": {
-        "values": [
-            {
-                "type": "SIGABRT",
-                "value": "<redacted>",
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "function": "_pthread_start",
-                            "symbol": "_pthread_start",
-                            "package": "libsystem_pthread.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "filename": "stripped_application_code",
-                            "abs_path": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "filename": "stripped_application_code",
-                            "abs_path": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "filename": "stripped_application_code",
-                            "abs_path": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "filename": "stripped_application_code",
-                            "abs_path": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "filename": "stripped_application_code",
-                            "abs_path": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "filename": "stripped_application_code",
-                            "abs_path": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "stripped_application_code",
-                            "symbol": "stripped_application_code",
-                            "package": "stripped_application_code",
-                            "in_app": false
-                        },
-                        {
-                            "function": "std::__1::basic_string<T>::~basic_string",
-                            "raw_function": "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::~basic_string()",
-                            "symbol": "_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev",
-                            "package": "libc++.1.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "free",
-                            "symbol": "free",
-                            "package": "libsystem_malloc.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "malloc_report",
-                            "symbol": "malloc_report",
-                            "package": "libsystem_malloc.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "malloc_vreport",
-                            "symbol": "malloc_vreport",
-                            "package": "libsystem_malloc.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "abort",
-                            "symbol": "abort",
-                            "package": "libsystem_c.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "pthread_kill",
-                            "symbol": "pthread_kill",
-                            "package": "libsystem_pthread.dylib",
-                            "in_app": false
-                        },
-                        {
-                            "function": "__pthread_kill",
-                            "symbol": "__pthread_kill",
-                            "package": "libsystem_kernel.dylib",
-                            "in_app": false
-                        }
-                    ]
-                },
-                "thread_id": 6,
-                "mechanism": {
-                    "type": "signal",
-                    "handled": false,
-                    "meta": {
-                        "signal": {
-                            "number": 6,
-                            "code": 0,
-                            "name": "SIGABRT"
-                        },
-                        "mach_exception": {
-                            "exception": 10,
-                            "code": 0,
-                            "subcode": 0,
-                            "name": "EXC_CRASH"
-                        }
-                    }
-                }
+  "event_id": "0f79414d8b894e199c467cf859cc84a5",
+  "exception": {
+    "values": [
+      {
+        "mechanism": {
+          "handled": false,
+          "meta": {
+            "mach_exception": {
+              "code": 0,
+              "exception": 10,
+              "name": "EXC_CRASH",
+              "subcode": 0
+            },
+            "signal": {
+              "code": 0,
+              "name": "SIGABRT",
+              "number": 6
             }
-        ]
-    }
+          },
+          "type": "signal"
+        },
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "_pthread_start",
+              "package": "libsystem_pthread.dylib"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "stripped_application_code"
+            },
+            {
+              "function": "std::__1::basic_string<T>::~basic_string",
+              "package": "libc++.1.dylib"
+            },
+            {
+              "function": "free",
+              "package": "libsystem_malloc.dylib"
+            },
+            {
+              "function": "malloc_report",
+              "package": "libsystem_malloc.dylib"
+            },
+            {
+              "function": "malloc_vreport",
+              "package": "libsystem_malloc.dylib"
+            },
+            {
+              "function": "abort",
+              "package": "libsystem_c.dylib"
+            },
+            {
+              "function": "pthread_kill",
+              "package": "libsystem_pthread.dylib"
+            },
+            {
+              "function": "__pthread_kill",
+              "package": "libsystem_kernel.dylib"
+            }
+          ]
+        },
+        "type": "SIGABRT",
+        "value": "<redacted>"
+      }
+    ]
+  },
+  "platform": "cocoa"
 }

--- a/tests/sentry/grouping/grouping_inputs/malloc-sentinel.json
+++ b/tests/sentry/grouping/grouping_inputs/malloc-sentinel.json
@@ -1,0 +1,190 @@
+{
+    "platform": "cocoa",
+    "exception": {
+        "values": [
+            {
+                "type": "SIGABRT",
+                "value": "<redacted>",
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "_pthread_start",
+                            "symbol": "_pthread_start",
+                            "package": "libsystem_pthread.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "filename": "stripped_application_code",
+                            "abs_path": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code",
+                            "symbol": "stripped_application_code",
+                            "package": "stripped_application_code",
+                            "in_app": false
+                        },
+                        {
+                            "function": "std::__1::basic_string<T>::~basic_string",
+                            "raw_function": "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::~basic_string()",
+                            "symbol": "_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev",
+                            "package": "libc++.1.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "free",
+                            "symbol": "free",
+                            "package": "libsystem_malloc.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "malloc_report",
+                            "symbol": "malloc_report",
+                            "package": "libsystem_malloc.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "malloc_vreport",
+                            "symbol": "malloc_vreport",
+                            "package": "libsystem_malloc.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "abort",
+                            "symbol": "abort",
+                            "package": "libsystem_c.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "pthread_kill",
+                            "symbol": "pthread_kill",
+                            "package": "libsystem_pthread.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "__pthread_kill",
+                            "symbol": "__pthread_kill",
+                            "package": "libsystem_kernel.dylib",
+                            "in_app": false
+                        }
+                    ]
+                },
+                "thread_id": 6,
+                "mechanism": {
+                    "type": "signal",
+                    "handled": false,
+                    "meta": {
+                        "signal": {
+                            "number": 6,
+                            "code": 0,
+                            "name": "SIGABRT"
+                        },
+                        "mach_exception": {
+                            "exception": 10,
+                            "code": 0,
+                            "subcode": 0,
+                            "name": "EXC_CRASH"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/malloc_sentinel.pysnap
@@ -1,0 +1,22 @@
+---
+created: '2021-07-08T15:46:42.382863Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","stripped_application_code"],["function","stripped_application_code"]],[["function","stripped_application_code"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","_pthread_start"]],[["function","stripped_application_code"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","abort"]],[["function","pthread_kill"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","free"]],[["function","malloc_report"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","malloc_report"]],[["function","malloc_vreport"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","malloc_vreport"]],[["function","abort"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","pthread_kill"]],[["function","__pthread_kill"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","std::__1::basic_string<T>::~basic_string"]],[["function","free"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","stripped_application_code"]],[["filename","stripped_application_code"],["function","stripped_application_code"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","stripped_application_code"]],[["function","std::__1::basic_string<T>::~basic_string"]]]
+similarity:2020-07-23:type:ident-shingle: "SIGABRT"
+similarity:2020-07-23:value:character-5-shingle: "<reda"
+similarity:2020-07-23:value:character-5-shingle: "acted"
+similarity:2020-07-23:value:character-5-shingle: "cted>"
+similarity:2020-07-23:value:character-5-shingle: "dacte"
+similarity:2020-07-23:value:character-5-shingle: "edact"
+similarity:2020-07-23:value:character-5-shingle: "redac"

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T17:53:01.482967Z'
+created: '2021-07-08T18:20:25.202164Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -7,22 +7,22 @@ source: tests/sentry/grouping/test_categorization.py
 
 SIGABRT:<redacted> (thread_id:_, crashed:_)
                      libsystem_pthread.dylib  _pthread_start category=threadbase
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
-                   stripped_application_code  stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
+                                              stripped_application_code
                               libc++.1.dylib  std::__1::basic_string<T>::~basic_string category=internals
                       libsystem_malloc.dylib  free category=free
                       libsystem_malloc.dylib  malloc_report category=malloc

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/malloc_sentinel.pysnap
@@ -1,0 +1,32 @@
+---
+created: '2021-07-08T17:53:01.482967Z'
+creator: sentry
+source: tests/sentry/grouping/test_categorization.py
+---
+
+
+SIGABRT:<redacted> (thread_id:_, crashed:_)
+                     libsystem_pthread.dylib  _pthread_start category=threadbase
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                   stripped_application_code  stripped_application_code
+                              libc++.1.dylib  std::__1::basic_string<T>::~basic_string category=internals
+                      libsystem_malloc.dylib  free category=free
+                      libsystem_malloc.dylib  malloc_report category=malloc
+                      libsystem_malloc.dylib  malloc_vreport category=internals
+                           libsystem_c.dylib  abort category=throw
+                     libsystem_pthread.dylib  pthread_kill category=indirection
+                      libsystem_kernel.dylib  __pthread_kill category=internals

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/mobile1_xmm.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/mobile1_xmm.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T10:29:51.974612Z'
+created: '2021-07-08T17:38:02.005485Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -57,7 +57,7 @@ SIGABRT:_ (thread_id:_, crashed:_)
                                               stripped_application_code
                                               stripped_application_code
                                               stripped_application_code
-                      libsystem_malloc.dylib  malloc_vreport category=oom
+                      libsystem_malloc.dylib  malloc_vreport category=malloc
                            libsystem_c.dylib  abort category=throw
                                               stripped_application_code
                                               stripped_application_code

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xeh.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xeh.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-03-29T17:02:07.565940Z'
+created: '2021-07-08T17:38:01.894295Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -80,12 +80,12 @@ source: tests/sentry/grouping/test_categorization.py
             abcui.framework/Versions/A/abcui  boost::detail::shared_count::shared_count<T> category=internals
             abcui.framework/Versions/A/abcui  boost::detail::shared_count::shared_count<T> category=internals
                                               stripped_application_code
-      /usr/lib/system/libsystem_malloc.dylib  _malloc_zone_malloc category=malloc
+      /usr/lib/system/libsystem_malloc.dylib  _malloc_zone_malloc category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_malloc category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate_from_block category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate_from_block.cold.1 category=indirection
-      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_error category=internals
-      /usr/lib/system/libsystem_malloc.dylib  malloc_vreport category=oom
+      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_error category=system
+      /usr/lib/system/libsystem_malloc.dylib  malloc_vreport category=internals
            /usr/lib/system/libsystem_c.dylib  abort category=throw
       /usr/lib/system/libsystem_kernel.dylib  __pthread_kill category=internals

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xeh.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xeh.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T17:38:01.894295Z'
+created: '2021-07-08T17:52:58.623531Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -80,12 +80,12 @@ source: tests/sentry/grouping/test_categorization.py
             abcui.framework/Versions/A/abcui  boost::detail::shared_count::shared_count<T> category=internals
             abcui.framework/Versions/A/abcui  boost::detail::shared_count::shared_count<T> category=internals
                                               stripped_application_code
-      /usr/lib/system/libsystem_malloc.dylib  _malloc_zone_malloc category=internals
+      /usr/lib/system/libsystem_malloc.dylib  _malloc_zone_malloc category=malloc
       /usr/lib/system/libsystem_malloc.dylib  nanov2_malloc category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate_from_block category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate_from_block.cold.1 category=indirection
-      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_error category=system
+      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_error category=internals
       /usr/lib/system/libsystem_malloc.dylib  malloc_vreport category=internals
            /usr/lib/system/libsystem_c.dylib  abort category=throw
       /usr/lib/system/libsystem_kernel.dylib  __pthread_kill category=internals

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xhl.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xhl.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T17:38:01.875479Z'
+created: '2021-07-08T17:52:59.172534Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -22,7 +22,7 @@ source: tests/sentry/grouping/test_categorization.py
         abccore.framework/Versions/A/abccore  boost::function0<T>::~function0 category=indirection
         abccore.framework/Versions/A/abccore  boost::function0<T>::clear category=indirection
         abccore.framework/Versions/A/abccore  boost::detail::function::basic_vtable0<T>::clear category=std
-      /usr/lib/system/libsystem_malloc.dylib  malloc_report category=internals
+      /usr/lib/system/libsystem_malloc.dylib  malloc_report category=malloc
       /usr/lib/system/libsystem_malloc.dylib  malloc_vreport category=internals
            /usr/lib/system/libsystem_c.dylib  abort category=throw
            /usr/lib/system/libsystem_c.dylib  __abort category=internals

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xhl.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xhl.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-03-29T16:34:09.431456Z'
+created: '2021-07-08T17:38:01.875479Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -22,8 +22,8 @@ source: tests/sentry/grouping/test_categorization.py
         abccore.framework/Versions/A/abccore  boost::function0<T>::~function0 category=indirection
         abccore.framework/Versions/A/abccore  boost::function0<T>::clear category=indirection
         abccore.framework/Versions/A/abccore  boost::detail::function::basic_vtable0<T>::clear category=std
-      /usr/lib/system/libsystem_malloc.dylib  malloc_report category=oom
-      /usr/lib/system/libsystem_malloc.dylib  malloc_vreport category=oom
+      /usr/lib/system/libsystem_malloc.dylib  malloc_report category=internals
+      /usr/lib/system/libsystem_malloc.dylib  malloc_vreport category=internals
            /usr/lib/system/libsystem_c.dylib  abort category=throw
            /usr/lib/system/libsystem_c.dylib  __abort category=internals
       /usr/lib/system/libsystem_kernel.dylib  __pthread_kill category=internals

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xim.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xim.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-03-29T16:34:16.704993Z'
+created: '2021-07-08T17:38:02.058680Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -60,7 +60,7 @@ EXC_BAD_INSTRUCTION / EXC_I386_INVOP:Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386
   abcaudiofilterhost.framework/Versions/A/ab  std::__1::__libcpp_allocate category=internals
                                               stripped_application_code
       /usr/lib/system/libsystem_malloc.dylib  malloc category=malloc
-      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_malloc category=internals
+      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_malloc category=system
       /usr/lib/system/libsystem_malloc.dylib  nanov2_malloc category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate_from_block category=internals

--- a/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xim.pysnap
+++ b/tests/sentry/grouping/snapshots/test_categorization/test_categorization/native1_xim.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T17:38:02.058680Z'
+created: '2021-07-08T17:53:00.031281Z'
 creator: sentry
 source: tests/sentry/grouping/test_categorization.py
 ---
@@ -60,7 +60,7 @@ EXC_BAD_INSTRUCTION / EXC_I386_INVOP:Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386
   abcaudiofilterhost.framework/Versions/A/ab  std::__1::__libcpp_allocate category=internals
                                               stripped_application_code
       /usr/lib/system/libsystem_malloc.dylib  malloc category=malloc
-      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_malloc category=system
+      /usr/lib/system/libsystem_malloc.dylib  malloc_zone_malloc category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_malloc category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate category=internals
       /usr/lib/system/libsystem_malloc.dylib  nanov2_allocate_from_block category=internals

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/malloc_sentinel.pysnap
@@ -1,0 +1,290 @@
+---
+created: '2021-07-08T15:46:20.880500Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "_pthread_start"
+            function (function name is not used if module or filename are available)
+              "_pthread_start"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame* (frame considered in-app because no frame is in-app)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev"
+            function (function name is not used if module or filename are available)
+              "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::~basic_string()"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "free"
+            function (function name is not used if module or filename are available)
+              "free"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "malloc_report"
+            function (function name is not used if module or filename are available)
+              "malloc_report"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "malloc_vreport"
+            function (function name is not used if module or filename are available)
+              "malloc_vreport"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "abort"
+            function (function name is not used if module or filename are available)
+              "abort"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "pthread_kill"
+            function (function name is not used if module or filename are available)
+              "pthread_kill"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "__pthread_kill"
+            function (function name is not used if module or filename are available)
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (stacktrace and type take precedence)
+          "<redacted>"
+--------------------------------------------------------------------------
+system:
+  hash: "d63ee001e5f5763d56b6e25284bd480e"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "_pthread_start"
+            function (function name is not used if module or filename are available)
+              "_pthread_start"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame*
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "stripped_application_code"
+            symbol*
+              "stripped_application_code"
+            function (symbol takes precedence)
+              "stripped_application_code"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            symbol (symbol is not used if module or filename are available)
+              "stripped_application_code"
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "_ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEED2Ev"
+            function (function name is not used if module or filename are available)
+              "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >::~basic_string()"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "free"
+            function (function name is not used if module or filename are available)
+              "free"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "malloc_report"
+            function (function name is not used if module or filename are available)
+              "malloc_report"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "malloc_vreport"
+            function (function name is not used if module or filename are available)
+              "malloc_vreport"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "abort"
+            function (function name is not used if module or filename are available)
+              "abort"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "pthread_kill"
+            function (function name is not used if module or filename are available)
+              "pthread_kill"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "__pthread_kill"
+            function (function name is not used if module or filename are available)
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (stacktrace and type take precedence)
+          "<redacted>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_200_event_200.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:53.318342Z'
+created: '2021-07-08T17:38:04.749059Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "4d4c43d1d793f5a308704e28502a515f"
-  tree_label: "RtlFreeHeap | RtlFreeHeap | destructor'"
+  hash: "3a4c4c96a80c9be6a81afca4bb54f6ef"
+  tree_label: "destructor'"
   component:
     app-depth-1*
       exception*
@@ -15,12 +15,71 @@ app-depth-1:
               "destructor'"
             package (ignored because function takes precedence)
               "winhttp.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+        type (ignored because exception is synthetic (detected via exception type))
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "fb961faae31201361a148da84b7b886b"
+  tree_label: "RtlFreeHeap | RtlFreeHeap | destructor' | destructor'"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
             package (ignored because function takes precedence)
               "ntdll.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "RtlFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+        type (ignored because exception is synthetic (detected via exception type))
+          "EXCEPTION_ACCESS_VIOLATION_WRITE"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXCEPTION_ACCESS_VIOLATION_WRITE"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "6b9106347534a0018fe5f3d9993b3bb5"
+  tree_label: "RtlFreeHeap | RtlFreeHeap | destructor' | destructor' | TppWorkerThread"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "TppWorkerThread"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame*
+            function*
+              "destructor'"
+            package (ignored because function takes precedence)
+              "winhttp.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "RtlFreeHeap"
+            package (ignored because function takes precedence)
+              "ntdll.dll"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
             package (ignored because function takes precedence)
@@ -97,7 +156,7 @@ app-depth-max:
               "destructor'"
             package (ignored because function takes precedence)
               "winhttp.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
             package (ignored because function takes precedence)
@@ -117,7 +176,7 @@ app-depth-max:
               "RtlpFreeUserBlockToHeap"
             package (ignored because function takes precedence)
               "ntdll.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
             package (ignored because function takes precedence)
@@ -229,7 +288,7 @@ system:
               "destructor'"
             package (ignored because function takes precedence)
               "winhttp.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
             package (ignored because function takes precedence)
@@ -249,7 +308,7 @@ system:
               "RtlpFreeUserBlockToHeap"
             package (ignored because function takes precedence)
               "ntdll.dll"
-          frame* (marked as prefix frame by stack trace rule (category:free +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "RtlFreeHeap"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_289_event_312.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.846235Z'
+created: '2021-07-08T17:38:04.235986Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "c20e97250c9dbf61615dff51c4bcc286"
-  tree_label: "abort | gldCreateDevice | glDeleteTextures_Exec"
+  hash: "40019a41fe12c75d56cbdba3707ac3e9"
+  tree_label: "gldCreateDevice | glDeleteTextures_Exec"
   component:
     app-depth-1*
       exception*
@@ -20,11 +20,6 @@ app-depth-1:
               "gldCreateDevice"
             package (ignored because function takes precedence)
               "geforcegldriver"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -130,17 +125,17 @@ app-depth-max:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -250,17 +245,17 @@ system:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_294.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.614372Z'
+created: '2021-07-08T17:38:05.197656Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "d0c847d9bc45ca8c26389be94bd21878"
-  tree_label: "std::terminate | stripped_application_code"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -13,11 +13,6 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "std::terminate"
-            package (ignored because function takes precedence)
-              "libc++abi.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -33,7 +28,7 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename (discarded native filename for grouping stability)
               "memory"
             function*
@@ -41,7 +36,72 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "e2d054b3c180378b8c1d14f638acac94"
+  tree_label: "std::terminate | stripped_application_code | std::__1::allocator_traits<T>::destroy<T> | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::destroy<T>"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "a3681449b8f66e38697bba72bab32569"
+  tree_label: "std::terminate | stripped_application_code | std::__1::allocator_traits<T>::destroy<T> | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::destroy<T>"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
@@ -133,7 +193,7 @@ app-depth-max:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename (discarded native filename for grouping stability)
               "memory"
             function*
@@ -182,37 +242,37 @@ app-depth-max:
               "std::__1::thread::~thread"
             package (ignored because function takes precedence)
               "libc++.1.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::__terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "default_terminate_handler"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort_message"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             package* (used as fallback because function name is not available)
               "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)
@@ -302,7 +362,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename (discarded native filename for grouping stability)
               "memory"
             function*
@@ -351,37 +411,37 @@ system:
               "std::__1::thread::~thread"
             package (ignored because function takes precedence)
               "libc++.1.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::__terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "default_terminate_handler"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort_message"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             package* (used as fallback because function name is not available)
               "libsystem_kernel.dylib"
         type (ignored because exception is synthetic)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_294_event_329.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:53.367172Z'
+created: '2021-07-08T17:38:05.386260Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "d0c847d9bc45ca8c26389be94bd21878"
-  tree_label: "std::terminate | stripped_application_code"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -13,11 +13,6 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "std::terminate"
-            package (ignored because function takes precedence)
-              "libc++abi.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -33,7 +28,7 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename (discarded native filename for grouping stability)
               "memory"
             function*
@@ -41,7 +36,72 @@ app-depth-2:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "e2d054b3c180378b8c1d14f638acac94"
+  tree_label: "std::terminate | stripped_application_code | std::__1::allocator_traits<T>::destroy<T> | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::destroy<T>"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "std::terminate"
+            package (ignored because function takes precedence)
+              "libc++abi.dylib"
+        type (ignored because exception is synthetic)
+          "0x00000000 / 0x00000000"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "a3681449b8f66e38697bba72bab32569"
+  tree_label: "std::terminate | stripped_application_code | std::__1::allocator_traits<T>::destroy<T> | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+            filename (discarded native filename for grouping stability)
+              "memory"
+            function*
+              "std::__1::allocator_traits<T>::destroy<T>"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
@@ -149,7 +209,7 @@ app-depth-max:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename (discarded native filename for grouping stability)
               "memory"
             function*
@@ -193,37 +253,37 @@ app-depth-max:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::__terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "demangling_terminate_handler"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort_message"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -331,7 +391,7 @@ system:
               "__tree"
             function*
               "std::__1::__tree<T>::destroy"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             filename (discarded native filename for grouping stability)
               "memory"
             function*
@@ -375,37 +435,37 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "std::__terminate"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "demangling_terminate_handler"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort_message"
             package (ignored because function takes precedence)
               "libc++abi.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_313.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.793509Z'
+created: '2021-07-08T17:38:05.908253Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "f594e5549c122b83e267719d16333d98"
-  tree_label: "abort | dlopen | stripped_application_code"
+  hash: "b7de92d39e823772baa9a88863c07cab"
+  tree_label: "dlopen | stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -18,11 +18,6 @@ app-depth-1:
               "dlopen"
             package (ignored because function takes precedence)
               "libdyld.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -239,17 +234,17 @@ app-depth-max:
               "__report_load.cold.1"
             package (ignored because function takes precedence)
               "libcrypto.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -470,17 +465,17 @@ system:
               "__report_load.cold.1"
             package (ignored because function takes precedence)
               "libcrypto.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_313_event_333.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:53.094809Z'
+created: '2021-07-08T17:38:06.243751Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "f594e5549c122b83e267719d16333d98"
-  tree_label: "abort | dlopen | stripped_application_code"
+  hash: "b7de92d39e823772baa9a88863c07cab"
+  tree_label: "dlopen | stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -18,11 +18,6 @@ app-depth-1:
               "dlopen"
             package (ignored because function takes precedence)
               "libdyld.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -238,17 +233,17 @@ app-depth-max:
               "__report_load"
             package (ignored because function takes precedence)
               "libcrypto.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -468,17 +463,17 @@ system:
               "__report_load"
             package (ignored because function takes precedence)
               "libcrypto.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_319_event_321.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:53.207343Z'
+created: '2021-07-08T17:38:05.219004Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "6aaea3702ff04eef387e90d3080f0659"
-  tree_label: "abort | gpusSubmitDataBuffers | CGLFlushDrawable"
+  hash: "eeeee4251de9dab933f0b3ac128e7a83"
+  tree_label: "gpusSubmitDataBuffers | CGLFlushDrawable"
   component:
     app-depth-1*
       exception*
@@ -20,11 +20,6 @@ app-depth-1:
               "gpusSubmitDataBuffers"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -191,20 +186,20 @@ app-depth-max:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_sigtramp"
             package (ignored because function takes precedence)
               "libsystem_platform.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -213,98 +208,98 @@ app-depth-max:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "NSRunAlertPanel"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_NSTryRunModal"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Transaction::commit"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Context::commit_transaction"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Layer::display_if_needed"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLTexImageIOSurface2D"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLDescribeRenderer"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gliSetInteger"
             package (ignored because function takes precedence)
               "glengine"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gldFlushObject"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "intelSubmitCommands"
             package (ignored because function takes precedence)
               "appleintelhd4000graphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "IntelCommandBuffer::getNew"
             package (ignored because function takes precedence)
               "appleintelhd4000graphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusSubmitDataBuffers"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusKillClientExt"
             package (ignored because function takes precedence)
               "appleintelhd4000graphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -475,20 +470,20 @@ system:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_sigtramp"
             package (ignored because function takes precedence)
               "libsystem_platform.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
@@ -497,98 +492,98 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "NSRunAlertPanel"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_NSTryRunModal"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Transaction::commit"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Context::commit_transaction"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Layer::display_if_needed"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "stripped_application_code"
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLTexImageIOSurface2D"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLDescribeRenderer"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gliSetInteger"
             package (ignored because function takes precedence)
               "glengine"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gldFlushObject"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "intelSubmitCommands"
             package (ignored because function takes precedence)
               "appleintelhd4000graphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "IntelCommandBuffer::getNew"
             package (ignored because function takes precedence)
               "appleintelhd4000graphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusSubmitDataBuffers"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusKillClientExt"
             package (ignored because function takes precedence)
               "appleintelhd4000graphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_432.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.704892Z'
+created: '2021-07-08T17:38:05.601489Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "578743178fb72882e3c4d60b1c30d225"
-  tree_label: "abort | stripped_application_code"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -13,7 +13,112 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "3cd20dc9b7e7fea3e8575c7cae7b76c2"
+  tree_label: "abort | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "6816ce334af8d6b9fb66dc1265c9fccc"
+  tree_label: "abort | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "26eb79a70b1adbd61006c21288099591"
+  tree_label: "abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-5:
+  hash: "1056f62d72ff8b4d0c3842d696dbb10a"
+  tree_label: "abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-5*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
@@ -141,17 +246,17 @@ app-depth-max:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename (discarded native filename for grouping stability)
               "crashpad_client_win.cc"
             function*
@@ -279,17 +384,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename (discarded native filename for grouping stability)
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_432_event_453.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.822716Z'
+created: '2021-07-08T17:38:04.805020Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "578743178fb72882e3c4d60b1c30d225"
-  tree_label: "abort | stripped_application_code"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -13,7 +13,112 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "3cd20dc9b7e7fea3e8575c7cae7b76c2"
+  tree_label: "abort | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "6816ce334af8d6b9fb66dc1265c9fccc"
+  tree_label: "abort | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "26eb79a70b1adbd61006c21288099591"
+  tree_label: "abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-5:
+  hash: "1056f62d72ff8b4d0c3842d696dbb10a"
+  tree_label: "abort | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-5*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
@@ -141,17 +246,17 @@ app-depth-max:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename (discarded native filename for grouping stability)
               "crashpad_client_win.cc"
             function*
@@ -279,17 +384,17 @@ system:
           frame (ignored due to recursion)
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename (discarded native filename for grouping stability)
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/group_445_event_445.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.309356Z'
+created: '2021-07-08T17:38:04.688810Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "2d19dfc08a0a1656533e4dc4cc4c7b40"
-  tree_label: "raise | stripped_application_code"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "stripped_application_code"
   component:
     app-depth-1*
       exception*
@@ -13,7 +13,114 @@ app-depth-1:
           frame*
             function*
               "stripped_application_code"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "9a6cd9472e8cac05c8e9b555384341d9"
+  tree_label: "raise | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "raise"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "10931b6ba91d6826d5cce1682fd9d67b"
+  tree_label: "raise | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "raise"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "4b191f37efd301221e8e32962b44f4d5"
+  tree_label: "raise | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "raise"
+            package (ignored because function takes precedence)
+              "ucrtbase.dll"
+        type (ignored because exception is synthetic)
+          "0x40000015 / 0x00000001"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: <hex> / <hex>"
+--------------------------------------------------------------------------
+app-depth-5:
+  hash: "fca1c2ac2f8b338a36b19dc2064660d9"
+  tree_label: "raise | stripped_application_code | stripped_application_code | stripped_application_code | stripped_application_code | DispatchMessageWorker"
+  component:
+    app-depth-5*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "DispatchMessageWorker"
+            package (ignored because function takes precedence)
+              "user32.dll"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
@@ -169,12 +276,12 @@ app-depth-max:
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename (discarded native filename for grouping stability)
               "crashpad_client_win.cc"
             function*
@@ -330,12 +437,12 @@ system:
               "abort"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "raise"
             package (ignored because function takes precedence)
               "ucrtbase.dll"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             filename (discarded native filename for grouping stability)
               "crashpad_client_win.cc"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_amd_driver.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.563409Z'
+created: '2021-07-08T17:38:05.319276Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "df30c081c8ab27eecf8395e0a0ab0e5d"
-  tree_label: "abort | amdradeonx5000gldriver | glTexSubImage2D"
+  hash: "1504fadcf68879fb8afe4560c4d7f91b"
+  tree_label: "amdradeonx5000gldriver | glTexSubImage2D"
   component:
     app-depth-1*
       exception*
@@ -18,11 +18,6 @@ app-depth-1:
           frame* (marked as prefix frame by stack trace rule (category:driver +sentinel +prefix))
             package* (used as fallback because function name is not available)
               "amdradeonx5000gldriver"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -202,12 +197,12 @@ app-depth-max:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -391,12 +386,12 @@ system:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/macos_intel_driver.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:52.866752Z'
+created: '2021-07-08T17:38:04.563312Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "407bfa003f7687a0ef24e66384725f7c"
-  tree_label: "abort | gpusSubmitDataBuffers | CGLTexImageIOSurface2D"
+  hash: "17c59182fb8b1d23212186daabefd0ec"
+  tree_label: "gpusSubmitDataBuffers | CGLTexImageIOSurface2D"
   component:
     app-depth-1*
       exception*
@@ -20,11 +20,6 @@ app-depth-1:
               "gpusSubmitDataBuffers"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
-            function*
-              "abort"
-            package (ignored because function takes precedence)
-              "libsystem_c.dylib"
         type (ignored because exception is synthetic)
           "0x00000000 / 0x00000000"
         value (ignored because stacktrace takes precedence)
@@ -184,20 +179,20 @@ app-depth-max:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             package* (used as fallback because function name is not available)
               "corefoundation"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_sigtramp"
             package (ignored because function takes precedence)
               "libsystem_platform.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -206,98 +201,98 @@ app-depth-max:
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "NSRunAlertPanel"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_NSTryRunModal"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Transaction::commit"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Context::commit_transaction"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Layer::display_if_needed"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLTexImageIOSurface2D"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLDescribeRenderer"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gliSetInteger"
             package (ignored because function takes precedence)
               "glengine"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gldFlushObject"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "intelSubmitCommands"
             package (ignored because function takes precedence)
               "appleinteliclgraphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "IntelCommandBuffer::getNew"
             package (ignored because function takes precedence)
               "appleinteliclgraphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusSubmitDataBuffers"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusKillClientExt"
             package (ignored because function takes precedence)
               "appleinteliclgraphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)
@@ -461,20 +456,20 @@ system:
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             package* (used as fallback because function name is not available)
               "corefoundation"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_sigtramp"
             package (ignored because function takes precedence)
               "libsystem_platform.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "code"
           frame (ignored due to recursion)
@@ -483,98 +478,98 @@ system:
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "NSRunAlertPanel"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "_NSTryRunModal"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Transaction::commit"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Context::commit_transaction"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CA::Layer::display_if_needed"
             package (ignored because function takes precedence)
               "quartzcore"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "-[_NSOpenGLViewBackingLayer display]"
             package (ignored because function takes precedence)
               "appkit"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "code"
           frame (ignored due to recursion)
             function*
               "code"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLTexImageIOSurface2D"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "CGLDescribeRenderer"
             package (ignored because function takes precedence)
               "opengl"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gliSetInteger"
             package (ignored because function takes precedence)
               "glengine"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gldFlushObject"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "intelSubmitCommands"
             package (ignored because function takes precedence)
               "appleinteliclgraphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "IntelCommandBuffer::getNew"
             package (ignored because function takes precedence)
               "appleinteliclgraphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusSubmitDataBuffers"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusKillClientExt"
             package (ignored because function takes precedence)
               "appleinteliclgraphicsgldriver"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "gpusGenerateCrashLog.cold.1"
             package (ignored because function takes precedence)
               "libgpusupportmercury.dylib"
-          frame (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
             package (ignored because function takes precedence)
               "libsystem_c.dylib"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/malloc_sentinel.pysnap
@@ -1,19 +1,77 @@
 ---
-created: '2021-07-08T15:46:30.436775Z'
+created: '2021-07-08T17:33:15.879513Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "8e74af4b7493abe2ea1e99a13c1c12da"
-  tree_label: "abort | malloc_vreport"
+  hash: "aeed765d29d1a60cb094f66d2cd8efb2"
+  tree_label: "stripped_application_code"
   component:
     app-depth-1*
       exception*
         stacktrace*
           frame*
             function*
-              "malloc_vreport"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+              "stripped_application_code"
+        type (ignored because exception is synthetic (detected via exception type))
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "03195849378c2d0057736e05eb9226af"
+  tree_label: "abort | malloc_report | free | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "free"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+            function*
+              "malloc_report"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
+            function*
+              "abort"
+        type (ignored because exception is synthetic (detected via exception type))
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "aef58de07534b583f7a4bbc9c5201ebf"
+  tree_label: "abort | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "free"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
+            function*
+              "malloc_report"
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
         type (ignored because exception is synthetic (detected via exception type))
@@ -22,8 +80,8 @@ app-depth-1:
           "<redacted>"
 --------------------------------------------------------------------------
 app-depth-max:
-  hash: "30b99c80005e4b810a9f20e43235ebb6"
-  tree_label: "abort | malloc_vreport | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
+  hash: "aef58de07534b583f7a4bbc9c5201ebf"
+  tree_label: "abort | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
   component:
     app-depth-max*
       exception*
@@ -94,22 +152,22 @@ app-depth-max:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "free"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_report"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "malloc_vreport"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "pthread_kill"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type (ignored because exception is synthetic (detected via exception type))
@@ -118,8 +176,8 @@ app-depth-max:
           "<redacted>"
 --------------------------------------------------------------------------
 system:
-  hash: "3263441211518f877b7e1d20167eb33d"
-  tree_label: "abort | malloc_vreport | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
+  hash: "804f08432027d0246c7e7bda086f6c15"
+  tree_label: "abort | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
   component:
     system*
       exception*
@@ -190,22 +248,22 @@ system:
           frame (ignored by stack trace rule (category:internals -group))
             function*
               "std::__1::basic_string<T>::~basic_string"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
             function*
               "free"
-          frame*
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_report"
-          frame*
+          frame (ignored by stack trace rule (category:internals -group))
             function*
               "malloc_vreport"
-          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame* (marked as prefix frame by stack trace rule (category:throw +prefix ^-group))
             function*
               "abort"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "pthread_kill"
-          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+          frame (ignored by stack trace rule (category:throw +prefix ^-group))
             function*
               "__pthread_kill"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/malloc_sentinel.pysnap
@@ -1,0 +1,214 @@
+---
+created: '2021-07-08T15:46:30.436775Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: "8e74af4b7493abe2ea1e99a13c1c12da"
+  tree_label: "abort | malloc_vreport"
+  component:
+    app-depth-1*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "malloc_vreport"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+        type (ignored because exception is synthetic (detected via exception type))
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "30b99c80005e4b810a9f20e43235ebb6"
+  tree_label: "abort | malloc_vreport | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "pthread_kill"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+        type (ignored because exception is synthetic (detected via exception type))
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"
+--------------------------------------------------------------------------
+system:
+  hash: "3263441211518f877b7e1d20167eb33d"
+  tree_label: "abort | malloc_vreport | malloc_report | free | stripped_application_code | stripped_application_code | stripped_application_code"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame* (marked as prefix frame by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "abort"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "pthread_kill"
+          frame (ignored by stack trace rule (category:throw +sentinel +prefix ^-group))
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_malloc_chain.pysnap
@@ -1,11 +1,11 @@
 ---
-created: '2021-07-07T15:30:53.548695Z'
+created: '2021-07-08T17:46:16.023926Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "3ff01ce959249abecc6bc8a8f1432b0b"
-  tree_label: "malloc_zone_malloc | application_frame"
+  hash: "1523e835042dfe806fce37ff02ffa142"
+  tree_label: "application_frame"
   component:
     app-depth-1*
       exception*
@@ -13,7 +13,22 @@ app-depth-1:
           frame*
             function*
               "application_frame"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+        type (ignored because exception is synthetic (detected via exception type))
+          "EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+        value (ignored because stacktrace takes precedence)
+          "Fatal Error: EXC_BAD_INSTRUCTION / EXC_I386_INVOP"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "3ff01ce959249abecc6bc8a8f1432b0b"
+  tree_label: "malloc_zone_malloc | application_frame"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "application_frame"
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_zone_malloc"
             package (ignored because function takes precedence)
@@ -33,7 +48,7 @@ app-depth-max:
           frame*
             function*
               "application_frame"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_zone_malloc"
             package (ignored because function takes precedence)
@@ -73,7 +88,7 @@ system:
           frame*
             function*
               "application_frame"
-          frame* (marked as prefix frame by stack trace rule (category:malloc +sentinel +prefix))
+          frame* (marked as prefix frame by stack trace rule (category:malloc +prefix))
             function*
               "malloc_zone_malloc"
             package (ignored because function takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/malloc_sentinel.pysnap
@@ -1,0 +1,190 @@
+---
+created: '2021-07-08T15:46:33.498715Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "_pthread_start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            function* (isolated function)
+              "std::__1::basic_string<T>::~basic_string"
+          frame (non app frame)
+            function*
+              "free"
+          frame (non app frame)
+            function*
+              "malloc_report"
+          frame (non app frame)
+            function*
+              "malloc_vreport"
+          frame (non app frame)
+            function*
+              "abort"
+          frame (non app frame)
+            function*
+              "pthread_kill"
+          frame (non app frame)
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+--------------------------------------------------------------------------
+system:
+  hash: "2f4ae73b88dbbc7e1cee4f86e270c4b4"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            function* (isolated function)
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame*
+            function*
+              "abort"
+          frame*
+            function*
+              "pthread_kill"
+          frame*
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/malloc_sentinel.pysnap
@@ -1,0 +1,194 @@
+---
+created: '2021-07-08T15:46:36.560968Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "_pthread_start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame (non app frame)
+            function*
+              "free"
+          frame (non app frame)
+            function*
+              "malloc_report"
+          frame (non app frame)
+            function*
+              "malloc_vreport"
+          frame (non app frame)
+            function*
+              "abort"
+          frame (non app frame)
+            function*
+              "pthread_kill"
+          frame (non app frame)
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value*
+          "<redacted>"
+--------------------------------------------------------------------------
+system:
+  hash: "2f4ae73b88dbbc7e1cee4f86e270c4b4"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame*
+            function*
+              "abort"
+          frame*
+            function*
+              "pthread_kill"
+          frame*
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/malloc_sentinel.pysnap
@@ -1,0 +1,194 @@
+---
+created: '2021-07-08T15:46:23.885265Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "_pthread_start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame (non app frame)
+            function*
+              "free"
+          frame (non app frame)
+            function*
+              "malloc_report"
+          frame (non app frame)
+            function*
+              "malloc_vreport"
+          frame (non app frame)
+            function*
+              "abort"
+          frame (non app frame)
+            function*
+              "pthread_kill"
+          frame (non app frame)
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value*
+          "<redacted>"
+--------------------------------------------------------------------------
+system:
+  hash: "2f4ae73b88dbbc7e1cee4f86e270c4b4"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame*
+            function*
+              "abort"
+          frame*
+            function*
+              "pthread_kill"
+          frame*
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/malloc_sentinel.pysnap
@@ -1,0 +1,194 @@
+---
+created: '2021-07-08T15:46:26.994351Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "_pthread_start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame (non app frame)
+            function*
+              "free"
+          frame (non app frame)
+            function*
+              "malloc_report"
+          frame (non app frame)
+            function*
+              "malloc_vreport"
+          frame (non app frame)
+            function*
+              "abort"
+          frame (non app frame)
+            function*
+              "pthread_kill"
+          frame (non app frame)
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value*
+          "<redacted>"
+--------------------------------------------------------------------------
+system:
+  hash: "2f4ae73b88dbbc7e1cee4f86e270c4b4"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame*
+            function*
+              "abort"
+          frame*
+            function*
+              "pthread_kill"
+          frame*
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/malloc_sentinel.pysnap
@@ -1,0 +1,194 @@
+---
+created: '2021-07-08T15:46:39.688891Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "_pthread_start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (marked out of app by stack trace rule (family:native function:std::* -app))
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame (non app frame)
+            function*
+              "free"
+          frame (non app frame)
+            function*
+              "malloc_report"
+          frame (non app frame)
+            function*
+              "malloc_vreport"
+          frame (non app frame)
+            function*
+              "abort"
+          frame (non app frame)
+            function*
+              "pthread_kill"
+          frame (non app frame)
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value*
+          "<redacted>"
+--------------------------------------------------------------------------
+system:
+  hash: "2f4ae73b88dbbc7e1cee4f86e270c4b4"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "_pthread_start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            filename*
+              "stripped_application_code"
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame (ignored due to recursion)
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "std::__1::basic_string<T>::~basic_string"
+          frame*
+            function*
+              "free"
+          frame*
+            function*
+              "malloc_report"
+          frame*
+            function*
+              "malloc_vreport"
+          frame*
+            function*
+              "abort"
+          frame*
+            function*
+              "pthread_kill"
+          frame*
+            function*
+              "__pthread_kill"
+        type*
+          "SIGABRT"
+        value (ignored because stacktrace takes precedence)
+          "<redacted>"

--- a/tests/sentry/grouping/test_categorization.py
+++ b/tests/sentry/grouping/test_categorization.py
@@ -59,7 +59,9 @@ from sentry.utils.safe import get_path
 _fixture_path = os.path.join(os.path.dirname(__file__), "categorization_inputs")
 
 _SHOULD_DELETE_DATA = os.environ.get("SENTRY_TEST_GROUPING_DELETE_USELESS_DATA") == "1"
-_DELETE_KEYWORDS = os.environ.get("SENTRY_TEST_GROUPING_DELETE_KEYWORDS", "").lower().split(",")
+_DELETE_KEYWORDS = [
+    x for x in os.environ.get("SENTRY_TEST_GROUPING_DELETE_KEYWORDS", "").lower().split(",") if x
+]
 
 
 class CategorizationInput:


### PR DESCRIPTION
Do not mark `malloc`, `free`, and `throw` categories as sentinel.
Skip prefix frames when looking for blaming frame in fallback tree.

https://getsentry.atlassian.net/browse/INGEST-144