### PR TITLE
Fix slow commit exists query by not joining in Release model

### DIFF
--- a/src/sentry/api/endpoints/project_release_setup.py
+++ b/src/sentry/api/endpoints/project_release_setup.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
-from sentry.models import Deploy, Group, Release, ReleaseCommit, Repository
+from sentry.models import Deploy, Group, ReleaseCommit, ReleaseProject, Repository
 from sentry.utils.hashlib import hash_values
 
 
@@ -38,9 +38,9 @@ class ProjectReleaseSetupCompletionEndpoint(ProjectEndpoint):
         if commit is None:
             # only get the last 1000 releases
             release_ids = (
-                Release.objects.filter(projects=project.id)
-                .order_by("-id")
-                .values_list("id", flat=True)
+                ReleaseProject.objects.filter(project=project.id)
+                .order_by("-release_id")
+                .values_list("release_id", flat=True)
             )[:1000]
             commit = ReleaseCommit.objects.filter(
                 organization_id=project.organization_id, release__id__in=release_ids


### PR DESCRIPTION
`Release.objects.filter(projects=project.id)`  does inner join on the `ReleaseProject` and `Release` tables implicitly. We can avoid this join by using directly `ReleaseProject` to get the `release_ids`.

Before
```
getsentry=# explain analyze SELECT (1) AS "a" FROM "sentry_releasecommit" WHERE ("sentry_releasecommit"."organization_id" = % AND "sentry_releasecommit"."release_id" IN (SELECT U0."id" AS Col1 FROM "sentry_release" U0 INNER JOIN "sentry_release_project" U1 ON (U0."id" = U1."release_id") WHERE U1."project_id" = % ORDER BY U0."id" DESC LIMIT 1000)) LIMIT 1;

                                                                                                              QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.70..1159.32 rows=1 width=4) (actual time=243986.294..243986.307 rows=1 loops=1)
   ->  Nested Loop Semi Join  (cost=1.70..32891669.45 rows=28413 width=4) (actual time=243986.293..243986.293 rows=1 loops=1)
         Join Filter: (sentry_releasecommit.release_id = u0.id)
         Rows Removed by Join Filter: 2327757999
         ->  Index Only Scan using sentry_releasecommit_organization_id_release_id_jtcunning on sentry_releasecommit  (cost=0.57..56725.60 rows=2188821 width=8) (actual time=0.012..290.187 rows=2327758 loops=1)
               Index Cond: (organization_id = 23399)
               Heap Fetches: 16877
         ->  Materialize  (cost=1.13..2631.35 rows=1000 width=4) (actual time=0.000..0.039 rows=1000 loops=2327758)
               ->  Limit  (cost=1.13..2616.35 rows=1000 width=4) (actual time=0.038..6.543 rows=1000 loops=1)
                     ->  Nested Loop  (cost=1.13..5566.31 rows=2128 width=4) (actual time=0.038..6.461 rows=1000 loops=1)
                           ->  Index Only Scan Backward using sentry_release_project_project_id_35add08b8e678ec7_uniq on sentry_release_project u1  (cost=0.56..63.47 rows=2128 width=8) (actual time=0.025..1.559 rows=1000 loops=1)
                                 Index Cond: (project_id = 47546)
                                 Heap Fetches: 948
                           ->  Index Only Scan using sentry_release_id_organization_id on sentry_release u0  (cost=0.56..2.58 rows=1 width=4) (actual time=0.005..0.005 rows=1 loops=1000)
                                 Index Cond: (id = u1.release_id)
                                 Heap Fetches: 341
 Planning time: 0.866 ms
 Execution time: 243986.384 ms
```

After
```
getsentry=# explain analyze SELECT (1) AS "a" FROM "sentry_releasecommit" WHERE ("sentry_releasecommit"."organization_id" = % AND "sentry_releasecommit"."release_id" IN (SELECT U1."release_id" AS Col1 FROM "sentry_release_project" U1 WHERE U1."project_id" = % ORDER BY U1."release_id" DESC LIMIT 1000)) LIMIT 1;
                                                                                                           QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=43.19..43.32 rows=1 width=4) (actual time=18.002..18.003 rows=1 loops=1)
   ->  Nested Loop  (cost=43.19..752.05 rows=5881 width=4) (actual time=18.001..18.001 rows=1 loops=1)
         ->  HashAggregate  (cost=42.63..44.70 rows=207 width=8) (actual time=17.882..17.883 rows=1 loops=1)
               Group Key: u1.release_id
               ->  Limit  (cost=0.56..30.13 rows=1000 width=8) (actual time=0.148..17.497 rows=1000 loops=1)
                     ->  Index Only Scan Backward using sentry_release_project_project_id_35add08b8e678ec7_uniq on sentry_release_project u1  (cost=0.56..63.47 rows=2128 width=8) (actual time=0.148..17.400 rows=1000 loops=1)
                           Index Cond: (project_id = 47546)
                           Heap Fetches: 948
         ->  Index Only Scan using sentry_releasecommit_organization_id_release_id_jtcunning on sentry_releasecommit  (cost=0.57..3.14 rows=28 width=8) (actual time=0.110..0.110 rows=1 loops=1)
               Index Cond: ((organization_id = 23399) AND (release_id = u1.release_id))
               Heap Fetches: 0
 Planning time: 0.624 ms
 Execution time: 18.046 ms
```