### PR TITLE
feat(semver): Add queryset method to filter releases by semver build

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -148,7 +148,7 @@ class ReleaseQuerySet(models.QuerySet):
                 )
             )
 
-        if build.isnumeric():
+        if build.isnumeric() and validate_bigint(int(build)):
             qs = qs.filter(**{f"build_number__{operator}": int(build)})
         else:
             if not build or build.endswith("*"):

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -133,6 +133,12 @@ class ReleaseQuerySet(models.QuerySet):
     def filter_by_semver_build(
         self, organization_id: int, operator: str, build: str, project_ids: Sequence[int] = None
     ) -> models.QuerySet:
+        """
+        Filters released by build. If the passed `build` is a numeric string, we'll filter on
+        `build_number` and make use of the passed operator.
+        If it is a non-numeric string, then we'll filter on `build_code` instead. We support a
+        wildcard only at the end of this string, so that we can filter efficiently via the index.
+        """
         qs = self.filter(organization_id=organization_id)
 
         if project_ids:
@@ -159,7 +165,7 @@ class ReleaseQuerySet(models.QuerySet):
         project_ids: Sequence[int] = None,
     ) -> models.QuerySet:
         """
-        Filters released based on a based `SemverFilter` instance.
+        Filters releases based on a based `SemverFilter` instance.
         `SemverFilter.version_parts` can contain up to 6 components, which should map
         to the columns defined in `Release.SEMVER_COLS`. If fewer components are
         included, then we will exclude later columns from the filter.

--- a/src/sentry/utils/numbers.py
+++ b/src/sentry/utils/numbers.py
@@ -92,3 +92,7 @@ def format_grouped_length(length: int, steps: Optional[List[int]] = None) -> str
             return f"<{step}"
 
     return f">{steps[-1]}"
+
+
+def validate_bigint(value):
+    return isinstance(value, int) and value >= 0 and value.bit_length() <= 63

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -918,6 +918,14 @@ class ReleaseFilterBySemverBuildTest(TestCase):
         self.run_test("lte", "123", [release_1])
         self.run_test("exact", "123", [release_1])
 
+    def test_large_numeric(self):
+        release_1 = self.create_release(version="test@1.2.3+9223372036854775808")
+        self.create_release(version="test@1.2.3+9223372036854775809")
+
+        # This should only return `release_1`, since this exceeds the max size for a bigint and
+        # so should fall back to an exact string match instead.
+        self.run_test("gt", "9223372036854775808", [release_1])
+
     def test_text(self):
         release_1 = self.create_release(version="test@1.2.3+123")
         release_2 = self.create_release(version="test@1.2.4+1234")


### PR DESCRIPTION
This adds a queryset method to allow us to filter by semver build. If the passed string is numeric,
we attempt to filter on `build_number`. Otherwise we attempt to filter on `build_code`.

It might make sense to move the parsing logic out of this function, but leaving for now so that we
can get this functionality in place.