### PR TITLE
ref(ui): Replace jQuery.param w/ qs.stringify

### DIFF
--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -1,8 +1,8 @@
 import {browserHistory} from 'react-router';
 import {Severity} from '@sentry/react';
-import jQuery from 'jquery';
 import Cookies from 'js-cookie';
 import isUndefined from 'lodash/isUndefined';
+import * as qs from 'query-string';
 
 import {openSudo, redirectToProject} from 'app/actionCreators/modal';
 import {EXPERIMENTAL_SPA} from 'app/constants';
@@ -118,7 +118,7 @@ export const initApiClientErrorHandling = () =>
 function buildRequestUrl(baseUrl: string, path: string, query: RequestOptions['query']) {
   let params: string;
   try {
-    params = jQuery.param(query ?? [], true);
+    params = qs.stringify(query ?? []);
   } catch (err) {
     run(Sentry =>
       Sentry.withScope(scope => {
@@ -328,7 +328,7 @@ export class Client {
     // object for GET requets. jQuery just sticks it onto the URL as query
     // parameters
     if (method === 'GET' && data) {
-      const queryString = typeof data === 'string' ? data : jQuery.param(data);
+      const queryString = typeof data === 'string' ? data : qs.stringify(data);
 
       if (queryString.length > 0) {
         fullUrl = fullUrl + (fullUrl.indexOf('?') !== -1 ? '&' : '?') + queryString;


### PR DESCRIPTION
I verified some common cases between these two calls:

```
> qs.stringify({key: 'value', key2: 'value2'})
'key=value&key2=value2'
> jquery2.param({key: 'value', key2: 'value2'}, true)
'key=value&key2=value2'
```

```
> qs.stringify({key: [1, 2, 3]})
'key=1&key=2&key=3'
> jquery.param({key: [1, 2, 3]}, true)
'key=1&key=2&key=3'
```

```
> jquery2.param({key: {subkey1: 'value'}}, true)
'key=%5Bobject+Object%5D'
> qs.stringify({key: {subkey1: 'value'}})
'key=%5Bobject%20Object%5D'
```
(this already did nothing)

I think we're safe here