### PR TITLE
fix(mail): Change alert email to show time in user's tz

### DIFF
--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -1,7 +1,9 @@
 import logging
 from typing import Any, Mapping, MutableMapping, Optional, Set
 
-from sentry.models import User
+import pytz
+
+from sentry.models import User, UserOption
 from sentry.notifications.base import BaseNotification
 from sentry.notifications.types import ActionTargetType
 from sentry.notifications.utils import (
@@ -56,6 +58,15 @@ class AlertRuleNotification(BaseNotification):
 
     def get_reference(self) -> Any:
         return self.group
+
+    def get_user_context(
+        self, user: User, extra_context: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        return {
+            "timezone": pytz.timezone(
+                UserOption.objects.get_value(user=user, key="timezone", default="UTC")
+            )
+        }
 
     def get_context(self) -> MutableMapping[str, Any]:
         environment = self.event.get_tag("environment")

--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -62,11 +62,15 @@ class AlertRuleNotification(BaseNotification):
     def get_user_context(
         self, user: User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
-        return {
-            "timezone": pytz.timezone(
-                UserOption.objects.get_value(user=user, key="timezone", default="UTC")
-            )
-        }
+        # AlertRuleNotification is shared among both email and slack notifications, and in slack
+        # notifications, the `user` arg could be of type `Team` which is why we need this check
+        if isinstance(user, User):
+            return {
+                "timezone": pytz.timezone(
+                    UserOption.objects.get_value(user=user, key="timezone", default="UTC")
+                )
+            }
+        return super().get_user_context(user, extra_context)
 
     def get_context(self) -> MutableMapping[str, Any]:
         environment = self.event.get_tag("environment")

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -1,5 +1,6 @@
 {% extends "sentry/emails/base.html" %}
 
+{% load timezone from tz %}
 {% load sentry_avatars %}
 {% load sentry_helpers %}
 {% load sentry_features %}
@@ -46,7 +47,7 @@
     {% if enhanced_privacy %}
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-        <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e" }}</div>
+        <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
       </div>
 
       <div class="notice">Details about this issue are not shown in this notification since enhanced privacy
@@ -110,7 +111,7 @@
 
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-        <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e" }}</div>
+        <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
       </div>
 
       {% if commits %}

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timedelta
 from random import Random
 
+import pytz
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils import timezone
@@ -274,6 +275,7 @@ def alert(request):
             "rule": rule,
             "group": group,
             "event": event,
+            "timezone": pytz.timezone("Europe/Vienna"),
             "link": "http://example.com/link",
             "interfaces": interface_list,
             "tags": event.tags,


### PR DESCRIPTION
This PR replaces default UTC timezone in Issue alert emails with the user's timezone

Before:
![Screenshot 2021-07-21 at 17 16 42](https://user-images.githubusercontent.com/10855986/126514075-51ae47e6-b3a9-4387-af2d-a8a247a815a0.png)


After:
![Screenshot 2021-07-21 at 16 23 14](https://user-images.githubusercontent.com/10855986/126513947-79ba2882-9a40-4eb9-88e7-0e9c1e0d9a8f.png)
