### PR TITLE
test(audit-log): test for audit log

### DIFF
--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -162,6 +162,20 @@ class CreateAuditEntryTest(TestCase):
         self.assert_valid_deleted_log(deleted_project, self.project)
         assert deleted_project.platform == self.project.platform
 
+    def test_audit_entry_project_edit_log(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=AuditLogEntryEvent.PROJECT_EDIT,
+            data={"old_slug": "old", "new_slug": "new"},
+        )
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == AuditLogEntryEvent.PROJECT_EDIT
+        assert entry.get_note() == "renamed project slug from old to new"
+
     def test_audit_entry_integration_log(self):
         project = self.create_project()
         self.login_as(user=self.user)


### PR DESCRIPTION
Added test for editing project slug for audit logs, , didn't include in pr before due a previous pr breaking prod.