### PR TITLE
fix(ui): Display release filter dropdowns in a row

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -615,6 +615,7 @@ const AlertText = styled('div')`
 const SortAndFilterWrapper = styled('div')`
   display: flex;
   flex-direction: column;
+  justify-content: stretch;
   grid-gap: ${space(2)};
   margin-bottom: ${space(2)};
 
@@ -622,17 +623,37 @@ const SortAndFilterWrapper = styled('div')`
     flex: 1;
   }
 
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+  /* Below this width search bar needs its own row no to wrap placeholder text
+   * Above this width search bar and controls can be on the same row */
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
     flex-direction: row;
   }
 `;
 
 const DropdownsWrapper = styled('div')`
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  grid-gap: ${space(2)};
+  flex-direction: column;
+  gap: ${space(2)};
+
+  /* At the narrower widths wrapper is on its own in a row
+   * Expand the dropdown controls to fill the empty space */
+  & button {
+    width: 100%;
+  }
+
+  /* At narrower widths space bar needs a separate row
+   * Divide space evenly when 3 dropdowns are in their own row */
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+  }
+
+  /* At wider widths everything is in 1 row
+   * Auto space dropdowns when they are in the same row with search bar */
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    display: grid;
+    grid-template-columns: auto auto auto;
+  }
 `;
 
 export default withOrganization(withGlobalSelection(ReleasesList));

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -565,20 +565,22 @@ class ReleasesList extends AsyncView<Props, State> {
                   query={this.getQuery()}
                 />
               )}
-              <ReleaseListStatusOptions
-                selected={activeStatus}
-                onSelect={this.handleStatus}
-              />
-              <ReleaseListSortOptions
-                selected={activeSort}
-                selectedDisplay={activeDisplay}
-                onSelect={this.handleSortBy}
-                organization={organization}
-              />
-              <ReleaseDisplayOptions
-                selected={activeDisplay}
-                onSelect={this.handleDisplay}
-              />
+              <DropdownsWrapper>
+                <ReleaseListStatusOptions
+                  selected={activeStatus}
+                  onSelect={this.handleStatus}
+                />
+                <ReleaseListSortOptions
+                  selected={activeSort}
+                  selectedDisplay={activeDisplay}
+                  onSelect={this.handleSortBy}
+                  organization={organization}
+                />
+                <ReleaseDisplayOptions
+                  selected={activeDisplay}
+                  onSelect={this.handleDisplay}
+                />
+              </DropdownsWrapper>
             </SortAndFilterWrapper>
 
             {!reloading &&
@@ -611,13 +613,26 @@ const AlertText = styled('div')`
 `;
 
 const SortAndFilterWrapper = styled('div')`
-  display: inline-grid;
+  display: flex;
+  flex-direction: column;
   grid-gap: ${space(2)};
   margin-bottom: ${space(2)};
 
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    grid-template-columns: 1fr repeat(3, auto);
+  > *:nth-child(1) {
+    flex: 1;
   }
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    flex-direction: row;
+  }
+`;
+
+const DropdownsWrapper = styled('div')`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  grid-gap: ${space(2)};
 `;
 
 export default withOrganization(withGlobalSelection(ReleasesList));

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -616,7 +616,6 @@ const SortAndFilterWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: stretch;
-  grid-gap: ${space(2)};
   margin-bottom: ${space(2)};
 
   > *:nth-child(1) {
@@ -633,7 +632,10 @@ const SortAndFilterWrapper = styled('div')`
 const DropdownsWrapper = styled('div')`
   display: flex;
   flex-direction: column;
-  gap: ${space(2)};
+
+  & > * {
+    margin-top: ${space(2)};
+  }
 
   /* At the narrower widths wrapper is on its own in a row
    * Expand the dropdown controls to fill the empty space */
@@ -644,6 +646,17 @@ const DropdownsWrapper = styled('div')`
   /* At narrower widths space bar needs a separate row
    * Divide space evenly when 3 dropdowns are in their own row */
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    margin-top: ${space(2)};
+
+    & > * {
+      margin-top: ${space(0)};
+      margin-left: ${space(2)};
+    }
+
+    & > *:nth-child(1) {
+      margin-left: ${space(0)};
+    }
+
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
   }
@@ -651,6 +664,12 @@ const DropdownsWrapper = styled('div')`
   /* At wider widths everything is in 1 row
    * Auto space dropdowns when they are in the same row with search bar */
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    margin-top: ${space(0)};
+
+    & > * {
+      margin-left: ${space(2)} !important;
+    }
+
     display: grid;
     grid-template-columns: auto auto auto;
   }


### PR DESCRIPTION
This updates the release page filter dropdowns to fit better in narrow widths.

DEMO:
https://user-images.githubusercontent.com/15015880/126244029-37cb61b4-3f7c-4452-9f70-408ca42e0036.mov

Fixes: [WOR-1055](https://getsentry.atlassian.net/browse/WOR-1055)