### PR TITLE
fix(scim): no-op if member-team already exists

### DIFF
--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -118,6 +118,10 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             member = OrganizationMember.objects.get(
                 organization=team.organization, id=member["value"]
             )
+            if OrganizationMemberTeam.objects.filter(team=team, organizationmember=member).exists():
+                # if a member already belongs to a team, do nothing
+                continue
+
             with transaction.atomic():
                 omt = OrganizationMemberTeam.objects.create(team=team, organizationmember=member)
                 self.create_audit_entry(

--- a/tests/sentry/api/endpoints/test_scim.py
+++ b/tests/sentry/api/endpoints/test_scim.py
@@ -817,3 +817,39 @@ class SCIMGroupTests(SCIMTestCase):
             "members": None,
             "meta": {"resourceType": "Group"},
         }
+
+    def test_add_member_already_in_team(self):
+        member1 = self.create_member(user=self.create_user(), organization=self.organization)
+        url = reverse(
+            "sentry-api-0-organization-scim-team-details",
+            args=[self.organization.slug, self.team.id],
+        )
+        response = self.client.patch(
+            url,
+            response=self.client.patch(
+                url,
+                {
+                    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+                    "Operations": [
+                        {
+                            "op": "add",
+                            "path": "members",
+                            "value": [
+                                {
+                                    "value": member1.id,
+                                    "display": member1.email,
+                                }
+                            ],
+                        },
+                    ],
+                },
+            ),
+        )
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": str(self.team.id),
+            "displayName": self.team.name,
+            "members": None,
+            "meta": {"resourceType": "Group"},
+        }


### PR DESCRIPTION
right now if SCIM tries to add a member<>team relationship that already exists, it errors out. This change instead makes it a no-op, since it will be quite common when syncing for a member<>team to already exist.