### PR TITLE
feat(mobile-vitals): Add more mobile vitals to discover

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -647,7 +647,7 @@ export enum MobileVital {
   StallCount = 'measurements.stall_count',
   StallTotalTime = 'measurements.stall_total_time',
   StallLongestTime = 'measurements.stall_longest_time',
-  StallRate = 'measurements.stall_rate',
+  StallPercentage = 'measurements.stall_percentage',
 }
 
 const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
@@ -668,7 +668,7 @@ const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
   [MobileVital.StallCount]: 'number',
   [MobileVital.StallTotalTime]: 'duration',
   [MobileVital.StallLongestTime]: 'duration',
-  [MobileVital.StallRate]: 'percentage',
+  [MobileVital.StallPercentage]: 'percentage',
 };
 
 // This list contains fields/functions that are available with performance-view feature.

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -143,6 +143,7 @@ export const AGGREGATIONS = {
           'number',
           'duration',
           'date',
+          'percentage',
         ]),
         required: true,
       },
@@ -160,6 +161,7 @@ export const AGGREGATIONS = {
           'number',
           'duration',
           'date',
+          'percentage',
         ]),
         required: true,
       },
@@ -172,7 +174,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: true,
       },
@@ -185,7 +187,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         required: true,
       },
     ],
@@ -215,7 +217,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -228,7 +230,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -241,7 +243,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -255,7 +257,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -268,7 +270,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: false,
       },
@@ -281,7 +283,7 @@ export const AGGREGATIONS = {
     parameters: [
       {
         kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number']),
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
         defaultValue: 'transaction.duration',
         required: true,
       },
@@ -640,6 +642,12 @@ export enum MobileVital {
   FramesTotal = 'measurements.frames_total',
   FramesSlow = 'measurements.frames_slow',
   FramesFrozen = 'measurements.frames_frozen',
+  FramesSlowRate = 'measurements.frames_slow_rate',
+  FramesFrozenRate = 'measurements.frames_frozen_rate',
+  StallCount = 'measurements.stall_count',
+  StallTotalTime = 'measurements.stall_total_time',
+  StallLongestTime = 'measurements.stall_longest_time',
+  StallRate = 'measurements.stall_rate',
 }
 
 const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
@@ -655,6 +663,12 @@ const MEASUREMENTS: Readonly<Record<WebVital | MobileVital, ColumnType>> = {
   [MobileVital.FramesTotal]: 'number',
   [MobileVital.FramesSlow]: 'number',
   [MobileVital.FramesFrozen]: 'number',
+  [MobileVital.FramesSlowRate]: 'percentage',
+  [MobileVital.FramesFrozenRate]: 'percentage',
+  [MobileVital.StallCount]: 'number',
+  [MobileVital.StallTotalTime]: 'duration',
+  [MobileVital.StallLongestTime]: 'duration',
+  [MobileVital.StallRate]: 'percentage',
 };
 
 // This list contains fields/functions that are available with performance-view feature.

--- a/static/app/utils/performance/vitals/constants.tsx
+++ b/static/app/utils/performance/vitals/constants.tsx
@@ -142,7 +142,7 @@ export const MOBILE_VITAL_DETAILS: Record<MobileVital, Vital> = {
   },
   [MobileVital.StallTotalTime]: {
     slug: 'stall_total_time',
-    name: t('Stall Total Time'),
+    name: t('Total Stall Time'),
     description: t(
       'Stall Total Time is the total amount of time the application is stalled within a transaction.'
     ),
@@ -150,18 +150,18 @@ export const MOBILE_VITAL_DETAILS: Record<MobileVital, Vital> = {
   },
   [MobileVital.StallLongestTime]: {
     slug: 'stall_longest_time',
-    name: t('Stall Longest Time'),
+    name: t('Longest Stall Time'),
     description: t(
       'Stall Longest Time is the longest amount of time the application is stalled within a transaction.'
     ),
     type: measurementType(MobileVital.StallLongestTime),
   },
-  [MobileVital.StallRate]: {
-    slug: 'stall_rate',
-    name: t('Stall Rate'),
+  [MobileVital.StallPercentage]: {
+    slug: 'stall_percentage',
+    name: t('Stall Percentage'),
     description: t(
-      'Stall Rate is the percentage of the transaction duration the application was stalled.'
+      'Stall Percentage is the percentage of the transaction duration the application was stalled.'
     ),
-    type: measurementType(MobileVital.StallRate),
+    type: measurementType(MobileVital.StallPercentage),
   },
 };

--- a/static/app/utils/performance/vitals/constants.tsx
+++ b/static/app/utils/performance/vitals/constants.tsx
@@ -116,4 +116,52 @@ export const MOBILE_VITAL_DETAILS: Record<MobileVital, Vital> = {
     ),
     type: measurementType(MobileVital.FramesFrozen),
   },
+  [MobileVital.FramesSlowRate]: {
+    slug: 'frames_slow_rate',
+    name: t('Slow Frames Rate'),
+    description: t(
+      'Slow Frames Rate is the percentage of frames recorded within a transaction that is considered slow.'
+    ),
+    type: measurementType(MobileVital.FramesSlowRate),
+  },
+  [MobileVital.FramesFrozenRate]: {
+    slug: 'frames_frozen_rate',
+    name: t('Frozen Frames Rate'),
+    description: t(
+      'Frozen Frames Rate is the percentage of frames recorded within a transaction that is considered frozen.'
+    ),
+    type: measurementType(MobileVital.FramesFrozenRate),
+  },
+  [MobileVital.StallCount]: {
+    slug: 'stall_count',
+    name: t('Stalls'),
+    description: t(
+      'Stalls is the number of times the application stalled within a transaction.'
+    ),
+    type: measurementType(MobileVital.StallCount),
+  },
+  [MobileVital.StallTotalTime]: {
+    slug: 'stall_total_time',
+    name: t('Stall Total Time'),
+    description: t(
+      'Stall Total Time is the total amount of time the application is stalled within a transaction.'
+    ),
+    type: measurementType(MobileVital.StallTotalTime),
+  },
+  [MobileVital.StallLongestTime]: {
+    slug: 'stall_longest_time',
+    name: t('Stall Longest Time'),
+    description: t(
+      'Stall Longest Time is the longest amount of time the application is stalled within a transaction.'
+    ),
+    type: measurementType(MobileVital.StallLongestTime),
+  },
+  [MobileVital.StallRate]: {
+    slug: 'stall_rate',
+    name: t('Stall Rate'),
+    description: t(
+      'Stall Rate is the percentage of the transaction duration the application was stalled.'
+    ),
+    type: measurementType(MobileVital.StallRate),
+  },
 };


### PR DESCRIPTION
This adds the following mobile vitals to discover

- `measurements.frames_slow_rate`
- `measurements.frames_frozen_rate`
- `measurements.stall_count`
- `measurements.stall_total_time`
- `measurements.stall_longest_time`
- `measurements.stall_rate`

Also allows users to use them in aggregate functions.

Depends on #27544