### PR TITLE
feat(codeowners): Parse & convert CODEOWNERS into codeowners type IssueOwners

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -411,17 +411,12 @@ def convert_codeowners_syntax(codeowners, associations, code_mapping):
             continue
 
         path, *code_owners = (x.strip() for x in rule.split())
-        # Escape invalid rules
-        # Check if rule has whitespace
-        # Check if rule has '#' not as first character
-        # Check if rule contains '!'
-        if re.search(r"[\s!#]", path):
-            continue
-
-        # Check if rule has '[' and ']'
-        if re.search(r"^([^[^\s]*)\[([^]^\s]*)\][^\s]*$", path):
-            # if rule has whitespace, it will pass.
-            # we escape for that in the beginning
+        # Escape invalid paths
+        # Check if path has whitespace
+        # Check if path has '#' not as first character
+        # Check if path contains '!'
+        # Check if path has a '[' followed by a ']'
+        if re.search(r"(\[([^]^\s]*)\])|[\s!#]", path):
             continue
 
         sentry_assignees = []

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -411,7 +411,7 @@ def convert_codeowners_syntax(codeowners, associations, code_mapping):
             continue
 
         path, *code_owners = (x.strip() for x in rule.split())
-        # Escape invalid paths
+        # Escape invalid paths https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#syntax-exceptions
         # Check if path has whitespace
         # Check if path has '#' not as first character
         # Check if path contains '!'

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -119,7 +119,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert response.data["raw"] == "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem"
         assert response.data["codeMappingId"] == str(self.code_mapping.id)
         assert response.data["provider"] == "github"
-        assert response.data["ownershipSyntax"] == "path:docs/* admin@sentry.io #tiger-team\n"
+        assert response.data["ownershipSyntax"] == "codeowners:docs/* admin@sentry.io #tiger-team\n"
 
         errors = response.data["errors"]
         assert errors["missing_external_teams"] == []
@@ -246,7 +246,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             "$version": 1,
             "rules": [
                 {
-                    "matcher": {"pattern": "docs/*", "type": "path"},
+                    "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
                         {"identifier": self.user.email, "type": "user"},
                         {"identifier": self.team.slug, "type": "team"},
@@ -266,7 +266,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             "$version": 1,
             "rules": [
                 {
-                    "matcher": {"pattern": "docs/*", "type": "path"},
+                    "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
                         {"identifier": self.user.email, "type": "user"},
                         {"identifier": self.team.slug, "type": "team"},
@@ -286,7 +286,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             "$version": 1,
             "rules": [
                 {
-                    "matcher": {"pattern": "docs/*", "type": "path"},
+                    "matcher": {"pattern": "docs/*", "type": "codeowners"},
                     "owners": [
                         {"identifier": self.user.email, "type": "user"},
                         {"identifier": self.team.slug, "type": "team"},
@@ -308,7 +308,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert response.data["raw"] == "docs/*    @NisanthanNanthakumar   user2@sentry.io"
         assert response.data["codeMappingId"] == str(self.code_mapping.id)
         assert response.data["provider"] == "github"
-        assert response.data["ownershipSyntax"] == "path:docs/* admin@sentry.io\n"
+        assert response.data["ownershipSyntax"] == "codeowners:docs/* admin@sentry.io\n"
 
         errors = response.data["errors"]
         assert errors["missing_external_teams"] == []

--- a/tests/sentry/tasks/test_code_owners.py
+++ b/tests/sentry/tasks/test_code_owners.py
@@ -44,7 +44,7 @@ class CodeOwnersTest(TestCase):
             "$version": 1,
             "rules": [
                 {
-                    "matcher": {"type": "path", "pattern": "docs/*"},
+                    "matcher": {"type": "codeowners", "pattern": "docs/*"},
                     "owners": [
                         {"type": "team", "identifier": "tiger-team"},
                     ],


### PR DESCRIPTION
## Objective
We now have a `codeowners` Matcher type for Code Owner rules. We need to update our convert_codeowners_syntax function to use the `codeowner` type instead of `path` type. This function will also parse out invalid rules.