### PR TITLE
ref(post-process): Skip creating event object in post process forwarder

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -1,8 +1,6 @@
 import logging
 
 from sentry import options
-from sentry.eventstore.models import Event
-from sentry.models import EventDict
 from sentry.utils import json, metrics
 
 logger = logging.getLogger(__name__)
@@ -20,20 +18,12 @@ def basic_protocol_handler(unsupported_operations):
         if task_state and task_state.get("skip_consume", False):
             return None  # nothing to do
 
-        # This data is already normalized as we're currently in the
-        # ingestion pipeline and the event was in store
-        # normalization just a few seconds ago. Running it through
-        # Rust (re)normalization here again would be too slow.
-        event_data["data"] = EventDict(event_data["data"], skip_renormalization=True)
-
-        event = Event(
-            event_id=event_data["event_id"],
-            group_id=event_data["group_id"],
-            project_id=event_data["project_id"],
-        )
-        event.data.bind_data(event_data["data"])
-
-        kwargs = {"event": event, "primary_hash": event_data["primary_hash"]}
+        kwargs = {
+            "event_id": event_data["event_id"],
+            "project_id": event_data["project_id"],
+            "group_id": event_data["group_id"],
+            "primary_hash": event_data["primary_hash"],
+        }
 
         for name in ("is_new", "is_regression", "is_new_group_environment"):
             kwargs[name] = task_state[name]

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -345,5 +345,12 @@ class SnubaEventStream(SnubaProtocolEventStream):
             skip_consume,
         )
         self._dispatch_post_process_group_task(
-            event, is_new, is_regression, is_new_group_environment, primary_hash, skip_consume
+            event.event_id,
+            event.project_id,
+            event.group_id,
+            is_new,
+            is_regression,
+            is_new_group_environment,
+            primary_hash,
+            skip_consume,
         )

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -1,7 +1,4 @@
-from datetime import datetime
-
 import pytest
-import pytz
 
 from sentry.eventstream.kafka.protocol import (
     InvalidPayload,
@@ -46,13 +43,9 @@ def test_get_task_kwargs_for_message_version_1():
     task_state = {"is_new": True, "is_regression": False, "is_new_group_environment": True}
 
     kwargs = get_task_kwargs_for_message(json.dumps([1, "insert", event_data, task_state]))
-    event = kwargs.pop("event")
-    assert event.project_id == 1
-    assert event.group_id == 2
-    assert event.event_id == "00000000000010008080808080808080"
-    assert event.message == "message"
-    assert event.platform == "python"
-    assert event.datetime == datetime(2018, 7, 20, 21, 4, 27, 600640, tzinfo=pytz.utc)
+    assert kwargs.pop("project_id") == 1
+    assert kwargs.pop("event_id") == "00000000000010008080808080808080"
+    assert kwargs.pop("group_id") == 2
     assert kwargs.pop("primary_hash") == "49f68a5c8493ec2c0bf489821c21fc3b"
 
     assert kwargs.pop("is_new") is True


### PR DESCRIPTION
This change removes the unnecessary creation of an event object in the post
process forwarder in order to dispatch a post processing task. Since we
only need event_id, group_id and project_id from the event, creating the
entire event object is unnecessary.

This is a first step towards the goal of eventually having the post process
forwarder avoid parsing event bodies entirely and instead get all required
information for dispatching from the kafka headers.