### PR TITLE
build(ci): Increase acceptance test timeout to 25 minutes

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -83,7 +83,7 @@ jobs:
   acceptance:
     name: acceptance
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       matrix:
         instance: [0, 1, 2, 3]


### PR DESCRIPTION
Acceptance tests have been timing out recently - this could be due to our growing codebase, as well as potential regressions with webpack and webpack-related packages. We do not have time right now to look further into this, so just going to bump the timeout until we do have the time.