### PR TITLE
fix(semver): Fix bug in tag autocomplete where non-semver releases show for an empty version

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -747,7 +747,9 @@ class SnubaTagStorage(TagStorage):
             )
 
         order_by = map(_flip_field_sort, Release.SEMVER_COLS + ["package"])
-        versions = versions.order_by(*order_by).values_list("version", flat=True)[:1000]
+        versions = (
+            versions.filter_to_semver().order_by(*order_by).values_list("version", flat=True)[:1000]
+        )
 
         seen = set()
         formatted_versions = []

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -726,7 +726,7 @@ class SnubaTagStorage(TagStorage):
             include_package = True
             versions = self._get_semver_versions_for_package(projects, organization_id, query)
         else:
-            include_package = not query or "@" in query
+            include_package = "@" in query
             if not query:
                 query = "*"
             elif query[-1] not in SEMVER_WILDCARDS | {"@"}:

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -274,7 +274,7 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
     def test_semver(self):
         self.create_release(version="test@1.0.0.0")
         self.create_release(version="test@2.0.0.0")
-        self.run_test(SEMVER_ALIAS, expected=[("test@2.0.0.0", None), ("test@1.0.0.0", None)])
+        self.run_test(SEMVER_ALIAS, expected=[("2.0.0.0", None), ("1.0.0.0", None)])
         self.run_test(SEMVER_ALIAS, query="1.", expected=[("1.0.0.0", None)])
         self.run_test(SEMVER_ALIAS, query="test@1.", expected=[("test@1.0.0.0", None)])
         self.run_test(

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -732,6 +732,8 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
         self.create_release(version="test2@2.0.0.0+456", environments=[self.environment, env_2])
         self.create_release(version="z_test@1.0.0.0")
         self.create_release(version="z_test@2.0.0.0+456", additional_projects=[project_2])
+        # This shouldn't appear for any semver autocomplete
+        self.create_release(version="test@abc123", additional_projects=[project_2])
 
         self.run_test(
             None,
@@ -808,6 +810,8 @@ class GetTagValuePaginatorForProjectsSemverPackageTest(BaseSemverTest, TestCase,
         self.create_release(version="test@1.2.0.0-alpha", environments=[self.environment])
         self.create_release(version="test2@2.0.0.0+456", environments=[self.environment, env_2])
         self.create_release(version="z_test@2.0.0.0+456", additional_projects=[project_2])
+        # This shouldn't appear for any semver autocomplete
+        self.create_release(version="test@abc123", additional_projects=[project_2])
 
         self.run_test(None, ["test", "test2", "z_test"])
         self.run_test("", ["test", "test2", "z_test"])
@@ -896,6 +900,8 @@ class GetTagValuePaginatorForProjectsSemverBuildTest(BaseSemverTest, TestCase, S
         self.create_release(version="test@2.0.0.0+456", environments=[self.environment, env_2])
         self.create_release(version="test@2.0.1.0+457a", additional_projects=[project_2])
         self.create_release(version="test@2.0.1.0+789", additional_projects=[project_2])
+        # This shouldn't appear for any semver autocomplete
+        self.create_release(version="test@abc123", additional_projects=[project_2])
 
         self.run_test(None, ["123", "124", "456", "457a", "789"])
         self.run_test("", ["123", "124", "456", "457a", "789"])

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -738,25 +738,21 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
         self.run_test(
             None,
             [
-                "z_test@2.0.0.0",
-                "test2@2.0.0.0",
-                "test@1.2.3.4",
-                "test@1.2.3.0-beta",
-                "test@1.2.0.0-alpha",
-                "z_test@1.0.0.0",
-                "test@1.0.0.0",
+                "2.0.0.0",
+                "1.2.3.4",
+                "1.2.3.0-beta",
+                "1.2.0.0-alpha",
+                "1.0.0.0",
             ],
         )
         self.run_test(
             "",
             [
-                "z_test@2.0.0.0",
-                "test2@2.0.0.0",
-                "test@1.2.3.4",
-                "test@1.2.3.0-beta",
-                "test@1.2.0.0-alpha",
-                "z_test@1.0.0.0",
-                "test@1.0.0.0",
+                "2.0.0.0",
+                "1.2.3.4",
+                "1.2.3.0-beta",
+                "1.2.0.0-alpha",
+                "1.0.0.0",
             ],
         )
 
@@ -769,8 +765,8 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
 
         self.run_test("1.2", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha"])
 
-        self.run_test("", ["test2@2.0.0.0", "test@1.2.0.0-alpha"], self.environment)
-        self.run_test("", ["test2@2.0.0.0", "test@1.2.3.4", "test@1.2.3.0-beta"], env_2)
+        self.run_test("", ["2.0.0.0", "1.2.0.0-alpha"], self.environment)
+        self.run_test("", ["2.0.0.0", "1.2.3.4", "1.2.3.0-beta"], env_2)
         self.run_test("1", ["1.2.0.0-alpha"], self.environment)
         self.run_test("1", ["1.2.3.4", "1.2.3.0-beta"], env_2)
 


### PR DESCRIPTION
If a user types `release.version:` in the autocomplete we show all release tags, regardless of
whether they're semver releases or not. This fixes the endpoint to correctly filter down to semver
only.