### PR TITLE
fix(mobile-vitals): Decrease fidelity even more on the spark lines

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -73,6 +73,15 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     return '1d';
   }
 
+  if (diffInMinutes >= TWO_WEEKS) {
+    if (fidelity === 'high') {
+      return '30m';
+    } else if (fidelity === 'medium') {
+      return '1h';
+    }
+    return '12h';
+  }
+
   if (diffInMinutes > TWENTY_FOUR_HOURS) {
     // Greater than 24 hours
     if (fidelity === 'high') {
@@ -80,7 +89,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     } else if (fidelity === 'medium') {
       return '1h';
     }
-    return '2h';
+    return '6h';
   }
 
   if (diffInMinutes > ONE_HOUR) {
@@ -90,7 +99,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
     } else if (fidelity === 'medium') {
       return '15m';
     } else {
-      return '30m';
+      return '1h';
     }
   }
 
@@ -100,7 +109,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
   } else if (fidelity === 'medium') {
     return '5m';
   } else {
-    return '15m';
+    return '10m';
   }
 }
 

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -146,6 +146,7 @@ type GenericCardsProps = BaseCardsProps & {
 
 function GenericCards(props: GenericCardsProps) {
   const {api, eventView: baseEventView, location, organization, functions} = props;
+  const {query} = location;
   const eventView = baseEventView.withColumns(functions);
 
   // construct request parameters for fetching chart data
@@ -156,6 +157,17 @@ function GenericCards(props: GenericCardsProps) {
   const end = globalSelection.datetime.end
     ? getUtcToLocalDateObject(globalSelection.datetime.end)
     : undefined;
+  const interval =
+    typeof query.sparkInterval === 'string'
+      ? query.sparkInterval
+      : getInterval(
+          {
+            start: start || null,
+            end: end || null,
+            period: globalSelection.datetime.period,
+          },
+          'low'
+        );
   const apiPayload = eventView.getEventsAPIPayload(location);
 
   return (
@@ -176,14 +188,7 @@ function GenericCards(props: GenericCardsProps) {
           team={apiPayload.team}
           start={start}
           end={end}
-          interval={getInterval(
-            {
-              start: start || null,
-              end: end || null,
-              period: globalSelection.datetime.period,
-            },
-            'low'
-          )}
+          interval={interval}
           query={apiPayload.query}
           includePrevious={false}
           yAxis={eventView.getFields()}

--- a/tests/js/spec/components/charts/utils.spec.jsx
+++ b/tests/js/spec/components/charts/utils.spec.jsx
@@ -18,6 +18,9 @@ describe('Chart Utils', function () {
       it('between 30 minutes and 24 hours', function () {
         expect(getInterval({period: '12h'}, 'high')).toBe('5m');
       });
+      it('more than 14 days', function () {
+        expect(getInterval({period: '14d'}, 'high')).toBe('30m');
+      });
       it('more than 30 days', function () {
         expect(getInterval({period: '30d'}, 'high')).toBe('1h');
       });
@@ -40,6 +43,10 @@ describe('Chart Utils', function () {
         expect(getInterval({period: '12h'})).toBe('15m');
         expect(getInterval({period: '12h'}, 'medium')).toBe('15m');
       });
+      it('more than 14 days', function () {
+        expect(getInterval({period: '14d'})).toBe('1h');
+        expect(getInterval({period: '14d'}, 'medium')).toBe('1h');
+      });
       it('more than 30 days', function () {
         expect(getInterval({period: '30d'})).toBe('4h');
         expect(getInterval({period: '30d'}, 'medium')).toBe('4h');
@@ -52,14 +59,17 @@ describe('Chart Utils', function () {
 
     describe('with low fidelity', function () {
       it('greater than 24 hours', function () {
-        expect(getInterval({period: '25h'}, 'low')).toBe('2h');
+        expect(getInterval({period: '25h'}, 'low')).toBe('6h');
       });
 
       it('less than 30 minutes', function () {
-        expect(getInterval({period: '20m'}, 'low')).toBe('15m');
+        expect(getInterval({period: '20m'}, 'low')).toBe('10m');
       });
       it('between 30 minutes and 24 hours', function () {
-        expect(getInterval({period: '12h'}, 'low')).toBe('30m');
+        expect(getInterval({period: '12h'}, 'low')).toBe('1h');
+      });
+      it('more than 14 days', function () {
+        expect(getInterval({period: '14d'}, 'low')).toBe('12h');
       });
       it('more than 30 days', function () {
         expect(getInterval({period: '30d'}, 'low')).toBe('1d');


### PR DESCRIPTION
The fidelity of the spark lines are still too high. This aims to have around
20-30 data points for the possible stats periods. Also provides an override via
the url param `sparkInterval`.