### PR TITLE
fix(web-vitals): Remove ms unit for CLS tooltip

### DIFF
--- a/static/app/views/performance/vitalDetail/vitalPercents.tsx
+++ b/static/app/views/performance/vitalDetail/vitalPercents.tsx
@@ -19,20 +19,21 @@ type Props = {
   showVitalPercentNames?: boolean;
 };
 
-function getVitalStateText(vital, vitalState) {
+function getVitalStateText(vital: WebVital | WebVital[], vitalState) {
+  const unit = !Array.isArray(vital) && vital !== WebVital.CLS ? 'ms' : '';
   switch (vitalState) {
     case VitalState.POOR:
       return Array.isArray(vital)
         ? t('Poor')
-        : tct('Poor: >[threshold]ms', {threshold: webVitalPoor[vital]});
+        : tct('Poor: >[threshold][unit]', {threshold: webVitalPoor[vital], unit});
     case VitalState.MEH:
       return Array.isArray(vital)
         ? t('Meh')
-        : tct('Meh: >[threshold]ms', {threshold: webVitalMeh[vital]});
+        : tct('Meh: >[threshold][unit]', {threshold: webVitalMeh[vital], unit});
     case VitalState.GOOD:
       return Array.isArray(vital)
         ? t('Good')
-        : tct('Good: <[threshold]ms', {threshold: webVitalMeh[vital]});
+        : tct('Good: <[threshold][unit]', {threshold: webVitalMeh[vital], unit});
     default:
       return null;
   }


### PR DESCRIPTION
CLS is an unitless quantity, so we should not be using ms in the tooltip for it.

Before:

![image](https://user-images.githubusercontent.com/18689448/126582272-34a70d91-67a3-4c45-8d71-a3fa6f737618.png)

After:

![image](https://user-images.githubusercontent.com/18689448/126582285-e8e981b4-3f88-446f-be1e-5f1c4a2386f2.png)

Not sure if I'm abusing `tct`, lmk if there is a better way to do things. Also wanted to write a test, but wasn't sure what the state was with enzyme and react-testing-library (if you point me in the right direction I can quickly add one).