### PR TITLE
fix(github): Prevent race condition IntegrityErrors

### DIFF
--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -347,14 +347,14 @@ class PullRequestEventWebhook(Webhook):
                 organization_id=organization.id, external_id=self.get_external_id(user["login"])
             )
         except CommitAuthor.DoesNotExist:
-            author = CommitAuthor.objects.get_or_create(
+            author, _created = CommitAuthor.objects.get_or_create(
                 organization_id=organization.id,
                 email=author_email,
                 defaults={
                     "name": user["login"][:128],
                     "external_id": self.get_external_id(user["login"]),
                 },
-            )[0]
+            )
 
         try:
             PullRequest.create_or_save(

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -347,14 +347,15 @@ class PullRequestEventWebhook(Webhook):
                 organization_id=organization.id, external_id=self.get_external_id(user["login"])
             )
         except CommitAuthor.DoesNotExist:
-            author, created = CommitAuthor.objects.get_or_create(
+            author = CommitAuthor.objects.get_or_create(
                 organization_id=organization.id,
                 email=author_email,
-                defaults={"name": user["login"][:128]},
-            )
-            if created:
-                author.external_id = self.get_external_id(user["login"])
-                author.save()
+                defaults={
+                    "name": user["login"][:128],
+                    "external_id": self.get_external_id(user["login"]),
+                },
+            )[0]
+
         try:
             PullRequest.create_or_save(
                 organization_id=organization.id,


### PR DESCRIPTION
Pretty sure the `IntegrityError`s we've been seeing here are from race conditions, so switched to using `get_or_create` to help prevent that. 