### PR TITLE
fix(perf): Fix frequency underestimation due to aggregate column

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -235,6 +235,8 @@ def query_tag_data(
         # Resolve the public aliases into the discover dataset names.
         snuba_filter, translated_columns = discover.resolve_discover_aliases(snuba_filter)
 
+    translated_aggregate_column = discover.resolve_discover_column(aggregate_column)
+
     with sentry_sdk.start_span(op="discover.discover", description="facets.frequent_tags"):
         # Get the average and count to use to filter the next request to facets
         tag_data = discover.query(
@@ -243,6 +245,9 @@ def query_tag_data(
                 f"avg({aggregate_column}) as aggregate",
                 f"max({aggregate_column}) as max",
                 f"min({aggregate_column}) as min",
+            ],
+            conditions=[
+                [translated_aggregate_column, "IS NOT NULL", None],
             ],
             query=filter_query,
             params=params,


### PR DESCRIPTION
### Summary
On the tag page, we want the aggregate column (lcp, duration etc) to automatically be applied as a condition for both the performance and the counts. The heatmap does the same thing, we shouldn't consider frequency to be of all the transactions, just the ones that can be selected (eg. only frontend transactions with LCP should be considered when looking at frequency).