### PR TITLE
fix(semver): Change semver autocomplete sort to be desc

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -25,7 +25,7 @@ from sentry.search.events.constants import (
     USER_DISPLAY_ALIAS,
 )
 from sentry.search.events.fields import FIELD_ALIASES
-from sentry.search.events.filter import parse_semver
+from sentry.search.events.filter import _flip_field_sort, parse_semver
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagStorage
@@ -745,9 +745,8 @@ class SnubaTagStorage(TagStorage):
                 ).values_list("release_id", flat=True)
             )
 
-        versions = versions.order_by(*Release.SEMVER_COLS, "package").values_list(
-            "version", flat=True
-        )[:1000]
+        order_by = map(_flip_field_sort, Release.SEMVER_COLS + ["package"])
+        versions = versions.order_by(*order_by).values_list("version", flat=True)[:1000]
 
         seen = set()
         formatted_versions = []

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -274,11 +274,11 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
     def test_semver(self):
         self.create_release(version="test@1.0.0.0")
         self.create_release(version="test@2.0.0.0")
-        self.run_test(SEMVER_ALIAS, expected=[("test@1.0.0.0", None), ("test@2.0.0.0", None)])
+        self.run_test(SEMVER_ALIAS, expected=[("test@2.0.0.0", None), ("test@1.0.0.0", None)])
         self.run_test(SEMVER_ALIAS, query="1.", expected=[("1.0.0.0", None)])
         self.run_test(SEMVER_ALIAS, query="test@1.", expected=[("test@1.0.0.0", None)])
         self.run_test(
-            SEMVER_ALIAS, query="test", expected=[("test@1.0.0.0", None), ("test@2.0.0.0", None)]
+            SEMVER_ALIAS, query="test", expected=[("test@2.0.0.0", None), ("test@1.0.0.0", None)]
         )
 
 

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -731,66 +731,66 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
         self.run_test(
             None,
             [
-                "test@1.0.0.0",
-                "z_test@1.0.0.0",
-                "test@1.2.0.0-alpha",
-                "test@1.2.3.0-beta",
-                "test@1.2.3.4",
-                "test2@2.0.0.0",
                 "z_test@2.0.0.0",
+                "test2@2.0.0.0",
+                "test@1.2.3.4",
+                "test@1.2.3.0-beta",
+                "test@1.2.0.0-alpha",
+                "z_test@1.0.0.0",
+                "test@1.0.0.0",
             ],
         )
         self.run_test(
             "",
             [
-                "test@1.0.0.0",
-                "z_test@1.0.0.0",
-                "test@1.2.0.0-alpha",
-                "test@1.2.3.0-beta",
-                "test@1.2.3.4",
-                "test2@2.0.0.0",
                 "z_test@2.0.0.0",
+                "test2@2.0.0.0",
+                "test@1.2.3.4",
+                "test@1.2.3.0-beta",
+                "test@1.2.0.0-alpha",
+                "z_test@1.0.0.0",
+                "test@1.0.0.0",
             ],
         )
 
         # These should all be equivalent
-        self.run_test("1", ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4"])
-        self.run_test("1.", ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4"])
-        self.run_test("1.*", ["1.0.0.0", "1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4"])
+        self.run_test("1", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha", "1.0.0.0"])
+        self.run_test("1.", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha", "1.0.0.0"])
+        self.run_test("1.*", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha", "1.0.0.0"])
 
         self.run_test("1.*", ["1.0.0.0"], project=project_2)
 
-        self.run_test("1.2", ["1.2.0.0-alpha", "1.2.3.0-beta", "1.2.3.4"])
+        self.run_test("1.2", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha"])
 
-        self.run_test("", ["test@1.2.0.0-alpha", "test2@2.0.0.0"], self.environment)
-        self.run_test("", ["test@1.2.3.0-beta", "test@1.2.3.4", "test2@2.0.0.0"], env_2)
+        self.run_test("", ["test2@2.0.0.0", "test@1.2.0.0-alpha"], self.environment)
+        self.run_test("", ["test2@2.0.0.0", "test@1.2.3.4", "test@1.2.3.0-beta"], env_2)
         self.run_test("1", ["1.2.0.0-alpha"], self.environment)
-        self.run_test("1", ["1.2.3.0-beta", "1.2.3.4"], env_2)
+        self.run_test("1", ["1.2.3.4", "1.2.3.0-beta"], env_2)
 
         # Test packages handling
 
         self.run_test(
             "test",
             [
-                "test@1.0.0.0",
-                "test@1.2.0.0-alpha",
-                "test@1.2.3.0-beta",
-                "test@1.2.3.4",
                 "test2@2.0.0.0",
+                "test@1.2.3.4",
+                "test@1.2.3.0-beta",
+                "test@1.2.0.0-alpha",
+                "test@1.0.0.0",
             ],
         )
         self.run_test("test", ["test@1.0.0.0"], project=project_2)
         self.run_test("test2", ["test2@2.0.0.0"])
-        self.run_test("z", ["z_test@1.0.0.0", "z_test@2.0.0.0"])
+        self.run_test("z", ["z_test@2.0.0.0", "z_test@1.0.0.0"])
         self.run_test("z", ["z_test@2.0.0.0"], project=project_2)
 
         self.run_test(
-            "test@", ["test@1.0.0.0", "test@1.2.0.0-alpha", "test@1.2.3.0-beta", "test@1.2.3.4"]
+            "test@", ["test@1.2.3.4", "test@1.2.3.0-beta", "test@1.2.0.0-alpha", "test@1.0.0.0"]
         )
         self.run_test(
-            "test@*", ["test@1.0.0.0", "test@1.2.0.0-alpha", "test@1.2.3.0-beta", "test@1.2.3.4"]
+            "test@*", ["test@1.2.3.4", "test@1.2.3.0-beta", "test@1.2.0.0-alpha", "test@1.0.0.0"]
         )
-        self.run_test("test@1.2", ["test@1.2.0.0-alpha", "test@1.2.3.0-beta", "test@1.2.3.4"])
+        self.run_test("test@1.2", ["test@1.2.3.4", "test@1.2.3.0-beta", "test@1.2.0.0-alpha"])
 
 
 class GetTagValuePaginatorForProjectsSemverPackageTest(BaseSemverTest, TestCase, SnubaTestCase):


### PR DESCRIPTION
This matches the order of the releases page better, and likely users will want to access more recent
releases more often.