### PR TITLE
fix(ui): Only show percentage guide when project with sessions selected

### DIFF
--- a/static/app/views/issueList/displayOptions.tsx
+++ b/static/app/views/issueList/displayOptions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import FeatureBadge from 'app/components/featureBadge';
 import Tooltip from 'app/components/tooltip';
@@ -58,22 +59,28 @@ const IssueListDisplayOptions = ({
   };
 
   return (
-    <DropdownControl
-      buttonProps={{prefix: t('Display')}}
-      buttonTooltipTitle={
-        display === IssueDisplayOptions.SESSIONS
-          ? t(
-              'This shows the event count as a percent of sessions in the same time period.'
-            )
-          : null
-      }
-      label={getDisplayLabel(display)}
+    <GuideAnchor
+      target="percentage_based_alerts"
+      position="bottom"
+      disabled={!hasSessions || hasMultipleProjectsSelected}
     >
-      <React.Fragment>
-        {getMenuItem(IssueDisplayOptions.EVENTS)}
-        {getMenuItem(IssueDisplayOptions.SESSIONS)}
-      </React.Fragment>
-    </DropdownControl>
+      <DropdownControl
+        buttonProps={{prefix: t('Display')}}
+        buttonTooltipTitle={
+          display === IssueDisplayOptions.SESSIONS
+            ? t(
+                'This shows the event count as a percent of sessions in the same time period.'
+              )
+            : null
+        }
+        label={getDisplayLabel(display)}
+      >
+        <React.Fragment>
+          {getMenuItem(IssueDisplayOptions.EVENTS)}
+          {getMenuItem(IssueDisplayOptions.SESSIONS)}
+        </React.Fragment>
+      </DropdownControl>
+    </GuideAnchor>
   );
 };
 

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -85,14 +85,12 @@ class IssueListFilters extends React.Component<Props> {
           </ClassNames>
           <ButtonBar gap={1}>
             <Feature features={['issue-percent-display']} organization={organization}>
-              <GuideAnchor target="percentage_based_alerts" position="bottom">
-                <IssueListDisplayOptions
-                  onDisplayChange={onDisplayChange}
-                  display={display}
-                  hasSessions={hasSessions}
-                  hasMultipleProjectsSelected={selectedProjects.length !== 1}
-                />
-              </GuideAnchor>
+              <IssueListDisplayOptions
+                onDisplayChange={onDisplayChange}
+                display={display}
+                hasSessions={hasSessions}
+                hasMultipleProjectsSelected={selectedProjects.length !== 1}
+              />
             </Feature>
             <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
           </ButtonBar>


### PR DESCRIPTION
This adds a check to the percentage based issue alerts guide to only show when user has selected a project with sessions.

[WOR-1062](https://getsentry.atlassian.net/browse/WOR-1062)