### PR TITLE
feat(performance): optional withoutZerofill and include start end times in events-stats response

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -359,14 +359,6 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     allow_partial_buckets=allow_partial_buckets,
                     zerofill_results=zerofill_results,
                 )
-            if hasattr(result, "start") and hasattr(result, "end"):
-                if is_multiple_axis:
-                    for value in serialized_result.values():
-                        value["start"] = result.start
-                        value["end"] = result.end
-                else:
-                    serialized_result["start"] = result.start
-                    serialized_result["end"] = result.end
 
             return serialized_result
 
@@ -393,6 +385,12 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         # Set order if multi-axis + top events
         if "order" in event_result.data:
             result["order"] = event_result.data["order"]
+
+        if zerofill_results and hasattr(event_result, "start") and hasattr(event_result, "end"):
+            for value in result.values():
+                value["start"] = event_result.start
+                value["end"] = event_result.end
+
         return result
 
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -342,9 +342,9 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                             allow_partial_buckets=allow_partial_buckets,
                             zerofill_results=zerofill_results,
                         )
-                serializedResult = results
+                serialized_result = results
             elif is_multiple_axis:
-                serializedResult = self.serialize_multiple_axis(
+                serialized_result = self.serialize_multiple_axis(
                     serializer,
                     result,
                     columns,
@@ -361,14 +361,14 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 )
             if hasattr(result, "start") and hasattr(result, "end"):
                 if is_multiple_axis:
-                    for value in serializedResult.values():
+                    for value in serialized_result.values():
                         value["start"] = result.start
                         value["end"] = result.end
                 else:
-                    serializedResult["start"] = result.start
-                    serializedResult["end"] = result.end
+                    serialized_result["start"] = result.start
+                    serialized_result["end"] = result.end
 
-            return serializedResult
+            return serialized_result
 
     def serialize_multiple_axis(
         self,

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -386,7 +386,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         if "order" in event_result.data:
             result["order"] = event_result.data["order"]
 
-        if zerofill_results and hasattr(event_result, "start") and hasattr(event_result, "end"):
+        if hasattr(event_result, "start") and hasattr(event_result, "end"):
             for value in result.values():
                 value["start"] = event_result.start
                 value["end"] = event_result.end

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -321,10 +321,11 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             # When the request is for top_events, result can be a SnubaTSResult in the event that
             # there were no top events found. In this case, result contains a zerofilled series
             # that acts as a placeholder.
+            is_multiple_axis = len(query_columns) > 1
             if top_events > 0 and isinstance(result, dict):
                 results = {}
                 for key, event_result in result.items():
-                    if len(query_columns) > 1:
+                    if is_multiple_axis:
                         results[key] = self.serialize_multiple_axis(
                             serializer,
                             event_result,
@@ -342,7 +343,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                             zerofill_results=zerofill_results,
                         )
                 serializedResult = results
-            elif len(query_columns) > 1:
+            elif is_multiple_axis:
                 serializedResult = self.serialize_multiple_axis(
                     serializer,
                     result,
@@ -359,8 +360,13 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     zerofill_results=zerofill_results,
                 )
             if hasattr(result, "start") and hasattr(result, "end"):
-                serializedResult["start"] = result.start
-                serializedResult["end"] = result.end
+                if is_multiple_axis:
+                    for value in serializedResult.values():
+                        value["start"] = result.start
+                        value["end"] = result.end
+                else:
+                    serializedResult["start"] = result.start
+                    serializedResult["end"] = result.end
 
             return serializedResult
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -386,11 +386,6 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         if "order" in event_result.data:
             result["order"] = event_result.data["order"]
 
-        if hasattr(event_result, "start") and hasattr(event_result, "end"):
-            for value in result.values():
-                value["start"] = event_result.start
-                value["end"] = event_result.end
-
         return result
 
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -353,7 +353,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     zerofill_results=zerofill_results,
                 )
             else:
-                serializedResult = serializer.serialize(
+                serialized_result = serializer.serialize(
                     result,
                     resolve_axis_column(query_columns[0]),
                     allow_partial_buckets=allow_partial_buckets,

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -313,9 +313,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
 
                 query_columns = [column_map.get(column, column) for column in columns]
             with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):
-                result = get_event_stats(
-                    query_columns, query, params, rollup, zerofill_results=zerofill_results
-                )
+                result = get_event_stats(query_columns, query, params, rollup, zerofill_results)
 
         serializer = SnubaTSResultSerializer(organization, None, request.user)
 

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -1,6 +1,7 @@
 import sentry_sdk
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.bases import OrganizationEventsV2EndpointBase
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.snuba import discover
@@ -36,7 +37,12 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             # the start of the bucket does not align with the rollup.
             allow_partial_buckets = request.GET.get("partial") == "1"
 
-        def get_event_stats(query_columns, query, params, rollup):
+        def has_chart_interpolation(self, organization, request):
+            return features.has(
+                "organizations:performance-chart-interpolation", organization, actor=request.user
+            )
+
+        def get_event_stats(query_columns, query, params, rollup, zerofill_results):
             if top_events > 0:
                 return discover.top_events_timeseries(
                     timeseries_columns=query_columns,
@@ -57,6 +63,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                 params=params,
                 rollup=rollup,
                 referrer="api.organization-event-stats",
+                zerofill_results=zerofill_results,
             )
 
         return Response(
@@ -66,6 +73,10 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                 get_event_stats,
                 top_events,
                 allow_partial_buckets=allow_partial_buckets,
+                zerofill_results=not (
+                    request.GET.get("withoutZerofill") == "1"
+                    and has_chart_interpolation(self, organization, request)
+                ),
             ),
             status=200,
         )

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -56,6 +56,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     organization=organization,
                     referrer="api.organization-event-stats.find-topn",
                     allow_empty=False,
+                    zerofill_results=zerofill_results,
                 )
             return discover.timeseries_query(
                 selected_columns=query_columns,

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -256,7 +256,7 @@ class OrganizationEventsTrendsStatsEndpoint(OrganizationEventsTrendsEndpointBase
         self, request, organization, params, trend_function, selected_columns, orderby, query
     ):
         def on_results(events_results):
-            def get_event_stats(query_columns, query, params, rollup):
+            def get_event_stats(query_columns, query, params, rollup, zerofill_results):
                 return discover.top_events_timeseries(
                     query_columns,
                     selected_columns,

--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -268,6 +268,7 @@ class OrganizationEventsTrendsStatsEndpoint(OrganizationEventsTrendsEndpointBase
                     organization,
                     top_events=events_results,
                     referrer="api.trends.get-event-stats",
+                    zerofill_results=zerofill_results,
                 )
 
             stats_results = (

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -346,7 +346,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
         elif "order" in result.data:
             res["order"] = result.data["order"]
 
-        if zerofill_results and hasattr(result, "start") and hasattr(result, "end"):
+        if hasattr(result, "start") and hasattr(result, "end"):
             res["start"] = result.start
             res["end"] = result.end
 

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -304,7 +304,9 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
     Serializer for time-series Snuba data.
     """
 
-    def serialize(self, result, column="count", order=None, allow_partial_buckets=False):
+    def serialize(
+        self, result, column="count", order=None, allow_partial_buckets=False, zerofill_results=True
+    ):
         data = [
             (key, list(group))
             for key, group in itertools.groupby(result.data["data"], key=lambda r: r["time"])
@@ -332,6 +334,8 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
                 result.rollup,
                 allow_partial_buckets=allow_partial_buckets,
             )
+            if zerofill_results
+            else rv
         }
 
         if result.data.get("totals"):

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -346,4 +346,8 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
         elif "order" in result.data:
             res["order"] = result.data["order"]
 
+        if zerofill_results and hasattr(result, "start") and hasattr(result, "end"):
+            res["start"] = result.start
+            res["end"] = result.end
+
         return res

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -347,7 +347,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
             res["order"] = result.data["order"]
 
         if hasattr(result, "start") and hasattr(result, "end"):
-            res["start"] = result.start
-            res["end"] = result.end
+            res["start"] = result.start.timestamp()
+            res["end"] = result.end.timestamp()
 
         return res

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -964,6 +964,8 @@ SENTRY_FEATURES = {
     "organizations:performance-landing-widgets": False,
     # Enable views for transaction events page in performance
     "organizations:performance-events-page": False,
+    # Enable interpolation of null data points in charts instead of zerofilling in performance
+    "organizations:performance-chart-interpolation": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -110,6 +110,7 @@ default_manager.add("organizations:performance-ops-breakdown", OrganizationFeatu
 default_manager.add("organizations:performance-tag-explorer", OrganizationFeature, True)
 default_manager.add("organizations:performance-tag-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-events-page", OrganizationFeature, True)
+default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:project-transaction-threshold", OrganizationFeature, True)
 default_manager.add(

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -546,6 +546,7 @@ def top_events_timeseries(
     referrer=None,
     top_events=None,
     allow_empty=True,
+    zerofill_results=True,
 ):
     """
     High-level API for doing arbitrary user timeseries queries for a limited number of top events
@@ -643,7 +644,11 @@ def top_events_timeseries(
 
     if not allow_empty and not len(result.get("data", [])):
         return SnubaTSResult(
-            {"data": zerofill([], snuba_filter.start, snuba_filter.end, rollup, "time")},
+            {
+                "data": zerofill([], snuba_filter.start, snuba_filter.end, rollup, "time")
+                if zerofill_results
+                else [],
+            },
             snuba_filter.start,
             snuba_filter.end,
             rollup,
@@ -690,7 +695,9 @@ def top_events_timeseries(
                 {
                     "data": zerofill(
                         item["data"], snuba_filter.start, snuba_filter.end, rollup, "time"
-                    ),
+                    )
+                    if zerofill_results
+                    else item["data"],
                     "order": item["order"],
                 },
                 snuba_filter.start,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -454,7 +454,7 @@ def get_timeseries_snuba_filter(selected_columns, query, params):
     return snuba_filter, translated_columns
 
 
-def timeseries_query(selected_columns, query, params, rollup, referrer=None):
+def timeseries_query(selected_columns, query, params, rollup, referrer=None, zerofill_results=True):
     """
     High-level API for doing arbitrary user timeseries queries against events.
 
@@ -508,7 +508,11 @@ def timeseries_query(selected_columns, query, params, rollup, referrer=None):
         op="discover.discover", description="timeseries.transform_results"
     ) as span:
         span.set_data("result_count", len(result.get("data", [])))
-        result = zerofill(result["data"], snuba_filter.start, snuba_filter.end, rollup, "time")
+        result = (
+            zerofill(result["data"], snuba_filter.start, snuba_filter.end, rollup, "time")
+            if zerofill_results
+            else result["data"]
+        )
 
         return SnubaTSResult({"data": result}, snuba_filter.start, snuba_filter.end, rollup)
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import timedelta
 from uuid import uuid4
 
+import dateutil.parser as parse_date
 import pytest
 from django.urls import reverse
 from pytz import utc
@@ -814,11 +815,13 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             "organizations:discover-basic": True,
         }
         with self.feature(self.enabled_features):
+            start = iso_format(self.day_ago)
+            end = iso_format(self.day_ago + timedelta(hours=2))
             response = self.client.get(
                 self.url,
                 data={
-                    "start": iso_format(self.day_ago),
-                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "start": start,
+                    "end": end,
                     "interval": "30m",
                     "withoutZerofill": "1",
                 },
@@ -830,6 +833,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
                 [{"count": 1}],
                 [{"count": 2}],
             ]
+            assert response.data["start"] == parse_date.parse(start).timestamp()
+            assert response.data["end"] == parse_date.parse(end).timestamp()
 
 
 class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):


### PR DESCRIPTION
This pr includes backend changes to support displaying interpolated graphs on the performance transaction summary page rather than zerofilled graphs.
The first change is a `withoutZerofill` option on get requests to `events-stats`. Querying with `withoutZerofill` will skip the zerofilling step before response. ie the results from `events-stats` will return data such as this without zerofill:
```
[
[1626616800, [{count: 4818.5}]],
[1626617400, [{count: 5394.5}]],
[1626618300, [{count: 3601}]],
]
```

rather than something like this with zerofill on (dependant on the timeframe selected):
```
[
[1626615600, [{count: 0}]],
[1626615900, [{count: 0}]],
[1626616200, [{count: 0}]],
[1626616500, [{count: 0}]],
[1626616800, [{count: 4818.5}]],
[1626617100, [{count: 0}]],
[1626617400, [{count: 5394.5}]],
[1626617700, [{count: 0}]],
[1626618000, [{count: 0}]],
[1626618300, [{count: 3601}]],
]
```

The second change in this pr is to include `start` and `end` to indicate the start and end times of the timeframe selected on `events-stats`. This will allow the frontend to always know what timeframe to display when using `withoutZerofill` since we previously relied on zerofill to fill in gaps for the full timeframe.

Frontend changes to the Transaction Summary page: https://github.com/getsentry/sentry/pull/27536