### PR TITLE
wizard(capacitor): add to mobile category

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -44,6 +44,7 @@ export const mobile = [
   'android',
   'apple-ios',
   'cordova',
+  'capacitor',
   'javascript-cordova',
   'javascript-capacitor',
   'react-native',


### PR DESCRIPTION
Turns out #27378 doesn't seem to work.
Perhaps that explains why we have both `cordova` and `javascript-cordova`.

Might be safe to delete it then if it's just used on the grouping in the wizard?

Still not showing up:
![image](https://user-images.githubusercontent.com/1633368/125686319-8bacf007-8de9-4eac-a47c-5b75bf1b00da.png)

It's still on All:
![image](https://user-images.githubusercontent.com/1633368/125686343-f6afb414-5548-414c-a8a1-638cf1a653ac.png)
