### PR TITLE
fix(workflow): Fixing issue where project filter is not applied to adoption filter

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -99,7 +99,6 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
 
         if search_filter.key.name == RELEASE_STAGE_ALIAS:
             queryset = queryset.filter_by_stage(
-                # organization.id, search_filter.operator, search_filter.value.value
                 organization.id,
                 search_filter.operator,
                 search_filter.value.value,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -752,6 +752,50 @@ class OrganizationReleasesStatsTest(APITestCase):
         )
         assert response.status_code == 400
 
+    def test_multi_project_release_gets_filtered(self):
+        multi_project_release = self.create_release(version="multi_project_release")
+        single_project_release = self.create_release(version="single_project_release")
+        project2 = self.create_project(teams=[self.team], organization=self.organization)
+
+        # One project not adopted
+        ReleaseProjectEnvironment.objects.create(
+            project_id=self.project.id,
+            release_id=multi_project_release.id,
+            environment_id=self.environment.id,
+        )
+        # One project adopted
+        ReleaseProjectEnvironment.objects.create(
+            project_id=project2.id,
+            release_id=multi_project_release.id,
+            environment_id=self.environment.id,
+            adopted=timezone.now(),
+        )
+        ReleaseProjectEnvironment.objects.create(
+            project_id=self.project.id,
+            release_id=single_project_release.id,
+            environment_id=self.environment.id,
+            adopted=timezone.now(),
+        )
+
+        # Filtering to self.environment.name and self.project with release.stage:adopted should NOT return multi_project_release.
+        response = self.get_valid_response(
+            self.organization.slug,
+            project=self.project.id,
+            environment=self.environment.name,
+            query=f"{RELEASE_STAGE_ALIAS}:adopted",
+        )
+        assert [r["version"] for r in response.data] == [single_project_release.version]
+
+        response = self.get_valid_response(
+            self.organization.slug,
+            environment=self.environment.name,
+            query=f"{RELEASE_STAGE_ALIAS}:adopted",
+        )
+        assert [r["version"] for r in response.data] == [
+            single_project_release.version,
+            multi_project_release.version,
+        ]
+
     def test_query_filter(self):
         self.login_as(user=self.user)
 


### PR DESCRIPTION
This shouldn't happen:
![Screen Shot 2021-07-19 at 10 55 56 AM](https://user-images.githubusercontent.com/6395250/126180780-4e99d940-dfe7-4e4b-82da-c11e31670838.png)

but it does and this PR wants to change that. 

(those releases are getting returned because they have an adopted release in another project)