### PR TITLE
fix(mail): Handle UnknownTimeZoneError when fetching User timezone

### DIFF
--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -62,14 +62,17 @@ class AlertRuleNotification(BaseNotification):
     def get_user_context(
         self, user: User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
-        # AlertRuleNotification is shared among both email and slack notifications, and in slack
-        # notifications, the `user` arg could be of type `Team` which is why we need this check
-        if isinstance(user, User):
-            return {
-                "timezone": pytz.timezone(
-                    UserOption.objects.get_value(user=user, key="timezone", default="UTC")
-                )
-            }
+        try:
+            # AlertRuleNotification is shared among both email and slack notifications, and in slack
+            # notifications, the `user` arg could be of type `Team` which is why we need this check
+            if isinstance(user, User):
+                return {
+                    "timezone": pytz.timezone(
+                        UserOption.objects.get_value(user=user, key="timezone", default="UTC")
+                    )
+                }
+        except pytz.UnknownTimeZoneError:
+            ...
         return super().get_user_context(user, extra_context)
 
     def get_context(self) -> MutableMapping[str, Any]:


### PR DESCRIPTION
This PR adds error handling in case an incorrect timezone is returned by `UserOption`