### PR TITLE
fix(perf): Fix duplicate tags appearing in search

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1295,7 +1295,13 @@ class EventView {
     }
     const conditions = tokenizeSearch(query);
     Object.entries(this.additionalConditions.tagValues).forEach(([tag, tagValues]) => {
-      conditions.addTagValues(tag, tagValues);
+      const existingTagValues = conditions.getTagValues(tag);
+      const newTagValues = tagValues.filter(
+        tagValue => !existingTagValues.includes(tagValue)
+      );
+      if (newTagValues.length) {
+        conditions.addTagValues(tag, newTagValues);
+      }
     });
     return conditions.formatString();
   }

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2224,6 +2224,23 @@ describe('EventView.getQuery()', function () {
   });
 });
 
+describe('EventView.getQueryWithAdditionalConditions', function () {
+  it('with overlapping conditions', function () {
+    const eventView = new EventView({
+      fields: [],
+      sorts: [],
+      project: [],
+      query: 'event.type:transaction foo:bar',
+    });
+
+    eventView.additionalConditions.setTagValues('event.type', ['transaction']);
+
+    expect(eventView.getQueryWithAdditionalConditions()).toEqual(
+      'event.type:transaction foo:bar'
+    );
+  });
+});
+
 describe('EventView.sortForField()', function () {
   const state = {
     id: '1234',


### PR DESCRIPTION
### Summary
When navigating between landing and the summary page, extra tags kept appearing. This will stop adding additional conditions to a query if the same condition value already exists.