### PR TITLE
feat(assets): Add temp cache busting on unversioned assets

### DIFF
--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% unversioned_asset_url "sentry" "entrypoints/pipeline.js" as asset_url %}
+    {% unversioned_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% unversioned_asset_url "sentry" "entrypoints/sentry.css" %}" rel="stylesheet"/>
+  <link href="{% unversioned_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -54,7 +54,7 @@
 
   {% block scripts %}
   {% block scripts_main_entrypoint %}
-    {% unversioned_asset_url "sentry" "entrypoints/app.js?invalidCache=1" as asset_url %}
+    {% unversioned_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,18 +1,29 @@
 from django.conf import settings
 
 
-def get_unversioned_asset_url(module, key):
+def get_unversioned_asset_url(module, key, cache_bust=False):
     """
     Returns an asset URL that is unversioned. These assets should have a
     `Cache-Control: max-age=0, must-revalidate` so that clients must validate with the origin
     server before using their locally cached asset.
 
+    XXX(epurkhiser): As a temporary workaround for flakeyness with the CDN,
+    we're busting caches when version_bust is True using a query parameter with
+    the currently deployed backend SHA. This will have to change in the future
+    for frontend only deploys.
+
     Example:
       {% unversioned_asset_url 'sentry' 'sentry.css' %}
       =>  "/_static/dist/sentry/sentry.css"
-    """
 
-    return "{}/{}/{}".format(settings.STATIC_UNVERSIONED_URL.rstrip("/"), module, key.lstrip("/"))
+      {% unversioned_asset_url 'sentry' 'sentry.css' cache_bust=True %}
+      =>  "/_static/dist/sentry/sentry.css?bust=xxx"
+    """
+    args = (settings.STATIC_UNVERSIONED_URL.rstrip("/"), module, key.lstrip("/"))
+
+    if not cache_bust:
+        return "{}/{}/{}".format(*args)
+    return "{}/{}/{}?v={}".format(*args, settings.SENTRY_SDK_CONFIG["release"])
 
 
 def get_asset_url(module, path):

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -17,7 +17,7 @@ def get_unversioned_asset_url(module, key, cache_bust=False):
       =>  "/_static/dist/sentry/sentry.css"
 
       {% unversioned_asset_url 'sentry' 'sentry.css' cache_bust=True %}
-      =>  "/_static/dist/sentry/sentry.css?bust=xxx"
+      =>  "/_static/dist/sentry/sentry.css?v=xxx"
     """
     args = (settings.STATIC_UNVERSIONED_URL.rstrip("/"), module, key.lstrip("/"))
 

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -58,7 +58,8 @@ class StaticMediaTest(TestCase):
 
         try:
             with open(os.path.join(dist_path, "test.js"), "a"):
-                url = get_unversioned_asset_url("sentry", "test.js")
+                url = get_unversioned_asset_url("sentry", "test.js", cache_bust=True)
+                assert "?v=" in url
 
                 response = self.client.get(url)
                 assert response.status_code == 200, response


### PR DESCRIPTION
After a recent CDN issue where our unversioned assets were not being
revalidated, we're adding this temporary cache busting locked to the
backend version.

We'll have to implement this differently for frontend only builds