### PR TITLE
fix(auth): handle SSO / member invites better for authed users

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -171,7 +171,7 @@ class ApiInviteHelper:
             and not any(self.get_onboarding_steps().values())
         )
 
-    def accept_invite(self, user=None):
+    def accept_invite(self, user=None, sso_validated=False):
         om = self.om
 
         if user is None:
@@ -209,6 +209,8 @@ class ApiInviteHelper:
 
         self.handle_success()
         metrics.incr("organization.invite-accepted", sample_rate=1.0)
+
+        return om
 
     def _needs_2fa(self) -> bool:
         org_requires_2fa = self.om.organization.flags.require_2fa.is_set

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -171,7 +171,7 @@ class ApiInviteHelper:
             and not any(self.get_onboarding_steps().values())
         )
 
-    def accept_invite(self, user=None, sso_validated=False):
+    def accept_invite(self, user=None):
         om = self.om
 
         if user is None:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -176,8 +176,7 @@ class AuthIdentityHandler:
         # organization, do so, otherwise handle new membership
         if invite_helper:
             if invite_helper.invite_approved:
-                invite_helper.accept_invite(user)
-                return None
+                return invite_helper.accept_invite(user)
 
             # It's possible the user has an _invite request_ that hasn't been approved yet,
             # and is able to join the organization without an invite through the SSO flow.
@@ -275,7 +274,7 @@ class AuthIdentityHandler:
             )
 
         if member is None:
-            member = self._get_organization_member()
+            member = self._get_organization_member(auth_identity)
         self._set_linked_flag(member)
 
         if auth_is_new:
@@ -317,33 +316,15 @@ class AuthIdentityHandler:
 
         return deletion_result
 
-    def _get_organization_member(self) -> OrganizationMember:
+    def _get_organization_member(self, auth_identity: AuthIdentity) -> OrganizationMember:
+        """
+        Check to see if the user has a member associated, if not, create a new membership
+        based on the auth_identity email.
+        """
         try:
             return OrganizationMember.objects.get(user=self.user, organization=self.organization)
         except OrganizationMember.DoesNotExist:
-            pass
-
-        member = OrganizationMember.objects.create(
-            organization=self.organization,
-            role=self.organization.default_role,
-            user=self.user,
-            flags=OrganizationMember.flags["sso:linked"],
-        )
-
-        default_teams = self.auth_provider.default_teams.all()
-        for team in default_teams:
-            OrganizationMemberTeam.objects.create(team=team, organizationmember=member)
-
-        AuditLogEntry.objects.create(
-            organization=self.organization,
-            actor=self.user,
-            ip_address=self.request.META["REMOTE_ADDR"],
-            target_object=member.id,
-            target_user=self.user,
-            event=AuditLogEntryEvent.MEMBER_ADD,
-            data=member.get_audit_log_data(),
-        )
-        return member
+            return self._handle_new_membership(auth_identity)
 
     def _respond(
         self,


### PR DESCRIPTION
Fixes a bug in the following scenario:
- An organization has SSO turned on
- A user is assigned to the org in their SSO provider
- The user already has an existing sentry account
- The user is not a member of the organization
- The user has a pending organization member invite either through SCIM or the UI

If the above conditions are true, and the user does not accept the invite through their email, but instead logs in directly to the platform, the existing invite will not be merged with their account, but instead, a new member object is created with the same email, and none of the team assignments transferred. This bug came up during SCIM testing.

Additions
- modify `_get_organization_member` to use `_handle_new_membership` in the case that the authenticated user does not have an OM associated with their user object already. This behaviour should be equivalent, (`auth_identity.user` is always = to `request.user`)
- small changes to functions to return the member object created by the invite helper
- A test that fails on master that passes on this branch confirming that in this scenario the user account is merged with the invite member.
