### PR TITLE
fix(api): Fix error in OrganizationActivityEndpoint when user has access to no projects

### DIFF
--- a/src/sentry/api/endpoints/organization_activity.py
+++ b/src/sentry/api/endpoints/organization_activity.py
@@ -46,10 +46,15 @@ class OrganizationActivityEndpoint(OrganizationMemberEndpoint, EnvironmentMixin)
             ).values_list("id", flat=True)
         )
 
-        union_qs = reduce(
-            lambda qs1, qs2: qs1.union(qs2, all=True),
-            [base_qs.filter(project_id=project)[: paginator.max_limit] for project in project_ids],
-        )
+        union_qs = Activity.objects.none()
+        if project_ids:
+            union_qs = reduce(
+                lambda qs1, qs2: qs1.union(qs2, all=True),
+                [
+                    base_qs.filter(project_id=project)[: paginator.max_limit]
+                    for project in project_ids
+                ],
+            )
 
         # We do `select_related` here to make the unions less heavy. This way we only join these
         # table for the rows we actually want.

--- a/tests/sentry/api/endpoints/test_organization_activity.py
+++ b/tests/sentry/api/endpoints/test_organization_activity.py
@@ -10,6 +10,10 @@ class OrganizationActivityTest(APITestCase):
         super().setUp()
         self.login_as(self.user)
 
+    def test_empty(self):
+        response = self.get_success_response(self.organization.slug)
+        assert response.data == []
+
     def test_simple(self):
         group = self.group
         org = group.organization


### PR DESCRIPTION
`reduce` ends up with an error if we have no project ids

Fixes SENTRY-RNW