### PR TITLE
fix(audit-log): fix to KeyError: 'old_slug'

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -278,7 +278,7 @@ class AuditLogEntry(Model):
         elif self.event == AuditLogEntryEvent.PROJECT_ADD:
             return "created project {}".format(self.data["slug"])
         elif self.event == AuditLogEntryEvent.PROJECT_EDIT:
-            if self.data["old_slug"] is not None:
+            if self.data.get("old_slug") is not None:
                 return (
                     "renamed project slug from "
                     + self.data["old_slug"]

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -121,13 +121,13 @@ class ProjectDetailsTest(APITestCase):
         assert (
             AuditLogEntry.objects.get(
                 organization=project.organization, event=AuditLogEntryEvent.PROJECT_EDIT
-            ).data["old_slug"]
+            ).data.get("old_slug")
             == project.slug
         )
         assert (
             AuditLogEntry.objects.get(
                 organization=project.organization, event=AuditLogEntryEvent.PROJECT_EDIT
-            ).data["new_slug"]
+            ).data.get("new_slug")
             == "foobar"
         )
         assert response.data["slug"] == "foobar"


### PR DESCRIPTION
this pr broke audit-logs in prod due to some objets not having old_slug https://github.com/getsentry/sentry/commit/254868a277315b824aaa8373801792bd42db538a

replaced it with .get() to default to None value if old_slug doesnt exist