### PR TITLE
fix(ui): Remove divider in sidebar dropdown in sandbox mode

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -140,9 +140,8 @@ const SidebarDropdown = ({
                 </Fragment>
               )}
 
-              {hasOrganization && user && <Divider />}
-
               <DemoModeGate>
+                {hasOrganization && user && <Divider />}
                 {!!user && (
                   <Fragment>
                     <UserSummary to="/settings/account/details/">


### PR DESCRIPTION
Removed bottom border for sandbox mode. 