### PR TITLE
fix(copy): removed unnecessary colon from subtitle

### DIFF
--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -199,7 +199,7 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
         )}
 
         <Wrapper>
-          <TextBlock noMargin>{t('Uploaded debug information files')}:</TextBlock>
+          <TextBlock noMargin>{t('Uploaded debug information files')}</TextBlock>
 
           <Filters>
             <Label>


### PR DESCRIPTION
Removed unnecessary colon 

![CleanShot 2021-07-16 at 10 51 06](https://user-images.githubusercontent.com/1900676/125988893-41d8c836-900e-4797-aa57-c7c4eda2cb98.png)

