### PR TITLE
feat(ui): Release stages guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -52,6 +52,7 @@ GUIDES = {
         "required_targets": ["percentage_based_alerts"],
     },
     "semver": {"id": 22, "required_targets": ["releases_search"]},
+    "release_stages": {"id": 23, "required_targets": ["release_stages"]},
 }
 
 # demo mode has different guides

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -351,12 +351,13 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
     {
       guide: 'release_stages',
       requiredTargets: ['release_stages'],
+      dateThreshold: new Date(2021, 6, 1),
       steps: [
         {
           title: t('Adoption Filter'),
           target: 'release_stages',
           description: tct(
-            'Select an environment and search for `release.stage:adopted` to filter out releases with low adoption. [link:Learn more]',
+            'Select an environment and search for `release.stage:adopted` to filter out releases with low adoption. [br] [link:Learn more]',
             {
               br: <br />,
               link: (

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -348,6 +348,26 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         },
       ],
     },
+    {
+      guide: 'release_stages',
+      requiredTargets: ['release_stages'],
+      steps: [
+        {
+          title: t('Adoption Filter'),
+          target: 'release_stages',
+          description: tct(
+            'Select an environment and search for `release.stage:adopted` to filter out releases with low adoption. [link:Learn more]',
+            {
+              br: <br />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/releases/usage/sorting-filtering/#filtering-releases" />
+              ),
+            }
+          ),
+          nextText: t('Got it'),
+        },
+      ],
+    },
   ];
 }
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -552,16 +552,18 @@ class ReleasesList extends AsyncView<Props, State> {
             <SortAndFilterWrapper>
               {hasSemver ? (
                 <GuideAnchor target="releases_search" position="bottom">
-                  <SmartSearchBar
-                    searchSource="releases"
-                    query={this.getQuery()}
-                    placeholder={t('Search by release version')}
-                    maxSearchItems={5}
-                    hasRecentSearches={false}
-                    supportedTags={supportedTags}
-                    onSearch={this.handleSearch}
-                    onGetTagValues={this.getTagValues}
-                  />
+                  <GuideAnchor target="release_stages" position="bottom">
+                    <SmartSearchBar
+                      searchSource="releases"
+                      query={this.getQuery()}
+                      placeholder={t('Search by release version')}
+                      maxSearchItems={5}
+                      hasRecentSearches={false}
+                      supportedTags={supportedTags}
+                      onSearch={this.handleSearch}
+                      onGetTagValues={this.getTagValues}
+                    />
+                  </GuideAnchor>
                 </GuideAnchor>
               ) : (
                 <SearchBar

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -7,7 +7,7 @@ import pick from 'lodash/pick';
 import {fetchTagValues} from 'app/actionCreators/tags';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
-import {GuideAnchor} from 'app/components/assistant/guideAnchor';
+import GuideAnchorWrapper, {GuideAnchor} from 'app/components/assistant/guideAnchor';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import ExternalLink from 'app/components/links/externalLink';
@@ -533,6 +533,7 @@ class ReleasesList extends AsyncView<Props, State> {
     const activeDisplay = this.getDisplay();
 
     const hasSemver = organization.features.includes('semver');
+    const hasReleaseStages = organization.features.includes('release-adoption-stage');
 
     return (
       <GlobalSelectionHeader
@@ -552,7 +553,7 @@ class ReleasesList extends AsyncView<Props, State> {
             <SortAndFilterWrapper>
               {hasSemver ? (
                 <GuideAnchor target="releases_search" position="bottom">
-                  <GuideAnchor target="release_stages" position="bottom">
+                  <GuideAnchorWrapper target="release_stages" position="bottom" disabled={!hasReleaseStages}>
                     <SmartSearchBar
                       searchSource="releases"
                       query={this.getQuery()}
@@ -563,7 +564,7 @@ class ReleasesList extends AsyncView<Props, State> {
                       onSearch={this.handleSearch}
                       onGetTagValues={this.getTagValues}
                     />
-                  </GuideAnchor>
+                  </GuideAnchorWrapper>
                 </GuideAnchor>
               ) : (
                 <SearchBar

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -553,7 +553,11 @@ class ReleasesList extends AsyncView<Props, State> {
             <SortAndFilterWrapper>
               {hasSemver ? (
                 <GuideAnchor target="releases_search" position="bottom">
-                  <GuideAnchorWrapper target="release_stages" position="bottom" disabled={!hasReleaseStages}>
+                  <GuideAnchorWrapper
+                    target="release_stages"
+                    position="bottom"
+                    disabled={!hasReleaseStages}
+                  >
                     <SmartSearchBar
                       searchSource="releases"
                       query={this.getQuery()}

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -70,11 +70,13 @@ const Content = ({
   isTopRelease,
   getHealthData,
 }: Props) => {
+  const hasReleaseStages = organization.features.includes('release-adoption-stage');
   const anyProjectMobile =
     projects.filter(
       project => project.platform && isProjectMobileForReleases(project.platform)
     ).length > 0;
-  const hasAdoptionStagesColumn: boolean = anyProjectMobile && showAdoptionStageLabels;
+  const hasAdoptionStagesColumn: boolean =
+    hasReleaseStages && anyProjectMobile && showAdoptionStageLabels;
   return (
     <Fragment>
       <Header>


### PR DESCRIPTION
This adds a guide for the `release.stage` filter that can be used in the search bar and the corresponding labels on the releases page. Also added a check to the list to control adoption stage column with the release stages flag, this isn't really changing much since we check the flag on the backend and send stage accordingly, but having a frontend check also is better.

Jira: [WOR-1107](https://getsentry.atlassian.net/browse/WOR-1107)