### PR TITLE
feat(asyncComponent): Display only unique loading error messages

### DIFF
--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -432,7 +432,7 @@ export default class AsyncComponent<
         .map(resp => resp.responseJSON.detail);
 
       if (badRequests.length) {
-        return <LoadingError message={badRequests.join('\n')} />;
+        return <LoadingError message={[...new Set(badRequests)].join('\n')} />;
       }
     }
 

--- a/tests/js/spec/components/asyncComponent.spec.jsx
+++ b/tests/js/spec/components/asyncComponent.spec.jsx
@@ -50,6 +50,56 @@ describe('AsyncComponent', function () {
     expect(wrapper.find('LoadingError').text()).toEqual('oops there was a problem');
   });
 
+  it('renders only unique error message', async function () {
+    Client.clearMockResponses();
+    Client.addMockResponse({
+      url: '/first/path/',
+      method: 'GET',
+      body: {
+        detail: 'oops there was a problem',
+      },
+      statusCode: 400,
+    });
+    Client.addMockResponse({
+      url: '/second/path/',
+      method: 'GET',
+      body: {
+        detail: 'oops there was a problem',
+      },
+      statusCode: 400,
+    });
+    Client.addMockResponse({
+      url: '/third/path/',
+      method: 'GET',
+      body: {
+        detail: 'oops there was a different problem',
+      },
+      statusCode: 400,
+    });
+
+    class UniqueErrorsAsyncComponent extends AsyncComponent {
+      shouldRenderBadRequests = true;
+
+      getEndpoints() {
+        return [
+          ['first', '/first/path/'],
+          ['second', '/second/path/'],
+          ['third', '/third/path/'],
+        ];
+      }
+
+      renderBody() {
+        return <div>{this.state.data.message}</div>;
+      }
+    }
+
+    const wrapper = mountWithTheme(<UniqueErrorsAsyncComponent />);
+
+    expect(wrapper.find('LoadingError').text()).toEqual(
+      'oops there was a problem\noops there was a different problem'
+    );
+  });
+
   describe('multi-route component', () => {
     class MultiRouteComponent extends TestAsyncComponent {
       getEndpoints() {


### PR DESCRIPTION
Right now when multiple API requests in asyncComponent fail with the same message, we get the multiple error messages repeated in the `LoadingError` component, which looks funny. This PR makes it so that we always show only unique error messages.