### PR TITLE
fix(arithmetic): Autocomplete breaks on invalid terms

### DIFF
--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -155,6 +155,9 @@ export default class ArithmeticInput extends PureComponent<Props, State> {
 
       const newOptionGroups = makeOptions(options, partialTerm);
       const flattenedOptions = newOptionGroups.map(group => group.options).flat();
+      if (flattenedOptions.length === 0) {
+        return;
+      }
 
       let newSelection;
       if (!startedSelection) {

--- a/tests/js/spec/views/eventsV2/table/arithmeticInput.spec.tsx
+++ b/tests/js/spec/views/eventsV2/table/arithmeticInput.spec.tsx
@@ -188,5 +188,8 @@ describe('ArithmeticInput', function () {
     const value = 'foo + bar';
     input.simulate('change', {target: {value}});
     input.simulate('keydown', {key: 'ArrowDown'});
+
+    const option = wrapper.find('DropdownListItem');
+    expect(option).toHaveLength(0);
   });
 });

--- a/tests/js/spec/views/eventsV2/table/arithmeticInput.spec.tsx
+++ b/tests/js/spec/views/eventsV2/table/arithmeticInput.spec.tsx
@@ -180,4 +180,13 @@ describe('ArithmeticInput', function () {
     input.simulate('blur');
     expect(query).toEqual(`transaction.duration + measurements.lcp `);
   });
+
+  it('handles autocomplete on invalid term', function () {
+    const input = wrapper.find('input');
+    input.simulate('focus');
+
+    const value = 'foo + bar';
+    input.simulate('change', {target: {value}});
+    input.simulate('keydown', {key: 'ArrowDown'});
+  });
 });


### PR DESCRIPTION
- When an arrow key is hit when the current term doesn't exist
  autocomplete errors
- Fixes JAVASCRIPT-24ZG