### PR TITLE
feat(ui): Add 24hr support to timeAndDate format

### DIFF
--- a/static/app/components/dateTime.tsx
+++ b/static/app/components/dateTime.tsx
@@ -37,6 +37,10 @@ class DateTime extends Component<Props> {
 
     // Oct 26, 11:30 AM
     if (timeAndDate) {
+      if (clock24Hours) {
+        return 'MMM DD, HH:mm';
+      }
+
       return 'MMM DD, LT';
     }
 

--- a/tests/js/spec/components/dateTime.spec.jsx
+++ b/tests/js/spec/components/dateTime.spec.jsx
@@ -71,6 +71,11 @@ describe('DateTime', () => {
       expect(wrapper.text()).toBe('19:41');
     });
 
+    it('renders timeAndDate', () => {
+      const wrapper = mountWithTheme(<DateTime date={new Date()} timeAndDate />);
+      expect(wrapper.text()).toBe('Oct 16, 19:41');
+    });
+
     it('renders date with forced utc', () => {
       const wrapper = mountWithTheme(<DateTime date={new Date()} utc />);
       expect(wrapper.text()).toBe('Oct 17, 2017 02:41');


### PR DESCRIPTION
Before, this branch of code would not respect the `Use a 24-hour clock` user preference.