### PR TITLE
fix(performance): Value unpack error in facets endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -188,7 +188,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
                 )
 
                 if not results:
-                    return {"data": []}, []
+                    return {"data": []}, top_tags
 
                 for row in results["data"]:
                     row["tags_value"] = tagstore.get_tag_value_label(

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -174,7 +174,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
                 )
 
                 if not top_tags:
-                    return {"data": []}
+                    return {"data": []}, []
 
                 results = query_facet_performance_key_histogram(
                     top_tags=top_tags,
@@ -188,7 +188,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
                 )
 
                 if not results:
-                    return {"data": []}
+                    return {"data": []}, []
 
                 for row in results["data"]:
                     row["tags_value"] = tagstore.get_tag_value_label(

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
@@ -190,6 +190,28 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert tag_data[0]["tags_value"] == "red"
         assert tag_data[1]["tags_value"] == "blue"
 
+    def test_no_top_tags(self):
+        request = {
+            "aggregateColumn": "transaction.duration",
+            "sort": "-frequency",
+            "per_page": 5,
+            "statsPeriod": "14d",
+            "tagKeyLimit": 10,
+            "numBucketsPerKey": 10,
+            "tagKey": "color",
+            "query": "(color:teal or color:oak)",
+        }
+
+        data_response = self.do_request(
+            request, feature_list=self.feature_list + ("organizations:performance-tag-page",)
+        )
+
+        histogram_data = data_response.data["histogram"]["data"]
+        assert histogram_data == []
+
+        tag_data = data_response.data["tags"]["data"]
+        assert tag_data == []
+
     def test_tag_key_histogram_buckets(self):
         request = {
             "aggregateColumn": "transaction.duration",


### PR DESCRIPTION
The data_fn() was returning a mismatched number of
values at different return statements which caused
a value unpack error.

Fixes SENTRY-RM4