### PR TITLE
fix(slow-query): fix slow query for ReleaseCommit

### DIFF
--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.models import Deploy, Group, ReleaseCommit, Repository
+from sentry.models import Deploy, Group, Release, ReleaseCommit, Repository
 from sentry.utils.hashlib import hash_values
 
 
@@ -36,8 +36,10 @@ class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
 
         commit = onboard_cache.get(commit_key)
         if commit is None:
+            # Maybe we should limit by date_added to only check the most recent releases?
+            release_ids = Release.objects.filter(projects=project.id).values_list("id", flat=True)
             commit = ReleaseCommit.objects.filter(
-                organization_id=project.organization_id, release__projects=project.id
+                organization_id=project.organization_id, release__id__in=release_ids
             ).exists()
             cache.set(commit_key, commit, 3600 if commit else 60)
 

--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -36,8 +36,12 @@ class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
 
         commit = onboard_cache.get(commit_key)
         if commit is None:
-            # Maybe we should limit by date_added to only check the most recent releases?
-            release_ids = Release.objects.filter(projects=project.id).values_list("id", flat=True)
+            # only get the last 1000 releases
+            release_ids = (
+                Release.objects.filter(projects=project.id)
+                .order_by("-id")
+                .values_list("id", flat=True)
+            )[:1000]
             commit = ReleaseCommit.objects.filter(
                 organization_id=project.organization_id, release__id__in=release_ids
             ).exists()

--- a/tests/sentry/api/endpoints/test_project_release_setup.py
+++ b/tests/sentry/api/endpoints/test_project_release_setup.py
@@ -34,3 +34,38 @@ class ProjectReleaseSetupCompletionTest(APITestCase):
         assert response.data[2]["complete"] is True
         assert response.data[3]["step"] == "deploy"
         assert response.data[3]["complete"] is False
+
+    def test_commit_different_project(self):
+        project = self.create_project()
+        other_project = self.create_project()
+
+        organization_id = project.organization_id
+
+        release = self.create_release(project)
+        other_release = self.create_release(other_project)
+
+        self.create_group(project=project, first_release=release)
+
+        other_repo = Repository.objects.create(
+            organization_id=organization_id, name=other_project.name
+        )
+        other_commit = Commit.objects.create(
+            organization_id=organization_id, repository_id=other_repo.id, key="b" * 40
+        )
+
+        ReleaseCommit.objects.create(
+            organization_id=organization_id, release=other_release, commit=other_commit, order=0
+        )
+        assert ReleaseCommit.objects.filter(release__projects=project).count() == 0
+
+        url = reverse(
+            "sentry-api-0-project-releases-completion-status",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        self.login_as(user=self.user)
+
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert response.data[2]["step"] == "commit"
+        assert response.data[2]["complete"] is False


### PR DESCRIPTION
This PR fixes a slow query with `ReleaseCommit` that was doing a three-table join. Instead, we do an `id__in` query which should be faster. Since there could be millions of releases for a project, I am limiting the releases we query for to just the last 1000 based on the ID.