### PR TITLE
fix(mocks): Use release_id when creating ReleaseFile obj

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -483,7 +483,7 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
                 for file in raw_commit["files"]:
                     ReleaseFile.objects.get_or_create(
                         organization_id=project.organization_id,
-                        release=release,
+                        release_id=release.id,
                         name=file[0],
                         file=File.objects.get_or_create(
                             name=file[0], type="release.file", checksum="abcde" * 8, size=13043


### PR DESCRIPTION
The release FK was replaced with a release_id integer
field [here](https://github.com/getsentry/sentry/pull/27098).
Updating `load-mocks` to use release_id when creating
a ReleaseFile row.