### PR TITLE
fix(grouping): negative sentinel and prefix rules

### DIFF
--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -125,12 +125,12 @@ class FlagAction(Action):
 
             elif self.key == "prefix":
                 component.update(
-                    is_prefix_frame=True, hint=f"marked as prefix frame by {rule_hint}"
+                    is_prefix_frame=self.flag, hint=f"marked as prefix frame by {rule_hint}"
                 )
 
             elif self.key == "sentinel":
                 component.update(
-                    is_sentinel_frame=True, hint=f"marked as sentinel frame by {rule_hint}"
+                    is_sentinel_frame=self.flag, hint=f"marked as sentinel frame by {rule_hint}"
                 )
 
 


### PR DESCRIPTION
Allow removing the sentinel and prefix properties from a frame by setting `-sentinel` / `-prefix`.