### PR TITLE
feat(spans): Group chain of parent-child spans that are the only sibling

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -58,6 +58,7 @@ import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
 import SpanDetail from './spanDetail';
+import {MeasurementMarker} from './styles';
 import {
   FetchEmbeddedChildrenState,
   ParsedTraceType,
@@ -973,22 +974,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     );
   }
 }
-
-const MeasurementMarker = styled('div')<{failedThreshold: boolean}>`
-  position: absolute;
-  top: 0;
-  height: ${ROW_HEIGHT}px;
-  user-select: none;
-  width: 1px;
-  background: repeating-linear-gradient(
-      to bottom,
-      transparent 0 4px,
-      ${p => (p.failedThreshold ? p.theme.red300 : 'black')} 4px 8px
-    )
-    80%/2px 100% no-repeat;
-  z-index: ${p => p.theme.zIndex.traceView.dividerLine};
-  color: ${p => p.theme.textColor};
-`;
 
 const StyledIconWarning = styled(IconWarning)`
   margin-left: ${space(0.25)};

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -117,6 +117,7 @@ type SpanBarProps = {
     | ((props: {orgSlug: string; eventSlug: string}) => void)
     | undefined;
   fetchEmbeddedChildrenState: FetchEmbeddedChildrenState;
+  hasCollapsedSpanGroup: boolean;
 };
 
 type SpanBarState = {
@@ -307,6 +308,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       continuingTreeDepths,
       span,
       showSpanTree,
+      hasCollapsedSpanGroup,
     } = this.props;
 
     const spanID = getSpanID(span);
@@ -352,13 +354,40 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
         <ConnectorBar
           style={{
             right: '16px',
-            height: '10px',
+            height: `${ROW_HEIGHT / 2}px`,
             bottom: isLast ? `-${ROW_HEIGHT / 2}px` : '0',
             top: 'auto',
           }}
-          key={`${spanID}-last`}
+          key={`${spanID}-last-bottom`}
           orphanBranch={false}
         />
+      );
+
+      if (hasCollapsedSpanGroup) {
+        connectorBars.push(
+          <ConnectorBar
+            style={{
+              right: '16px',
+              height: `${ROW_HEIGHT / 2}px`,
+              top: '0',
+            }}
+            key={`${spanID}-last-top`}
+            orphanBranch={false}
+          />
+        );
+      }
+    }
+
+    if (hasCollapsedSpanGroup) {
+      return (
+        <TreeConnector
+          isLast
+          hasToggler={hasToggler}
+          orphanBranch={isOrphanSpan(span)}
+          hasCollapsedSpanGroup
+        >
+          {connectorBars}
+        </TreeConnector>
       );
     }
 

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -363,23 +363,21 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           orphanBranch={false}
         />
       );
-
-      if (hasCollapsedSpanGroup) {
-        connectorBars.push(
-          <ConnectorBar
-            style={{
-              right: '16px',
-              height: `${ROW_HEIGHT / 2}px`,
-              top: '0',
-            }}
-            key={`${spanID}-last-top`}
-            orphanBranch={false}
-          />
-        );
-      }
     }
 
     if (hasCollapsedSpanGroup) {
+      connectorBars.push(
+        <ConnectorBar
+          style={{
+            right: '16px',
+            height: `${ROW_HEIGHT / 2}px`,
+            top: '0',
+          }}
+          key={`${spanID}-last-top`}
+          orphanBranch={false}
+        />
+      );
+
       return (
         <TreeConnector
           isLast

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -1,0 +1,431 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+import countBy from 'lodash/countBy';
+
+import Count from 'app/components/count';
+import {ROW_HEIGHT} from 'app/components/performance/waterfall/constants';
+import {Row, RowCell, RowCellContainer} from 'app/components/performance/waterfall/row';
+import {DurationPill, RowRectangle} from 'app/components/performance/waterfall/rowBar';
+import {
+  DividerContainer,
+  DividerLine,
+  DividerLineGhostContainer,
+} from 'app/components/performance/waterfall/rowDivider';
+import {
+  RowTitle,
+  RowTitleContainer,
+  SpanGroupRowTitleContent,
+} from 'app/components/performance/waterfall/rowTitle';
+import {
+  ConnectorBar,
+  TOGGLE_BORDER_BOX,
+  TreeConnector,
+  TreeToggle,
+  TreeToggleContainer,
+} from 'app/components/performance/waterfall/treeConnector';
+import {
+  getDurationDisplay,
+  getHumanDuration,
+  toPercent,
+} from 'app/components/performance/waterfall/utils';
+import {t} from 'app/locale';
+import theme from 'app/utils/theme';
+
+import * as CursorGuideHandler from './cursorGuideHandler';
+import * as DividerHandlerManager from './dividerHandlerManager';
+import * as ScrollbarManager from './scrollbarManager';
+import {EnhancedSpan, ProcessedSpanType, SpanGroupProps, TreeDepthType} from './types';
+import {
+  getSpanOperation,
+  isOrphanSpan,
+  isOrphanTreeDepth,
+  SpanBoundsType,
+  SpanGeneratedBoundsType,
+  SpanViewBoundsType,
+  unwrapTreeDepth,
+} from './utils';
+
+const MARGIN_LEFT = 0;
+
+type Props = {
+  treeDepth: number;
+  span: Readonly<ProcessedSpanType>;
+  generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType;
+  spanNumber: number;
+  continuingTreeDepths: Array<TreeDepthType>;
+  spanGrouping: EnhancedSpan[];
+  toggleSpanGroup: () => void;
+};
+
+class SpanGroupBar extends React.Component<Props> {
+  getSpanGroupTimestamps(spanGroup: EnhancedSpan[]) {
+    return spanGroup.reduce(
+      (acc, spanGroupItem) => {
+        const {start_timestamp, timestamp} = spanGroupItem.span;
+
+        let newStartTimestamp = acc.startTimestamp;
+        let newEndTimestamp = acc.endTimestamp;
+
+        if (start_timestamp < newStartTimestamp) {
+          newStartTimestamp = start_timestamp;
+        }
+
+        if (newEndTimestamp > timestamp) {
+          newEndTimestamp = timestamp;
+        }
+
+        return {
+          startTimestamp: newStartTimestamp,
+          endTimestamp: newEndTimestamp,
+        };
+      },
+      {
+        startTimestamp: spanGroup[0].span.start_timestamp,
+        endTimestamp: spanGroup[0].span.timestamp,
+      }
+    );
+  }
+
+  getSpanGroupBounds(spanGroup: EnhancedSpan[]): SpanViewBoundsType {
+    const {generateBounds} = this.props;
+
+    const {startTimestamp, endTimestamp} = this.getSpanGroupTimestamps(spanGroup);
+
+    const bounds = generateBounds({
+      startTimestamp,
+      endTimestamp,
+    });
+
+    switch (bounds.type) {
+      case 'TRACE_TIMESTAMPS_EQUAL':
+      case 'INVALID_VIEW_WINDOW': {
+        return {
+          warning: void 0,
+          left: void 0,
+          width: void 0,
+          isSpanVisibleInView: bounds.isSpanVisibleInView,
+        };
+      }
+      case 'TIMESTAMPS_EQUAL': {
+        return {
+          warning: void 0,
+          left: bounds.start,
+          width: 0.00001,
+          isSpanVisibleInView: bounds.isSpanVisibleInView,
+        };
+      }
+      case 'TIMESTAMPS_REVERSED':
+      case 'TIMESTAMPS_STABLE': {
+        return {
+          warning: void 0,
+          left: bounds.start,
+          width: bounds.end - bounds.start,
+          isSpanVisibleInView: bounds.isSpanVisibleInView,
+        };
+      }
+      default: {
+        const _exhaustiveCheck: never = bounds;
+        return _exhaustiveCheck;
+      }
+    }
+  }
+
+  renderGroupedSpansToggler() {
+    const {spanGrouping, treeDepth, toggleSpanGroup} = this.props;
+
+    const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+
+    return (
+      <TreeToggleContainer style={{left: `${left}px`}} hasToggler>
+        {this.renderSpanTreeConnector()}
+        <TreeToggle
+          disabled={false}
+          isExpanded={false}
+          errored={false}
+          isSpanGroupToggler
+          onClick={event => {
+            event.stopPropagation();
+
+            toggleSpanGroup();
+          }}
+        >
+          <Count value={spanGrouping.length} />
+        </TreeToggle>
+      </TreeToggleContainer>
+    );
+  }
+
+  generateGroupSpansTitle(spanGroup: EnhancedSpan[]): React.ReactNode {
+    if (spanGroup.length === 0) {
+      return '';
+    }
+
+    const operationCounts = countBy(spanGroup, enhancedSpan =>
+      getSpanOperation(enhancedSpan.span)
+    );
+
+    const hasOthers = Object.keys(operationCounts).length > 1;
+
+    const [mostFrequentOperationName] = Object.entries(operationCounts).reduce(
+      (acc, [operationNameKey, count]) => {
+        if (count > acc[1]) {
+          return [operationNameKey, count];
+        }
+        return acc;
+      }
+    );
+
+    return (
+      <strong>{`${t('Autogroup spans')} \u2014 ${mostFrequentOperationName}${
+        hasOthers ? t(' and others') : ''
+      }`}</strong>
+    );
+  }
+
+  renderDivider(
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+  ) {
+    const {addDividerLineRef} = dividerHandlerChildrenProps;
+
+    return (
+      <DividerLine
+        ref={addDividerLineRef()}
+        style={{
+          position: 'absolute',
+        }}
+        onMouseEnter={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseLeave={() => {
+          dividerHandlerChildrenProps.setHover(false);
+        }}
+        onMouseOver={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseDown={dividerHandlerChildrenProps.onDragStart}
+        onClick={event => {
+          // we prevent the propagation of the clicks from this component to prevent
+          // the span detail from being opened.
+          event.stopPropagation();
+        }}
+      />
+    );
+  }
+
+  renderSpanTreeConnector() {
+    const {treeDepth: spanTreeDepth, continuingTreeDepths, span} = this.props;
+
+    const connectorBars: Array<React.ReactNode> = continuingTreeDepths.map(treeDepth => {
+      const depth: number = unwrapTreeDepth(treeDepth);
+
+      if (depth === 0) {
+        // do not render a connector bar at depth 0,
+        // if we did render a connector bar, this bar would be placed at depth -1
+        // which does not exist.
+        return null;
+      }
+      const left = ((spanTreeDepth - depth) * (TOGGLE_BORDER_BOX / 2) + 1) * -1;
+
+      return (
+        <ConnectorBar
+          style={{left}}
+          key={`span-group-${depth}`}
+          orphanBranch={isOrphanTreeDepth(treeDepth)}
+        />
+      );
+    });
+
+    connectorBars.push(
+      <ConnectorBar
+        style={{
+          right: '16px',
+          height: `${ROW_HEIGHT / 2}px`,
+          bottom: `-${ROW_HEIGHT / 2}px`,
+          top: 'auto',
+        }}
+        key="collapsed-span-group-row-bottom"
+        orphanBranch={false}
+      />
+    );
+
+    return (
+      <TreeConnector isLast hasToggler orphanBranch={isOrphanSpan(span)}>
+        {connectorBars}
+      </TreeConnector>
+    );
+  }
+
+  renderCursorGuide() {
+    // TODO: move this into its own component
+    return (
+      <CursorGuideHandler.Consumer>
+        {({
+          showCursorGuide,
+          traceViewMouseLeft,
+        }: {
+          showCursorGuide: boolean;
+          traceViewMouseLeft: number | undefined;
+        }) => {
+          if (!showCursorGuide || !traceViewMouseLeft) {
+            return null;
+          }
+
+          return (
+            <CursorGuide
+              style={{
+                left: toPercent(traceViewMouseLeft),
+              }}
+            />
+          );
+        }}
+      </CursorGuideHandler.Consumer>
+    );
+  }
+
+  render() {
+    return (
+      <ScrollbarManager.Consumer>
+        {scrollbarManagerChildrenProps => (
+          <DividerHandlerManager.Consumer>
+            {(
+              dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+            ) => {
+              const {
+                span,
+                generateBounds,
+                treeDepth,
+                spanGrouping,
+                toggleSpanGroup,
+                spanNumber,
+              } = this.props;
+
+              const {isSpanVisibleInView: isSpanVisible} = generateBounds({
+                startTimestamp: span.start_timestamp,
+                endTimestamp: span.timestamp,
+              });
+
+              const {dividerPosition, addGhostDividerLineRef} =
+                dividerHandlerChildrenProps;
+              const {generateContentSpanBarRef} = scrollbarManagerChildrenProps;
+              const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+
+              const bounds = this.getSpanGroupBounds(spanGrouping);
+              const durationDisplay = getDurationDisplay(bounds);
+              const {startTimestamp, endTimestamp} =
+                this.getSpanGroupTimestamps(spanGrouping);
+              const duration = Math.abs(endTimestamp - startTimestamp);
+              const durationString = getHumanDuration(duration);
+
+              return (
+                <Row visible={isSpanVisible} showBorder={false}>
+                  <RowCellContainer>
+                    <RowCell
+                      data-type="span-row-cell"
+                      style={{
+                        width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+                        paddingTop: 0,
+                      }}
+                      onClick={() => {
+                        toggleSpanGroup();
+                      }}
+                    >
+                      <RowTitleContainer ref={generateContentSpanBarRef()}>
+                        {this.renderGroupedSpansToggler()}
+                        <RowTitle
+                          style={{
+                            left: `${left}px`,
+                            width: '100%',
+                          }}
+                        >
+                          <SpanGroupRowTitleContent>
+                            {this.generateGroupSpansTitle(spanGrouping)}
+                          </SpanGroupRowTitleContent>
+                        </RowTitle>
+                      </RowTitleContainer>
+                    </RowCell>
+                    <DividerContainer>
+                      {this.renderDivider(dividerHandlerChildrenProps)}
+                    </DividerContainer>
+                    <RowCell
+                      data-type="span-row-cell"
+                      showStriping={spanNumber % 2 !== 0}
+                      style={{
+                        width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
+                      }}
+                      onClick={() => {
+                        toggleSpanGroup();
+                      }}
+                    >
+                      <RowRectangle
+                        spanBarHatch={false}
+                        style={{
+                          backgroundColor: theme.blue300,
+                          left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
+                          width: toPercent(bounds.width || 0),
+                        }}
+                      >
+                        <DurationPill
+                          durationDisplay={durationDisplay}
+                          showDetail={false}
+                          spanBarHatch={false}
+                        >
+                          {durationString}
+                        </DurationPill>
+                      </RowRectangle>
+                      {this.renderCursorGuide()}
+                    </RowCell>
+                    <DividerLineGhostContainer
+                      style={{
+                        width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
+                        display: 'none',
+                      }}
+                    >
+                      <DividerLine
+                        ref={addGhostDividerLineRef()}
+                        style={{
+                          right: 0,
+                        }}
+                        className="hovering"
+                        onClick={event => {
+                          // the ghost divider line should not be interactive.
+                          // we prevent the propagation of the clicks from this component to prevent
+                          // the span detail from being opened.
+                          event.stopPropagation();
+                        }}
+                      />
+                    </DividerLineGhostContainer>
+                  </RowCellContainer>
+                </Row>
+              );
+            }}
+          </DividerHandlerManager.Consumer>
+        )}
+      </ScrollbarManager.Consumer>
+    );
+  }
+}
+
+export function isCollapsedSpanGroup({
+  spanGrouping,
+  showSpanGroup,
+  toggleSpanGroup,
+}: SpanGroupProps) {
+  return (
+    Array.isArray(spanGrouping) &&
+    spanGrouping.length !== 0 &&
+    !showSpanGroup &&
+    typeof toggleSpanGroup === 'function'
+  );
+}
+
+// TODO: move this
+const CursorGuide = styled('div')`
+  position: absolute;
+  top: 0;
+  width: 1px;
+  background-color: ${p => p.theme.red300};
+  transform: translateX(-50%);
+  height: 100%;
+`;
+
+export default SpanGroupBar;

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import styled from '@emotion/styled';
 import countBy from 'lodash/countBy';
 
 import Count from 'app/components/count';
@@ -33,9 +32,9 @@ import {EventTransaction} from 'app/types/event';
 import {defined} from 'app/utils';
 import theme from 'app/utils/theme';
 
-import * as CursorGuideHandler from './cursorGuideHandler';
 import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
+import SpanBarCursorGuide from './spanBarCursorGuide';
 import {MeasurementMarker} from './styles';
 import {EnhancedSpan, ProcessedSpanType, SpanGroupProps, TreeDepthType} from './types';
 import {
@@ -291,33 +290,6 @@ class SpanGroupBar extends React.Component<Props> {
     );
   }
 
-  renderCursorGuide() {
-    // TODO: move this into its own component
-    return (
-      <CursorGuideHandler.Consumer>
-        {({
-          showCursorGuide,
-          traceViewMouseLeft,
-        }: {
-          showCursorGuide: boolean;
-          traceViewMouseLeft: number | undefined;
-        }) => {
-          if (!showCursorGuide || !traceViewMouseLeft) {
-            return null;
-          }
-
-          return (
-            <CursorGuide
-              style={{
-                left: toPercent(traceViewMouseLeft),
-              }}
-            />
-          );
-        }}
-      </CursorGuideHandler.Consumer>
-    );
-  }
-
   render() {
     return (
       <ScrollbarManager.Consumer>
@@ -409,7 +381,7 @@ class SpanGroupBar extends React.Component<Props> {
                         </DurationPill>
                       </RowRectangle>
                       {this.renderMeasurements()}
-                      {this.renderCursorGuide()}
+                      <SpanBarCursorGuide />
                     </RowCell>
                     <DividerLineGhostContainer
                       style={{
@@ -454,15 +426,5 @@ export function isCollapsedSpanGroup({
     typeof toggleSpanGroup === 'function'
   );
 }
-
-// TODO: move this
-const CursorGuide = styled('div')`
-  position: absolute;
-  top: 0;
-  width: 1px;
-  background-color: ${p => p.theme.red300};
-  transform: translateX(-50%);
-  height: 100%;
-`;
 
 export default SpanGroupBar;

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -325,7 +325,7 @@ class SpanGroupBar extends React.Component<Props> {
               const durationString = getHumanDuration(duration);
 
               return (
-                <Row visible={isSpanVisible} showBorder={false}>
+                <Row visible={isSpanVisible} showBorder={false} data-test-id="span-row">
                   <RowCellContainer>
                     <RowCell
                       data-type="span-row-cell"

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -218,6 +218,7 @@ class SpanTree extends React.Component<PropType> {
           acc.spanTree.push(
             <SpanGroupBar
               key={`${key}-span-group`}
+              event={waterfallModel.event}
               span={span}
               generateBounds={generateBounds}
               treeDepth={treeDepth}

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -6,11 +6,18 @@ import {MessageRow} from 'app/components/performance/waterfall/messageRow';
 import {pickBarColor} from 'app/components/performance/waterfall/utils';
 import {t, tct} from 'app/locale';
 import {Organization} from 'app/types';
+import {assert} from 'app/types/utils';
 
 import {DragManagerChildrenProps} from './dragManager';
 import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
 import SpanBar from './spanBar';
-import {EnhancedProcessedSpanType, FilterSpans, ParsedTraceType} from './types';
+import SpanGroupBar, {isCollapsedSpanGroup} from './spanGroupBar';
+import {
+  EnhancedProcessedSpanType,
+  EnhancedSpan,
+  FilterSpans,
+  ParsedTraceType,
+} from './types';
 import {getSpanID, getSpanOperation} from './utils';
 import WaterfallModel from './waterfallModel';
 
@@ -147,10 +154,11 @@ class SpanTree extends React.Component<PropType> {
       numOfSpansOutOfViewAbove: number;
       numOfFilteredSpansAbove: number;
       spanTree: React.ReactNode[];
+      spanNumber: number;
     };
 
     const {spanTree, numOfSpansOutOfViewAbove, numOfFilteredSpansAbove} = spans.reduce(
-      (acc: AccType, payload: EnhancedProcessedSpanType, index) => {
+      (acc: AccType, payload: EnhancedProcessedSpanType) => {
         const {type} = payload;
 
         switch (payload.type) {
@@ -182,18 +190,47 @@ class SpanTree extends React.Component<PropType> {
 
         const {span} = payload;
 
-        const key = getSpanID(span, `span-${index}`);
+        let spanNumber = acc.spanNumber;
 
+        const key = getSpanID(span, `span-${spanNumber}`);
         const isLast = payload.isLastSibling;
         const isRoot = type === 'root_span';
         const spanBarColor: string = pickBarColor(getSpanOperation(span));
-        const spanNumber = index + 1;
         const numOfSpanChildren = payload.numOfSpanChildren;
         const treeDepth = payload.treeDepth;
         const continuingTreeDepths = payload.continuingTreeDepths;
 
         acc.numOfFilteredSpansAbove = 0;
         acc.numOfSpansOutOfViewAbove = 0;
+
+        const hasCollapsedSpanGroup: boolean =
+          (payload.type === 'span' || payload.type === 'root_span') &&
+          isCollapsedSpanGroup({
+            spanGrouping: payload.spanGrouping,
+            showSpanGroup: payload.showSpanGroup,
+            toggleSpanGroup: payload.toggleSpanGroup,
+          });
+
+        if (hasCollapsedSpanGroup) {
+          assert(payload.type === 'span' || payload.type === 'root_span');
+          // If the span has a collapsed span group, then we render it above the associated span.
+          // The associated span will be the last span of the span group.
+          acc.spanTree.push(
+            <SpanGroupBar
+              key={`${key}-span-group`}
+              span={span}
+              generateBounds={generateBounds}
+              treeDepth={treeDepth}
+              continuingTreeDepths={continuingTreeDepths}
+              spanNumber={spanNumber}
+              spanGrouping={payload.spanGrouping as EnhancedSpan[]}
+              toggleSpanGroup={payload.toggleSpanGroup as () => void}
+            />
+          );
+
+          spanNumber = spanNumber + 1;
+        }
+
         acc.spanTree.push(
           <SpanBar
             key={key}
@@ -215,15 +252,18 @@ class SpanTree extends React.Component<PropType> {
             showEmbeddedChildren={payload.showEmbeddedChildren}
             toggleEmbeddedChildren={payload.toggleEmbeddedChildren}
             fetchEmbeddedChildrenState={payload.fetchEmbeddedChildrenState}
+            hasCollapsedSpanGroup={hasCollapsedSpanGroup}
           />
         );
 
+        acc.spanNumber = spanNumber + 1;
         return acc;
       },
       {
         numOfSpansOutOfViewAbove: 0,
         numOfFilteredSpansAbove: 0,
         spanTree: [],
+        spanNumber: 1, // 1-based indexing
       }
     );
 

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -297,18 +297,16 @@ class SpanTreeModel {
             spanGrouping: shouldGroup
               ? [...(spanGrouping ?? []), wrappedSpan]
               : undefined,
-            toggleSpanGroup:
-              toggleSpanGroup === undefined && isNotLastSpanOfGroup
+            toggleSpanGroup: isNotLastSpanOfGroup
+              ? toggleSpanGroup === undefined
                 ? this.toggleSpanGroup
-                : toggleSpanGroup !== undefined && isNotLastSpanOfGroup
-                ? toggleSpanGroup
-                : undefined,
-            showSpanGroup:
-              toggleSpanGroup === undefined && isNotLastSpanOfGroup
+                : toggleSpanGroup
+              : undefined,
+            showSpanGroup: isNotLastSpanOfGroup
+              ? toggleSpanGroup === undefined
                 ? this.showSpanGroup
-                : toggleSpanGroup !== undefined && isNotLastSpanOfGroup
-                ? showSpanGroup
-                : false,
+                : showSpanGroup
+              : false,
           })
         );
 

--- a/static/app/components/events/interfaces/spans/styles.tsx
+++ b/static/app/components/events/interfaces/spans/styles.tsx
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+import {ROW_HEIGHT} from 'app/components/performance/waterfall/constants';
+
+export const MeasurementMarker = styled('div')<{failedThreshold: boolean}>`
+  position: absolute;
+  top: 0;
+  height: ${ROW_HEIGHT}px;
+  user-select: none;
+  width: 1px;
+  background: repeating-linear-gradient(
+      to bottom,
+      transparent 0 4px,
+      ${p => (p.failedThreshold ? p.theme.red300 : 'black')} 4px 8px
+    )
+    80%/2px 100% no-repeat;
+  z-index: ${p => p.theme.zIndex.traceView.dividerLine};
+  color: ${p => p.theme.textColor};
+`;

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -49,6 +49,12 @@ export type FetchEmbeddedChildrenState =
   | 'loading_embedded_transactions'
   | 'error_fetching_embedded_transactions';
 
+export type SpanGroupProps = {
+  spanGrouping: EnhancedSpan[] | undefined;
+  showSpanGroup: boolean;
+  toggleSpanGroup: (() => void) | undefined;
+};
+
 type CommonEnhancedProcessedSpanType = {
   numOfSpanChildren: number;
   treeDepth: number;
@@ -61,16 +67,21 @@ type CommonEnhancedProcessedSpanType = {
     | undefined;
 };
 
-// ProcessedSpanType with additional information
-export type EnhancedProcessedSpanType =
+export type EnhancedSpan =
   | ({
       type: 'root_span';
       span: SpanType;
-    } & CommonEnhancedProcessedSpanType)
+    } & CommonEnhancedProcessedSpanType &
+      SpanGroupProps)
   | ({
       type: 'span';
       span: SpanType;
-    } & CommonEnhancedProcessedSpanType)
+    } & CommonEnhancedProcessedSpanType &
+      SpanGroupProps);
+
+// ProcessedSpanType with additional information
+export type EnhancedProcessedSpanType =
+  | EnhancedSpan
   | ({
       type: 'gap';
       span: GapSpanType;

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -243,6 +243,10 @@ class WaterfallModel {
       filterSpans: this.filterSpans,
       previousSiblingEndTimestamp: undefined,
       event: this.event,
+      isOnlySibling: true,
+      spanGrouping: undefined,
+      toggleSpanGroup: undefined,
+      showSpanGroup: false,
     });
   };
 }

--- a/static/app/components/performance/waterfall/rowTitle.tsx
+++ b/static/app/components/performance/waterfall/rowTitle.tsx
@@ -26,3 +26,7 @@ export const RowTitle = styled('div')`
 export const RowTitleContent = styled('span')<{errored: boolean}>`
   color: ${p => (p.errored ? p.theme.error : 'inherit')};
 `;
+
+export const SpanGroupRowTitleContent = styled('span')`
+  color: ${p => p.theme.blue300};
+`;

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -29,7 +29,7 @@ export const TreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean
   width: 100%;
   border-left: ${p => {
     if (p.hasCollapsedSpanGroup) {
-      return 'none';
+      return '1px solid transparent';
     }
 
     return `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border}`;

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -9,6 +9,7 @@ import {OmitHtmlDivProps} from 'app/utils';
 const TOGGLE_BUTTON_MARGIN_RIGHT = 16;
 const TOGGLE_BUTTON_MAX_WIDTH = 30;
 export const TOGGLE_BORDER_BOX = TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT;
+const TREE_TOGGLE_CONTAINER_WIDTH = 40;
 
 export const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
   height: 250%;
@@ -40,13 +41,13 @@ export const TreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean
   &:before {
     content: '';
     height: 1px;
-    border-bottom: ${p => {
-      if (p.hasCollapsedSpanGroup) {
-        return 'none';
-      }
-      return `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border};`;
-    }};
-    width: 100%;
+    border-bottom: ${p =>
+      `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border};`};
+    left: ${p => (p.hasCollapsedSpanGroup ? `${TOGGLE_BORDER_BOX / 2}px` : '0')};
+    width: ${p =>
+      p.hasCollapsedSpanGroup
+        ? `${TREE_TOGGLE_CONTAINER_WIDTH - TOGGLE_BORDER_BOX / 2 - 2}px`
+        : '100%'};
     position: absolute;
     bottom: ${p => (p.isLast ? '0' : '50%')};
   }
@@ -90,8 +91,8 @@ export const TreeToggle = styled('div')<SpanTreeTogglerAndDivProps>`
 export const TreeToggleContainer = styled('div')<TogglerTypes>`
   position: relative;
   height: ${ROW_HEIGHT}px;
-  width: 40px;
-  min-width: 40px;
+  width: ${TREE_TOGGLE_CONTAINER_WIDTH}px;
+  min-width: ${TREE_TOGGLE_CONTAINER_WIDTH}px;
   margin-right: ${space(1)};
   z-index: ${p => p.theme.zIndex.traceView.spanTreeToggler};
   display: flex;

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -21,21 +21,31 @@ export const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
 type TogglerTypes = OmitHtmlDivProps<{
   hasToggler?: boolean;
   isLast?: boolean;
+  hasCollapsedSpanGroup?: boolean;
 }>;
 
 export const TreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   height: ${p => (p.isLast ? ROW_HEIGHT / 2 : ROW_HEIGHT)}px;
   width: 100%;
-  border-left: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')} ${p => p.theme.border};
+  border-left: ${p => {
+    if (p.hasCollapsedSpanGroup) {
+      return 'none';
+    }
+
+    return `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border}`;
+  }};
   position: absolute;
   top: 0;
 
   &:before {
     content: '';
     height: 1px;
-    border-bottom: 1px ${p => (p.orphanBranch ? 'dashed' : 'solid')}
-      ${p => p.theme.border};
-
+    border-bottom: ${p => {
+      if (p.hasCollapsedSpanGroup) {
+        return 'none';
+      }
+      return `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border};`;
+    }};
     width: 100%;
     position: absolute;
     bottom: ${p => (p.isLast ? '0' : '50%')};
@@ -57,6 +67,7 @@ type SpanTreeTogglerAndDivProps = OmitHtmlDivProps<{
   isExpanded: boolean;
   disabled: boolean;
   errored: boolean;
+  isSpanGroupToggler?: boolean;
 }>;
 
 export const TreeToggle = styled('div')<SpanTreeTogglerAndDivProps>`

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -113,7 +113,7 @@ export const getToggleTheme = ({
     background: ${theme.blue300};
     border: 1px solid ${theme.button.default.border};
     color: ${color};
-    cursor: default;
+    cursor: pointer;
   `;
   }
 

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -85,11 +85,13 @@ export const getToggleTheme = ({
   isExpanded,
   disabled,
   errored,
+  isSpanGroupToggler,
 }: {
   theme: Theme;
   isExpanded: boolean;
   disabled: boolean;
   errored: boolean;
+  isSpanGroupToggler?: boolean;
 }) => {
   const buttonTheme = isExpanded ? theme.button.default : theme.button.primary;
   const errorTheme = theme.button.danger;
@@ -105,6 +107,15 @@ export const getToggleTheme = ({
       ? errorTheme.background
       : buttonTheme.color
     : buttonTheme.color;
+
+  if (isSpanGroupToggler) {
+    return `
+    background: ${theme.blue300};
+    border: 1px solid ${theme.button.default.border};
+    color: ${color};
+    cursor: default;
+  `;
+  }
 
   if (disabled) {
     return `

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -404,6 +404,11 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.elements('[data-test-id="view-event"]')[0].click()
             self.wait_until_loaded()
 
+            self.browser.snapshot("events-v2 - transactions event with auto-grouped spans")
+
+            # Expand auto-grouped spans
+            self.browser.elements('[data-test-id="span-row"]')[4].click()
+
             # Open a span detail so we can check the search by trace link.
             # Click on the 6th one as a missing instrumentation span is inserted.
             self.browser.elements('[data-test-id="span-row"]')[6].click()

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -220,6 +220,9 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
       },
       {
         type: 'span',
@@ -248,6 +251,9 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
       },
       {
         type: 'span',
@@ -276,6 +282,9 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
       },
       {
         type: 'span',
@@ -300,6 +309,9 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
       },
     ];
 
@@ -323,6 +335,10 @@ describe('SpanTreeModel', () => {
       filterSpans: undefined,
       previousSiblingEndTimestamp: undefined,
       event,
+      isOnlySibling: true,
+      spanGrouping: undefined,
+      toggleSpanGroup: undefined,
+      showSpanGroup: false,
     });
 
     expect(spans).toEqual(fullWaterfall);
@@ -352,6 +368,10 @@ describe('SpanTreeModel', () => {
       filterSpans: undefined,
       previousSiblingEndTimestamp: undefined,
       event,
+      isOnlySibling: true,
+      spanGrouping: undefined,
+      toggleSpanGroup: undefined,
+      showSpanGroup: false,
     });
 
     const fullWaterfallExpected: EnhancedProcessedSpanType[] = [...fullWaterfall];
@@ -380,6 +400,9 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
       },
       {
         type: 'span',
@@ -401,6 +424,9 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
       }
     );
 

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -114,6 +114,9 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
+      spanGrouping: undefined,
+      showSpanGroup: false,
+      toggleSpanGroup: undefined,
     },
     {
       type: 'span',
@@ -136,6 +139,9 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
+      spanGrouping: undefined,
+      showSpanGroup: false,
+      toggleSpanGroup: undefined,
     },
     {
       type: 'gap',
@@ -175,6 +181,9 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
+      spanGrouping: undefined,
+      showSpanGroup: false,
+      toggleSpanGroup: undefined,
     },
     {
       type: 'span',
@@ -199,6 +208,9 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
+      spanGrouping: undefined,
+      showSpanGroup: false,
+      toggleSpanGroup: undefined,
     },
     {
       type: 'gap',
@@ -240,6 +252,9 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
+      spanGrouping: undefined,
+      showSpanGroup: false,
+      toggleSpanGroup: undefined,
     },
   ];
 

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -522,7 +522,7 @@ describe('WaterfallModel', () => {
     ]);
   });
 
-  it('span grouping - only child parent-child chain - 2 spans are not grouped', () => {
+  it('span grouping - only child parent-child chain - root span and a span (2 spans) are not grouped', () => {
     const event2: EventTransaction = {
       ...event,
       entries: [
@@ -559,7 +559,7 @@ describe('WaterfallModel', () => {
     ]);
   });
 
-  it('span grouping - only child parent-child chain - 3 or more spans are grouped', () => {
+  it('span grouping - only child parent-child chain - root span and 2 spans (3 spans) are not grouped', () => {
     const event2: EventTransaction = {
       ...event,
       entries: [
@@ -569,7 +569,72 @@ describe('WaterfallModel', () => {
             {
               ...event.entries[0].data[0],
               parent_span_id: event.entries[0].data[0].span_id,
-              span_id: 'something',
+              span_id: 'foo',
+            },
+          ],
+          type: EntryType.SPANS,
+        },
+      ],
+    };
+
+    const waterfallModel = new WaterfallModel(event2);
+
+    const spans = waterfallModel.getWaterfall({
+      viewStart: 0,
+      viewEnd: 1,
+    });
+
+    expect(spans).toEqual([
+      {
+        ...fullWaterfall[0],
+        treeDepth: 0,
+        numOfSpanChildren: 1,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        treeDepth: 1,
+        isLastSibling: true,
+        numOfSpanChildren: 1,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        span: {
+          ...fullWaterfall[1].span,
+          parent_span_id: event.entries[0].data[0].span_id,
+          span_id: 'foo',
+        },
+        treeDepth: 2,
+        isLastSibling: true,
+        numOfSpanChildren: 0,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+    ]);
+  });
+
+  it('span grouping - only child parent-child chain - root span and 3+ spans (4 spans) are not grouped', () => {
+    const event2: EventTransaction = {
+      ...event,
+      entries: [
+        {
+          data: [
+            event.entries[0].data[0],
+            {
+              ...event.entries[0].data[0],
+              parent_span_id: event.entries[0].data[0].span_id,
+              span_id: 'foo',
+            },
+            {
+              ...event.entries[0].data[0],
+              parent_span_id: 'foo',
+              span_id: 'bar',
             },
           ],
           type: EntryType.SPANS,
@@ -583,7 +648,7 @@ describe('WaterfallModel', () => {
       viewEnd: 1,
     });
 
-    // 1 or more spans are grouped
+    // expect 1 or more spans are grouped
     expect(spans).toHaveLength(2);
 
     expect(spans).toEqual([
@@ -598,8 +663,8 @@ describe('WaterfallModel', () => {
         ...fullWaterfall[1],
         span: {
           ...fullWaterfall[1].span,
-          parent_span_id: event.entries[0].data[0].span_id,
-          span_id: 'something',
+          parent_span_id: 'foo',
+          span_id: 'bar',
         },
         isLastSibling: true,
         numOfSpanChildren: 0,
@@ -607,6 +672,19 @@ describe('WaterfallModel', () => {
         spanGrouping: [
           {
             ...fullWaterfall[1],
+            isLastSibling: true,
+            numOfSpanChildren: 1,
+            spanGrouping: undefined,
+            showSpanGroup: false,
+            toggleSpanGroup: undefined,
+          },
+          {
+            ...fullWaterfall[1],
+            span: {
+              ...fullWaterfall[1].span,
+              parent_span_id: event.entries[0].data[0].span_id,
+              span_id: 'foo',
+            },
             isLastSibling: true,
             numOfSpanChildren: 1,
             spanGrouping: undefined,
@@ -628,13 +706,14 @@ describe('WaterfallModel', () => {
       viewEnd: 1,
     });
 
-    // 1 or more spans are grouped
-    expect(spans).toHaveLength(3);
+    // expect span group to be expanded
+    expect(spans).toHaveLength(4);
 
     expect(spans).toEqual([
       {
         ...fullWaterfall[0],
         numOfSpanChildren: 1,
+        treeDepth: 0,
         spanGrouping: undefined,
         showSpanGroup: false,
         toggleSpanGroup: undefined,
@@ -653,14 +732,42 @@ describe('WaterfallModel', () => {
         span: {
           ...fullWaterfall[1].span,
           parent_span_id: event.entries[0].data[0].span_id,
-          span_id: 'something',
+          span_id: 'foo',
+        },
+        isLastSibling: true,
+        numOfSpanChildren: 1,
+        treeDepth: 2,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        span: {
+          ...fullWaterfall[1].span,
+          parent_span_id: 'foo',
+          span_id: 'bar',
         },
         isLastSibling: true,
         numOfSpanChildren: 0,
-        treeDepth: 2,
+        treeDepth: 3,
         spanGrouping: [
           {
             ...fullWaterfall[1],
+            isLastSibling: true,
+            numOfSpanChildren: 1,
+            spanGrouping: undefined,
+            showSpanGroup: false,
+            toggleSpanGroup: undefined,
+          },
+          {
+            ...fullWaterfall[1],
+            span: {
+              ...fullWaterfall[1].span,
+              parent_span_id: event.entries[0].data[0].span_id,
+              span_id: 'foo',
+            },
+            treeDepth: 2,
             isLastSibling: true,
             numOfSpanChildren: 1,
             spanGrouping: undefined,

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -2,6 +2,7 @@ import {ActiveFilter, noFilter} from 'app/components/events/interfaces/spans/fil
 import {EnhancedProcessedSpanType} from 'app/components/events/interfaces/spans/types';
 import WaterfallModel from 'app/components/events/interfaces/spans/waterfallModel';
 import {EntryType, EventTransaction} from 'app/types/event';
+import {assert} from 'app/types/utils';
 
 describe('WaterfallModel', () => {
   const event = {
@@ -495,5 +496,181 @@ describe('WaterfallModel', () => {
     });
 
     expect(spans).toEqual(fullWaterfall);
+  });
+
+  it('span grouping - only child parent-child chain - root is not grouped', () => {
+    const event2 = {
+      ...event,
+      entries: [],
+    };
+
+    const waterfallModel = new WaterfallModel(event2);
+
+    const spans = waterfallModel.getWaterfall({
+      viewStart: 0,
+      viewEnd: 1,
+    });
+
+    expect(spans).toEqual([
+      {
+        ...fullWaterfall[0],
+        numOfSpanChildren: 0,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+    ]);
+  });
+
+  it('span grouping - only child parent-child chain - 2 spans are not grouped', () => {
+    const event2: EventTransaction = {
+      ...event,
+      entries: [
+        {
+          data: [event.entries[0].data[0]],
+          type: EntryType.SPANS,
+        },
+      ],
+    };
+
+    const waterfallModel = new WaterfallModel(event2);
+
+    const spans = waterfallModel.getWaterfall({
+      viewStart: 0,
+      viewEnd: 1,
+    });
+
+    expect(spans).toEqual([
+      {
+        ...fullWaterfall[0],
+        numOfSpanChildren: 1,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        isLastSibling: true,
+        numOfSpanChildren: 0,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+    ]);
+  });
+
+  it('span grouping - only child parent-child chain - 3 or more spans are grouped', () => {
+    const event2: EventTransaction = {
+      ...event,
+      entries: [
+        {
+          data: [
+            event.entries[0].data[0],
+            {
+              ...event.entries[0].data[0],
+              parent_span_id: event.entries[0].data[0].span_id,
+              span_id: 'something',
+            },
+          ],
+          type: EntryType.SPANS,
+        },
+      ],
+    };
+    const waterfallModel = new WaterfallModel(event2);
+
+    let spans = waterfallModel.getWaterfall({
+      viewStart: 0,
+      viewEnd: 1,
+    });
+
+    // 1 or more spans are grouped
+    expect(spans).toHaveLength(2);
+
+    expect(spans).toEqual([
+      {
+        ...fullWaterfall[0],
+        numOfSpanChildren: 1,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        span: {
+          ...fullWaterfall[1].span,
+          parent_span_id: event.entries[0].data[0].span_id,
+          span_id: 'something',
+        },
+        isLastSibling: true,
+        numOfSpanChildren: 0,
+        treeDepth: 1,
+        spanGrouping: [
+          {
+            ...fullWaterfall[1],
+            isLastSibling: true,
+            numOfSpanChildren: 1,
+            spanGrouping: undefined,
+            showSpanGroup: false,
+            toggleSpanGroup: undefined,
+          },
+        ],
+        showSpanGroup: false,
+        toggleSpanGroup: expect.any(Function),
+      },
+    ]);
+
+    // Expand span group
+    assert(spans[1].type === 'span' && spans[1].toggleSpanGroup);
+    spans[1].toggleSpanGroup();
+
+    spans = waterfallModel.getWaterfall({
+      viewStart: 0,
+      viewEnd: 1,
+    });
+
+    // 1 or more spans are grouped
+    expect(spans).toHaveLength(3);
+
+    expect(spans).toEqual([
+      {
+        ...fullWaterfall[0],
+        numOfSpanChildren: 1,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        isLastSibling: true,
+        numOfSpanChildren: 1,
+        treeDepth: 1,
+        spanGrouping: undefined,
+        showSpanGroup: false,
+        toggleSpanGroup: undefined,
+      },
+      {
+        ...fullWaterfall[1],
+        span: {
+          ...fullWaterfall[1].span,
+          parent_span_id: event.entries[0].data[0].span_id,
+          span_id: 'something',
+        },
+        isLastSibling: true,
+        numOfSpanChildren: 0,
+        treeDepth: 2,
+        spanGrouping: [
+          {
+            ...fullWaterfall[1],
+            isLastSibling: true,
+            numOfSpanChildren: 1,
+            spanGrouping: undefined,
+            showSpanGroup: false,
+            toggleSpanGroup: undefined,
+          },
+        ],
+        showSpanGroup: true,
+        toggleSpanGroup: expect.any(Function),
+      },
+    ]);
   });
 });


### PR DESCRIPTION
Some SDKs (notably the Python SDK) may send span trees of the following structure:

<img width="1302" alt="Screen Shot 2021-07-15 at 2 28 28 PM" src="https://user-images.githubusercontent.com/139499/125843622-5c596d18-d252-4548-bcd2-0a7515bd1708.png">

In the above example, the `django.middleware` spans are chained together in such a way that adds more "noise" to the span view than necessary. 

This pull request adds an implementation to automatically group these spans together into one pseudo (or virtual) span row. In addition, one may choose to expand the grouped spans:

https://user-images.githubusercontent.com/139499/125843601-579c0b38-25af-438b-97ff-121489e11487.mp4

If the grouped spans contains multiple operation names, the most frequent operation name is shown:

<img width="482" alt="Screen Shot 2021-07-15 at 2 57 22 PM" src="https://user-images.githubusercontent.com/139499/125843624-bf1312d6-aab6-4b5f-8ba9-f5a948f9baad.png">
