### PR TITLE
fix(onboardingpanel): flip primary and secondary btn position

### DIFF
--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -111,6 +111,13 @@ function Onboarding({organization}: Props) {
         )}
       </p>
       <ButtonList gap={1}>
+        <Button
+          priority="primary"
+          target="_blank"
+          href="https://docs.sentry.io/performance-monitoring/getting-started/"
+        >
+          {t('Start Setup')}
+        </Button>
         <FeatureTourModal
           steps={PERFORMANCE_TOUR_STEPS}
           onAdvance={handleAdvance}
@@ -134,13 +141,6 @@ function Onboarding({organization}: Props) {
             </Button>
           )}
         </FeatureTourModal>
-        <Button
-          priority="primary"
-          target="_blank"
-          href="https://docs.sentry.io/performance-monitoring/getting-started/"
-        >
-          {t('Start Setup')}
-        </Button>
       </ButtonList>
     </OnboardingPanel>
   );

--- a/static/app/views/releases/list/releasePromo.tsx
+++ b/static/app/views/releases/list/releasePromo.tsx
@@ -130,6 +130,9 @@ class ReleasePromo extends Component<Props> {
           )}
         </p>
         <ButtonList gap={1}>
+          <Button priority="primary" href={releasesSetupUrl} external>
+            {t('Start Setup')}
+          </Button>
           <FeatureTourModal
             steps={RELEASES_TOUR_STEPS}
             onAdvance={this.handleTourAdvance}
@@ -143,9 +146,6 @@ class ReleasePromo extends Component<Props> {
               </Button>
             )}
           </FeatureTourModal>
-          <Button priority="primary" href={releasesSetupUrl} external>
-            {t('Start Setup')}
-          </Button>
         </ButtonList>
       </OnboardingPanel>
     );


### PR DESCRIPTION
**Before:**
![Screen Shot 2021-07-20 at 12 36 02 PM](https://user-images.githubusercontent.com/4830259/126384964-56050281-d742-42f4-a7d3-163acc106de3.png)
![Screen Shot 2021-07-20 at 12 36 13 PM](https://user-images.githubusercontent.com/4830259/126384967-03c8302a-f487-41f1-a2d0-661d5ff36e03.png)

**After:**
![Screen Shot 2021-07-20 at 12 31 11 PM](https://user-images.githubusercontent.com/4830259/126384685-a74aa731-1d9d-4d68-a5ad-e61e97494dcb.png)
![Screen Shot 2021-07-20 at 12 31 19 PM](https://user-images.githubusercontent.com/4830259/126384692-1568eaa9-6bf9-4157-8e66-e02c402c5701.png)
![Screen Shot 2021-07-20 at 12 31 26 PM](https://user-images.githubusercontent.com/4830259/126384696-c7024c2e-83df-4bf1-9c73-504e79ece988.png)
