### PR TITLE
feat(notifications): Confirmation Modal

### DIFF
--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -27,6 +27,7 @@ export type ConfirmMessageRenderProps = {
    * This should be called in the components componentDidMount.
    */
   setConfirmCallback: (cb: () => void) => void;
+  selectedValue?: string;
 };
 
 export type ConfirmButtonsRenderProps = {
@@ -42,7 +43,7 @@ export type ConfirmButtonsRenderProps = {
 };
 
 type ChildrenRenderProps = {
-  open: () => void;
+  open: (e?: React.MouseEvent, selectedValue?: string) => void;
 };
 
 export type OpenConfirmOptions = {
@@ -106,6 +107,7 @@ export type OpenConfirmOptions = {
    * Text to show in the confirmation button
    */
   confirmText?: React.ReactNode;
+  selectedValue?: string;
 };
 
 type Props = OpenConfirmOptions & {
@@ -167,7 +169,7 @@ function Confirm({
   stopPropagation = false,
   ...openConfirmOptions
 }: Props) {
-  const triggerModal = (e?: React.MouseEvent) => {
+  const triggerModal = (e?: React.MouseEvent, selectedValue?: string) => {
     if (stopPropagation) {
       e?.stopPropagation();
     }
@@ -176,7 +178,7 @@ function Confirm({
       return;
     }
 
-    openConfirmModal(openConfirmOptions);
+    openConfirmModal({...openConfirmOptions, ...(selectedValue && {selectedValue})});
   };
 
   if (typeof children === 'function') {
@@ -205,6 +207,7 @@ type ModalProps = ModalRenderProps &
     | 'onConfirm'
     | 'onCancel'
     | 'disableConfirmButton'
+    | 'selectedValue'
   >;
 
 type ModalState = {
@@ -253,7 +256,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
   };
 
   get confirmMessage() {
-    const {message, renderMessage} = this.props;
+    const {message, renderMessage, selectedValue} = this.props;
 
     if (typeof renderMessage === 'function') {
       return renderMessage({
@@ -263,6 +266,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
           this.setState({disableConfirmButton: state}),
         setConfirmCallback: (confirmCallback: () => void) =>
           this.setState({confirmCallback}),
+        selectedValue,
       });
     }
 

--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -27,7 +27,7 @@ export type ConfirmMessageRenderProps = {
    * This should be called in the components componentDidMount.
    */
   setConfirmCallback: (cb: () => void) => void;
-  selectedValue?: string;
+  selectedValue?: any;
 };
 
 export type ConfirmButtonsRenderProps = {
@@ -50,7 +50,7 @@ export type OpenConfirmOptions = {
   /**
    * Callback when user confirms
    */
-  onConfirm?: () => void;
+  onConfirm?: (selectedValue?: any) => void;
   /**
    * Custom function to render the confirm button
    */
@@ -241,12 +241,12 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
   };
 
   handleConfirm = () => {
-    const {onConfirm, closeModal} = this.props;
+    const {onConfirm, closeModal, selectedValue} = this.props;
 
     // `confirming` is used to ensure `onConfirm` or the confirm callback is
     // only called once
     if (!this.confirming) {
-      onConfirm?.();
+      onConfirm?.(selectedValue);
       this.state.confirmCallback?.();
     }
 

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -12,6 +12,7 @@ export const VALUE_MAPPING = {
   committed_only: 40,
 };
 
+export const MIN_PROJECTS_FOR_CONFIRMATION = 3;
 export const MIN_PROJECTS_FOR_SEARCH = 3;
 export const MIN_PROJECTS_FOR_PAGINATION = 100;
 

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -36,6 +36,15 @@ export const SELF_NOTIFICATION_SETTINGS_TYPES = [
   'selfAssignOnResolve',
 ];
 
-export const CONFIRMATION_MESSAGE = t(
-  'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
+export const CONFIRMATION_MESSAGE = (
+  <div>
+    <p style={{marginBottom: '20px'}}>
+      <strong>Are you sure you want to disable these notifications?</strong>
+    </p>
+    <p>
+      {t(
+        'Turning this off will irreversibly overwrite all of your fine-tuning settings to "off".'
+      )}
+    </p>
+  </div>
 );

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -1,3 +1,5 @@
+import {t} from 'app/locale';
+
 export const ALL_PROVIDERS = {
   email: 'default',
   slack: 'never',
@@ -33,3 +35,7 @@ export const SELF_NOTIFICATION_SETTINGS_TYPES = [
   'personalActivityNotifications',
   'selfAssignOnResolve',
 ];
+
+export const CONFIRMATION_MESSAGE = t(
+  'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
+);

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -8,10 +8,7 @@ export type NotificationSettingField = {
   defaultValue?: string;
   defaultFieldName?: string;
   help?: string;
-  confirm?: {
-    message: string;
-    values?: string[];
-  };
+  confirm?: {[key: string]: string};
 };
 
 export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingField> = {

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -8,6 +8,10 @@ export type NotificationSettingField = {
   defaultValue?: string;
   defaultFieldName?: string;
   help?: string;
+  confirm?: {
+    message: string;
+    values?: string[];
+  };
 };
 
 export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingField> = {

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import {t} from 'app/locale';
 
 export type NotificationSettingField = {
@@ -8,7 +10,7 @@ export type NotificationSettingField = {
   defaultValue?: string;
   defaultFieldName?: string;
   help?: string;
-  confirm?: {[key: string]: string};
+  confirm?: {[key: string]: React.ReactNode | string};
 };
 
 export const NOTIFICATION_SETTING_FIELDS: Record<string, NotificationSettingField> = {

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -107,12 +107,14 @@ class NotificationSettings extends AsyncComponent<Props, State> {
         ),
       }) as any;
 
-      if (isSufficientlyComplex(notificationType, notificationSettings)) {
+      if (
+        isSufficientlyComplex(notificationType, notificationSettings) &&
+        typeof field !== 'function'
+      ) {
         field.confirm = {
-          message: t(
+          never: t(
             'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
           ),
-          values: ['never'],
         };
       }
 

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -16,6 +16,7 @@ import {
   decideDefault,
   getParentIds,
   getStateToPutForDefault,
+  isSufficientlyComplex,
   mergeNotificationSettings,
 } from 'app/views/settings/account/notifications/utils';
 import Form from 'app/views/settings/components/forms/form';
@@ -89,21 +90,35 @@ class NotificationSettings extends AsyncComponent<Props, State> {
   }
 
   getFields(): FieldObject[] {
-    return NOTIFICATION_SETTINGS_TYPES.map(
-      notificationType =>
-        Object.assign({}, NOTIFICATION_SETTING_FIELDS[notificationType], {
-          getData: data => this.getStateToPutForDefault(data, notificationType),
-          help: (
-            <React.Fragment>
-              {NOTIFICATION_SETTING_FIELDS[notificationType].help}
-              &nbsp;
-              <Link to={`/settings/account/notifications/${notificationType}`}>
-                Fine tune
-              </Link>
-            </React.Fragment>
+    const {notificationSettings} = this.state;
+
+    const fields: FieldObject[] = [];
+    for (const notificationType of NOTIFICATION_SETTINGS_TYPES) {
+      const field = Object.assign({}, NOTIFICATION_SETTING_FIELDS[notificationType], {
+        getData: data => this.getStateToPutForDefault(data, notificationType),
+        help: (
+          <React.Fragment>
+            {NOTIFICATION_SETTING_FIELDS[notificationType].help}
+            &nbsp;
+            <Link to={`/settings/account/notifications/${notificationType}`}>
+              Fine tune
+            </Link>
+          </React.Fragment>
+        ),
+      }) as any;
+
+      if (isSufficientlyComplex(notificationType, notificationSettings)) {
+        field.confirm = {
+          message: t(
+            'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
           ),
-        }) as FieldObject
-    );
+          values: ['never'],
+        };
+      }
+
+      fields.push(field);
+    }
+    return fields;
   }
 
   renderBody() {

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -6,6 +6,7 @@ import Link from 'app/components/links/link';
 import {IconMail} from 'app/icons';
 import {t} from 'app/locale';
 import {
+  CONFIRMATION_MESSAGE,
   NOTIFICATION_SETTINGS_TYPES,
   NotificationSettingsObject,
   SELF_NOTIFICATION_SETTINGS_TYPES,
@@ -111,11 +112,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
         isSufficientlyComplex(notificationType, notificationSettings) &&
         typeof field !== 'function'
       ) {
-        field.confirm = {
-          never: t(
-            'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
-          ),
-        };
+        field.confirm = {never: CONFIRMATION_MESSAGE};
       }
 
       fields.push(field);

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -176,10 +176,9 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
     );
     if (isSufficientlyComplex(notificationType, notificationSettings)) {
       defaultField.confirm = {
-        message: t(
+        never: t(
           'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
         ),
-        values: ['never'],
       };
     }
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -27,6 +27,7 @@ import {
   getStateToPutForProvider,
   isEverythingDisabled,
   isGroupedByProject,
+  isSufficientlyComplex,
   mergeNotificationSettings,
   providerListToString,
 } from 'app/views/settings/account/notifications/utils';
@@ -165,12 +166,24 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
     const {notificationType} = this.props;
     const {notificationSettings} = this.state;
 
-    const fields = [
-      Object.assign({}, NOTIFICATION_SETTING_FIELDS[notificationType], {
+    const defaultField = Object.assign(
+      {},
+      NOTIFICATION_SETTING_FIELDS[notificationType],
+      {
         help: t('This is the default for all projects.'),
         getData: data => this.getStateToPutForDefault(data),
-      }),
-    ];
+      }
+    );
+    if (isSufficientlyComplex(notificationType, notificationSettings)) {
+      defaultField.confirm = {
+        message: t(
+          'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
+        ),
+        values: ['never'],
+      };
+    }
+
+    const fields = [defaultField];
     if (!isEverythingDisabled(notificationType, notificationSettings)) {
       fields.push(
         Object.assign(

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -5,6 +5,7 @@ import {t} from 'app/locale';
 import {Organization, OrganizationSummary} from 'app/types';
 import withOrganizations from 'app/utils/withOrganizations';
 import {
+  CONFIRMATION_MESSAGE,
   NotificationSettingsByProviderObject,
   NotificationSettingsObject,
 } from 'app/views/settings/account/notifications/constants';
@@ -175,11 +176,7 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
       }
     );
     if (isSufficientlyComplex(notificationType, notificationSettings)) {
-      defaultField.confirm = {
-        never: t(
-          'Setting the default to "never" will irreversibly overwrite all of your fine-tuning settings. Continue?'
-        ),
-      };
+      defaultField.confirm = {never: CONFIRMATION_MESSAGE};
     }
 
     const fields = [defaultField];

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -4,6 +4,7 @@ import {t} from 'app/locale';
 import {OrganizationSummary, Project} from 'app/types';
 import {
   ALL_PROVIDERS,
+  MIN_PROJECTS_FOR_CONFIRMATION,
   NotificationSettingsByProviderObject,
   NotificationSettingsObject,
   VALUE_MAPPING,
@@ -251,6 +252,17 @@ export const getParentData = (
       parent.id,
       getParentValues(notificationType, notificationSettings, parent.id)[provider],
     ])
+  );
+};
+
+export const isSufficientlyComplex = (
+  notificationType: string,
+  notificationSettings: NotificationSettingsObject
+): boolean => {
+  /** Are there are more than N project or organization settings? */
+  return (
+    getParentIds(notificationType, notificationSettings).length >
+    MIN_PROJECTS_FOR_CONFIRMATION
   );
 };
 

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -3,6 +3,7 @@ import {OptionsType, ValueType} from 'react-select';
 
 import Confirm from 'app/components/confirm';
 import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
+import {t} from 'app/locale';
 import {Choices, SelectValue} from 'app/types';
 import InputField from 'app/views/settings/components/forms/inputField';
 
@@ -23,10 +24,6 @@ type Props<OptionType> = InputFieldProps &
      * A label that is shown inside the select control.
      */
     inFieldLabel?: string;
-    confirm?: {
-      message: React.ReactNode;
-      values?: string[];
-    };
   };
 
 function getChoices<T>(props: Props<T>): Choices {
@@ -91,7 +88,12 @@ export default class SelectField<
         alignRight={small}
         field={({onChange, onBlur, required: _required, ...props}) => (
           <Confirm
-            message={confirm?.message}
+            renderMessage={({selectedValue}) =>
+              confirm && selectedValue
+                ? confirm[selectedValue]
+                : // Set a default confirm message
+                  t('Continue with these changes?')
+            }
             onCancel={() => {}}
             onConfirm={this.handleChange.bind(this, onBlur, onChange)}
           >
@@ -108,7 +110,7 @@ export default class SelectField<
                     (!confirm.values || confirm.values.includes(newValue)) &&
                     previousValue !== newValue
                   ) {
-                    open();
+                    open(undefined, newValue);
                     return;
                   }
                   this.handleChange.bind(this, onBlur, onChange)(val);

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {OptionsType, ValueType} from 'react-select';
 
+import Confirm from 'app/components/confirm';
 import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
 import {Choices, SelectValue} from 'app/types';
 import InputField from 'app/views/settings/components/forms/inputField';
@@ -22,6 +23,10 @@ type Props<OptionType> = InputFieldProps &
      * A label that is shown inside the select control.
      */
     inFieldLabel?: string;
+    confirm?: {
+      message: React.ReactNode;
+      values?: string[];
+    };
   };
 
 function getChoices<T>(props: Props<T>): Choices {
@@ -79,18 +84,38 @@ export default class SelectField<
   };
 
   render() {
-    const {multiple, allowClear, small, ...otherProps} = this.props;
+    const {allowClear, confirm, multiple, small, ...otherProps} = this.props;
     return (
       <InputField
         {...otherProps}
         alignRight={small}
         field={({onChange, onBlur, required: _required, ...props}) => (
-          <SelectControl
-            {...props}
-            clearable={allowClear}
-            multiple={multiple}
-            onChange={this.handleChange.bind(this, onBlur, onChange)}
-          />
+          <Confirm
+            message={confirm?.message}
+            onCancel={() => {}}
+            onConfirm={this.handleChange.bind(this, onBlur, onChange)}
+          >
+            {({open}) => (
+              <SelectControl
+                {...props}
+                clearable={allowClear}
+                multiple={multiple}
+                onChange={val => {
+                  const previousValue = props.value.toString();
+                  const newValue = val.value.toString();
+                  if (
+                    confirm &&
+                    (!confirm.values || confirm.values.includes(newValue)) &&
+                    previousValue !== newValue
+                  ) {
+                    open();
+                    return;
+                  }
+                  this.handleChange.bind(this, onBlur, onChange)(val);
+                }}
+              />
+            )}
+          </Confirm>
         )}
       />
     );

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -90,7 +90,7 @@ export default class SelectField<
           <Confirm
             renderMessage={({selectedValue}) =>
               confirm && selectedValue
-                ? confirm[selectedValue]
+                ? confirm[selectedValue.value]
                 : // Set a default confirm message
                   t('Continue with these changes?')
             }
@@ -103,14 +103,10 @@ export default class SelectField<
                 clearable={allowClear}
                 multiple={multiple}
                 onChange={val => {
-                  const previousValue = props.value.toString();
-                  const newValue = val.value.toString();
-                  if (
-                    confirm &&
-                    (!confirm.values || confirm.values.includes(newValue)) &&
-                    previousValue !== newValue
-                  ) {
-                    open(undefined, newValue);
+                  const previousValue = props.value?.toString();
+                  const newValue = val.value?.toString();
+                  if (confirm && confirm[newValue] && previousValue !== newValue) {
+                    open(undefined, val);
                     return;
                   }
                   this.handleChange.bind(this, onBlur, onChange)(val);

--- a/static/app/views/settings/components/forms/type.tsx
+++ b/static/app/views/settings/components/forms/type.tsx
@@ -31,8 +31,6 @@ export const FieldType = [
 
 export type FieldValue = any;
 
-type ConfirmKeyType = 'true' | 'false';
-
 // TODO(ts): A lot of these attributes are missing correct types. We'll likely
 // need to introduce some generics in here to get rid of some of these anys.
 
@@ -53,7 +51,7 @@ type BaseField = {
   updatesForm?: boolean;
   /** Does editing this field need to clear all other fields? */
   resetsForm?: boolean;
-  confirm?: {[key in ConfirmKeyType]?: string};
+  confirm?: {[key: string]: string};
   autosize?: boolean;
   maxRows?: number;
   extraHelp?: string;


### PR DESCRIPTION
The new Notification Settings designs treat the default settings as an override when the value is "off". This override erases all of the user's fine-tuned settings so this PR adds a confirmation modal.
![Screen Shot 2021-09-02 at 12 19 44 PM](https://user-images.githubusercontent.com/31750075/131903686-25c3c527-f5d5-4270-b556-77cfc46ecccd.png)
