### PR TITLE
fix: update issue grouping pattern to avoid misinterpretation

### DIFF
--- a/static/app/data/forms/projectIssueGrouping.tsx
+++ b/static/app/data/forms/projectIssueGrouping.tsx
@@ -117,7 +117,7 @@ stack.function:malloc -> memory-allocation-error`}
             `This can be used to enhance the grouping algorithm with custom rules.
         Rules follow the pattern [pattern]. To learn more about stack trace rules, [docs:read the docs].`,
             {
-              pattern: <code>matcher:glob [^v]?[+-]flag</code>,
+              pattern: <code>matcher:glob [v^]?[+-]flag</code>,
               docs: (
                 <ExternalLink href="https://docs.sentry.io/product/data-management-settings/event-grouping/stack-trace-rules/" />
               ),


### PR DESCRIPTION
Previous grouping pattern could be interpreted as negated character class, as in every character other than `v`. This can be avoided by moving `^` to be later in a pattern, as in regular expressions `^` can mean negated character class when it's at beginning of a character class.