### PR TITLE
fix(github): Project selector properly drops down on clicking the name

### DIFF
--- a/static/app/views/settings/components/forms/sentryProjectSelectorField.tsx
+++ b/static/app/views/settings/components/forms/sentryProjectSelectorField.tsx
@@ -82,7 +82,7 @@ class RenderField extends React.Component<RenderProps> {
         options={projectOptions}
         components={{
           Option: customOptionProject,
-          ValueContainer: customValueContainer,
+          SingleValue: customValueContainer,
         }}
         {...rest}
         onChange={this.handleChange.bind(this, onBlur, onChange)}


### PR DESCRIPTION
Before, changing the project on an existing code mapping could only be done by clicking on the triangle to show to drop down. Changing the component from ValueContainer to SingleValue fixes this.

Original bug: 

https://user-images.githubusercontent.com/85517732/126684818-1c43f826-5bd7-489b-b870-2629a423f6a6.mov

Fixes API-1910