### PR TITLE
fix(trace-navigator): Single event targets contain incorrect project

### DIFF
--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -43,12 +43,11 @@ function generatePerformanceEventTarget(
     id: event.event_id,
     project: event.project_slug,
   });
-  return getTransactionDetailsUrl(
-    organization,
-    eventSlug,
-    event.transaction,
-    location.query
-  );
+  const query = {
+    ...location.query,
+    project: String(event.project_id),
+  };
+  return getTransactionDetailsUrl(organization, eventSlug, event.transaction, query);
 }
 
 function generateDiscoverEventTarget(
@@ -60,10 +59,17 @@ function generateDiscoverEventTarget(
     id: event.event_id,
     project: event.project_slug,
   });
+  const newLocation = {
+    ...location,
+    query: {
+      ...location.query,
+      project: String(event.project_id),
+    },
+  };
   return eventDetailsRouteWithEventView({
     orgSlug: organization.slug,
     eventSlug,
-    eventView: EventView.fromLocation(location),
+    eventView: EventView.fromLocation(newLocation),
   });
 }
 

--- a/tests/js/spec/components/quickTrace.spec.tsx
+++ b/tests/js/spec/components/quickTrace.spec.tsx
@@ -48,10 +48,16 @@ describe('Quick Trace', function () {
     };
   }
 
-  function makeTransactionTarget(pid, eid, transaction) {
+  function makeTransactionTarget(
+    pid: string,
+    eid: string,
+    transaction: string,
+    project: string
+  ) {
+    const query = {transaction, project};
     return {
       pathname: `/organizations/${organization.slug}/performance/${pid}:${eid}/`,
-      query: {transaction},
+      query,
     };
   }
 
@@ -378,12 +384,12 @@ describe('Quick Trace', function () {
       const nodes = quickTrace.find('EventNode');
       expect(nodes.length).toEqual(6);
       [
-        makeTransactionTarget('p0', 'e0', 't0'),
-        makeTransactionTarget('p1', 'e1', 't1'),
-        makeTransactionTarget('p2', 'e2', 't2'),
+        makeTransactionTarget('p0', 'e0', 't0', '0'),
+        makeTransactionTarget('p1', 'e1', 't1', '1'),
+        makeTransactionTarget('p2', 'e2', 't2', '2'),
         undefined, // the "This Event" node has no target
-        makeTransactionTarget('p4', 'e4', 't4'),
-        makeTransactionTarget('p5', 'e5', 't5'),
+        makeTransactionTarget('p4', 'e4', 't4', '4'),
+        makeTransactionTarget('p5', 'e5', 't5', '5'),
       ].forEach((target, i) => expect(nodes.at(i).props().to).toEqual(target));
     });
 


### PR DESCRIPTION
The single event targets in the trace navigator does not update the project
correctly. As as result, any links on the new page will have the wrong project
set. This change ensures that the correct project is set when navigating.