### PR TITLE
fix(scim): token format for Azure

### DIFF
--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -65,7 +65,7 @@
       </div>
       <div class="box-content with-padding">
         <b>Auth Token:</b>
-        <pre>Bearer {{ scim_api_token }}</pre>
+        <pre>{% if provider_name != "Active Directory" %}Bearer{% endif %} {{ scim_api_token }}</pre>
         <b>SCIM URL:</b>
         <pre>{{ scim_url }}</pre>
         <p>See provider specific SCIM documentation <a href="#TODO">here</a>.</p>


### PR DESCRIPTION
Azure automatically inserts the "Bearer" text part of a token that is inputted to their ui, so omit it in the token we display for them to copy and paste.