### PR TITLE
feat(workflow): Track issue alert conditions, filters, actions

### DIFF
--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -34,7 +34,7 @@ import {
   IssueAlertRuleConditionTemplate,
   UnsavedIssueAlertRule,
 } from 'app/types/alerts';
-import {metric} from 'app/utils/analytics';
+import {metric, trackAnalyticsEvent} from 'app/utils/analytics';
 import {getDisplayName} from 'app/utils/environment';
 import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
 import recreateRoute from 'app/utils/recreateRoute';
@@ -425,6 +425,16 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
       set(clonedState, `rule[${type}]`, [...newTypeList, newRule]);
       return clonedState;
+    });
+
+    const {organization, project} = this.props;
+    trackAnalyticsEvent({
+      eventKey: 'edit_alert_rule.add_row',
+      eventName: 'Edit Alert Rule: Add Row',
+      organization_id: organization.id,
+      project_id: project.id,
+      type,
+      name: id,
     });
   };
 

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -11,7 +11,7 @@ import {
 
 import * as memberActionCreators from 'app/actionCreators/members';
 import ProjectsStore from 'app/stores/projectsStore';
-import {metric} from 'app/utils/analytics';
+import {metric, trackAnalyticsEvent} from 'app/utils/analytics';
 import AlertsContainer from 'app/views/alerts';
 import AlertBuilderProjectProvider from 'app/views/alerts/builder/projectProvider';
 import ProjectAlertsCreate from 'app/views/alerts/create';
@@ -113,6 +113,7 @@ describe('ProjectAlertsCreate', function () {
   afterEach(function () {
     cleanup();
     MockApiClient.clearMockResponses();
+    trackAnalyticsEvent.mockClear();
   });
 
   const createWrapper = (props = {}) => {
@@ -185,6 +186,15 @@ describe('ProjectAlertsCreate', function () {
         'A new issue is created',
       ]);
       fireEvent.click(getByLabelText('Delete Node'));
+
+      expect(trackAnalyticsEvent).toHaveBeenCalledWith({
+        eventKey: 'edit_alert_rule.add_row',
+        eventName: 'Edit Alert Rule: Add Row',
+        name: 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition',
+        organization_id: '3',
+        project_id: '2',
+        type: 'conditions',
+      });
 
       // Add a filter and remove it
       await selectEvent.select(getByText('Add optional filter...'), [


### PR DESCRIPTION
we want to track how often users are picking our new alert rule conditions. This will track all 3 dropdowns from the screenshot below.

- `type` - Which of the 3 dropdowns eg. conditions, filters, actions
- `name` - What was selected eg. `sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition`

<img width="1036" alt="Screen Shot 2021-07-21 at 2 19 32 PM" src="https://user-images.githubusercontent.com/1400464/126562671-90f36f76-b8be-44b5-8482-360c03a7a01a.png">



