### PR TITLE
feat(notification platform): fix deploy notification buttons

### DIFF
--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -14,7 +14,7 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
 
     @staticmethod
     def _build(
-        text: Optional[str] = None,
+        text: str,
         title: Optional[str] = None,
         footer: Optional[str] = None,
         color: Optional[str] = None,
@@ -39,11 +39,9 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         if title:
             kwargs["title"] = title
 
-        if text:
-            kwargs["text"] = text
-            kwargs["mrkdwn_in"] = ["text"]
-
         return {
+            "text": text,
+            "mrkdwn_in": ["text"],
             "color": LEVEL_TO_COLOR[color or "info"],
             **kwargs,
         }

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -30,8 +30,14 @@ def build_deploy_buttons(notification: ReleaseActivityNotification) -> List[Dict
                 project_url = absolute_uri(
                     f"/organizations/{project.organization.slug}/releases/{release.version}/?project={project.id}&unselectedSeries=Healthy/"
                 )
-                buttons.append({"text": project.slug, "type": "button", "url": project_url})
-
+                buttons.append(
+                    {
+                        "text": project.slug,
+                        "name": project.slug,
+                        "type": "button",
+                        "url": project_url,
+                    }
+                )
     return buttons
 
 
@@ -61,6 +67,7 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
 
         if isinstance(self.notification, ReleaseActivityNotification):
             return self._build(
+                text=" ",
                 actions=build_deploy_buttons(self.notification),
                 footer=build_notification_footer(self.notification, self.recipient),
             )

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -67,7 +67,7 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
 
         if isinstance(self.notification, ReleaseActivityNotification):
             return self._build(
-                text=" ",
+                text="",
                 actions=build_deploy_buttons(self.notification),
                 footer=build_notification_footer(self.notification, self.recipient),
             )

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -97,6 +97,7 @@ class BuildIncidentAttachmentTest(TestCase):
         group = self.create_group(project=self.project)
         ts = group.last_seen
         assert build_group_attachment(group) == {
+            "text": "",
             "color": "#E03E2F",
             "actions": [
                 {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
@@ -128,6 +129,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     "name": "assign",
                 },
             ],
+            "mrkdwn_in": ["text"],
             "title": group.title,
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
@@ -143,6 +145,7 @@ class BuildIncidentAttachmentTest(TestCase):
         ts = event.datetime
         assert build_group_attachment(group, event) == {
             "color": "#E03E2F",
+            "text": "",
             "actions": [
                 {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
                 {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
@@ -173,6 +176,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     "name": "assign",
                 },
             ],
+            "mrkdwn_in": ["text"],
             "title": event.title,
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
@@ -187,6 +191,7 @@ class BuildIncidentAttachmentTest(TestCase):
 
         assert build_group_attachment(group, event, link_to_event=True) == {
             "color": "#E03E2F",
+            "text": "",
             "actions": [
                 {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
                 {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
@@ -217,6 +222,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     "name": "assign",
                 },
             ],
+            "mrkdwn_in": ["text"],
             "title": event.title,
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",


### PR DESCRIPTION
Fix a bug where the buttons aren't rendering anymore for deploy notifications. I think this commit caused it: https://github.com/getsentry/sentry/pull/27453/commits/78d1e9ba18b2e94fab71a31c89b6fc72cfe78fc8

and I didn't notice :( 

**Before**
<img width="508" alt="Screen Shot 2021-07-19 at 12 54 10 PM" src="https://user-images.githubusercontent.com/29959063/126219040-88987f54-13bc-460f-9900-1c8bdc4b604e.png">

**After**
<img width="527" alt="Screen Shot 2021-07-19 at 12 54 21 PM" src="https://user-images.githubusercontent.com/29959063/126219059-c392c3a4-8f92-4d0c-84be-dc8f1e033a8e.png">