### PR TITLE
fix(group-index): Add ability to disable cache when fetching group last release

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -536,7 +536,11 @@ def get_current_release_version_of_group(group, follows_semver=False):
             ...
     else:
         # This sets current_release_version to the most recent release associated with a group
-        current_release_version = group.get_last_release()
+        # In order to be able to do that, `use_cache` has to be set to False. Otherwise,
+        # group.get_last_release might not return the actual latest release associated with a
+        # group but rather a cached version (which might or might not be the actual latest. It is
+        # the first latest observed by Sentry)
+        current_release_version = group.get_last_release(use_cache=False)
     return current_release_version
 
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -494,13 +494,13 @@ class Group(Model):
     def _get_cache_key(self, project_id, group_id, first):
         return f"g-r:{group_id}-{project_id}-{first}"
 
-    def __get_release(self, project_id, group_id, first=True):
+    def __get_release(self, project_id, group_id, first=True, use_cache=True):
         from sentry.models import GroupRelease, Release
 
         orderby = "first_seen" if first else "-last_seen"
         cache_key = self._get_cache_key(project_id, group_id, first)
         try:
-            release_version = cache.get(cache_key)
+            release_version = cache.get(cache_key) if use_cache else None
             if release_version is None:
                 release_version = Release.objects.get(
                     id__in=GroupRelease.objects.filter(group_id=group_id)
@@ -522,8 +522,8 @@ class Group(Model):
 
         return self.first_release.version
 
-    def get_last_release(self):
-        return self.__get_release(self.project_id, self.id, False)
+    def get_last_release(self, use_cache=True):
+        return self.__get_release(self.project_id, self.id, False, use_cache=use_cache)
 
     def get_event_type(self):
         """


### PR DESCRIPTION
This PR:
- Adds ability to disable cache when fetching last release associated with a group. 

This is necessary when setting `current_release_version` to the last release associated with a group when we resolve a group in next release as we want to set the actual last release not the 'first last' observed release in Sentry. (This applies to non-semver releases)

Example of the behaviour that this PR changes:-
```
- Create release "foobar 1"
- Issue A occurs in release "foobar 1"
- GroupFirstLastReleaseEndpoint gets called, last release is fetched and cached as "foobar 1"
- Create Release "foobar 2"
- Issue A occurs in release "foobar 2"
- Click on Resolve in Next Release, last release is fetched from the cache in this case as "foobar 1", and is stored in current_release_version
- Issue A occurs in "foobar 2" again and is incorrectly marked as a regression
```

Instead what should happen is the following 
```
- Create release "foobar 1"
- Issue A occurs in release "foobar 1"
- GroupFirstLastReleaseEndpoint gets called, last release is fetched and cached as "foobar 1"
- Create Release "foobar 2"
- Issue A occurs in release "foobar 2"
- Click on Resolve in Next Release, cache is disabled, last release is fetched from the db in this case as "foobar 2", and is stored in current_release_version
- Issue A occurs in "foobar 2" again and is ignored
```