### PR TITLE
fix(ui): Remove Skip Onboarding

### DIFF
--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -78,14 +78,7 @@ class OnboardingWelcome extends Component<Props> {
               <PositionedFallingError>{fallingError}</PositionedFallingError>
             </CTAContainer>
             <SecondaryAction {...fadeAway}>
-              {tct('[flavorText][br][exitLink:Skip onboarding].', {
-                br: <br />,
-                exitLink: <Button priority="link" href="/" />,
-                flavorText:
-                  fallCount > 0
-                    ? easterEggText[fallCount - 1]
-                    : t("Really, this again? I've used Sentry before."),
-              })}
+              {fallCount > 0 ? easterEggText[fallCount - 1] : <br />}
             </SecondaryAction>
           </Wrapper>
         )}


### PR DESCRIPTION
Removed the option to skip onboarding because a user would still need to set up a project as a first step anyway.

Note that the FallingError easter egg is still there. When `fallCount` is 0, nothing will be displayed, and I return `<br />` to maintain the appropriate spacing.

Before:
![image](https://user-images.githubusercontent.com/8980455/125706181-0986f7f0-e0be-4287-8684-45a3a0acfb8f.png)
![image](https://user-images.githubusercontent.com/8980455/125706205-78d4a44d-bed0-4b91-9724-ed80ce34acd1.png)


After:
![image](https://user-images.githubusercontent.com/8980455/125706106-37869de1-cf62-43fc-9056-938a2bcebce0.png)
![image](https://user-images.githubusercontent.com/8980455/125706129-fab5030c-3bb1-4960-b64d-335da945b5a4.png)
