### PR TITLE
feat(perf): Change tags page UI to beta

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -248,7 +248,7 @@ class TransactionHeader extends React.Component<Props> {
                 onClick={this.trackTagsTabClick}
               >
                 {t('Tags')}
-                <FeatureBadge type="alpha" noTooltip />
+                <FeatureBadge type="beta" noTooltip />
               </ListLink>
             </Feature>
             <Feature features={['organizations:performance-events-page']}>


### PR DESCRIPTION
### Summary
For the EA of tags page, switch to beta badge.