### PR TITLE
feat(spans): Support dark mode for embedded transactions badge

### DIFF
--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {IconCollapse, IconExpand, IconFire} from 'app/icons';
 import space from 'app/styles/space';
-import {Color} from 'app/utils/theme';
+import {Aliases, Color} from 'app/utils/theme';
 
 export const DividerContainer = styled('div')`
   position: relative;
@@ -49,7 +49,7 @@ export const DividerLineGhostContainer = styled('div')`
   height: 100%;
 `;
 
-const BadgeBorder = styled('div')<{borderColor: Color}>`
+const BadgeBorder = styled('div')<{borderColor: Color | keyof Aliases}>`
   position: absolute;
   margin: ${space(0.25)};
   left: -11px;
@@ -81,7 +81,7 @@ export function EmbeddedTransactionBadge({
 }) {
   return (
     <BadgeBorder
-      borderColor="gray500"
+      borderColor="border"
       onClick={event => {
         event.stopPropagation();
         event.preventDefault();
@@ -89,9 +89,9 @@ export function EmbeddedTransactionBadge({
       }}
     >
       {expanded ? (
-        <IconCollapse color="gray500" size="xs" />
+        <IconCollapse color="textColor" size="xs" />
       ) : (
-        <IconExpand color="gray500" size="xs" />
+        <IconExpand color="textColor" size="xs" />
       )}
     </BadgeBorder>
   );


### PR DESCRIPTION
**Before:**

<img width="577" alt="Screen Shot 2021-07-08 at 5 13 10 PM" src="https://user-images.githubusercontent.com/139499/124991623-e66d8300-e00f-11eb-84d0-c978f0058c3b.png">



**After:**

<img width="553" alt="Screen Shot 2021-07-08 at 4 31 10 PM" src="https://user-images.githubusercontent.com/139499/124991624-e66d8300-e00f-11eb-8f17-df0322f14fa7.png">