### PR TITLE
chore(api): Add query info tags to group search endpoints

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import timedelta
 from uuid import uuid4
 
+import sentry_sdk
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 from rest_framework import serializers
@@ -93,6 +94,10 @@ def build_query_params_from_request(request, organization, projects, environment
         except ValueError:
             raise ParseError(detail="Invalid cursor parameter.")
     query = request.GET.get("query", "is:unresolved").strip()
+    sentry_sdk.set_tag("search.query", query)
+    sentry_sdk.set_tag("search.sort", query)
+    sentry_sdk.set_tag("search.projects", len(projects) if len(projects) <= 5 else ">5")
+    sentry_sdk.set_tag("search.environments", len(environments) if len(environments) <= 5 else ">5")
     if query:
         try:
             search_filters = convert_query_values(

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -96,8 +96,12 @@ def build_query_params_from_request(request, organization, projects, environment
     query = request.GET.get("query", "is:unresolved").strip()
     sentry_sdk.set_tag("search.query", query)
     sentry_sdk.set_tag("search.sort", query)
-    sentry_sdk.set_tag("search.projects", len(projects) if len(projects) <= 5 else ">5")
-    sentry_sdk.set_tag("search.environments", len(environments) if len(environments) <= 5 else ">5")
+    if projects:
+        sentry_sdk.set_tag("search.projects", len(projects) if len(projects) <= 5 else ">5")
+    if environments:
+        sentry_sdk.set_tag(
+            "search.environments", len(environments) if len(environments) <= 5 else ">5"
+        )
     if query:
         try:
             search_filters = convert_query_values(


### PR DESCRIPTION
We want to store information about the query being made on the group search endpoints so that we can
more easily see which types of queries are slow in the performance view.