### PR TITLE
fix(grp-resolution): Fix ResolvedInNextRelease for date ordered releases

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -525,6 +525,9 @@ def get_current_release_version_of_group(group, follows_semver=False):
             )
         except Release.DoesNotExist:
             ...
+    else:
+        # This sets current_release_version to the most recent release associated with a group
+        current_release_version = group.get_last_release()
     return current_release_version
 
 
@@ -705,15 +708,14 @@ def update_groups(request, group_ids, projects, organization_id, search_fn):
                             project_id=group.project.id,
                             release_version=release.version,
                         )
-                        if follows_semver:
-                            current_release_version = get_current_release_version_of_group(
-                                group=group, follows_semver=follows_semver
-                            )
 
-                            if current_release_version:
-                                resolution_params.update(
-                                    {"current_release_version": current_release_version}
-                                )
+                        current_release_version = get_current_release_version_of_group(
+                            group=group, follows_semver=follows_semver
+                        )
+                        if current_release_version:
+                            resolution_params.update(
+                                {"current_release_version": current_release_version}
+                            )
                     resolution, created = GroupResolution.objects.get_or_create(
                         group=group, defaults=resolution_params
                     )

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -61,11 +61,7 @@ class GroupResolution(Model):
             Helper function that compares release versions based on date for
             `GroupResolution.Type.in_next_release`
             """
-            if res_release == release.id:
-                return True
-            elif res_release_datetime > release.date_added:
-                return True
-            return False
+            return res_release == release.id or res_release_datetime > release.date_added
 
         try:
             res_type, res_release, res_release_datetime, current_release_version = (
@@ -106,7 +102,9 @@ class GroupResolution(Model):
                     ...
             else:
                 try:
-                    current_release_obj = Release.objects.get(version=current_release_version)
+                    current_release_obj = Release.objects.get(
+                        organization_id=group.organization.id, version=current_release_version
+                    )
 
                     return compare_release_dates_for_in_next_release(
                         res_release=current_release_obj.id,

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1990,16 +1990,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         GroupResolution.current_release_version is set to the most recent release associated with a
         Group, when the project does not follow semantic versioning scheme
         """
-        release_1 = Release.objects.create(
-            organization_id=self.project.organization_id, version="foobar 1"
+        release_1 = self.create_release(
+            date_added=timezone.now() - timedelta(minutes=45), version="foobar 1"
         )
-        release_1.update(date_added=timezone.now() - timedelta(minutes=45))
-        release_2 = Release.objects.create(
-            organization_id=self.project.organization_id, version="foobar 2"
-        )
-
-        for release in [release_1, release_2]:
-            release.add_project(self.project)
+        release_2 = self.create_release(version="foobar 2")
 
         group = self.store_event(
             data={
@@ -2020,11 +2014,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         # Add a new release that is between 1 and 2, to make sure that if a the same issue/group
         # occurs in that issue, then it should not have a resolution
-        release_3 = Release.objects.create(
-            organization_id=self.project.organization_id, version="foobar 3"
+        release_3 = self.create_release(
+            date_added=timezone.now() - timedelta(minutes=30), version="foobar 3"
         )
-        release_3.add_project(self.project)
-        release_3.update(date_added=timezone.now() - timedelta(minutes=30))
 
         grp_resolution = GroupResolution.objects.filter(group=group)
 


### PR DESCRIPTION
This PR:
- Changes the behaviour of how we handle GroupResolutions for date ordered releases. Currently, when we resolve a group in next release, the release set to compare future releases against for handling regression is set to the most recent release
of the project rather than the most recent associated with the group. 
Consequently,
```
- release-1 -> Issue Happens 
- release-2 -> Issue does not happen
- Click on Issue resolve in next release 
- Group Resolution created with release is set to release-2 and in_next_release
- Create release 3 => GroupResolution for grp changes to in_release type & `GroupResolution.release` is set to release-3 
- Detects regression from release 3 onwards (not from release-2 onwards)
```

Fix:
- Unify the approach used in #27573 , to work for both semver and date releases, and it should go something like this
```
- release-1 -> Issue Happens 
- release-2 -> Issue does not happen
- Click on Issue resolve in next release 
- Group Resolution created with current_release_version is set to release-1 (which is the latest version associated with the group) and in_next_release
- Create release 3 => GroupResolution for grp changes to in_release type & `GroupResolution.release` is set to release-3 (to not break UI) but current_release_version does not change
- Detects regression from release 2 onwards by detecting regressions if group happens in release versions that are >current_release_version
```
