### PR TITLE
feat(discover): snql support for no arg functions

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2178,6 +2178,42 @@ class QueryFields(QueryBase):
                     ),
                     default_result_type="integer",
                 ),
+                SnQLFunction(
+                    "count",
+                    snql_aggregate=lambda _, alias: Function(
+                        "count",
+                        [],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "last_seen",
+                    snql_aggregate=lambda _, alias: Function(
+                        "max",
+                        [self.column("timestamp")],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "latest_event",
+                    snql_aggregate=lambda _, alias: Function(
+                        "argMax",
+                        [self.column("id"), self.column("timestamp")],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
+                SnQLFunction(
+                    "failure_rate",
+                    snql_aggregate=lambda _, alias: Function(
+                        "failure_rate",
+                        [],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                ),
                 # TODO: implement these
                 SnQLFunction("percentile", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("p50", snql_aggregate=self._resolve_unimplemented_function),
@@ -2187,18 +2223,14 @@ class QueryFields(QueryBase):
                 SnQLFunction("p100", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("eps", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("epm", snql_aggregate=self._resolve_unimplemented_function),
-                SnQLFunction("last_seen", snql_aggregate=self._resolve_unimplemented_function),
-                SnQLFunction("latest_event", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("apdex", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction(
                     "count_miserable", snql_aggregate=self._resolve_unimplemented_function
                 ),
                 SnQLFunction("user_misery", snql_aggregate=self._resolve_unimplemented_function),
-                SnQLFunction("failure_rate", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("array_join", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("histogram", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("count_unique", snql_aggregate=self._resolve_unimplemented_function),
-                SnQLFunction("count", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("count_at_least", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("min", snql_aggregate=self._resolve_unimplemented_function),
                 SnQLFunction("max", snql_aggregate=self._resolve_unimplemented_function),

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2194,7 +2194,8 @@ class QueryFields(QueryBase):
                         [self.column("timestamp")],
                         alias,
                     ),
-                    default_result_type="integer",
+                    default_result_type="date",
+                    redundant_grouping=True,
                 ),
                 SnQLFunction(
                     "latest_event",
@@ -2203,7 +2204,7 @@ class QueryFields(QueryBase):
                         [self.column("id"), self.column("timestamp")],
                         alias,
                     ),
-                    default_result_type="integer",
+                    default_result_type="string",
                 ),
                 SnQLFunction(
                     "failure_rate",
@@ -2212,7 +2213,7 @@ class QueryFields(QueryBase):
                         [],
                         alias,
                     ),
-                    default_result_type="integer",
+                    default_result_type="percentage",
                 ),
                 # TODO: implement these
                 SnQLFunction("percentile", snql_aggregate=self._resolve_unimplemented_function),

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -569,6 +569,162 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 assert data[0]["failure_count"] == 2
                 assert data[1]["failure_count"] == 1
 
+    def test_count(self):
+        project = self.create_project()
+
+        for i in range(6):
+            data = load_data("transaction", timestamp=before_now(minutes=5))
+            data["transaction"] = "/count/6"
+            self.store_event(data, project_id=project.id)
+        for i in range(8):
+            data = load_data("transaction", timestamp=before_now(minutes=5))
+            data["transaction"] = "/count/8"
+            self.store_event(data, project_id=project.id)
+
+        queries = [
+            ("", 2, (6, 8), True),
+            ("count():>6", 2, (6, 8), False),
+            ("count():>6", 1, (8,), True),
+        ]
+
+        for query, expected_length, expected_counts, use_aggregate_conditions in queries:
+            for query_fn in [discover.query, discover.wip_snql_query]:
+                result = query_fn(
+                    selected_columns=["transaction", "count()"],
+                    query=query,
+                    orderby="transaction",
+                    params={
+                        "start": before_now(minutes=10),
+                        "end": before_now(minutes=2),
+                        "project_id": [project.id],
+                    },
+                    use_aggregate_conditions=use_aggregate_conditions,
+                )
+                data = result["data"]
+
+                assert len(data) == expected_length
+                for index, count in enumerate(data):
+                    assert count["count"] == expected_counts[index]
+
+    def test_last_seen(self):
+        project = self.create_project()
+
+        expected_timestamp = before_now(minutes=3)
+        string_condition_timestamp = before_now(minutes=4).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+
+        data = load_data("transaction", timestamp=expected_timestamp)
+        data["transaction"] = "/last_seen"
+        self.store_event(data, project_id=project.id)
+
+        for i in range(6):
+            data = load_data("transaction", timestamp=before_now(minutes=i + 4))
+            data["transaction"] = "/last_seen"
+            self.store_event(data, project_id=project.id)
+
+        queries = [
+            ("", 1, True),
+            (f"last_seen():>{string_condition_timestamp}", 1, True),
+            ("last_seen():>0", 1, False),
+        ]
+
+        for query, expected_length, use_aggregate_conditions in queries:
+            for query_fn in [discover.query, discover.wip_snql_query]:
+                result = query_fn(
+                    selected_columns=["transaction", "last_seen()"],
+                    query=query,
+                    orderby="transaction",
+                    params={
+                        "start": before_now(minutes=10),
+                        "end": before_now(minutes=2),
+                        "project_id": [project.id],
+                    },
+                    use_aggregate_conditions=use_aggregate_conditions,
+                )
+                data = result["data"]
+
+                assert len(data) == expected_length
+                assert data[0]["last_seen"] == expected_timestamp.strftime(
+                    "%Y-%m-%dT%H:%M:%S+00:00"
+                )
+
+    def test_latest_event(self):
+        project = self.create_project()
+
+        expected_timestamp = before_now(minutes=3)
+        data = load_data("transaction", timestamp=expected_timestamp)
+        data["transaction"] = "/latest_event"
+        stored_event = self.store_event(data, project_id=project.id)
+
+        for i in range(6):
+            data = load_data("transaction", timestamp=before_now(minutes=i + 4))
+            data["transaction"] = "/latest_event"
+            self.store_event(data, project_id=project.id)
+
+        for query_fn in [discover.query, discover.wip_snql_query]:
+            result = query_fn(
+                selected_columns=["transaction", "latest_event()"],
+                query="",
+                orderby="transaction",
+                params={
+                    "start": before_now(minutes=10),
+                    "end": before_now(minutes=2),
+                    "project_id": [project.id],
+                },
+                use_aggregate_conditions=False,
+            )
+            data = result["data"]
+
+            assert len(data) == 1
+            assert data[0]["latest_event"] == stored_event.event_id
+
+    def test_failure_rate(self):
+        project = self.create_project()
+
+        for i in range(6):
+            data = load_data("transaction", timestamp=before_now(minutes=5))
+            data["transaction"] = "/failure_rate/over"
+            data["contexts"]["trace"]["status"] = "unauthenticated"
+            self.store_event(data, project_id=project.id)
+        for i in range(4):
+            data = load_data("transaction", timestamp=before_now(minutes=5))
+            data["transaction"] = "/failure_rate/over"
+            self.store_event(data, project_id=project.id)
+        for i in range(7):
+            data = load_data("transaction", timestamp=before_now(minutes=5))
+            data["transaction"] = "/failure_rate/under"
+            self.store_event(data, project_id=project.id)
+        for i in range(3):
+            data = load_data("transaction", timestamp=before_now(minutes=5))
+            data["transaction"] = "/failure_rate/under"
+            data["contexts"]["trace"]["status"] = "unauthenticated"
+            self.store_event(data, project_id=project.id)
+
+        queries = [
+            ("", 2, True),
+            ("failure_rate():>0.5", 1, True),
+            ("failure_rate():>0.5", 2, False),
+        ]
+
+        for query, expected_length, use_aggregate_conditions in queries:
+            for query_fn in [discover.wip_snql_query]:
+                result = query_fn(
+                    selected_columns=["transaction", "failure_rate()"],
+                    query=query,
+                    orderby="transaction",
+                    params={
+                        "start": before_now(minutes=10),
+                        "end": before_now(minutes=2),
+                        "project_id": [project.id],
+                    },
+                    use_aggregate_conditions=use_aggregate_conditions,
+                )
+                data = result["data"]
+
+                assert len(data) == expected_length
+                assert data[0]["failure_rate"] == 0.6
+                if expected_length > 1:
+                    assert data[1]["failure_rate"] == 0.3
+
     def test_transaction_status(self):
         data = load_data("transaction", timestamp=before_now(minutes=1))
         data["transaction"] = "/test_transaction/success"

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -706,7 +706,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         ]
 
         for query, expected_length, use_aggregate_conditions in queries:
-            for query_fn in [discover.wip_snql_query]:
+            for query_fn in [discover.query, discover.wip_snql_query]:
                 result = query_fn(
                     selected_columns=["transaction", "failure_rate()"],
                     query=query,


### PR DESCRIPTION
Implemented snql support for count, last_seen, latest_event, and failure_rate.
Added tests for the above functions.