### PR TITLE
feat(search): Add discover search failed analytics

### DIFF
--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -6,7 +6,7 @@ import {Client} from 'app/api';
 import Pagination from 'app/components/pagination';
 import {t} from 'app/locale';
 import {Organization, TagCollection} from 'app/types';
-import {metric} from 'app/utils/analytics';
+import {metric, trackAnalyticsEvent} from 'app/utils/analytics';
 import {TableData} from 'app/utils/discover/discoverQuery';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import Measurements from 'app/utils/measurements/measurements';
@@ -145,6 +145,16 @@ class Table extends PureComponent<TableProps, TableState> {
           pageLinks: null,
           tableData: null,
         });
+
+        trackAnalyticsEvent({
+          eventKey: 'discover_search.failed',
+          eventName: 'Discover Search: Failed',
+          organization_id: this.props.organization.id,
+          search_type: 'events',
+          search_source: 'discover_search',
+          error: message,
+        });
+
         setError(message, err.status);
       });
   };


### PR DESCRIPTION
Reports failed discover queries. Will be useful to track failures with the new search bar