### PR TITLE
feat(semver): Change invalid semver message

### DIFF
--- a/src/sentry/api/release_search.py
+++ b/src/sentry/api/release_search.py
@@ -10,6 +10,9 @@ from sentry.search.events.constants import (
 )
 
 RELEASE_FREE_TEXT_KEY = "release_free_text"
+INVALID_SEMVER_MESSAGE = (
+    'Invalid format of semantic version. For searching non-semver releases, use "release:" instead.'
+)
 
 release_search_config = SearchConfig.create_from(
     default_config,

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -547,7 +547,9 @@ def parse_semver(version, operator) -> Optional[SemverFilter]:
                     # part of these
                     version_parts.append(int(part))
                 except ValueError:
-                    raise InvalidSearchQuery(f"Invalid format for semver query {version}")
+                    raise InvalidSearchQuery(
+                        'Invalid format of semantic version. For searching non-semver releases, use "release:" instead.'
+                    )
 
         package = package if package and package != SEMVER_FAKE_PACKAGE else None
         return SemverFilter("exact", version_parts, package)

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -17,6 +17,7 @@ from sentry.api.event_search import (
     SearchValue,
     parse_search_query,
 )
+from sentry.api.release_search import INVALID_SEMVER_MESSAGE
 from sentry.constants import SEMVER_FAKE_PACKAGE
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Project, Release, SemverFilter
@@ -547,9 +548,7 @@ def parse_semver(version, operator) -> Optional[SemverFilter]:
                     # part of these
                     version_parts.append(int(part))
                 except ValueError:
-                    raise InvalidSearchQuery(
-                        'Invalid format of semantic version. For searching non-semver releases, use "release:" instead.'
-                    )
+                    raise InvalidSearchQuery(INVALID_SEMVER_MESSAGE)
 
         package = package if package and package != SEMVER_FAKE_PACKAGE else None
         return SemverFilter("exact", version_parts, package)

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -3,6 +3,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.api.exceptions import InvalidRepository
+from sentry.api.release_search import INVALID_SEMVER_MESSAGE
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
     Commit,
@@ -833,7 +834,7 @@ class ReleaseFilterBySemverTest(TestCase):
     def test_invalid_query(self):
         with pytest.raises(
             InvalidSearchQuery,
-            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+            match=INVALID_SEMVER_MESSAGE,
         ):
             Release.objects.filter_by_semver(self.organization.id, parse_semver("1.2.hi", ">"))
 

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -831,7 +831,10 @@ class SemverReleaseParseTestCase(TestCase):
 
 class ReleaseFilterBySemverTest(TestCase):
     def test_invalid_query(self):
-        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+        with pytest.raises(
+            InvalidSearchQuery,
+            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+        ):
             Release.objects.filter_by_semver(self.organization.id, parse_semver("1.2.hi", ">"))
 
     def run_test(self, operator, version, expected_releases, organization_id=None, projects=None):

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1511,7 +1511,10 @@ class SemverFilterConverterTest(TestCase):
     def test_invalid_query(self):
         key = SEMVER_ALIAS
         filter = SearchFilter(SearchKey(key), ">", SearchValue("1.2.hi"))
-        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+        with pytest.raises(
+            InvalidSearchQuery,
+            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+        ):
             _semver_filter_converter(filter, key, {"organization_id": self.organization.id})
 
     def run_test(
@@ -1705,9 +1708,15 @@ class ParseSemverTest(unittest.TestCase):
         assert semver_filter == expected
 
     def test_invalid(self):
-        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+        with pytest.raises(
+            InvalidSearchQuery,
+            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+        ):
             parse_semver("1.hello", ">") is None
-        with pytest.raises(InvalidSearchQuery, match="Invalid format for semver query"):
+        with pytest.raises(
+            InvalidSearchQuery,
+            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+        ):
             parse_semver("hello", ">") is None
 
     def test_normal(self):

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
+from sentry.api.release_search import INVALID_SEMVER_MESSAGE
 from sentry.models import ReleaseProjectEnvironment, ReleaseStages
 from sentry.models.release import SemverFilter
 from sentry.search.events.constants import (
@@ -1513,7 +1514,7 @@ class SemverFilterConverterTest(TestCase):
         filter = SearchFilter(SearchKey(key), ">", SearchValue("1.2.hi"))
         with pytest.raises(
             InvalidSearchQuery,
-            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+            match=INVALID_SEMVER_MESSAGE,
         ):
             _semver_filter_converter(filter, key, {"organization_id": self.organization.id})
 
@@ -1710,12 +1711,12 @@ class ParseSemverTest(unittest.TestCase):
     def test_invalid(self):
         with pytest.raises(
             InvalidSearchQuery,
-            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+            match=INVALID_SEMVER_MESSAGE,
         ):
             parse_semver("1.hello", ">") is None
         with pytest.raises(
             InvalidSearchQuery,
-            match='Invalid format of semantic version. For searching non-semver releases, use "release:" instead.',
+            match=INVALID_SEMVER_MESSAGE,
         ):
             parse_semver("hello", ">") is None
 


### PR DESCRIPTION
If someone tries to use `release.version` to search for non-semver releases, we give them a hint to use keyword `release:` instead.