### PR TITLE
fix(discover): Revert automatic thesholds in discover

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -304,9 +304,6 @@ export const AGGREGATIONS = {
   },
   apdex: {
     getFieldOverrides({parameter, organization}: DefaultValueInputs) {
-      if (organization.features.includes('project-transaction-threshold')) {
-        return {required: false, placeholder: 'Automatic', defaultValue: ''};
-      }
       return {
         defaultValue: organization.apdexThreshold?.toString() ?? parameter.defaultValue,
       };
@@ -325,9 +322,6 @@ export const AGGREGATIONS = {
   },
   user_misery: {
     getFieldOverrides({parameter, organization}: DefaultValueInputs) {
-      if (organization.features.includes('project-transaction-threshold')) {
-        return {required: false, placeholder: 'Automatic', defaultValue: ''};
-      }
       return {
         defaultValue: organization.apdexThreshold?.toString() ?? parameter.defaultValue,
       };
@@ -360,9 +354,6 @@ export const AGGREGATIONS = {
     getFieldOverrides({parameter, organization}: DefaultValueInputs) {
       if (parameter.kind === 'column') {
         return {defaultValue: 'user'};
-      }
-      if (organization.features.includes('project-transaction-threshold')) {
-        return {required: false, placeholder: 'Automatic', defaultValue: ''};
       }
       return {
         defaultValue: organization.apdexThreshold?.toString() ?? parameter.defaultValue,

--- a/tests/js/spec/utils/discover/fields.spec.jsx
+++ b/tests/js/spec/utils/discover/fields.spec.jsx
@@ -1,3 +1,5 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
 import {
   aggregateMultiPlotType,
   aggregateOutputType,
@@ -314,19 +316,15 @@ describe('generateAggregateFields', function () {
 });
 
 describe('parameterOverrides', function () {
-  const organization = TestStubs.Organization();
+  const {organization} = initializeOrg({
+    organization: {
+      apdexThreshold: 500,
+    },
+  });
   it('handles parameter overrides', function () {
     expect(generateAggregateFields(organization, [])).toContainEqual({
-      field: 'apdex(300)',
+      field: 'apdex(500)',
     });
-    expect(generateAggregateFields(organization, [])).not.toContainEqual({
-      field: 'apdex()',
-    });
-    organization.features = ['project-transaction-threshold'];
-    expect(generateAggregateFields(organization, [])).not.toContainEqual({
-      field: 'apdex(300)',
-    });
-    expect(generateAggregateFields(organization, [])).toContainEqual({field: 'apdex()'});
   });
 });
 

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -249,41 +249,6 @@ describe('EventsV2 -> ColumnEditModal', function () {
 
       // Trigger a blur and make sure the column is not wrong.
       field.simulate('blur');
-
-      const newData = initializeOrg({
-        organization: {
-          features: ['performance-view', 'project-transaction-threshold'],
-          apdexThreshold: 400,
-        },
-      });
-
-      const newApply = jest.fn();
-      const newWrapper = mountModal(
-        {
-          columns,
-          onApply: newApply,
-          tagKeys,
-        },
-        newData
-      );
-
-      selectByLabel(newWrapper, 'apdex(\u2026)', {name: 'field', at: 0, control: true});
-
-      // Parameter select should display and use the default value.
-      const newField = newWrapper.find('QueryField input[name="refinement"]');
-      expect(newField.props().value).toBe('');
-      expect(newField.prop('placeholder')).toBe('Automatic');
-
-      // Trigger a blur and make sure the column is not wrong.
-      newField.simulate('blur');
-
-      // Apply the changes so we can see the new columns.
-      newWrapper.find('Button[priority="primary"]').simulate('click');
-      expect(newApply).toHaveBeenCalledWith(
-        expect.objectContaining([
-          {kind: 'function', function: ['apdex', '', undefined, undefined]},
-        ])
-      );
     });
 
     it('clears unused parameters', function () {


### PR DESCRIPTION
Making the threshold field required in discover for
Apdex, User Misery and Count Miserable functions till
we are able to plot the timeseries chart from the same
data source. This won't break any existing discover
saved queries that have apdex() as a selected column.