### PR TITLE
feat(semver): Adds Resolved in Next Release behavior for semver releases

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -31,6 +31,7 @@ from sentry.models import (
     GroupHash,
     GroupInboxReason,
     GroupLink,
+    GroupRelease,
     GroupResolution,
     GroupSeen,
     GroupShare,
@@ -43,6 +44,7 @@ from sentry.models import (
     Team,
     User,
     UserOption,
+    follows_semver_versioning_scheme,
     remove_group_from_inbox,
 )
 from sentry.models.group import STATUS_UPDATE_CHOICES, looks_like_short_id
@@ -493,6 +495,42 @@ def rate_limit_endpoint(limit=1, window=1):
     return inner
 
 
+def get_current_release_version_of_group(group, follows_semver=False):
+    """
+    Function that returns the latest release version associated with a Group, and by latest we
+    mean either most recent (date) or latest in semver versioning scheme
+    Inputs:
+        * group: Group of the issue
+        * follows_semver: flag that determines whether the project of the group follows semantic
+                          versioning or not.
+    Returns:
+        current_release_version
+    """
+    current_release_version = None
+    if follows_semver:
+        try:
+            # This sets current_release_version to the latest semver version associated with a group
+            order_by_semver_desc = [f"-{col}" for col in Release.SEMVER_COLS]
+            current_release_version = (
+                Release.objects.filter_to_semver()
+                .filter(
+                    id__in=GroupRelease.objects.filter(
+                        project_id=group.project.id, group_id=group.id
+                    ).values_list("release_id"),
+                )
+                .annotate_prerelease_column()
+                .order_by(*order_by_semver_desc)
+                .values_list("version", flat=True)[:1]
+                .get()
+            )
+        except IndexError:
+            ...
+    else:
+        # This sets current_release_version to the most recent release associated with a group
+        current_release_version = group.get_last_release()
+    return current_release_version
+
+
 def update_groups(request, group_ids, projects, organization_id, search_fn):
     if group_ids:
         group_list = Group.objects.filter(
@@ -658,6 +696,26 @@ def update_groups(request, group_ids, projects, organization_id, search_fn):
                         "status": res_status,
                         "actor_id": request.user.id if request.user.is_authenticated else None,
                     }
+
+                    # We only set `current_release_version` if GroupResolution type is
+                    # in_next_release, because we need to store information about the latest/most
+                    # recent release that was associated with a group and that is required for
+                    # release comparisons (i.e. handling regressions)
+                    if res_type == GroupResolution.Type.in_next_release:
+                        # Check if semver versioning scheme is followed
+                        follows_semver = follows_semver_versioning_scheme(
+                            org_id=group.organization.id,
+                            project_id=group.project.id,
+                            release_version=release.version,
+                        )
+
+                        current_release_version = get_current_release_version_of_group(
+                            group=group, follows_semver=follows_semver
+                        )
+                        if current_release_version:
+                            resolution_params.update(
+                                {"current_release_version": current_release_version}
+                            )
                     resolution, created = GroupResolution.objects.get_or_create(
                         group=group, defaults=resolution_params
                     )

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -1,9 +1,11 @@
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from sentry_relay import RelayError, parse_release
+from sentry_relay.processing import compare_version as compare_version_relay
 
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
-from sentry.models.release import DB_VERSION_LENGTH
+from sentry.models.release import DB_VERSION_LENGTH, Release, follows_semver_versioning_scheme
 from sentry.utils import metrics
 
 
@@ -53,11 +55,25 @@ class GroupResolution(Model):
 
         This is used to suggest if a regression has occurred.
         """
+
+        def compare_release_dates_for_in_next_release(res_release, res_release_datetime, release):
+            """
+            Helper function that compares release versions based on date for
+            `GroupResolution.Type.in_next_release`
+            """
+            if res_release == release.id:
+                return True
+            elif res_release_datetime > release.date_added:
+                return True
+            return False
+
         try:
-            res_type, res_release, res_release_datetime = (
+            res_type, res_release, res_release_datetime, current_release_version = (
                 cls.objects.filter(group=group)
                 .select_related("release")
-                .values_list("type", "release__id", "release__date_added")[0]
+                .values_list(
+                    "type", "release__id", "release__date_added", "current_release_version"
+                )[0]
             )
         except IndexError:
             return False
@@ -67,17 +83,51 @@ class GroupResolution(Model):
         if not release:
             return True
 
+        # if current_release_version was set, then it means that initially Group was resolved in
+        # next release, which means a release will have a resolution if it is the same as
+        # `current_release_version` or was released before it according to either its semver version
+        # or its date. We make that decision based on whether the project follows semantic
+        # versioning or not
+        if current_release_version:
+            follows_semver = follows_semver_versioning_scheme(
+                project_id=group.project.id,
+                org_id=group.organization.id,
+                release_version=release.version,
+            )
+            if follows_semver:
+                try:
+                    # If current_release_version == release.version => 0
+                    # If current_release_version < release.version => -1
+                    # If current_release_version > release.version => 1
+                    current_release_raw = parse_release(current_release_version).get("version_raw")
+                    release_raw = parse_release(release.version).get("version_raw")
+                    return compare_version_relay(current_release_raw, release_raw) >= 0
+                except RelayError:
+                    ...
+            else:
+                try:
+                    current_release_obj = Release.objects.get(version=current_release_version)
+
+                    return compare_release_dates_for_in_next_release(
+                        res_release=current_release_obj.id,
+                        res_release_datetime=current_release_obj.date_added,
+                        release=release,
+                    )
+                except Release.DoesNotExist:
+                    ...
+
+        # We still fallback to the older model if either current_release_version was not set (
+        # i.e. In all resolved cases except for Resolved in Next Release) or if for whatever
+        # reason the semver/date checks fail (which should not happen!)
         if res_type in (None, cls.Type.in_next_release):
             # Add metric here to ensure that this code branch ever runs given that
             # clear_expired_resolutions changes the type to `in_release` once a Release instance
             # is created
             metrics.incr("groupresolution.has_resolution.in_next_release", sample_rate=1.0)
 
-            if res_release == release.id:
-                return True
-            elif res_release_datetime > release.date_added:
-                return True
-            return False
+            return compare_release_dates_for_in_next_release(
+                res_release=res_release, res_release_datetime=res_release_datetime, release=release
+            )
         elif res_type == cls.Type.in_release:
             if res_release == release.id:
                 return False

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 from sentry.models.release import DB_VERSION_LENGTH
+from sentry.utils import metrics
 
 
 class GroupResolution(Model):
@@ -67,6 +68,11 @@ class GroupResolution(Model):
             return True
 
         if res_type in (None, cls.Type.in_next_release):
+            # Add metric here to ensure that this code branch ever runs given that
+            # clear_expired_resolutions changes the type to `in_release` once a Release instance
+            # is created
+            metrics.incr("groupresolution.has_resolution.in_next_release", sample_rate=1.0)
+
             if res_release == release.id:
                 return True
             elif res_release_datetime > release.date_added:

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -25,10 +25,8 @@ class GroupResolution(Model):
     # the release in which its suggested this was resolved
     # which allows us to indicate if it still happens in newer versions
     release = FlexibleForeignKey("sentry.Release")
-    # This release field represents the release version of the bug when the user clicked on the
-    # "resolve in next release" button
-    # This column is specifically added for semver release comparison to be able to compare this
-    # semver release against "future/resolved" semver releases
+    # This release field represents the latest release version associated with a group when the
+    # user chooses "resolve in next release", and is set for both semver and date ordered releases
     current_release_version = models.CharField(max_length=DB_VERSION_LENGTH, null=True, blank=True)
     type = BoundedPositiveIntegerField(
         choices=((Type.in_next_release, "in_next_release"), (Type.in_release, "in_release")),

--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -13,6 +13,12 @@ class GroupResolutionTest(TestCase):
         self.old_release.update(date_added=timezone.now() - timedelta(minutes=30))
         self.new_release = self.create_release(version="b", project=self.project)
         self.group = self.create_group()
+        self.old_semver_release = self.create_release(
+            version="foo_package@1.0", project=self.project
+        )
+        self.new_semver_release = self.create_release(
+            version="foo_package@2.0", project=self.project
+        )
 
     def test_in_next_release_with_new_release(self):
         GroupResolution.objects.create(
@@ -31,6 +37,120 @@ class GroupResolutionTest(TestCase):
             release=self.new_release, group=self.group, type=GroupResolution.Type.in_next_release
         )
         assert GroupResolution.has_resolution(self.group, self.old_release)
+
+    def test_for_semver_when_current_release_version_is_set_with_new_semver_release(self):
+        # Behaviour should be the same in both `in_release` and `in_next_release` because if
+        # `current_release_version` is set then comparison will be > current_release_version
+        # should not have a resolution
+        for grp_res_type in [GroupResolution.Type.in_release, GroupResolution.Type.in_next_release]:
+            grp_resolution = GroupResolution.objects.create(
+                release=self.old_semver_release,
+                current_release_version=self.old_semver_release.version,
+                group=self.group,
+                type=grp_res_type,
+            )
+            assert not GroupResolution.has_resolution(self.group, self.new_semver_release)
+
+            grp_resolution.delete()
+
+    def test_for_semver_when_current_release_version_is_set_with_same_release(self):
+        for grp_res_type in [GroupResolution.Type.in_release, GroupResolution.Type.in_next_release]:
+            grp_resolution = GroupResolution.objects.create(
+                release=self.old_semver_release,
+                current_release_version=self.old_semver_release.version,
+                group=self.group,
+                type=grp_res_type,
+            )
+            assert GroupResolution.has_resolution(self.group, self.old_semver_release)
+
+            grp_resolution.delete()
+
+    def test_for_semver_when_current_release_version_is_set_with_old_semver_release(self):
+        for grp_res_type in [GroupResolution.Type.in_release, GroupResolution.Type.in_next_release]:
+            grp_resolution = GroupResolution.objects.create(
+                release=self.new_semver_release,
+                current_release_version=self.new_semver_release.version,
+                group=self.group,
+                type=grp_res_type,
+            )
+            assert GroupResolution.has_resolution(self.group, self.old_semver_release)
+            grp_resolution.delete()
+
+    def test_when_current_release_version_is_set_with_new_release(self):
+        for grp_res_type in [GroupResolution.Type.in_release, GroupResolution.Type.in_next_release]:
+            grp_resolution = GroupResolution.objects.create(
+                release=self.old_release,
+                current_release_version=self.old_release.version,
+                group=self.group,
+                type=grp_res_type,
+            )
+            assert not GroupResolution.has_resolution(self.group, self.new_release)
+
+            grp_resolution.delete()
+
+    def test_when_current_release_version_is_set_with_same_release(self):
+        for grp_res_type in [GroupResolution.Type.in_release, GroupResolution.Type.in_next_release]:
+            grp_resolution = GroupResolution.objects.create(
+                release=self.old_release,
+                current_release_version=self.old_release.version,
+                group=self.group,
+                type=grp_res_type,
+            )
+            assert GroupResolution.has_resolution(self.group, self.old_release)
+
+            grp_resolution.delete()
+
+    def test_when_current_release_version_is_set_with_old_release(self):
+        for grp_res_type in [GroupResolution.Type.in_release, GroupResolution.Type.in_next_release]:
+            grp_resolution = GroupResolution.objects.create(
+                release=self.new_release,
+                current_release_version=self.new_release.version,
+                group=self.group,
+                type=grp_res_type,
+            )
+            assert GroupResolution.has_resolution(self.group, self.old_release)
+
+            grp_resolution.delete()
+
+    def test_when_current_release_version_is_set_incorrect_inputs_fallback_to_older_model(self):
+        """
+        Test that ensures in a project that follows semverand where current_release_version is
+        set, wrong release input (non semver) comparison does not break the method, but rather
+        fallsback to the older model of comparison
+        """
+        old_random_release = self.create_release(version="doggo", project=self.project)
+        old_random_release.update(date_added=timezone.now() - timedelta(minutes=45))
+
+        GroupResolution.objects.create(
+            release=old_random_release,
+            current_release_version=old_random_release.version,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+        )
+
+        for release in [
+            self.old_release,
+            self.new_release,
+            self.old_semver_release,
+            self.new_semver_release,
+        ]:
+            assert not GroupResolution.has_resolution(self.group, release)
+
+    def test_when_current_release_version_is_set_but_does_not_exist_fallback_to_older_model(self):
+        """
+        Test that ensures in a project that does not follows semver, and current_release_version
+        is set but no corresponding Release instance exists for that release version then
+        comparison does not break the method, but rather fallsback to the older model
+        """
+        GroupResolution.objects.create(
+            release=self.old_release,
+            current_release_version="kittie 12",
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+        )
+
+        for release in [self.new_release, self.old_semver_release, self.new_semver_release]:
+            assert not GroupResolution.has_resolution(self.group, release)
 
     def test_in_release_with_new_release(self):
         GroupResolution.objects.create(

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1927,6 +1927,121 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert activity.data["version"] == ""
         uo1.delete()
 
+    def test_in_semver_projects_group_resolution_stores_current_release_version(self):
+        """
+        Test that ensures that when we resolve a group in the next release, then
+        GroupResolution.current_release_version is set to the latest release associated with a
+        Group, when the project follows semantic versioning scheme
+        """
+        release_1 = Release.objects.create(
+            organization_id=self.project.organization_id, version="fake_package@21.1.0"
+        )
+        release_2 = Release.objects.create(
+            organization_id=self.project.organization_id, version="fake_package@21.1.1"
+        )
+        release_3 = Release.objects.create(
+            organization_id=self.project.organization_id, version="fake_package@21.1.2"
+        )
+
+        for release in [release_1, release_2, release_3]:
+            release.add_project(self.project)
+
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+                "release": release_2.version,
+            },
+            project_id=self.project.id,
+        )
+        group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=12)),
+                "fingerprint": ["group-1"],
+                "release": release_1.version,
+            },
+            project_id=self.project.id,
+        ).group
+
+        self.login_as(user=self.user)
+
+        response = self.get_valid_response(
+            qs_params={"id": group.id}, status="resolvedInNextRelease"
+        )
+        assert response.data["status"] == "resolved"
+        assert response.data["statusDetails"]["inNextRelease"]
+
+        # The current_release_version should be to the latest (in semver) release associated with
+        # a group
+        grp_resolution = GroupResolution.objects.filter(group=group)
+
+        assert len(grp_resolution) == 1
+        assert grp_resolution[0].current_release_version == release_2.version
+
+        # Add release that is between 2 and 3 to ensure that any release after release 2 should
+        # not have a resolution
+        release_4 = Release.objects.create(
+            organization_id=self.project.organization_id, version="fake_package@21.1.1+1"
+        )
+        release_4.add_project(self.project)
+
+        for release in [release_1, release_2]:
+            assert GroupResolution.has_resolution(group=group, release=release)
+
+        for release in [release_3, release_4]:
+            assert not GroupResolution.has_resolution(group=group, release=release)
+
+    def test_in_non_semver_projects_group_resolution_stores_current_release_version(self):
+        """
+        Test that ensures that when we resolve a group in the next release, then
+        GroupResolution.current_release_version is set to the most recent release associated with a
+        Group, when the project does not follow semantic versioning scheme
+        """
+        release_1 = Release.objects.create(
+            organization_id=self.project.organization_id, version="foobar 1"
+        )
+        release_1.update(date_added=timezone.now() - timedelta(minutes=45))
+        release_2 = Release.objects.create(
+            organization_id=self.project.organization_id, version="foobar 2"
+        )
+
+        for release in [release_1, release_2]:
+            release.add_project(self.project)
+
+        group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=12)),
+                "fingerprint": ["group-1"],
+                "release": release_1.version,
+            },
+            project_id=self.project.id,
+        ).group
+
+        self.login_as(user=self.user)
+
+        response = self.get_valid_response(
+            qs_params={"id": group.id}, status="resolvedInNextRelease"
+        )
+        assert response.data["status"] == "resolved"
+        assert response.data["statusDetails"]["inNextRelease"]
+
+        # Add a new release that is between 1 and 2, to make sure that if a the same issue/group
+        # occurs in that issue, then it should not have a resolution
+        release_3 = Release.objects.create(
+            organization_id=self.project.organization_id, version="foobar 3"
+        )
+        release_3.add_project(self.project)
+        release_3.update(date_added=timezone.now() - timedelta(minutes=30))
+
+        grp_resolution = GroupResolution.objects.filter(group=group)
+
+        assert len(grp_resolution) == 1
+        assert grp_resolution[0].current_release_version == release_1.version
+
+        assert GroupResolution.has_resolution(group=group, release=release_1)
+        for release in [release_2, release_3]:
+            assert not GroupResolution.has_resolution(group=group, release=release)
+
     def test_selective_status_update(self):
         group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
         group2 = self.create_group(checksum="b" * 32, status=GroupStatus.UNRESOLVED)


### PR DESCRIPTION
This PR:
- Sets `current_release_version` on `GroupResolution` when choosing to "resolve in next release"
<p> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This is necessary for "resolve in next release" (semver) because `current_release_resolution` represents the latest semver version associated with a specific group and that is required to compare semver releases on GroupResolution.has_resolution </p>

- feat(semver): Adds ability to resolve semver releases (#27477)

This needs some changes!


Jira: 
https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=91&projectKey=WOR&modal=detail&selectedIssue=WOR-1059
https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=91&projectKey=WOR&modal=detail&selectedIssue=WOR-1060