### PR TITLE
ref(build): Remove runtime.js

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -53,9 +53,6 @@
   {% endscript %}
 
   {% block scripts %}
-  {% unversioned_asset_url "sentry" "entrypoints/runtime.js" as asset_url %}
-  {% script src=asset_url %}{% endscript %}
-
   {% block scripts_main_entrypoint %}
     {% unversioned_asset_url "sentry" "entrypoints/app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -434,7 +434,6 @@ let appConfig: Configuration = {
   optimization: {
     chunkIds: 'named',
     moduleIds: 'named',
-    runtimeChunk: {name: 'runtime'},
     splitChunks: {
       // Only affect async chunks, otherwise webpack could potentially split our initial chunks
       // Which means the app will not load because we'd need these additional chunks to be loaded in our


### PR DESCRIPTION
We're seeing some mismatches between runtime and app.

This is likely due to the CDN (fastley) serving from different edge nodes, where one old fine and one new file are served, causing mismatches in the webpack chunk names.