### PR TITLE
feat(mobile-vitals): Add optional stall percentage vital card

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -48,6 +48,7 @@ export enum PERFORMANCE_TERM {
   APP_START_WARM = 'appStartWarm',
   SLOW_FRAMES = 'slowFrames',
   FROZEN_FRAMES = 'frozenFrames',
+  STALL_PERCENTAGE = 'stallPercentage',
 }
 
 export type TooltipOption = SelectValue<string> & {
@@ -384,6 +385,10 @@ const PERFORMANCE_TERMS: Record<PERFORMANCE_TERM, TermFormatter> = {
     t('Warm start is a measure of the application start up time while still in memory.'),
   slowFrames: () => t('The count of the number of slow frames in the transaction.'),
   frozenFrames: () => t('The count of the number of frozen frames in the transaction.'),
+  stallPercentage: () =>
+    t(
+      'The percentage of the transaction duration in which the application is in a stalled state.'
+    ),
 };
 
 export function getTermHelp(

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -157,6 +157,11 @@ export const vitalCardDetails = (
       tooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
       formatter: value => getDuration(value / 1000, value >= 1000 ? 3 : 0, true),
     },
+    'p75(measurements.stall_percentage)': {
+      title: t('Stall Percentage (p75)'),
+      tooltip: getTermHelp(organization, PERFORMANCE_TERM.STALL_PERCENTAGE),
+      formatter: value => formatPercentage(value, 2),
+    },
   };
 };
 


### PR DESCRIPTION
This change adds an optionl vital card for the stall percentage that will only
be shown when there is data.