### PR TITLE
perf(post-process-forwarder): Register option for experiment

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -355,5 +355,5 @@ register("processing.use-release-archives-sample-rate", default=0.0)  # unused
 # All Relay options (statically authenticated Relays can be registered here)
 register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 
-# Use rapidjson in post process forwarder
-register("post-process-forwarder:rapidjson", default=False)
+# Post process forwarder gets data from Kafka headers
+register("post-process-forwarder:kafka-headers", default=False)


### PR DESCRIPTION
Register option to be used for https://github.com/getsentry/sentry/pull/27456

Cleans up the rapidjson option that is no longer being used.