### PR TITLE
feat(ui): Add handled/unhandled issues to release comparison

### DIFF
--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -114,7 +114,6 @@ function ReleaseComparisonChart({
     start,
     end,
     utc,
-    environment,
   } = useMemo(
     () =>
       // Memoizing this so that it does not calculate different `end` for releases without events+sessions each rerender
@@ -217,7 +216,7 @@ function ReleaseComparisonChart({
         {
           query: {
             project: project.id,
-            environment,
+            environment: decodeList(location.query.environment),
             start,
             end,
             ...(period ? {statsPeriod: period} : {}),

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -3,6 +3,7 @@ import pick from 'lodash/pick';
 import round from 'lodash/round';
 import moment from 'moment';
 
+import {DateTimeObject} from 'app/components/charts/utils';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {PAGE_URL_PARAM, URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {tn} from 'app/locale';
@@ -89,15 +90,37 @@ export const getReleaseNewIssuesUrl = (
 export const getReleaseUnhandledIssuesUrl = (
   orgSlug: string,
   projectId: string | number | null,
-  version: string
+  version: string,
+  dateTime: DateTimeObject = {}
 ) => {
   return {
     pathname: `/organizations/${orgSlug}/issues/`,
     query: {
+      ...dateTime,
       project: projectId,
       query: new QueryResults([
         `release:${version}`,
         'error.unhandled:true',
+      ]).formatString(),
+      sort: IssueSortOptions.FREQ,
+    },
+  };
+};
+
+export const getReleaseHandledIssuesUrl = (
+  orgSlug: string,
+  projectId: string | number | null,
+  version: string,
+  dateTime: DateTimeObject = {}
+) => {
+  return {
+    pathname: `/organizations/${orgSlug}/issues/`,
+    query: {
+      ...dateTime,
+      project: projectId,
+      query: new QueryResults([
+        `release:${version}`,
+        'error.handled:true',
       ]).formatString(),
       sort: IssueSortOptions.FREQ,
     },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/126149918-e487559f-a6bf-4e9a-97c1-0785de56ea5d.png)

Extending release comparison table to include Handled/Unhandled issues count with link to issues stream.

This should better explain that errored sessions most likely result in handled issues and crashed sessions in unhandled issues.