### PR TITLE
fix(tests): Fix tests that create their own models so that they work when MIGRATIONS_TEST_MIGRATE=1

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -58,7 +58,7 @@ def pytest_configure(config):
     settings.STATIC_BUNDLES = {}
 
     # override a few things with our test specifics
-    settings.INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + ("tests",)
+    settings.INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + ("tests", "sentry.demo")
     # Need a predictable key for tests that involve checking signatures
     settings.SENTRY_PUBLIC = False
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -58,7 +58,9 @@ def pytest_configure(config):
     settings.STATIC_BUNDLES = {}
 
     # override a few things with our test specifics
-    settings.INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + ("tests", "sentry.demo")
+    settings.INSTALLED_APPS = tuple(settings.INSTALLED_APPS) + ("tests",)
+    if "sentry" in settings.INSTALLED_APPS:
+        settings.INSTALLED_APPS = settings.INSTALLED_APPS + ("sentry.demo",)
     # Need a predictable key for tests that involve checking signatures
     settings.SENTRY_PUBLIC = False
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -173,7 +173,7 @@ def pytest_configure(config):
         # Migrations for the "sentry" app take a long time to run, which makes test startup time slow in dev.
         # This is a hack to force django to sync the database state from the models rather than use migrations.
         settings.MIGRATION_MODULES["sentry"] = None
-        settings.MIGRATION_MODULES["sentry.demo"] = None
+        settings.MIGRATION_MODULES["demo"] = None
 
     asset_version_patcher = mock.patch(
         "sentry.runner.initializer.get_asset_version", return_value="{version}"

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -173,6 +173,7 @@ def pytest_configure(config):
         # Migrations for the "sentry" app take a long time to run, which makes test startup time slow in dev.
         # This is a hack to force django to sync the database state from the models rather than use migrations.
         settings.MIGRATION_MODULES["sentry"] = None
+        settings.MIGRATION_MODULES["sentry.demo"] = None
 
     asset_version_patcher = mock.patch(
         "sentry.runner.initializer.get_asset_version", return_value="{version}"

--- a/tests/sentry/db/models/fields/bitfield/test_bitfield.py
+++ b/tests/sentry/db/models/fields/bitfield/test_bitfield.py
@@ -12,7 +12,7 @@ from bitfield.compat import bitand, bitor
 
 class BitFieldTestModel(models.Model):
     class Meta:
-        app_label = "sentry"
+        app_label = "tests"
 
     flags = BitField(
         flags=("FLAG_0", "FLAG_1", "FLAG_2", "FLAG_3"), default=3, db_column="another_name"

--- a/tests/sentry/db/models/fields/test_jsonfield.py
+++ b/tests/sentry/db/models/fields/test_jsonfield.py
@@ -10,14 +10,14 @@ class JSONFieldTestModel(models.Model):
     json = JSONField("test", null=True, blank=True)
 
     class Meta:
-        app_label = "sentry"
+        app_label = "tests"
 
 
 class JSONFieldWithDefaultTestModel(models.Model):
     json = JSONField(default={"sukasuka": "YAAAAAZ"})
 
     class Meta:
-        app_label = "sentry"
+        app_label = "tests"
 
 
 class BlankJSONFieldTestModel(models.Model):
@@ -25,7 +25,7 @@ class BlankJSONFieldTestModel(models.Model):
     blank_json = JSONField(blank=True)
 
     class Meta:
-        app_label = "sentry"
+        app_label = "tests"
 
 
 def default():
@@ -36,7 +36,7 @@ class CallableDefaultModel(models.Model):
     json = JSONField(default=default)
 
     class Meta:
-        app_label = "sentry"
+        app_label = "tests"
 
 
 class JSONFieldTest(TestCase):


### PR DESCRIPTION
This got broken at some point in the last 9 months, should unbreak the tests in https://github.com/getsentry/sentry/pull/27556

Also added `sentry.demo` to `INSTALLED_APPS` when running tests. Since we run the demo tests we need this in place so that models are generated properly there