### PR TITLE
ref(sdk-updates-broadcast): Update design & add raven alert

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1927,19 +1927,14 @@ SDK_VERSIONS = {
 
 # Some of the migration links below are not ideal, but that is all migration documentation we currently have and can provide at this point
 SDK_URLS = {
-    "raven-js": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser",
-    "raven-node": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser",
-    "raven-python": "https://docs.sentry.io/platforms/python/migration/",
-    "raven-ruby": "https://docs.sentry.io/platforms/ruby/migration/",
-    "raven-swift": "https://docs.sentry.io/platforms/apple/migration/",
-    "raven-php": "https://github.com/getsentry/sentry-php/blob/master/UPGRADE-2.0.md",
-    "raven-csharp": "https://docs.sentry.io/platforms/dotnet/migration/#migrating-from-sharpraven-to-sentry-sdk",
-    "raven-go": "https://docs.sentry.io/platforms/go/migration/",
-    "sentry-java": "https://docs.sentry.io/clients/java/",
+    "sentry-java": "https://docs.sentry.io/platforms/java/legacy/migration/",
+    "@sentry/browser": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser",
+    "sentry-cocoa": "https://docs.sentry.io/platforms/apple/migration/",
     "sentry-php": "https://docs.sentry.io/platforms/php/",
-    "sentry-laravel": "https://docs.sentry.io/platforms/php/laravel/",
-    "sentry-swift": "https://docs.sentry.io/clients/cocoa/",
-    "raven-objc": "raven-objc",
+    "sentry-python": "https://docs.sentry.io/platforms/python/migration/",
+    "sentry-ruby": "https://docs.sentry.io/platforms/ruby/migration/",
+    "sentry-dotnet": "https://docs.sentry.io/platforms/dotnet/migration/#migrating-from-sharpraven-to-sentry-sdk",
+    "sentry-go": "https://docs.sentry.io/platforms/go/migration/",
 }
 
 DEPRECATED_SDKS = {
@@ -1949,16 +1944,20 @@ DEPRECATED_SDKS = {
     "raven-java:log4j": "sentry-java",
     "raven-java:log4j2": "sentry-java",
     "raven-java:logback": "sentry-java",
-    "raven-js": "sentry.javascript.browser",
-    "raven-node": "sentry.javascript.node",
-    "raven-objc": "sentry-swift",
+    "raven-js": "@sentry/browser",
+    "raven-node": "@sentry/browser",
+    "raven-objc": "sentry-cocoa",
     "raven-php": "sentry-php",
-    "raven-python": "sentry.python",
-    "sentry-android": "raven-java",
+    "raven-python": "sentry-python",
+    "raven-ruby": "sentry-ruby",
+    "raven-swift": "sentry-cocoa",
+    "raven-csharp": "sentry-dotnet",
+    "raven-go": "sentry-go",
+    "sentry-android": "sentry-java",
     "sentry-swift": "sentry-cocoa",
-    "SharpRaven": "sentry.dotnet",
+    "SharpRaven": "sentry-dotnet",
     # The Ruby SDK used to go by the name 'sentry-raven'...
-    "sentry-raven": "raven-ruby",
+    "sentry-raven": "sentry-ruby",
 }
 
 TERMS_URL = None

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -974,8 +974,6 @@ SENTRY_FEATURES = {
     "organizations:invite-members": True,
     # Enable rate limits for inviting members.
     "organizations:invite-members-rate-limits": True,
-    # Enable Jira AC for select organizations.
-    "organizations:jira-ac-plugin": False,
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
     "organizations:org-subdomains": False,
@@ -991,10 +989,6 @@ SENTRY_FEATURES = {
     "organizations:performance-events-page": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
-    # Enable ingestion for suspect spans
-    "organizations:performance-suspect-spans-ingestion": False,
-    # Enable views for suspect tags
-    "organizations:performance-suspect-spans-view": False,
     # Allow the user to create a sample transaction while onboarding
     "organizations:performance-create-sample-transaction": False,
     # Enable the new Related Events feature
@@ -1931,16 +1925,21 @@ SDK_VERSIONS = {
     "sentry-php": "2.0.1",
 }
 
+# Some of the migration links below are not ideal, but that is all migration documentation we currently have and can provide at this point
 SDK_URLS = {
-    "raven-js": "https://docs.sentry.io/clients/javascript/",
-    "raven-node": "https://docs.sentry.io/clients/node/",
-    "raven-python": "https://docs.sentry.io/clients/python/",
-    "raven-ruby": "https://docs.sentry.io/clients/ruby/",
-    "raven-swift": "https://docs.sentry.io/clients/cocoa/",
+    "raven-js": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser",
+    "raven-node": "https://github.com/getsentry/sentry-javascript/blob/master/MIGRATION.md#migrating-from-raven-js-to-sentrybrowser",
+    "raven-python": "https://docs.sentry.io/platforms/python/migration/",
+    "raven-ruby": "https://docs.sentry.io/platforms/ruby/migration/",
+    "raven-swift": "https://docs.sentry.io/platforms/apple/migration/",
+    "raven-php": "https://github.com/getsentry/sentry-php/blob/master/UPGRADE-2.0.md",
+    "raven-csharp": "https://docs.sentry.io/platforms/dotnet/migration/#migrating-from-sharpraven-to-sentry-sdk",
+    "raven-go": "https://docs.sentry.io/platforms/go/migration/",
     "sentry-java": "https://docs.sentry.io/clients/java/",
     "sentry-php": "https://docs.sentry.io/platforms/php/",
     "sentry-laravel": "https://docs.sentry.io/platforms/php/laravel/",
     "sentry-swift": "https://docs.sentry.io/clients/cocoa/",
+    "raven-objc": "raven-objc",
 }
 
 DEPRECATED_SDKS = {

--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -67,7 +67,7 @@ const alertStyles = ({theme, type = DEFAULT_TYPE, system}: Props & {theme: Theme
   flex-direction: column;
   margin: 0 0 ${space(3)};
   padding: ${space(1.5)} ${space(2)};
-  font-size: 15px;
+  font-size: ${theme.fontSizeLarge};
   box-shadow: ${theme.dropShadowLight};
   border-radius: ${theme.borderRadius};
   background: ${theme.backgroundSecondary};

--- a/static/app/components/idBadge/projectBadge.tsx
+++ b/static/app/components/idBadge/projectBadge.tsx
@@ -25,6 +25,7 @@ type Props = Partial<Omit<BaseBadgeProps, 'project' | 'organization' | 'team'>> 
    * Overides where the project badge links
    */
   to?: React.ComponentProps<typeof Link>['to'];
+  className?: string;
 };
 
 const ProjectBadge = ({
@@ -33,6 +34,7 @@ const ProjectBadge = ({
   to,
   hideOverflow = true,
   disableLink = false,
+  className,
   ...props
 }: Props) => {
   const {slug, id} = project;
@@ -52,10 +54,14 @@ const ProjectBadge = ({
       id ? `?project=${id}` : ''
     }`;
 
-    return <StyledLink to={to ?? defaultTo}>{badge}</StyledLink>;
+    return (
+      <StyledLink to={to ?? defaultTo} className={className}>
+        {badge}
+      </StyledLink>
+    );
   }
 
-  return badge;
+  return React.cloneElement(badge, {className});
 };
 
 const StyledLink = styled(Link)`

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -1,14 +1,19 @@
 import styled from '@emotion/styled';
 import groupBy from 'lodash/groupBy';
+import partition from 'lodash/partition';
 
 import ProjectBadge from 'app/components/idBadge/projectBadge';
-import {t} from 'app/locale';
+import Tag from 'app/components/tag';
+import {IconWarning} from 'app/icons/iconWarning';
+import {t, tct, tn} from 'app/locale';
 import space from 'app/styles/space';
-import {Project, ProjectSdkUpdates, SDKUpdatesSuggestion} from 'app/types';
+import {Organization, Project, ProjectSdkUpdates, SDKUpdatesSuggestion} from 'app/types';
 import getSdkUpdateSuggestion from 'app/utils/getSdkUpdateSuggestion';
+import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 import withSdkUpdates from 'app/utils/withSdkUpdates';
 
+import Alert from '../alert';
 import Collapsible from '../collapsible';
 import List from '../list';
 import ListItem from '../list/listItem';
@@ -17,6 +22,7 @@ import SidebarPanelItem from './sidebarPanelItem';
 
 type Props = {
   projects: Project[];
+  organization: Organization;
   sdkUpdates?: ProjectSdkUpdates[] | null;
 };
 
@@ -26,18 +32,83 @@ const flattenSuggestions = (list: ProjectSdkUpdates[]) =>
     []
   );
 
-const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
+function BroadcastSdkUpdates({projects, sdkUpdates, organization}: Props) {
   if (!sdkUpdates) {
     return null;
   }
 
   // Are there any updates?
-  if (flattenSuggestions(sdkUpdates).length === 0) {
+  if (!flattenSuggestions(sdkUpdates).length) {
     return null;
   }
 
-  // Group SDK updates by project
-  const items = Object.entries(groupBy(sdkUpdates, 'projectId'));
+  function renderUpdates(projectSdkUpdates: ProjectSdkUpdates[]) {
+    // Group SDK updates by project
+    const items = Object.entries(groupBy(projectSdkUpdates, 'projectId'));
+
+    return items
+      .map(([projectId, updates]) => {
+        const project = projects.find(p => p.id === projectId);
+
+        if (!project) {
+          return null;
+        }
+
+        // Updates should only be shown to users who are project members or users who have open membership or org write permission
+        const hasPermissionToSeeUpdates =
+          project.isMember ||
+          organization.features.includes('open-membership') ||
+          organization.access.includes('org:write');
+
+        if (!hasPermissionToSeeUpdates) {
+          return null;
+        }
+
+        return updates.map(({sdkName, sdkVersion, suggestions}) => {
+          const isDeprecated = suggestions.some(
+            suggestion => suggestion.type === 'changeSdk'
+          );
+          return (
+            <div key={sdkName}>
+              <Header>
+                <SdkProjectBadge project={project} />
+                {isDeprecated && <Tag type="warning">{t('Deprecated')}</Tag>}
+              </Header>
+              <SdkOutdatedVersion>
+                {tct('This project is on [current-version]', {
+                  ['current-version']: (
+                    <OutdatedVersion>{`${sdkName}@v${sdkVersion}`}</OutdatedVersion>
+                  ),
+                })}
+              </SdkOutdatedVersion>
+              <StyledList>
+                {suggestions.map((suggestion, i) => (
+                  <ListItem key={i}>
+                    {getSdkUpdateSuggestion({
+                      sdk: {
+                        name: sdkName,
+                        version: sdkVersion,
+                      },
+                      suggestion,
+                      shortStyle: true,
+                      capitalized: true,
+                    })}
+                  </ListItem>
+                ))}
+              </StyledList>
+            </div>
+          );
+        });
+      })
+      .filter(item => !!item);
+  }
+
+  const [deprecatedRavenSdkUpdates, otherSdkUpdates] = partition(
+    sdkUpdates,
+    sdkUpdate =>
+      sdkUpdate.sdkName.includes('raven') &&
+      sdkUpdate.suggestions.some(suggestion => suggestion.type === 'changeSdk')
+  );
 
   return (
     <SidebarPanelItem
@@ -47,50 +118,31 @@ const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
         'We recommend updating the following SDKs to make sure you’re getting all the data you need.'
       )}
     >
+      {!!deprecatedRavenSdkUpdates.length && (
+        <StyledAlert type="warning" icon={<IconWarning />}>
+          {tct(
+            `[first-sentence]. Any SDK that has the package name ‘raven’ may be missing data. Migrate to the latest SDK version.`,
+            {
+              ['first-sentence']: tn(
+                'You have %s project using a deprecated version of the Sentry client',
+                'You have %s projects using a deprecated version of the Sentry client',
+                deprecatedRavenSdkUpdates.length
+              ),
+            }
+          )}
+        </StyledAlert>
+      )}
       <UpdatesList>
         <Collapsible>
-          {items.map(([projectId, updates]) => {
-            const project = projects.find(p => p.id === projectId);
-            if (project === undefined) {
-              return null;
-            }
-
-            return (
-              <div key={project.id}>
-                <SdkProjectBadge project={project} />
-                <Suggestions>
-                  {updates.map(sdkUpdate => (
-                    <div key={sdkUpdate.sdkName}>
-                      <SdkName>
-                        {sdkUpdate.sdkName}{' '}
-                        <SdkOutdatedVersion>@v{sdkUpdate.sdkVersion}</SdkOutdatedVersion>
-                      </SdkName>
-                      <List>
-                        {sdkUpdate.suggestions.map((suggestion, i) => (
-                          <ListItem key={i}>
-                            {getSdkUpdateSuggestion({
-                              sdk: {
-                                name: sdkUpdate.sdkName,
-                                version: sdkUpdate.sdkVersion,
-                              },
-                              suggestion,
-                              shortStyle: true,
-                              capitalized: true,
-                            })}
-                          </ListItem>
-                        ))}
-                      </List>
-                    </div>
-                  ))}
-                </Suggestions>
-              </div>
-            );
-          })}
+          {renderUpdates(deprecatedRavenSdkUpdates)}
+          {renderUpdates(otherSdkUpdates)}
         </Collapsible>
       </UpdatesList>
     </SidebarPanelItem>
   );
-};
+}
+
+export default withSdkUpdates(withProjects(withOrganization(BroadcastSdkUpdates)));
 
 const UpdatesList = styled('div')`
   margin-top: ${space(3)};
@@ -99,24 +151,34 @@ const UpdatesList = styled('div')`
   grid-gap: ${space(3)};
 `;
 
-const Suggestions = styled('div')`
-  margin-left: calc(${space(4)} + ${space(0.25)});
+const Header = styled('div')`
   display: grid;
-  grid-auto-flow: row;
+  grid-template-columns: 1fr auto;
   grid-gap: ${space(0.5)};
+  margin-bottom: ${space(0.25)};
+  align-items: center;
+`;
+
+const SdkOutdatedVersion = styled('div')`
+  /* 24px + 8px to be aligned with the SdkProjectBadge data */
+  padding-left: calc(24px + ${space(1)});
+`;
+
+const OutdatedVersion = styled('span')`
+  color: ${p => p.theme.gray400};
 `;
 
 const SdkProjectBadge = styled(ProjectBadge)`
-  font-size: ${p => p.theme.fontSizeLarge};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  line-height: 1;
 `;
 
-const SdkName = styled('div')`
-  font-family: ${p => p.theme.text.familyMono};
-  font-weight: bold;
+const StyledAlert = styled(Alert)`
+  margin-top: ${space(2)};
 `;
 
-const SdkOutdatedVersion = styled('span')`
-  color: ${p => p.theme.subText};
+const StyledList = styled(List)`
+  /* 24px + 8px to be aligned with the project name
+  * displayed by the SdkProjectBadge component */
+  padding-left: calc(24px + ${space(1)});
 `;
-
-export default withSdkUpdates(withProjects(BroadcastSdkUpdates));

--- a/static/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/static/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -124,8 +124,8 @@ function BroadcastSdkUpdates({projects, sdkUpdates, organization}: Props) {
             `[first-sentence]. Any SDK that has the package name ‘raven’ may be missing data. Migrate to the latest SDK version.`,
             {
               ['first-sentence']: tn(
-                'You have %s project using a deprecated version of the Sentry client',
-                'You have %s projects using a deprecated version of the Sentry client',
+                'You have %s project using a deprecated version of the Sentry client.',
+                'You have %s projects using a deprecated version of the Sentry client.',
                 deprecatedRavenSdkUpdates.length
               ),
             }

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -32,7 +32,7 @@ const PanelContainer = styled('div')<PositionProps>`
           right: 0;
         `
       : css`
-          width: 360px;
+          width: 460px;
           top: 0;
           left: ${p.collapsed
             ? p.theme.sidebar.collapsedWidth

--- a/static/app/utils/getSdkUpdateSuggestion.tsx
+++ b/static/app/utils/getSdkUpdateSuggestion.tsx
@@ -2,6 +2,8 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import ExternalLink from 'app/components/links/externalLink';
+import List from 'app/components/list';
+import ListItem from 'app/components/list/listItem';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {UpdateSdkSuggestion} from 'app/types';
@@ -20,29 +22,39 @@ function getSdkUpdateSuggestion({
   shortStyle = false,
   capitalized = false,
 }: Props) {
-  function getUpdateSdkContent(newSdkVersion: UpdateSdkSuggestion['newSdkVersion']) {
+  function getUpdateSdkContent({newSdkVersion, sdkName}: UpdateSdkSuggestion) {
     if (capitalized) {
       return sdk
         ? shortStyle
-          ? tct('Update to @v[new-sdk-version]', {
-              ['new-sdk-version']: newSdkVersion,
+          ? tct('Update to [sdk-name]@v[new-sdk-version]', {
+              'sdk-name': sdkName,
+              'new-sdk-version': newSdkVersion,
             })
-          : tct('Update your SDK from @v[sdk-version] to @v[new-sdk-version]', {
-              ['sdk-version']: sdk.version,
-              ['new-sdk-version']: newSdkVersion,
-            })
+          : tct(
+              'Update your SDK from [sdk-name]@v[sdk-version] to [sdk-name]@v[new-sdk-version]',
+              {
+                'sdk-name': sdkName,
+                'sdk-version': sdk.version,
+                'new-sdk-version': newSdkVersion,
+              }
+            )
         : t('Update your SDK version');
     }
 
     return sdk
       ? shortStyle
-        ? tct('update to @v[new-sdk-version]', {
-            ['new-sdk-version']: newSdkVersion,
+        ? tct('update to [sdk-name]@v[new-sdk-version]', {
+            'sdk-name': sdkName,
+            'new-sdk-version': newSdkVersion,
           })
-        : tct('update your SDK from @v[sdk-version] to @v[new-sdk-version]', {
-            ['sdk-version']: sdk.version,
-            ['new-sdk-version']: newSdkVersion,
-          })
+        : tct(
+            'update your SDK from [sdk-name]@v[sdk-version] to [sdk-name]@v[new-sdk-version]',
+            {
+              'sdk-name': sdkName,
+              'sdk-version': sdk.version,
+              'new-sdk-version': newSdkVersion,
+            }
+          )
       : t('update your SDK version');
   }
 
@@ -51,19 +63,29 @@ function getSdkUpdateSuggestion({
       case 'updateSdk':
         return {
           href: suggestion?.sdkUrl,
-          content: getUpdateSdkContent(suggestion.newSdkVersion),
+          content: getUpdateSdkContent(suggestion),
         };
       case 'changeSdk':
         return {
           href: suggestion?.sdkUrl,
-          content: tct('migrate to the [sdkName] SDK', {
-            sdkName: <code>{suggestion.newSdkName}</code>,
-          }),
+          content: capitalized
+            ? tct('Migrate to [recommended-sdk-version]', {
+                'recommended-sdk-version': suggestion.newSdkName,
+              })
+            : tct('migrate to [recommended-sdk-version]', {
+                'recommended-sdk-version': suggestion.newSdkName,
+              }),
         };
       case 'enableIntegration':
         return {
           href: suggestion?.integrationUrl,
-          content: t("enable the '%s' integration", suggestion.integrationName),
+          content: capitalized
+            ? tct('Enable to [recommended-integration-name]', {
+                'recommended-integration-name': suggestion.integrationName,
+              })
+            : tct('enable to the integration [recommended-integration-name]', {
+                'recommended-integration-name': suggestion.integrationName,
+              }),
         };
       default:
         return null;
@@ -97,11 +119,12 @@ function getSdkUpdateSuggestion({
       const subSuggestionContent = getSdkUpdateSuggestion({
         suggestion: subSuggestion,
         sdk,
+        capitalized,
       });
       if (!subSuggestionContent) {
         return null;
       }
-      return <Fragment key={index}>{subSuggestionContent}</Fragment>;
+      return <ListItem key={index}>{subSuggestionContent}</ListItem>;
     })
     .filter(content => !!content);
 
@@ -109,16 +132,16 @@ function getSdkUpdateSuggestion({
     return title;
   }
 
-  return tct('[title] so you can: [suggestion]', {
-    title,
-    suggestion: <AlertUl>{alertContent}</AlertUl>,
-  });
+  return (
+    <span>
+      {tct('[title] so you can:', {title})}
+      <StyledList symbol="bullet">{alertContent}</StyledList>
+    </span>
+  );
 }
 
 export default getSdkUpdateSuggestion;
 
-const AlertUl = styled('ul')`
+const StyledList = styled(List)`
   margin-top: ${space(1)};
-  margin-bottom: ${space(1)};
-  padding-left: 0 !important;
 `;


### PR DESCRIPTION
INGEST-158

https://getsentry.atlassian.net/secure/RapidBoard.jspa?rapidView=113&projectKey=INGEST&view=planning&selectedIssue=INGEST-158&quickFilter=196&issueLimit=100

https://www.notion.so/sentry/Update-your-SDKs-notes-9ee74ad6566e4ec99bf10b01b7009981

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/126798027-446e6a0b-d80b-4fe5-881b-3b4e0cf1f0a4.png)

- [x] Add warning alert
- [x] Add a deprecated tag to raven projects only
- [x] Migrate link goes to corresponding SDK docs migration page -> added some links, but unfortunately, they don't cover all deprecated sdks that we have
- [ ] Update link goes to corresponding SDK docs installation page -> we decided to discuss this further internally
- [x] Sort by deprecated, then by platform
- [x] Updates should only be shown to users who are project members or users who have open membership or org write permission

ps: will test this on staging