### PR TITLE
fix(ui): removed double panel from user feedback tab

### DIFF
--- a/static/app/views/organizationGroupDetails/groupUserFeedback.tsx
+++ b/static/app/views/organizationGroupDetails/groupUserFeedback.tsx
@@ -6,7 +6,6 @@ import EventUserFeedback from 'app/components/events/userFeedback';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
-import {Panel} from 'app/components/panels';
 import {Group, Organization, Project, UserReport} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 import UserFeedbackEmpty from 'app/views/userFeedback/userFeedbackEmpty';
@@ -110,11 +109,7 @@ class GroupUserFeedback extends Component<Props, State> {
       );
     }
 
-    return (
-      <Panel>
-        <UserFeedbackEmpty projectIds={[group.project.id]} />
-      </Panel>
-    );
+    return <UserFeedbackEmpty projectIds={[group.project.id]} />;
   }
 }
 


### PR DESCRIPTION
Duplicated panel inside user feedback tab

## Before

![CleanShot 2021-07-13 at 09 18 43](https://user-images.githubusercontent.com/1900676/125492343-772a96f3-8b64-4757-82fc-bd26f8369b35.png)

## After
![CleanShot 2021-07-13 at 09 18 19](https://user-images.githubusercontent.com/1900676/125492367-1b657a33-11c6-4081-b71f-62abf51805c4.png)
