### PR TITLE
feat(backend): adds get_prompt_activities_for_user

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -47,8 +47,16 @@ class PromptsConfig:
 prompt_config = PromptsConfig(DEFAULT_PROMPTS)
 
 
+# TODO: remove get_prompt_activities and use get_prompt_activities_for_user instead
 @request_cache
 def get_prompt_activities(organization_ids, features):
     return PromptsActivity.objects.filter(
         organization_id__in=organization_ids, feature__in=features
+    )
+
+
+@request_cache
+def get_prompt_activities_for_user(organization_ids, user_id, features):
+    return PromptsActivity.objects.filter(
+        organization_id__in=organization_ids, feature__in=features, user_id=user_id
     )


### PR DESCRIPTION
This PR adds a new function (`get_prompt_activities_for_user `) for checking prompt activity for a given user and set of organizations and features. This is needed because when we check prompt activities, we need to scope it per user as well which was lacking in `get_prompt_activities`. Used in https://github.com/getsentry/sentry/pull/27549. My plan is to remove `get_prompt_activities` once the getsentry PR is merged (doing it this way to avoid potential build failures).