### PR TITLE
fix(migrations): Fix history check when we have no migrations in the table

### DIFF
--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -24,7 +24,9 @@ def _check_history():
 
     # If we haven't run all the migration up to the latest squash abort.
     # As we squash more history this should be updated.
-    cursor.execute("SELECT 1 FROM django_migrations WHERE name = '0200_release_indices'")
+    cursor.execute(
+        "SELECT 1 FROM django_migrations WHERE name in ('0200_release_indices', '0001_squashed_0200_release_indices')"
+    )
     row = cursor.fetchone()
     if not row or not row[0]:
         raise click.ClickException(

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -13,7 +13,7 @@ def _check_history():
         # If this query fails because there are no tables we're good to go.
         cursor.execute("SELECT COUNT(*) FROM django_migrations")
         row = cursor.fetchone()
-        if not row or row == 0:
+        if not row or row[0] == 0:
             return
     except ProgrammingError as e:
         # Having no migrations table is ok, as we're likely operating on a new install.

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -12,7 +12,8 @@ def _check_history():
     try:
         # If this query fails because there are no tables we're good to go.
         cursor.execute("SELECT COUNT(*) FROM django_migrations")
-        if cursor.fetchone()[0] == 0:
+        row = cursor.fetchone()
+        if not row or row == 0:
             return
     except ProgrammingError as e:
         # Having no migrations table is ok, as we're likely operating on a new install.
@@ -24,7 +25,8 @@ def _check_history():
     # If we haven't run all the migration up to the latest squash abort.
     # As we squash more history this should be updated.
     cursor.execute("SELECT 1 FROM django_migrations WHERE name = '0200_release_indices'")
-    if not cursor.fetchone()[0]:
+    row = cursor.fetchone()
+    if not row or not row[0]:
         raise click.ClickException(
             "It looks like you've skipped a hard stop in our upgrade process. "
             "Please follow the upgrade process here: https://develop.sentry.dev/self-hosted/#hard-stops"


### PR DESCRIPTION
This was broken in a couple ways:

If the expected squash migration didn't exist, then `fetchone` would return `None` and indexing into it would fail.
After that, we were incorrectly firing a history check error for installs that had only ever run the squash. Since they would never have run migration 0200, they also failed. Good note for when we squash - we need to include both the latest migration that we're going squash, and also the squashed itself.