### PR TITLE
feat(grouping): Mark mobile strategy as "latest" to allow upgrading

### DIFF
--- a/src/sentry/api/endpoints/project_grouping_configs.py
+++ b/src/sentry/api/endpoints/project_grouping_configs.py
@@ -1,0 +1,30 @@
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.grouping.strategies.configurations import CONFIGURATIONS
+
+
+class ProjectGroupingConfigsEndpoint(ProjectEndpoint):
+    """Retrieve available grouping configs with project-specific information
+
+    See GroupingConfigsEndpoint
+    """
+
+    def get(self, request, project):
+
+        configs = [
+            config.as_dict() for config in sorted(CONFIGURATIONS.values(), key=lambda x: x.id)
+        ]
+        latest = next(config["id"] for config in configs if config["latest"])
+
+        # As long as newstyle:2019-10-29 is the global "latest", allow orgs to upgrade
+        # to mobile:2021-02-12 if the appropriate feature flag is on:
+        if latest == "newstyle:2019-10-29" and features.has(
+            "organizations:grouping-tree-ui", project.organization, actor=request.user
+        ):
+            for config in configs:
+                config["latest"] = config["id"] == "mobile:2021-02-12"
+
+        return Response(serialize(configs))

--- a/src/sentry/api/endpoints/project_grouping_configs.py
+++ b/src/sentry/api/endpoints/project_grouping_configs.py
@@ -4,6 +4,7 @@ from sentry import features
 from sentry.api.bases import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
+from sentry.projectoptions.defaults import BETA_GROUPING_CONFIG, DEFAULT_GROUPING_CONFIG
 
 
 class ProjectGroupingConfigsEndpoint(ProjectEndpoint):
@@ -21,10 +22,10 @@ class ProjectGroupingConfigsEndpoint(ProjectEndpoint):
 
         # As long as newstyle:2019-10-29 is the global "latest", allow orgs to upgrade
         # to mobile:2021-02-12 if the appropriate feature flag is on:
-        if latest == "newstyle:2019-10-29" and features.has(
+        if latest == DEFAULT_GROUPING_CONFIG and features.has(
             "organizations:grouping-tree-ui", project.organization, actor=request.user
         ):
             for config in configs:
-                config["latest"] = config["id"] == "mobile:2021-02-12"
+                config["latest"] = config["id"] == BETA_GROUPING_CONFIG
 
         return Response(serialize(configs))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
+from sentry.api.endpoints.project_grouping_configs import ProjectGroupingConfigsEndpoint
 from sentry.api.endpoints.project_transaction_threshold_override import (
     ProjectTransactionThresholdOverrideEndpoint,
 )
@@ -1888,6 +1889,12 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/repo-path-parsing/$",
                     ProjectRepoPathParsingEndpoint.as_view(),
                     name="sentry-api-0-project-repo-path-parsing",
+                ),
+                # Grouping configs
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/grouping-configs/$",
+                    ProjectGroupingConfigsEndpoint.as_view(),
+                    name="sentry-api-0-project-grouping-configs",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/$",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -14,6 +14,7 @@ LATEST_EPOCH = 7
 # epoch instead.
 LEGACY_GROUPING_CONFIG = "legacy:2019-03-12"
 DEFAULT_GROUPING_CONFIG = "newstyle:2019-10-29"
+BETA_GROUPING_CONFIG = "mobile:2021-02-12"
 register(
     key="sentry:grouping_config",
     epoch_defaults={

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -25,7 +25,7 @@ type State = {
   groupingConfigs: EventGroupingConfig[] | null;
 } & AsyncView['state'];
 
-class ProjectDebugSymbols extends AsyncView<Props, State> {
+class ProjectIssueGrouping extends AsyncView<Props, State> {
   getTitle() {
     const {projectId} = this.props.params;
 
@@ -40,7 +40,8 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    return [['groupingConfigs', '/grouping-configs/']];
+    const {projectId, orgId} = this.props.params;
+    return [['groupingConfigs', `/projects/${orgId}/${projectId}/grouping-configs/`]];
   }
 
   handleSubmit = (response: Project) => {
@@ -125,4 +126,4 @@ class ProjectDebugSymbols extends AsyncView<Props, State> {
   }
 }
 
-export default ProjectDebugSymbols;
+export default ProjectIssueGrouping;

--- a/tests/sentry/api/endpoints/test_project_grouping_configs.py
+++ b/tests/sentry/api/endpoints/test_project_grouping_configs.py
@@ -1,0 +1,42 @@
+from unittest import mock
+
+from django.urls import reverse
+
+from sentry.models import ApiToken
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import with_feature
+
+
+class ProjectGroupingConfigsPermissionsTest(APITestCase):
+
+    endpoint = "sentry-api-0-project-grouping-configs"
+
+    def test_permissions(self):
+        token = ApiToken.objects.create(user=self.user, scope_list=[])
+        url = reverse(self.endpoint, args=(self.project.organization.slug, self.project.slug))
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json")
+
+        assert response.status_code == 403
+
+
+class ProjectGroupingConfigsTest(APITestCase):
+
+    endpoint = "sentry-api-0-project-grouping-configs"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+
+    @with_feature({"organizations:grouping-tree-ui": False})
+    @mock.patch("sentry.grouping.strategies.base.projectoptions.LATEST_EPOCH", 7)
+    def test_feature_flag_off(self):
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        for config in response.data:
+            assert config["latest"] == (config["id"] == "newstyle:2019-10-29")
+
+    @with_feature({"organizations:grouping-tree-ui": True})
+    @mock.patch("sentry.grouping.strategies.base.projectoptions.LATEST_EPOCH", 7)
+    def test_feature_flag_on(self):
+        response = self.get_success_response(self.project.organization.slug, self.project.slug)
+        for config in response.data:
+            assert config["latest"] == (config["id"] == "mobile:2021-02-12")


### PR DESCRIPTION
We only allow upgrading the grouping configuration of a project to the strategy marked "latest".

"latest" should now be `mobile`, but _only_ for organizations which have the appropriate feature flag turned on, so we need a project-specific (or at least organization-specific) endpoint to load grouping configs.

https://getsentry.atlassian.net/browse/INGEST-177