### PR TITLE
fix(discover): Try to get these tests to flake less

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -56,8 +56,8 @@ def transactions_query(**kwargs):
 
 
 def generate_transaction(trace=None, span=None):
-    start_datetime = before_now(minutes=1, milliseconds=500)
     end_datetime = before_now(minutes=1)
+    start_datetime = end_datetime - timedelta(milliseconds=500)
     event_data = load_data(
         "transaction",
         timestamp=end_datetime,
@@ -167,9 +167,10 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_all_events_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        min_ago = iso_format(before_now(minutes=1))
-        two_min_ago = iso_format(before_now(minutes=2))
+        now = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = now
+        min_ago = iso_format(now - timedelta(minutes=1))
+        two_min_ago = iso_format(now - timedelta(minutes=2))
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -228,8 +229,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_errors_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        min_ago = iso_format(before_now(minutes=1))
+        now = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = now
+        min_ago = iso_format(now - timedelta(minutes=1))
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -299,8 +301,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_all_events(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        min_ago = iso_format(before_now(minutes=1))
+        now = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = now
+        min_ago = iso_format(now - timedelta(minutes=1))
 
         event_data = load_data("python")
         event_data.update(
@@ -336,12 +339,13 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
     @patch("django.utils.timezone.now")
     def test_event_detail_view_from_errors_view(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+        now = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = now
 
         event_data = load_data("javascript")
         event_data.update(
             {
-                "timestamp": iso_format(before_now(minutes=5)),
+                "timestamp": iso_format(now - timedelta(minutes=5)),
                 "event_id": "d" * 32,
                 "fingerprint": ["group-1"],
             }
@@ -567,8 +571,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     @pytest.mark.skip(reason="causing timeouts in github actions and travis")
     @patch("django.utils.timezone.now")
     def test_drilldown_result(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-        min_ago = iso_format(before_now(minutes=1))
+        now = before_now().replace(tzinfo=pytz.utc)
+        mock_now.return_value = now
+        min_ago = iso_format(now - timedelta(minutes=1))
         events = (
             ("a" * 32, "oh no", "group-1"),
             ("b" * 32, "oh no", "group-1"),


### PR DESCRIPTION
- This changes how we get `now` so we're hopefully more consistent with
  the timestamps in the screenshots