### PR TITLE
fix(ui): Match layout header and body padding at breakpoint

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -13,15 +13,12 @@ export const Body = styled('div')`
   background-color: ${p => p.theme.background};
   flex-grow: 1;
 
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    padding: ${space(3)} ${space(4)};
-  }
-
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: grid;
     grid-template-columns: 66% auto;
     align-content: start;
     grid-gap: ${space(3)};
+    padding: ${space(3)} ${space(4)};
   }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {


### PR DESCRIPTION
at one breakpoint the padding wasn't matched between the header and the body

![image](https://user-images.githubusercontent.com/1400464/126541422-82b67dfb-94e9-43e2-ab8d-7007f5a59805.png)
