### PR TITLE
fix(event-title): Fix event title firefox

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -17,7 +17,6 @@ import withOrganization from 'app/utils/withOrganization';
 import {TagAndMessageWrapper} from 'app/views/organizationGroupDetails/unhandledTag';
 
 import EventTitleError from './eventTitleError';
-import {Divider} from './eventTitleTreeLabel';
 
 type DefaultProps = {
   includeLink: boolean;
@@ -46,7 +45,7 @@ class EventOrGroupHeader extends Component<Props> {
   };
 
   getTitleChildren() {
-    const {hideIcons, hideLevel, data, index, organization, includeLink} = this.props;
+    const {hideIcons, hideLevel, data, index, organization} = this.props;
     const {level, status, isBookmarked, hasSeen} = data as Group;
     const hasGroupingTreeUI = !!organization.features?.includes('grouping-tree-ui');
 
@@ -74,8 +73,6 @@ class EventOrGroupHeader extends Component<Props> {
           <StyledEventOrGroupTitle
             {...this.props}
             hasSeen={hasGroupingTreeUI && hasSeen === undefined ? true : hasSeen}
-            hasGroupingTreeUI={hasGroupingTreeUI}
-            includeLink={!!includeLink}
             withStackTracePreview
             hasGuideAnchor={index === 0}
             guideAnchorName="issue_stream_title"
@@ -227,19 +224,6 @@ export default withRouter(withOrganization(EventOrGroupHeader));
 
 const StyledEventOrGroupTitle = styled(EventOrGroupTitle)<{
   hasSeen: boolean;
-  hasGroupingTreeUI: boolean;
-  includeLink: boolean;
 }>`
   font-weight: ${p => (p.hasSeen ? 400 : 600)};
-  ${p =>
-    p.hasGroupingTreeUI &&
-    `
-      color: ${p.theme.textColor};
-      :hover {
-        color: inherit;
-        ${Divider}{
-          color: inherit;
-        }
-      }
-    `}
 `;

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import ProjectsStore from 'app/stores/projectsStore';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {BaseGroup, GroupTombstone, Organization} from 'app/types';
 import {Event} from 'app/types/event';
 import {getTitle} from 'app/utils/events';
@@ -33,12 +34,14 @@ function EventOrGroupTitle({
   className,
 }: Props) {
   const event = data as Event;
+
+  const hasGroupingTreeUI = !!organization?.features.includes('grouping-tree-ui');
   const {id, eventID, groupID, projectID} = event;
 
   const {title, subtitle, treeLabel} = getTitle(event, organization?.features);
 
   return (
-    <span className={className}>
+    <Wrapper className={className} hasGroupingTreeUI={hasGroupingTreeUI}>
       <GuideAnchor disabled={!hasGuideAnchor} target={guideAnchorName} position="bottom">
         <StacktracePreview
           organization={organization}
@@ -59,7 +62,7 @@ function EventOrGroupTitle({
           <br />
         </Fragment>
       )}
-    </span>
+    </Wrapper>
   );
 }
 
@@ -75,4 +78,23 @@ const Spacer = () => <span style={{display: 'inline-block', width: 10}}>&nbsp;</
 const Subtitle = styled('em')`
   color: ${p => p.theme.gray300};
   font-style: normal;
+`;
+
+const Wrapper = styled('span')<{hasGroupingTreeUI: boolean}>`
+  ${p =>
+    p.hasGroupingTreeUI &&
+    `
+      display: inline-grid;
+      grid-template-columns: auto min-content 1fr;
+      align-items: flex-end;
+
+      > *: first-child   {
+        line-height: 1;
+      }
+
+      ${Subtitle} {
+        ${overflowEllipsis};
+        display: inline-block;
+      }
+    `}
 `;

--- a/static/app/components/eventTitleTreeLabel.tsx
+++ b/static/app/components/eventTitleTreeLabel.tsx
@@ -53,39 +53,40 @@ function EventTitleTreeLabel({treeLabel}: Props) {
 
 export default EventTitleTreeLabel;
 
-const Wrapper = styled('span')`
-  display: inline-grid;
+const Wrapper = styled('div')`
+  display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
 `;
 
-const FirstFourParts = styled('span')`
+const FirstFourParts = styled('div')`
   display: grid;
   grid-auto-flow: column;
   align-items: center;
 `;
 
-const Label = styled('span')<{highlight: boolean}>`
-  padding: ${space(0.25)} 0;
+const Label = styled('div')<{highlight: boolean}>`
   ${p =>
     p.highlight &&
     `
       background: ${p.theme.alert.info.backgroundLight};
       border-radius: ${p.theme.borderRadius};
-      padding: ${space(0.25)} ${space(0.5)};
+      padding: 0 ${space(0.5)};
     `}
 `;
 
 const PriorityPart = styled(Label)`
   ${overflowEllipsis}
+  display: inline-block;
 `;
 
 const RemainingLabels = styled('div')`
   ${overflowEllipsis}
+  display: inline-block;
   min-width: 50px;
 `;
 
-export const Divider = styled('span')`
+export const Divider = styled('div')`
   color: ${p => p.theme.gray200};
   display: inline-block;
   margin: 0 ${space(1)};


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/29228205/125681484-03e7a683-e2e6-4ae3-a891-9a20fececf4d.png)

**After:**

![image](https://user-images.githubusercontent.com/29228205/125681323-bb4d6c26-4c9e-4642-980e-23a72da9d900.png)


Fix and revert link color

ps: these changes are under the feature flag 'grouping-tree-ui'