### PR TITLE
fix(ui): moved crash free rate next to crashes column

### DIFF
--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -398,6 +398,7 @@ const CountColumn = styled(Column)`
     display: flex;
     /* Chart tooltips need overflow */
     overflow: visible;
+    margin-left: ${space(2)};
   }
 `;
 

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -386,7 +386,7 @@ const CrashFreeRateColumn = styled(Column)`
     text-align: center;
   }
 
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+  @media (min-width: ${p => p.theme.breakpoints[3]}) {
     text-align: right;
   }
 `;
@@ -398,7 +398,7 @@ const CountColumn = styled(Column)`
     display: flex;
     /* Chart tooltips need overflow */
     overflow: visible;
-    margin-left: ${space(2)};
+    margin-left: ${space(3)};
   }
 `;
 

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -86,11 +86,11 @@ const Content = ({
           {adoptionStages && (
             <AdoptionStageColumn>{t('Adoption Stage')}</AdoptionStageColumn>
           )}
-          <CrashFreeRateColumn>{t('Crash Free Rate')}</CrashFreeRateColumn>
           <CountColumn>
             <span>{t('Count')}</span>
             <HealthStatsPeriod location={location} />
           </CountColumn>
+          <CrashFreeRateColumn>{t('Crash Free Rate')}</CrashFreeRateColumn>
           <CrashesColumn>{t('Crashes')}</CrashesColumn>
           <NewIssuesColumn>{t('New Issues')}</NewIssuesColumn>
           <ViewColumn />
@@ -189,16 +189,6 @@ const Content = ({
                     </AdoptionStageColumn>
                   )}
 
-                  <CrashFreeRateColumn>
-                    {showPlaceholders ? (
-                      <StyledPlaceholder width="60px" />
-                    ) : defined(crashFreeRate) ? (
-                      <CrashFree percent={crashFreeRate} />
-                    ) : (
-                      <NotAvailable />
-                    )}
-                  </CrashFreeRateColumn>
-
                   <CountColumn>
                     {showPlaceholders ? (
                       <StyledPlaceholder />
@@ -214,6 +204,16 @@ const Content = ({
                       <NotAvailable />
                     )}
                   </CountColumn>
+
+                  <CrashFreeRateColumn>
+                    {showPlaceholders ? (
+                      <StyledPlaceholder width="60px" />
+                    ) : defined(crashFreeRate) ? (
+                      <CrashFree percent={crashFreeRate} />
+                    ) : (
+                      <NotAvailable />
+                    )}
+                  </CrashFreeRateColumn>
 
                   <CrashesColumn>
                     {showPlaceholders ? (
@@ -384,6 +384,10 @@ const AdoptionWrapper = styled('span')`
 const CrashFreeRateColumn = styled(Column)`
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     text-align: center;
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    text-align: right;
   }
 `;
 


### PR DESCRIPTION
Moving `Crash Free Rate` column next to `Crashes` so it's easier to read and isn't confused with the `Count` column

## Before 
![CleanShot 2021-07-08 at 12 16 18](https://user-images.githubusercontent.com/1900676/124978198-523af600-dfe6-11eb-9369-3b32a48ceea0.png)


## After 

![CleanShot 2021-07-08 at 12 14 26](https://user-images.githubusercontent.com/1900676/124978054-228bee00-dfe6-11eb-9515-58c08078f895.png)
