### PR TITLE
fix(scim): rate limits on invites

### DIFF
--- a/src/sentry/scim/endpoints/constants.py
+++ b/src/sentry/scim/endpoints/constants.py
@@ -48,6 +48,11 @@ SCIM_400_INVALID_PATCH = {
     "detail": "Invalid Patch Operation.",
 }
 
+SCIM_429_RATE_LIMITED = {
+    "schemas": [SCIM_API_ERROR],
+    "detail": "You are being rate limited.",
+}
+
 
 class TeamPatchOps(str, Enum):
     ADD = "add"

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -20,8 +20,8 @@ from .constants import (
     SCIM_400_INVALID_PATCH,
     SCIM_400_TOO_MANY_PATCH_OPS_ERROR,
     SCIM_409_USER_EXISTS,
-    MemberPatchOps,
     SCIM_429_RATE_LIMITED,
+    MemberPatchOps,
 )
 from .utils import OrganizationSCIMMemberPermission, SCIMEndpoint, parse_filter_conditions
 

--- a/src/sentry/utils/ratelimits.py
+++ b/src/sentry/utils/ratelimits.py
@@ -12,6 +12,16 @@ DEFAULT_CONFIG = {
 }
 
 
+SCIM_CONFIG = {
+    # 20000 invites from a user per day
+    "members:invite-by-user": {"limit": 20000, "window": 3600 * 24},
+    # 20000 invites from an org per day
+    "members:invite-by-org": {"limit": 20000, "window": 3600 * 24},
+    # 10 invites per email per org per day
+    "members:org-invite-to-email": {"limit": 10, "window": 3600 * 24},
+}
+
+
 def for_organization_member_invite(organization, email, user=None, auth=None, config=None):
     """
     Rate limit logic for triggering a user invite email, which should also be applied for generating


### PR DESCRIPTION
- In other places in the application we rate limit invites to prevent spam attacks etc., so they are also added here for SCIM.
- since in theory SCIM could invite hundreds / thousands of members upped some of the limits from the default config in the rate_limiter file.