### PR TITLE
feat(performance): remove beta badge from events tab

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -245,7 +245,6 @@ class TransactionHeader extends React.Component<Props> {
                 onClick={this.trackEventsTabClick}
               >
                 {t('All Events')}
-                <FeatureBadge type="beta" noTooltip />
               </ListLink>
             </Feature>
           </StyledNavTabs>

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -164,10 +164,7 @@ describe('Performance > TransactionSummary', function () {
     wrapper.update();
 
     expect(
-      wrapper
-        .find('NavTabs')
-        .find({children: ['All Events']})
-        .find('Link')
+      wrapper.find('NavTabs').find({children: 'All Events'}).find('Link')
     ).toHaveLength(1);
     expect(wrapper.find('SentryDocumentTitle')).toHaveLength(1);
     expect(wrapper.find('SearchBar')).toHaveLength(1);


### PR DESCRIPTION
Removed beta badge from events tab
![image](https://user-images.githubusercontent.com/83961295/126509991-45e6ce3f-3edd-4af4-b251-25bbe113ac47.png)
