### PR TITLE
feat(releases): Hide adoption stage labels if > 1 environment is selected

### DIFF
--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -54,11 +54,13 @@ type Props = {
   showPlaceholders: boolean;
   isTopRelease: boolean;
   getHealthData: ReleaseHealthRequestRenderProps['getHealthData'];
+  showAdoptionStageLabels: boolean;
   adoptionStages?: Release['adoptionStages'];
 };
 
 const Content = ({
   projects,
+  showAdoptionStageLabels,
   adoptionStages,
   releaseVersion,
   location,
@@ -68,7 +70,8 @@ const Content = ({
   isTopRelease,
   getHealthData,
 }: Props) => {
-  const hasAdoptionStages: boolean = adoptionStages !== undefined;
+  const hasAdoptionStages: boolean =
+    showAdoptionStageLabels && adoptionStages !== undefined;
   return (
     <Fragment>
       <Header>
@@ -83,7 +86,7 @@ const Content = ({
               {t('Adoption')}
             </GuideAnchor>
           </AdoptionColumn>
-          {adoptionStages && (
+          {hasAdoptionStages && (
             <AdoptionStageColumn>{t('Adoption Stage')}</AdoptionStageColumn>
           )}
           <CountColumn>
@@ -148,9 +151,9 @@ const Content = ({
               timeSeries[0].data.some(item => item.value > 0);
 
             const adoptionStage =
-              adoptionStages &&
-              adoptionStages[project.slug] &&
-              adoptionStages[project.slug].stage;
+              hasAdoptionStages &&
+              adoptionStages?.[project.slug] &&
+              adoptionStages?.[project.slug].stage;
 
             return (
               <ProjectRow key={`${releaseVersion}-${slug}-health`}>
@@ -177,9 +180,9 @@ const Content = ({
                     )}
                   </AdoptionColumn>
 
-                  {adoptionStages && (
+                  {hasAdoptionStages && (
                     <AdoptionStageColumn>
-                      {adoptionStages[project.slug] ? (
+                      {adoptionStages?.[project.slug] ? (
                         <Tag type={ADOPTION_STAGE_LABELS[adoptionStage].type}>
                           {ADOPTION_STAGE_LABELS[adoptionStage].name}
                         </Tag>

--- a/static/app/views/releases/list/releaseHealth/index.tsx
+++ b/static/app/views/releases/list/releaseHealth/index.tsx
@@ -76,6 +76,7 @@ class ReleaseHealth extends Component<Props> {
           organization={organization}
           activeDisplay={activeDisplay}
           releaseVersion={release.version}
+          showAdoptionStageLabels={selection.environments.length === 1}
           adoptionStages={release.adoptionStages}
           projects={projectsToShow}
           location={location}

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -13,6 +13,7 @@ describe('ReleasesList', function () {
     organization,
     selection: {
       projects: [],
+      environments: [],
       datetime: {
         period: '14d',
       },
@@ -368,7 +369,7 @@ describe('ReleasesList', function () {
       ],
     });
     const healthSection = mountWithTheme(
-      <ReleasesList {...props} selection={{projects: [2]}} />,
+      <ReleasesList {...props} selection={{...props.selection, projects: [2]}} />,
       routerContext
     ).find('ReleaseHealth');
     const hiddenProjectsMessage = healthSection.find('HiddenProjectsMessage');
@@ -388,7 +389,7 @@ describe('ReleasesList', function () {
       body: [TestStubs.Release({version: '2.0.0'})],
     });
     const healthSection = mountWithTheme(
-      <ReleasesList {...props} selection={{projects: [-1]}} />,
+      <ReleasesList {...props} selection={{...props.selection, projects: [-1]}} />,
       routerContext
     ).find('ReleaseHealth');
 


### PR DESCRIPTION
This adds a check to release health to hide the adoption stage labels unless exactly 1 environment is selected (if 0 is selected it is treated as "All Environments").

Jira: [WOR-1077](https://getsentry.atlassian.net/browse/WOR-1077)