### PR TITLE
feat(performance): Make txn name obvious in threshold modal

### DIFF
--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactRouter from 'react-router';
 import {Location, LocationDescriptorObject} from 'history';
 
+import {addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
 import {fetchLegacyKeyTransactionsCount} from 'app/actionCreators/performance';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
@@ -11,6 +12,7 @@ import Link from 'app/components/links/link';
 import Pagination from 'app/components/pagination';
 import Tooltip from 'app/components/tooltip';
 import {IconStar} from 'app/icons';
+import {tct} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -126,6 +128,11 @@ class Table extends React.Component<Props, State> {
                     transactionThresholdMetric: metric,
                   });
                 }
+                addSuccessMessage(
+                  tct('[transactionName] updated successfully', {
+                    transactionName,
+                  })
+                );
               }}
             />
           ),

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.tsx
@@ -22,6 +22,8 @@ import withProjects from 'app/utils/withProjects';
 import Input from 'app/views/settings/components/forms/controls/input';
 import Field from 'app/views/settings/components/forms/field';
 
+import {transactionSummaryRouteWithQuery} from './utils';
+
 export enum TransactionThresholdMetric {
   TRANSACTION_DURATION = 'duration',
   LARGEST_CONTENTFUL_PAINT = 'lcp',
@@ -229,9 +231,18 @@ class TransactionThresholdModal extends React.Component<Props, State> {
   }
 
   render() {
-    const {Header, Body, Footer, organization} = this.props;
+    const {Header, Body, Footer, organization, transactionName, eventView} = this.props;
 
     const project = this.getProject();
+
+    const summaryView = eventView.clone();
+    summaryView.query = summaryView.getQueryWithAdditionalConditions();
+    const target = transactionSummaryRouteWithQuery({
+      orgSlug: organization.slug,
+      transaction: transactionName,
+      query: summaryView.generateQueryStringObject(),
+      projectID: project?.id,
+    });
 
     return (
       <React.Fragment>
@@ -243,8 +254,9 @@ class TransactionThresholdModal extends React.Component<Props, State> {
         <Body>
           <Instruction>
             {tct(
-              'The changes below will only be applied to this Transaction. To set it at a more global level, go to [projectSettings: Project Settings].',
+              'The changes below will only be applied to [transaction]. To set it at a more global level, go to [projectSettings: Project Settings].',
               {
+                transaction: <Link to={target}>{transactionName}</Link>,
                 projectSettings: (
                   <Link
                     to={`/settings/${organization.slug}/projects/${project?.slug}/performance/`}


### PR DESCRIPTION
Add the transaction name to thre transaction threshold modal
and a success toast with the transaction name when threshold
is updated from the perf landing page.

Screenshots:

<img width="646" alt="Screen Shot 2021-07-12 at 5 12 08 PM" src="https://user-images.githubusercontent.com/63818634/125357692-f3eb7b80-e335-11eb-80a9-a0301c0befb5.png">

<img width="416" alt="Screen Shot 2021-07-12 at 5 12 20 PM" src="https://user-images.githubusercontent.com/63818634/125357700-f64dd580-e335-11eb-8ee8-0a60a02eac32.png">
