### PR TITLE
feat(ui): Custom rendering functions for buttons on the confirm modal

### DIFF
--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -29,6 +29,18 @@ export type ConfirmMessageRenderProps = {
   setConfirmCallback: (cb: () => void) => void;
 };
 
+export type ConfirmButtonsRenderProps = {
+  /**
+   * Applications can call this function to manually close the modal.
+   */
+  closeModal: () => void;
+  /**
+   * The default onClick behavior, including closing the modal and triggering the
+   * onConfirm / onCancel callbacks.
+   */
+  defaultOnClick: () => void;
+};
+
 type ChildrenRenderProps = {
   open: () => void;
 };
@@ -41,11 +53,11 @@ type Props = {
   /**
    * Custom function to render the confirm button
    */
-  renderConfirmButton?: (closeModal: () => void, defaultOnClick: () => void) => void;
+  renderConfirmButton?: (props: ConfirmButtonsRenderProps) => React.ReactNode;
   /**
    * Custom function to render the cancel button
    */
-  renderCancelButton?: (closeModal: () => void, defaultOnClick: () => void) => void;
+  renderCancelButton?: (props: ConfirmButtonsRenderProps) => React.ReactNode;
   /**
    * If true, will skip the confirmation modal and call `onConfirm` callback
    */
@@ -278,12 +290,18 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
         <Footer>
           <ButtonBar gap={2}>
             {renderCancelButton ? (
-              renderCancelButton(this.props.closeModal, this.handleClose)
+              renderCancelButton({
+                closeModal: this.props.closeModal,
+                defaultOnClick: this.handleClose,
+              })
             ) : (
               <Button onClick={this.handleClose}>{cancelText}</Button>
             )}
             {renderConfirmButton ? (
-              renderConfirmButton(this.props.closeModal, this.handleConfirm)
+              renderConfirmButton({
+                closeModal: this.props.closeModal,
+                defaultOnClick: this.handleConfirm,
+              })
             ) : (
               <Button
                 data-test-id="confirm-button"

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -39,6 +39,14 @@ type Props = {
    */
   onConfirm?: () => void;
   /**
+   * Custom function to render the confirm button
+   */
+  renderConfirmButton?: (closeModal: () => void, defaultOnClick: () => void) => void;
+  /**
+   * Custom function to render the cancel button
+   */
+  renderCancelButton?: (closeModal: () => void, defaultOnClick: () => void) => void;
+  /**
    * If true, will skip the confirmation modal and call `onConfirm` callback
    */
   bypass?: boolean;
@@ -105,6 +113,8 @@ type Props = {
 function Confirm({
   bypass,
   renderMessage,
+  renderConfirmButton,
+  renderCancelButton,
   message,
   header,
   disabled,
@@ -137,6 +147,8 @@ function Confirm({
     const modalProps = {
       priority,
       renderMessage,
+      renderConfirmButton,
+      renderCancelButton,
       message,
       confirmText,
       cancelText,
@@ -166,6 +178,8 @@ type ModalProps = ModalRenderProps &
     Props,
     | 'priority'
     | 'renderMessage'
+    | 'renderConfirmButton'
+    | 'renderCancelButton'
     | 'message'
     | 'confirmText'
     | 'cancelText'
@@ -246,24 +260,41 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
   }
 
   render() {
-    const {Header, Body, Footer, priority, confirmText, cancelText, header} = this.props;
-
+    const {
+      Header,
+      Body,
+      Footer,
+      priority,
+      confirmText,
+      cancelText,
+      header,
+      renderConfirmButton,
+      renderCancelButton,
+    } = this.props;
     return (
       <React.Fragment>
         {header && <Header>{header}</Header>}
         <Body>{this.confirmMessage}</Body>
         <Footer>
           <ButtonBar gap={2}>
-            <Button onClick={this.handleClose}>{cancelText}</Button>
-            <Button
-              data-test-id="confirm-button"
-              disabled={this.state.disableConfirmButton}
-              priority={priority}
-              onClick={this.handleConfirm}
-              autoFocus
-            >
-              {confirmText}
-            </Button>
+            {renderCancelButton ? (
+              renderCancelButton(this.props.closeModal, this.handleClose)
+            ) : (
+              <Button onClick={this.handleClose}>{cancelText}</Button>
+            )}
+            {renderConfirmButton ? (
+              renderConfirmButton(this.props.closeModal, this.handleConfirm)
+            ) : (
+              <Button
+                data-test-id="confirm-button"
+                disabled={this.state.disableConfirmButton}
+                priority={priority}
+                onClick={this.handleConfirm}
+                autoFocus
+              >
+                {confirmText}
+              </Button>
+            )}
           </ButtonBar>
         </Footer>
       </React.Fragment>

--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -16,6 +16,58 @@ describe('Confirm', function () {
     expect(wrapper).toSnapshot();
   });
 
+  it('renders custom confirm button & callbacks work', async function () {
+    const mock = jest.fn();
+    const wrapper = mountWithTheme(
+      <Confirm
+        message="Are you sure?"
+        onConfirm={mock}
+        renderConfirmButton={({defaultOnClick}) => (
+          <button data-test-id="confirm-btn" onClick={defaultOnClick}>
+            Confirm Button
+          </button>
+        )}
+      >
+        <button data-test-id="trigger-btn">Confirm?</button>
+      </Confirm>,
+      TestStubs.routerContext()
+    );
+    wrapper.find('button[data-test-id="trigger-btn"]').simulate('click');
+    const modal = await mountGlobalModal();
+
+    const confirmBtn = modal.find('button[data-test-id="confirm-btn"]');
+    expect(confirmBtn.exists()).toBe(true);
+
+    expect(mock).not.toHaveBeenCalled();
+    confirmBtn.simulate('click');
+    expect(mock).toHaveBeenCalled();
+  });
+  it('renders custom cancel button & callbacks work', async function () {
+    const mock = jest.fn();
+    const wrapper = mountWithTheme(
+      <Confirm
+        message="Are you sure?"
+        onCancel={mock}
+        renderCancelButton={({defaultOnClick}) => (
+          <button data-test-id="cancel-btn" onClick={defaultOnClick}>
+            Cancel Button
+          </button>
+        )}
+      >
+        <button data-test-id="trigger-btn">Confirm?</button>
+      </Confirm>,
+      TestStubs.routerContext()
+    );
+    wrapper.find('button[data-test-id="trigger-btn"]').simulate('click');
+    const modal = await mountGlobalModal();
+
+    const cancelBtn = modal.find('button[data-test-id="cancel-btn"]');
+    expect(cancelBtn.exists()).toBe(true);
+
+    expect(mock).not.toHaveBeenCalled();
+    cancelBtn.simulate('click');
+    expect(mock).toHaveBeenCalled();
+  });
   it('clicking action button opens Modal', async function () {
     const mock = jest.fn();
     const wrapper = shallow(


### PR DESCRIPTION
This PR added `renderConfirmButton` and `renderCancelButton` functions to the `Confirm` modal component. By supplying these two props one can completely customize the shape and behaviors of the buttons. The functions were supplied two arguments for closing the modal or triggering the default `onConfirm` / `onCancel` actions.
