### PR TITLE
test(ui): Target `current node` in browserslist for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,17 @@
     "validate-api-examples": "yarn install-api-docs && cd api-docs && yarn openapi-examples-validator ./openapi.json --no-additional-properties",
     "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost"
   },
+  "browserslist": {
+    "production": [
+      "defaults"
+    ],
+    "development": [
+      "defaults"
+    ],
+    "test": [
+      "current node"
+    ]
+  },
   "volta": {
     "node": "12.19.0",
     "yarn": "1.22.5"


### PR DESCRIPTION
the idea this time is to leave defaults alone for all other environments, but target the current version of node for tests run with jest

when running one test without cache its noticeable
```console
$ node scripts/test.js tests/js/spec/views/alerts/create.spec.jsx --no-cache
 PASS  tests/js/spec/views/alerts/create.spec.jsx (29.81 s)
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Time:        30.39 s
✨  Done in 35.88s.
$ node scripts/test.js tests/js/spec/views/alerts/create.spec.jsx --no-cache
 PASS  tests/js/spec/views/alerts/create.spec.jsx (19.062 s)
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Time:        19.644 s
✨  Done in 24.72s.
```

In CI

I think the first few tests will show the greatest change because of the cache?

before
```
PASS tests/js/spec/views/issueList/overview.spec.jsx (60.534 s)
PASS tests/js/spec/views/eventsV2/utils.spec.jsx (12.89 s)
PASS tests/js/spec/views/eventsV2/results.spec.jsx (29.942 s)
```

after
```
PASS tests/js/spec/views/issueList/overview.spec.jsx (42.049 s)
PASS tests/js/spec/views/eventsV2/utils.spec.jsx (7.692 s)
PASS tests/js/spec/views/eventsV2/results.spec.jsx (19.561 s)
```