### PR TITLE
feat(releases): Hide release stage labels for non-mobile projects

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -478,7 +478,8 @@ class ReleasesList extends AsyncView<Props, State> {
             selection.projects[0] !== ALL_ACCESS_PROJECTS;
           const selectedProject = this.getSelectedProject();
           const isMobileProject =
-            selectedProject && isProjectMobileForReleases(selectedProject.platform);
+            selectedProject?.platform &&
+            isProjectMobileForReleases(selectedProject.platform);
 
           return (
             <Fragment>

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -19,7 +19,7 @@ import SearchBar from 'app/components/searchBar';
 import SmartSearchBar from 'app/components/smartSearchBar';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
-import {desktop, mobile, releaseHealth} from 'app/data/platformCategories';
+import {desktop, mobile, PlatformKey, releaseHealth} from 'app/data/platformCategories';
 import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
@@ -69,6 +69,11 @@ const supportedTags = {
     name: 'release',
   },
 };
+
+export const isProjectMobileForReleases = (projectPlatform: PlatformKey) =>
+  (
+    [...mobile, ...desktop, 'java-android', 'cocoa-objc', 'cocoa-swift'] as string[]
+  ).includes(projectPlatform);
 
 type RouteParams = {
   orgId: string;
@@ -473,17 +478,7 @@ class ReleasesList extends AsyncView<Props, State> {
             selection.projects[0] !== ALL_ACCESS_PROJECTS;
           const selectedProject = this.getSelectedProject();
           const isMobileProject =
-            selectedProject &&
-            selectedProject.platform &&
-            (
-              [
-                ...mobile,
-                ...desktop,
-                'java-android',
-                'cocoa-objc',
-                'cocoa-swift',
-              ] as string[]
-            ).includes(selectedProject.platform as string);
+            selectedProject && isProjectMobileForReleases(selectedProject.platform);
 
           return (
             <Fragment>

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -75,8 +75,6 @@ const Content = ({
       project => project.platform && isProjectMobileForReleases(project.platform)
     ).length > 0;
   const hasAdoptionStagesColumn: boolean = anyProjectMobile && showAdoptionStageLabels;
-  const hasAdoptionStagesLabel: boolean =
-    hasAdoptionStagesColumn && adoptionStages !== undefined;
   return (
     <Fragment>
       <Header>
@@ -146,6 +144,8 @@ const Content = ({
               adoptionStages?.[project.slug].stage;
 
             const isMobileProject = isProjectMobileForReleases(project.platform);
+            const hasAdoptionStagesLabel =
+              get24hCountByProject && adoptionStage && isMobileProject;
 
             return (
               <ProjectRow key={`${releaseVersion}-${slug}-health`}>
@@ -156,10 +156,7 @@ const Content = ({
 
                   {hasAdoptionStagesColumn && (
                     <AdoptionStageColumn>
-                      {isMobileProject &&
-                      adoptionStage &&
-                      hasAdoptionStagesLabel &&
-                      get24hCountByProject ? (
+                      {hasAdoptionStagesLabel ? (
                         <Tag type={ADOPTION_STAGE_LABELS[adoptionStage].type}>
                           {ADOPTION_STAGE_LABELS[adoptionStage].name}
                         </Tag>


### PR DESCRIPTION
This adds a check on the projects for releases list adoption stages labels column, hiding it if there's no mobile projects selected. Also hides the release stages labels for the non-mobile projects that are selected if there's any project that will show labels otherwise or if the old condition for the adoption bar `!get24hCountByProject` is met we also hide the label otherwise you see an empty row with just a label. 

[WOR-1104](https://getsentry.atlassian.net/browse/WOR-1104)