### PR TITLE
ref(notification platform): Update help text link

### DIFF
--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -8,7 +8,7 @@ HEADER_MESSAGE = "Here are the commands you can use. Commands not working? Re-in
 DM_COMMAND_HEADER = "*Direct Message Commands:*"
 CHANNEL_COMMANDS_HEADER = "*Channel Commands:*"
 CONTACT_HEADER = "*Contact:*"
-GENERAL_MESSAGE = "Just want to learn more about Sentry? Check out our <https://docs.sentry.io/product/integrations/notification-incidents/slack/>."
+GENERAL_MESSAGE = "Just want to learn more about Sentry? Check out our <https://docs.sentry.io/product/integrations/notification-incidents/slack/|documentation>."
 
 DM_COMMANDS = {
     "link": "Link your Slack identity to your Sentry account to receive notifications. You'll also be able to perform actions in Sentry through Slack.",

--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -8,7 +8,7 @@ HEADER_MESSAGE = "Here are the commands you can use. Commands not working? Re-in
 DM_COMMAND_HEADER = "*Direct Message Commands:*"
 CHANNEL_COMMANDS_HEADER = "*Channel Commands:*"
 CONTACT_HEADER = "*Contact:*"
-GENERAL_MESSAGE = "Just want to learn more about Sentry? Check out our <https://docs.sentry.io/product/alerts-notifications/alerts/|documentation>."
+GENERAL_MESSAGE = "Just want to learn more about Sentry? Check out our <https://docs.sentry.io/product/integrations/notification-incidents/slack/>."
 
 DM_COMMANDS = {
     "link": "Link your Slack identity to your Sentry account to receive notifications. You'll also be able to perform actions in Sentry through Slack.",


### PR DESCRIPTION
Update the Slack help text link from https://docs.sentry.io/product/alerts/alert-types/ to https://docs.sentry.io/product/integrations/notification-incidents/slack/