### PR TITLE
perf(api): Improve performance on `OrganizationActivityEndpoint`

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -292,6 +292,15 @@ class Endpoint(APIView):
 
         return per_page
 
+    def get_cursor_from_request(self, request, cursor_cls=Cursor):
+        if not request.GET.get(self.cursor_name):
+            return
+
+        try:
+            return cursor_cls.from_string(request.GET.get(self.cursor_name))
+        except ValueError:
+            raise ParseError(detail="Invalid cursor parameter.")
+
     def paginate(
         self,
         request,
@@ -307,12 +316,7 @@ class Endpoint(APIView):
 
         per_page = self.get_per_page(request, default_per_page, max_per_page)
 
-        input_cursor = None
-        if request.GET.get(self.cursor_name):
-            try:
-                input_cursor = cursor_cls.from_string(request.GET.get(self.cursor_name))
-            except ValueError:
-                raise ParseError(detail="Invalid cursor parameter.")
+        input_cursor = self.get_cursor_from_request(request, cursor_cls=cursor_cls)
 
         if not paginator:
             paginator = paginator_cls(**paginator_kwargs)

--- a/src/sentry/api/endpoints/organization_activity.py
+++ b/src/sentry/api/endpoints/organization_activity.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.paginator import DateTimePaginator
@@ -7,22 +9,51 @@ from sentry.models import Activity, OrganizationMemberTeam, Project
 
 class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
     def get(self, request, organization, member):
+        project_ids = list(
+            Project.objects.filter(
+                organization=organization,
+                teams__in=OrganizationMemberTeam.objects.filter(organizationmember=member).values(
+                    "team"
+                ),
+            ).values_list("id", flat=True)
+        )
         # There is an activity record created for both sides of the unmerge
         # operation, so we only need to include one of them here to avoid
         # showing the same entry twice.
-        queryset = (
-            Activity.objects.filter(
-                project__in=list(
-                    Project.objects.filter(
-                        organization=organization,
-                        teams__in=OrganizationMemberTeam.objects.filter(
-                            organizationmember=member
-                        ).values("team"),
-                    ).values_list("id", flat=True)
-                )
-            )
-            .exclude(type=Activity.UNMERGE_SOURCE)
-            .select_related("project", "group", "user")
+        base_qs = Activity.objects.exclude(type=Activity.UNMERGE_SOURCE).values_list(
+            "id", flat=True
+        )
+
+        # To make this query efficient, we have to hammer it into a weird format. This table is
+        # extremely large and if we are making a query across many projects, in a lot of cases
+        # Postgres decides that the best query plan is to iterate backwards on the datetime index.
+        # This means it does something close to a table scan to get the results it wants - this can
+        # be the case even for orgs with less than a page of activity rows, and often results in
+        # queries that take > 30s, which get killed by stomper.
+        # To convince Postgres to use the index on `(project_id, datetime)`, it basically needs to
+        # see queries that filter on a single project id and then order by datetime. So we replicate
+        # the query for every project and UNION ALL them together to get the candidate set of rows.
+        # Then we sort these and return the final result. Convoluted, but it improves the query a
+        # lot.
+        # To make this work well with pagination, we have to also apply the pagination queries to
+        # the subqueries.
+        cursor = self.get_cursor_from_request(request)
+        paginator = DateTimePaginator(base_qs, order_by="-datetime")
+        if cursor is not None and cursor.value:
+            cursor_value = paginator.value_from_cursor(cursor)
+        else:
+            cursor_value = 0
+        base_qs = paginator._build_queryset(cursor_value, False)
+
+        union_qs = reduce(
+            lambda qs1, qs2: qs1.union(qs2, all=True),
+            [base_qs.filter(project_id=project)[: paginator.max_limit] for project in project_ids],
+        )
+
+        # We do `select_related` here to make the unions less heavy. This way we only join these
+        # table for the rows we actually want.
+        queryset = Activity.objects.filter(id__in=union_qs[: paginator.max_limit]).select_related(
+            "project", "group", "user"
         )
 
         return self.paginate(

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -44,7 +44,7 @@ class BasePaginator:
     def _is_asc(self, is_prev):
         return (self.desc and is_prev) or not (self.desc or is_prev)
 
-    def _build_queryset(self, value, is_prev):
+    def build_queryset(self, value, is_prev):
         queryset = self.queryset
 
         # "asc" controls whether or not we need to change the ORDER BY to
@@ -114,7 +114,7 @@ class BasePaginator:
         else:
             cursor_value = 0
 
-        queryset = self._build_queryset(cursor_value, cursor.is_prev)
+        queryset = self.build_queryset(cursor_value, cursor.is_prev)
 
         # TODO(dcramer): this does not yet work correctly for ``is_prev`` when
         # the key is not unique

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -427,6 +427,14 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
 
         return response
 
+    def get_cursor_headers(self, response):
+        return [
+            link["cursor"]
+            for link in requests.utils.parse_header_links(
+                response.get("link").rstrip(">").replace(">,<", ",<")
+            )
+        ]
+
 
 class TwoFactorAPITestCase(APITestCase):
     @fixture

--- a/tests/sentry/api/endpoints/test_organization_activity.py
+++ b/tests/sentry/api/endpoints/test_organization_activity.py
@@ -1,5 +1,6 @@
 from sentry.models import Activity
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class OrganizationActivityTest(APITestCase):
@@ -22,4 +23,45 @@ class OrganizationActivityTest(APITestCase):
         )
 
         response = self.get_success_response(org.slug)
+        assert [r["id"] for r in response.data] == [str(activity.id)]
+
+    def test_paginate(self):
+        group = self.group
+        org = group.organization
+        project_2 = self.create_project()
+        group_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=1)),
+                "tags": {"group_id": "group-2"},
+            },
+            project_id=project_2.id,
+        ).group
+
+        activity = Activity.objects.create(
+            group=group,
+            project=group.project,
+            type=Activity.NOTE,
+            user=self.user,
+            data={"text": "hello world"},
+        )
+        activity_2 = Activity.objects.create(
+            group=group_2,
+            project=group_2.project,
+            type=Activity.NOTE,
+            user=self.user,
+            data={"text": "hello world 2"},
+        )
+        activity_3 = Activity.objects.create(
+            group=group,
+            project=group.project,
+            type=Activity.NOTE,
+            user=self.user,
+            data={"text": "hello world 3"},
+        )
+
+        response = self.get_success_response(org.slug, per_page=2)
+        assert [r["id"] for r in response.data] == [str(activity_3.id), str(activity_2.id)]
+        next_cursor = self.get_cursor_headers(response)[1]
+
+        response = self.get_success_response(org.slug, per_page=2, cursor=next_cursor)
         assert [r["id"] for r in response.data] == [str(activity.id)]


### PR DESCRIPTION
We see a lot of queries timing out on this endpoint. Some of the orgs that are timing out here have
less than 100 rows across their projects - Postgres is just producing a generally bad query plan
here. It's also made worse by us having no org_id to filter on.

Most of the time, once a certain number of projects are included in the query, postgres decides to
iterate backwards on the datetime index to find the candidate rows. For active orgs this might work
ok, but frequently it ends up behaving poorly and making extremely slow queries.

We have an index on `project_id, datetime` which seems perfect for this, but Postgres doesn't seem
to be able to make use of it as is. It does use it when we make queries with a single project
though. So as a work around, I'm changing this endpoint to do a UNION ALL for each project, limited
to the page size and filtered by cursor. Then we sort/limit the result of the unions to get the
final result.

This seems to perform pretty well - I tested it on an org with 50 projects and it was fast. Postgres
seems to skip a bunch of the subqueries when it has stats that those projects have no rows as well.

Fixes SENTRY-N5B