### PR TITLE
feat(ui): Adding additional operators to semver

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -116,6 +116,12 @@ export const interchangeableFilterOperators = {
   [FilterType.Date]: [FilterType.SpecificDate],
 };
 
+export const tagValidOps = {
+  'release.version': allOperators,
+  'release.build': allOperators,
+  'release.package': allOperators,
+};
+
 const textKeys = [Token.KeySimple, Token.KeyExplicitTag] as const;
 
 const numberUnits = {

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -1,10 +1,12 @@
 import {
   filterTypeConfig,
   interchangeableFilterOperators,
+  tagValidOps,
   TermOperator,
   Token,
   TokenResult,
 } from 'app/components/searchSyntax/parser';
+import {getKeyName} from 'app/components/searchSyntax/utils';
 import {IconClock, IconStar, IconTag, IconToggle, IconUser} from 'app/icons';
 import {t} from 'app/locale';
 
@@ -223,13 +225,17 @@ export function getValidOps(
     type => interchangeableFilterOperators[type] ?? []
   );
 
+  // Determine any valid ops from the filter's tag
+  const validOpsFromTag = tagValidOps[getKeyName(filterToken.key)] ?? [];
+
   // Combine all types
   const allValidTypes = [...new Set([...validTypes, ...interchangeableTypes.flat()])];
 
   // Find all valid operations
-  const validOps = new Set<TermOperator>(
-    allValidTypes.map(type => filterTypeConfig[type].validOps).flat()
-  );
+  const validOps = new Set<TermOperator>([
+    ...allValidTypes.map(type => filterTypeConfig[type].validOps).flat(),
+    ...validOpsFromTag,
+  ]);
 
   return [...validOps];
 }


### PR DESCRIPTION
Adds the ability to specify what operators are valid for a given tag (`release.version`, `release.build`, etc...) Using this for better semver autocomplete

![image](https://user-images.githubusercontent.com/9372512/126224757-3870cc1f-93b2-4d36-9f8d-fa1233bfa191.png)
