### PR TITLE
fix(gitlab): fix logger.info

### DIFF
--- a/src/sentry/identity/gitlab/provider.py
+++ b/src/sentry/identity/gitlab/provider.py
@@ -97,7 +97,7 @@ class GitlabIdentityProvider(OAuth2Provider):
             # from GitLab, and won't have the `code` attribute
             # we use the req.status_code instead in that case
             error_status = getattr(e, "code", req.status_code)
-            self.logger(
+            self.logger.info(
                 "gitlab.refresh-identity-failure",
                 extra={
                     "identity_id": identity.id,


### PR DESCRIPTION
When I put up https://github.com/getsentry/sentry/pull/27682, I didn't even realize the logger was incorrectedly used. This fixes that. 

FIXES SENTRY-RP6