### PR TITLE
perf: Fix slow query in `Group.__get_release`

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -503,7 +503,7 @@ class Group(Model):
             release_version = cache.get(cache_key)
             if release_version is None:
                 release_version = Release.objects.get(
-                    id__in=GroupRelease.objects.filter(group_id=group_id, project_id=project_id)
+                    id__in=GroupRelease.objects.filter(group_id=group_id)
                     .order_by(orderby)
                     .values("release_id")[:1]
                 ).version


### PR DESCRIPTION
The filter on `project_id` is unnecessary and causes the query plan to be more complex than
necessary. Just dropping it, since group is more specific and is all we need here.