### PR TITLE
fix(org-stats): orgstats api rounding

### DIFF
--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -29,7 +29,6 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
                     result_totals = run_outcomes_query_totals(query)
                     result_timeseries = ""
                 else:
-                    # result_totals, result_timeseries = run_outcomes_query(query)
                     result_totals = run_outcomes_query_totals(query)
                     result_timeseries = run_outcomes_query_timeseries(query)
             with sentry_sdk.start_span(

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -27,7 +27,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
             with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
                 if "project_id" in query.query_groupby:
                     result_totals = run_outcomes_query_totals(query)
-                    result_timeseries = []
+                    result_timeseries = None
                 else:
                     result_totals = run_outcomes_query_totals(query)
                     result_timeseries = run_outcomes_query_timeseries(query)

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -25,12 +25,12 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
                     organization,
                 )
             with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
-                if "project_id" in query.query_groupby:
-                    result_totals = run_outcomes_query_totals(query)
-                    result_timeseries = None
-                else:
-                    result_totals = run_outcomes_query_totals(query)
-                    result_timeseries = run_outcomes_query_timeseries(query)
+                result_totals = run_outcomes_query_totals(query)
+                result_timeseries = (
+                    None
+                    if "project_id" in query.query_groupby
+                    else run_outcomes_query_timeseries(query)
+                )
             with sentry_sdk.start_span(
                 op="outcomes.endpoint", description="massage_outcomes_result"
             ):

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -7,7 +7,12 @@ from rest_framework.response import Response
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.search.utils import InvalidQuery
-from sentry.snuba.outcomes import QueryDefinition, massage_outcomes_result, run_outcomes_query
+from sentry.snuba.outcomes import (
+    QueryDefinition,
+    massage_outcomes_result,
+    run_outcomes_query_timeseries,
+    run_outcomes_query_totals,
+)
 from sentry.snuba.sessions_v2 import InvalidField, InvalidParams
 
 
@@ -20,7 +25,13 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
                     organization,
                 )
             with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
-                result_totals, result_timeseries = run_outcomes_query(query)
+                if "project_id" in query.query_groupby:
+                    result_totals = run_outcomes_query_totals(query)
+                    result_timeseries = ""
+                else:
+                    # result_totals, result_timeseries = run_outcomes_query(query)
+                    result_totals = run_outcomes_query_totals(query)
+                    result_timeseries = run_outcomes_query_timeseries(query)
             with sentry_sdk.start_span(
                 op="outcomes.endpoint", description="massage_outcomes_result"
             ):

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -27,7 +27,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
             with sentry_sdk.start_span(op="outcomes.endpoint", description="run_outcomes_query"):
                 if "project_id" in query.query_groupby:
                     result_totals = run_outcomes_query_totals(query)
-                    result_timeseries = ""
+                    result_timeseries = []
                 else:
                     result_totals = run_outcomes_query_totals(query)
                     result_timeseries = run_outcomes_query_timeseries(query)

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -269,7 +269,7 @@ class QueryDefinition:
         self.conditions, self.filter_keys = get_filter(query, params)
 
 
-def run_outcomes_query_totals(query: QueryDefinition) -> List[List[ResultSet]]:
+def run_outcomes_query_totals(query: QueryDefinition) -> ResultSet:
     result = raw_query(
         dataset=query.dataset,
         start=query.start,
@@ -287,7 +287,7 @@ def run_outcomes_query_totals(query: QueryDefinition) -> List[List[ResultSet]]:
     return result_totals
 
 
-def run_outcomes_query_timeseries(query: QueryDefinition) -> List[List[ResultSet]]:
+def run_outcomes_query_timeseries(query: QueryDefinition) -> ResultSet:
     result_timeseries = raw_query(
         dataset=query.dataset,
         selected_columns=[TS_COL] + query.query_columns,

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -269,7 +269,7 @@ class QueryDefinition:
         self.conditions, self.filter_keys = get_filter(query, params)
 
 
-def run_outcomes_query_totals(query: QueryDefinition) -> List[ResultSet]:
+def run_outcomes_query_totals(query: QueryDefinition) -> List[List[ResultSet]]:
     result = raw_query(
         dataset=query.dataset,
         start=query.start,
@@ -287,7 +287,7 @@ def run_outcomes_query_totals(query: QueryDefinition) -> List[ResultSet]:
     return result_totals
 
 
-def run_outcomes_query_timeseries(query: QueryDefinition) -> List[ResultSet]:
+def run_outcomes_query_timeseries(query: QueryDefinition) -> List[List[ResultSet]]:
     result_timeseries = raw_query(
         dataset=query.dataset,
         selected_columns=[TS_COL] + query.query_columns,

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -269,7 +269,7 @@ class QueryDefinition:
         self.conditions, self.filter_keys = get_filter(query, params)
 
 
-def run_outcomes_query_totals(query: QueryDefinition) -> Tuple[ResultSet, ResultSet]:
+def run_outcomes_query_totals(query: QueryDefinition) -> List[ResultSet]:
     result = raw_query(
         dataset=query.dataset,
         start=query.start,
@@ -287,7 +287,7 @@ def run_outcomes_query_totals(query: QueryDefinition) -> Tuple[ResultSet, Result
     return result_totals
 
 
-def run_outcomes_query_timeseries(query: QueryDefinition) -> Tuple[ResultSet, ResultSet]:
+def run_outcomes_query_timeseries(query: QueryDefinition) -> List[ResultSet]:
     result_timeseries = raw_query(
         dataset=query.dataset,
         selected_columns=[TS_COL] + query.query_columns,

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -301,8 +301,8 @@ def run_outcomes_query_timeseries(query: QueryDefinition) -> ResultSet:
         referrer="outcomes.timeseries",
         limit=10000,
     )
-    result_timeseries = _format_rows(result_timeseries["data"], query)
-    return result_timeseries
+    formatted_results = _format_rows(result_timeseries["data"], query)
+    return formatted_results
 
 
 def _format_rows(rows: ResultSet, query: QueryDefinition) -> ResultSet:

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -346,7 +346,7 @@ def _outcomes_dataset(rollup: int) -> Dataset:
 def massage_outcomes_result(
     query: QueryDefinition,
     result_totals: ResultSet,
-    result_timeseries: ResultSet,
+    result_timeseries: Optional[ResultSet],
 ) -> Dict[str, List[Any]]:
     result: Dict[str, List[Any]] = massage_sessions_result(
         query, result_totals, result_timeseries, ts_col=TS_COL

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -17,9 +17,6 @@ from sentry.utils.snuba import raw_query
 
 from .dataset import Dataset
 
-# from sentry.api.utils import get_date_range_from_params
-
-
 """
 The new Outcomes API defines a "metrics"-like interface which is can be used in
 a similar way to "sessions" and "discover"
@@ -270,39 +267,6 @@ class QueryDefinition:
         self.query_groupby = list(query_groupby)
 
         self.conditions, self.filter_keys = get_filter(query, params)
-
-
-# def run_outcomes_query(query: QueryDefinition) -> Tuple[ResultSet, ResultSet]:
-#     result = raw_query(
-#         dataset=query.dataset,
-#         start=query.start,
-#         end=query.end,
-#         groupby=query.query_groupby,
-#         aggregations=query.aggregations,
-#         rollup=query.rollup,
-#         filter_keys=query.filter_keys,
-#         conditions=query.conditions,
-#         selected_columns=query.query_columns,
-#         referrer="outcomes.totals",
-#         limit=10000,
-#     )
-#     result_timeseries = raw_query(
-#         dataset=query.dataset,
-#         selected_columns=[TS_COL] + query.query_columns,
-#         groupby=[TS_COL] + query.query_groupby,
-#         aggregations=query.aggregations,
-#         conditions=query.conditions,
-#         filter_keys=query.filter_keys,
-#         start=query.start,
-#         end=query.end,
-#         rollup=query.rollup,
-#         referrer="outcomes.timeseries",
-#         limit=10000,
-#     )
-
-#     result_totals = _format_rows(result["data"], query)
-#     result_timeseries = _format_rows(result_timeseries["data"], query)
-#     return result_totals, result_timeseries
 
 
 def run_outcomes_query_totals(query: QueryDefinition) -> Tuple[ResultSet, ResultSet]:

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -351,5 +351,7 @@ def massage_outcomes_result(
     result: Dict[str, List[Any]] = massage_sessions_result(
         query, result_totals, result_timeseries, ts_col=TS_COL
     )
+    if result_timeseries is None:
+        del result["intervals"]
     del result["query"]
     return result

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -226,15 +226,10 @@ class QueryDefinition:
         raw_groupby = query.getlist("groupBy", [])
         if len(raw_fields) == 0:
             raise InvalidField('At least one "field" is required.')
-        custom_interval = None
-        if query["statsPeriod"] != "90d":
-            custom_interval = ONE_HOUR * 4 if query["interval"] == "4h" else ONE_HOUR
         self.fields = {}
         self.aggregations = []
         self.query: List[Any] = []  # not used but needed for compat with sessions logic
-        start, end, rollup = get_constrained_date_range(
-            query, allow_minute_resolution, custom_interval
-        )
+        start, end, rollup = get_constrained_date_range(query, allow_minute_resolution)
         self.dataset = _outcomes_dataset(rollup)
         self.rollup = rollup
         self.start = start

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -297,7 +297,7 @@ class InvalidParams(Exception):
 
 
 def get_constrained_date_range(
-    params, allow_minute_resolution=False, max_points=MAX_POINTS
+    params, allow_minute_resolution=False, isProject=False, max_points=MAX_POINTS
 ) -> Tuple[datetime, datetime, int]:
     interval = parse_stats_period(params.get("interval", "1h"))
     interval = int(3600 if interval is None else interval.total_seconds())
@@ -352,7 +352,8 @@ def get_constrained_date_range(
             "Your interval and date range would create too many results. "
             "Use a larger interval, or a smaller date range."
         )
-
+    if isProject:
+        rounding_interval = ONE_HOUR
     end_ts = int(rounding_interval * math.ceil(to_timestamp(end) / rounding_interval))
     end = to_datetime(end_ts)
     # when expanding the rounding interval, we would adjust the end time too far

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -297,7 +297,7 @@ class InvalidParams(Exception):
 
 
 def get_constrained_date_range(
-    params, allow_minute_resolution=False, custom_interval=None, max_points=MAX_POINTS
+    params, allow_minute_resolution=False, max_points=MAX_POINTS
 ) -> Tuple[datetime, datetime, int]:
     interval = parse_stats_period(params.get("interval", "1h"))
     interval = int(3600 if interval is None else interval.total_seconds())
@@ -333,11 +333,7 @@ def get_constrained_date_range(
     # as soon as snuba can provide us with grouped totals in the same query
     # as the timeseries (using `WITH ROLLUP` in clickhouse)
 
-    rounding_interval = (
-        int(math.ceil(interval / ONE_HOUR) * ONE_HOUR)
-        if custom_interval is None
-        else custom_interval
-    )
+    rounding_interval = int(math.ceil(interval / ONE_HOUR) * ONE_HOUR)
 
     date_range = timedelta(
         seconds=int(rounding_interval * math.ceil(date_range.total_seconds() / rounding_interval))

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -490,8 +490,9 @@ def massage_sessions_result(
         group = {
             "by": by,
             "totals": make_totals(total_groups.get(key, [None]), by),
-            "series": make_timeseries(timeseries_groups.get(key, []), by),
         }
+        if result_timeseries is not None:
+            group["series"] = make_timeseries(timeseries_groups.get(key, []), by)
 
         groups.append(group)
 
@@ -521,6 +522,8 @@ def _get_timestamps(query):
 
 def _split_rows_groupby(rows, groupby):
     groups = {}
+    if rows is None:
+        return groups
     for row in rows:
         key_parts = (group.get_keys_for_row(row) for group in groupby)
         keys = itertools.product(*key_parts)

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -338,10 +338,6 @@ def get_constrained_date_range(
         if custom_interval is None
         else custom_interval
     )
-    # print("_____________________________")
-    # print(int(math.ceil(interval / ONE_HOUR) * ONE_HOUR))
-    # print(custom_interval)
-    # print("_____________________________")
 
     date_range = timedelta(
         seconds=int(rounding_interval * math.ceil(date_range.total_seconds() / rounding_interval))

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/react';
 import {LocationDescriptorObject} from 'history';
 
 import AsyncComponent from 'app/components/asyncComponent';
-import {DateTimeObject} from 'app/components/charts/utils';
+import {DateTimeObject, getSeriesApiInterval} from 'app/components/charts/utils';
 import SortLink, {Alignments, Directions} from 'app/components/gridEditable/sortLink';
 import Pagination from 'app/components/pagination';
 import SearchBar from 'app/components/searchBar';
@@ -96,7 +96,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
     // We do not need more granularity in the data so interval is '1d'
     return {
       ...queryDatetime,
-      interval: '1d',
+      interval: getSeriesApiInterval(dataDatetime),
       groupBy: ['outcome', 'project'],
       field: ['sum(quantity)'],
       project: '-1', // get all project user has access to

--- a/tests/js/spec/views/organizationStats/index.spec.jsx
+++ b/tests/js/spec/views/organizationStats/index.spec.jsx
@@ -104,7 +104,7 @@ describe('OrganizationStats', function () {
       expect.objectContaining({
         query: {
           statsPeriod: DEFAULT_STATS_PERIOD,
-          interval: '1d',
+          interval: '1h',
           groupBy: ['outcome', 'project'],
           project: '-1',
           field: ['sum(quantity)'],

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -319,9 +319,9 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200
         assert result_sorted(response.data) == {
-            "start": "2021-03-14T00:00:00Z",
+            "start": "2021-03-13T13:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-14T00:00:00Z"],
+            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [],
         }
 
@@ -383,18 +383,18 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200
         assert result_sorted(response.data) == {
-            "start": "2021-03-14T00:00:00Z",
+            "start": "2021-03-13T13:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-14T00:00:00Z"],
+            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [
                 {
                     "by": {"project": self.project.id},
-                    "series": {"sum(quantity)": [6]},
+                    "series": {"sum(quantity)": [0]},
                     "totals": {"sum(quantity)": 6},
                 },
                 {
                     "by": {"project": self.project2.id},
-                    "series": {"sum(quantity)": [1]},
+                    "series": {"sum(quantity)": [0]},
                     "totals": {"sum(quantity)": 1},
                 },
             ],
@@ -510,19 +510,19 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200, response.content
         assert result_sorted(response.data) == {
-            "start": "2021-03-14T00:00:00Z",
+            "start": "2021-03-13T13:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-14T00:00:00Z"],
+            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [
                 {
                     "by": {"project": self.project.id},
                     "totals": {"sum(times_seen)": 6},
-                    "series": {"sum(times_seen)": [6]},
+                    "series": {"sum(times_seen)": [0]},
                 },
                 {
                     "by": {"project": self.project2.id},
                     "totals": {"sum(times_seen)": 1},
-                    "series": {"sum(times_seen)": [1]},
+                    "series": {"sum(times_seen)": [0]},
                 },
             ],
         }

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -546,7 +546,7 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         response_total = make_request(
             {
                 "statsPeriod": "1d",
-                "interval": "1d",
+                "interval": "1h",
                 "field": ["sum(times_seen)"],
                 "category": ["error", "transaction"],
             }

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -87,6 +87,17 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
                 "quantity": 1,
             }
         )
+        self.store_outcomes(
+            {
+                "org_id": self.org.id,
+                "timestamp": datetime(2021, 3, 13, 13, 30, 28, tzinfo=pytz.utc),
+                "project_id": self.project2.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.ERROR,
+                "quantity": 1,
+            }
+        )
 
     def do_request(self, query, user=None, org=None):
         self.login_as(user=user or self.user)

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -662,9 +662,9 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         )
         assert response.status_code == 200, response.content
         assert result_sorted(response.data) == {
-            "start": "2021-03-13T13:00:00Z",
+            "start": "2021-03-14T00:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-13T13:00:00Z"],
+            "intervals": ["2021-03-14T00:00:00Z"],
             "groups": [
                 {"by": {}, "totals": {"sum(quantity)": 6}, "series": {"sum(quantity)": [6]}}
             ],

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -87,17 +87,6 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
                 "quantity": 1,
             }
         )
-        self.store_outcomes(
-            {
-                "org_id": self.org.id,
-                "timestamp": datetime(2021, 3, 13, 13, 30, 28, tzinfo=pytz.utc),
-                "project_id": self.project2.id,
-                "outcome": Outcome.ACCEPTED,
-                "reason": "none",
-                "category": DataCategory.ERROR,
-                "quantity": 1,
-            }
-        )
 
     def do_request(self, query, user=None, org=None):
         self.login_as(user=user or self.user)

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -662,9 +662,9 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         )
         assert response.status_code == 200, response.content
         assert result_sorted(response.data) == {
-            "start": "2021-03-14T00:00:00Z",
+            "start": "2021-03-13T13:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-14T00:00:00Z"],
+            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [
                 {"by": {}, "totals": {"sum(quantity)": 6}, "series": {"sum(quantity)": [6]}}
             ],

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -536,7 +536,7 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
         response_per_group = make_request(
             {
                 "statsPeriod": "1d",
-                "interval": "1d",
+                "interval": "1h",
                 "field": ["sum(times_seen)"],
                 "groupBy": ["project"],
                 "category": ["error", "transaction"],

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -319,9 +319,8 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200
         assert result_sorted(response.data) == {
-            "start": "2021-03-13T13:00:00Z",
+            "start": "2021-03-14T00:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [],
         }
 
@@ -383,18 +382,15 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200
         assert result_sorted(response.data) == {
-            "start": "2021-03-13T13:00:00Z",
+            "start": "2021-03-14T00:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [
                 {
                     "by": {"project": self.project.id},
-                    "series": {"sum(quantity)": [0]},
                     "totals": {"sum(quantity)": 6},
                 },
                 {
                     "by": {"project": self.project2.id},
-                    "series": {"sum(quantity)": [0]},
                     "totals": {"sum(quantity)": 1},
                 },
             ],
@@ -510,19 +506,16 @@ class OrganizationStatsTestV2(APITestCase, OutcomesSnubaTest):
 
         assert response.status_code == 200, response.content
         assert result_sorted(response.data) == {
-            "start": "2021-03-13T13:00:00Z",
+            "start": "2021-03-14T00:00:00Z",
             "end": "2021-03-14T12:28:00Z",
-            "intervals": ["2021-03-13T13:00:00Z"],
             "groups": [
                 {
                     "by": {"project": self.project.id},
                     "totals": {"sum(times_seen)": 6},
-                    "series": {"sum(times_seen)": [0]},
                 },
                 {
                     "by": {"project": self.project2.id},
                     "totals": {"sum(times_seen)": 1},
-                    "series": {"sum(times_seen)": [0]},
                 },
             ],
         }

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -321,6 +321,32 @@ def test_massage_simple_timeseries():
     assert actual_result == expected_result
 
 
+@freeze_time("2020-12-18T11:14:17.105Z")
+def test_massage_no_timeseries():
+
+    query = _make_query("statsPeriod=1d&interval=6h&field=sum(session)&groupby=projects")
+    result_totals = [{"sessions": 4}]
+    # snuba returns the datetimes as strings for now
+    result_timeseries = None
+
+    expected_result = {
+        "start": "2020-12-17T12:00:00Z",
+        "end": "2020-12-18T11:15:00Z",
+        "query": "",
+        "intervals": [
+            "2020-12-17T12:00:00Z",
+            "2020-12-17T18:00:00Z",
+            "2020-12-18T00:00:00Z",
+            "2020-12-18T06:00:00Z",
+        ],
+        "groups": [{"by": {}, "totals": {"sum(session)": 4}}],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
+
+
 def test_massage_exact_timeseries():
     query = _make_query(
         "start=2020-12-17T15:12:34Z&end=2020-12-18T11:14:17Z&interval=6h&field=sum(session)"


### PR DESCRIPTION
On the org-stats page, there is a rounding behaviour with the start and end times of the projects sections which leads to a mismatch of information between project-wide and per-project data. 

New behavior: Orgstats project queries no longer return a timeseries interval, and change frontend to use interval solely for how to round the project total queries. Interval parameter is still used to decide how to round the dates. This is done to prevent max row errors from snuba at smaller time intervals.

The problem could be seen with the time interval of the following queries:
project_total:https://sentry.io/api/0/organizations/sentry/stats_v2/?statsPeriod=14d&interval=1h&groupBy=category&groupBy=outcome&field=sum(quantity)
per_project:https://sentry.io/api/0/organizations/sentry/stats_v2/?statsPeriod=14d&interval=1d&groupBy=outcome&groupBy=project&field=sum(quantity)&project=-1&category=error

before:
![image](https://user-images.githubusercontent.com/22259802/125341424-96e5ca80-e321-11eb-8170-fed2b0cc28b5.png)

after:
![image](https://user-images.githubusercontent.com/22259802/125341459-9e0cd880-e321-11eb-9c70-3a8ad8e63425.png)

ticket: https://getsentry.atlassian.net/browse/ER-667