### PR TITLE
fix(spans): Indent last span of the span group chain

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -118,7 +118,6 @@ type SpanBarProps = {
     | ((props: {orgSlug: string; eventSlug: string}) => void)
     | undefined;
   fetchEmbeddedChildrenState: FetchEmbeddedChildrenState;
-  hasCollapsedSpanGroup: boolean;
   toggleSpanGroup: (() => void) | undefined;
 };
 
@@ -310,7 +309,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       continuingTreeDepths,
       span,
       showSpanTree,
-      hasCollapsedSpanGroup,
     } = this.props;
 
     const spanID = getSpanID(span);
@@ -363,31 +361,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           key={`${spanID}-last-bottom`}
           orphanBranch={false}
         />
-      );
-    }
-
-    if (hasCollapsedSpanGroup) {
-      connectorBars.push(
-        <ConnectorBar
-          style={{
-            right: '16px',
-            height: `${ROW_HEIGHT / 2}px`,
-            top: '0',
-          }}
-          key={`${spanID}-last-top`}
-          orphanBranch={false}
-        />
-      );
-
-      return (
-        <TreeConnector
-          isLast
-          hasToggler={hasToggler}
-          orphanBranch={isOrphanSpan(span)}
-          hasCollapsedSpanGroup
-        >
-          {connectorBars}
-        </TreeConnector>
       );
     }
 

--- a/static/app/components/events/interfaces/spans/spanGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanGroupBar.tsx
@@ -36,7 +36,7 @@ import * as DividerHandlerManager from './dividerHandlerManager';
 import * as ScrollbarManager from './scrollbarManager';
 import SpanBarCursorGuide from './spanBarCursorGuide';
 import {MeasurementMarker} from './styles';
-import {EnhancedSpan, ProcessedSpanType, SpanGroupProps, TreeDepthType} from './types';
+import {EnhancedSpan, ProcessedSpanType, TreeDepthType} from './types';
 import {
   getMeasurementBounds,
   getMeasurements,
@@ -412,19 +412,6 @@ class SpanGroupBar extends React.Component<Props> {
       </ScrollbarManager.Consumer>
     );
   }
-}
-
-export function isCollapsedSpanGroup({
-  spanGrouping,
-  showSpanGroup,
-  toggleSpanGroup,
-}: SpanGroupProps) {
-  return (
-    Array.isArray(spanGrouping) &&
-    spanGrouping.length !== 0 &&
-    !showSpanGroup &&
-    typeof toggleSpanGroup === 'function'
-  );
 }
 
 export default SpanGroupBar;

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -219,26 +219,29 @@ class SpanTreeModel {
       (spanGrouping === undefined ||
         (Array.isArray(spanGrouping) && spanGrouping.length === 0));
 
-    // For a collapsed span group chain to be useful, we prefer span groupings
-    // that are two or more spans.
-    // Since there is no concept of "backtracking" when constructing the span tree,
-    // we will need to reconstruct the tree depth information. This is only neccessary
-    // when the span group chain is hidden/collapsed.
     if (
       isLastSpanOfGroup &&
       Array.isArray(spanGrouping) &&
-      spanGrouping.length === 1 &&
+      spanGrouping.length >= 1 &&
       !showSpanGroup
     ) {
-      const treeDepthEntryFoo = isOrphanSpan(spanGrouping[0].span)
-        ? ({type: 'orphan', depth: spanGrouping[0].treeDepth} as OrphanTreeDepth)
-        : spanGrouping[0].treeDepth;
-
-      if (!spanGrouping[0].isLastSibling) {
-        continuingTreeDepths = [...continuingTreeDepths, treeDepthEntryFoo];
-      }
-
+      // We always want to indent the last span of the span group chain
       treeDepth = treeDepth + 1;
+
+      // For a collapsed span group chain to be useful, we prefer span groupings
+      // that are two or more spans.
+      // Since there is no concept of "backtracking" when constructing the span tree,
+      // we will need to reconstruct the tree depth information. This is only neccessary
+      // when the span group chain is hidden/collapsed.
+      if (spanGrouping.length === 1) {
+        const treeDepthEntryFoo = isOrphanSpan(spanGrouping[0].span)
+          ? ({type: 'orphan', depth: spanGrouping[0].treeDepth} as OrphanTreeDepth)
+          : spanGrouping[0].treeDepth;
+
+        if (!spanGrouping[0].isLastSibling) {
+          continuingTreeDepths = [...continuingTreeDepths, treeDepthEntryFoo];
+        }
+      }
     }
 
     // Criteria for propagating information about the span group to the last span of the span group chain
@@ -255,16 +258,12 @@ class SpanTreeModel {
       fetchEmbeddedChildrenState: this.fetchEmbeddedChildrenState,
       showEmbeddedChildren: this.showEmbeddedChildren,
       toggleEmbeddedChildren: this.toggleEmbeddedChildren,
-      spanGrouping: spanGroupingCriteria ? spanGrouping : undefined,
       toggleSpanGroup:
-        spanGroupingCriteria && toggleSpanGroup
+        spanGroupingCriteria && toggleSpanGroup && !showSpanGroup
           ? toggleSpanGroup
           : isFirstSpanOfGroup && this.showSpanGroup && !hideSpanTree
           ? this.toggleSpanGroup
           : undefined,
-      showSpanGroup:
-        (spanGroupingCriteria && toggleSpanGroup === undefined && this.showSpanGroup) ||
-        (spanGroupingCriteria && toggleSpanGroup !== undefined && showSpanGroup),
     };
 
     const treeDepthEntry = isOrphanSpan(this.span)
@@ -368,10 +367,37 @@ class SpanTreeModel {
     }
 
     if (
+      isLastSpanOfGroup &&
+      Array.isArray(spanGrouping) &&
+      spanGrouping.length > 1 &&
+      !showSpanGroup &&
+      wrappedSpan.type === 'span'
+    ) {
+      const spanGroupChain: EnhancedProcessedSpanType = {
+        type: 'span_group_chain',
+        span: this.span,
+        treeDepth: treeDepth - 1,
+        continuingTreeDepths,
+        spanGrouping: spanGroupingCriteria ? spanGrouping : undefined,
+        showSpanGroup:
+          (spanGroupingCriteria && toggleSpanGroup === undefined && this.showSpanGroup) ||
+          (spanGroupingCriteria && toggleSpanGroup !== undefined && showSpanGroup),
+        toggleSpanGroup: wrappedSpan.toggleSpanGroup,
+      };
+
+      return [
+        spanGroupChain,
+        {...wrappedSpan, toggleSpanGroup: undefined},
+        ...descendants,
+      ];
+    }
+
+    if (
       isFirstSpanOfGroup &&
       this.showSpanGroup &&
       !hideSpanTree &&
-      descendants.length <= 1
+      descendants.length <= 1 &&
+      wrappedSpan.type === 'span'
     ) {
       // If we know the descendants will be one span or less, we remove the "regroup" feature (therefore hide it)
       // by setting toggleSpanGroup to be undefined for the first span of the group chain.

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -378,10 +378,8 @@ class SpanTreeModel {
         span: this.span,
         treeDepth: treeDepth - 1,
         continuingTreeDepths,
-        spanGrouping: spanGroupingCriteria ? spanGrouping : undefined,
-        showSpanGroup:
-          (spanGroupingCriteria && toggleSpanGroup === undefined && this.showSpanGroup) ||
-          (spanGroupingCriteria && toggleSpanGroup !== undefined && showSpanGroup),
+        spanGrouping,
+        showSpanGroup,
         toggleSpanGroup: wrappedSpan.toggleSpanGroup,
       };
 

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -71,13 +71,12 @@ export type EnhancedSpan =
   | ({
       type: 'root_span';
       span: SpanType;
-    } & CommonEnhancedProcessedSpanType &
-      SpanGroupProps)
+    } & CommonEnhancedProcessedSpanType)
   | ({
       type: 'span';
       span: SpanType;
-    } & CommonEnhancedProcessedSpanType &
-      SpanGroupProps);
+      toggleSpanGroup: (() => void) | undefined;
+    } & CommonEnhancedProcessedSpanType);
 
 // ProcessedSpanType with additional information
 export type EnhancedProcessedSpanType =
@@ -93,7 +92,13 @@ export type EnhancedProcessedSpanType =
   | {
       type: 'out_of_view';
       span: SpanType;
-    };
+    }
+  | ({
+      type: 'span_group_chain';
+      span: SpanType;
+      treeDepth: number;
+      continuingTreeDepths: Array<TreeDepthType>;
+    } & SpanGroupProps);
 
 export type SpanEntry = {
   type: 'spans';

--- a/static/app/components/performance/waterfall/treeConnector.tsx
+++ b/static/app/components/performance/waterfall/treeConnector.tsx
@@ -22,17 +22,12 @@ export const ConnectorBar = styled('div')<{orphanBranch: boolean}>`
 type TogglerTypes = OmitHtmlDivProps<{
   hasToggler?: boolean;
   isLast?: boolean;
-  hasCollapsedSpanGroup?: boolean;
 }>;
 
 export const TreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean}>`
   height: ${p => (p.isLast ? ROW_HEIGHT / 2 : ROW_HEIGHT)}px;
   width: 100%;
   border-left: ${p => {
-    if (p.hasCollapsedSpanGroup) {
-      return '1px solid transparent';
-    }
-
     return `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border}`;
   }};
   position: absolute;
@@ -43,11 +38,8 @@ export const TreeConnector = styled('div')<TogglerTypes & {orphanBranch: boolean
     height: 1px;
     border-bottom: ${p =>
       `1px ${p.orphanBranch ? 'dashed' : 'solid'} ${p.theme.border};`};
-    left: ${p => (p.hasCollapsedSpanGroup ? `${TOGGLE_BORDER_BOX / 2}px` : '0')};
-    width: ${p =>
-      p.hasCollapsedSpanGroup
-        ? `${TREE_TOGGLE_CONTAINER_WIDTH - TOGGLE_BORDER_BOX / 2 - 2}px`
-        : '100%'};
+    left: 0;
+    width: 100%;
     position: absolute;
     bottom: ${p => (p.isLast ? '0' : '50%')};
   }

--- a/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -220,8 +220,6 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -251,8 +249,6 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -282,8 +278,6 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -309,8 +303,6 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
     ];
@@ -400,8 +392,6 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -424,8 +414,6 @@ describe('SpanTreeModel', () => {
         showEmbeddedChildren: false,
         toggleEmbeddedChildren: expect.any(Function),
         fetchEmbeddedChildrenState: 'idle',
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       }
     );

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -115,9 +115,6 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
-      spanGrouping: undefined,
-      showSpanGroup: false,
-      toggleSpanGroup: undefined,
     },
     {
       type: 'span',
@@ -140,8 +137,6 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
-      spanGrouping: undefined,
-      showSpanGroup: false,
       toggleSpanGroup: undefined,
     },
     {
@@ -182,8 +177,6 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
-      spanGrouping: undefined,
-      showSpanGroup: false,
       toggleSpanGroup: undefined,
     },
     {
@@ -209,8 +202,6 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
-      spanGrouping: undefined,
-      showSpanGroup: false,
       toggleSpanGroup: undefined,
     },
     {
@@ -253,8 +244,6 @@ describe('WaterfallModel', () => {
       showEmbeddedChildren: false,
       toggleEmbeddedChildren: expect.any(Function),
       fetchEmbeddedChildrenState: 'idle',
-      spanGrouping: undefined,
-      showSpanGroup: false,
       toggleSpanGroup: undefined,
     },
   ];
@@ -515,8 +504,6 @@ describe('WaterfallModel', () => {
       {
         ...fullWaterfall[0],
         numOfSpanChildren: 0,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
     ]);
@@ -544,16 +531,12 @@ describe('WaterfallModel', () => {
       {
         ...fullWaterfall[0],
         numOfSpanChildren: 1,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
         ...fullWaterfall[1],
         isLastSibling: true,
         numOfSpanChildren: 0,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
     ]);
@@ -589,8 +572,6 @@ describe('WaterfallModel', () => {
         ...fullWaterfall[0],
         treeDepth: 0,
         numOfSpanChildren: 1,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -598,8 +579,6 @@ describe('WaterfallModel', () => {
         treeDepth: 1,
         isLastSibling: true,
         numOfSpanChildren: 1,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -612,8 +591,6 @@ describe('WaterfallModel', () => {
         treeDepth: 2,
         isLastSibling: true,
         numOfSpanChildren: 0,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
     ]);
@@ -649,33 +626,29 @@ describe('WaterfallModel', () => {
     });
 
     // expect 1 or more spans are grouped
-    expect(spans).toHaveLength(2);
+    expect(spans).toHaveLength(3);
 
+    assert(fullWaterfall[1].type === 'span');
     const collapsedWaterfallExpected = [
       {
         ...fullWaterfall[0],
         numOfSpanChildren: 1,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
-        ...fullWaterfall[1],
+        type: 'span_group_chain',
+        treeDepth: 1,
+        continuingTreeDepths: fullWaterfall[1].continuingTreeDepths,
         span: {
           ...fullWaterfall[1].span,
           parent_span_id: 'foo',
           span_id: 'bar',
         },
-        isLastSibling: true,
-        numOfSpanChildren: 0,
-        treeDepth: 1,
         spanGrouping: [
           {
             ...fullWaterfall[1],
             isLastSibling: true,
             numOfSpanChildren: 1,
-            spanGrouping: undefined,
-            showSpanGroup: false,
             toggleSpanGroup: undefined,
           },
           {
@@ -687,13 +660,23 @@ describe('WaterfallModel', () => {
             },
             isLastSibling: true,
             numOfSpanChildren: 1,
-            spanGrouping: undefined,
-            showSpanGroup: false,
             toggleSpanGroup: undefined,
           },
         ],
         showSpanGroup: false,
         toggleSpanGroup: expect.any(Function),
+      },
+      {
+        ...fullWaterfall[1],
+        span: {
+          ...fullWaterfall[1].span,
+          parent_span_id: 'foo',
+          span_id: 'bar',
+        },
+        isLastSibling: true,
+        numOfSpanChildren: 0,
+        treeDepth: 2,
+        toggleSpanGroup: undefined,
       },
     ];
 
@@ -716,8 +699,6 @@ describe('WaterfallModel', () => {
         ...fullWaterfall[0],
         numOfSpanChildren: 1,
         treeDepth: 0,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -725,8 +706,6 @@ describe('WaterfallModel', () => {
         isLastSibling: true,
         numOfSpanChildren: 1,
         treeDepth: 1,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: expect.any(Function),
       },
       {
@@ -739,8 +718,6 @@ describe('WaterfallModel', () => {
         isLastSibling: true,
         numOfSpanChildren: 1,
         treeDepth: 2,
-        spanGrouping: undefined,
-        showSpanGroup: false,
         toggleSpanGroup: undefined,
       },
       {
@@ -753,32 +730,7 @@ describe('WaterfallModel', () => {
         isLastSibling: true,
         numOfSpanChildren: 0,
         treeDepth: 3,
-        spanGrouping: [
-          {
-            ...fullWaterfall[1],
-            isLastSibling: true,
-            numOfSpanChildren: 1,
-            spanGrouping: undefined,
-            showSpanGroup: false,
-            toggleSpanGroup: expect.any(Function),
-          },
-          {
-            ...fullWaterfall[1],
-            span: {
-              ...fullWaterfall[1].span,
-              parent_span_id: event.entries[0].data[0].span_id,
-              span_id: 'foo',
-            },
-            treeDepth: 2,
-            isLastSibling: true,
-            numOfSpanChildren: 1,
-            spanGrouping: undefined,
-            showSpanGroup: false,
-            toggleSpanGroup: undefined,
-          },
-        ],
-        showSpanGroup: true,
-        toggleSpanGroup: expect.any(Function),
+        toggleSpanGroup: undefined,
       },
     ]);
 
@@ -791,7 +743,7 @@ describe('WaterfallModel', () => {
       viewEnd: 1,
     });
 
-    expect(spans).toHaveLength(2);
+    expect(spans).toHaveLength(3);
     expect(spans).toEqual(collapsedWaterfallExpected);
   });
 });


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/27716

This PR includes additional changes to treat the virtual span row that represents the collapsed span group chain as its own dedicated span internal representation.

**Before:**

<img width="305" alt="Screen Shot 2021-07-23 at 6 20 36 PM" src="https://user-images.githubusercontent.com/139499/126847671-4ca0692a-6a86-4dcb-9abc-07a342ab719a.png">

**After:**

<img width="342" alt="Screen Shot 2021-07-23 at 6 20 50 PM" src="https://user-images.githubusercontent.com/139499/126847676-c6d3aacd-23da-434c-b9d4-c4d661df60c5.png">

