### PR TITLE
feat(semver): Add secondary order to semver sort on release endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -262,7 +262,14 @@ class OrganizationReleasesEndpoint(
             paginator_kwargs["order_by"] = "-build_number"
         elif sort == "semver":
             order_by = [f"-{col}" for col in Release.SEMVER_COLS]
-            queryset = queryset.annotate_prerelease_column().filter_to_semver().order_by(*order_by)
+            # TODO: Adding this extra sort order breaks index usage. Index usage is already broken
+            # when we filter by status, so when we fix that we should also consider the best way to
+            # make this work as expected.
+            queryset = (
+                queryset.annotate_prerelease_column()
+                .filter_to_semver()
+                .order_by(*order_by, "-date_added")
+            )
             paginator_kwargs["order_by"] = order_by
         elif sort in self.SESSION_SORTS:
             if not flatten:

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -156,17 +156,19 @@ class OrganizationReleaseListTest(APITestCase):
     def test_release_list_order_by_semver(self):
         self.login_as(user=self.user)
         release_1 = self.create_release(version="test@2.2")
-        release_2 = self.create_release(version="test@10.0")
+        release_2 = self.create_release(version="test@10.0+122")
         release_3 = self.create_release(version="test@2.2-alpha")
         release_4 = self.create_release(version="test@2.2.3")
         release_5 = self.create_release(version="test@2.20.3")
         release_6 = self.create_release(version="test@2.20.3.3")
+        release_7 = self.create_release(version="test@10.0+123")
         self.create_release(version="test@some_thing")
         self.create_release(version="random_junk")
 
         response = self.get_valid_response(self.organization.slug, sort="semver")
         assert [r["version"] for r in response.data] == [
             release_2.version,
+            release_7.version,
             release_6.version,
             release_5.version,
             release_4.version,


### PR DESCRIPTION
This adds a sort on `date_added` to differentiate releases that are identical apart from build. Note
that this ends up causing us issues with not using the index, but we already have issues there due
to filtering on release status as well. Will solve that separately.