### PR TITLE
fix(perf): Fix heatmap label abbreviation

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -31,6 +31,7 @@ import {Organization, Project} from 'app/types';
 import {ReactEchartsRef, Series} from 'app/types/echarts';
 import {axisLabelFormatter} from 'app/utils/discover/charts';
 import EventView from 'app/utils/discover/eventView';
+import {formatAbbreviatedNumber} from 'app/utils/formatters';
 import getDynamicText from 'app/utils/getDynamicText';
 import {TableData as TagTableData} from 'app/utils/performance/segmentExplorer/tagKeyHistogramQuery';
 import TagTransactionsQuery from 'app/utils/performance/segmentExplorer/tagTransactionsQuery';
@@ -223,6 +224,7 @@ const TagsHeatMap = (
       dataArray: _data,
       label: {
         show: true,
+        formatter: data => formatAbbreviatedNumber(data.value[2]),
       },
       emphasis: {
         itemStyle: {


### PR DESCRIPTION
### Summary
Labels were displaying full numbers even at high counts, which was causing issues with small buckets.

### Screenshots
#### Before
![Screen Shot 2021-07-21 at 3 11 33 PM](https://user-images.githubusercontent.com/6111995/126546633-1e1da7a0-cf0f-4dae-b802-2dbfc1361a0a.png)

#### After
![Screen Shot 2021-07-21 at 3 11 04 PM](https://user-images.githubusercontent.com/6111995/126546627-cd350b68-4a04-4991-baba-82682c7d98b5.png)
