### PR TITLE
ref(test): Add vis acceptance for tags page

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -35,7 +35,10 @@ class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2Endpoi
         return features.has("organizations:performance-tag-page", organization, actor=request.user)
 
     def setup(self, request, organization):
-        if not self.has_feature(organization, request):
+        if not (
+            self.has_feature(organization, request)
+            or self.has_tag_page_feature(organization, request)
+        ):
             raise Http404
 
         params = self.get_snuba_params(request, organization)

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -96,16 +96,13 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
         # Create a transaction
         event_data = load_data("transaction", timestamp=before_now(minutes=3))
-        # only frontend pageload transactions can be shown on the vitals tab
-        event_data["contexts"]["trace"]["op"] = "pageload"
-        event_data["measurements"]["fp"]["value"] = 5000
+
         event = make_event(event_data)
         self.store_event(data=event, project_id=self.project.id)
 
         with self.feature(FEATURE_NAMES + ("organizations:performance-tag-page",)):
             self.browser.get(tags_path)
             self.page.wait_until_loaded()
-
             self.browser.snapshot("transaction summary tags page")
 
     @patch("django.utils.timezone.now")


### PR DESCRIPTION
### Summary
This will add a visual test for the tags page, also found a small bug with the double feature flag that the base endpoint didn't work with just tag explorer (it wouldn't have an effect on EA but would have on GA).