### PR TITLE
feat(semver): Determine latest release using semver when applicable

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -65,7 +65,10 @@ def convert_user_value(value, projects, user, environments):
 def convert_release_value(value, projects, user, environments) -> Union[str, List[str]]:
     # TODO: This will make N queries. This should be ok, we don't typically have large
     # lists of versions here, but we can look into batching it if needed.
-    releases = [parse_release(version, projects, environments) for version in value]
+    releases = set()
+    for version in value:
+        releases.update(parse_release(version, projects, environments))
+    releases = list(releases)
     if len(releases) == 1:
         return releases[0]
     return releases
@@ -74,7 +77,10 @@ def convert_release_value(value, projects, user, environments) -> Union[str, Lis
 def convert_first_release_value(value, projects, user, environments) -> List[str]:
     # TODO: This will make N queries. This should be ok, we don't typically have large
     # lists of versions here, but we can look into batching it if needed.
-    return [parse_release(version, projects, environments) for version in value]
+    releases = set()
+    for version in value:
+        releases.update(parse_release(version, projects, environments))
+    return list(releases)
 
 
 def convert_status_value(value, projects, user, environments):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Optional, Sequence, FrozenSet
+from typing import TYPE_CHECKING, FrozenSet, Optional, Sequence
 
 from django.db import DataError
 from django.utils import timezone

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import TYPE_CHECKING, FrozenSet, Optional, Sequence
 
-from django.db import DataError
+from django.db import DataError, connection
 from django.utils import timezone
 
 if TYPE_CHECKING:
@@ -11,7 +14,9 @@ if TYPE_CHECKING:
 
 from sentry.models import (
     KEYWORD_MAP,
+    Environment,
     EventUser,
+    Project,
     Release,
     Team,
     User,
@@ -264,45 +269,113 @@ def parse_user_value(value, user):
         return User(id=0)
 
 
-def get_latest_release(projects, environments, organization_id=None):
+class LatestReleaseOrders(Enum):
+    DATE = 0
+    SEMVER = 1
+
+
+def get_latest_release(
+    projects: Sequence[Project | int],
+    environments: Optional[Sequence[Environment]],
+    organization_id: Optional[int] = None,
+) -> Sequence[str]:
     if organization_id is None:
         project = projects[0]
         if hasattr(project, "organization_id"):
             organization_id = project.organization_id
         else:
-            return ""
+            return []
 
-    release_qs = Release.objects.filter(organization_id=organization_id, projects__in=projects)
+    # Convert projects to ids so that we can work with them more easily
+    project_ids = [getattr(project, "id", project) for project in projects]
 
-    if environments:
-        release_qs = release_qs.filter(
-            releaseprojectenvironment__environment__id__in=[
-                environment.id for environment in environments
-            ]
+    semver_project_ids = []
+    date_project_ids = []
+    for project_id in project_ids:
+        if follows_semver_versioning_scheme(organization_id, project_id):
+            semver_project_ids.append(project_id)
+        else:
+            date_project_ids.append(project_id)
+
+    versions = set()
+    versions.update(
+        _run_latest_release_query(
+            LatestReleaseOrders.SEMVER, semver_project_ids, environments, organization_id
         )
+    )
+    versions.update(
+        _run_latest_release_query(
+            LatestReleaseOrders.DATE, date_project_ids, environments, organization_id
+        )
+    )
 
-    if len(projects) == 1 and follows_semver_versioning_scheme(
-        organization_id, getattr(projects[0], "id", projects[0])
-    ):
-        order_by = [f"-{col}" for col in Release.SEMVER_COLS]
-        release_qs = release_qs.filter_to_semver().annotate_prerelease_column().order_by(*order_by)
+    if not versions:
+        raise Release.DoesNotExist()
+
+    return list(sorted(versions))
+
+
+def _run_latest_release_query(
+    query_type: LatestReleaseOrders,
+    project_ids: Sequence[int],
+    environments: Optional[Sequence[Environment]],
+    organization_id: int,
+) -> Sequence[str]:
+    if not project_ids:
+        return []
+
+    env_join = ""
+    env_where = ""
+    if environments:
+        env_join = "INNER JOIN sentry_releaseprojectenvironment srpe on srpe.release_id = sr.id"
+        env_where = "AND srpe.environment_id in %s"
+
+    extra_conditions = ""
+    if query_type == LatestReleaseOrders.SEMVER:
+        rank_order_by = "major DESC, minor DESC, patch DESC, revision DESC, CASE WHEN (prerelease = '') THEN 1 ELSE 0 END DESC, prerelease DESC, sr.id desc"
+        extra_conditions = "AND sr.major IS NOT NULL"
     else:
-        release_qs = release_qs.extra(
-            select={"sort": "COALESCE(date_released, date_added)"}
-        ).order_by("-sort")
+        rank_order_by = "COALESCE(date_released, date_added) DESC"
 
-    return release_qs.values_list("version", flat=True)[:1].get()
+    query = f"""
+        SELECT DISTINCT version
+        FROM (
+            SELECT sr.version, rank() OVER (
+                PARTITION BY srp.project_id
+                ORDER BY {rank_order_by}
+            ) AS rank
+            FROM "sentry_release" sr
+            INNER JOIN "sentry_release_project" srp ON sr.id = srp.release_id
+            {env_join}
+            WHERE sr.organization_id = %s
+            AND srp.project_id IN %s
+            {extra_conditions}
+            {env_where}
+        ) sr
+        WHERE rank = 1
+    """
+    cursor = connection.cursor()
+    query_args = [organization_id, tuple(project_ids)]
+    if environments:
+        query_args.append(tuple(e.id for e in environments))
+    cursor.execute(query, query_args)
+    return [row[0] for row in cursor.fetchall()]
 
 
-def parse_release(value, projects, environments, organization_id=None):
+def parse_release(
+    value: str,
+    projects: Sequence[Project | int],
+    environments: Sequence[Environment],
+    organization_id: Optional[int] = None,
+) -> Sequence[str]:
     if value == "latest":
         try:
             return get_latest_release(projects, environments, organization_id)
         except Release.DoesNotExist:
             # Should just get no results here, so return an empty release name.
-            return ""
+            return [""]
     else:
-        return value
+        return [value]
 
 
 numeric_modifiers = [
@@ -584,7 +657,7 @@ supported_cdc_conditions_lookup = {
 }
 
 
-def validate_cdc_search_filters(search_filters: Sequence["SearchFilter"]) -> bool:
+def validate_cdc_search_filters(search_filters: Sequence[SearchFilter]) -> bool:
     """
     Validates whether a set of search filters can be handled by the cdc search backend.
     """

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -72,6 +72,7 @@ from sentry.models import (
     ReleaseCommit,
     ReleaseEnvironment,
     ReleaseFile,
+    ReleaseProjectEnvironment,
     Repository,
     RepositoryProjectPathConfig,
     Rule,
@@ -371,6 +372,7 @@ class Factories:
         date_added: Optional[datetime] = None,
         additional_projects: Optional[Sequence[Project]] = None,
         environments: Optional[Sequence[Environment]] = None,
+        date_released: Optional[datetime] = None,
     ):
         if version is None:
             version = force_text(hexlify(os.urandom(20)))
@@ -382,7 +384,10 @@ class Factories:
             additional_projects = []
 
         release = Release.objects.create(
-            version=version, organization_id=project.organization_id, date_added=date_added
+            version=version,
+            organization_id=project.organization_id,
+            date_added=date_added,
+            date_released=date_released,
         )
 
         release.add_project(project)
@@ -393,6 +398,10 @@ class Factories:
             ReleaseEnvironment.objects.create(
                 organization=project.organization, release=release, environment=environment
             )
+            for project in [project] + additional_projects:
+                ReleaseProjectEnvironment.objects.create(
+                    project=project, release=release, environment=environment
+                )
 
         Activity.objects.create(
             type=Activity.RELEASE,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -373,6 +373,8 @@ class Factories:
         additional_projects: Optional[Sequence[Project]] = None,
         environments: Optional[Sequence[Environment]] = None,
         date_released: Optional[datetime] = None,
+        adopted: Optional[datetime] = None,
+        unadopted: Optional[datetime] = None,
     ):
         if version is None:
             version = force_text(hexlify(os.urandom(20)))
@@ -400,7 +402,11 @@ class Factories:
             )
             for project in [project] + additional_projects:
                 ReleaseProjectEnvironment.objects.create(
-                    project=project, release=release, environment=environment
+                    project=project,
+                    release=release,
+                    environment=environment,
+                    adopted=adopted,
+                    unadopted=unadopted,
                 )
 
         Activity.objects.create(

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -43,7 +43,7 @@ class QueryBuilderTest(TestCase):
             query.where,
             [
                 Condition(Column("email"), Op.EQ, "foo@example.com"),
-                Condition(Column("release"), Op.EQ, "1.2.1"),
+                Condition(Column("release"), Op.IN, ["1.2.1"]),
                 *self.default_conditions,
             ],
         )

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -383,31 +383,31 @@ class ParseQueryTest(TestCase):
 
     def test_first_release(self):
         result = self.parse_query("first-release:bar")
-        assert result == {"first_release": "bar", "tags": {}, "query": ""}
+        assert result == {"first_release": ["bar"], "tags": {}, "query": ""}
 
     def test_first_release_latest(self):
         result = self.parse_query("first-release:latest")
-        assert result == {"first_release": "", "tags": {}, "query": ""}
+        assert result == {"first_release": [""], "tags": {}, "query": ""}
         release = self.create_release(
             project=self.project,
             version="older_release",
             date_added=datetime.now() - timedelta(days=1),
         )
         result = self.parse_query("first-release:latest")
-        assert result == {"first_release": release.version, "tags": {}, "query": ""}
+        assert result == {"first_release": [release.version], "tags": {}, "query": ""}
         release = self.create_release(
             project=self.project, version="new_release", date_added=datetime.now()
         )
         result = self.parse_query("first-release:latest")
-        assert result == {"first_release": release.version, "tags": {}, "query": ""}
+        assert result == {"first_release": [release.version], "tags": {}, "query": ""}
 
     def test_release(self):
         result = self.parse_query("release:bar")
-        assert result == {"tags": {"sentry:release": "bar"}, "query": ""}
+        assert result == {"tags": {"sentry:release": ["bar"]}, "query": ""}
 
     def test_release_latest(self):
         result = self.parse_query("release:latest")
-        assert result == {"tags": {"sentry:release": ""}, "query": ""}
+        assert result == {"tags": {"sentry:release": [""]}, "query": ""}
 
         release = self.create_release(
             project=self.project,
@@ -415,12 +415,12 @@ class ParseQueryTest(TestCase):
             date_added=datetime.now() - timedelta(days=1),
         )
         result = self.parse_query("release:latest")
-        assert result == {"tags": {"sentry:release": release.version}, "query": ""}
+        assert result == {"tags": {"sentry:release": [release.version]}, "query": ""}
         release = self.create_release(
             project=self.project, version="new_release", date_added=datetime.now()
         )
         result = self.parse_query("release:latest")
-        assert result == {"tags": {"sentry:release": release.version}, "query": ""}
+        assert result == {"tags": {"sentry:release": [release.version]}, "query": ""}
 
     def test_dist(self):
         result = self.parse_query("dist:123")
@@ -428,7 +428,7 @@ class ParseQueryTest(TestCase):
 
     def test_padded_spacing(self):
         result = self.parse_query("release:bar  foo   bar")
-        assert result == {"tags": {"sentry:release": "bar"}, "query": "foo bar"}
+        assert result == {"tags": {"sentry:release": ["bar"]}, "query": "foo bar"}
 
     def test_unknown_user_with_dot_query(self):
         result = self.parse_query("user.email:fake@example.com")

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -7,12 +7,7 @@ from django.utils import timezone
 from sentry.discover.arithmetic import ArithmeticValidationError
 from sentry.discover.models import TeamKeyTransaction
 from sentry.exceptions import InvalidSearchQuery
-from sentry.models import (
-    ProjectTeam,
-    ProjectTransactionThreshold,
-    ReleaseProjectEnvironment,
-    ReleaseStages,
-)
+from sentry.models import ProjectTeam, ProjectTransactionThreshold, ReleaseStages
 from sentry.models.transaction_threshold import (
     ProjectTransactionThresholdOverride,
     TransactionMetric,
@@ -2512,32 +2507,17 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
     def test_release_stage_condition(self):
         replaced_release = self.create_release(
-            version="replaced_release", environments=[self.environment]
-        )
-        adopted_release = self.create_release(
-            version="adopted_release", environments=[self.environment]
-        )
-        not_adopted_release = self.create_release(
-            version="not_adopted_release", environments=[self.environment]
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=adopted_release.id,
-            environment_id=self.environment.id,
-            adopted=timezone.now(),
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=replaced_release.id,
-            environment_id=self.environment.id,
+            version="replaced_release",
+            environments=[self.environment],
             adopted=timezone.now(),
             unadopted=timezone.now(),
         )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=not_adopted_release.id,
-            environment_id=self.environment.id,
+        adopted_release = self.create_release(
+            version="adopted_release",
+            environments=[self.environment],
+            adopted=timezone.now(),
         )
+        self.create_release(version="not_adopted_release", environments=[self.environment])
 
         adopted_release_e_1 = self.store_event(
             data={"release": adopted_release.version, "environment": self.environment.name},

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -7,13 +7,7 @@ from django.utils import timezone
 from pytz import utc
 
 from sentry.discover.models import TeamKeyTransaction
-from sentry.models import (
-    ApiKey,
-    ProjectTeam,
-    ProjectTransactionThreshold,
-    ReleaseProjectEnvironment,
-    ReleaseStages,
-)
+from sentry.models import ApiKey, ProjectTeam, ProjectTransactionThreshold, ReleaseStages
 from sentry.models.transaction_threshold import (
     ProjectTransactionThresholdOverride,
     TransactionMetric,
@@ -891,32 +885,17 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
     def test_release_stage(self):
         replaced_release = self.create_release(
-            version="replaced_release", environments=[self.environment]
-        )
-        adopted_release = self.create_release(
-            version="adopted_release", environments=[self.environment]
-        )
-        not_adopted_release = self.create_release(
-            version="not_adopted_release", environments=[self.environment]
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=adopted_release.id,
-            environment_id=self.environment.id,
-            adopted=timezone.now(),
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=replaced_release.id,
-            environment_id=self.environment.id,
+            version="replaced_release",
+            environments=[self.environment],
             adopted=timezone.now(),
             unadopted=timezone.now(),
         )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=not_adopted_release.id,
-            environment_id=self.environment.id,
+        adopted_release = self.create_release(
+            version="adopted_release",
+            environments=[self.environment],
+            adopted=timezone.now(),
         )
+        self.create_release(version="not_adopted_release", environments=[self.environment])
 
         adopted_release_e_1 = self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -32,7 +32,6 @@ from sentry.models import (
     Integration,
     OrganizationIntegration,
     Release,
-    ReleaseProjectEnvironment,
     ReleaseStages,
     UserOption,
     add_group_to_inbox,
@@ -1292,32 +1291,17 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     def test_release_stage(self):
         replaced_release = self.create_release(
-            version="replaced_release", environments=[self.environment]
-        )
-        adopted_release = self.create_release(
-            version="adopted_release", environments=[self.environment]
-        )
-        not_adopted_release = self.create_release(
-            version="not_adopted_release", environments=[self.environment]
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=adopted_release.id,
-            environment_id=self.environment.id,
-            adopted=timezone.now(),
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=replaced_release.id,
-            environment_id=self.environment.id,
+            version="replaced_release",
+            environments=[self.environment],
             adopted=timezone.now(),
             unadopted=timezone.now(),
         )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=not_adopted_release.id,
-            environment_id=self.environment.id,
+        adopted_release = self.create_release(
+            version="adopted_release",
+            environments=[self.environment],
+            adopted=timezone.now(),
         )
+        self.create_release(version="not_adopted_release", environments=[self.environment])
 
         adopted_release_g_1 = self.store_event(
             data={

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -922,31 +922,16 @@ class GetTagValuePaginatorForProjectsReleaseStageTest(TestCase, SnubaTestCase):
 
     def test_release_stage(self):
         replaced_release = self.create_release(
-            version="replaced_release", environments=[self.environment]
-        )
-        adopted_release = self.create_release(
-            version="adopted_release", environments=[self.environment]
-        )
-        not_adopted_release = self.create_release(
-            version="not_adopted_release", environments=[self.environment]
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=adopted_release.id,
-            environment_id=self.environment.id,
-            adopted=timezone.now(),
-        )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=replaced_release.id,
-            environment_id=self.environment.id,
+            version="replaced_release",
+            environments=[self.environment],
             adopted=timezone.now(),
             unadopted=timezone.now(),
         )
-        ReleaseProjectEnvironment.objects.create(
-            project_id=self.project.id,
-            release_id=not_adopted_release.id,
-            environment_id=self.environment.id,
+        adopted_release = self.create_release(
+            version="adopted_release", environments=[self.environment], adopted=timezone.now()
+        )
+        not_adopted_release = self.create_release(
+            version="not_adopted_release", environments=[self.environment]
         )
 
         env_2 = self.create_environment()


### PR DESCRIPTION
`latest` release currently only works based on release date. This changes is to use semver for
projects where semver is in use. If multiple projects are being checked, for the moment we'll fall
back to date released.

We also switch `latest` to fetch the latest release for all selected projects. To do this we had to 
fall back to raw sql, since even though Django does support window functions now, we don't have
a good way to filter on the `rank` window function