### PR TITLE
fix(integrations): Add `ExpiredSignatureError` to catch statement

### DIFF
--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -119,9 +119,9 @@ class JiraConfigView(BaseJiraWidgetView):
     @transaction_start("JiraConfigView.post")
     def post(self, request, *args, **kwargs):
         try:
-            jira_auth = get_jira_auth_from_request(request)
+            jira_auth = self.get_jira_auth()
         except CATCHABLE_AUTH_ERRORS:
-            self.get_response("error.html")
+            return self.get_response("error.html")
 
         if request.user.is_anonymous:
             return self.get_response("signin.html")


### PR DESCRIPTION
I noticed that the two GETs and the POST all call `get_jira_auth()` differently. This PR makes them all catch the same errors.

Fixes [SENTRY-R95](https://sentry.io/organizations/sentry/issues/2511166319/).