### PR TITLE
build(ci): Fix `MIGRATIONS_TEST_MIGRATE` always "0"

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -42,8 +42,12 @@ runs:
         MATRIX_INSTANCE: ${{ matrix.instance }}
         MATRIX_INSTANCE_TOTAL: ${{ strategy.job-total }}
       run: |
+        # Only set `MIGRATIONS_TEST_MIGRATE` if it is not already set (or if it's an empty string)
+        if [ -z $MIGRATIONS_TEST_MIGRATE ]; then
+          echo "MIGRATIONS_TEST_MIGRATE=0" >> $GITHUB_ENV
+        fi
+
         echo "PIP_DISABLE_PIP_VERSION_CHECK=on" >> $GITHUB_ENV
-        echo "MIGRATIONS_TEST_MIGRATE=0" >> $GITHUB_ENV
         echo "SENTRY_LIGHT_BUILD=1" >> $GITHUB_ENV
         echo "SENTRY_SKIP_BACKEND_VALIDATION=1" >> $GITHUB_ENV
 

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -45,6 +45,7 @@ backend_build_changes: &backend_build_changes
   - '.pre-commit-config.yaml'
   - '.python-version'
   - '.github/workflows/!(js-*)'
+  - '.github/actions/setup-sentry/action.yml'
 
 backend: &backend
   - *backend_build_changes


### PR DESCRIPTION
`setup-sentry` action was alway overriding `MIGRATIONS_TEST_MIGRATE` and setting it as "0". Now we only define it if it is not set (or if it is an empty string).