### PR TITLE
feat(semver): Filter semver related filters by any project ids passed to the search.

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -767,6 +767,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         collapse=None,
         expand=None,
         organization_id=None,
+        project_ids=None,
     ):
         super().__init__(collapse=collapse, expand=expand)
         from sentry.search.snuba.executors import get_search_filter
@@ -789,7 +790,8 @@ class GroupSerializerSnuba(GroupSerializerBase):
         self.conditions = (
             [
                 convert_search_filter_to_snuba_query(
-                    search_filter, params={"organization_id": organization_id}
+                    search_filter,
+                    params={"organization_id": organization_id, "project_id": project_ids},
                 )
                 for search_filter in search_filters
                 if search_filter.key.name not in self.skip_snuba_fields

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -139,7 +139,11 @@ class ReleaseQuerySet(models.QuerySet):
         return self.filter(major__isnull=False)
 
     def filter_by_semver_build(
-        self, organization_id: int, operator: str, build: str, project_ids: Sequence[int] = None
+        self,
+        organization_id: int,
+        operator: str,
+        build: str,
+        project_ids: Optional[Sequence[int]] = None,
     ) -> models.QuerySet:
         """
         Filters released by build. If the passed `build` is a numeric string, we'll filter on
@@ -170,7 +174,7 @@ class ReleaseQuerySet(models.QuerySet):
         self,
         organization_id: int,
         semver_filter: SemverFilter,
-        project_ids: Sequence[int] = None,
+        project_ids: Optional[Sequence[int]] = None,
     ) -> models.QuerySet:
         """
         Filters releases based on a based `SemverFilter` instance.
@@ -261,14 +265,21 @@ class ReleaseModelManager(models.Manager):
         return self.get_queryset().filter_to_semver()
 
     def filter_by_semver_build(
-        self, organization_id: int, operator: str, build: str, project_ids: Sequence[int] = None
+        self,
+        organization_id: int,
+        operator: str,
+        build: str,
+        project_ids: Optional[Sequence[int]] = None,
     ) -> models.QuerySet:
         return self.get_queryset().filter_by_semver_build(
             organization_id, operator, build, project_ids
         )
 
     def filter_by_semver(
-        self, organization_id: int, semver_filter: SemverFilter, project_ids: Sequence[int] = None
+        self,
+        organization_id: int,
+        semver_filter: SemverFilter,
+        project_ids: Optional[Sequence[int]] = None,
     ) -> models.QuerySet:
         return self.get_queryset().filter_by_semver(organization_id, semver_filter, project_ids)
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -134,7 +134,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             ):
                 continue
             converted_filter = convert_search_filter_to_snuba_query(
-                search_filter, params={"organization_id": organization_id}
+                search_filter,
+                params={"organization_id": organization_id, "project_id": project_ids},
             )
             converted_filter = self._transform_converted_filter(
                 search_filter, converted_filter, project_ids, environment_ids


### PR DESCRIPTION
Currently we only filter releases used in semver down to the org level. This can cause issues in
projects with many releases in cases when we return a lot of release candidates.

This pr fixes the semver and release related filters to include project_id in the queries used to fetch
release candidates.