### PR TITLE
Revert "perf(post-process-forwarder): Add option to skip parsing Kafk…

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional, Sequence, Tuple
 
 from sentry.utils import json, metrics
 
@@ -97,73 +96,3 @@ def get_task_kwargs_for_message(value):
         )
 
     return handler(*payload[1:])
-
-
-def get_task_kwargs_for_message_from_headers(headers: Sequence[Tuple[str, Optional[bytes]]]):
-    """
-    Same as get_task_kwargs_for_message but gets the required information from
-    the kafka message headers.
-    """
-    try:
-        header_data = {k: v for k, v in headers}
-
-        def decode_str(value: Optional[bytes]) -> str:
-            assert isinstance(value, bytes)
-            return value.decode("utf-8")
-
-        def decode_optional_str(value: Optional[bytes]) -> Optional[str]:
-            if value is None:
-                return None
-            return decode_str(value)
-
-        def decode_int(value: Optional[bytes]) -> int:
-            assert isinstance(value, bytes)
-            return int(value)
-
-        def decode_optional_int(value: Optional[bytes]) -> Optional[int]:
-            if value is None:
-                return None
-            return decode_int(value)
-
-        def decode_optional_bool(value: Optional[bytes]) -> Optional[bool]:
-            if value is None:
-                return None
-            return bool(int(decode_str(value)))
-
-        version = decode_int(header_data["version"])
-        operation = decode_str(header_data["operation"])
-        primary_hash = decode_optional_str(header_data["primary_hash"])
-        event_id = decode_str(header_data["event_id"])
-        group_id = decode_optional_int(header_data["group_id"])
-        project_id = decode_int(header_data["project_id"])
-
-        event_data = {
-            "event_id": event_id,
-            "group_id": group_id,
-            "project_id": project_id,
-            "primary_hash": primary_hash,
-        }
-
-        skip_consume = decode_optional_bool(header_data["skip_consume"])
-        is_new = decode_optional_bool(header_data["is_new"])
-        is_regression = decode_optional_bool(header_data["is_regression"])
-        is_new_group_environment = decode_optional_bool(header_data["is_new_group_environment"])
-
-        task_state = {
-            "skip_consume": skip_consume,
-            "is_new": is_new,
-            "is_regression": is_regression,
-            "is_new_group_environment": is_new_group_environment,
-        }
-
-    except Exception:
-        raise InvalidPayload("Received event payload with unexpected structure")
-
-    try:
-        handler = version_handlers[version]
-    except (ValueError, KeyError):
-        raise InvalidVersion(
-            f"Received event payload with unexpected version identifier: {version}"
-        )
-
-    return handler(operation, event_data, task_state)

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from typing import Any, Mapping, Optional, Tuple, Union
 from uuid import uuid4
 
 import pytz
@@ -99,30 +98,6 @@ class SnubaProtocolEventStream(EventStream):
         if unexpected_tags:
             logger.error("%r received unexpected tags: %r", self, unexpected_tags)
 
-        # HACK: We are putting all this extra information that is required by the
-        # post process forwarder into the headers so we can skip parsing entire json
-        # messages. The post process forwarder is currently bound to a single core.
-        # Once we are able to parallelize the JSON parsing and other transformation
-        # steps being done there we may want to remove this hack.
-        def encode_bool(value: Optional[bool]) -> Optional[str]:
-            if value is None:
-                return None
-            return str(int(value))
-
-        headers = {
-            "Received-Timestamp": str(received_timestamp),
-            "event_id": str(event.event_id),
-            "project_id": str(event.project_id),
-            "group_id": str(event.group_id) if event.group_id is not None else None,
-            "primary_hash": str(primary_hash) if primary_hash is not None else None,
-            "is_new": encode_bool(is_new),
-            "is_new_group_environment": encode_bool(is_new_group_environment),
-            "is_regression": encode_bool(is_regression),
-            "version": str(self.EVENT_PROTOCOL_VERSION),
-            "operation": "insert",
-            "skip_consume": encode_bool(skip_consume),
-        }
-
         self._send(
             project.id,
             "insert",
@@ -148,7 +123,7 @@ class SnubaProtocolEventStream(EventStream):
                     "skip_consume": skip_consume,
                 },
             ),
-            headers=headers,
+            headers={"Received-Timestamp": str(received_timestamp)},
         )
 
     def start_delete_groups(self, project_id, group_ids):
@@ -301,11 +276,11 @@ class SnubaProtocolEventStream(EventStream):
 
     def _send(
         self,
-        project_id: int,
-        _type: str,
-        extra_data: Tuple[Any, ...] = (),
-        asynchronous: bool = True,
-        headers: Optional[Mapping[str, Union[str, None]]] = None,
+        project_id,
+        _type,
+        extra_data=(),
+        asynchronous=True,
+        headers=None,  # Optional[Mapping[str, str]]
     ):
         raise NotImplementedError
 
@@ -313,11 +288,11 @@ class SnubaProtocolEventStream(EventStream):
 class SnubaEventStream(SnubaProtocolEventStream):
     def _send(
         self,
-        project_id: int,
-        _type: str,
-        extra_data: Tuple[Any, ...] = (),
-        asynchronous: bool = True,
-        headers: Optional[Mapping[str, Union[str, None]]] = None,
+        project_id,
+        _type,
+        extra_data=(),
+        asynchronous=True,
+        headers=None,  # Optional[Mapping[str, str]]
     ):
         if headers is None:
             headers = {}
@@ -337,6 +312,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
                     "POST",
                     f"/tests/{dataset}/eventstream",
                     body=json.dumps(data),
+                    headers={f"X-Sentry-{k}": v for k, v in headers.items()},
                 )
                 if resp.status != 200:
                     raise snuba.SnubaError("HTTP %s response from Snuba!" % resp.status)

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -5,7 +5,6 @@ from sentry.eventstream.kafka.protocol import (
     InvalidVersion,
     UnexpectedOperation,
     get_task_kwargs_for_message,
-    get_task_kwargs_for_message_from_headers,
 )
 from sentry.testutils.helpers import override_options
 from sentry.utils import json
@@ -72,32 +71,3 @@ def test_get_task_kwargs_for_message_version_1_unsupported_operation():
 def test_get_task_kwargs_for_message_version_1_unexpected_operation():
     with pytest.raises(UnexpectedOperation):
         get_task_kwargs_for_message(json.dumps([1, "invalid", {}, {}]))
-
-
-@pytest.mark.django_db
-def test_get_task_kwargs_for_message_version_1_kafka_headers():
-    kafka_headers = [
-        ("Received-Timestamp", b"1626301534.910839"),
-        ("event_id", b"00000000000010008080808080808080"),
-        ("project_id", b"1"),
-        ("group_id", b"2"),
-        ("primary_hash", b"49f68a5c8493ec2c0bf489821c21fc3b"),
-        ("is_new", b"1"),
-        ("is_new_group_environment", b"1"),
-        ("is_regression", None),
-        ("version", b"2"),
-        ("operation", b"insert"),
-        ("skip_consume", b"0"),
-    ]
-
-    kwargs = get_task_kwargs_for_message_from_headers(kafka_headers)
-    assert kwargs.pop("project_id") == 1
-    assert kwargs.pop("event_id") == "00000000000010008080808080808080"
-    assert kwargs.pop("group_id") == 2
-    assert kwargs.pop("primary_hash") == "49f68a5c8493ec2c0bf489821c21fc3b"
-
-    assert kwargs.pop("is_new") is True
-    assert kwargs.pop("is_regression") is None
-    assert kwargs.pop("is_new_group_environment") is True
-
-    assert not kwargs, f"unexpected values remaining: {kwargs!r}"


### PR DESCRIPTION
…a messages (#27456)"

This reverts commit 1c82cee207cb0c4d965ad6ca52c0dbbfbeb40624.

Sending Kafka headers which contain `None` values appears to cause
the Snuba consumer to crash with the error
`Fatal Python error: deallocating None`.