### PR TITLE
fix(integrations): Vercel webhook KeyError

### DIFF
--- a/src/sentry/integrations/vercel/generic_webhook.py
+++ b/src/sentry/integrations/vercel/generic_webhook.py
@@ -230,7 +230,7 @@ class VercelGenericWebhookEndpoint(Endpoint):
         if configuration_id == integration.metadata["installation_id"]:
             # if we are uninstalling a primary configuration, and there are
             # multiple orgs connected to this integration we must update
-            # the crendentials (access_token, webhook_id etc)
+            # the credentials (access_token, webhook_id etc).
             next_config_id, next_config = list(integration.metadata["configurations"].items())[0]
 
             integration.metadata["access_token"] = next_config["access_token"]
@@ -270,7 +270,7 @@ class VercelGenericWebhookEndpoint(Endpoint):
 
     def _deployment_created(self, external_id, request):
         payload = request.data["payload"]
-        # Only create releases for production deloys for now
+        # Only create releases for production deploys for now
         if payload["target"] != "production":
             logger.info(
                 "Ignoring deployment for environment: %s" % payload["target"],

--- a/src/sentry/integrations/vercel/generic_webhook.py
+++ b/src/sentry/integrations/vercel/generic_webhook.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import logging
+from typing import Any, Mapping, Tuple
 
 from django.utils.crypto import constant_time_compare
 from django.views.decorators.csrf import csrf_exempt
@@ -50,7 +51,9 @@ def safe_json_parse(resp):
     return None
 
 
-def get_payload_and_token(payload, organization_id, sentry_project_id):
+def get_payload_and_token(
+    payload: Mapping[str, Any], organization_id: int, sentry_project_id: int
+) -> Tuple[Mapping[str, Any], str]:
     meta = payload["deployment"]["meta"]
 
     # look up the project so we can get the slug
@@ -97,7 +100,7 @@ def get_payload_and_token(payload, organization_id, sentry_project_id):
         "projects": [project.slug],
         "refs": [{"repository": repository, "commit": commit_sha}],
     }
-    return [release_payload, sentry_app_installation_token.api_token.token]
+    return release_payload, sentry_app_installation_token.api_token.token
 
 
 class VercelGenericWebhookEndpoint(Endpoint):
@@ -287,7 +290,7 @@ class VercelGenericWebhookEndpoint(Endpoint):
                 logging_params["project_id"] = sentry_project_id
 
                 try:
-                    [release_payload, token] = get_payload_and_token(
+                    release_payload, token = get_payload_and_token(
                         payload, organization.id, sentry_project_id
                     )
                 except Project.DoesNotExist:

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -25,6 +25,8 @@ class VercelWebhookEndpoint(VercelGenericWebhookEndpoint):
             logger.error("vercel.webhook.invalid-signature")
             return self.respond(status=401)
 
-        external_id = request.data.get("teamId") or request.data["userId"]
+        external_id = request.data.get("teamId") or request.data.get("userId")
+        if not external_id:
+            return self.respond({"detail": "Either teamId or userId must be defined"}, status=400)
 
         return self._deployment_created(external_id, request)

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -21,6 +21,7 @@ from sentry.utils.http import absolute_uri
 from .testutils import (
     DEPLOYMENT_WEBHOOK_NO_COMMITS,
     EXAMPLE_DEPLOYMENT_WEBHOOK_RESPONSE,
+    MINIMAL_WEBHOOK,
     SECRET,
     SIGNATURE,
 )
@@ -258,6 +259,12 @@ class VercelReleasesTest(APITestCase):
         assert response.status_code == 404
         assert "No commit found" == response.data["detail"]
         assert len(responses.calls) == 0
+
+    def test_missing_repository(self):
+        response = self._get_response(MINIMAL_WEBHOOK)
+
+        assert response.status_code == 400
+        assert "Could not determine repository" == response.data["detail"]
 
 
 class VercelReleasesNewTest(VercelReleasesTest):

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -260,6 +260,11 @@ class VercelReleasesTest(APITestCase):
         assert "No commit found" == response.data["detail"]
         assert len(responses.calls) == 0
 
+    def test_empty_payload(self):
+        response = self._get_response("{}")
+
+        assert response.status_code == 400
+
     def test_missing_repository(self):
         response = self._get_response(MINIMAL_WEBHOOK)
 

--- a/tests/sentry/integrations/vercel/testutils.py
+++ b/tests/sentry/integrations/vercel/testutils.py
@@ -74,6 +74,7 @@ DEPLOYMENT_WEBHOOK_NO_COMMITS = """
 
 MINIMAL_WEBHOOK = """
     {
+        "type": "deployment",
         "payload": {
             "project": "nextjsblog-demo",
             "url": "nextjsblog-demo-gogovbsz1.vercel.app",

--- a/tests/sentry/integrations/vercel/testutils.py
+++ b/tests/sentry/integrations/vercel/testutils.py
@@ -71,3 +71,20 @@ DEPLOYMENT_WEBHOOK_NO_COMMITS = """
         "userId": "cstd1xKmLGVMed0z0f3SHlD2"
     }
 """
+
+MINIMAL_WEBHOOK = """
+    {
+        "payload": {
+            "project": "nextjsblog-demo",
+            "url": "nextjsblog-demo-gogovbsz1.vercel.app",
+            "projectId": "QmQPfU4xn5APjEsSje4ccPcSJCmVAByA8CDKfZRhYyVPAg",
+            "target": "production",
+            "deployment": {
+                "meta": {
+                    "githubCommitSha": "7488658dfcf24d9b735e015992b316e2a8340d9d"
+                }
+            }
+        },
+        "userId": "cstd1xKmLGVMed0z0f3SHlD2"
+    }
+"""


### PR DESCRIPTION
The Vercel webhook is raising a `KeyError` when `gitlabProjectNamespace` in not in `meta`. 
```python
repository = "{} / {}".format(
    meta["gitlabProjectNamespace"],
    meta["gitlabProjectName"],
)
```
This might be due to user error or a change to the API. Either way I'm catching the error and responding with a `400`. Let me know if it'd make more sense to just pass along a blank repository.

Fixes [SENTRY-RAM](https://sentry.io/organizations/sentry/issues/2513675091/).