### PR TITLE
feat: django 2.0 compatible way to directly set a field's cached value

### DIFF
--- a/src/sentry/api/endpoints/organization_auth_provider_details.py
+++ b/src/sentry/api/endpoints/organization_auth_provider_details.py
@@ -26,6 +26,6 @@ class OrganizationAuthProviderDetailsEndpoint(OrganizationEndpoint):
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         # cache organization so that we don't need to query for org when serializing
-        auth_provider._organization_cache = organization
+        auth_provider.set_cached_field_value("organization", organization)
 
         return Response(serialize(auth_provider, request.user))

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -118,9 +118,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
             if organization is None:
                 continue
 
-            # Try to prevent organization from being fetched again in quotas.
-            project.organization = organization
-            project._organization_cache = organization
+            # Prevent organization from being fetched again in quotas.
+            project.set_cached_field_value("organization", organization)
 
             with Hub.current.start_span(op="get_config"):
                 with metrics.timer("relay_project_configs.get_config.duration"):
@@ -183,9 +182,8 @@ class RelayProjectConfigsEndpoint(Endpoint):
             if organization is None:
                 continue
 
-            # Try to prevent organization from being fetched again in quotas.
-            project.organization = organization
-            project._organization_cache = organization
+            # Prevent organization from being fetched again in quotas.
+            project.set_cached_field_value("organization", organization)
 
             with start_span(op="get_config"):
                 with metrics.timer("relay_project_configs.get_config.duration"):

--- a/src/sentry/api/endpoints/team_groups_new.py
+++ b/src/sentry/api/endpoints/team_groups_new.py
@@ -40,7 +40,7 @@ class TeamGroupsNewEndpoint(TeamEndpoint, EnvironmentMixin):
         )
 
         for group in group_list:
-            group._project_cache = project_dict.get(group.project_id)
+            group.set_cached_field_value("project", project_dict.get(group.project_id))
 
         return Response(
             serialize(

--- a/src/sentry/api/endpoints/team_groups_trending.py
+++ b/src/sentry/api/endpoints/team_groups_trending.py
@@ -40,7 +40,7 @@ class TeamGroupsTrendingEndpoint(TeamEndpoint, EnvironmentMixin):
         )
 
         for group in group_list:
-            group._project_cache = project_dict.get(group.project_id)
+            group.set_cached_field_value("project", project_dict.get(group.project_id))
 
         return Response(
             serialize(

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -322,7 +322,8 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         project_list = sorted(other_projects + member_projects, key=lambda x: x.slug)
 
         for project in project_list:
-            project._organization_cache = organization
+            project.set_cached_field_value("organization", organization)
+
         return project_list
 
     def _team_list(self, organization, access):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -337,7 +337,8 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         team_list = sorted(other_teams + member_teams, key=lambda x: x.slug)
 
         for team in team_list:
-            team._organization_cache = organization
+            team.set_cached_field_value("organization", organization)
+
         return team_list
 
     def serialize(self, obj, attrs, user, access):

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -167,7 +167,9 @@ class TeamWithProjectsSerializer(TeamSerializer):
         orgs = {i.organization_id: i.organization for i in item_list}
 
         for project_team in project_teams:
-            project_team.project._organization_cache = orgs[project_team.project.organization_id]
+            project_team.project.set_cached_field_value(
+                "organization", orgs[project_team.project.organization_id]
+            )
 
         projects = [pt.project for pt in project_teams]
         projects_by_id = {

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -58,6 +58,10 @@ class BaseModel(models.Model):
     def set_cached_field_value(self, field_name, value):
         # Django 1.11 + at least 2.0 compatible method
         # to explicitly set a field's cached value.
+        # This only works for relational fields, and is useful when
+        # you already have the value and can therefore use this
+        # to populate Django's cache before accessing the attribute
+        # and triggering a duplicate, unnecessary query.
         if django.VERSION[:2] < (2, 0):
             setattr(self, f"_{field_name}_cache", value)
             return
@@ -66,6 +70,7 @@ class BaseModel(models.Model):
     def is_field_cached(self, field_name):
         # Django 1.11 + at least 2.0 compatible method
         # to ask if a field has a cached value.
+        # See set_cached_field_value for more information.
         if django.VERSION[:2] < (2, 0):
             if not getattr(self, f"_{field_name}_cache", False):
                 return False

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -63,6 +63,15 @@ class BaseModel(models.Model):
             return
         self._meta.get_field(field_name).set_cached_value(self, value)
 
+    def is_field_cached(self, field_name):
+        # Django 1.11 + at least 2.0 compatible method
+        # to ask if a field has a cached value.
+        if django.VERSION[:2] < (2, 0):
+            if not getattr(self, f"_{field_name}_cache", False):
+                return False
+            return True
+        return self._meta.get_field(field_name).get_cache_name() in self._state.fields_cache
+
 
 class Model(BaseModel):
     id = BoundedBigAutoField(primary_key=True)

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -1,3 +1,4 @@
+import django
 from django.db import models
 from django.db.models import signals
 from django.utils import timezone
@@ -53,6 +54,14 @@ class BaseModel(models.Model):
 
     def __setstate__(self, state):
         self.__dict__.update(state)
+
+    def set_cached_field_value(self, field_name, value):
+        # Django 1.11 + at least 2.0 compatible method
+        # to explicitly set a field's cached value.
+        if django.VERSION[:2] < (2, 0):
+            setattr(self, f"_{field_name}_cache", value)
+            return
+        self._meta.get_field(field_name).set_cached_value(self, value)
 
 
 class Model(BaseModel):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -590,7 +590,7 @@ def _pull_out_data(jobs, projects):
         job["data"] = data = event.data.data
         job["category"] = DataCategory.from_event_type(data.get("type"))
         job["platform"] = event.platform
-        event.set_cached_field_value("project", projects[job["project_id"]])
+        event._project_cache = projects[job["project_id"]]
 
         # Some of the data that are toplevel attributes are duplicated
         # into tags (logger, level, environment, transaction).  These are

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -319,8 +319,8 @@ class EventManager:
             return jobs[0]["event"]
 
         with metrics.timer("event_manager.save.organization.get_from_cache"):
-            project._organization_cache = Organization.objects.get_from_cache(
-                id=project.organization_id
+            project.set_cached_field_value(
+                "organization", Organization.objects.get_from_cache(id=project.organization_id)
             )
 
         job = {"data": self._data, "project_id": project_id, "raw": raw, "start_time": start_time}
@@ -590,7 +590,7 @@ def _pull_out_data(jobs, projects):
         job["data"] = data = event.data.data
         job["category"] = DataCategory.from_event_type(data.get("type"))
         job["platform"] = event.platform
-        event._project_cache = projects[job["project_id"]]
+        event.set_cached_field_value("project", projects[job["project_id"]])
 
         # Some of the data that are toplevel attributes are duplicated
         # into tags (logger, level, environment, transaction).  These are
@@ -1679,7 +1679,9 @@ def save_transaction_events(jobs, projects):
     with metrics.timer("event_manager.save_transactions.set_organization_cache"):
         for project in projects.values():
             try:
-                project._organization_cache = organizations[project.organization_id]
+                project.set_cached_field_value(
+                    "organization", organizations[project.organization_id]
+                )
             except KeyError:
                 continue
 

--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -325,10 +325,12 @@ class Quota(Service):
     def get_project_quota(self, project):
         from sentry.models import Organization, OrganizationOption
 
-        org = getattr(project, "_organization_cache", None)
-        if not org:
-            org = Organization.objects.get_from_cache(id=project.organization_id)
-            project._organization_cache = org
+        if not project.is_field_cached("organization"):
+            project.set_cached_field_value(
+                "organization", Organization.objects.get_from_cache(id=project.organization_id)
+            )
+
+        org = project.organization
 
         max_quota_share = int(
             OrganizationOption.objects.get_value(org, "sentry:project-rate-limit", 100)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -215,8 +215,8 @@ def post_process_group(
         # Re-bind Project and Org since we're reading the Event object
         # from cache which may contain stale parent models.
         event.project = Project.objects.get_from_cache(id=event.project_id)
-        event.project._organization_cache = Organization.objects.get_from_cache(
-            id=event.project.organization_id
+        event.project.set_cached_field_value(
+            "organization", Organization.objects.get_from_cache(id=event.project.organization_id)
         )
 
         # Simplified post processing for transaction events.
@@ -251,7 +251,9 @@ def post_process_group(
         event.group_id = event.group.id
 
         event.group.project = event.project
-        event.group.project._organization_cache = event.project._organization_cache
+        event.group.project.set_cached_field_value(
+            "organization", event.project._organization_cache
+        )
 
         bind_organization_context(event.project.organization)
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -251,9 +251,7 @@ def post_process_group(
         event.group_id = event.group.id
 
         event.group.project = event.project
-        event.group.project.set_cached_field_value(
-            "organization", event.project._organization_cache
-        )
+        event.group.project.set_cached_field_value("organization", event.project.organization)
 
         bind_organization_context(event.project.organization)
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -126,8 +126,8 @@ def _do_preprocess_event(cache_key, data, start_time, event_id, process_task, pr
     from_reprocessing = process_task is process_event_from_reprocessing
 
     with metrics.timer("tasks.store.preprocess_event.organization.get_from_cache"):
-        project._organization_cache = Organization.objects.get_from_cache(
-            id=project.organization_id
+        project.set_cached_field_value(
+            "organization", Organization.objects.get_from_cache(id=project.organization_id)
         )
 
     if should_process_with_symbolicator(data):
@@ -421,8 +421,8 @@ def _do_process_event(
         project = Project.objects.get_from_cache(id=project_id)
 
     with metrics.timer("tasks.store.process_event.organization.get_from_cache"):
-        project._organization_cache = Organization.objects.get_from_cache(
-            id=project.organization_id
+        project.set_cached_field_value(
+            "organization", Organization.objects.get_from_cache(id=project.organization_id)
         )
 
     has_changed = bool(data_has_changed)

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -14,7 +14,7 @@ class QuotaTest(TestCase):
         org = self.create_organization()
         project = self.create_project(organization=org)
 
-        with self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0):
+        with self.assertNumQueries(7), self.settings(SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE=0):
             with self.options({"system.rate-limit": 0}):
                 assert self.backend.get_project_quota(project) == (None, 60)
 


### PR DESCRIPTION
We're currently relying on setting the private `model._{field_name}_cache`, however Django changes this in 2.0 [here](https://github.com/django/django/commit/bfb746f983aa741afa3709794e70f1e0ab6040b5). This was discovered with `OrganizationDetailsTest::test_with_projects` failing `assertNumQueries` with 4 extra queries for `project.organization` coming from [here](https://github.com/getsentry/sentry/blob/424ace6562bf57403a1f824baf6a5f97ab6941c5/src/sentry/api/serializers/models/project.py#L104) since the cache isn't set by us anymore.

This introduces a 1.11 and 2.0(+?, if it breaks, tests will catch it) compatible `set_cached_field_value` and `is_field_cached` onto our BaseModel.