### PR TITLE
fix(ui): table row draggable background

### DIFF
--- a/static/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
@@ -91,6 +91,8 @@ const Wrapper = styled('div')`
 `;
 
 const InnerWrapper = styled('div')`
+  background-color: ${p => p.theme.background};
+
   animation: pop 200ms cubic-bezier(0.18, 0.67, 0.6, 1.22);
   box-shadow: var(--box-shadow-picked-up);
   opacity: 1;


### PR DESCRIPTION
Was a bit too quick with https://github.com/getsentry/sentry/pull/27511

We still need to set a background for this row when it's being dragged, so fixing that here.