### PR TITLE
ref: remove django 2.0 training wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,7 @@ filterwarnings = [
     # This is just to prevent pytest from exiting if pytest-xdist isn't installed.
     "ignore:Unknown config option.*looponfailroots:pytest.PytestConfigWarning",
 
-    # TODO(joshuarli): Enable this and address all after Django 2.0 lands.
-    "ignore::django.utils.deprecation.RemovedInDjango21Warning",
-
+    # TODO(joshuarli): Remove this and address all after Django 2.1 lands.
     "ignore::django.utils.deprecation.RemovedInDjango30Warning",
 
     # DeprecationWarnings from Python 3.6's sre_parse are just so painful,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ filterwarnings = [
     # This is just to prevent pytest from exiting if pytest-xdist isn't installed.
     "ignore:Unknown config option.*looponfailroots:pytest.PytestConfigWarning",
 
-    # TODO(joshuarli): Remove this and address all after Django 2.1 lands.
     "ignore::django.utils.deprecation.RemovedInDjango30Warning",
 
     # DeprecationWarnings from Python 3.6's sre_parse are just so painful,

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -1,4 +1,3 @@
-import django
 from django.db import models
 from django.db.models import signals
 from django.utils import timezone
@@ -56,48 +55,29 @@ class BaseModel(models.Model):
         self.__dict__.update(state)
 
     def set_cached_field_value(self, field_name, value):
-        # Django 1.11 + at least 2.0 compatible method
-        # to explicitly set a field's cached value.
+        # Explicitly set a field's cached value.
         # This only works for relational fields, and is useful when
         # you already have the value and can therefore use this
         # to populate Django's cache before accessing the attribute
         # and triggering a duplicate, unnecessary query.
-        if django.VERSION[:2] < (2, 0):
-            setattr(self, f"_{field_name}_cache", value)
-            return
-
         self._meta.get_field(field_name).set_cached_value(self, value)
 
     def get_cached_field_value(self, field_name):
-        # Django 1.11 + at least 2.0 compatible method
-        # to get a relational field's cached value.
+        # Get a relational field's cached value.
         # It's recommended to only use this in testing code,
         # for when you would like to inspect the cache.
         # In production, you should guard `model.field` with an
         # `if model.is_field_cached`.
-        if django.VERSION[:2] < (2, 0):
-            return getattr(self, f"_{field_name}_cache", None)
-
         name = self._meta.get_field(field_name).get_cache_name()
         return self._state.fields_cache.get(name, None)
 
     def delete_cached_field_value(self, field_name):
-        if django.VERSION[:2] < (2, 0):
-            setattr(self, f"_{field_name}_cache", None)
-            return
-
         name = self._meta.get_field(field_name).get_cache_name()
         if name in self._state.fields_cache:
             del self._state.fields_cache[name]
 
     def is_field_cached(self, field_name):
-        # Django 1.11 + at least 2.0 compatible method
-        # to ask if a relational field has a cached value.
-        if django.VERSION[:2] < (2, 0):
-            if not getattr(self, f"_{field_name}_cache", False):
-                return False
-            return True
-
+        # Ask if a relational field has a cached value.
         name = self._meta.get_field(field_name).get_cache_name()
         return name in self._state.fields_cache
 

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -92,11 +92,7 @@ def configure(ctx, py, yaml, skip_service_validation=False):
     # Make sure that our warnings are always displayed.
     warnings.filterwarnings("default", "", Warning, r"^sentry")
 
-    from django.utils.deprecation import RemovedInDjango21Warning, RemovedInDjango30Warning
-
-    # While we're on Django 1.9, we only care about RemovedInDjango20Warning.
-    # TODO(joshuarli): Remove this after RemovedInDjango21Warnings are fixed in testing.
-    warnings.filterwarnings(action="ignore", category=RemovedInDjango21Warning)
+    from django.utils.deprecation import RemovedInDjango30Warning
 
     warnings.filterwarnings(action="ignore", category=RemovedInDjango30Warning)
 


### PR DESCRIPTION
Also, we don't have any RemovedInDjango21Warnings or RemovedInDjango22Warnings during testing, so unignoring them so that they can fail tests if introduced.