### PR TITLE
fix(ui): removed border on dark mode

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -148,9 +148,6 @@ const styles = (theme: Theme, isDark: boolean) => css`
         .group-detail h3 em {
           color: ${theme.subText};
         }
-        .context-summary {
-          border-top: 1px solid ${theme.border};
-        }
         .event-details-container {
           background-color: ${theme.background};
           .secondary {


### PR DESCRIPTION
Removed random border that shows up only on dark mode for the issue details page.

## Before

![CleanShot 2021-07-08 at 12 19 00](https://user-images.githubusercontent.com/1900676/124986811-ee69fa80-dff0-11eb-8d0b-5304419d166d.png)

## After

![CleanShot 2021-07-08 at 12 19 22](https://user-images.githubusercontent.com/1900676/124986829-f3c74500-dff0-11eb-8995-d3021188f67f.png)
