### PR TITLE
fix(ui): apple icons in dark mode

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -193,6 +193,17 @@ const styles = (theme: Theme, isDark: boolean) => css`
             border-bottom-color: ${theme.background};
           }
         }
+        .context-summary .context-item.darwin .context-item-icon,
+        .context-summary .context-item.ios .context-item-icon,
+        .context-summary .context-item.macos .context-item-icon,
+        .context-summary .context-item.tvos .context-item-icon,
+        .context-summary .context-item.mac-os-x .context-item-icon,
+        .context-summary .context-item.mac .context-item-icon,
+        .context-summary .context-item.apple .context-item-icon,
+        .context-summary .context-item.watchos .context-item-icon {
+          filter: invert(100%);
+          opacity: 0.8;
+        }
       `
     : ''}
 `;


### PR DESCRIPTION
Using a somewhat hacky CSS filter here to change the color of the tag icons on issue details. Haven’t done a full audit of how these icons work in dark mode yet, but I’ll get around to that eventually. 

## Before

![CleanShot 2021-07-12 at 10 27 33](https://user-images.githubusercontent.com/1900676/125330650-e2857d80-e2fb-11eb-923a-9f326ac02c85.png)

## After

![CleanShot 2021-07-12 at 10 12 19](https://user-images.githubusercontent.com/1900676/125330679-e913f500-e2fb-11eb-98eb-9a0552a8c311.png)
