### PR TITLE
fix(ui): Tracing missing pointing to the wrong documentation

### DIFF
--- a/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
@@ -117,7 +117,7 @@ class IssueQuickTrace extends Component<Props, State> {
             {tct('The [type] for this error cannot be found. [link]', {
               type: type === 'missing' ? t('transaction') : t('trace'),
               link: (
-                <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#troubleshooting">
+                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting">
                   {t('Read the docs to understand why.')}
                 </ExternalLink>
               ),


### PR DESCRIPTION
The old link redirected for me, thus, it worked in order to get me to the documentation (except it didn't take me to the troubleshooting section):
https://docs.sentry.io/product/sentry-basics/tracing/trace-view/  <-- Redirected to this
vs
https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting <-- Where I assume we want the user to get to