### PR TITLE
fix(ui): Wrap alert filter to prevent overflow (WOR-1037)

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -514,6 +514,7 @@ const RuleText = styled('div')`
 const Filters = styled('span')`
   width: 100%;
   overflow-wrap: break-word;
+  word-break: break-all;
   font-size: ${p => p.theme.fontSizeMedium};
   gap: ${space(1)};
 `;


### PR DESCRIPTION
Filters on the right column could overflow the page

<img width="1074" alt="Screen Shot 2021-07-14 at 3 05 06 PM" src="https://user-images.githubusercontent.com/1400464/125702648-d7a7bade-ef2c-4f4b-932d-13eebc3a3da8.png">
