### PR TITLE
chore(auth): add extra log to AuthHelper.error

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -876,6 +876,16 @@ class AuthHelper:
             skip_internal=False,
             sample_rate=1.0,
         )
+        logger.warning(
+            "sso.login-pipeline.error",
+            extra={
+                "flow": self.state.flow,
+                "provider": self.provider.key,
+                "organization_id": self.organization.id,
+                "user_id": self.request.user.id,
+                "message": message,
+            },
+        )
 
         messages.add_message(self.request, messages.ERROR, f"Authentication error: {message}")
 

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -883,7 +883,7 @@ class AuthHelper:
                 "provider": self.provider.key,
                 "organization_id": self.organization.id,
                 "user_id": self.request.user.id,
-                "message": message,
+                "error_message": message,
             },
         )
 


### PR DESCRIPTION
adds a log with the error message in addition to the metric we have for easier debugging. 

Sidenote: should we enable transactions for this endpoint? don't think we have them currently