### PR TITLE
feat(search): Add improved search experiment

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -34,6 +34,7 @@ import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import withApi from 'app/utils/withApi';
+import withExperiment from 'app/utils/withExperiment';
 import withOrganization from 'app/utils/withOrganization';
 
 import {ActionButton} from './actions';
@@ -224,6 +225,10 @@ type Props = WithRouterProps & {
    * trigger re-renders.
    */
   members?: User[];
+  /**
+   * Tracks whether the experiment for improved search is active or not
+   */
+  experimentAssignment: 0 | 1;
 };
 
 type State = {
@@ -324,7 +329,10 @@ class SmartSearchBar extends React.Component<Props, State> {
   }
 
   get hasImprovedSearch() {
-    return this.props.organization.features.includes('improved-search');
+    return (
+      this.props.organization.features.includes('improved-search') ||
+      !!this.props.experimentAssignment
+    );
   }
 
   get initialQuery() {
@@ -1424,7 +1432,14 @@ class SmartSearchBarContainer extends React.Component<Props, ContainerState> {
   }
 }
 
-export default withApi(withRouter(withOrganization(SmartSearchBarContainer)));
+const SmartSearchBarContainerWithExperiment = withExperiment(SmartSearchBarContainer, {
+  experiment: 'ImprovedSearchExperiment',
+});
+
+export default withApi(
+  withRouter(withOrganization(SmartSearchBarContainerWithExperiment))
+);
+
 export {SmartSearchBar};
 
 const Container = styled('div')<{isOpen: boolean}>`

--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -19,6 +19,12 @@ export const experimentList = [
     parameter: 'exposed',
     assignments: [0, 1],
   },
+  {
+    key: 'ImprovedSearchExperiment',
+    type: ExperimentType.Organization,
+    parameter: 'exposed',
+    assignments: [0, 1],
+  },
 ] as const;
 
 export const experimentConfig = experimentList.reduce(

--- a/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
@@ -15,6 +15,7 @@ jest.mock('app/utils/analytics', () => ({
     })),
     endTransaction: jest.fn(),
   },
+  logExperiment: jest.fn(),
 }));
 
 describe('Incident Rules Details', function () {

--- a/tests/js/spec/views/alerts/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/ruleForm.spec.jsx
@@ -15,6 +15,7 @@ jest.mock('app/utils/analytics', () => ({
     })),
     endTransaction: jest.fn(),
   },
+  logExperiment: jest.fn(),
 }));
 
 describe('Incident Rules Form', function () {


### PR DESCRIPTION
Uses https://github.com/getsentry/getsentry/pull/5899 and `withExperiment` to conditionally toggle the new search experiment based on feature flags and A/B test assignment.