### PR TITLE
fix(workflow): changing logic flow

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -332,11 +332,12 @@ class ReleaseSerializer(Serializer):
         if with_health_data and no_snuba:
             raise TypeError("health data requires snuba")
 
+        adoption_stages = {}
+        release_project_envs = None
         if self.with_adoption_stages:
             release_project_envs = self._get_release_project_envs(item_list, environments, project)
             adoption_stages = self._get_release_adoption_stages(release_project_envs)
-        else:
-            release_project_envs = None
+
         if environments is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
                 project, item_list
@@ -432,7 +433,7 @@ class ReleaseSerializer(Serializer):
                 "first_seen": first_seen.get(item.version),
                 "last_seen": last_seen.get(item.version),
             }
-            if self.with_adoption_stages:
+            if adoption_stages:
                 p.update(
                     {
                         "adoption_stages": adoption_stages.get(item.version),


### PR DESCRIPTION
It seems like every few days we get an error like SENTRY-R9B.
![Screen Shot 2021-07-15 at 8 38 47 AM](https://user-images.githubusercontent.com/6395250/125789338-d745847f-b062-493b-aa31-7d6677be9639.png)

I don't exactly understand why this is possible (losing scope of `adoption_stages` in rare instances?), so this is somewhat of a blind change. Small refactor to change it in a way that it shouldn't possibly happen anymore...