### PR TITLE
fix(ui): Change Button text "Login" to "Sign In"

### DIFF
--- a/src/sentry/templates/sentry/auth-confirm-identity.html
+++ b/src/sentry/templates/sentry/auth-confirm-identity.html
@@ -49,7 +49,7 @@
       {% endfor %}
 
       <fieldset class="form-actions">
-        <button type="submit" class="btn btn-primary" name="op" value="login">{% trans "Login" %}</button>
+        <button type="submit" class="btn btn-primary" name="op" value="login">{% trans "Sign In" %}</button>
         <a class="pull-right" style="margin-top: 9px" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
       </fieldset>
     </form>

--- a/src/sentry/templates/sentry/auth-link-login.html
+++ b/src/sentry/templates/sentry/auth-link-login.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load sentry_assets %}
 
-{% block title %}{% trans "Login" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans "Sign In" %} | {{ block.super }}{% endblock %}
 
 {% block auth_main %}
   <div class="align-center p-b-1">
@@ -28,7 +28,7 @@
     {% endfor %}
 
     <fieldset class="form-actions">
-      <button type="submit" class="btn btn-primary">{% trans "Login" %}</button> <a class="pull-right" style="margin-top: 9px" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
+      <button type="submit" class="btn btn-primary">{% trans "Sign In" %}</button> <a class="pull-right" style="margin-top: 9px" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
     </fieldset>
   </form>
 {% endblock %}

--- a/src/sentry/templates/sentry/login.html
+++ b/src/sentry/templates/sentry/login.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
 
-{% block title %}{% trans "Login" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans "Sign In" %} | {{ block.super }}{% endblock %}
 
 {% block auth_container %}
   {% if banner %}
@@ -14,7 +14,7 @@
     <h3>{% trans "Sign in to continue" %}</h3>
     <ul class="nav nav-tabs auth-toggle m-b-0">
       <li{% if op == "login" %} class="active"{% endif %}>
-        <a href="#login" data-toggle="tab">{% trans "Login" %}</a>
+        <a href="#login" data-toggle="tab">{% trans "Sign In" %}</a>
       </li>
       {% if CAN_REGISTER %}
         <li{% if op == "register" %} class="active"{% endif %}>

--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -19,7 +19,7 @@
 {% endscript %}
 {% endblock %}
 
-{% block title %}{% trans "Login" %} | {{ block.super }}{% endblock %}
+{% block title %}{% trans "Sign In" %} | {{ block.super }}{% endblock %}
 
 {% block auth_container %}
 <div>
@@ -51,7 +51,7 @@
     <div class="auth-container p-t-0 border-bottom">
       <ul class="nav nav-tabs auth-toggle m-b-0">
         <li{% if op == "login" %} class="active"{% endif %}>
-          <a href="#login" data-toggle="tab">{% trans "Login" %}</a>
+          <a href="#login" data-toggle="tab">{% trans "Sign In" %}</a>
         </li>
         {% if CAN_REGISTER %}
           <li{% if op == "register" %} class="active"{% endif %}>
@@ -85,7 +85,7 @@
               {% endfor %}
 
               <div class="auth-footer m-t-1">
-                <button type="submit" class="btn btn-primary">{% trans "Login" %}</button>
+                <button type="submit" class="btn btn-primary">{% trans "Sign In" %}</button>
                 <a class="secondary" href="{% url 'sentry-account-recover' %}">{% trans "Lost your password?" %}</a>
               </div>
             </form>


### PR DESCRIPTION
https://twitter.com/itisJames/status/1412014346289418241

This PR changed "Login" to "Sign In" on related pages, including the button, the browser tab titles, and the tab component titles.
