### PR TITLE
fix(notification platform): Ignore bot replies

### DIFF
--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -27,6 +27,13 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
     authentication_classes = ()
     permission_classes = ()
 
+    def is_bot(self, data: Mapping[str, Any]) -> bool:
+        """
+        If it's a message posted by our bot, we don't want to respond since that
+        will cause an infinite loop of messages.
+        """
+        return bool(data.get("bot_id"))
+
     def get_command_and_args(self, slack_request: SlackRequest) -> Tuple[str, Sequence[str]]:
         data = slack_request.data.get("event")
         command = data["text"].lower().split()
@@ -66,9 +73,7 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
         self, request: Request, integration: Integration, token: str, data: Mapping[str, Any]
     ) -> Response:
         channel = data["channel"]
-        # if it's a message posted by our bot, we don't want to respond since
-        # that will cause an infinite loop of messages
-        if data.get("bot_id"):
+        if self.is_bot(data):
             return self.respond()
         access_token = self._get_access_token(integration)
         headers = {"Authorization": "Bearer %s" % access_token}
@@ -166,7 +171,7 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
 
         if slack_request.type == "message":
             data = slack_request.data.get("event")
-            if data.get("bot_id"):
+            if self.is_bot(data):
                 return self.respond()
 
             command = data.get("text")

--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -166,7 +166,10 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
 
         if slack_request.type == "message":
             data = slack_request.data.get("event")
-            command = data["text"]
+            if data.get("bot_id"):
+                return self.respond()
+
+            command = data.get("text")
             if command in COMMANDS:
                 resp = super().post_dispatcher(slack_request)
 


### PR DESCRIPTION
Sometimes Slackbots reply w/ no text and we need to handle that case - I'm ignoring bots replies but also doing a .get to be super sure. 

Fixes [SENTRY-RNZ](https://sentry.io/organizations/sentry/issues/2528599519/?project=1&referrer=AssignedActivitySlack)