### PR TITLE
fix(ui): Set hasSessions to false when there are no groups for display

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -417,6 +417,7 @@ class IssueListOverview extends React.Component<Props, State> {
   fetchStats = (groups: string[]) => {
     // If we have no groups to fetch, just skip stats
     if (!groups.length) {
+      this.setState({hasSessions: false});
       return;
     }
     const requestParams: StatEndpointParams = {


### PR DESCRIPTION
This fixes an issue where: when you select a project with sessions `Events as %` display option is enabled in the display dropdown but when you switch to a project with no issues, the option doesn't get disabled. By default it is disabled so it should be disabled when there's no issue/session data.

Resolves: [WOR-1061](https://getsentry.atlassian.net/browse/WOR-1061)