### PR TITLE
feat(performance): added open in discover button to events tab

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import omit from 'lodash/omit';
 
 import Alert from 'app/components/alert';
+import Button from 'app/components/button';
 import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import SearchBar from 'app/components/events/searchBar';
@@ -258,7 +259,7 @@ const Search = (props: Props) => {
         fields={eventView.fields}
         onSearch={handleSearch}
       />
-      <LatencyDropdown>
+      <SearchRowMenuItem>
         <DropdownControl
           buttonProps={{prefix: t('Percentile')}}
           label={eventsFilterOptions[eventsDisplayFilterName].label}
@@ -277,7 +278,12 @@ const Search = (props: Props) => {
             );
           })}
         </DropdownControl>
-      </LatencyDropdown>
+      </SearchRowMenuItem>
+      <SearchRowMenuItem>
+        <Button to={eventView.getResultsViewUrlTarget(organization.slug)}>
+          {t('Open in Discover')}
+        </Button>
+      </SearchRowMenuItem>
     </SearchWrapper>
   );
 };
@@ -307,7 +313,7 @@ const StyledSdkUpdatesAlert = styled(GlobalSdkUpdateAlert)`
   }
 `;
 
-const LatencyDropdown = styled('div')`
+const SearchRowMenuItem = styled('div')`
   margin-left: ${space(1)};
   flex-grow: 0;
 `;

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -195,7 +195,7 @@ describe('Performance Transaction Events Content', function () {
     wrapper.update();
 
     expect(wrapper.find('EventsTable')).toHaveLength(1);
-    expect(wrapper.find('LatencyDropdown')).toHaveLength(1);
+    expect(wrapper.find('SearchRowMenuItem')).toHaveLength(2);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
     expect(wrapper.find('Filter')).toHaveLength(1);
     expect(wrapper.find('TransactionHeader')).toHaveLength(1);
@@ -233,7 +233,7 @@ describe('Performance Transaction Events Content', function () {
     wrapper.update();
 
     expect(wrapper.find('EventsTable')).toHaveLength(1);
-    expect(wrapper.find('LatencyDropdown')).toHaveLength(1);
+    expect(wrapper.find('SearchRowMenuItem')).toHaveLength(2);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
     expect(wrapper.find('Filter')).toHaveLength(1);
     expect(wrapper.find('TransactionHeader')).toHaveLength(1);


### PR DESCRIPTION
Added an `Open in DIscover` button to events tab
![image](https://user-images.githubusercontent.com/83961295/125805267-065c8046-0034-47e9-9d98-09232f7f265e.png)

Links to the following:
![image](https://user-images.githubusercontent.com/83961295/125805380-4e71e544-4f4c-41a8-ba4a-92a06bfae519.png)
