### PR TITLE
test(audit-log):regression test for no old_slug

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -286,7 +286,7 @@ class AuditLogEntry(Model):
                     + self.data["new_slug"]
                 )
             return "edited project settings " + (
-                " ".join(f" in {key} to {value}" for (key, value) in self.data.items())
+                " ".join(f"in {key} to {value}" for (key, value) in self.data.items())
             )
         elif self.event == AuditLogEntryEvent.PROJECT_REMOVE:
             return "removed project {}".format(self.data["slug"])

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -176,6 +176,20 @@ class CreateAuditEntryTest(TestCase):
         assert entry.event == AuditLogEntryEvent.PROJECT_EDIT
         assert entry.get_note() == "renamed project slug from old to new"
 
+    def test_audit_entry_project_edit_log_regression(self):
+        entry = create_audit_entry(
+            request=self.req,
+            organization=self.org,
+            target_object=self.project.id,
+            event=AuditLogEntryEvent.PROJECT_EDIT,
+            data={"new_slug": "new"},
+        )
+
+        assert entry.actor == self.user
+        assert entry.target_object == self.project.id
+        assert entry.event == AuditLogEntryEvent.PROJECT_EDIT
+        assert entry.get_note() == "edited project settings in new_slug to new"
+
     def test_audit_entry_integration_log(self):
         project = self.create_project()
         self.login_as(user=self.user)


### PR DESCRIPTION
Added regression test for old audit log in Project_edit having no old_slug. Also got rid of double spacing in audit log string.