### PR TITLE
feat(search): Enable default search elements

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -69,11 +69,6 @@ const ACTION_OVERFLOW_WIDTH = 400;
  */
 const ACTION_OVERFLOW_STEPS = 75;
 
-/**
- * Is the SearchItem a default item
- */
-const isDefaultDropdownItem = (item: SearchItem) => item?.type === ItemType.DEFAULT;
-
 const makeQueryState = (query: string) => ({
   query,
   parsedQuery: parseSearch(query),
@@ -560,7 +555,7 @@ class SmartSearchBar extends React.Component<Props, State> {
         childrenIndex !== undefined &&
         searchGroups[groupIndex].children[childrenIndex];
 
-      if (item && !isDefaultDropdownItem(item)) {
+      if (item) {
         this.onAutoComplete(item.value, item);
       }
       return;

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -32,13 +32,13 @@ const SEARCH_ITEMS: SearchItem[] = [
   {
     title: t('Time or Count'),
     desc: 'firstSeen, lastSeen, event.timestamp, timesSeen',
-    value: '',
+    value: 'firstSeen:',
     type: ItemType.DEFAULT,
   },
   {
     title: t('Assigned'),
     desc: 'assigned, assigned_or_suggested:[me|[me, none]|user@example.com|#team-example]',
-    value: '',
+    value: 'assigned:',
     type: ItemType.DEFAULT,
   },
   {


### PR DESCRIPTION
Some default search elements on issue search had no value. We will default to using the first value shown in the description. Also, enabling pressing enter on these default search items.

Default search items in question:
![image](https://user-images.githubusercontent.com/9372512/126574534-8ce5534e-d735-4f43-8f27-398df1824844.png)
