### PR TITLE
fix(invites): correct behavior for sso orgs and logged in users

### DIFF
--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -255,6 +255,8 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
           ? this.warning2fa
           : inviteDetails.needsEmailVerification
           ? this.warningEmailVerification
+          : inviteDetails.needsSso
+          ? this.authenticationActions
           : this.acceptActions}
       </NarrowLayout>
     );


### PR DESCRIPTION
if a user is authenticated but needs to go through an SSO flow for an invite, they need to be redirected to that flow, otherwise, the invite fails to be accepted and they are presented with an "Error has occurred" message in the UI. This change puts the user through that flow if they are authenticated, and aren't prompted with anything else previously in the conditional chain.