### PR TITLE
feat(search): Improve free text autocomplete

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1009,10 +1009,10 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     if (cursorToken.type === Token.FreeText) {
-      const autocompleteGroups = [
-        await this.generateTagAutocompleteGroup(cursorToken.text),
-      ];
-      this.setState({searchTerm: cursorToken.text});
+      const lastToken = cursorToken.text.trim().split(' ').pop() ?? '';
+      const keyText = lastToken.replace(new RegExp(`^${NEGATION_OPERATOR}`), '');
+      const autocompleteGroups = [await this.generateTagAutocompleteGroup(keyText)];
+      this.setState({searchTerm: keyText});
       this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
       return;
     }


### PR DESCRIPTION
when doing autocomplete on a query like: `free text tag_key` the autocomplete logic would try to match that as one tag and there would be no matches but now we take the last token (which would be `tag_key` in the prev example) delimited by spaces and apply that in our autocomplete logic.