### PR TITLE
fix(gitlab): Handle JSONDecodeError

### DIFF
--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -93,6 +93,9 @@ class GitlabIdentityProvider(OAuth2Provider):
             body = safe_urlread(req)
             payload = json.loads(body)
         except Exception as e:
+            # JSONDecodeError's will happen when we get a 301
+            # from GitLab, and won't have the `code` attribute
+            # we use the req.status_code instead in that case
             error_status = getattr(e, "code", req.status_code)
             self.logger(
                 "gitlab.refresh-identity-failure",

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -97,7 +97,7 @@ class GitlabIdentityProvider(OAuth2Provider):
                 "gitlab.refresh-identity-failure",
                 extra={
                     "identity_id": identity.id,
-                    "error_status": e.code,
+                    "error_status": req.status_code,
                     "error_message": str(e),
                 },
             )

--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -93,11 +93,12 @@ class GitlabIdentityProvider(OAuth2Provider):
             body = safe_urlread(req)
             payload = json.loads(body)
         except Exception as e:
+            error_status = getattr(e, "code", req.status_code)
             self.logger(
                 "gitlab.refresh-identity-failure",
                 extra={
                     "identity_id": identity.id,
-                    "error_status": req.status_code,
+                    "error_status": error_status,
                     "error_message": str(e),
                 },
             )


### PR DESCRIPTION
We are getting a `JSONDecodeError` when gitlab responds back with a `301` on refreshing identities because we attempt to get the status code from the decoded json when there isn't any. Let's just use the response code from the `req` so that we actually can log the refresh failures (currently we aren't logging it at all)


FIXES SENTRY-RKE