### PR TITLE
fix(ui): copywriting fixes for the notifications page

### DIFF
--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -22,8 +22,8 @@ export type NotificationSettingsObject = {
 
 export const NOTIFICATION_SETTINGS_TYPES = [
   'alerts',
-  'deploy',
   'workflow',
+  'deploy',
   'reports',
   'email',
 ];

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -12,7 +12,9 @@ export type FineTuneField = {
 export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
   alerts: {
     title: 'Project Alerts',
-    description: t('Control alerts that you receive per project.'),
+    description: t(
+      'Notifications from Alert Rules that your team has setup. You’ll always receive notifications from Alerts configured to be sent directly to you.'
+    ),
     type: 'select',
     choices: [
       ['-1', t('Default')],

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -19,7 +19,7 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
       ['always', t('On')],
       ['never', t('Off')],
     ],
-    help: t('Notifications sent from Alert rules that your team has setup.'),
+    help: t('Notifications sent from Alert rules that your team has set up.'),
   },
   workflow: {
     name: 'workflow',

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -14,17 +14,28 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
   alerts: {
     name: 'alerts',
     type: 'select',
-    label: t('Issue Alert Notifications'),
+    label: t('Issue Alerts'),
     choices: [
       ['always', t('On')],
       ['never', t('Off')],
     ],
-    help: t('Enable this to receive notifications sent from project alerts.'),
+    help: t('Notifications sent from Alert rules that your team has setup.'),
+  },
+  workflow: {
+    name: 'workflow',
+    type: 'select',
+    label: t('Issue Workflow'),
+    choices: [
+      ['always', t('On')],
+      ['subscribe_only', t('Only Subscribed Issues')],
+      ['never', t('Off')],
+    ],
+    help: t('Changes in issue assignment, resolution status, and comments.'),
   },
   deploy: {
     name: 'deploy',
     type: 'select',
-    label: t('Deploy Notifications'),
+    label: t('Deploys'),
     choices: [
       ['always', t('On')],
       ['committed_only', t('Only Committed Issues')],
@@ -42,17 +53,6 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
       ['email+slack', t('Send to Email and Slack')],
     ],
   },
-  workflow: {
-    name: 'workflow',
-    type: 'select',
-    label: t('Workflow Notifications'),
-    choices: [
-      ['always', t('On')],
-      ['subscribe_only', t('Only Subscribed Issues')],
-      ['never', t('Off')],
-    ],
-    help: t('Changes in issue assignment, resolution status, and comments.'),
-  },
   reports: {
     name: 'weekly reports',
     type: 'blank',
@@ -63,18 +63,18 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingFiel
     name: 'email routing',
     type: 'blank',
     label: t('Email Routing'),
-    help: t('Select which email address should receive notifications per project.'),
+    help: t('Change the email address that receives notifications.'),
   },
   personalActivityNotifications: {
     name: 'personalActivityNotifications',
     type: 'boolean',
-    label: t('Notify Me About My Own Activity'),
-    help: t('Enable this to receive notifications about your own actions on Sentry.'),
+    label: t('My Own Activity'),
+    help: t('Notifications about your own actions on Sentry.'),
   },
   selfAssignOnResolve: {
     name: 'selfAssignOnResolve',
     type: 'boolean',
-    label: t("Claim Unassigned Issues I've Resolved"),
-    help: t("You'll receive notifications about any changes that happen afterwards."),
+    label: t('Claim Unassigned Issues I’ve Resolved'),
+    help: t('You’ll receive notifications about any changes that happen afterwards.'),
   },
 };

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -112,7 +112,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
     return (
       <React.Fragment>
         <SettingsPageHeader title="Notifications" />
-        <TextBlock>Control alerts that you receive.</TextBlock>
+        <TextBlock>Personal notifications sent via email or an integration.</TextBlock>
         <FeedbackAlert />
         <Form
           saveOnBlur

--- a/tests/js/spec/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/tests/js/spec/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -28,7 +28,7 @@ describe('NotificationSettingsByType', function () {
     // There is only one field and it is the default and it is set to "off".
     const fields = wrapper.find('Field');
     expect(fields).toHaveLength(1);
-    expect(fields.at(0).find('FieldLabel').text()).toEqual('Issue Alert Notifications');
+    expect(fields.at(0).find('FieldLabel').text()).toEqual('Issue Alerts');
     expect(fields.at(0).find('Select').text()).toEqual('Off');
   });
 });


### PR DESCRIPTION
Tidied up copy for notifications page.

## Before
![CleanShot 2021-07-08 at 16 27 15](https://user-images.githubusercontent.com/1900676/125002280-6e03c380-e009-11eb-9495-5fe4990c445d.png)

## After

![CleanShot 2021-07-08 at 16 26 30](https://user-images.githubusercontent.com/1900676/125002275-63e1c500-e009-11eb-83de-695364b43cb2.png)
