### PR TITLE
fix(perf): Fix user field for tag page

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -194,9 +194,6 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
                     return {"data": []}, top_tags
 
                 for row in results["data"]:
-                    row["tags_value"] = tagstore.get_tag_value_label(
-                        row["tags_key"], row["tags_value"]
-                    )
                     row["tags_key"] = tagstore.get_standardized_key(row["tags_key"])
 
                 return results, top_tags

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
@@ -49,7 +49,13 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         )
 
     def store_transaction(
-        self, name="exampleTransaction", duration=100, tags=None, project_id=None, lcp=None
+        self,
+        name="exampleTransaction",
+        duration=100,
+        tags=None,
+        project_id=None,
+        lcp=None,
+        user_id=None,
     ):
         if tags is None:
             tags = []
@@ -65,6 +71,14 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
                 "timestamp": iso_format(self.two_mins_ago),
             }
         )
+        if user_id:
+            event["user"] = {
+                "email": "foo@example.com",
+                "id": user_id,
+                "ip_address": "127.0.0.1",
+                "username": "foo",
+            }
+
         if lcp:
             event["measurements"]["lcp"]["value"] = lcp
         else:
@@ -299,3 +313,30 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert histogram_data[2]["histogram_measurements_lcp_750_750_1"] == 4500.0
         assert histogram_data[2]["tags_value"] == "green"
         assert histogram_data[2]["tags_key"] == "color"
+
+    def test_histogram_user_field(self):
+        self.store_transaction(
+            tags=[["color", "blue"], ["many", "yes"]], duration=4000, user_id=555
+        )
+
+        request = {
+            "aggregateColumn": "transaction.duration",
+            "per_page": 5,
+            "tagKeyLimit": 1,
+            "numBucketsPerKey": 2,
+            "tagKey": "user",
+            "query": "(user.id:555)",
+        }
+
+        data_response = self.do_request(
+            request, feature_list=self.feature_list + ("organizations:performance-tag-page",)
+        )
+
+        histogram_data = data_response.data["histogram"]["data"]
+        assert histogram_data[0]["count"] == 1
+        assert histogram_data[0]["tags_value"] == "id:555"
+        assert histogram_data[0]["tags_key"] == "user"
+
+        tag_data = data_response.data["tags"]["data"]
+        assert tag_data[0]["count"] == 1
+        assert tag_data[0]["tags_value"] == "id:555"


### PR DESCRIPTION
### Summary

This will fix the user field tag values being normalized (removing the id:) coming out of the histogram endpoint. This should populate the heat map on the user tag. Previously the tag_values inside the histogram response we including `123` instead of the full value of `id:123`. 