### PR TITLE
fix(semver): Make dynamic counts on issue stream work with semver

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -325,6 +325,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 search_filters=query_kwargs["search_filters"]
                 if "search_filters" in query_kwargs
                 else None,
+                organization_id=organization.id,
             ),
         )
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -103,6 +103,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
                 search_filters=query_kwargs["search_filters"]
                 if "search_filters" in query_kwargs
                 else None,
+                organization_id=organization.id,
             ),
         )
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -49,12 +49,7 @@ from sentry.notifications.helpers import (
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.reprocessing2 import get_progress
-from sentry.search.events.constants import (
-    RELEASE_STAGE_ALIAS,
-    SEMVER_ALIAS,
-    SEMVER_BUILD_ALIAS,
-    SEMVER_PACKAGE_ALIAS,
-)
+from sentry.search.events.constants import RELEASE_STAGE_ALIAS
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
@@ -757,17 +752,10 @@ class GroupSerializerSnuba(GroupSerializerBase):
         "times_seen",
         "date",  # We merge this with start/end, so don't want to include it as its own
         # condition
-        # We don't need to filter by the semver query again here since we're
+        # We don't need to filter by release stage again here since we're
         # filtering to specific groups. Saves us making a second query to
         # postgres for no reason
-        # TODO: Above comment is wrong, we do need to filter by at least `SEMVER_ALIAS` and
-        # `SEMVER_BUILD_ALIAS` here since groups can appear across releases. Probably unnecessary
-        # for the `SEMVER_PACKAGE_ALIAS` though, since package tends to be tied to a specific
-        # project.
         RELEASE_STAGE_ALIAS,
-        SEMVER_ALIAS,
-        SEMVER_PACKAGE_ALIAS,
-        SEMVER_BUILD_ALIAS,
     }
 
     def __init__(
@@ -778,6 +766,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         search_filters=None,
         collapse=None,
         expand=None,
+        organization_id=None,
     ):
         super().__init__(collapse=collapse, expand=expand)
         from sentry.search.snuba.executors import get_search_filter
@@ -799,7 +788,9 @@ class GroupSerializerSnuba(GroupSerializerBase):
 
         self.conditions = (
             [
-                convert_search_filter_to_snuba_query(search_filter)
+                convert_search_filter_to_snuba_query(
+                    search_filter, params={"organization_id": organization_id}
+                )
                 for search_filter in search_filters
                 if search_filter.key.name not in self.skip_snuba_fields
             ]
@@ -891,6 +882,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         search_filters=None,
         collapse=None,
         expand=None,
+        organization_id=None,
     ):
         super().__init__(
             environment_ids,
@@ -899,6 +891,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             search_filters,
             collapse=collapse,
             expand=expand,
+            organization_id=organization_id,
         )
 
         if stats_period is not None:


### PR DESCRIPTION
I incorrectly excluded semver fields from dynamic counts when first implementing semver. This makes
dynamic counts work as expected with semver fields.