### PR TITLE
fix(workflow): Set isActive on alert rule display dropdown

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -310,6 +310,9 @@ export default class DetailsBody extends React.Component<Props> {
                               <DropdownItem
                                 key={value}
                                 eventKey={value}
+                                isActive={
+                                  !timePeriod.custom && timePeriod.period === value
+                                }
                                 onSelect={this.props.handleTimePeriodChange}
                               >
                                 {label}


### PR DESCRIPTION
Adds an active state to the display dropdown

<img width="1048" alt="Screen Shot 2021-07-21 at 4 08 49 PM" src="https://user-images.githubusercontent.com/1400464/126571266-2234542e-b93b-4bcc-8cca-3c9282c7b2b0.png">
