### PR TITLE
chore: Clean up dead code paths around spans.total.time

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -559,7 +559,6 @@ const spanOperationRelativeBreakdownRenderer = (
   const cumulativeSpanOpBreakdown = Math.max(sumOfSpanTime, data['transaction.duration']);
 
   if (
-    !isDurationValue(data, 'spans.total.time') ||
     SPAN_OP_BREAKDOWN_FIELDS.every(field => !isDurationValue(data, field)) ||
     cumulativeSpanOpBreakdown === 0
   ) {

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -285,9 +285,6 @@ class SummaryContent extends React.Component<Props, State> {
       fields.splice(2, 0, {field: durationField});
 
       if (spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None) {
-        // Add spans.total.time field so that the span op breakdown can be compared against it.
-        // This is used to generate the relative
-        fields.push({field: 'spans.total.time'});
         fields.push(
           ...SPAN_OP_BREAKDOWN_FIELDS.map(field => {
             return {field};

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -329,7 +329,7 @@ function generateEventsEventView(
   if (breakdown !== SpanOperationBreakdownFilter.None) {
     fields.splice(2, 1, `spans.${breakdown}`);
   } else {
-    fields.push(...SPAN_OP_BREAKDOWN_FIELDS, 'spans.total.time');
+    fields.push(...SPAN_OP_BREAKDOWN_FIELDS);
   }
   const webVital = getWebVital(location);
   if (webVital) {


### PR DESCRIPTION
`spans.total.time` is no longer used in the product; this PR removes any remaining dead code paths that references `spans.total.time`. 