### PR TITLE
fix(scim): replace TODO with product doc link

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -78,7 +78,7 @@
     {
       "name": "SCIM",
       "x-sidebar-name": "SCIM (Beta)",
-      "description": "System for Cross-Domain Identity Management ([SCIM](http://www.simplecloud.info/)) is a standard implemented by Identity Providers and applications in order to facilitate federated identity management. Through these APIs you can add and delete members as well as teams. Sentry SaaS customers must be on a Business Plan with SAML2 Enabled. SCIM uses a bearer token for authentication that is created when SCIM is enabled. For how to enable SCIM, see our docs [here](TODO).\n Sentry's SCIM API does not currently support syncing passwords, or setting any User attributes other than `active`.",
+      "description": "System for Cross-Domain Identity Management ([SCIM](http://www.simplecloud.info/)) is a standard implemented by Identity Providers and applications in order to facilitate federated identity management. Through these APIs you can add and delete members as well as teams. Sentry SaaS customers must be on a Business Plan with SAML2 Enabled. SCIM uses a bearer token for authentication that is created when SCIM is enabled. For how to enable SCIM, see our docs [here](/product/accounts/sso/#scim-provisioning).\n Sentry's SCIM API does not currently support syncing passwords, or setting any User attributes other than `active`.",
       "x-display-description": true,
       "externalDocs": {
         "description": "Found an error? Let us know.",


### PR DESCRIPTION
now the product docs exist, use the right link. (note the description is not being displayed until https://github.com/getsentry/sentry-docs/pull/3827 is merged)