### PR TITLE
feat(semver): Add ability to resolve semver releases

### DIFF
--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -1,9 +1,11 @@
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from sentry_relay import RelayError, parse_release
+from sentry_relay.processing import compare_version as compare_version_relay
 
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
-from sentry.models.release import DB_VERSION_LENGTH
+from sentry.models.release import DB_VERSION_LENGTH, follows_semver_versioning_scheme
 
 
 class GroupResolution(Model):
@@ -55,10 +57,12 @@ class GroupResolution(Model):
         This is used to suggest if a regression has occurred.
         """
         try:
-            res_type, res_release, res_release_datetime = (
+            res_type, res_release, res_release_datetime, current_release_version = (
                 cls.objects.filter(group=group)
                 .select_related("release")
-                .values_list("type", "release__id", "release__date_added")[0]
+                .values_list(
+                    "type", "release__id", "release__date_added", "current_release_version"
+                )[0]
             )
         except IndexError:
             return False
@@ -69,6 +73,35 @@ class GroupResolution(Model):
             return True
 
         if res_type in (None, cls.Type.in_next_release):
+            # If current_release_version was set, it means we are probably using semver since
+            # current_release_version is only set after checking that the project is following
+            # semver versioning scheme
+            if current_release_version:
+                follows_semver = follows_semver_versioning_scheme(
+                    project_id=group.project.id,
+                    org_id=group.organization.id,
+                    release_version=release.version,
+                )
+                # However even though we are almost sure that we are following semver, we need to
+                # check once more to ensure that both the release version passed follows semver
+                # and that the user did not stop using semver
+                if follows_semver:
+                    try:
+                        # If current_release_version == release.version => 0
+                        # If current_release_version < release.version => -1
+                        # If current_release_version > release.version => 1
+                        current_release_raw = parse_release(current_release_version).get(
+                            "version_raw"
+                        )
+                        release_raw = parse_release(release.version).get("version_raw")
+                        return compare_version_relay(current_release_raw, release_raw) == -1
+                    except RelayError:
+                        ...
+
+            # ID check and Date also act as fallback in case compare_versions that compares
+            # semver releases fail
+            # This should never happen though because it is ensures that current_release_version
+            # follows semver when it is set, and we check if release.version follows semver
             if res_release == release.id:
                 return True
             elif res_release_datetime > release.date_added:

--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -13,6 +13,12 @@ class GroupResolutionTest(TestCase):
         self.old_release.update(date_added=timezone.now() - timedelta(minutes=30))
         self.new_release = self.create_release(version="b", project=self.project)
         self.group = self.create_group()
+        self.old_semver_release = self.create_release(
+            version="foo_package@1.0", project=self.project
+        )
+        self.new_semver_release = self.create_release(
+            version="foo_package@2.0", project=self.project
+        )
 
     def test_in_next_release_with_new_release(self):
         GroupResolution.objects.create(
@@ -31,6 +37,33 @@ class GroupResolutionTest(TestCase):
             release=self.new_release, group=self.group, type=GroupResolution.Type.in_next_release
         )
         assert GroupResolution.has_resolution(self.group, self.old_release)
+
+    def test_in_next_semver_release_with_new_semver_release(self):
+        GroupResolution.objects.create(
+            release=self.old_semver_release,
+            current_release_version=self.old_semver_release.version,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+        )
+        assert GroupResolution.has_resolution(self.group, self.new_semver_release)
+
+    def test_in_next_semver_release_with_same_release(self):
+        GroupResolution.objects.create(
+            release=self.old_semver_release,
+            current_release_version=self.old_semver_release.version,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+        )
+        assert not GroupResolution.has_resolution(self.group, self.old_semver_release)
+
+    def test_in_next_semver_release_with_old_semver_release(self):
+        GroupResolution.objects.create(
+            release=self.new_semver_release,
+            current_release_version=self.new_semver_release.version,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+        )
+        assert not GroupResolution.has_resolution(self.group, self.old_semver_release)
 
     def test_in_release_with_new_release(self):
         GroupResolution.objects.create(


### PR DESCRIPTION
This PR:

Adds to GroupResolution.has_resolution the ability to identify whether a certain group has been resolved in the next semver release or not