### PR TITLE
build(webpack): Increase mem when using webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
     "build-chartcuterie-config": "NODE_ENV=production yarn webpack --config=config/webpack.chartcuterie.config.ts",
     "build-acceptance": "IS_ACCEPTANCE_TEST=1 NODE_ENV=production yarn webpack --mode development",
     "build-production": "NODE_ENV=production yarn webpack --mode production",
-    "build": "yarn build-production --output-path=public",
+    "build": "NODE_OPTIONS=--max-old-space-size=4096 yarn webpack",
     "validate-api-examples": "yarn install-api-docs && cd api-docs && yarn openapi-examples-validator ./openapi.json --no-additional-properties",
     "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost"
   },


### PR DESCRIPTION
`build` was used in Vercel, I have updated it to call build-production instead. This will speed up our webpack job because it won't build in production mode. The size limit action is currently not working, so there's no reason to build in production as we only had it to compare bundle sizes in prod.