### PR TITLE
fix(scim): remove errant space at beginning of token

### DIFF
--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -65,7 +65,7 @@
       </div>
       <div class="box-content with-padding">
         <b>Auth Token:</b>
-        <pre>{% if provider_name != "Active Directory" %}Bearer{% endif %} {{ scim_api_token }}</pre>
+        <pre>{% if provider_name != "Active Directory" %}Bearer {% endif %}{{ scim_api_token }}</pre>
         <b>SCIM URL:</b>
         <pre>{{ scim_url }}</pre>
         <p>See provider specific SCIM documentation <a href="#TODO">here</a>.</p>


### PR DESCRIPTION
- can accidentally grab an extra space while copying the token on azure orgs, this fixes the formatting issue.