### PR TITLE
ref(notification platform): Improve team linking flow

### DIFF
--- a/src/sentry/integrations/slack/endpoints/command.py
+++ b/src/sentry/integrations/slack/endpoints/command.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Sequence, Tuple
+from typing import Optional, Sequence, Tuple
 
 from django.http import HttpResponse
 from rest_framework import status
@@ -38,7 +38,7 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
     authentication_classes = ()
     permission_classes = ()
 
-    def get_identity(self, slack_request: SlackRequest) -> Any:
+    def get_identity(self, slack_request: SlackRequest) -> Optional[Identity]:
         try:
             idp = IdentityProvider.objects.get(type="slack", external_id=slack_request.team_id)
         except IdentityProvider.DoesNotExist:

--- a/src/sentry/integrations/slack/endpoints/command.py
+++ b/src/sentry/integrations/slack/endpoints/command.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Sequence, Tuple
+from typing import Any, Sequence, Tuple
 
 from django.http import HttpResponse
 from rest_framework import status
@@ -11,9 +11,10 @@ from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestEr
 from sentry.integrations.slack.requests.command import SlackCommandRequest
 from sentry.integrations.slack.views.link_team import build_team_linking_url
 from sentry.integrations.slack.views.unlink_team import build_team_unlinking_url
-from sentry.models import ExternalActor
+from sentry.models import ExternalActor, Identity, IdentityProvider, OrganizationMember
 from sentry.types.integrations import ExternalProviders
 
+from ..utils import is_valid_role
 from .base import SlackDMEndpoint
 
 logger = logging.getLogger("sentry.integrations.slack")
@@ -30,11 +31,29 @@ LINK_FROM_CHANNEL_MESSAGE = "You must type this command in a channel, not a DM."
 UNLINK_TEAM_MESSAGE = "<{associate_url}|Click here to unlink your team from this channel.>"
 TEAM_NOT_LINKED_MESSAGE = "No team is linked to this channel."
 DIRECT_MESSAGE_CHANNEL_NAME = "directmessage"
+INSUFFICIENT_ROLE_MESSAGE = "You must be a Sentry admin, manager, or owner to link or unlink teams."
 
 
 class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
     authentication_classes = ()
     permission_classes = ()
+
+    def get_identity(self, slack_request: SlackRequest) -> Any:
+        try:
+            idp = IdentityProvider.objects.get(type="slack", external_id=slack_request.team_id)
+        except IdentityProvider.DoesNotExist:
+            logger.error(
+                "slack.action.invalid-team-id", extra={"slack_team": slack_request.team_id}
+            )
+            return None
+        try:
+            identity = Identity.objects.select_related("user").get(
+                idp=idp, external_id=slack_request.user_id
+            )
+        except Identity.DoesNotExist:
+            return None
+
+        return identity
 
     def get_command_and_args(self, payload: SlackRequest) -> Tuple[str, Sequence[str]]:
         payload = payload.data
@@ -58,8 +77,16 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
         if slack_request.channel_name == DIRECT_MESSAGE_CHANNEL_NAME:
             return self.reply(slack_request, LINK_FROM_CHANNEL_MESSAGE)
 
-        if not slack_request.has_identity:
+        identity = self.get_identity(slack_request)
+        if not identity:
             return self.reply(slack_request, LINK_USER_FIRST_MESSAGE)
+
+        integration = slack_request.integration
+        organization = integration.organizations.all()[0]
+        org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
+
+        if not is_valid_role(org_member):
+            return self.reply(slack_request, INSUFFICIENT_ROLE_MESSAGE)
 
         associate_url = build_team_linking_url(
             integration=slack_request.integration,
@@ -75,7 +102,8 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
         if slack_request.channel_name == DIRECT_MESSAGE_CHANNEL_NAME:
             return self.reply(slack_request, LINK_FROM_CHANNEL_MESSAGE)
 
-        if not slack_request.has_identity:
+        identity = self.get_identity(slack_request)
+        if not identity:
             return self.reply(slack_request, LINK_USER_FIRST_MESSAGE)
 
         integration = slack_request.integration
@@ -89,6 +117,11 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
             external_id=slack_request.channel_id,
         ).exists():
             return self.reply(slack_request, TEAM_NOT_LINKED_MESSAGE)
+
+        org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
+
+        if not is_valid_role(org_member):
+            return self.reply(slack_request, INSUFFICIENT_ROLE_MESSAGE)
 
         associate_url = build_team_unlinking_url(
             integration=integration,

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -317,10 +317,8 @@ def get_identities_by_user(idp, users):
     return {identity.user: identity for identity in identity_models}
 
 
-def is_valid_role(org_member, team, organization):
-    return org_member.role in ALLOWED_ROLES and (
-        organization.flags.allow_joinleave or team in org_member.teams.all()
-    )
+def is_valid_role(org_member):
+    return org_member.role in ALLOWED_ROLES
 
 
 def render_error_page(request: Request, body_text: str) -> HttpResponse:

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -10,7 +10,6 @@ from sentry.models import (
     IdentityProvider,
     Integration,
     NotificationSetting,
-    OrganizationMember,
     Team,
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
@@ -19,14 +18,12 @@ from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 
-from ..utils import is_valid_role, logger, render_error_page, send_confirmation
+from ..utils import logger, render_error_page, send_confirmation
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
 ALLOWED_METHODS = ["GET", "POST"]
 
-INSUFFICIENT_ROLE_TITLE = "Insufficient role"
-INSUFFICIENT_ROLE_MESSAGE = "You must be an admin or higher to link teams."
 ALREADY_LINKED_TITLE = "Already linked"
 ALREADY_LINKED_MESSAGE = "The {slug} team has already been linked to a Slack channel."
 SUCCESS_LINKED_TITLE = "Team linked"
@@ -102,26 +99,13 @@ class SlackLinkTeamView(BaseView):  # type: ignore
             return render_error_page(request, body_text="HTTP 403: Invalid team ID")
 
         try:
-            identity = Identity.objects.select_related("user").get(
-                idp=idp, external_id=params["slack_id"]
-            )
+            Identity.objects.select_related("user").get(idp=idp, external_id=params["slack_id"])
         except Identity.DoesNotExist:
             logger.error(
                 "slack.action.missing-identity", extra={"slack_id": integration.external_id}
             )
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")
 
-        org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
-
-        if not is_valid_role(org_member, team, organization):
-            return send_confirmation(
-                integration,
-                channel_id,
-                INSUFFICIENT_ROLE_TITLE,
-                INSUFFICIENT_ROLE_MESSAGE,
-                "sentry/integrations/slack-post-linked-team.html",
-                request,
-            )
         external_team, created = ExternalActor.objects.get_or_create(
             actor_id=team.actor_id,
             organization=organization,

--- a/src/sentry/integrations/slack/views/link_team.py
+++ b/src/sentry/integrations/slack/views/link_team.py
@@ -98,12 +98,7 @@ class SlackLinkTeamView(BaseView):  # type: ignore
             )
             return render_error_page(request, body_text="HTTP 403: Invalid team ID")
 
-        try:
-            Identity.objects.select_related("user").get(idp=idp, external_id=params["slack_id"])
-        except Identity.DoesNotExist:
-            logger.error(
-                "slack.action.missing-identity", extra={"slack_id": integration.external_id}
-            )
+        if not Identity.objects.filter(idp=idp, external_id=params["slack_id"]).exists():
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")
 
         external_team, created = ExternalActor.objects.get_or_create(

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -90,12 +90,7 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
             )
             return render_error_page(request, body_text="HTTP 403: Invalid team ID")
 
-        try:
-            Identity.objects.select_related("user").get(idp=idp, external_id=params["slack_id"])
-        except Identity.DoesNotExist:
-            logger.error(
-                "slack.action.missing-identity", extra={"slack_id": integration.external_id}
-            )
+        if not Identity.objects.filter(idp=idp, external_id=params["slack_id"]).exists():
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")
 
         external_team.delete()

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -9,7 +9,6 @@ from sentry.models import (
     IdentityProvider,
     Integration,
     NotificationSetting,
-    OrganizationMember,
     Team,
 )
 from sentry.types.integrations import ExternalProviders
@@ -18,10 +17,9 @@ from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
-from ..utils import get_identity, is_valid_role, logger, render_error_page, send_confirmation
+from ..utils import get_identity, logger, render_error_page, send_confirmation
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
-from .link_team import INSUFFICIENT_ROLE_MESSAGE, INSUFFICIENT_ROLE_TITLE
 
 SUCCESS_UNLINKED_TITLE = "Team unlinked"
 SUCCESS_UNLINKED_MESSAGE = (
@@ -93,26 +91,12 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
             return render_error_page(request, body_text="HTTP 403: Invalid team ID")
 
         try:
-            identity = Identity.objects.select_related("user").get(
-                idp=idp, external_id=params["slack_id"]
-            )
+            Identity.objects.select_related("user").get(idp=idp, external_id=params["slack_id"])
         except Identity.DoesNotExist:
             logger.error(
                 "slack.action.missing-identity", extra={"slack_id": integration.external_id}
             )
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")
-
-        org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
-
-        if not is_valid_role(org_member, team, organization):
-            return send_confirmation(
-                integration,
-                channel_id,
-                INSUFFICIENT_ROLE_TITLE,
-                INSUFFICIENT_ROLE_MESSAGE,
-                "sentry/integrations/slack-post-linked-team.html",
-                request,
-            )
 
         external_team.delete()
         NotificationSetting.objects.remove_for_team(team, ExternalProviders.SLACK)

--- a/src/sentry/templates/sentry/integrations/slack-unlinked-team.html
+++ b/src/sentry/templates/sentry/integrations/slack-unlinked-team.html
@@ -8,7 +8,7 @@
 {% block main %}
   <div class="align-center">
     <p>
-      <b>#{{ channel_name }}</b> will no longer receive issue alert notifications for the <b>#{{ team.slug }}</b> team.
+      Your team will no longer receive issue alert notifications in Slack.
     </p>
     <p>
       <a href="slack://channel?id={{ channel_id }}&team={{ team_id }}" class="btn btn-default btn-login-slack">

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -9,6 +9,7 @@ from rest_framework import status
 from sentry import options
 from sentry.integrations.slack.endpoints.base import NOT_LINKED_MESSAGE
 from sentry.integrations.slack.endpoints.command import (
+    INSUFFICIENT_ROLE_MESSAGE,
     LINK_FROM_CHANNEL_MESSAGE,
     LINK_USER_FIRST_MESSAGE,
     TEAM_NOT_LINKED_MESSAGE,
@@ -325,8 +326,7 @@ class SlackCommandsLinkTeamTest(SlackCommandsTest):
 
     @responses.activate
     def test_link_team_insufficient_role(self):
-        """Test that when a user whose role is insufficient and is a member of the
-        team in question in a closed membership org attempts to link a team, we reject
+        """Test that when a user whose role is insufficient attempts to link a team, we reject
         them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
         user2 = self.create_user()
         self.create_member(
@@ -340,72 +340,9 @@ class SlackCommandsLinkTeamTest(SlackCommandsTest):
             status=IdentityStatus.VALID,
             scopes=[],
         )
-        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
-        linking_url = build_team_linking_url(
-            self.integration,
-            "UXXXXXXX2",
-            "CXXXXXXX9",
-            "general",
-            "http://example.slack.com/response_url",
-        )
-
-        resp = self.client.get(linking_url)
-
-        assert resp.status_code == 200
-        self.assertTemplateUsed(resp, "sentry/integrations/slack-link-team.html")
-
-        data = urlencode({"team": self.team.id})
-        resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
-        assert resp.status_code == 200
-        self.assertTemplateUsed(resp, "sentry/integrations/slack-post-linked-team.html")
-
+        data = self.send_slack_message("link team", user_id="UXXXXXXX2")
+        assert INSUFFICIENT_ROLE_MESSAGE in data["text"]
         assert len(self.external_actor) == 0
-
-        assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
-        assert "You must be an admin or higher" in data["text"]
-
-    @responses.activate
-    def test_link_team_insufficient_role_open_membership(self):
-        """Test that when a user whose role is insufficient in an open membership organization
-        attempts to link a team, we reject them and reply with the INSUFFICIENT_ROLE_MESSAGE"""
-        self.organization.flags.allow_joinleave = True
-        user2 = self.create_user()
-        self.create_member(
-            teams=[self.team], user=user2, role="member", organization=self.organization
-        )
-        self.login_as(user2)
-        Identity.objects.create(
-            external_id="UXXXXXXX2",
-            idp=self.idp,
-            user=user2,
-            status=IdentityStatus.VALID,
-            scopes=[],
-        )
-        assert "Link your Sentry team to this Slack channel!" in self.data["text"]
-        linking_url = build_team_linking_url(
-            self.integration,
-            "UXXXXXXX2",
-            "CXXXXXXX9",
-            "general",
-            "http://example.slack.com/response_url",
-        )
-
-        resp = self.client.get(linking_url)
-
-        assert resp.status_code == 200
-        self.assertTemplateUsed(resp, "sentry/integrations/slack-link-team.html")
-
-        data = urlencode({"team": self.team.id})
-        resp = self.client.post(linking_url, data, content_type="application/x-www-form-urlencoded")
-        assert resp.status_code == 200
-        self.assertTemplateUsed(resp, "sentry/integrations/slack-post-linked-team.html")
-
-        assert len(self.external_actor) == 0
-
-        assert len(responses.calls) >= 1
-        data = json.loads(str(responses.calls[0].request.body.decode("utf-8")))
-        assert "You must be an admin or higher" in data["text"]
 
     @responses.activate
     def test_link_team_already_linked(self):


### PR DESCRIPTION
**Motivation**
We released this feature internally and got some good feedback that the team linking flow sucks if you don't have the correct permissions to complete the linking. 
<img width="347" alt="Screen Shot 2021-07-23 at 12 34 35 PM" src="https://user-images.githubusercontent.com/29959063/126832537-719f9bec-f55a-4285-8652-1083477951eb.png">

**Before**
A member would type `/sentry link team` into a channel, we'd reply with a link. User clicks the link, chooses a team from a dropdown that is populated with teams the user has access to, and clicks submit. We'd reply letting them know they cannot complete the linking due to their membership level. We checked for validity based on roles AND open org membership OR the user belonging to the team that was selected.

**After**
A member types `/sentry link team` and we reply letting them know they cannot complete the linking due to their membership level. We now check for validity by checking permissions as soon as the command is typed in. When a user who has the correct permissions types the command, we know they have access to the team they've selected because the dropdown is only populated with teams they have access to. 

**Other small updates**
* Updates the insufficient role message to be ephemeral, rather than notifying the entire channel that the user failed to link.
* Updates the insufficient role text to make it clear that your role is your Sentry role, and not your Slack role.
* Updates the successful team unlinking template - before it was attempting to render text using variables it didn't have access to and looked bad.