### PR TITLE
fix(ui) Update sidebar menu

### DIFF
--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -34,22 +34,16 @@ const SidebarHelp = ({orientation, collapsed, hidePanel, organization}: Props) =
 
         {isOpen && (
           <HelpMenu {...getMenuProps({})}>
-            <Hook name="sidebar:help-menu" organization={organization} />
             <SidebarMenuItem
               data-test-id="search-docs-and-faqs"
               onClick={() => openHelpSearchModal({organization})}
             >
-              {t('Search Docs and FAQs')}
+              {t('Search support, docs and more')}
             </SidebarMenuItem>
-            <SidebarMenuItem href="https://forum.sentry.io/">
-              {t('Community Discussions')}
+            <SidebarMenuItem href="https://help.sentry.io/">
+              {t('Visit help center')}
             </SidebarMenuItem>
-            <SidebarMenuItem href="https://discord.com/invite/sentry/">
-              {t('Join the Sentry Discord')}
-            </SidebarMenuItem>
-            <SidebarMenuItem href="https://status.sentry.io/">
-              {t('Service Status')}
-            </SidebarMenuItem>
+            <Hook name="sidebar:help-menu" organization={organization} />
           </HelpMenu>
         )}
       </HelpRoot>

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -112,7 +112,7 @@ describe('Sidebar', function () {
       const menu = wrapper.find('HelpMenu');
       expect(menu).toHaveLength(1);
       expect(wrapper).toSnapshot();
-      expect(menu.find('SidebarMenuItem')).toHaveLength(4);
+      expect(menu.find('SidebarMenuItem')).toHaveLength(2);
       wrapper.find('HelpActor').simulate('click');
       expect(wrapper.find('HelpMenu')).toHaveLength(0);
     });


### PR DESCRIPTION
Add a link to help.sentry.io as customers are expecting to find it in
the help menu. Remove the discord and forum links as they are present on
help.sentry.io as well. Move 'contact support' (provided via a hook) to
the bottom so that the menu is ordered by self-service and general
solution time finding.

Fixes RV-455

Details on this change are in https://www.notion.so/sentry/Mini-DACI-Content-of-in-app-Help-Menu-d8db987de48b4ccfaec9aad5d4a98956