### PR TITLE
chore(deps): bump relay version from version 0.8.7 to 0.8.8

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ requests==2.25.1
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay==0.8.7
+sentry-relay==0.8.8
 sentry-sdk>=1.0.0,<1.2.0
 snuba-sdk>=0.0.19,<1.0.0
 simplejson==3.17.2

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -159,7 +159,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         assert result["versionInfo"]["version"]["pre"] == "a"
         assert result["versionInfo"]["version"]["buildCode"] == "20200101100"
         assert result["versionInfo"]["buildHash"] is None
-        assert result["versionInfo"]["description"] == "1.0-a (20200101100)"
+        assert result["versionInfo"]["description"] == "1.0a (20200101100)"
         assert result["versionInfo"]["version"]["components"] == 2
 
     def test_no_tag_data(self):

--- a/tests/sentry/event_manager/test_validate_data.py
+++ b/tests/sentry/event_manager/test_validate_data.py
@@ -185,7 +185,11 @@ def test_site_too_long():
 
 def test_release_too_long():
     data = validate_and_normalize({"release": "a" * (MAX_VERSION_LENGTH + 1)})
-    assert len(data.get("release")) == MAX_VERSION_LENGTH
+    assert not data.get("release")
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["type"] == "invalid_data"
+    assert data["errors"][0]["name"] == "release"
+    assert data["errors"][0]["value"] == "a" * (MAX_VERSION_LENGTH + 1)
 
 
 def test_release_as_non_string():
@@ -242,7 +246,12 @@ def test_invalid_platform():
 
 def test_environment_too_long():
     data = validate_and_normalize({"environment": "a" * 65})
-    assert len(data["environment"]) == 64
+    assert not data.get("environment")
+    (error,) = data["errors"]
+    error["type"] == "invalid_data"
+
+    assert error["name"] == "environment"
+    assert error["value"] == "a" * 65
 
 
 def test_environment_invalid():


### PR DESCRIPTION
This PR bumps relay to 0.8.8 which allows for ability to compare semver releases