### PR TITLE
fix(ui): Fix smartSearchBar reset from outside

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -314,9 +314,9 @@ class SmartSearchBar extends React.Component<Props, State> {
     const {query} = this.props;
     const {query: lastQuery} = prevProps;
 
-    if (query !== lastQuery && defined(query)) {
+    if (query !== lastQuery && (defined(query) || defined(lastQuery))) {
       // eslint-disable-next-line react/no-did-update-set-state
-      this.setState(makeQueryState(addSpace(query)));
+      this.setState(makeQueryState(addSpace(query ?? undefined)));
     }
   }
 

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -234,6 +234,22 @@ describe('SmartSearchBar', function () {
       expect(searchBar.state().query).toEqual('two ');
     });
 
+    it('should update state.query if props.query is updated to null/undefined from outside', function () {
+      const searchBar = mountWithTheme(
+        <SmartSearchBar
+          organization={organization}
+          location={location}
+          supportedTags={supportedTags}
+          query="one"
+        />,
+        options
+      );
+
+      searchBar.setProps({query: null});
+
+      expect(searchBar.state().query).toEqual('');
+    });
+
     it('should not reset user textarea if a noop props change happens', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar


### PR DESCRIPTION
Fixes a bug where smart search did not update its internal state when clearing query from outside.

https://user-images.githubusercontent.com/9060071/125430162-017471b8-346d-49dc-9197-b6a89cf291ed.mp4

