### PR TITLE
ref(appconnect): Unify APM sampling with a setting

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1111,6 +1111,9 @@ SENTRY_RELAY_ENDPOINT_APM_SAMPLING = 0
 # sample rate for ingest consumer processing functions
 SENTRY_INGEST_CONSUMER_APM_SAMPLING = 0
 
+# sample rate for Apple App Store Connect tasks transactions
+SENTRY_APPCONNECT_APM_SAMPLING = 1
+
 # ----
 # end APM config
 # ----

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -69,7 +69,8 @@ SAMPLED_TASKS = {
     "sentry.tasks.store.process_event": settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
     "sentry.tasks.store.process_event_from_reprocessing": settings.SENTRY_PROCESS_EVENT_APM_SAMPLING,
     "sentry.tasks.assemble.assemble_dif": 0.1,
-    "sentry.tasks.app_store_connect.dsym_download": 1,
+    "sentry.tasks.app_store_connect.dsym_download": settings.SENTRY_APPCONNECT_APM_SAMPLING,
+    "sentry.tasks.app_store_connect.refresh_all_builds": settings.SENTRY_APPCONNECT_APM_SAMPLING,
 }
 
 


### PR DESCRIPTION
This adds sampling to the second App Store Connect task as well and
introduces a setting to control the sampling together for all App
Store Connect tasks.