### PR TITLE
fix(grouping): Tree labels are optional per-variant

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -399,7 +399,9 @@ class Event:
             seen_hashes.add(hash_)
             filtered_hashes.append(hash_)
             tree_labels.append(
-                variant.component.tree_label if isinstance(variant, ComponentVariant) else None
+                variant.component.tree_label or None
+                if isinstance(variant, ComponentVariant)
+                else None
             )
 
         return filtered_hashes, tree_labels

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -81,7 +81,7 @@ def _write_tree_labels(tree_labels: Sequence[TreeLabel], event_data: EventData) 
 class CalculatedHashes:
     hashes: Sequence[str]
     hierarchical_hashes: Sequence[str]
-    tree_labels: Sequence[TreeLabel]
+    tree_labels: Sequence[Optional[TreeLabel]]
 
     def write_to_event(self, event_data: EventData) -> None:
         event_data["hashes"] = self.hashes
@@ -106,16 +106,18 @@ class CalculatedHashes:
     @property
     def finest_tree_label(self) -> Optional[StrippedTreeLabel]:
         try:
-            return _strip_tree_label(self.tree_labels[-1])
+            tree_label = self.tree_labels[-1]
+            return tree_label and _strip_tree_label(tree_label)
         except IndexError:
             return None
 
     def group_metadata_from_hash(self, hash: str) -> EventMetadata:
         try:
             i = self.hierarchical_hashes.index(hash)
+            tree_label = self.tree_labels[i]
             return {
                 "current_level": i,
-                "current_tree_label": _strip_tree_label(self.tree_labels[i]),
+                "current_tree_label": tree_label and _strip_tree_label(tree_label),
             }
         except (IndexError, ValueError):
             return {}


### PR DESCRIPTION
Tree labels are optional, meaning that a variant can choose not to
produce one

`event.hierarchical_tree_labels` is a `Sequence[Optional[..]]` now, but
in all other code that we don't touch in this commit, optionality should
already be handled.

Fix SENTRY-R86