### PR TITLE
feat(codeowners): Async update Code Owners on association updates

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -1,6 +1,5 @@
 from django.utils import timezone
 from rest_framework import serializers
-from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
@@ -30,17 +29,13 @@ class ProjectOwnershipSerializer(serializers.Serializer):
     def validate(self, attrs):
         if "raw" not in attrs:
             return attrs
-        try:
-            schema = create_schema_from_issue_owners(
-                attrs["raw"], self.context["ownership"].project_id
-            )
 
-            self._validate_no_codeowners(schema["rules"])
+        schema = create_schema_from_issue_owners(attrs["raw"], self.context["ownership"].project_id)
 
-            attrs["schema"] = schema
-            return attrs
-        except ValidationError as e:
-            raise serializers.ValidationError(e)
+        self._validate_no_codeowners(schema["rules"])
+
+        attrs["schema"] = schema
+        return attrs
 
     def save(self):
         ownership = self.context["ownership"]

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -2,12 +2,17 @@ from typing import List
 
 from django.utils import timezone
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ProjectOwnership, resolve_actors
-from sentry.ownership.grammar import CODEOWNERS, ParseError, Rule, dump_schema, parse_rules
+from sentry.models import ProjectOwnership
+from sentry.ownership.grammar import (
+    CODEOWNERS,
+    Rule,
+    create_schema_from_issue_owners,
+)
 from sentry.signals import ownership_rule_created
 
 
@@ -32,38 +37,16 @@ class ProjectOwnershipSerializer(serializers.Serializer):
         if "raw" not in attrs:
             return attrs
         try:
-            rules = parse_rules(attrs["raw"])
-        except ParseError as e:
-            raise serializers.ValidationError(
-                {
-                    "raw": "Parse error: %r (line %d, column %d)"
-                    % (e.expr.name, e.line(), e.column())
-                }
+            schema = create_schema_from_issue_owners(
+                attrs["raw"], self.context["ownership"].project_id
             )
 
-        schema = dump_schema(rules)
+            self._validate_no_codeowners(schema)
 
-        self._validate_no_codeowners(rules)
-
-        owners = {o for rule in rules for o in rule.owners}
-        actors = resolve_actors(owners, self.context["ownership"].project_id)
-
-        bad_actors = []
-        for owner, actor in actors.items():
-            if actor is None:
-                if owner.type == "user":
-                    bad_actors.append(owner.identifier)
-                elif owner.type == "team":
-                    bad_actors.append(f"#{owner.identifier}")
-
-        if bad_actors:
-            bad_actors.sort()
-            raise serializers.ValidationError(
-                {"raw": "Invalid rule owners: {}".format(", ".join(bad_actors))}
-            )
-
-        attrs["schema"] = schema
-        return attrs
+            attrs["schema"] = schema
+            return attrs
+        except ValidationError as e:
+            raise serializers.ValidationError(e)
 
     def save(self):
         ownership = self.context["ownership"]

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -8,11 +6,7 @@ from rest_framework.response import Response
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import ProjectOwnership
-from sentry.ownership.grammar import (
-    CODEOWNERS,
-    Rule,
-    create_schema_from_issue_owners,
-)
+from sentry.ownership.grammar import CODEOWNERS, create_schema_from_issue_owners
 from sentry.signals import ownership_rule_created
 
 
@@ -22,13 +16,13 @@ class ProjectOwnershipSerializer(serializers.Serializer):
     autoAssignment = serializers.BooleanField()
 
     @staticmethod
-    def _validate_no_codeowners(rules: List[Rule]):
+    def _validate_no_codeowners(rules):
         """
         codeowner matcher types cannot be added via ProjectOwnership, only through codeowner
         specific serializers
         """
         for rule in rules:
-            if rule.matcher.type == CODEOWNERS:
+            if rule["matcher"]["type"] == CODEOWNERS:
                 raise serializers.ValidationError(
                     {"raw": "Codeowner type paths can only be added by importing CODEOWNER files"}
                 )
@@ -41,7 +35,7 @@ class ProjectOwnershipSerializer(serializers.Serializer):
                 attrs["raw"], self.context["ownership"].project_id
             )
 
-            self._validate_no_codeowners(schema)
+            self._validate_no_codeowners(schema["rules"])
 
             attrs["schema"] = schema
             return attrs

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -53,7 +53,7 @@ class ProjectCodeOwnersSerializer(Serializer):
             data["ownershipSyntax"] = convert_schema_to_rules_text(obj.schema)
 
         if "errors" in self.expand:
-            _, errors = ProjectCodeOwners.validate_codeowners_associations(data, obj.project)
+            _, errors = ProjectCodeOwners.validate_codeowners_associations(obj.raw, obj.project)
             data["errors"] = errors
 
         return data

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -575,6 +575,7 @@ CELERY_QUEUES = [
     Queue("auth", routing_key="auth"),
     Queue("buffers.process_pending", routing_key="buffers.process_pending"),
     Queue("cleanup", routing_key="cleanup"),
+    Queue("code_owners", routing_key="code_owners"),
     Queue("commits", routing_key="commits"),
     Queue("data_export", routing_key="data_export"),
     Queue("default", routing_key="default"),

--- a/src/sentry/models/externalactor.py
+++ b/src/sentry/models/externalactor.py
@@ -1,8 +1,10 @@
 import logging
 
 from django.db import models
+from django.db.models.signals import post_delete, post_save
 
 from sentry.db.models import BoundedPositiveIntegerField, DefaultFieldsModel, FlexibleForeignKey
+from sentry.tasks.code_owners import update_code_owners_schema
 from sentry.types.integrations import ExternalProviders
 
 logger = logging.getLogger(__name__)
@@ -35,3 +37,19 @@ class ExternalActor(DefaultFieldsModel):
         app_label = "sentry"
         db_table = "sentry_externalactor"
         unique_together = (("organization", "provider", "external_name", "actor"),)
+
+
+post_save.connect(
+    lambda instance, **kwargs: update_code_owners_schema.apply_async(
+        kwargs={"organization": instance.organization, "integration": instance.integration}
+    ),
+    sender=ExternalActor,
+    weak=False,
+)
+post_delete.connect(
+    lambda instance, **kwargs: update_code_owners_schema.apply_async(
+        kwargs={"organization": instance.organization, "integration": instance.integration}
+    ),
+    sender=ExternalActor,
+    weak=False,
+)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -438,14 +438,20 @@ class Project(Model, PendingDeletionMixin):
 pre_delete.connect(delete_pending_deletion_option, sender=Project, weak=False)
 post_save.connect(
     lambda instance, **kwargs: update_code_owners_schema.apply_async(
-        kwargs={"organization": None, "integration": None, "projects": [instance.project]}
+        kwargs={
+            "organization": instance.project.organization,
+            "projects": [instance.project],
+        }
     ),
     sender=ProjectTeam,
     weak=False,
 )
 post_delete.connect(
     lambda instance, **kwargs: update_code_owners_schema.apply_async(
-        kwargs={"organization": None, "integration": None, "projects": [instance.project]}
+        kwargs={
+            "organization": instance.project.organization,
+            "projects": [instance.project],
+        }
     ),
     sender=ProjectTeam,
     weak=False,

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -15,6 +15,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.utils import slugify_instance
+from sentry.tasks.code_owners import update_code_owners_schema
 from sentry.utils.retries import TimedRetryPolicy
 
 
@@ -84,6 +85,25 @@ class TeamManager(BaseManager):
                 results[idx] = (team, team_projects)
 
         return results
+
+    def post_save(self, instance, **kwargs):
+
+        update_code_owners_schema.apply_async(
+            kwargs={
+                "organization": instance.organization,
+                "integration": None,
+                "projects": instance.get_projects(),
+            }
+        ),
+
+    # def post_delete(self, instance, **kwargs):
+    #     update_code_owners_schema.apply_async(
+    #         kwargs={
+    #             "organization": instance.organization,
+    #             "integration": None,
+    #             "projects": instance.get_projects(),
+    #         }
+    #     ),
 
 
 # TODO(dcramer): pull in enum library

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -91,7 +91,6 @@ class TeamManager(BaseManager):
         update_code_owners_schema.apply_async(
             kwargs={
                 "organization": instance.organization,
-                "integration": None,
                 "projects": instance.get_projects(),
             }
         ),
@@ -100,7 +99,6 @@ class TeamManager(BaseManager):
         update_code_owners_schema.apply_async(
             kwargs={
                 "organization": instance.organization,
-                "integration": None,
                 "projects": instance.get_projects(),
             }
         ),
@@ -272,10 +270,9 @@ class Team(Model):
         return Project.objects.get_for_team_ids({self.id})
 
     def delete(self, **kwargs):
-        from sentry.models import Actor, ExternalActor
+        from sentry.models import Actor
 
-        # There is no foreign key relationship so we have to manually cascade.
-        ExternalActor.objects.filter(actor=self.actor).delete()
+        # There is no foreign key relationship so we have to manually cascade Actors. This will cascade delete the ExternalActors
         Actor.objects.filter(id=self.actor_id).delete()
 
         return super().delete(**kwargs)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -270,9 +270,8 @@ class Team(Model):
         return Project.objects.get_for_team_ids({self.id})
 
     def delete(self, **kwargs):
-        from sentry.models import Actor
+        from sentry.models import ExternalActor
 
-        # There is no foreign key relationship so we have to manually cascade Actors. This will cascade delete the ExternalActors
-        Actor.objects.filter(id=self.actor_id).delete()
-
+        # There is no foreign key relationship so we have to manually delete the ExternalActors
+        ExternalActor.objects.filter(actor_id=self.actor_id).delete()
         return super().delete(**kwargs)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -87,7 +87,6 @@ class TeamManager(BaseManager):
         return results
 
     def post_save(self, instance, **kwargs):
-
         update_code_owners_schema.apply_async(
             kwargs={
                 "organization": instance.organization,

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -7,7 +7,7 @@ from typing import List, Pattern, Tuple
 from django.db.models import Q
 from parsimonious.exceptions import ParseError  # noqa
 from parsimonious.grammar import Grammar, NodeVisitor
-from rest_framework.exceptions import ValidationError
+from rest_framework.serializers import ValidationError
 
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import get_path

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -1,9 +1,13 @@
+import operator
 import re
 from collections import namedtuple
+from functools import reduce
 from typing import List, Pattern, Tuple
 
+from django.db.models import Q
 from parsimonious.exceptions import ParseError  # noqa
 from parsimonious.grammar import Grammar, NodeVisitor
+from rest_framework.exceptions import ValidationError
 
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import get_path
@@ -391,25 +395,25 @@ def parse_code_owners(data: str) -> Tuple[List[str], List[str], List[str]]:
     return teams, usernames, emails
 
 
-def convert_codeowners_syntax(data, associations, code_mapping):
+def convert_codeowners_syntax(codeowners, associations, code_mapping):
     """Converts CODEOWNERS text into IssueOwner syntax
-    data: CODEOWNERS text
+    codeowners: CODEOWNERS text
     associations: dict of {externalName: sentryName}
     code_mapping: RepositoryProjectPathConfig object
     """
 
     result = ""
 
-    for rule in data.splitlines():
+    for rule in codeowners.splitlines():
         if rule.startswith("#") or not len(rule):
             # We want to preserve comments from CODEOWNERS
             result += f"{rule}\n"
             continue
 
-        path, *codeowners = rule.split()
+        path, *code_owners = rule.split()
         sentry_assignees = []
 
-        for owner in codeowners:
+        for owner in code_owners:
             try:
                 sentry_assignees.append(associations[owner])
             except KeyError:
@@ -427,3 +431,83 @@ def convert_codeowners_syntax(data, associations, code_mapping):
             result += f'path:{formatted_path} {" ".join(sentry_assignees)}\n'
 
     return result
+
+
+def resolve_actors(owners, project_id):
+    """Convert a list of Owner objects into a dictionary
+    of {Owner: Actor} pairs. Actors not identified are returned
+    as None."""
+    from sentry.models import ActorTuple, Team, User
+
+    if not owners:
+        return {}
+
+    users, teams = [], []
+    owners_lookup = {}
+
+    for owner in owners:
+        # teams aren't technical case insensitive, but teams also
+        # aren't allowed to have non-lowercase in slugs, so
+        # this kinda works itself out correctly since they won't match
+        owners_lookup[(owner.type, owner.identifier.lower())] = owner
+        if owner.type == "user":
+            users.append(owner)
+        elif owner.type == "team":
+            teams.append(owner)
+
+    actors = {}
+    if users:
+        actors.update(
+            {
+                ("user", email.lower()): ActorTuple(u_id, User)
+                for u_id, email in User.objects.filter(
+                    reduce(operator.or_, [Q(emails__email__iexact=o.identifier) for o in users]),
+                    # We don't require verified emails
+                    # emails__is_verified=True,
+                    is_active=True,
+                    sentry_orgmember_set__organizationmemberteam__team__projectteam__project_id=project_id,
+                )
+                .distinct()
+                .values_list("id", "emails__email")
+            }
+        )
+
+    if teams:
+        actors.update(
+            {
+                ("team", slug): ActorTuple(t_id, Team)
+                for t_id, slug in Team.objects.filter(
+                    slug__in=[o.identifier for o in teams], projectteam__project_id=project_id
+                ).values_list("id", "slug")
+            }
+        )
+
+    return {o: actors.get((o.type, o.identifier.lower())) for o in owners}
+
+
+def create_schema_from_issue_owners(issue_owners, project_id):
+    try:
+        rules = parse_rules(issue_owners)
+    except ParseError as e:
+        raise ValidationError(
+            {"raw": f"Parse error: {e.expr.name} (line {e.line()}, column {e.column()})"}
+        )
+
+    schema = dump_schema(rules)
+
+    owners = {o for rule in rules for o in rule.owners}
+    actors = resolve_actors(owners, project_id)
+
+    bad_actors = []
+    for owner, actor in actors.items():
+        if actor is None:
+            if owner.type == "user":
+                bad_actors.append(owner.identifier)
+            elif owner.type == "team":
+                bad_actors.append(f"#{owner.identifier}")
+
+    if bad_actors:
+        bad_actors.sort()
+        raise ValidationError({"raw": "Invalid rule owners: {}".format(", ".join(bad_actors))})
+
+    return schema

--- a/src/sentry/tasks/code_owners.py
+++ b/src/sentry/tasks/code_owners.py
@@ -1,0 +1,40 @@
+import logging
+
+from sentry import features
+from sentry.tasks.base import instrumented_task
+
+logger = logging.getLogger("sentry.tasks.code_owners")
+
+
+@instrumented_task(
+    name="sentry.tasks.update_code_owners_schema",
+    queue="code_owners",
+    default_retry_delay=5,
+    max_retries=5,
+)
+def update_code_owners_schema(organization=None, integration=None, projects=None, **kwargs):
+    from sentry.models import ProjectCodeOwners, RepositoryProjectPathConfig
+
+    if not features.has("organizations:integrations-codeowners", organization):
+        return
+    try:
+        code_owners = []
+
+        if projects:
+            code_owners = ProjectCodeOwners.objects.filter(project__in=projects)
+
+        if organization and integration:
+            code_mapping_ids = RepositoryProjectPathConfig.objects.filter(
+                organization_integration__organization=organization,
+                organization_integration__integration=integration,
+            ).values_list("id", flat=True)
+
+            code_owners = ProjectCodeOwners.objects.filter(
+                repository_project_path_config__in=code_mapping_ids
+            )
+
+        for code_owner in code_owners:
+            code_owner.update_schema()
+
+    except (RepositoryProjectPathConfig.DoesNotExist, ProjectCodeOwners.DoesNotExist):
+        return

--- a/src/sentry/tasks/code_owners.py
+++ b/src/sentry/tasks/code_owners.py
@@ -36,5 +36,6 @@ def update_code_owners_schema(organization, integration=None, projects=None, **k
         for code_owner in code_owners:
             code_owner.update_schema()
 
+    # TODO(nisanthan): May need to add logging  for the cases where we might want to have more information if something fails
     except (RepositoryProjectPathConfig.DoesNotExist, ProjectCodeOwners.DoesNotExist):
         return

--- a/src/sentry/tasks/code_owners.py
+++ b/src/sentry/tasks/code_owners.py
@@ -12,7 +12,7 @@ logger = logging.getLogger("sentry.tasks.code_owners")
     default_retry_delay=5,
     max_retries=5,
 )
-def update_code_owners_schema(organization=None, integration=None, projects=None, **kwargs):
+def update_code_owners_schema(organization, integration=None, projects=None, **kwargs):
     from sentry.models import ProjectCodeOwners, RepositoryProjectPathConfig
 
     if not features.has("organizations:integrations-codeowners", organization):
@@ -23,7 +23,7 @@ def update_code_owners_schema(organization=None, integration=None, projects=None
         if projects:
             code_owners = ProjectCodeOwners.objects.filter(project__in=projects)
 
-        if organization and integration:
+        if integration:
             code_mapping_ids = RepositoryProjectPathConfig.objects.filter(
                 organization_integration__organization=organization,
                 organization_integration__integration=integration,

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -1,6 +1,5 @@
 from sentry.models import ActorTuple, ProjectOwnership, Team, User
-from sentry.models.projectownership import resolve_actors
-from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
+from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema, resolve_actors
 from sentry.testutils import TestCase
 from sentry.utils.cache import cache
 

--- a/tests/sentry/tasks/test_code_owners.py
+++ b/tests/sentry/tasks/test_code_owners.py
@@ -1,0 +1,62 @@
+from sentry.models import ExternalActor, Integration
+from sentry.models.projectcodeowners import ProjectCodeOwners
+from sentry.tasks.code_owners import update_code_owners_schema
+from sentry.testutils import TestCase
+
+
+class CodeOwnersTest(TestCase):
+    def setup(self):
+        self.login_as(user=self.user)
+        self.integration = Integration.objects.create(
+            provider="github", name="GitHub", external_id="github:1"
+        )
+        self.oi = self.integration.add_organization(self.organization, self.user)
+
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+
+        self.project = self.project = self.create_project(
+            organization=self.organization, teams=[self.team], slug="bengal"
+        )
+        self.code_mapping = self.create_code_mapping(
+            project=self.project,
+            organization_integration=self.oi,
+        )
+
+        self.data = {
+            "raw": "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem\n",
+        }
+
+        self.code_owners = self.create_codeowners(
+            self.project, self.code_mapping, raw=self.data["raw"]
+        )
+
+    def test_simple(self):
+        with self.tasks() and self.feature({"organizations:integrations-codeowners": True}):
+            # new external team mapping
+            self.external_team = self.create_external_team(integration=self.integration)
+            update_code_owners_schema(organization=self.organization, integration=self.integration)
+
+        code_owners = ProjectCodeOwners.objects.get(id=self.code_owners.id)
+
+        assert code_owners.schema == {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"type": "path", "pattern": "docs/*"},
+                    "owners": [
+                        {"type": "team", "identifier": "tiger-team"},
+                    ],
+                }
+            ],
+        }
+
+        with self.tasks() and self.feature({"organizations:integrations-codeowners": True}):
+            # delete external team mapping
+            ExternalActor.objects.get(id=self.external_team.id).delete()
+            update_code_owners_schema(organization=self.organization, integration=self.integration)
+
+        code_owners = ProjectCodeOwners.objects.get(id=self.code_owners.id)
+
+        assert code_owners.schema == {"$version": 1, "rules": []}

--- a/tests/sentry/tasks/test_code_owners.py
+++ b/tests/sentry/tasks/test_code_owners.py
@@ -5,7 +5,7 @@ from sentry.testutils import TestCase
 
 
 class CodeOwnersTest(TestCase):
-    def setup(self):
+    def setUp(self):
         self.login_as(user=self.user)
         self.integration = Integration.objects.create(
             provider="github", name="GitHub", external_id="github:1"


### PR DESCRIPTION
Objective:
Now, we will allow users to upload CodeOwners with incomplete external mappings. So when they start to fill out the missing mappings, we should automatically update our `sentry_projectcodeowners.schema` to use the new mappings. 

We will trigger an async task to re-evaluate the most recent CODEOWNERS raw with the new mappings using Django signals `post_save` and `post_delete` for ExternalActor, Team and ProjectTeam models.