### PR TITLE
feat(codeowners): ProjectOwnership validation blocks codeowner paths

### DIFF
--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -18,13 +18,14 @@ class ProjectOwnershipSerializer(serializers.Serializer):
 
     @staticmethod
     def _validate_no_codeowners(rules: List[Rule]):
-        """codeowner matcher types cannot be added via ProjectOwnership, only via github"""
+        """
+        codeowner matcher types cannot be added via ProjectOwnership, only through codeowner
+        specific serializers
+        """
         for rule in rules:
             if rule.matcher.type == CODEOWNERS:
                 raise serializers.ValidationError(
-                    {
-                        "raw": f'"{CODEOWNERS}" type paths can only be added by importing CODEOWNER files'
-                    }
+                    {"raw": "Codeowner type paths can only be added by importing CODEOWNER files"}
                 )
 
     def validate(self, attrs):

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -76,7 +76,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
     A Matcher represents a type:pattern pairing for use in
     comparing with an Event.
 
-    type is either `path` or `url` at this point.
+    type is either `path`, `url`, `module` or `codeowners` at this point.
 
     TODO(mattrobenolt): pattern needs to be parsed into a regex
 

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -12,9 +12,14 @@ __all__ = ("parse_rules", "dump_schema", "load_schema")
 
 VERSION = 1
 
+URL = "url"
+PATH = "path"
+MODULE = "module"
+CODEOWNERS = "codeowners"
+
 # Grammar is defined in EBNF syntax.
 ownership_grammar = Grammar(
-    r"""
+    fr"""
 
 ownership = line+
 
@@ -24,7 +29,7 @@ rule = _ matcher owners
 
 matcher      = _ matcher_tag any_identifier
 matcher_tag  = (matcher_type sep)?
-matcher_type = "url" / "path" / "module" / "codeowners" / event_tag
+matcher_type = "{URL}" / "{PATH}" / "{MODULE}" / "{CODEOWNERS}" / event_tag
 
 event_tag   = ~r"tags.[^:]+"
 
@@ -89,15 +94,15 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         return cls(data["type"], data["pattern"])
 
     def test(self, data):
-        if self.type == "url":
+        if self.type == URL:
             return self.test_url(data)
-        elif self.type == "path":
+        elif self.type == PATH:
             return self.test_frames(data, ["filename", "abs_path"])
-        elif self.type == "module":
+        elif self.type == MODULE:
             return self.test_frames(data, ["module"])
         elif self.type.startswith("tags."):
             return self.test_tag(data)
-        elif self.type.startswith("codeowners"):
+        elif self.type == CODEOWNERS:
             return self.test_codeowners(data)
         return False
 

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -96,5 +96,5 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         resp = self.client.put(self.path, {"raw": "codeowners:*.js admin@localhost #tiger-team"})
         assert resp.status_code == 400
         assert resp.data == {
-            "raw": ['"codeowners" type paths can only be added by importing CODEOWNER files']
+            "raw": ["Codeowner type paths can only be added by importing CODEOWNER files"]
         }

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -88,3 +88,13 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         )
         assert resp.status_code == 400
         assert resp.data == {"raw": ["Invalid rule owners: #faketeam, idont@exist.com"]}
+
+    def test_invalid_matcher_type(self):
+        """Check for matcher types that aren't allowed when updating issue owners"""
+
+        # Codeowners cannot be added by modifying issue owners
+        resp = self.client.put(self.path, {"raw": "codeowners:*.js admin@localhost #tiger-team"})
+        assert resp.status_code == 400
+        assert resp.data == {
+            "raw": ['"codeowners" type paths can only be added by importing CODEOWNER files']
+        }


### PR DESCRIPTION
Codeowners should only be able to be added through importing a codeowners file. In order to prevent a user from modifying their issue owners to add a codeowners path, ProjectOwnershipSerializer now validates that there are no "codeowners" matcher types in the raw lines.

Bonus: made matcher types constants in grammar.py

Fixes API-1968