### PR TITLE
feat(appstore): Include the last time sentry checked for new builds

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -426,10 +426,10 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
             latestBuildVersion = latest_build.bundle_short_version
             latestBuildNumber = latest_build.bundle_version
 
-        build_refresh_dates = project.get_option(
-            appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, default={}
+        build_check_dates = project.get_option(
+            appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, default={}
         )
-        last_checked_builds = build_refresh_dates[symbol_source_cfg.id]
+        last_checked_builds = build_check_dates[symbol_source_cfg.id]
 
         return Response(
             {

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -426,8 +426,10 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
             latestBuildVersion = latest_build.bundle_short_version
             latestBuildNumber = latest_build.bundle_version
 
-        builds_check_dates = project.get_option("sentry:last_checked_appstore", default={})
-        last_checked_builds = builds_check_dates[symbol_source_cfg.id]
+        build_refresh_dates = project.get_option(
+            appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, default={}
+        )
+        last_checked_builds = build_refresh_dates[symbol_source_cfg.id]
 
         return Response(
             {

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -414,10 +414,8 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
 
         pending_downloads = AppConnectBuild.objects.filter(project=project, fetched=False).count()
 
-        last_checked_builds = project.get_option("sentry:last_checked_appstore")
-
         latest_build = (
-            AppConnectBuild.objects.filter(project=project)
+            AppConnectBuild.objects.filter(project=project, bundle_id=symbol_source_cfg.bundleId)
             .order_by("-uploaded_to_appstore")
             .first()
         )
@@ -427,6 +425,9 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         else:
             latestBuildVersion = latest_build.bundle_short_version
             latestBuildNumber = latest_build.bundle_version
+
+        builds_check_dates = project.get_option("sentry:last_checked_appstore", default={})
+        last_checked_builds = builds_check_dates[symbol_source_cfg.id]
 
         return Response(
             {

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -380,9 +380,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
     identifier for the latest build recognized by Sentry.
 
     ``lastCheckedBuilds`` is when sentry last checked for new builds, regardless
-    of whether there were any or no builds in App Store Connect at the time, or
-    if the check failed due to an expired iTunes session. In other words, this
-    date may represent a failed check.
+    of whether there were any or no builds in App Store Connect at the time.
     """
 
     permission_classes = [StrictProjectPermission]

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -68,6 +68,7 @@ from sentry.api.exceptions import (
 from sentry.lang.native import appconnect
 from sentry.models import AppConnectBuild, AuditLogEntryEvent, Project
 from sentry.tasks.app_store_connect import dsym_download
+from sentry.utils import json
 from sentry.utils.appleconnect import appstore_connect, itunes_connect
 from sentry.utils.appleconnect.itunes_connect import ITunesHeaders
 from sentry.utils.safe import get_path
@@ -426,9 +427,12 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
             latestBuildVersion = latest_build.bundle_short_version
             latestBuildNumber = latest_build.bundle_version
 
-        build_check_dates = project.get_option(
-            appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, default={}
+        serialized_check_dates = project.get_option(
+            appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, default="{}"
         )
+        build_check_dates = json.loads(serialized_check_dates)
+        # This is sent over as a part of a JSON response already, so there's no need to parse this
+        # only to have it serialized again
         last_checked_builds = build_check_dates[symbol_source_cfg.id]
 
         return Response(

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -369,6 +369,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         "itunesSessionRefreshAt": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ" | null
         "latestBuildVersion: "9.8.7" | null,
         "latestBuildNumber": "987000" | null,
+        "lastCheckedBuilds": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ" | null
     }
     ```
 
@@ -377,6 +378,11 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
     downloads, and an indicator if we do need the session to fetch new builds.
     ``latestBuildVersion`` and ``latestBuildNumber`` together form a unique
     identifier for the latest build recognized by Sentry.
+
+    ``lastCheckedBuilds`` is when sentry last checked for new builds, regardless
+    of whether there were any or no builds in App Store Connect at the time, or
+    if the check failed due to an expired iTunes session. In other words, this
+    date may represent a failed check.
     """
 
     permission_classes = [StrictProjectPermission]
@@ -410,6 +416,8 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
 
         pending_downloads = AppConnectBuild.objects.filter(project=project, fetched=False).count()
 
+        last_checked_builds = project.get_option("sentry:last_checked_appstore")
+
         latest_build = (
             AppConnectBuild.objects.filter(project=project)
             .order_by("-uploaded_to_appstore")
@@ -430,6 +438,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "pendingDownloads": pending_downloads,
                 "latestBuildVersion": latestBuildVersion,
                 "latestBuildNumber": latestBuildNumber,
+                "lastCheckedBuilds": last_checked_builds,
             },
             status=200,
         )

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -158,27 +158,6 @@ class AppStoreConnectConfig:
         return cls(**data)
 
     @classmethod
-    def from_option(cls, raw_sources_option: str) -> "List[AppStoreConnectConfig]":
-        """Creates a list of new instances from a raw serialized JSON list of symbol sources,
-        typically fetched directly from a project's ``sentry:symbol_sources`` option. Useful when
-        App Store Connect symbol sources need to be updated across multiple projects.
-
-        :raises InvalidConfigError: if the data does not contain a valid App Store Connect
-           symbol source configuration.
-        """
-
-        try:
-            all_sources = json.loads(raw_sources_option)
-        except json.JSONDecodeError:
-            return []
-
-        return [
-            cls.from_json(source)
-            for source in all_sources
-            if source.get("type") == SYMBOL_SOURCE_TYPE_NAME
-        ]
-
-    @classmethod
     def from_project_config(cls, project: Project, config_id: str) -> "AppStoreConnectConfig":
         """Creates a new instance from the symbol source configured in the project.
 

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -167,11 +167,10 @@ class AppStoreConnectConfig:
            symbol source configuration.
         """
 
-        sources = []
         try:
             all_sources = json.loads(raw_sources_option)
         except json.JSONDecodeError:
-            return sources
+            return []
 
         return [
             cls.from_json(source)

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 # The key in the project options under which all symbol sources are stored.
 SYMBOL_SOURCES_PROP_NAME = "sentry:symbol_sources"
 
+# The key in the project options under which all refresh dates for symbol sources are stored.
+SYMBOL_SOURCE_REFRESH_PROP_NAME = "sentry:symbol_source_refresh_dates"
 
 # The symbol source type for an App Store Connect symbol source.
 SYMBOL_SOURCE_TYPE_NAME = "appStoreConnect"
@@ -166,11 +168,16 @@ class AppStoreConnectConfig:
         """
 
         sources = []
-        all_sources = json.loads(raw_sources_option)
-        for source in all_sources:
-            if source.get("type") == SYMBOL_SOURCE_TYPE_NAME:
-                sources.append(cls.from_json(source))
-        return sources
+        try:
+            all_sources = json.loads(raw_sources_option)
+        except json.JSONDecodeError:
+            return sources
+
+        return [
+            cls.from_json(source)
+            for source in all_sources
+            if source.get("type") == SYMBOL_SOURCE_TYPE_NAME
+        ]
 
     @classmethod
     def from_project_config(cls, project: Project, config_id: str) -> "AppStoreConnectConfig":

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -28,8 +28,9 @@ logger = logging.getLogger(__name__)
 # The key in the project options under which all symbol sources are stored.
 SYMBOL_SOURCES_PROP_NAME = "sentry:symbol_sources"
 
-# The key in the project options under which all refresh dates for symbol sources are stored.
-SYMBOL_SOURCE_REFRESH_PROP_NAME = "sentry:symbol_source_refresh_dates"
+# The key in the project options under which all of the dates corresponding to the last time sentry
+# checked for new builds in App Store Connect are stored.
+APPSTORECONNECT_BUILD_REFRESHES_OPTION = "sentry:asc_build_refresh_dates"
 
 # The symbol source type for an App Store Connect symbol source.
 SYMBOL_SOURCE_TYPE_NAME = "appStoreConnect"

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -156,10 +156,17 @@ class AppStoreConnectConfig:
         return cls(**data)
 
     @classmethod
-    def all_for_project(cls, project: Project) -> "List[AppStoreConnectConfig]":
+    def from_option(cls, raw_sources_option: str) -> "List[AppStoreConnectConfig]":
+        """Creates a list of new instances from a raw serialized JSON list of symbol sources,
+        typically fetched directly from a project's ``sentry:symbol_sources`` option. Useful when
+        App Store Connect symbol sources need to be updated across multiple projects.
+
+        :raises InvalidConfigError: if the data does not contain a valid App Store Connect
+           symbol source configuration.
+        """
+
         sources = []
-        raw = project.get_option(SYMBOL_SOURCES_PROP_NAME, default="[]")
-        all_sources = json.loads(raw)
+        all_sources = json.loads(raw_sources_option)
         for source in all_sources:
             if source.get("type") == SYMBOL_SOURCE_TYPE_NAME:
                 sources.append(cls.from_json(source))

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -43,8 +43,6 @@ def inner_dsym_download(project_id: int, config_id: str) -> None:
     config = appconnect.AppStoreConnectConfig.from_project_config(project, config_id)
     client = appconnect.AppConnectClient.from_config(config)
 
-    build_refresh_dates = project.get_option(appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, default={})
-
     # persist all fetched builds into the database as "pending"
     builds = []
     listed_builds = client.list_builds()
@@ -56,6 +54,7 @@ def inner_dsym_download(project_id: int, config_id: str) -> None:
             if not build_state.fetched:
                 builds.append((build, build_state))
 
+    build_refresh_dates = project.get_option(appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, default={})
     build_refresh_dates[config_id] = datetime.now()
     project.update_option(appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, build_refresh_dates)
 

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -58,7 +58,10 @@ def inner_dsym_download(project_id: int, config_id: str) -> None:
         appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, default={}
     )
     build_refresh_dates[config_id] = datetime.now()
-    project.update_option(appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, build_refresh_dates)
+    serialized_refresh_dates = json.dumps(build_refresh_dates)
+    project.update_option(
+        appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, serialized_refresh_dates
+    )
 
     itunes_client = client.itunes_client()
     for (build, build_state) in builds:

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -54,9 +54,11 @@ def inner_dsym_download(project_id: int, config_id: str) -> None:
             if not build_state.fetched:
                 builds.append((build, build_state))
 
-    build_refresh_dates = project.get_option(appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, default={})
+    build_refresh_dates = project.get_option(
+        appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, default={}
+    )
     build_refresh_dates[config_id] = datetime.now()
-    project.update_option(appconnect.SYMBOL_SOURCE_REFRESH_PROP_NAME, build_refresh_dates)
+    project.update_option(appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, build_refresh_dates)
 
     itunes_client = client.itunes_client()
     for (build, build_state) in builds:


### PR DESCRIPTION
Store the last time App Store Connect was checked for builds in a project option. This is always updated and does not get skipped even if the iTunes session is expired, or if there are no builds to download debug files for.

These changes will most likely conflict with #27462.