### PR TITLE
fix(apidocs): add description to orgslug param in SCIM member APIs

### DIFF
--- a/api-docs/paths/scim/member_details.json
+++ b/api-docs/paths/scim/member_details.json
@@ -8,6 +8,7 @@
         "parameters": [
             {
                 "name": "organization_slug",
+                "description": "The slug of the organization.",
                 "in": "path",
                 "required": true,
                 "schema": {
@@ -81,6 +82,7 @@
         "parameters": [
             {
                 "name": "organization_slug",
+                "description": "The slug of the organization.",
                 "in": "path",
                 "required": true,
                 "schema": {
@@ -166,6 +168,7 @@
         "parameters": [
             {
                 "name": "organization_slug",
+                "description": "The slug of the organization.",
                 "in": "path",
                 "required": true,
                 "schema": {

--- a/api-docs/paths/scim/member_index.json
+++ b/api-docs/paths/scim/member_index.json
@@ -8,6 +8,7 @@
         "parameters": [
             {
                 "name": "organization_slug",
+                "description": "The slug of the organization.",
                 "in": "path",
                 "required": true,
                 "schema": {
@@ -94,6 +95,7 @@
         "parameters": [
             {
                 "name": "organization_slug",
+                "description": "The slug of the organization.",
                 "in": "path",
                 "required": true,
                 "schema": {


### PR DESCRIPTION
if an API parameter does not have a description it can break our sentry-docs build.