### PR TITLE
Fix(audit-logs): improved audit log to have old project slug

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -420,6 +420,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             project.slug = result["slug"]
             changed = True
             changed_proj_settings["new_slug"] = project.slug
+            changed_proj_settings["old_slug"] = old_slug
 
         if result.get("name"):
             project.name = result["name"]

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -278,8 +278,11 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.PROJECT_ADD:
             return "created project {}".format(self.data["slug"])
         elif self.event == AuditLogEntryEvent.PROJECT_EDIT:
+            # __import__("pdb").set_trace()
             return "edited project settings " + (
                 " ".join(f" in {key} to {value}" for (key, value) in self.data.items())
+                if self.data["old_slug"] is None
+                else "in " + self.data["old_slug"] + " to " + self.data["new_slug"]
             )
         elif self.event == AuditLogEntryEvent.PROJECT_REMOVE:
             return "removed project {}".format(self.data["slug"])

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -278,7 +278,6 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.PROJECT_ADD:
             return "created project {}".format(self.data["slug"])
         elif self.event == AuditLogEntryEvent.PROJECT_EDIT:
-            # __import__("pdb").set_trace()
             return "edited project settings " + (
                 " ".join(f" in {key} to {value}" for (key, value) in self.data.items())
                 if self.data["old_slug"] is None

--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -278,10 +278,15 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.PROJECT_ADD:
             return "created project {}".format(self.data["slug"])
         elif self.event == AuditLogEntryEvent.PROJECT_EDIT:
+            if self.data["old_slug"] is not None:
+                return (
+                    "renamed project slug from "
+                    + self.data["old_slug"]
+                    + " to "
+                    + self.data["new_slug"]
+                )
             return "edited project settings " + (
                 " ".join(f" in {key} to {value}" for (key, value) in self.data.items())
-                if self.data["old_slug"] is None
-                else "in " + self.data["old_slug"] + " to " + self.data["new_slug"]
             )
         elif self.event == AuditLogEntryEvent.PROJECT_REMOVE:
             return "removed project {}".format(self.data["slug"])

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -118,6 +118,12 @@ class ProjectDetailsTest(APITestCase):
         )
 
         response = self.get_valid_response(project.organization.slug, project.slug, status_code=302)
+        assert (
+            AuditLogEntry.objects.get(
+                organization=project.organization, event=AuditLogEntryEvent.PROJECT_EDIT
+            ).data["old_slug"]
+            == project.slug
+        )
         assert response.data["slug"] == "foobar"
         assert (
             response.data["detail"]["extra"]["url"]

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -124,6 +124,12 @@ class ProjectDetailsTest(APITestCase):
             ).data["old_slug"]
             == project.slug
         )
+        assert (
+            AuditLogEntry.objects.get(
+                organization=project.organization, event=AuditLogEntryEvent.PROJECT_EDIT
+            ).data["new_slug"]
+            == "foobar"
+        )
         assert response.data["slug"] == "foobar"
         assert (
             response.data["detail"]["extra"]["url"]


### PR DESCRIPTION
Added the old project slug in the PROJECT_EDIT message in audit log.

before: 
![image](https://user-images.githubusercontent.com/22259802/126529091-596abdc9-d7fd-4f2c-bc7e-2e2ebb6df767.png)
after:
![image](https://user-images.githubusercontent.com/22259802/126529141-2538da97-a197-4c8e-9070-f22b97164070.png)

JIRA:https://getsentry.atlassian.net/browse/ER-731