### PR TITLE
ref(notification platform): Add unlink team to help text

### DIFF
--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -16,7 +16,8 @@ DM_COMMANDS = {
     "help": "View this list of commands.",
 }
 CHANNEL_COMMANDS = {
-    "link team": "Get your Sentry team's issue alert notifications in the channel this command is typed in."
+    "link team": "Get your Sentry team's issue alert notifications in the channel this command is typed in.",
+    "unlink team": "Unlink a team from the channel this command is typed in.",
 }
 CONTACT_MESSAGE = "Let us know if you have feedback: ecosystem-feedback@sentry.io"
 


### PR DESCRIPTION
I added the `/sentry unlink team` command in https://github.com/getsentry/sentry/pull/27118 but forgot to add this to the help text - this PR just adds a line of text to the help text to let users know about unlinking a team. 
<img width="764" alt="Screen Shot 2021-07-12 at 5 09 09 PM" src="https://user-images.githubusercontent.com/29959063/125370687-e03f1580-e333-11eb-8e9a-38613c4a4b0d.png">
