### PR TITLE
chore(spans): Remove un-used isCurrentSpanFilteredOut prop

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -112,7 +112,6 @@ type SpanBarProps = {
   isLast?: boolean;
   isRoot?: boolean;
   toggleSpanTree: () => void;
-  isCurrentSpanFilteredOut: boolean;
   showEmbeddedChildren: boolean;
   toggleEmbeddedChildren:
     | ((props: {orgSlug: string; eventSlug: string}) => void)
@@ -923,17 +922,14 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
   }
 
   render() {
-    const {isCurrentSpanFilteredOut} = this.props;
     const bounds = this.getBounds();
-
-    const isSpanVisibleInView = bounds.isSpanVisibleInView;
-    const isSpanVisible = isSpanVisibleInView && !isCurrentSpanFilteredOut;
+    const {isSpanVisibleInView} = bounds;
 
     return (
       <React.Fragment>
         <Row
           ref={this.spanRowDOMRef}
-          visible={isSpanVisible}
+          visible={isSpanVisibleInView}
           showBorder={this.state.showDetail}
           data-test-id="span-row"
         >
@@ -959,7 +955,11 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
                       </DividerHandlerManager.Consumer>
                     )}
                   </ScrollbarManager.Consumer>
-                  {this.renderDetail({isVisible: isSpanVisible, transactions, errors})}
+                  {this.renderDetail({
+                    isVisible: isSpanVisibleInView,
+                    transactions,
+                    errors,
+                  })}
                 </React.Fragment>
               );
             }}

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -212,7 +212,6 @@ class SpanTree extends React.Component<PropType> {
             spanNumber={spanNumber}
             isLast={isLast}
             isRoot={isRoot}
-            isCurrentSpanFilteredOut={false}
             showEmbeddedChildren={payload.showEmbeddedChildren}
             toggleEmbeddedChildren={payload.toggleEmbeddedChildren}
             fetchEmbeddedChildrenState={payload.fetchEmbeddedChildrenState}


### PR DESCRIPTION
`isCurrentSpanFilteredOut` prop is always `false` and is redundant. This was a leftover from a previous major refactor of span tree construction algorithm. 