### PR TITLE
ref(slack): Update Slack app scopes on install

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -87,6 +87,14 @@ class SlackIntegrationProvider(IntegrationProvider):
             "im:history",
             "chat:write.public",
             "chat:write.customize",
+            "commands",
+        ]
+    )
+    user_scopes = frozenset(
+        [
+            "links:read",
+            "users:read",
+            "users:read.email",
         ]
     )
 
@@ -95,7 +103,7 @@ class SlackIntegrationProvider(IntegrationProvider):
     def get_pipeline_views(self):
         identity_pipeline_config = {
             "oauth_scopes": self.identity_oauth_scopes,
-            "user_scopes": frozenset(["links:read"]),
+            "user_scopes": self.user_scopes,
             "redirect_url": absolute_uri("/extensions/slack/setup/"),
         }
 

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -41,7 +41,7 @@ class SlackIntegrationTest(IntegrationTestCase):
         assert params["response_type"] == ["code"]
         assert params["client_id"] == [expected_client_id]
 
-        assert params.get("user_scope") == ["links:read"]
+        assert params.get("user_scope") == [" ".join(self.provider.user_scopes)]
         # once we've asserted on it, switch to a singular values to make life
         # easier
         authorize_params = {k: v[0] for k, v in params.items()}


### PR DESCRIPTION
Add the new Slack app scopes so that when a users installs or re-installs they can use the new features.