### PR TITLE
feat(transaction-summary): Endpoint for checking existence of web vit…

### DIFF
--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -1,0 +1,124 @@
+from datetime import timedelta
+
+import sentry_sdk
+from django.core.cache import cache
+from django.utils import timezone
+from rest_framework import serializers
+from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
+
+from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.snuba import discover
+from sentry.utils.hashlib import md5_text
+from sentry.utils.snuba import is_measurement
+
+
+MEASUREMENT_TYPES = {
+    "web": [
+        "measurements.fp",
+        "measurements.fcp",
+        "measurements.lcp",
+        "measurements.fid",
+        "measurements.cls",
+    ],
+    "mobile": [
+        "measurements.app_start_cold",
+        "measurements.app_start_warm",
+        "measurements.frames_total",
+        "measurements.frames_slow",
+        "measurements.frames_frozen",
+        "measurements.stall_count",
+        "measurements.stall_stall_total_time",
+        "measurements.stall_stall_longest_time",
+    ],
+}
+
+class EventsHasMeasurementsQuerySerializer(serializers.Serializer):
+    transaction = serializers.CharField(max_length=200)
+    type = serializers.ChoiceField(choices=list(MEASUREMENT_TYPES.keys()))
+
+    def validate(self, data):
+        # only allow one project at a time in order to cache the results
+        # for a unique transaction
+        project_ids = self.context.get("params", {}).get("project_id", [])
+        if len(project_ids) != 1:
+            raise serializers.ValidationError("Only 1 project allowed.")
+        return data
+
+
+
+class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase):
+    def get_snuba_params(self, request, organization, check_global_views=True):
+        params = super().get_snuba_params(
+            request,
+            organization,
+            check_global_views=check_global_views
+        )
+
+        # Once an transaction begins containing measurement data, it is unlikely
+        # it will stop. So it makes more sense to always query the latest data.
+        #
+        # Additionally, to account for periods of low volume, increase the range
+        # to 7 days to have a better chance of finding an example event and provide
+        # a more consistent experience.
+        now = timezone.now()
+        params["start"] = now - timedelta(days=7)
+        params["end"] = now
+
+        return params
+
+
+    def get(self, request, organization):
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
+        with sentry_sdk.start_span(op="discover.endpoint", description="parse params"):
+            try:
+                params = self.get_snuba_params(request, organization)
+            except NoProjects:
+                return Response({"measurements": False})
+
+            data = {
+                "transaction": request.GET.get("transaction"),
+                "type": request.GET.get("type"),
+            }
+
+            serializer = EventsHasMeasurementsQuerySerializer(data=data, context={"params": params})
+            if not serializer.is_valid():
+                return Response(serializer.errors, status=400)
+
+        org_id = organization.id
+        project_id = params["project_id"][0]
+        md5_hash = md5_text(data["transaction"], data["type"]).hexdigest()
+
+        cache_key = f"check-events-measurements:{org_id}:{project_id}:{md5_hash}"
+        has_measurements = cache.get(cache_key)
+
+        # cache miss, need to make the query again
+        if has_measurements is None:
+            with self.handle_query_errors():
+                data = serializer.validated_data
+
+                # generate the appropriate query for the selected type
+                transaction_query = f'transaction:{data["transaction"]}'
+                measurements = MEASUREMENT_TYPES[data["type"]]
+                has_queries = [f"has:{measurement}" for measurement in measurements]
+                measurement_query = " OR ".join(has_queries)
+                query = f"{transaction_query} ({measurement_query})"
+
+                results = discover.query(
+                    selected_columns=["id"],
+                    query=query,
+                    params=params,
+                    limit=1,  # Just want to check for existence of such an event
+                    referrer="api.events.measurements",
+                    auto_fields=True,
+                    auto_aggregations=False,
+                    use_aggregate_conditions=False,
+                )
+            has_measurements = len(results["data"]) > 0
+
+            # cache the results for 5 minutes
+            cache.set(cache_key, has_measurements, 300)
+
+        return Response({"measurements": has_measurements})

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -4,13 +4,11 @@ import sentry_sdk
 from django.core.cache import cache
 from django.utils import timezone
 from rest_framework import serializers
-from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.snuba import discover
 from sentry.utils.hashlib import md5_text
-from sentry.utils.snuba import is_measurement
 
 MEASUREMENT_TYPES = {
     "web": [

--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -12,7 +12,6 @@ from sentry.snuba import discover
 from sentry.utils.hashlib import md5_text
 from sentry.utils.snuba import is_measurement
 
-
 MEASUREMENT_TYPES = {
     "web": [
         "measurements.fp",
@@ -33,6 +32,7 @@ MEASUREMENT_TYPES = {
     ],
 }
 
+
 class EventsHasMeasurementsQuerySerializer(serializers.Serializer):
     transaction = serializers.CharField(max_length=200)
     type = serializers.ChoiceField(choices=list(MEASUREMENT_TYPES.keys()))
@@ -46,13 +46,10 @@ class EventsHasMeasurementsQuerySerializer(serializers.Serializer):
         return data
 
 
-
 class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase):
     def get_snuba_params(self, request, organization, check_global_views=True):
         params = super().get_snuba_params(
-            request,
-            organization,
-            check_global_views=check_global_views
+            request, organization, check_global_views=check_global_views
         )
 
         # Once an transaction begins containing measurement data, it is unlikely
@@ -66,7 +63,6 @@ class OrganizationEventsHasMeasurementsEndpoint(OrganizationEventsV2EndpointBase
         params["end"] = now
 
         return params
-
 
     def get(self, request, organization):
         if not self.has_feature(organization, request):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -183,6 +183,7 @@ from .endpoints.organization_events_trends import (
     OrganizationEventsTrendsStatsEndpoint,
 )
 from .endpoints.organization_events_vitals import OrganizationEventsVitalsEndpoint
+from .endpoints.organization_events_has_measurements import OrganizationEventsHasMeasurementsEndpoint
 from .endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from .endpoints.organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
 from .endpoints.organization_has_mobile_app_events import OrganizationHasMobileAppEvents
@@ -988,6 +989,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events-vitals/$",
                     OrganizationEventsVitalsEndpoint.as_view(),
                     name="sentry-api-0-organization-events-vitals",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/events-has-measurements/$",
+                    OrganizationEventsHasMeasurementsEndpoint.as_view(),
+                    name="sentry-api-0-organization-events-has-measurements",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/events-trends-stats/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -166,6 +166,9 @@ from .endpoints.organization_events_facets_performance import (
     OrganizationEventsFacetsPerformanceEndpoint,
     OrganizationEventsFacetsPerformanceHistogramEndpoint,
 )
+from .endpoints.organization_events_has_measurements import (
+    OrganizationEventsHasMeasurementsEndpoint,
+)
 from .endpoints.organization_events_histogram import OrganizationEventsHistogramEndpoint
 from .endpoints.organization_events_meta import (
     OrganizationEventBaseline,
@@ -183,7 +186,6 @@ from .endpoints.organization_events_trends import (
     OrganizationEventsTrendsStatsEndpoint,
 )
 from .endpoints.organization_events_vitals import OrganizationEventsVitalsEndpoint
-from .endpoints.organization_events_has_measurements import OrganizationEventsHasMeasurementsEndpoint
 from .endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from .endpoints.organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
 from .endpoints.organization_has_mobile_app_events import OrganizationHasMobileAppEvents

--- a/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
+++ b/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
@@ -53,6 +53,32 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             "non_field_errors": [ErrorDetail("Only 1 project allowed.", code="invalid")],
         }
 
+    def test_no_transaction(self):
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "type": "web",
+            }
+        )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "transaction": [ErrorDetail("This field may not be null.", code="null")],
+        }
+
+    def test_no_type(self):
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+            }
+        )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "type": [ErrorDetail("This field may not be null.", code="null")],
+        }
+
     def test_unknown_type(self):
         response = self.do_request(
             {

--- a/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
+++ b/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
@@ -5,6 +5,7 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.samples import load_data
 
+
 class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
@@ -39,11 +40,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def test_more_than_one_project(self):
         project = self.create_project()
 
-        response = self.do_request({
-            "project": [self.project.id, project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "web",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id, project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "web",
+            }
+        )
 
         assert response.status_code == 400, response.content
         assert response.data == {
@@ -51,11 +54,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         }
 
     def test_unknown_type(self):
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "foo",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "foo",
+            }
+        )
 
         assert response.status_code == 400, response.content
         assert response.data == {
@@ -63,11 +68,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         }
 
     def test_no_events(self):
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "web",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "web",
+            }
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == {"measurements": False}
@@ -77,11 +84,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.transaction_data["measurements"] = {}
         self.store_event(self.transaction_data, self.project.id)
 
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "web",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "web",
+            }
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == {"measurements": False}
@@ -93,11 +102,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         transaction_data["measurements"] = {"lcp": {"value": 100}}
         self.store_event(transaction_data, self.project.id)
 
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "web",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "web",
+            }
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == {"measurements": False}
@@ -107,11 +118,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.transaction_data["measurements"] = {"lcp": {"value": 100}}
         self.store_event(self.transaction_data, self.project.id)
 
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "web",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "web",
+            }
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == {"measurements": True}
@@ -123,11 +136,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         transaction_data["measurements"] = {"app_start_cold": {"value": 100}}
         self.store_event(transaction_data, self.project.id)
 
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "mobile",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "mobile",
+            }
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == {"measurements": False}
@@ -137,12 +152,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         self.transaction_data["measurements"] = {"app_start_cold": {"value": 100}}
         self.store_event(self.transaction_data, self.project.id)
 
-        response = self.do_request({
-            "project": [self.project.id],
-            "transaction": self.transaction_data["transaction"],
-            "type": "mobile",
-        })
+        response = self.do_request(
+            {
+                "project": [self.project.id],
+                "transaction": self.transaction_data["transaction"],
+                "type": "mobile",
+            }
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == {"measurements": True}
-

--- a/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
+++ b/tests/snuba/api/endpoints/test_organization_events_has_measurements.py
@@ -1,0 +1,148 @@
+from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.utils.samples import load_data
+
+class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.two_min_ago = iso_format(before_now(minutes=2))
+        self.transaction_data = load_data("transaction", timestamp=before_now(minutes=1))
+
+    def do_request(self, query, features=None):
+        if features is None:
+            features = {
+                "organizations:discover-basic": True,
+                "organizations:global-views": True,
+            }
+        self.login_as(user=self.user)
+        url = reverse(
+            "sentry-api-0-organization-events-has-measurements",
+            kwargs={"organization_slug": self.organization.slug},
+        )
+        with self.feature(features):
+            return self.client.get(url, query, format="json")
+
+    def test_without_feature(self):
+        response = self.do_request({}, features={})
+        assert response.status_code == 404, response.content
+
+    def test_no_projects(self):
+        response = self.do_request({})
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": False}
+
+    def test_more_than_one_project(self):
+        project = self.create_project()
+
+        response = self.do_request({
+            "project": [self.project.id, project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "web",
+        })
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "non_field_errors": [ErrorDetail("Only 1 project allowed.", code="invalid")],
+        }
+
+    def test_unknown_type(self):
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "foo",
+        })
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "type": [ErrorDetail('"foo" is not a valid choice.', code="invalid_choice")],
+        }
+
+    def test_no_events(self):
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "web",
+        })
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": False}
+
+    def test_has_event_but_no_web_measurements(self):
+        # make sure the transaction doesnt have measurements
+        self.transaction_data["measurements"] = {}
+        self.store_event(self.transaction_data, self.project.id)
+
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "web",
+        })
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": False}
+
+    def test_has_event_and_no_recent_web_measurements(self):
+        # make sure the event is older than 7 days
+        transaction_data = load_data("transaction", timestamp=before_now(days=8))
+        # make sure the transaction has some web measurements
+        transaction_data["measurements"] = {"lcp": {"value": 100}}
+        self.store_event(transaction_data, self.project.id)
+
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "web",
+        })
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": False}
+
+    def test_has_event_and_web_measurements(self):
+        # make sure the transaction has some web measurements
+        self.transaction_data["measurements"] = {"lcp": {"value": 100}}
+        self.store_event(self.transaction_data, self.project.id)
+
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "web",
+        })
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": True}
+
+    def test_has_event_and_no_recent_mobile_measurements(self):
+        # make sure the event is older than 7 days
+        transaction_data = load_data("transaction", timestamp=before_now(days=8))
+        # make sure the transaction has some web measurements
+        transaction_data["measurements"] = {"app_start_cold": {"value": 100}}
+        self.store_event(transaction_data, self.project.id)
+
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "mobile",
+        })
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": False}
+
+    def test_has_event_and_mobile_measurements(self):
+        # make sure the transaction has some mobile measurements
+        self.transaction_data["measurements"] = {"app_start_cold": {"value": 100}}
+        self.store_event(self.transaction_data, self.project.id)
+
+        response = self.do_request({
+            "project": [self.project.id],
+            "transaction": self.transaction_data["transaction"],
+            "type": "mobile",
+        })
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"measurements": True}
+


### PR DESCRIPTION
…als data

This adds a new endpoint to check for the existence of web vitals data. A transaction is said to have web vitals data if at least one event contains at least one of the web vitals. This endpoint only checks the last 7 days because

1. If a transaction starts receiving web vitals data, it's unlikely to stop receiving it, so checking the latest events is better.
2. To account for periods of low volume, and the fact that not all transactions will have web vitals, use a longer period to increase accuracy without scanning too much data.

Additionally, the results are cached for 5 minutes to avoid unnecessary queries. This isn't too long so that new events coming in will result in the web vitals tab showing not long after ingestion.