### PR TITLE
fix(notification platform): Don't unfurl links

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -142,6 +142,8 @@ def send_notification_as_slack(
         context = get_context(notification, recipient, shared_context, extra_context)
         attachment = [build_notification_attachment(notification, context, recipient)]
         for channel, token in tokens_by_channel.items():
+            # unfurl_links and unfurl_media are needed to preserve the intended message format
+            # and prevent the app from replying with help text to the unfurl
             payload = {
                 "token": token,
                 "channel": channel,

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -146,6 +146,8 @@ def send_notification_as_slack(
                 "token": token,
                 "channel": channel,
                 "link_names": 1,
+                "unfurl_links": False,
+                "unfurl_media": False,
                 "text": notification.get_notification_title(),
                 "attachments": json.dumps(attachment),
             }


### PR DESCRIPTION
If we don't have `unfurl_links` and `unfurl_media` set to False, notifications that have a link to the issue in them will unfurl and look strange and also trigger the help text. This PR adds those fields in to preserve the message we want and avoid unnecessary help text being triggered.

**Before**
![badunfurl](https://user-images.githubusercontent.com/29959063/126016250-2fef5e9c-acdb-4c64-bf94-db77798a0cbc.jpg)


**After**
<img width="517" alt="Screen Shot 2021-07-16 at 4 00 12 PM" src="https://user-images.githubusercontent.com/29959063/126016106-7f8f022e-08ba-4a97-9ae4-a267b0058419.png">
