### PR TITLE
ref(ui): Remove theme space array

### DIFF
--- a/static/app/components/events/rrwebReplayer/index.tsx
+++ b/static/app/components/events/rrwebReplayer/index.tsx
@@ -41,7 +41,7 @@ const StyledRRWebReplayer = styled(RRWebReplayer)`
   .rr-controller {
     width: 100%;
     display: block;
-    padding: ${space(2)};
+    padding: ${space(2)} 0;
     background: ${p => p.theme.background};
     border-radius: 0 0 5px 5px;
     box-shadow: 0 -1px 3px 0 rgba(0, 0, 0, 0.1);

--- a/static/app/components/events/rrwebReplayer/index.tsx
+++ b/static/app/components/events/rrwebReplayer/index.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import space from 'app/styles/space';
+
 import RRWebReplayer from './rrWebReplayer';
 
 const StyledRRWebReplayer = styled(RRWebReplayer)`
@@ -39,7 +41,7 @@ const StyledRRWebReplayer = styled(RRWebReplayer)`
   .rr-controller {
     width: 100%;
     display: block;
-    padding: ${p => p.theme.space[2]}px 0;
+    padding: ${space(2)};
     background: ${p => p.theme.background};
     border-radius: 0 0 5px 5px;
     box-shadow: 0 -1px 3px 0 rgba(0, 0, 0, 0.1);

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -607,8 +607,6 @@ const commonTheme = {
     colors: ['#ec5e44', '#f38259', '#f9a66d', '#98b480', '#57be8c'],
   },
 
-  space: [0, 8, 16, 20, 30],
-
   // used as a gradient,
   businessIconColors: ['#EA5BC2', '#6148CE'],
 


### PR DESCRIPTION
Problem
`theme.tsx` includes a space array which was only used by one component.

Solution
Migrated the only component depending on the `theme.tsx` array to more commonly used `SPACING` object found in `space.tsx` and removed the `theme.space` array.