### PR TITLE
chore(api): Collect `DELETE` stats from api endpoints

### DIFF
--- a/src/sentry/middleware/stats.py
+++ b/src/sentry/middleware/stats.py
@@ -26,7 +26,7 @@ class ResponseCodeMiddleware(MiddlewareMixin):
 
 
 class RequestTimingMiddleware(MiddlewareMixin):
-    allowed_methods = ("POST", "GET", "PUT")
+    allowed_methods = ("POST", "GET", "PUT", "DELETE")
     allowed_paths = getattr(
         settings, "SENTRY_REQUEST_METRIC_ALLOWED_PATHS", ("sentry.web.api", "sentry.api.endpoints")
     )  # Store endpoints


### PR DESCRIPTION
We're wondering if there are spikes of deleting coming via a specific endpoint, so would like to
enable these stats.