### PR TITLE
fix(event-title): Fix crash when rendering tree labels

### DIFF
--- a/static/app/components/eventTitleTreeLabel.tsx
+++ b/static/app/components/eventTitleTreeLabel.tsx
@@ -26,7 +26,7 @@ function EventTitleTreeLabel({treeLabel}: Props) {
               </Fragment>
             );
           }
-          return <PriorityPart key={index}>{part}</PriorityPart>;
+          return <PriorityPart key={index}>{formatTreeLabelPart(part)}</PriorityPart>;
         })}
       </FirstFourParts>
       {!!remainingParts.length && (


### PR DESCRIPTION
Fix JAVASCRIPT-24Y7