### PR TITLE
fix(perf): Fix tag key not being selected

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 
 import {SectionHeading} from 'app/components/charts/styles';
 import SearchBar from 'app/components/events/searchBar';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import QuestionTooltip from 'app/components/questionTooltip';
 import Radio from 'app/components/radio';
@@ -97,7 +98,7 @@ function getTagKeyOptions(tableData: TableData) {
 const InnerContent = (
   props: Props & {tableData: TableData | null; isLoading?: boolean}
 ) => {
-  const {eventView: _eventView, location, organization, tableData} = props;
+  const {eventView: _eventView, location, organization, tableData, isLoading} = props;
   const eventView = _eventView.clone();
 
   const tagOptions = tableData ? getTagKeyOptions(tableData) : null;
@@ -111,13 +112,7 @@ const InnerContent = (
     ? allTags.find(tag => tag === decodedTagKey)
     : undefined;
 
-  const defaultTag = tagOptions
-    ? tagOptions.suspectTags.length
-      ? tagOptions.suspectTags[0]
-      : tagOptions.otherTags.length
-      ? tagOptions.otherTags[0]
-      : ''
-    : '';
+  const defaultTag = allTags.length ? allTags[0] : undefined;
 
   const initialTag = decodedTagFromOptions ?? defaultTag;
 
@@ -137,10 +132,10 @@ const InnerContent = (
   };
 
   useEffect(() => {
-    if (!decodedTagFromOptions && initialTag) {
+    if (initialTag) {
       changeTagSelected(initialTag);
     }
-  }, [decodedTagFromOptions, initialTag]);
+  }, [initialTag]);
 
   const handleSearch = (query: string) => {
     const queryParams = getParams({
@@ -170,6 +165,7 @@ const InnerContent = (
         otherTags={otherTags}
         tagSelected={tagSelected}
         changeTag={changeTag}
+        isLoading={isLoading}
       />
       <StyledMain>
         <StyledActions>
@@ -188,12 +184,13 @@ const InnerContent = (
 };
 
 const TagsSideBar = (props: {
-  tagSelected: string;
+  tagSelected?: string;
   changeTag: (tag: string) => void;
   suspectTags: TagOption[];
   otherTags: TagOption[];
+  isLoading?: boolean;
 }) => {
-  const {suspectTags, otherTags, changeTag, tagSelected} = props;
+  const {suspectTags, otherTags, changeTag, tagSelected, isLoading} = props;
   return (
     <StyledSide>
       <StyledSectionHeading>
@@ -204,7 +201,11 @@ const TagsSideBar = (props: {
           size="sm"
         />
       </StyledSectionHeading>
-      {suspectTags.length ? (
+      {isLoading ? (
+        <Center>
+          <LoadingIndicator mini />
+        </Center>
+      ) : suspectTags.length ? (
         suspectTags.map(tag => (
           <RadioLabel key={tag}>
             <Radio
@@ -229,7 +230,11 @@ const TagsSideBar = (props: {
         />
       </StyledSectionHeading>
 
-      {otherTags.length ? (
+      {isLoading ? (
+        <Center>
+          <LoadingIndicator mini />
+        </Center>
+      ) : otherTags.length ? (
         otherTags.map(tag => (
           <RadioLabel key={tag}>
             <Radio
@@ -246,6 +251,12 @@ const TagsSideBar = (props: {
     </StyledSide>
   );
 };
+
+const Center = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
 
 const RadioLabel = styled('label')`
   cursor: pointer;

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {withTheme} from '@emotion/react';
 import {Location} from 'history';
 
+import Placeholder from 'app/components/placeholder';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import SegmentExplorerQuery from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
@@ -19,7 +20,7 @@ type Props = {
   organization: Organization;
   projects: Project[];
   transactionName: string;
-  tagKey: string;
+  tagKey?: string;
 };
 
 const HISTOGRAM_TAG_KEY_LIMIT = 8;
@@ -34,48 +35,56 @@ const TagsDisplay = (props: Props) => {
   );
   return (
     <React.Fragment>
-      <TagKeyHistogramQuery
-        eventView={eventView}
-        orgSlug={organization.slug}
-        location={location}
-        aggregateColumn={aggregateColumn}
-        tagKeyLimit={HISTOGRAM_TAG_KEY_LIMIT}
-        numBucketsPerKey={HISTOGRAM_BUCKET_LIMIT}
-        tagKey={tagKey}
-        sort="-frequency"
-      >
-        {({isLoading, tableData}) => {
-          return (
-            <TagsHeatMap
-              {...props}
-              aggregateColumn={aggregateColumn}
-              tableData={tableData}
-              isLoading={isLoading}
-            />
-          );
-        }}
-      </TagKeyHistogramQuery>
-      <SegmentExplorerQuery
-        eventView={eventView}
-        orgSlug={organization.slug}
-        location={location}
-        aggregateColumn={aggregateColumn}
-        tagKey={tagKey}
-        limit={HISTOGRAM_TAG_KEY_LIMIT}
-        sort="-frequency"
-        allTagKeys
-      >
-        {({isLoading, tableData}) => {
-          return (
-            <TagValueTable
-              {...props}
-              aggregateColumn={aggregateColumn}
-              tableData={tableData}
-              isLoading={isLoading}
-            />
-          );
-        }}
-      </SegmentExplorerQuery>
+      {tagKey ? (
+        <React.Fragment>
+          <TagKeyHistogramQuery
+            eventView={eventView}
+            orgSlug={organization.slug}
+            location={location}
+            aggregateColumn={aggregateColumn}
+            tagKeyLimit={HISTOGRAM_TAG_KEY_LIMIT}
+            numBucketsPerKey={HISTOGRAM_BUCKET_LIMIT}
+            tagKey={tagKey}
+            sort="-frequency"
+          >
+            {({isLoading, tableData}) => {
+              return (
+                <TagsHeatMap
+                  {...props}
+                  tagKey={tagKey}
+                  aggregateColumn={aggregateColumn}
+                  tableData={tableData}
+                  isLoading={isLoading}
+                />
+              );
+            }}
+          </TagKeyHistogramQuery>
+          <SegmentExplorerQuery
+            eventView={eventView}
+            orgSlug={organization.slug}
+            location={location}
+            aggregateColumn={aggregateColumn}
+            tagKey={tagKey}
+            limit={HISTOGRAM_TAG_KEY_LIMIT}
+            sort="-frequency"
+            allTagKeys
+          >
+            {({isLoading, tableData}) => {
+              return (
+                <TagValueTable
+                  {...props}
+                  tagKey={tagKey}
+                  aggregateColumn={aggregateColumn}
+                  tableData={tableData}
+                  isLoading={isLoading}
+                />
+              );
+            }}
+          </SegmentExplorerQuery>
+        </React.Fragment>
+      ) : (
+        <Placeholder height="290" />
+      )}
     </React.Fragment>
   );
 };

--- a/tests/js/spec/views/performance/transactionTags/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.jsx
@@ -29,8 +29,11 @@ function initializeData({query} = {query: {}}) {
 }
 
 describe('Performance > Transaction Tags', function () {
+  let histogramMock;
+  let wrapper;
+
   beforeEach(function () {
-    browserHistory.push = jest.fn();
+    browserHistory.replace = jest.fn();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',
       body: [],
@@ -69,10 +72,19 @@ describe('Performance > Transaction Tags', function () {
             comparison: 1.45,
             aggregate: 2000.5,
           },
+          {
+            tags_key: 'effectiveConnectionType',
+            tags_value: '4g',
+            sumdelta: 45773.0,
+            count: 83,
+            frequency: 0.05,
+            comparison: 1.45,
+            aggregate: 2000.5,
+          },
         ],
       },
     });
-    MockApiClient.addMockResponse({
+    histogramMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-facets-performance-histogram/',
       body: {
         meta: {
@@ -94,13 +106,15 @@ describe('Performance > Transaction Tags', function () {
   });
 
   afterEach(function () {
+    wrapper.unmount();
+    histogramMock.mockReset();
     MockApiClient.clearMockResponses();
     ProjectsStore.reset();
   });
 
   it('renders basic UI elements', async function () {
     const initialData = initializeData();
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <TransactionTags
         organization={initialData.organization}
         location={initialData.router.location}
@@ -108,6 +122,7 @@ describe('Performance > Transaction Tags', function () {
       initialData.routerContext
     );
 
+    await tick();
     await tick();
     wrapper.update();
 
@@ -120,16 +135,25 @@ describe('Performance > Transaction Tags', function () {
     // It shows the tag display
     expect(wrapper.find('TagsDisplay')).toHaveLength(1);
 
-    // It shows the tag chart
-    expect(wrapper.find('TagsHeatMap')).toHaveLength(1);
+    expect(browserHistory.replace).toHaveBeenCalledWith({
+      query: {
+        project: 1,
+        statsPeriod: '14d',
+        tagKey: 'hardwareConcurrency',
+        transaction: 'Test Transaction',
+      },
+    });
 
     // It shows a table
     expect(wrapper.find('GridEditable')).toHaveLength(1);
+
+    // It shows the tag chart
+    expect(wrapper.find('TagsHeatMap')).toHaveLength(1);
   });
 
   it('Default tagKey is set when loading the page without one', async function () {
     const initialData = initializeData();
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <TransactionTags
         organization={initialData.organization}
         location={initialData.router.location}
@@ -137,6 +161,7 @@ describe('Performance > Transaction Tags', function () {
       initialData.routerContext
     );
 
+    await tick();
     await tick();
     wrapper.update();
 
@@ -151,5 +176,57 @@ describe('Performance > Transaction Tags', function () {
         transaction: 'Test Transaction',
       },
     });
+
+    expect(histogramMock).toHaveBeenCalledTimes(1);
+    expect(histogramMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          statsPeriod: '14d',
+          tagKey: 'hardwareConcurrency',
+        }),
+      })
+    );
+  });
+
+  it('Passed tagKey gets used when calling queries', async function () {
+    const initialData = initializeData({query: {tagKey: 'effectiveConnectionType'}});
+
+    wrapper = mountWithTheme(
+      <TransactionTags
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+
+    await tick();
+    await tick();
+    wrapper.update();
+
+    // Table is loaded.
+    expect(wrapper.find('GridEditable')).toHaveLength(1);
+
+    expect(browserHistory.replace).toHaveBeenCalledWith({
+      query: {
+        project: 1,
+        statsPeriod: '14d',
+        tagKey: 'effectiveConnectionType',
+        transaction: 'Test Transaction',
+      },
+    });
+
+    expect(histogramMock).toHaveBeenCalledTimes(1);
+    expect(histogramMock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          statsPeriod: '14d',
+          tagKey: 'effectiveConnectionType',
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION
### Summary
Clicking on a tag key from the transaction summary would take you to the tag page but wouldn't select the tag key from the sidebar and the heatmap would fail to load. This allows the tag key to temporarily be empty while still showing empty state before the tag key loads in.