### PR TITLE
fix(appstore): Needed to serialize dates since they don't automatically deserialize into datetimes

### DIFF
--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -57,7 +57,7 @@ def inner_dsym_download(project_id: int, config_id: str) -> None:
     build_refresh_dates = project.get_option(
         appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, default={}
     )
-    build_refresh_dates[config_id] = datetime.now()
+    build_refresh_dates[config_id] = json.dumps(datetime.now())
     serialized_refresh_dates = json.dumps(build_refresh_dates)
     project.update_option(
         appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION, serialized_refresh_dates


### PR DESCRIPTION
I made a dumb mistake and forgot that datetimes in JSON stringified objects remain as strings after deserialization. The code originally didn't JSONify the build refresh dates, so I missed a spot here when I did add that in.