### PR TITLE
feat(codeowners): Add a matcher for codeowners syntax

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -131,7 +131,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         """
         Codeowners has a slightly different syntax compared to issue owners
         As such we need to match it using gitignore logic.
-        See sytax documentation here:
+        See syntax documentation here:
         https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
         """
         spec = _path_to_regex(self.pattern)
@@ -228,7 +228,7 @@ def _path_to_regex(pattern: str) -> Pattern[str]:
     ported from https://github.com/hmarr/codeowners/blob/d0452091447bd2a29ee508eebc5a79874fb5d4ff/match.go#L33
     ported from https://github.com/sbdchd/codeowners/blob/6c5e8563f4c675abb098df704e19f4c6b95ff9aa/codeowners/__init__.py#L16
 
-    There are some special cases like backslash that was added
+    There are some special cases like backslash that were added
 
     MIT License
 

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -1,6 +1,6 @@
 import re
 from collections import namedtuple
-from typing import List, Tuple
+from typing import List, Pattern, Tuple
 
 from parsimonious.exceptions import ParseError  # noqa
 from parsimonious.grammar import Grammar, NodeVisitor
@@ -97,6 +97,8 @@ class Matcher(namedtuple("Matcher", "type pattern")):
             return self.test_frames(data, ["module"])
         elif self.type.startswith("tags."):
             return self.test_tag(data)
+        elif self.type.startswith("codeowners"):
+            return self.test_codeowners(data)
         return False
 
     def test_url(self, data):
@@ -123,6 +125,26 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         for k, v in get_path(data, "tags", filter=True) or ():
             if k == tag and glob_match(v, self.pattern):
                 return True
+        return False
+
+    def test_codeowners(self, data):
+        """
+        Codeowners has a slightly different syntax compared to issue owners
+        As such we need to match it using gitignore logic.
+        See sytax documentation here:
+        https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+        """
+        spec = _path_to_regex(self.pattern)
+        keys = ["abs_path"]
+        for frame in _iter_frames(data):
+            value = next((frame.get(key) for key in keys if frame.get(key)), None)
+
+            if not value:
+                continue
+
+            if spec.search(value):
+                return True
+
         return False
 
 
@@ -199,6 +221,92 @@ class OwnershipVisitor(NodeVisitor):
 
     def generic_visit(self, node, children):
         return children or node
+
+
+def _path_to_regex(pattern: str) -> Pattern[str]:
+    """
+    ported from https://github.com/hmarr/codeowners/blob/d0452091447bd2a29ee508eebc5a79874fb5d4ff/match.go#L33
+    ported from https://github.com/sbdchd/codeowners/blob/6c5e8563f4c675abb098df704e19f4c6b95ff9aa/codeowners/__init__.py#L16
+
+    MIT License
+
+    Copyright (c) 2020 Harry Marr
+    Copyright (c) 2019-2020 Steve Dignam
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+    """
+    regex = ""
+
+    slash_pos = pattern.find("/")
+    anchored = slash_pos > -1 and slash_pos != len(pattern) - 1
+
+    regex += r"\A" if anchored else r"(?:\A|/)"
+
+    matches_dir = pattern[-1] == "/"
+    pattern_trimmed = pattern.strip("/")
+
+    in_char_class = False
+    escaped = False
+
+    iterator = enumerate(pattern_trimmed)
+    for i, ch in iterator:
+
+        if escaped:
+            regex += re.escape(ch)
+            escaped = False
+            continue
+
+        if ch == "\\":
+            escaped = True
+        elif ch == "*":
+            if i + 1 < len(pattern_trimmed) and pattern_trimmed[i + 1] == "*":
+                left_anchored = i == 0
+                leading_slash = i > 0 and pattern_trimmed[i - 1] == "/"
+                right_anchored = i + 2 == len(pattern_trimmed)
+                trailing_slash = i + 2 < len(pattern_trimmed) and pattern_trimmed[i + 2] == "/"
+
+                if (left_anchored or leading_slash) and (right_anchored or trailing_slash):
+                    regex += ".*"
+
+                    next(iterator, None)
+                    next(iterator, None)
+                    continue
+            regex += "[^/]*"
+        elif ch == "?":
+            regex += "[^/]"
+        elif ch == "[":
+            in_char_class = True
+            regex += ch
+        elif ch == "]":
+            if in_char_class:
+                regex += ch
+                in_char_class = False
+            else:
+                regex += re.escape(ch)
+        else:
+            regex += re.escape(ch)
+
+    if in_char_class:
+        raise ValueError(f"unterminated character class in pattern {pattern}")
+
+    regex += "/" if matches_dir else r"(?:\Z|/)"
+    return re.compile(regex)
 
 
 def _iter_frames(data):

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -24,7 +24,7 @@ rule = _ matcher owners
 
 matcher      = _ matcher_tag any_identifier
 matcher_tag  = (matcher_type sep)?
-matcher_type = "url" / "path" / "module" / event_tag
+matcher_type = "url" / "path" / "module" / "codeowners" / event_tag
 
 event_tag   = ~r"tags.[^:]+"
 

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -206,7 +206,8 @@ def _assert_matcher(matcher: Matcher, path_details, expected):
     ],
 )
 def test_codeowners_match_any_file(path_details, expected):
-    """* should match to any file in the repo"""
+    """* and ** should match to any file"""
+    _assert_matcher(Matcher("codeowners", "**"), path_details, expected)
     _assert_matcher(Matcher("codeowners", "*"), path_details, expected)
 
 
@@ -216,10 +217,11 @@ def test_codeowners_match_any_file(path_details, expected):
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
         ([{"filename": "baz.txt"}, {"abs_path": "/usr/local/src/config/subdir/baz.txt"}], False),
         ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/config/subdir/baz.py"}], True),
+        ([{"filename": "baz.js"}, {"abs_path": "/usr/local/src/config/dir.py/baz.js"}], True),
     ],
 )
 def test_codeowners_match_extension(path_details, expected):
-    """*.py should match to any .py files in the repo"""
+    """*.py should match to any .py file or directory in the repo"""
     _assert_matcher(Matcher("codeowners", "*.py"), path_details, expected)
 
 
@@ -229,10 +231,17 @@ def test_codeowners_match_extension(path_details, expected):
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
         ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/config/subdir/baz.py"}], False),
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/subdir/test.py"}], True),
+        (
+            [
+                {"filename": "not_test.json"},
+                {"abs_path": "/usr/local/src/config/test.py/not_test.json"},
+            ],
+            True,
+        ),
     ],
 )
 def test_codeowners_match_specific_filename(path_details, expected):
-    """test.py should match to any test.py files in the repo"""
+    """test.py should match to any test.py file or directory in the repo"""
     _assert_matcher(Matcher("codeowners", "test.py"), path_details, expected)
 
 
@@ -240,32 +249,21 @@ def test_codeowners_match_specific_filename(path_details, expected):
     "path_details, expected",
     [
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
-        ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/config/subdir/baz.py"}], False),
-        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/subdir/test.py"}], False),
-        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/foo/test.py"}], True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/foo/test.py"}], False),
         (
             [
-                {"filename": "should_fail"},
-                {"abs_path": "/usr/local/src/config/foo/test.py/should_fail"},
+                {"filename": "dir_allowed"},
+                {"abs_path": "/usr/local/src/foo/test.py/dir_allowed"},
             ],
-            False,
+            True,
         ),
     ],
 )
-def test_codeowners_match_file_in_directory(path_details, expected):
-    """foo/test.py should match to any test.py files in a directory 'foo'"""
-    _assert_matcher(Matcher("codeowners", "foo/test.py"), path_details, expected)
-
-
-@pytest.mark.parametrize(
-    "path_details, expected",
-    [
-        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
-        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/foo/test.py"}], False),
-    ],
-)
 def test_codeowners_match_specific_path(path_details, expected):
-    """/usr/local/src/foo/test.py should match only one file in the repo"""
+    """
+    When codeowners is converted to issue owners, the code path is prepended
+    /usr/local/src/foo/test.py should match to any foo/test.py within the code path
+    """
     _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/test.py"), path_details, expected)
 
 
@@ -273,75 +271,143 @@ def test_codeowners_match_specific_path(path_details, expected):
     "path_details, expected",
     [
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
+        ([{"filename": "py_dir.txt"}, {"abs_path": "/usr/local/src/foo/dir.py/py_dir.txt"}], True),
         ([{"filename": "test.txt"}, {"abs_path": "/usr/local/src/foo/test.txt"}], False),
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/foo/test.py"}], False),
     ],
 )
 def test_codeowners_match_abs_wildcard(path_details, expected):
-    """/usr/local/src/foo/*.py should match only python files in the /usr/local/src/foo directory"""
+    """/usr/local/src/foo/*.py should match any file or directory"""
     _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/*.py"), path_details, expected)
 
 
 @pytest.mark.parametrize(
-    "path_details, strict_expected, loose_expected",
+    "path_details, expected",
     [
-        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True, True),
-        ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/foo/subdir/baz.py"}], True, True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
+        ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/foo/subdir/baz.py"}], True),
+        ([{"filename": "foo"}, {"abs_path": "/usr/local/src/foo"}], False),
         (
             [{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/subdir/test.py"}],
-            False,
             False,
         ),
         (
             [{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/src/foo/test.py"}],
             False,
-            True,
         ),
         (
             [{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/src/foo/subdir/test.py"}],
             False,
-            True,
         ),
     ],
 )
-def test_codeowners_match_recursive_directory(path_details, strict_expected, loose_expected):
+def test_codeowners_match_recursive_directory(path_details, expected):
     """
     /usr/local/src/foo/ should match recursively to any file within the /src/foo directory"
-    src/foo/ should match recursively to any file under any src/foo directories
+    /usr/local/src/foo/** should do the same"
     """
-    _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/"), path_details, strict_expected)
-    # _assert_matcher(Matcher("codeowners", "src/foo/"), path_details, loose_expected)
+    _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/"), path_details, expected)
+    _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/**"), path_details, expected)
 
 
 @pytest.mark.parametrize(
-    "path_details, strict_expected, loose_expected",
+    "path_details, expected",
     [
-        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True, True),
-        ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/foo/subdir/baz.py"}], False, False),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
+        ([{"filename": "baz.py"}, {"abs_path": "/usr/local/src/foo/subdir/baz.py"}], False),
         (
             [{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/subdir/test.py"}],
-            False,
             False,
         ),
         (
             [{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/src/foo/test.py"}],
             False,
-            True,
-        ),
-        (
-            [{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/src/foo/subdir/test.py"}],
-            False,
-            False,
         ),
     ],
 )
-def test_codeowners_match_nonrecursive_directory(path_details, strict_expected, loose_expected):
+def test_codeowners_match_nonrecursive_directory(path_details, expected):
     """
     /src/foo/* should match to any file directly within the /src/foo directory
     src/foo/* should match to any file directly withing any src/foo directory
     """
-    # _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/*"), path_details, strict_expected)
-    _assert_matcher(Matcher("codeowners", "src/foo/*"), path_details, loose_expected)
+    _assert_matcher(Matcher("codeowners", "/usr/local/src/foo/*"), path_details, expected)
+
+
+@pytest.mark.parametrize(
+    "path_details, single_star_expected, double_star_expected",
+    [
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/bar/test.py"}], True, True),
+        (
+            [{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/bar/baz/test.py"}],
+            False,
+            True,
+        ),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], False, True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/test.py"}], False, False),
+    ],
+)
+def test_codeowners_match_wildcard_directory(
+    path_details, single_star_expected, double_star_expected
+):
+    """
+    /src/foo/*/test.py should only match with test.py 1 directory deeper than foo
+    /src/foo/**/test.py can match with test.py anywhere under foo
+    """
+    _assert_matcher(
+        Matcher("codeowners", "/usr/local/src/foo/*/test.py"), path_details, single_star_expected
+    )
+    _assert_matcher(
+        Matcher("codeowners", "/usr/local/src/foo/**/test.py"), path_details, double_star_expected
+    )
+
+
+@pytest.mark.parametrize(
+    "path_details, expected",
+    [
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.jy"}], True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.;y"}], True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.pt"}], False),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test./y"}], False),
+    ],
+)
+def test_codeowners_match_question_mark(path_details, expected):
+    """
+    "?" should match any character execept slash
+    """
+    _assert_matcher(Matcher("codeowners", "test.?y"), path_details, expected)
+
+
+@pytest.mark.parametrize(
+    "path_details, expected",
+    [
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/bar/foo/test.jy"}], True),
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo"}], False),
+    ],
+)
+def test_codeowners_match_loose_directory(path_details, expected):
+    """
+    unanchored directories can match to a foo directory anywhere in the tree
+    """
+    _assert_matcher(Matcher("codeowners", "foo/"), path_details, expected)
+
+
+@pytest.mark.parametrize(
+    "path_details, expected",
+    [
+        ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/foo/test.py"}], True),
+        ([{"filename": "test.js"}, {"abs_path": "/usr/local/src/foo/test.js"}], True),
+        ([{"filename": "test."}, {"abs_path": "/usr/local/src/foo/test."}], True),
+        ([{"filename": "file"}, {"abs_path": "/usr/local/src/foo/test.d/file"}], True),
+        ([{"filename": "file"}, {"abs_path": "/usr/local/src/foo/test./file"}], True),
+    ],
+)
+def test_codeowners_match_wildcard_extension(path_details, expected):
+    """
+    "*" can match 0 or more characters in files or directories
+    """
+    _assert_matcher(Matcher("codeowners", "test.*"), path_details, expected)
 
 
 @pytest.mark.parametrize(
@@ -349,6 +415,13 @@ def test_codeowners_match_nonrecursive_directory(path_details, strict_expected, 
     [
         ([{"filename": "\\"}, {"abs_path": "/usr/local/src/foo/\\"}], True),
         ([{"filename": "\\filename"}, {"abs_path": "/usr/local/src/foo/subdir/\\filename"}], False),
+        (
+            [
+                {"filename": "backslash_dir"},
+                {"abs_path": "/usr/local/src/foo/subdir/\\/backslash_dir"},
+            ],
+            True,
+        ),
         ([{"filename": "test.py"}, {"abs_path": "/usr/local/src/config/subdir/test.py"}], False),
     ],
 )


### PR DESCRIPTION
Added a matcher for "codeowners-in-issue-owners" patterns.  The pattern-to-regex conversion follows .gitignore conventions with github CODEOWNERS exceptions.  These exceptions include ignoring `[...]` escape characters.

The unit tests different example patterns we might get as a part of codeowners. Let me know if you think of some cases I might have missed.

Fixes API-1966