### PR TITLE
Populate App Store Connect dates

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -375,8 +375,8 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
     Here the ``itunesSessionRefreshAt`` is when we recommend to refresh the
     iTunes session, and ``pendingDownloads`` is the number of pending build
     downloads, and an indicator if we do need the session to fetch new builds.
-    ``latestBuildVersion`` is a human-readable string representing the latest
-    build from App Store Connect recognized by Sentry.
+    ``latestBuildVersion`` is a human-readable equivalent of ``latestBuildNumber``,
+    which is specifically for the latest build that Sentry recognizes.
     """
 
     permission_classes = [StrictProjectPermission]

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -368,6 +368,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         "pendingDownloads": 123,
         "itunesSessionRefreshAt": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ" | null
         "latestBuildVersion: "9.8.7",
+        "latestBuildNumber": "987000",
     }
     ```
 
@@ -415,11 +416,11 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
             .first()
         )
         if latest_build is None:
-            latestBundleVersion = None
-            latestBundleShortVersion = None
+            latestBuildVersion = None
+            latestBuildNumber = None
         else:
-            latestBundleVersion = latest_build.bundle_version
-            latestBundleShortVersion = latest_build.bundle_short_version
+            latestBuildVersion = latest_build.bundle_short_version
+            latestBuildNumber = latest_build.bundle_version
 
         return Response(
             {
@@ -427,8 +428,8 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "itunesSessionValid": itunes_session_info is not None,
                 "itunesSessionRefreshAt": expiration_date if itunes_session_info else None,
                 "pendingDownloads": pending_downloads,
-                "latestBundleVersion": latestBundleVersion,
-                "latestBundleShortVersion": latestBundleShortVersion,
+                "latestBuildVersion": latestBuildVersion,
+                "latestBuildNumber": latestBuildNumber,
             },
             status=200,
         )

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -422,6 +422,9 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "itunesSessionRefreshAt": expiration_date if itunes_session_info else None,
                 "pendingDownloads": pending_downloads,
                 "latestBuildVersion": latest_build["build_version"] if latest_build else None,
+                "latestBundleVersion": latest_build["bundle_short_version"]
+                if latest_build
+                else None,
             },
             status=200,
         )

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -407,11 +407,12 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         itunes_connect.load_session_cookie(session, symbol_source_cfg.itunesSession)
         itunes_session_info = itunes_connect.get_session_info(session)
 
-        builds = AppConnectBuild.objects.filter(project=project)
-        pending_downloads = builds.filter(fetched=False).count()
-        sorted_builds = builds.sort(key=lambda b: b["uploaded_to_appstore"])
-        latest_build_version = (
-            sorted_builds[-1]["bundle_short_version"] if sorted_builds.len > 0 else None
+        pending_downloads = AppConnectBuild.objects.filter(project=project, fetched=False).count()
+
+        latest_build = (
+            AppConnectBuild.objects.filter(project=project)
+            .order_by("-uploaded_to_appstore")
+            .first()
         )
 
         return Response(
@@ -420,7 +421,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "itunesSessionValid": itunes_session_info is not None,
                 "itunesSessionRefreshAt": expiration_date if itunes_session_info else None,
                 "pendingDownloads": pending_downloads,
-                "latestBuildVersion": latest_build_version,
+                "latestBuildVersion": latest_build["build_version"] if latest_build else None,
             },
             status=200,
         )

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -367,12 +367,15 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         "itunesSessionValid": true,
         "pendingDownloads": 123,
         "itunesSessionRefreshAt": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ" | null
+        "latestBuildVersion: "9.8.7",
     }
     ```
 
     Here the ``itunesSessionRefreshAt`` is when we recommend to refresh the
-    iTunes session, and ``pendingDownloads`` is the number of pending downloads,
-    and an indicator if we do need the session to fetch new builds.
+    iTunes session, and ``pendingDownloads`` is the number of pending build
+    downloads, and an indicator if we do need the session to fetch new builds.
+    ``latestBuildVersion`` is a human-readable string representing the latest
+    build from App Store Connect recognized by Sentry.
     """
 
     permission_classes = [StrictProjectPermission]
@@ -404,7 +407,12 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         itunes_connect.load_session_cookie(session, symbol_source_cfg.itunesSession)
         itunes_session_info = itunes_connect.get_session_info(session)
 
-        pending_downloads = AppConnectBuild.objects.filter(project=project, fetched=False).count()
+        builds = AppConnectBuild.objects.filter(project=project)
+        pending_downloads = builds.filter(fetched=False).count()
+        sorted_builds = builds.sort(key=lambda b: b["uploaded_to_appstore"])
+        latest_build_version = (
+            sorted_builds[-1]["bundle_short_version"] if sorted_builds.len > 0 else None
+        )
 
         return Response(
             {
@@ -412,6 +420,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "itunesSessionValid": itunes_session_info is not None,
                 "itunesSessionRefreshAt": expiration_date if itunes_session_info else None,
                 "pendingDownloads": pending_downloads,
+                "latestBuildVersion": latest_build_version,
             },
             status=200,
         )

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -367,16 +367,16 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         "itunesSessionValid": true,
         "pendingDownloads": 123,
         "itunesSessionRefreshAt": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ" | null
-        "latestBuildVersion: "9.8.7",
-        "latestBuildNumber": "987000",
+        "latestBuildVersion: "9.8.7" | null,
+        "latestBuildNumber": "987000" | null,
     }
     ```
 
     Here the ``itunesSessionRefreshAt`` is when we recommend to refresh the
     iTunes session, and ``pendingDownloads`` is the number of pending build
     downloads, and an indicator if we do need the session to fetch new builds.
-    ``latestBuildVersion`` is a human-readable equivalent of ``latestBuildNumber``,
-    which is specifically for the latest build that Sentry recognizes.
+    ``latestBuildVersion`` and ``latestBuildNumber`` together form a unique
+    identifier for the latest build recognized by Sentry.
     """
 
     permission_classes = [StrictProjectPermission]

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -414,6 +414,12 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
             .order_by("-uploaded_to_appstore")
             .first()
         )
+        if latest_build is None:
+            latestBundleVersion = None
+            latestBundleShortVersion = None
+        else:
+            latestBundleVersion = latest_build.bundle_version
+            latestBundleShortVersion = latest_build.bundle_short_version
 
         return Response(
             {
@@ -421,10 +427,8 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "itunesSessionValid": itunes_session_info is not None,
                 "itunesSessionRefreshAt": expiration_date if itunes_session_info else None,
                 "pendingDownloads": pending_downloads,
-                "latestBuildVersion": latest_build["build_version"] if latest_build else None,
-                "latestBundleVersion": latest_build["bundle_short_version"]
-                if latest_build
-                else None,
+                "latestBundleVersion": latestBundleVersion,
+                "latestBundleShortVersion": latestBundleShortVersion,
             },
             status=200,
         )

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -16,6 +16,7 @@ import jsonschema
 import requests
 import sentry_sdk
 from django.db import transaction
+from django.db.models import DateTimeField
 
 from sentry.lang.native.symbolicator import APP_STORE_CONNECT_SCHEMA
 from sentry.models import Project
@@ -241,9 +242,9 @@ class BuildInfo:
     # The app ID
     app_id: str
 
-    # A platform identifying e.g. iOS, TvOS etc.
+    # A platform identifier, e.g. iOS, TvOS etc.
     #
-    # These are not always human readable but some opaque string supplied by apple.
+    # These are not always human-readable and can be some opaque string supplied by Apple.
     platform: str
 
     # The human-readable version, e.g. "7.2.0".
@@ -256,6 +257,9 @@ class BuildInfo:
     #
     # Apple naming calls this the "bundle_version".
     build_number: str
+
+    # The date and time the build was uploaded to App Store Connect.
+    uploaded_date: DateTimeField
 
 
 class ITunesClient:
@@ -359,6 +363,7 @@ class AppConnectClient:
                     platform=build["platform"],
                     version=build["version"],
                     build_number=build["build_number"],
+                    uploaded_date=build["uploaded_date"],
                 )
             )
 

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -16,7 +16,6 @@ import jsonschema
 import requests
 import sentry_sdk
 from django.db import transaction
-from django.db.models import DateTimeField
 
 from sentry.lang.native.symbolicator import APP_STORE_CONNECT_SCHEMA
 from sentry.models import Project
@@ -259,7 +258,7 @@ class BuildInfo:
     build_number: str
 
     # The date and time the build was uploaded to App Store Connect.
-    uploaded_date: DateTimeField
+    uploaded_date: datetime
 
 
 class ITunesClient:

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -10,6 +10,7 @@ import tempfile
 from typing import List, Mapping
 
 import sentry_sdk
+from django.utils import timezone
 
 from sentry.lang.native import appconnect
 from sentry.models import AppConnectBuild, Project, ProjectOption, debugfile
@@ -108,6 +109,8 @@ def get_or_create_persisted_build(
             platform=build.platform,
             bundle_short_version=build.version,
             bundle_version=build.build_number,
+            uploaded_to_appstore=build.uploaded_date,
+            first_seen=timezone.now(),
             fetched=False,
             # TODO: persist the `uploadedDate` attribute as well.
         )

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -112,7 +112,6 @@ def get_or_create_persisted_build(
             uploaded_to_appstore=build.uploaded_date,
             first_seen=timezone.now(),
             fetched=False,
-            # TODO: persist the `uploadedDate` attribute as well.
         )
         build_state.save()
     return build_state

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 from typing import Any, Dict, Generator, List, Mapping, Optional, Union
 
 import sentry_sdk
+from dateutil.parser import parse as parse_date
 from requests import Session
 
 from sentry.utils import jwt, safe
@@ -119,6 +120,7 @@ def get_build_info(
     version: str - the short version build info ( e.g. '1.0.1'), also called "train"
        in starship documentation
     build_number: str - the version of the build (e.g. '101'), looks like the build number
+    uploaded_date: datetime - when the build was uploaded to App Store Connect
     """
     with sentry_sdk.start_span(
         op="appconnect-list-builds", description="List all AppStoreConnect builds"
@@ -194,9 +196,15 @@ def get_build_info(
                     else:
                         raise KeyError("missing related version")
                     build_number = build["attributes"]["version"]
+                    uploaded_date = parse_date(build["attributes"]["uploadedDate"])
 
                     result.append(
-                        {"platform": platform, "version": version, "build_number": build_number}
+                        {
+                            "platform": platform,
+                            "version": version,
+                            "build_number": build_number,
+                            "uploaded_date": uploaded_date,
+                        }
                     )
                 except Exception:
                     logger.error(

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -45,11 +45,11 @@ export type AppStoreConnectValidationData = {
    * The version of the latest build recognized by sentry. The contents of this string is just a
    * number. This will be null if no builds can be found.
    */
-  latestBundleVersion: string | null;
+  latestBuildNumber: string | null;
   /**
    * A human-readable string representing the latest build recognized by sentry. i.e. 3.4.0.
    * This will be null if no builds can be found.
    */
-  latestBundleShortVersion: string | null;
+  latestBuildVersion: string | null;
   updateAlertMessage?: string;
 };

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -45,11 +45,11 @@ export type AppStoreConnectValidationData = {
    * The version of the latest build recognized by sentry. The contents of this string is just a
    * number. This will be null if no builds can be found.
    */
-  latestBuildVersion: string | null;
+  latestBundleVersion: string | null;
   /**
    * A human-readable string representing the latest build recognized by sentry. i.e. 3.4.0.
    * This will be null if no builds can be found.
    */
-  latestBundleVersion: string | null;
+  latestBundleShortVersion: string | null;
   updateAlertMessage?: string;
 };

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -41,7 +41,15 @@ export type AppStoreConnectValidationData = {
   itunesSessionRefreshAt: string | null;
   /** Indicates if the itunesSession is actually *needed* to complete any downloads that are pending. */
   pendingDownloads: number;
-  /** The version of the latest build recognized by sentry. Human-readable. */
+  /**
+   * The version of the latest build recognized by sentry. The contents of this string is just a
+   * number. This will be null if no builds can be found.
+   */
   latestBuildVersion: string | null;
+  /**
+   * A human-readable string representing the latest build recognized by sentry. i.e. 3.4.0.
+   * This will be null if no builds can be found.
+   */
+  latestBundleVersion: string | null;
   updateAlertMessage?: string;
 };

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -41,5 +41,7 @@ export type AppStoreConnectValidationData = {
   itunesSessionRefreshAt: string | null;
   /** Indicates if the itunesSession is actually *needed* to complete any downloads that are pending. */
   pendingDownloads: number;
+  /** The version of the latest build recognized by sentry. Human-readable. */
+  latestBuildVersion: string | null;
   updateAlertMessage?: string;
 };

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -42,13 +42,15 @@ export type AppStoreConnectValidationData = {
   /** Indicates if the itunesSession is actually *needed* to complete any downloads that are pending. */
   pendingDownloads: number;
   /**
-   * The version of the latest build recognized by sentry. The contents of this string is just a
-   * number. This will be null if no builds can be found.
+   * The build number of the latest build recognized by sentry. This does not imply the dSYMs for
+   * this build have been fetched. The contents of this string is just a number. This will be null
+   * if no builds can be found.
    */
   latestBuildNumber: string | null;
   /**
-   * A human-readable string representing the latest build recognized by sentry. i.e. 3.4.0.
-   * This will be null if no builds can be found.
+   * A human-readable string representing the latest build recognized by sentry. i.e. 3.4.0. This
+   * does not imply the dSYMs for this build have been fetched. This will be null if no builds can
+   * be found.
    */
   latestBuildVersion: string | null;
   updateAlertMessage?: string;


### PR DESCRIPTION
Populate the columns with useful dates related to builds on ASC. Having access to the upload date of the build (`uploaded_to_appstore`) also gives us the ability to easily determine what the latest recognized build is, so that value is also now being returned to the front end.

Changes related to returning the actual date of the last time builds were checked by sentry will be coming soon in a different PR.