### PR TITLE
fix(dashboards): dashboard modal Widget Name positioning

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -333,7 +333,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
         </Header>
         <Body>
           <DoubleFieldWrapper>
-            <Field
+            <StyledField
               data-test-id="widget-name"
               label={t('Widget Name')}
               inline={false}
@@ -352,8 +352,8 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                   this.handleFieldChange('title')(event.target.value);
                 }}
               />
-            </Field>
-            <Field
+            </StyledField>
+            <StyledField
               data-test-id="chart-type"
               label={t('Visualization Display')}
               inline={false}
@@ -372,7 +372,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                   this.handleFieldChange('displayType')(option.value);
                 }}
               />
-            </Field>
+            </StyledField>
           </DoubleFieldWrapper>
           <Measurements organization={organization}>
             {({measurements}) => {
@@ -449,6 +449,10 @@ export const modalCss = css`
   width: 100%;
   max-width: 700px;
   margin: 70px auto;
+`;
+
+const StyledField = styled(Field)`
+  position: relative;
 `;
 
 export default withApi(withGlobalSelection(withTags(AddDashboardWidgetModal)));


### PR DESCRIPTION
Fixed positioning on Widget Name errors in Dashboards Modal:
![image](https://user-images.githubusercontent.com/83961295/126342703-57215c28-f498-480d-96e0-daaba15fa43b.png)
