### PR TITLE
fix(arithmetic): Fix equation orderby with snql

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -747,9 +747,9 @@ def resolve_orderby(orderby, fields, aggregations, equations):
     """
     orderby = orderby if isinstance(orderby, (list, tuple)) else [orderby]
     if equations is not None:
-        equation_aliases = [equation[-1] for equation in equations]
+        equation_aliases = {equation[-1]: equation for equation in equations}
     else:
-        equation_aliases = []
+        equation_aliases = {}
     validated = []
     for column in orderby:
         bare_column = column.lstrip("-")
@@ -759,7 +759,10 @@ def resolve_orderby(orderby, fields, aggregations, equations):
             continue
 
         if equation_aliases and bare_column in equation_aliases:
-            validated.append(column)
+            equation = equation_aliases[bare_column]
+            prefix = "-" if column.startswith("-") else ""
+            # Drop alias because if prefix was included snuba thinks we're shadow aliasing
+            validated.append([prefix + equation[0], equation[1]])
             continue
 
         if is_function(bare_column):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1251,13 +1251,16 @@ def resolve_snuba_aliases(snuba_filter, resolve_func, function_translations=None
         resolved_orderby = []
 
         for field_with_order in orderby:
-            field = field_with_order.lstrip("-")
-            resolved_orderby.append(
-                "{}{}".format(
-                    "-" if field_with_order.startswith("-") else "",
-                    field if field in derived_columns else resolve_func(field),
+            if isinstance(field_with_order, str):
+                field = field_with_order.lstrip("-")
+                resolved_orderby.append(
+                    "{}{}".format(
+                        "-" if field_with_order.startswith("-") else "",
+                        field if field in derived_columns else resolve_func(field),
+                    )
                 )
-            )
+            else:
+                resolved_orderby.append(field_with_order)
         resolved.orderby = resolved_orderby
     return resolved, translated_columns
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -4814,6 +4814,45 @@ class ArithmeticTest(SnubaTestCase, TestCase):
         assert len(results["data"]) == 3
         assert [result["equation[0]"] for result in results["data"]] == [0.5, 0.2, 0.1]
 
+    # TODO: remove this once we're fully converted, this duplicate test is to test a specific bug with ordering and the
+    # new syntax
+    @patch("sentry.utils.snuba.should_use_snql", return_value=1)
+    def test_orderby_equation_with_snql(self, mock_use_snql):
+        for i in range(1, 3):
+            event_data = load_data("transaction")
+            # Half of duration so we don't get weird rounding differences when comparing the results
+            event_data["breakdowns"]["span_ops"]["ops.http"]["value"] = 300 * i
+            event_data["start_timestamp"] = iso_format(self.day_ago + timedelta(minutes=30))
+            event_data["timestamp"] = iso_format(self.day_ago + timedelta(minutes=30, seconds=3))
+            self.store_event(data=event_data, project_id=self.project.id)
+        query_params = {
+            "selected_columns": [
+                "spans.http",
+                "transaction.duration",
+            ],
+            "equations": [
+                "spans.http / transaction.duration",
+                "transaction.duration / spans.http",
+                "1500 + transaction.duration",
+            ],
+            "orderby": ["equation[0]"],
+            "query": self.query,
+            "params": self.params,
+        }
+        results = discover.query(**query_params)
+        assert len(results["data"]) == 3
+        assert [result["equation[0]"] for result in results["data"]] == [0.1, 0.2, 0.5]
+
+        query_params["orderby"] = ["equation[1]"]
+        results = discover.query(**query_params)
+        assert len(results["data"]) == 3
+        assert [result["equation[1]"] for result in results["data"]] == [2, 5, 10]
+
+        query_params["orderby"] = ["-equation[0]"]
+        results = discover.query(**query_params)
+        assert len(results["data"]) == 3
+        assert [result["equation[0]"] for result in results["data"]] == [0.5, 0.2, 0.1]
+
     def test_orderby_nonexistent_equation(self):
         with self.assertRaises(InvalidSearchQuery):
             discover.query(


### PR DESCRIPTION
- When the snql option is enabled, using only the alias to sort doesn't
  work because its ambiguous whether the alias is a column