### PR TITLE
fix(ci): switch order for openapi spec diff

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -39,4 +39,4 @@ jobs:
 
         - name: Compare OpenAPI Derefed JSON
           run: |
-            npx json-diff --color sentry/api-docs/openapi-derefed.json sentry-api-schema/openapi-derefed.json
+            npx json-diff --color sentry-api-schema/openapi-derefed.json sentry/api-docs/openapi-derefed.json


### PR DESCRIPTION
currently the open api diff checker's arguments are reversed, and results in opposite changes of what appears in the changeset. 
- this PR flips them according to the json-diff docs: https://www.npmjs.com/package/json-diff

example incorrect diff: SCIM API changes last week showing them removed instead of added: https://github.com/getsentry/sentry/pull/27154/checks?check_run_id=3048843286