### PR TITLE
feat(ui): Release comparison polish

### DIFF
--- a/static/app/views/releases/detail/overview/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/releaseAdoption.tsx
@@ -58,7 +58,7 @@ function ReleaseComparisonChart({
 
     const sessionsMarkLines = generateReleaseMarkLines(
       release,
-      project.slug,
+      project,
       theme,
       location,
       {
@@ -84,16 +84,10 @@ function ReleaseComparisonChart({
     ];
 
     if (hasUsers) {
-      const usersMarkLines = generateReleaseMarkLines(
-        release,
-        project.slug,
-        theme,
-        location,
-        {
-          hideLabel: true,
-          axisIndex: 1,
-        }
-      );
+      const usersMarkLines = generateReleaseMarkLines(release, project, theme, location, {
+        hideLabel: true,
+        axisIndex: 1,
+      });
 
       series.push(...usersMarkLines);
       series.push({

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -945,18 +945,24 @@ const ChartTableRow = styled('label')<{
   font-weight: 400;
   margin-bottom: 0;
 
+  > * {
+    padding: ${space(2)};
+  }
+
   ${p =>
     p.isActive &&
     !p.isLoading &&
     css`
-      ${Cell},${DescriptionCell}, ${TitleWrapper} {
+      ${Cell}, ${DescriptionCell}, ${TitleWrapper} {
         background-color: ${p.theme.bodyBackground};
       }
     `}
 
   &:hover {
     cursor: pointer;
-    ${Cell},${DescriptionCell}, ${TitleWrapper} {
+    ${/* sc-selector */ Cell}, ${/* sc-selector */ DescriptionCell}, ${
+      /* sc-selector */ TitleWrapper
+    } {
       ${p => !p.isLoading && `background-color: ${p.theme.bodyBackground}`}
     }
   }
@@ -1016,10 +1022,6 @@ const ChartTable = styled(PanelTable)`
 
   > * {
     border-bottom: 1px solid ${p => p.theme.border};
-  }
-
-  ${ChartTableRow} > * {
-    padding: ${space(2)};
   }
 
   @media (max-width: ${p => p.theme.breakpoints[2]}) {

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -181,7 +181,7 @@ class ReleaseSessionsChart extends React.Component<Props> {
       return {};
     }
 
-    const markLines = generateReleaseMarkLines(release, project.slug, theme, location);
+    const markLines = generateReleaseMarkLines(release, project, theme, location);
 
     switch (chartType) {
       case ReleaseComparisonChartType.CRASH_FREE_SESSIONS:

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -12,13 +12,16 @@ import {
   GlobalSelection,
   LightWeightOrganization,
   ReleaseComparisonChartType,
+  ReleaseProject,
   ReleaseWithHealth,
   Repository,
 } from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
+import {decodeList} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
 import {QueryResults} from 'app/utils/tokenizeSearch';
+import {isProjectMobileForReleases} from 'app/views/releases/list';
 
 import {commonTermsDescription, SessionTerm} from '../utils/sessionTerm';
 
@@ -232,19 +235,21 @@ export const releaseMarkLinesLabels = {
 
 export function generateReleaseMarkLines(
   release: ReleaseWithHealth,
-  projectSlug: string,
+  project: ReleaseProject,
   theme: Theme,
   location: Location,
   options?: GenerateReleaseMarklineOptions
 ) {
-  const adoptionStages = release.adoptionStages?.[projectSlug];
-
-  if (
+  const adoptionStages = release.adoptionStages?.[project.slug];
+  const isDefaultPeriod = !(
     location.query.pageStart ||
     location.query.pageEnd ||
     location.query.pageStatsPeriod
-  ) {
-    // for now want to show marklines only on default time period "Entire Release Period"
+  );
+  const isSingleEnv = decodeList(location.query.environment).length === 1;
+
+  if (!isDefaultPeriod) {
+    // do not show marklines on non-default period
     return [];
   }
 
@@ -256,6 +261,11 @@ export function generateReleaseMarkLines(
       options
     ),
   ];
+
+  if (!isSingleEnv || !isProjectMobileForReleases(project.platform)) {
+    // for now want to show marklines only on mobile platforms with single environment selected
+    return markLines;
+  }
 
   if (adoptionStages?.adopted) {
     markLines.push(

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -49,12 +49,12 @@ export const displayCrashFreePercent = (
   return `${rounded}\u0025`;
 };
 
-export const getSessionStatusPercent = (percent: number) => {
-  return round(percent, 3);
+export const getSessionStatusPercent = (percent: number, absolute = true) => {
+  return round(absolute ? Math.abs(percent) : percent, 3);
 };
 
-export const displaySessionStatusPercent = (percent: number) => {
-  return `${getSessionStatusPercent(percent).toLocaleString()}\u0025`;
+export const displaySessionStatusPercent = (percent: number, absolute = true) => {
+  return `${getSessionStatusPercent(percent, absolute).toLocaleString()}\u0025`;
 };
 
 export const displayCrashFreeDiff = (


### PR DESCRIPTION
- show adoption marklines only for mobile platforms with 1 env selected
- show absolute diff without -/+ sign (we have up and down arrows)
- in case of bad URL, fallback to first chart in an array
- add hover state to chart picker

https://user-images.githubusercontent.com/9060071/126472560-2e2bf751-720b-4788-8626-9f11af29bb96.mp4

