### PR TITLE
fix(ops breakdown): Remove redundant parameter when an ops breakdown is chosen

### DIFF
--- a/static/app/views/performance/transactionSummary/durationChart.tsx
+++ b/static/app/views/performance/transactionSummary/durationChart.tsx
@@ -27,7 +27,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
-import {filterToField, SpanOperationBreakdownFilter} from './filter';
+import {SpanOperationBreakdownFilter} from './filter';
 
 const QUERY_KEYS = [
   'environment',
@@ -50,20 +50,8 @@ type Props = ReactRouter.WithRouterProps &
     currentFilter: SpanOperationBreakdownFilter;
   };
 
-function generateYAxisValues(filter: SpanOperationBreakdownFilter) {
-  if (filter === SpanOperationBreakdownFilter.None) {
-    return ['p50()', 'p75()', 'p95()', 'p99()', 'p100()'];
-  }
-
-  const field = filterToField(filter);
-
-  return [
-    `p50(${field})`,
-    `p75(${field})`,
-    `p95(${field})`,
-    `p99(${field})`,
-    `p100(${field})`,
-  ];
+function generateYAxisValues() {
+  return ['p50()', 'p75()', 'p95()', 'p99()', 'p100()'];
 }
 
 /**
@@ -179,7 +167,7 @@ class DurationChart extends Component<Props> {
               showLoading={false}
               query={query}
               includePrevious={false}
-              yAxis={generateYAxisValues(currentFilter)}
+              yAxis={generateYAxisValues()}
               partial
             >
               {({results, errored, loading, reloading}) => {


### PR DESCRIPTION
For small-sized screens, when an operation breakdown is chose, the parameters for the chart legends on the Duration Breakdown charts is redundant if it's obvious on the chart title.

For example:

<img width="1063" alt="Fullscreen_2021-07-14__2_07_PM" src="https://user-images.githubusercontent.com/139499/125689116-60891901-88e2-480d-83d4-8fc79f731914.png">

------

**Before:**

<img width="1299" alt="Screen Shot 2021-07-14 at 4 19 34 PM" src="https://user-images.githubusercontent.com/139499/125689157-f92f5c26-d8e8-4aa5-a0d3-15688d4ec992.png">


**After:**


<img width="1301" alt="Screen Shot 2021-07-14 at 4 19 48 PM" src="https://user-images.githubusercontent.com/139499/125689153-e63cae78-126f-4748-98cf-b2939913c545.png">