### PR TITLE
feat(ui): Percentage based alerts guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -48,6 +48,10 @@ GUIDES = {
         "id": 20,
         "required_targets": ["project_transaction_threshold_override"],
     },
+    "percentage_based_alerts": {
+        "id": 21,
+        "required_targets": ["percentage_based_alerts"],
+    },
 }
 
 # demo mode has different guides

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -321,6 +321,25 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         },
       ],
     },
+    {
+      guide: 'percentage_based_alerts',
+      requiredTargets: ['percentage_based_alerts'],
+      steps: [
+        {
+          title: t('Percentage Based Alerts'),
+          target: 'percentage_based_alerts',
+          description: tct(
+            'View the event count as a percentage of sessions and alert on this number to adapt to changes in traffic patterns. [link:View the docs] to learn more.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/issue-alert-config/#when-conditions-triggers" />
+              ),
+            }
+          ),
+          nextText: t('Thank you but please go away'),
+        },
+      ],
+    },
   ];
 }
 

--- a/static/app/views/issueList/displayOptions.tsx
+++ b/static/app/views/issueList/displayOptions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import FeatureBadge from 'app/components/featureBadge';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import {getDisplayLabel, IssueDisplayOptions} from 'app/views/issueList/utils';
@@ -43,6 +44,7 @@ const IssueListDisplayOptions = ({
         isActive={key === display}
         disabled={disabled}
       >
+        {key === IssueDisplayOptions.SESSIONS && <FeatureBadge type="beta" noTooltip />}
         <StyledTooltip
           containerDisplayMode="block"
           position="top"

--- a/static/app/views/issueList/displayOptions.tsx
+++ b/static/app/views/issueList/displayOptions.tsx
@@ -44,7 +44,6 @@ const IssueListDisplayOptions = ({
         isActive={key === display}
         disabled={disabled}
       >
-        {key === IssueDisplayOptions.SESSIONS && <FeatureBadge type="beta" noTooltip />}
         <StyledTooltip
           containerDisplayMode="block"
           position="top"
@@ -52,6 +51,7 @@ const IssueListDisplayOptions = ({
           disabled={!tooltipText}
         >
           {getDisplayLabel(key)}
+          {key === IssueDisplayOptions.SESSIONS && <FeatureBadge type="beta" noTooltip />}
         </StyledTooltip>
       </DropdownItem>
     );

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -85,12 +85,14 @@ class IssueListFilters extends React.Component<Props> {
           </ClassNames>
           <ButtonBar gap={1}>
             <Feature features={['issue-percent-display']} organization={organization}>
-              <IssueListDisplayOptions
-                onDisplayChange={onDisplayChange}
-                display={display}
-                hasSessions={hasSessions}
-                hasMultipleProjectsSelected={selectedProjects.length !== 1}
-              />
+              <GuideAnchor target="percentage_based_alerts" position="bottom">
+                <IssueListDisplayOptions
+                  onDisplayChange={onDisplayChange}
+                  display={display}
+                  hasSessions={hasSessions}
+                  hasMultipleProjectsSelected={selectedProjects.length !== 1}
+                />
+              </GuideAnchor>
             </Feature>
             <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
           </ButtonBar>


### PR DESCRIPTION
This adds a new guide for %-based issue alerts and adds a beta tag for the display option for it in the issue stream.

Screenshot:
![Screen Shot 2021-07-08 at 2 15 41 PM](https://user-images.githubusercontent.com/15015880/124994473-c2537700-dffa-11eb-98d7-79f08b899226.png)

Resolves: [WOR-1025](https://getsentry.atlassian.net/browse/WOR-1025)