### PR TITLE
feat(mobile-vitals): Use lower fidelity for vital card charts

### DIFF
--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -413,7 +413,7 @@ class EventsChart extends React.Component<EventsChartProps> {
       previousName ?? (yAxisLabel ? t('previous %s', yAxisLabel) : undefined);
     const currentSeriesName = currentName ?? yAxisLabel;
 
-    const intervalVal = showDaily ? '1d' : interval || getInterval(this.props, true);
+    const intervalVal = showDaily ? '1d' : interval || getInterval(this.props, 'high');
 
     let chartImplementation = ({
       zoomRenderProps,

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -48,31 +48,60 @@ export function useShortInterval(datetimeObj: DateTimeObject): boolean {
   return diffInMinutes <= TWENTY_FOUR_HOURS;
 }
 
-export function getInterval(datetimeObj: DateTimeObject, highFidelity = false) {
+type Fidelity = 'high' | 'medium' | 'low';
+
+export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'medium') {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
 
   if (diffInMinutes >= SIXTY_DAYS) {
     // Greater than or equal to 60 days
-    return highFidelity ? '4h' : '1d';
+    if (fidelity === 'high') {
+      return '4h';
+    } else if (fidelity === 'medium') {
+      return '1d';
+    }
+    return '2d';
   }
 
   if (diffInMinutes >= THIRTY_DAYS) {
     // Greater than or equal to 30 days
-    return highFidelity ? '1h' : '4h';
+    if (fidelity === 'high') {
+      return '1h';
+    } else if (fidelity === 'medium') {
+      return '4h';
+    }
+    return '1d';
   }
 
   if (diffInMinutes > TWENTY_FOUR_HOURS) {
     // Greater than 24 hours
-    return highFidelity ? '30m' : '1h';
+    if (fidelity === 'high') {
+      return '30m';
+    } else if (fidelity === 'medium') {
+      return '1h';
+    }
+    return '2h';
   }
 
   if (diffInMinutes > ONE_HOUR) {
     // Between 1 hour and 24 hours
-    return highFidelity ? '5m' : '15m';
+    if (fidelity === 'high') {
+      return '5m';
+    } else if (fidelity === 'medium') {
+      return '15m';
+    } else {
+      return '30m';
+    }
   }
 
   // Less than or equal to 1 hour
-  return highFidelity ? '1m' : '5m';
+  if (fidelity === 'high') {
+    return '1m';
+  } else if (fidelity === 'medium') {
+    return '5m';
+  } else {
+    return '15m';
+  }
 }
 
 /**

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -100,7 +100,7 @@ export default class DetailsBody extends React.Component<Props> {
       return `${timeWindow}m`;
     }
 
-    return getInterval({start, end}, true);
+    return getInterval({start, end}, 'high');
   }
 
   getFilter() {

--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -45,7 +45,7 @@ function getWidgetInterval(
   const selectedRange = getDiffInMinutes(datetimeObj);
 
   if (selectedRange / desiredPeriod > MAX_BIN_COUNT) {
-    return getInterval(datetimeObj, true);
+    return getInterval(datetimeObj, 'high');
   }
   return interval;
 }

--- a/static/app/views/eventsV2/miniGraph.tsx
+++ b/static/app/views/eventsV2/miniGraph.tsx
@@ -61,7 +61,7 @@ class MiniGraph extends React.Component<Props> {
     const field = isTopEvents ? apiPayload.field : undefined;
     const topEvents = isTopEvents ? TOP_N : undefined;
     const orderby = isTopEvents ? decodeScalar(apiPayload.sort) : undefined;
-    const interval = isDaily ? '1d' : getInterval({start, end, period}, true);
+    const interval = isDaily ? '1d' : getInterval({start, end, period}, 'high');
 
     return {
       organization,

--- a/static/app/views/performance/charts/index.tsx
+++ b/static/app/views/performance/charts/index.tsx
@@ -76,7 +76,7 @@ class Container extends Component<Props> {
               end,
               period: globalSelection.datetime.period,
             },
-            true
+            'high'
           )}
           showLoading={false}
           query={apiPayload.query}

--- a/static/app/views/performance/landing/chart/durationChart.tsx
+++ b/static/app/views/performance/landing/chart/durationChart.tsx
@@ -83,7 +83,7 @@ function DurationChart(props: Props) {
           end,
           period: globalSelection.datetime.period,
         },
-        true
+        'high'
       )}
       showLoading={false}
       query={apiPayload.query}

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -166,11 +166,14 @@ function GenericCards(props: GenericCardsProps) {
           team={apiPayload.team}
           start={start}
           end={end}
-          interval={getInterval({
-            start: start || null,
-            end: end || null,
-            period: globalSelection.datetime.period,
-          })}
+          interval={getInterval(
+            {
+              start: start || null,
+              end: end || null,
+              period: globalSelection.datetime.period,
+            },
+            'low'
+          )}
           query={apiPayload.query}
           includePrevious={false}
           yAxis={eventView.getFields()}

--- a/static/app/views/performance/transactionSummary/durationChart.tsx
+++ b/static/app/views/performance/transactionSummary/durationChart.tsx
@@ -163,7 +163,7 @@ class DurationChart extends Component<Props> {
               environment={environment}
               start={start}
               end={end}
-              interval={getInterval(datetimeSelection, true)}
+              interval={getInterval(datetimeSelection, 'high')}
               showLoading={false}
               query={query}
               includePrevious={false}

--- a/static/app/views/performance/transactionSummary/trendChart.tsx
+++ b/static/app/views/performance/transactionSummary/trendChart.tsx
@@ -147,7 +147,7 @@ class TrendChart extends Component<Props> {
               environment={environment}
               start={start}
               end={end}
-              interval={getInterval(datetimeSelection, true)}
+              interval={getInterval(datetimeSelection, 'high')}
               showLoading={false}
               query={query}
               includePrevious={false}

--- a/static/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/static/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -164,7 +164,7 @@ class VitalsChart extends Component<Props> {
               environment={environment}
               start={start}
               end={end}
-              interval={getInterval(datetimeSelection, true)}
+              interval={getInterval(datetimeSelection, 'high')}
               showLoading={false}
               query={query}
               includePrevious={false}

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -258,7 +258,7 @@ function getQueryInterval(location: Location, eventView: TrendView) {
     period: statsPeriod,
   };
 
-  const intervalFromSmoothing = getInterval(datetimeSelection, true);
+  const intervalFromSmoothing = getInterval(datetimeSelection, 'high');
 
   return intervalFromQueryParam || intervalFromSmoothing;
 }

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -207,7 +207,7 @@ class VitalChart extends Component<Props> {
                 environment={environment}
                 start={start}
                 end={end}
-                interval={getInterval(datetimeSelection, true)}
+                interval={getInterval(datetimeSelection, 'high')}
                 showLoading={false}
                 query={query}
                 includePrevious={false}

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -133,7 +133,7 @@ function ReleaseEventsChart({
       environment={environments}
       start={start}
       end={end}
-      interval={getInterval({start, end, period, utc}, true)}
+      interval={getInterval({start, end, period, utc}, 'high')}
       query="event.type:transaction"
       includePrevious={false}
       currentSeriesName={t('All Releases')}

--- a/tests/js/spec/components/charts/utils.spec.jsx
+++ b/tests/js/spec/components/charts/utils.spec.jsx
@@ -9,39 +9,63 @@ describe('Chart Utils', function () {
   describe('getInterval()', function () {
     describe('with high fidelity', function () {
       it('greater than 24 hours', function () {
-        expect(getInterval({period: '25h'}, true)).toBe('30m');
+        expect(getInterval({period: '25h'}, 'high')).toBe('30m');
       });
 
       it('less than 30 minutes', function () {
-        expect(getInterval({period: '20m'}, true)).toBe('1m');
+        expect(getInterval({period: '20m'}, 'high')).toBe('1m');
       });
       it('between 30 minutes and 24 hours', function () {
-        expect(getInterval({period: '12h'}, true)).toBe('5m');
+        expect(getInterval({period: '12h'}, 'high')).toBe('5m');
       });
       it('more than 30 days', function () {
-        expect(getInterval({period: '30d'}, true)).toBe('1h');
+        expect(getInterval({period: '30d'}, 'high')).toBe('1h');
       });
       it('more than 60 days', function () {
-        expect(getInterval({period: '90d'}, true)).toBe('4h');
+        expect(getInterval({period: '90d'}, 'high')).toBe('4h');
+      });
+    });
+
+    describe('with medium fidelity', function () {
+      it('greater than 24 hours', function () {
+        expect(getInterval({period: '25h'})).toBe('1h');
+        expect(getInterval({period: '25h'}, 'medium')).toBe('1h');
+      });
+
+      it('less than 30 minutes', function () {
+        expect(getInterval({period: '20m'})).toBe('5m');
+        expect(getInterval({period: '20m'}, 'medium')).toBe('5m');
+      });
+      it('between 30 minutes and 24 hours', function () {
+        expect(getInterval({period: '12h'})).toBe('15m');
+        expect(getInterval({period: '12h'}, 'medium')).toBe('15m');
+      });
+      it('more than 30 days', function () {
+        expect(getInterval({period: '30d'})).toBe('4h');
+        expect(getInterval({period: '30d'}, 'medium')).toBe('4h');
+      });
+      it('more than 90 days', function () {
+        expect(getInterval({period: '90d'})).toBe('1d');
+        expect(getInterval({period: '90d'}, 'medium')).toBe('1d');
       });
     });
 
     describe('with low fidelity', function () {
       it('greater than 24 hours', function () {
-        expect(getInterval({period: '25h'})).toBe('1h');
+        expect(getInterval({period: '25h'}, 'low')).toBe('2h');
       });
 
       it('less than 30 minutes', function () {
-        expect(getInterval({period: '20m'})).toBe('5m');
+        expect(getInterval({period: '20m'}, 'low')).toBe('15m');
       });
       it('between 30 minutes and 24 hours', function () {
-        expect(getInterval({period: '12h'})).toBe('15m');
+        expect(getInterval({period: '12h'}, 'low')).toBe('30m');
       });
       it('more than 30 days', function () {
-        expect(getInterval({period: '30d'})).toBe('4h');
+        expect(getInterval({period: '30d'}, 'low')).toBe('1d');
       });
       it('more than 90 days', function () {
-        expect(getInterval({period: '90d'})).toBe('1d');
+        expect(getInterval({period: '90d'}, 'low')).toBe('2d');
       });
     });
   });


### PR DESCRIPTION
The default fidelity resulted in very spiky charts. Since these charts are small
to begin with, lower their fidelity to produce a smoother result.