### PR TITLE
feat(symbolicator): Add an internal global option to ignore a configured list of source IDs during symbolication

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -113,6 +113,9 @@ register(
 # The ratio of requests for which the new stackwalking method should be compared against the old one
 register("symbolicator.compare_stackwalking_methods_rate", default=0.0)
 
+# Ignore built-in sources during symbolication
+register("symbolicator.ignore_builtin_sources", default=False)
+
 # Backend chart rendering via chartcuterie
 register("chart-rendering.enabled", default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -113,8 +113,10 @@ register(
 # The ratio of requests for which the new stackwalking method should be compared against the old one
 register("symbolicator.compare_stackwalking_methods_rate", default=0.0)
 
-# Ignore built-in sources during symbolication
-register("symbolicator.ignore_builtin_sources", default=False)
+# Killswitch for symbolication sources, based on a list of source IDs. Meant to be used in extreme
+# situations where it is preferable to break symbolication in a few places as opposed to letting
+# it break everywhere.
+register("symbolicator.ignored_sources", type=Sequence, default=(), flags=FLAG_ALLOW_EMPTY)
 
 # Backend chart rendering via chartcuterie
 register("chart-rendering.enabled", default=False, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)


### PR DESCRIPTION
This registers a new config option that should allow sentry to omit specific sources during symbolication, which should enable a way to mitigate the impact of a cache refresh on servers.

This only includes registration based on the assumption that manual action is still required in between registration and the first read of the option. (see: https://github.com/getsentry/sentry/pull/25807#issuecomment-831297640)