### PR TITLE
fix(arithmetic): Don't allow equations only

### DIFF
--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -358,7 +358,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
   render() {
     const {className, columns, organization} = this.props;
-    const canDelete = columns.length > 1;
+    const canDelete = columns.filter(field => field.kind !== 'equation').length > 1;
     const canAdd = columns.length < MAX_COL_COUNT;
     const title = canAdd
       ? undefined

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -358,7 +358,11 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
   render() {
     const {className, columns, organization} = this.props;
-    const canDelete = columns.filter(field => field.kind !== 'equation').length > 1;
+    const canDelete =
+      columns.filter(
+        field =>
+          field.kind === 'function' || (field.kind === 'field' && field.field !== '')
+      ).length > 1;
     const canAdd = columns.length < MAX_COL_COUNT;
     const title = canAdd
       ? undefined

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -326,6 +326,38 @@ describe('EventsV2 -> ColumnEditModal', function () {
         wrapper.find('RowContainer button[aria-label="Drag to reorder"]')
       ).toHaveLength(0);
     });
+    it('does not count equations towards the count of rows', function () {
+      const newWrapper = mountModal(
+        {
+          columns: [
+            columns[0],
+            columns[1],
+            {
+              kind: 'equation',
+              field: '5 + 5',
+            },
+          ],
+          onApply: () => void 0,
+          tagKeys,
+        },
+        initialData
+      );
+      expect(newWrapper.find('QueryField')).toHaveLength(3);
+      newWrapper
+        .find('RowContainer button[aria-label="Remove column"]')
+        .first()
+        .simulate('click');
+
+      expect(newWrapper.find('QueryField')).toHaveLength(2);
+
+      // Last row cannot be removed or dragged.
+      expect(
+        newWrapper.find('RowContainer button[aria-label="Remove column"]')
+      ).toHaveLength(0);
+      expect(
+        newWrapper.find('RowContainer button[aria-label="Drag to reorder"]')
+      ).toHaveLength(0);
+    });
   });
 
   describe('apply action', function () {


### PR DESCRIPTION
- This is so selected columns can't only be a single equation, this is
  cause equations depend on fields selected, so a single equation can
  never be a valid discover query