### PR TITLE
test(ui): Fix flaky group "last seen" in snapshots

### DIFF
--- a/static/app/components/group/inboxBadges/timesTag.tsx
+++ b/static/app/components/group/inboxBadges/timesTag.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import TimeSince from 'app/components/timeSince';
 import {IconClock} from 'app/icons';
 import {t} from 'app/locale';
+import getDynamicText from 'app/utils/getDynamicText';
 
 /**
  * Used in new inbox
@@ -19,26 +20,34 @@ const TimesTag = ({lastSeen, firstSeen}: Props) => {
   return (
     <Wrapper>
       <StyledIconClock size="xs" color="gray300" />
-      {lastSeen && (
-        <TimeSince
-          tooltipTitle={t('Last Seen')}
-          date={lastSeen}
-          suffix={t('ago')}
-          shorten
-        />
-      )}
+      {lastSeen &&
+        getDynamicText({
+          value: (
+            <TimeSince
+              tooltipTitle={t('Last Seen')}
+              date={lastSeen}
+              suffix={t('ago')}
+              shorten
+            />
+          ),
+          fixed: '10s ago',
+        })}
       {firstSeen && lastSeen && (
         <Separator className="hidden-xs hidden-sm">&nbsp;|&nbsp;</Separator>
       )}
-      {firstSeen && (
-        <TimeSince
-          tooltipTitle={t('First Seen')}
-          date={firstSeen}
-          suffix={t('old')}
-          className="hidden-xs hidden-sm"
-          shorten
-        />
-      )}
+      {firstSeen &&
+        getDynamicText({
+          value: (
+            <TimeSince
+              tooltipTitle={t('First Seen')}
+              date={firstSeen}
+              suffix={t('old')}
+              className="hidden-xs hidden-sm"
+              shorten
+            />
+          ),
+          fixed: '10s old',
+        })}
     </Wrapper>
   );
 };


### PR DESCRIPTION
They can be seen in a few snapshots

![image](https://user-images.githubusercontent.com/1400464/125708655-e401bcf7-f539-4d81-b3a4-56bb74065e35.png)

https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/e4363bd566403e2687e2e2083658adb271e18d45/index.html
