### PR TITLE
ref(notification platform): Update formatting

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -39,9 +39,11 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         if title:
             kwargs["title"] = title
 
+        if text:
+            kwargs["text"] = text
+            kwargs["mrkdwn_in"] = ["text"]
+
         return {
-            "text": text,
-            "mrkdwn_in": ["text"],
             "color": LEVEL_TO_COLOR[color or "info"],
             **kwargs,
         }

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -14,7 +14,7 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
 
     @staticmethod
     def _build(
-        text: str,
+        text: Optional[str] = None,
         title: Optional[str] = None,
         footer: Optional[str] = None,
         color: Optional[str] = None,

--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -25,7 +25,7 @@ CONTACT_MESSAGE = "Let us know if you have feedback: ecosystem-feedback@sentry.i
 def list_commands(commands: Mapping[str, str]) -> str:
     return "\n".join(
         (
-            f"• `/sentry {command}`: {description}"
+            f"`/sentry {command}`: {description}"
             for command, description in sorted(tuple(commands.items()))
         )
     )

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -21,6 +21,7 @@ from sentry.models import (
     User,
 )
 from sentry.notifications.base import BaseNotification
+from sentry.notifications.rules import AlertRuleNotification
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
@@ -275,7 +276,10 @@ def get_timestamp(group: Group, event: Optional[Event]) -> float:
     return to_timestamp(max(ts, event.datetime) if event else ts)
 
 
-def get_color(event_for_tags: Optional[Event]) -> str:
+def get_color(event_for_tags: Optional[Event], notification: Optional[BaseNotification]) -> str:
+    if notification:
+        if not isinstance(notification, AlertRuleNotification):
+            return "info"
     if event_for_tags:
         color: Optional[str] = event_for_tags.get_tag("level")
         if color and color in LEVEL_TO_COLOR.keys():
@@ -316,7 +320,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
 
         # If an event is unspecified, use the tags of the latest event (if one exists).
         event_for_tags = self.event or self.group.get_latest_event()
-        color = get_color(event_for_tags)
+        color = get_color(event_for_tags, self.notification)
         fields = build_tag_fields(event_for_tags, self.tags)
         footer = (
             build_notification_footer(self.notification, self.recipient)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -21,6 +21,7 @@ from sentry.models import (
     User,
 )
 from sentry.notifications.base import BaseNotification
+from sentry.notifications.rules import AlertRuleNotification
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
@@ -275,12 +276,15 @@ def get_timestamp(group: Group, event: Optional[Event]) -> float:
     return to_timestamp(max(ts, event.datetime) if event else ts)
 
 
-def get_color(event_for_tags: Optional[Event]) -> str:
+def get_color(event_for_tags: Optional[Event], notification: Optional[BaseNotification]) -> str:
+    if notification:
+        if not isinstance(notification, AlertRuleNotification):
+            return "info"
     if event_for_tags:
         color: Optional[str] = event_for_tags.get_tag("level")
         if color and color in LEVEL_TO_COLOR.keys():
             return color
-    return "info"
+    return "error"
 
 
 class SlackIssuesMessageBuilder(SlackMessageBuilder):
@@ -316,7 +320,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
 
         # If an event is unspecified, use the tags of the latest event (if one exists).
         event_for_tags = self.event or self.group.get_latest_event()
-        color = get_color(event_for_tags)
+        color = get_color(event_for_tags, self.notification)
         fields = build_tag_fields(event_for_tags, self.tags)
         footer = (
             build_notification_footer(self.notification, self.recipient)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -21,7 +21,6 @@ from sentry.models import (
     User,
 )
 from sentry.notifications.base import BaseNotification
-from sentry.notifications.rules import AlertRuleNotification
 from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
@@ -276,15 +275,12 @@ def get_timestamp(group: Group, event: Optional[Event]) -> float:
     return to_timestamp(max(ts, event.datetime) if event else ts)
 
 
-def get_color(event_for_tags: Optional[Event], notification: Optional[BaseNotification]) -> str:
-    if notification:
-        if not isinstance(notification, AlertRuleNotification):
-            return "info"
+def get_color(event_for_tags: Optional[Event]) -> str:
     if event_for_tags:
         color: Optional[str] = event_for_tags.get_tag("level")
         if color and color in LEVEL_TO_COLOR.keys():
             return color
-    return "error"
+    return "info"
 
 
 class SlackIssuesMessageBuilder(SlackMessageBuilder):
@@ -320,7 +316,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
 
         # If an event is unspecified, use the tags of the latest event (if one exists).
         event_for_tags = self.event or self.group.get_latest_event()
-        color = get_color(event_for_tags, self.notification)
+        color = get_color(event_for_tags)
         fields = build_tag_fields(event_for_tags, self.tags)
         footer = (
             build_notification_footer(self.notification, self.recipient)

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Union
+from typing import Any, Dict, List, Mapping, Union
 from urllib.parse import urljoin
 
 from sentry.integrations.slack.message_builder import SlackBody
@@ -11,12 +11,31 @@ from sentry.integrations.slack.message_builder.issues import (
 from sentry.models import Team, User
 from sentry.notifications.activity.release import ReleaseActivityNotification
 from sentry.notifications.base import BaseNotification
+from sentry.utils.http import absolute_uri
 
 from ..utils import build_notification_footer, get_referrer_qstring
 
 
 def get_group_url(notification: BaseNotification) -> str:
     return str(urljoin(notification.group.get_absolute_url(), get_referrer_qstring(notification)))
+
+
+def build_deploy_buttons(notification: ReleaseActivityNotification) -> List[Dict[str, Any]]:
+    projects, release = notification.get_release_projects()
+    buttons = []
+    if release:
+        for project in projects:
+            project_url = absolute_uri(
+                f"/organizations/{project.organization.slug}/releases/{release.version}/?project={project.id}&unselectedSeries=Healthy/"
+            )
+            buttons.append(
+                {
+                    "text": project.slug,
+                    "type": "button",
+                    "url": project_url,
+                },
+            )
+    return buttons
 
 
 class SlackNotificationsMessageBuilder(SlackMessageBuilder):
@@ -46,7 +65,7 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
         if isinstance(self.notification, ReleaseActivityNotification):
             return self._build(
                 text="",
-                actions=self.notification.get_message_description(),
+                actions=build_deploy_buttons(self.notification),
                 footer=build_notification_footer(self.notification, self.recipient),
             )
 

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -45,7 +45,8 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
 
         if isinstance(self.notification, ReleaseActivityNotification):
             return self._build(
-                text=self.notification.get_message_description(),
+                text="",
+                actions=self.notification.get_message_description(),
                 footer=build_notification_footer(self.notification, self.recipient),
             )
 
@@ -56,6 +57,7 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
             ),
             text=self.notification.get_message_description(),
             footer=build_notification_footer(self.notification, self.recipient),
+            color="info",
         )
 
 

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -22,10 +22,12 @@ def get_group_url(notification: BaseNotification) -> str:
 
 
 def build_deploy_buttons(notification: ReleaseActivityNotification) -> List[Dict[str, Any]]:
-    projects = set(notification.release.projects.all())
-    release = get_release(notification.activity, notification.project.organization)
+    project_release = getattr(notification, "release", None)
+    if project_release:
+        projects = set(project_release.projects.all())
+        release = get_release(notification.activity, notification.project.organization)
     buttons = []
-    if release:
+    if release and projects:
         for project in projects:
             project_url = absolute_uri(
                 f"/organizations/{project.organization.slug}/releases/{release.version}/?project={project.id}&unselectedSeries=Healthy/"

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -21,24 +21,17 @@ def get_group_url(notification: BaseNotification) -> str:
     return str(urljoin(notification.group.get_absolute_url(), get_referrer_qstring(notification)))
 
 
-def build_deploy_buttons(notification: ReleaseActivityNotification) -> List[Dict[str, Any]]:
-    project_release = getattr(notification, "release", None)
-    if project_release:
-        projects = set(project_release.projects.all())
-        release = get_release(notification.activity, notification.project.organization)
+def build_deploy_buttons(notification: ReleaseActivityNotification) -> List[Dict[str, str]]:
     buttons = []
-    if release and projects:
-        for project in projects:
-            project_url = absolute_uri(
-                f"/organizations/{project.organization.slug}/releases/{release.version}/?project={project.id}&unselectedSeries=Healthy/"
-            )
-            buttons.append(
-                {
-                    "text": project.slug,
-                    "type": "button",
-                    "url": project_url,
-                },
-            )
+    if notification.release:
+        release = get_release(notification.activity, notification.project.organization)
+        if release:
+            for project in notification.release.projects.all():
+                project_url = absolute_uri(
+                    f"/organizations/{project.organization.slug}/releases/{release.version}/?project={project.id}&unselectedSeries=Healthy/"
+                )
+                buttons.append({"text": project.slug, "type": "button", "url": project_url})
+
     return buttons
 
 

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -11,6 +11,7 @@ from sentry.integrations.slack.message_builder.issues import (
 from sentry.models import Team, User
 from sentry.notifications.activity.release import ReleaseActivityNotification
 from sentry.notifications.base import BaseNotification
+from sentry.notifications.utils import get_release
 from sentry.utils.http import absolute_uri
 
 from ..utils import build_notification_footer, get_referrer_qstring
@@ -21,7 +22,8 @@ def get_group_url(notification: BaseNotification) -> str:
 
 
 def build_deploy_buttons(notification: ReleaseActivityNotification) -> List[Dict[str, Any]]:
-    projects, release = notification.get_release_projects()
+    projects = set(notification.release.projects.all())
+    release = get_release(notification.activity, notification.project.organization)
     buttons = []
     if release:
         for project in projects:

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -61,7 +61,6 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
 
         if isinstance(self.notification, ReleaseActivityNotification):
             return self._build(
-                text="",
                 actions=build_deploy_buttons(self.notification),
                 footer=build_notification_footer(self.notification, self.recipient),
             )

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -104,7 +104,10 @@ class ReleaseActivityNotification(ActivityNotification):
         return self.get_subject()
 
     def get_notification_title(self) -> str:
-        return f"Version {self.version} deployed to {self.environment}"
+        text = "this project"
+        if len(self.projects) > 1:
+            text = "these projects"
+        return f"Release {self.version[:12]} deployed to {self.environment} for {text}"
 
     def get_filename(self) -> str:
         return "activity/release"
@@ -117,11 +120,17 @@ class ReleaseActivityNotification(ActivityNotification):
         return "deploy/"
 
     def get_message_description(self) -> str:
-        text = ""
+        buttons = []
         if self.release:
             for project in self.projects:
                 project_url = absolute_uri(
                     f"/organizations/{self.organization.slug}/releases/{self.version}/?project={project.id}&unselectedSeries=Healthy/"
                 )
-                text += f"* <{project_url}|{project.slug}>\n"
-        return text.rstrip()
+                buttons.append(
+                    {
+                        "text": project.slug,
+                        "type": "button",
+                        "url": project_url,
+                    },
+                )
+        return buttons

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -118,6 +118,3 @@ class ReleaseActivityNotification(ActivityNotification):
     @property
     def fine_tuning_key(self) -> str:
         return "deploy/"
-
-    def get_release_projects(self) -> Any:
-        return self.projects, self.release

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set
+from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Set
 
 from sentry.models import Activity, CommitFileChange, Project, User
 from sentry.notifications.utils import (
@@ -119,18 +119,5 @@ class ReleaseActivityNotification(ActivityNotification):
     def fine_tuning_key(self) -> str:
         return "deploy/"
 
-    def get_message_description(self) -> List[Dict[str, Any]]:
-        buttons = []
-        if self.release:
-            for project in self.projects:
-                project_url = absolute_uri(
-                    f"/organizations/{self.organization.slug}/releases/{self.version}/?project={project.id}&unselectedSeries=Healthy/"
-                )
-                buttons.append(
-                    {
-                        "text": project.slug,
-                        "type": "button",
-                        "url": project_url,
-                    },
-                )
-        return buttons
+    def get_release_projects(self) -> Any:
+        return self.projects, self.release

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Set
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set
 
 from sentry.models import Activity, CommitFileChange, Project, User
 from sentry.notifications.utils import (
@@ -119,7 +119,7 @@ class ReleaseActivityNotification(ActivityNotification):
     def fine_tuning_key(self) -> str:
         return "deploy/"
 
-    def get_message_description(self) -> str:
+    def get_message_description(self) -> List[Dict[str, Any]]:
         buttons = []
         if self.release:
             for project in self.projects:

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -98,7 +98,6 @@ class BuildIncidentAttachmentTest(TestCase):
         ts = group.last_seen
         assert build_group_attachment(group) == {
             "color": "#E03E2F",
-            "text": "",
             "actions": [
                 {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
                 {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
@@ -129,7 +128,6 @@ class BuildIncidentAttachmentTest(TestCase):
                     "name": "assign",
                 },
             ],
-            "mrkdwn_in": ["text"],
             "title": group.title,
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
@@ -145,7 +143,6 @@ class BuildIncidentAttachmentTest(TestCase):
         ts = event.datetime
         assert build_group_attachment(group, event) == {
             "color": "#E03E2F",
-            "text": "",
             "actions": [
                 {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
                 {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
@@ -176,7 +173,6 @@ class BuildIncidentAttachmentTest(TestCase):
                     "name": "assign",
                 },
             ],
-            "mrkdwn_in": ["text"],
             "title": event.title,
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
@@ -191,7 +187,6 @@ class BuildIncidentAttachmentTest(TestCase):
 
         assert build_group_attachment(group, event, link_to_event=True) == {
             "color": "#E03E2F",
-            "text": "",
             "actions": [
                 {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
                 {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
@@ -222,7 +217,6 @@ class BuildIncidentAttachmentTest(TestCase):
                     "name": "assign",
                 },
             ],
-            "mrkdwn_in": ["text"],
             "title": event.title,
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -474,10 +474,19 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
             notification.send()
 
         attachment, text = get_attachment()
-        assert text == f"Version {release.version} deployed to {self.environment.name}"
         assert (
-            attachment["text"]
-            == f"* <http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy/|{self.project.slug}>\n* <http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={project2.id}&unselectedSeries=Healthy/|{project2.slug}>"
+            text
+            == f"Release {release.version[:12]} deployed to {self.environment.name} for these projects"
+        )
+        assert attachment["actions"][0]["text"] == self.project.slug
+        assert (
+            attachment["actions"][0]["url"]
+            == f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy/"
+        )
+        assert attachment["actions"][1]["text"] == project2.slug
+        assert (
+            attachment["actions"][1]["url"]
+            == f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={project2.id}&unselectedSeries=Healthy/"
         )
         assert (
             attachment["footer"]

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -525,7 +525,6 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         attachment, text = get_attachment()
 
         assert attachment["title"] == "Hello world"
-        assert attachment["text"] == ""
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=AlertRuleSlack|Notification Settings>"
@@ -602,7 +601,6 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         attachments = json.loads(data["attachments"][0])
         assert len(attachments) == 1
         assert attachments[0]["title"] == "Hello world"
-        assert attachments[0]["text"] == ""
         assert (
             attachments[0]["footer"]
             == f"{self.project.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=AlertRuleSlack|Notification Settings>"
@@ -683,7 +681,6 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         attachments = json.loads(data["attachments"][0])
         assert len(attachments) == 1
         assert attachments[0]["title"] == "Hello world"
-        assert attachments[0]["text"] == ""
         assert (
             attachments[0]["footer"]
             == f"{project2.slug} | <http://example.com/settings/{self.organization.slug}/teams/{self.team.slug}/notifications/?referrer=AlertRuleSlack|Notification Settings>"
@@ -786,7 +783,6 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         attachments = json.loads(data["attachments"][0])
         assert len(attachments) == 1
         assert attachments[0]["title"] == "Hello world"
-        assert attachments[0]["text"] == ""
         assert (
             attachments[0]["footer"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=AlertRuleSlack|Notification Settings>"
@@ -799,7 +795,6 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         attachments = json.loads(data2["attachments"][0])
         assert len(attachments) == 1
         assert attachments[0]["title"] == "Hello world"
-        assert attachments[0]["text"] == ""
         assert (
             attachments[0]["footer"]
             == f"{self.project.slug} | <http://example.com/settings/account/notifications/alerts/?referrer=AlertRuleSlack|Notification Settings>"

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -380,7 +380,6 @@ class ActivityNotificationTest(APITestCase):
         attachment, text = get_attachment()
 
         assert attachment["title"] == "Hello world"
-        assert attachment["text"] == ""
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=AlertRuleSlack|Notification Settings>"

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -238,10 +238,13 @@ class ActivityNotificationTest(APITestCase):
 
         attachment, text = get_attachment()
 
-        assert text == f"Version {release.version} deployed to {self.environment.name}"
         assert (
-            attachment["text"]
-            == f"* <http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy/|{self.project.slug}>"
+            text
+            == f"Release {release.version[:12]} deployed to {self.environment.name} for this project"
+        )
+        assert (
+            attachment["actions"][0]["url"]
+            == f"http://testserver/organizations/{self.organization.slug}/releases/{release.version}/?project={self.project.id}&unselectedSeries=Healthy/"
         )
         assert (
             attachment["footer"]


### PR DESCRIPTION
Various updates to the notification platform Slack messages:

### Updated Deploy Notification Format
We now shorten the release version as we do in the product and turn the links into buttons in a row
**Before**
<img width="711" alt="Screen Shot 2021-07-14 at 3 41 01 PM" src="https://user-images.githubusercontent.com/29959063/125702124-023878ef-aa4b-424f-a69e-f6ea9d72d756.png">

**After**
<img width="550" alt="Screen Shot 2021-07-14 at 3 40 25 PM" src="https://user-images.githubusercontent.com/29959063/125702140-a329dc79-be41-4389-a375-6c8347f58c52.png">

### Removed Bullet Points from Help Text
**Before**
<img width="797" alt="Screen Shot 2021-07-14 at 3 43 29 PM" src="https://user-images.githubusercontent.com/29959063/125702192-bd97dcff-fce9-45bb-839e-1a948e18176b.png">

**After**
<img width="728" alt="Screen Shot 2021-07-14 at 3 40 48 PM" src="https://user-images.githubusercontent.com/29959063/125702216-50e8ec6b-8422-4983-8e83-ce1fc7c048cc.png">

### Changed color of workflow notification attachment bar
Now only issue alerts are red, workflow notifications and deploy notifications use the "info" level blue
**Before**
<img width="380" alt="Screen Shot 2021-07-14 at 3 44 47 PM" src="https://user-images.githubusercontent.com/29959063/125702307-20f138ee-2cf4-4b66-9172-f97c82faad31.png">

**After**
<img width="411" alt="Screen Shot 2021-07-14 at 3 40 33 PM" src="https://user-images.githubusercontent.com/29959063/125702285-dbffb9b1-c973-48f4-b8a0-fa23ffabe3af.png">
