### PR TITLE
fix(performance): Display thresholds in all summary tabs

### DIFF
--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -70,9 +70,6 @@ type Props = {
   onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
   onChangeThreshold?: (threshold: number, metric: TransactionThresholdMetric) => void;
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
-  transactionThreshold?: number;
-  transactionThresholdMetric?: TransactionThresholdMetric;
-  loadingThreshold?: boolean;
 };
 
 type State = {
@@ -219,9 +216,6 @@ class SummaryContent extends React.Component<Props, State> {
       onChangeFilter,
       onChangeThreshold,
       spanOperationBreakdownFilter,
-      transactionThreshold,
-      transactionThresholdMetric,
-      loadingThreshold,
     } = this.props;
     const hasPerformanceEventsPage = organization.features.includes(
       'performance-events-page'
@@ -334,9 +328,6 @@ class SummaryContent extends React.Component<Props, State> {
           hasWebVitals={hasWebVitals}
           handleIncompatibleQuery={this.handleIncompatibleQuery}
           onChangeThreshold={onChangeThreshold}
-          transactionThreshold={transactionThreshold}
-          transactionThresholdMetric={transactionThresholdMetric}
-          loadingThreshold={loadingThreshold}
         />
         <Layout.Body>
           <StyledSdkUpdatesAlert />

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -135,8 +135,7 @@ class TransactionHeader extends React.Component<Props> {
   }
 
   renderSettingsButton() {
-    const {organization, location, transactionName, eventView, onChangeThreshold} =
-      this.props;
+    const {organization, transactionName, eventView, onChangeThreshold} = this.props;
 
     return (
       <Feature
@@ -150,7 +149,6 @@ class TransactionHeader extends React.Component<Props> {
               position="bottom"
             >
               <TransactionThresholdButton
-                location={location}
                 organization={organization}
                 transactionName={transactionName}
                 eventView={eventView}

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import {openModal} from 'app/actionCreators/modal';
 import Feature from 'app/components/acl/feature';
 import {GuideAnchor} from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
@@ -25,10 +24,8 @@ import {tagsRouteWithQuery} from './transactionTags/utils';
 import {vitalsRouteWithQuery} from './transactionVitals/utils';
 import KeyTransactionButton from './keyTransactionButton';
 import TeamKeyTransactionButton from './teamKeyTransactionButton';
-import TransactionThresholdModal, {
-  modalCss,
-  TransactionThresholdMetric,
-} from './transactionThresholdModal';
+import TransactionThresholdButton from './transactionThresholdButton';
+import {TransactionThresholdMetric} from './transactionThresholdModal';
 import {transactionSummaryRouteWithQuery} from './utils';
 
 export enum Tab {
@@ -50,9 +47,6 @@ type Props = {
   handleIncompatibleQuery: React.ComponentProps<
     typeof CreateAlertFromViewButton
   >['onIncompatibleQuery'];
-  transactionThreshold?: number;
-  transactionThresholdMetric?: TransactionThresholdMetric;
-  loadingThreshold?: boolean;
 };
 
 class TransactionHeader extends React.Component<Props> {
@@ -140,33 +134,9 @@ class TransactionHeader extends React.Component<Props> {
     );
   }
 
-  openModal() {
-    const {
-      organization,
-      transactionName,
-      eventView,
-      transactionThreshold,
-      transactionThresholdMetric,
-      onChangeThreshold,
-    } = this.props;
-    openModal(
-      modalProps => (
-        <TransactionThresholdModal
-          {...modalProps}
-          organization={organization}
-          transactionName={transactionName}
-          eventView={eventView}
-          transactionThreshold={transactionThreshold}
-          transactionThresholdMetric={transactionThresholdMetric}
-          onApply={onChangeThreshold}
-        />
-      ),
-      {modalCss, backdrop: 'static'}
-    );
-  }
-
   renderSettingsButton() {
-    const {organization, loadingThreshold} = this.props;
+    const {organization, location, transactionName, eventView, onChangeThreshold} =
+      this.props;
 
     return (
       <Feature
@@ -179,12 +149,12 @@ class TransactionHeader extends React.Component<Props> {
               target="project_transaction_threshold_override"
               position="bottom"
             >
-              <Button
-                onClick={() => this.openModal()}
-                data-test-id="set-transaction-threshold"
-                icon={<IconSettings />}
-                disabled={loadingThreshold}
-                aria-label={t('Settings')}
+              <TransactionThresholdButton
+                location={location}
+                organization={organization}
+                transactionName={transactionName}
+                eventView={eventView}
+                onChangeThreshold={onChangeThreshold}
               />
             </GuideAnchor>
           ) : (

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
-import {addErrorMessage} from 'app/actionCreators/indicator';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import {Client} from 'app/api';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
@@ -14,7 +13,6 @@ import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import {GlobalSelection, Organization, Project} from 'app/types';
-import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
@@ -62,7 +60,6 @@ type State = {
   eventView: EventView | undefined;
   transactionThreshold: number | undefined;
   transactionThresholdMetric: TransactionThresholdMetric | undefined;
-  loadingThreshold: boolean;
 };
 
 // Used to cast the totals request to numbers
@@ -73,7 +70,6 @@ class TransactionSummary extends Component<Props, State> {
   state: State = {
     transactionThreshold: undefined,
     transactionThresholdMetric: undefined,
-    loadingThreshold: false,
     spanOperationBreakdownFilter: decodeFilterFromLocation(this.props.location),
     eventView: generateSummaryEventView(
       this.props.location,
@@ -95,9 +91,6 @@ class TransactionSummary extends Component<Props, State> {
   componentDidMount() {
     const {api, organization, selection} = this.props;
     loadOrganizationTags(api, organization.slug, selection);
-    if (organization.features.includes('project-transaction-threshold-override')) {
-      this.fetchTransactionThreshold();
-    }
     addRoutePerformanceContext(selection);
   }
 
@@ -135,72 +128,6 @@ class TransactionSummary extends Component<Props, State> {
       pathname: location.pathname,
       query: nextQuery,
     });
-  };
-
-  getProject() {
-    const {projects} = this.props;
-    const {eventView} = this.state;
-    if (!defined(eventView)) {
-      return undefined;
-    }
-
-    const projectId = String(eventView.project[0]);
-    const project = projects.find(proj => proj.id === projectId);
-
-    return project;
-  }
-
-  fetchTransactionThreshold = () => {
-    const {api, organization, location} = this.props;
-    const transactionName = getTransactionName(location);
-
-    const project = this.getProject();
-    if (!defined(project)) {
-      return;
-    }
-    const transactionThresholdUrl = `/organizations/${organization.slug}/project-transaction-threshold-override/`;
-
-    this.setState({loadingThreshold: true});
-
-    api
-      .requestPromise(transactionThresholdUrl, {
-        method: 'GET',
-        includeAllArgs: true,
-        query: {
-          project: project.id,
-          transaction: transactionName,
-        },
-      })
-      .then(([data]) => {
-        this.setState({
-          loadingThreshold: false,
-          transactionThreshold: data.threshold,
-          transactionThresholdMetric: data.metric,
-        });
-      })
-      .catch(() => {
-        const projectThresholdUrl = `/projects/${organization.slug}/${project.slug}/transaction-threshold/configure/`;
-        this.props.api
-          .requestPromise(projectThresholdUrl, {
-            method: 'GET',
-            includeAllArgs: true,
-            query: {
-              project: project.id,
-            },
-          })
-          .then(([data]) => {
-            this.setState({
-              loadingThreshold: false,
-              transactionThreshold: data.threshold,
-              transactionThresholdMetric: data.metric,
-            });
-          })
-          .catch(err => {
-            this.setState({loadingThreshold: false});
-            const errorMessage = err.responseJSON?.threshold ?? null;
-            addErrorMessage(errorMessage);
-          });
-      });
   };
 
   getDocumentTitle(): string {
@@ -296,12 +223,7 @@ class TransactionSummary extends Component<Props, State> {
 
   render() {
     const {organization, projects, location} = this.props;
-    const {
-      eventView,
-      transactionThreshold,
-      transactionThresholdMetric,
-      loadingThreshold,
-    } = this.state;
+    const {eventView, transactionThreshold, transactionThresholdMetric} = this.state;
     const transactionName = getTransactionName(location);
     if (!eventView || transactionName === undefined) {
       // If there is no transaction name, redirect to the Performance landing page
@@ -371,9 +293,6 @@ class TransactionSummary extends Component<Props, State> {
                           transactionThresholdMetric: metric,
                         })
                       }
-                      transactionThreshold={transactionThreshold}
-                      transactionThresholdMetric={transactionThresholdMetric}
-                      loadingThreshold={loadingThreshold}
                     />
                   );
                 }}

--- a/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
@@ -1,0 +1,163 @@
+import {Component} from 'react';
+import {Location} from 'history';
+
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {openModal} from 'app/actionCreators/modal';
+import {Client} from 'app/api';
+import Button from 'app/components/button';
+import {IconSettings} from 'app/icons';
+import {t} from 'app/locale';
+import {Organization, Project} from 'app/types';
+import {defined} from 'app/utils';
+import EventView from 'app/utils/discover/eventView';
+import withApi from 'app/utils/withApi';
+import withProjects from 'app/utils/withProjects';
+
+import {getTransactionName} from '../utils';
+
+import TransactionThresholdModal, {
+  modalCss,
+  TransactionThresholdMetric,
+} from './transactionThresholdModal';
+
+type Props = {
+  api: Client;
+  location: Location;
+  organization: Organization;
+  transactionName: string;
+  projects: Project[];
+  eventView: EventView;
+  onChangeThreshold?: (threshold: number, metric: TransactionThresholdMetric) => void;
+};
+
+type State = {
+  transactionThreshold: number | undefined;
+  transactionThresholdMetric: TransactionThresholdMetric | undefined;
+  loadingThreshold: boolean;
+};
+
+class TransactionThresholdButton extends Component<Props, State> {
+  state: State = {
+    transactionThreshold: undefined,
+    transactionThresholdMetric: undefined,
+    loadingThreshold: false,
+  };
+
+  componentDidMount() {
+    this.fetchTransactionThreshold();
+  }
+
+  getProject() {
+    const {projects, eventView} = this.props;
+    if (!defined(eventView)) {
+      return undefined;
+    }
+
+    const projectId = String(eventView.project[0]);
+    const project = projects.find(proj => proj.id === projectId);
+
+    return project;
+  }
+
+  fetchTransactionThreshold = () => {
+    const {api, organization, location} = this.props;
+    const transactionName = getTransactionName(location);
+
+    const project = this.getProject();
+    if (!defined(project)) {
+      return;
+    }
+    const transactionThresholdUrl = `/organizations/${organization.slug}/project-transaction-threshold-override/`;
+
+    this.setState({loadingThreshold: true});
+
+    api
+      .requestPromise(transactionThresholdUrl, {
+        method: 'GET',
+        includeAllArgs: true,
+        query: {
+          project: project.id,
+          transaction: transactionName,
+        },
+      })
+      .then(([data]) => {
+        this.setState({
+          loadingThreshold: false,
+          transactionThreshold: data.threshold,
+          transactionThresholdMetric: data.metric,
+        });
+      })
+      .catch(() => {
+        const projectThresholdUrl = `/projects/${organization.slug}/${project.slug}/transaction-threshold/configure/`;
+        this.props.api
+          .requestPromise(projectThresholdUrl, {
+            method: 'GET',
+            includeAllArgs: true,
+            query: {
+              project: project.id,
+            },
+          })
+          .then(([data]) => {
+            this.setState({
+              loadingThreshold: false,
+              transactionThreshold: data.threshold,
+              transactionThresholdMetric: data.metric,
+            });
+          })
+          .catch(err => {
+            this.setState({loadingThreshold: false});
+            const errorMessage = err.responseJSON?.threshold ?? null;
+            addErrorMessage(errorMessage);
+          });
+      });
+  };
+
+  onChangeThreshold(threshold: number, metric: TransactionThresholdMetric) {
+    const {onChangeThreshold} = this.props;
+    this.setState({
+      transactionThreshold: threshold,
+      transactionThresholdMetric: metric,
+    });
+
+    if (defined(onChangeThreshold)) {
+      onChangeThreshold(threshold, metric);
+    }
+  }
+
+  openModal() {
+    const {organization, transactionName, eventView} = this.props;
+
+    const {transactionThreshold, transactionThresholdMetric} = this.state;
+
+    openModal(
+      modalProps => (
+        <TransactionThresholdModal
+          {...modalProps}
+          organization={organization}
+          transactionName={transactionName}
+          eventView={eventView}
+          transactionThreshold={transactionThreshold}
+          transactionThresholdMetric={transactionThresholdMetric}
+          onApply={(threshold, metric) => this.onChangeThreshold(threshold, metric)}
+        />
+      ),
+      {modalCss, backdrop: 'static'}
+    );
+  }
+
+  render() {
+    const {loadingThreshold} = this.state;
+
+    return (
+      <Button
+        onClick={() => this.openModal()}
+        data-test-id="set-transaction-threshold"
+        icon={<IconSettings />}
+        disabled={loadingThreshold}
+        aria-label={t('Settings')}
+      />
+    );
+  }
+}
+
+export default withApi(withProjects(TransactionThresholdButton));

--- a/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
@@ -1,5 +1,4 @@
 import {Component} from 'react';
-import {Location} from 'history';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
@@ -13,8 +12,6 @@ import EventView from 'app/utils/discover/eventView';
 import withApi from 'app/utils/withApi';
 import withProjects from 'app/utils/withProjects';
 
-import {getTransactionName} from '../utils';
-
 import TransactionThresholdModal, {
   modalCss,
   TransactionThresholdMetric,
@@ -22,7 +19,6 @@ import TransactionThresholdModal, {
 
 type Props = {
   api: Client;
-  location: Location;
   organization: Organization;
   transactionName: string;
   projects: Project[];
@@ -60,8 +56,7 @@ class TransactionThresholdButton extends Component<Props, State> {
   }
 
   fetchTransactionThreshold = () => {
-    const {api, organization, location} = this.props;
-    const transactionName = getTransactionName(location);
+    const {api, organization, transactionName} = this.props;
 
     const project = this.getProject();
     if (!defined(project)) {
@@ -139,6 +134,7 @@ class TransactionThresholdButton extends Component<Props, State> {
           transactionThreshold={transactionThreshold}
           transactionThresholdMetric={transactionThresholdMetric}
           onApply={(threshold, metric) => this.onChangeThreshold(threshold, metric)}
+          data-test-id="threshold-settings"
         />
       ),
       {modalCss, backdrop: 'static'}
@@ -147,11 +143,9 @@ class TransactionThresholdButton extends Component<Props, State> {
 
   render() {
     const {loadingThreshold} = this.state;
-
     return (
       <Button
         onClick={() => this.openModal()}
-        data-test-id="set-transaction-threshold"
         icon={<IconSettings />}
         disabled={loadingThreshold}
         aria-label={t('Settings')}

--- a/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdButton.tsx
@@ -134,7 +134,6 @@ class TransactionThresholdButton extends Component<Props, State> {
           transactionThreshold={transactionThreshold}
           transactionThresholdMetric={transactionThresholdMetric}
           onApply={(threshold, metric) => this.onChangeThreshold(threshold, metric)}
-          data-test-id="threshold-settings"
         />
       ),
       {modalCss, backdrop: 'static'}
@@ -149,6 +148,7 @@ class TransactionThresholdButton extends Component<Props, State> {
         icon={<IconSettings />}
         disabled={loadingThreshold}
         aria-label={t('Settings')}
+        data-test-id="set-transaction-threshold"
       />
     );
   }

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -206,5 +206,4 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             # We have to wait for this again because there are loaders inside of the table
             self.page.wait_until_loaded()
             self.browser.click('[data-test-id="set-transaction-threshold"]')
-            self.browser.wait_until_not(".loading-indicator")
-            self.browser.snapshot("performance summary - with data")
+            self.browser.snapshot("transaction threshold modal")

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -194,6 +194,7 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             (
                 "organizations:performance-view",
                 "organizations:project-transaction-threshold-override",
+                "organizations:project-transaction-threshold",
             )
         ):
             self.browser.get(self.path)
@@ -204,6 +205,5 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
                 '[data-test-id="grid-editable"] [data-test-id="empty-state"]', timeout=2
             )
             # We have to wait for this again because there are loaders inside of the table
-            self.page.wait_until_loaded()
             self.browser.click('[data-test-id="set-transaction-threshold"]')
             self.browser.snapshot("transaction threshold modal")

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -205,5 +205,6 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
                 '[data-test-id="grid-editable"] [data-test-id="empty-state"]', timeout=2
             )
             # We have to wait for this again because there are loaders inside of the table
+            self.page.wait_until_loaded()
             self.browser.click('[data-test-id="set-transaction-threshold"]')
             self.browser.snapshot("transaction threshold modal")

--- a/tests/js/spec/views/performance/transactionSummary/transactionThresholdButton.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionThresholdButton.spec.jsx
@@ -1,0 +1,127 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import ModalActions from 'app/actions/modalActions';
+import ProjectsStore from 'app/stores/projectsStore';
+import EventView from 'app/utils/discover/eventView';
+import TransactionThresholdButton from 'app/views/performance/transactionSummary/transactionThresholdButton';
+
+function mountComponent(eventView, organization, onChangeThreshold) {
+  return mountWithTheme(
+    <TransactionThresholdButton
+      eventView={eventView}
+      organization={organization}
+      transactionName="transaction/threshold"
+      onChangeThreshold={onChangeThreshold}
+    />
+  );
+}
+
+describe('TransactionThresholdButton', function () {
+  const organization = TestStubs.Organization({features: ['performance-view']});
+  const project = TestStubs.Project();
+  const eventView = new EventView({
+    id: '1',
+    name: 'my query',
+    fields: [{field: 'count()'}],
+    sorts: [{field: 'count', kind: 'desc'}],
+    query: '',
+    project: [project.id],
+    start: '2019-10-01T00:00:00',
+    end: '2019-10-02T00:00:00',
+    statsPeriod: '14d',
+    environment: [],
+  });
+  const onChangeThreshold = jest.fn();
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+    ProjectsStore.loadInitialData([project]);
+  });
+
+  it('renders element correctly', async function () {
+    const getTransactionThresholdMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/project-transaction-threshold-override/',
+      method: 'GET',
+      body: {
+        threshold: '800',
+        metric: 'lcp',
+      },
+    });
+
+    const getProjectThresholdMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/transaction-threshold/configure/',
+      method: 'GET',
+      body: {
+        threshold: '200',
+        metric: 'duration',
+      },
+    });
+    const wrapper = mountComponent(eventView, organization, onChangeThreshold);
+    await tick();
+    wrapper.update();
+
+    const button = wrapper.find('Button');
+    expect(button.prop('disabled')).toBeFalsy();
+    expect(getTransactionThresholdMock).toHaveBeenCalledTimes(1);
+    expect(getProjectThresholdMock).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('gets project threshold if transaction threshold does not exist', async function () {
+    const getTransactionThresholdMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/project-transaction-threshold-override/',
+      method: 'GET',
+      statusCode: 404,
+    });
+
+    const getProjectThresholdMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/transaction-threshold/configure/',
+      method: 'GET',
+      body: {
+        threshold: '200',
+        metric: 'duration',
+      },
+    });
+    const wrapper = mountComponent(eventView, organization, onChangeThreshold);
+    await tick();
+    wrapper.update();
+
+    const button = wrapper.find('Button');
+    expect(button.prop('disabled')).toBeFalsy();
+    expect(getTransactionThresholdMock).toHaveBeenCalledTimes(1);
+    expect(getProjectThresholdMock).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+  });
+
+  it('mounts modal with the right values', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/project-transaction-threshold-override/',
+      method: 'GET',
+      body: {
+        threshold: '800',
+        metric: 'lcp',
+      },
+    });
+
+    const wrapper = mountComponent(eventView, organization, onChangeThreshold);
+    await tick();
+    wrapper.update();
+
+    expect(
+      wrapper.find('TransactionThresholdButton').state('transactionThreshold')
+    ).toEqual('800');
+    expect(
+      wrapper.find('TransactionThresholdButton').state('transactionThresholdMetric')
+    ).toEqual('lcp');
+
+    const spy = jest.spyOn(ModalActions, 'openModal');
+    const button = wrapper.find('Button');
+    button.simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
The Transaction Threshold modal was not displaying
the threshold and metric when opened from the
tags and web vitals page. This is because the api
request to retrieve this info was only being fired off
in the txn summary overview page. Updated this by moving
the api calls closer to the settings button in -
TransactionThresholdButton that lives in the txn
summary headers so the api call is made on all the pages.