### PR TITLE
ref(perf): Add projects tag to sdk update endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -2,12 +2,14 @@ from datetime import timedelta
 from distutils.version import LooseVersion
 from itertools import chain, groupby
 
+import sentry_sdk
 from django.utils import timezone
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.sdk_updates import SdkIndexState, SdkSetupState, get_suggested_updates
 from sentry.snuba import discover
+from sentry.utils.numbers import format_grouped_length
 
 
 def by_sdk_name(sdk):
@@ -63,6 +65,10 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
 
         project_ids = self.get_requested_project_ids(request)
         projects = self.get_projects(request, organization, project_ids)
+
+        len_projects = len(project_ids)
+        sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
+
         if len(projects) == 0:
             return Response([])
 

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -67,6 +67,7 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
         projects = self.get_projects(request, organization, project_ids)
 
         len_projects = len(project_ids)
+        sentry_sdk.set_tag("query.num_projects", len_projects)
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
 
         if len(projects) == 0:


### PR DESCRIPTION
### Summary
Having looked at some performance profiles, sdk-updates seems to be heavily affected by the number of passed projects. This will add a tag to the transaction so that it will show up in suspect tags and can be analyzed using the tag page.