### PR TITLE
feat(workflow): Preserve display param when switching projects

### DIFF
--- a/static/app/views/issueList/displayOptions.tsx
+++ b/static/app/views/issueList/displayOptions.tsx
@@ -73,7 +73,11 @@ const IssueListDisplayOptions = ({
               )
             : null
         }
-        label={getDisplayLabel(display)}
+        label={
+          !hasSessions || hasMultipleProjectsSelected
+            ? getDisplayLabel(IssueDisplayOptions.EVENTS)
+            : getDisplayLabel(display)
+        }
       >
         <React.Fragment>
           {getMenuItem(IssueDisplayOptions.EVENTS)}

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -89,7 +89,9 @@ class IssueListFilters extends React.Component<Props> {
                 onDisplayChange={onDisplayChange}
                 display={display}
                 hasSessions={hasSessions}
-                hasMultipleProjectsSelected={selectedProjects.length !== 1}
+                hasMultipleProjectsSelected={
+                  selectedProjects.length !== 1 || selectedProjects[0] === -1
+                }
               />
             </Feature>
             <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -227,8 +227,11 @@ class IssueListOverview extends React.Component<Props, State> {
     if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
       this.fetchMemberList();
       this.fetchTags();
-      if (this.getDisplay() !== DEFAULT_DISPLAY) {
-        this.transitionTo({display: DEFAULT_DISPLAY});
+      // Reset display when selecting multiple projects
+      const projects = this.props.selection.projects ?? [];
+      const hasMultipleProjects = projects.length !== 1 || projects[0] === -1;
+      if (hasMultipleProjects && this.getDisplay() !== DEFAULT_DISPLAY) {
+        this.transitionTo({display: undefined});
       }
     }
 


### PR DESCRIPTION
we were resetting the query parameter before because the new project may not have session data, instead now we'll let the backend failover and correct what is displayed in the ui