### PR TITLE
fix(trace-view): Better error message for missing trace

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -97,6 +97,17 @@ class TraceDetailsContent extends React.Component<Props, State> {
   }
 
   renderTraceNotFound() {
+    const {meta} = this.props;
+
+    const transactions = meta?.transactions ?? 0;
+    const errors = meta?.errors ?? 0;
+
+    if (transactions === 0 && errors > 0) {
+      return (
+        <LoadingError message={t('The trace you are looking contains only errors.')} />
+      );
+    }
+
     return <LoadingError message={t('The trace you are looking for was not found.')} />;
   }
 


### PR DESCRIPTION
It is possible that a trace id has no transactions associated with it but it
does have errors. This change provides a better error message in this case over
a generic trace not found message.