### PR TITLE
ref(arithmetic): Remove any from options and add brackets

### DIFF
--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -347,6 +347,10 @@ function makeFieldOptions(
   const options = columns
     .filter(({kind}) => kind !== 'equation')
     .filter(option => {
+      // Any isn't allowed in arithmetic
+      if (option.kind === 'function' && option.function[0] === 'any') {
+        return false;
+      }
       const columnType = getColumnType(option);
       return (
         columnType === 'number' || columnType === 'integer' || columnType === 'duration'
@@ -366,7 +370,7 @@ function makeFieldOptions(
 }
 
 function makeOperatorOptions(partialTerm: string | null): DropdownOptionGroup {
-  const options = ['+', '-', '*', '/']
+  const options = ['+', '-', '*', '/', '(', ')']
     .filter(operator => (partialTerm ? operator.includes(partialTerm) : true))
     .map(operator => ({
       kind: 'operator' as const,

--- a/tests/js/spec/views/eventsV2/table/arithmeticInput.spec.tsx
+++ b/tests/js/spec/views/eventsV2/table/arithmeticInput.spec.tsx
@@ -9,7 +9,7 @@ describe('ArithmeticInput', function () {
   let handleQueryChange: (value: string) => void;
   let numericColumns: Column[];
   let columns: Column[];
-  const operators = ['+', '-', '*', '/'];
+  const operators = ['+', '-', '*', '/', '(', ')'];
 
   beforeEach(function () {
     query = '';
@@ -30,6 +30,7 @@ describe('ArithmeticInput', function () {
     columns = [
       ...numericColumns,
       // these columns will not be rendered in the dropdown
+      {kind: 'function', function: ['any', 'transaction.duration', undefined, undefined]},
       {kind: 'field', field: 'transaction'},
       {kind: 'function', function: ['failure_rate', '', undefined, undefined]},
       {kind: 'equation', field: 'transaction.duration+measurements.lcp'},


### PR DESCRIPTION
- This removes any, regardless of column used from the arithmetic
  autocomplete since it's not an allowed function
- This adds brackets to the autocomplete dropdown