### PR TITLE
ref(test): Allow getDynamicText to work in jest tests

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -248,8 +248,9 @@ export const ORGANIZATION_FETCH_ERROR_TYPES = {
 export const CONFIG_DOCS_URL = 'https://develop.sentry.dev/config/';
 export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/product/discover-queries/';
 
-export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
 export const NODE_ENV = process.env.NODE_ENV;
+export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
+export const IS_TEST_ENV = !!process.env.IS_TEST_ENV || NODE_ENV === 'test';
 export const DISABLE_RR_WEB = !!process.env.DISABLE_RR_WEB;
 export const SPA_DSN = process.env.SPA_DSN;
 

--- a/static/app/utils/getDynamicText.tsx
+++ b/static/app/utils/getDynamicText.tsx
@@ -1,4 +1,4 @@
-import {IS_ACCEPTANCE_TEST} from 'app/constants';
+import {IS_ACCEPTANCE_TEST, IS_TEST_ENV} from 'app/constants';
 
 /**
  * Return a specified "fixed" string when we are in a testing environment
@@ -7,9 +7,11 @@ import {IS_ACCEPTANCE_TEST} from 'app/constants';
 export default function getDynamicText<Value, Fixed = Value>({
   value,
   fixed,
+  inTestEnv,
 }: {
   value: Value;
   fixed: Fixed;
+  inTestEnv?: boolean;
 }): Value | Fixed {
-  return IS_ACCEPTANCE_TEST ? fixed : value;
+  return IS_ACCEPTANCE_TEST || (inTestEnv && IS_TEST_ENV) ? fixed : value;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -309,6 +309,7 @@ let appConfig = {
       'process.env': {
         NODE_ENV: JSON.stringify(env.NODE_ENV),
         IS_ACCEPTANCE_TEST: JSON.stringify(IS_ACCEPTANCE_TEST),
+        IS_TEST_ENV: JSON.stringify(IS_TEST),
         DEPLOY_PREVIEW_CONFIG: JSON.stringify(DEPLOY_PREVIEW_CONFIG),
         EXPERIMENTAL_SPA: JSON.stringify(SENTRY_EXPERIMENTAL_SPA),
         SPA_DSN: JSON.stringify(SENTRY_SPA_DSN),


### PR DESCRIPTION
Need this for some dynamic text that matches deeply in jest tests. Specifically for the search parser which uses JSON test cases, which makes it hard to mark deep values as dynamic, so it's easier to just make the text static in test mode.