### PR TITLE
feat(arithmetic): Update equation on column change

### DIFF
--- a/static/app/components/arithmeticInput/grammar.pegjs
+++ b/static/app/components/arithmeticInput/grammar.pegjs
@@ -1,5 +1,5 @@
 {
-  const {tc} = options;
+  const {tc, term} = options;
 }
 
 term
@@ -70,7 +70,7 @@ divide
 
 function_value "function"
   = function_name open_paren spaces function_args? spaces closed_paren {
-    return text();
+    return tc.tokenFunction(text(), location());
   }
 numeric_value "number"
   = [+-]?[0-9]+ ("." [0-9]*)? {
@@ -78,7 +78,7 @@ numeric_value "number"
   }
 field_value "field"
   = [a-zA-Z_\.]+ {
-    return text();
+    return tc.tokenField(text(), location());
   }
 
 function_args        = function_arg (spaces comma spaces function_arg)*

--- a/static/app/components/arithmeticInput/parser.tsx
+++ b/static/app/components/arithmeticInput/parser.tsx
@@ -10,17 +10,17 @@ const MAX_OPERATOR_MESSAGE = t('Maximum operators exceeded');
 
 type OperationOpts = {
   operator: Operator;
-  lhs?: Term;
-  rhs: Term;
+  lhs?: Expression;
+  rhs: Expression;
 };
 
 type Operator = 'plus' | 'minus' | 'multiply' | 'divide';
-type Term = Operation | string | number | null;
+type Expression = Operation | string | number | null;
 
 export class Operation {
   operator: Operator;
-  lhs?: Term;
-  rhs: Term;
+  lhs?: Expression;
+  rhs: Expression;
 
   constructor({operator, lhs = null, rhs}: OperationOpts) {
     this.operator = operator;
@@ -29,12 +29,12 @@ export class Operation {
   }
 }
 
-class Primary {
-  primary: Term;
+class Term {
+  term: Expression;
   location: LocationRange;
 
-  constructor({primary, location}: {primary: Term; location: LocationRange}) {
-    this.primary = primary;
+  constructor({term, location}: {term: Expression; location: LocationRange}) {
+    this.term = term;
     this.location = location;
   }
 }
@@ -42,8 +42,8 @@ class Primary {
 export class TokenConverter {
   numOperations: number;
   errors: Array<string>;
-  fields: Array<Primary>;
-  functions: Array<Primary>;
+  fields: Array<Term>;
+  functions: Array<Term>;
 
   constructor() {
     this.numOperations = 0;
@@ -52,7 +52,7 @@ export class TokenConverter {
     this.functions = [];
   }
 
-  tokenTerm = (maybeFactor: Term, remainingAdds: Array<Operation>): Term => {
+  tokenTerm = (maybeFactor: Expression, remainingAdds: Array<Operation>): Expression => {
     if (remainingAdds.length > 0) {
       remainingAdds[0].lhs = maybeFactor;
       return flatten(remainingAdds);
@@ -61,7 +61,7 @@ export class TokenConverter {
     }
   };
 
-  tokenOperation = (operator: Operator, rhs: Term): Operation => {
+  tokenOperation = (operator: Operator, rhs: Expression): Operation => {
     this.numOperations += 1;
     if (
       this.numOperations > MAX_OPERATORS &&
@@ -75,21 +75,21 @@ export class TokenConverter {
     return new Operation({operator, rhs});
   };
 
-  tokenFactor = (primary: Term, remaining: Array<Operation>): Operation => {
+  tokenFactor = (primary: Expression, remaining: Array<Operation>): Operation => {
     remaining[0].lhs = primary;
     return flatten(remaining);
   };
 
-  tokenField = (primary: Term, location: LocationRange): Term => {
-    const field = new Primary({primary, location});
+  tokenField = (term: Expression, location: LocationRange): Expression => {
+    const field = new Term({term, location});
     this.fields.push(field);
-    return primary;
+    return term;
   };
 
-  tokenFunction = (primary: Term, location: LocationRange): Term => {
-    const func = new Primary({primary, location});
+  tokenFunction = (term: Expression, location: LocationRange): Expression => {
+    const func = new Term({term, location});
     this.functions.push(func);
-    return primary;
+    return term;
   };
 }
 
@@ -112,7 +112,7 @@ function flatten(remaining: Array<Operation>): Operation {
 }
 
 type parseResult = {
-  result: Term;
+  result: Expression;
   error: string | undefined;
   tc: TokenConverter;
 };

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -845,7 +845,7 @@ export function isAggregateEquation(field: string): boolean {
   return isEquation(field) && results !== null && results.length > 0;
 }
 
-export function isEquationColumn(column: Column): boolean {
+export function isLegalEquationColumn(column: Column): boolean {
   // Any isn't allowed in arithmetic
   if (column.kind === 'function' && column.function[0] === 'any') {
     return false;
@@ -1136,17 +1136,8 @@ export function getColumnType(column: Column): ColumnType {
 }
 
 export function hasDuplicate(columnList: Column[], column: Column): boolean {
-  return (
-    columnList.filter(newColumn => {
-      return (
-        (column.kind !== 'equation' &&
-          column.kind === 'function' &&
-          newColumn.kind === 'function' &&
-          isEqual(column.function, newColumn.function)) ||
-        (column.kind === 'field' &&
-          newColumn.kind === 'field' &&
-          column.field === newColumn.field)
-      );
-    }).length > 1
-  );
+  if (column.kind !== 'function' && column.kind !== 'field') {
+    return false;
+  }
+  return columnList.filter(newColumn => isEqual(newColumn, column)).length > 1;
 }

--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -5,7 +5,11 @@ import isEqual from 'lodash/isEqual';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {Column, generateFieldAsString, isEquationColumn} from 'app/utils/discover/fields';
+import {
+  Column,
+  generateFieldAsString,
+  isLegalEquationColumn,
+} from 'app/utils/discover/fields';
 import Input from 'app/views/settings/components/forms/controls/input';
 
 const NONE_SELECTED = -1;
@@ -348,20 +352,20 @@ function makeFieldOptions(
   columns: Column[],
   partialTerm: string | null
 ): DropdownOptionGroup {
-  const fieldValues: string[] = [];
+  const fieldValues = new Set<string>();
   const options = columns
     .filter(({kind}) => kind !== 'equation')
-    .filter(isEquationColumn)
+    .filter(isLegalEquationColumn)
     .map(option => ({
       kind: 'field' as const,
       active: false,
       value: generateFieldAsString(option),
     }))
     .filter(({value}) => {
-      if (fieldValues.includes(value)) {
+      if (fieldValues.has(value)) {
         return false;
       } else {
-        fieldValues.push(value);
+        fieldValues.add(value);
         return true;
       }
     })

--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -5,7 +5,7 @@ import isEqual from 'lodash/isEqual';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {Column, generateFieldAsString, getColumnType} from 'app/utils/discover/fields';
+import {Column, generateFieldAsString, isEquationColumn} from 'app/utils/discover/fields';
 import Input from 'app/views/settings/components/forms/controls/input';
 
 const NONE_SELECTED = -1;
@@ -348,23 +348,23 @@ function makeFieldOptions(
   columns: Column[],
   partialTerm: string | null
 ): DropdownOptionGroup {
+  const fieldValues: string[] = [];
   const options = columns
     .filter(({kind}) => kind !== 'equation')
-    .filter(option => {
-      // Any isn't allowed in arithmetic
-      if (option.kind === 'function' && option.function[0] === 'any') {
-        return false;
-      }
-      const columnType = getColumnType(option);
-      return (
-        columnType === 'number' || columnType === 'integer' || columnType === 'duration'
-      );
-    })
+    .filter(isEquationColumn)
     .map(option => ({
       kind: 'field' as const,
       active: false,
       value: generateFieldAsString(option),
     }))
+    .filter(({value}) => {
+      if (fieldValues.includes(value)) {
+        return false;
+      } else {
+        fieldValues.push(value);
+        return true;
+      }
+    })
     .filter(({value}) => (partialTerm ? value.includes(partialTerm) : true));
 
   return {

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -12,7 +12,13 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {LightWeightOrganization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import {AGGREGATIONS, Column} from 'app/utils/discover/fields';
+import {
+  AGGREGATIONS,
+  Column,
+  generateFieldAsString,
+  hasDuplicate,
+  isEquationColumn,
+} from 'app/utils/discover/fields';
 import theme from 'app/utils/theme';
 import {getPointerPosition} from 'app/utils/touch';
 import {setBodyUserSelect, UserSelectValues} from 'app/utils/userselect';
@@ -136,20 +142,69 @@ class ColumnEditCollection extends React.Component<Props, State> {
     this.props.onChange([...this.props.columns, newColumn]);
   };
 
-  handleUpdateColumn = (index: number, column: Column) => {
+  handleUpdateColumn = (index: number, updatedColumn: Column) => {
     const newColumns = [...this.props.columns];
-    if (column.kind === 'equation') {
+    if (updatedColumn.kind === 'equation') {
       this.setState(prevState => {
         const error = new Map(prevState.error);
-        error.set(index, parseArithmetic(column.field).error);
+        error.set(index, parseArithmetic(updatedColumn.field).error);
         return {
           ...prevState,
           error,
         };
       });
+    } else {
+      // Update any equations that contain the existing column
+      this.updateEquationFields(newColumns, index, updatedColumn);
     }
-    newColumns.splice(index, 1, column);
+    newColumns.splice(index, 1, updatedColumn);
     this.props.onChange(newColumns);
+  };
+
+  updateEquationFields = (newColumns: Column[], index: number, updatedColumn: Column) => {
+    const oldColumn = newColumns[index];
+    const existingColumn = generateFieldAsString(newColumns[index]);
+    const updatedColumnString = generateFieldAsString(updatedColumn);
+    if (hasDuplicate(newColumns, oldColumn) || !isEquationColumn(updatedColumn)) {
+      return;
+    }
+    // Find the equations in the list of columns
+    for (let i = 0; i < newColumns.length; i++) {
+      const newColumn = newColumns[i];
+      if (newColumn.kind === 'equation') {
+        const result = parseArithmetic(newColumn.field);
+        let newEquation = '';
+        // Track where to continue from, not reconstructing from result so we don't have to worry
+        // about spacing
+        let lastIndex = 0;
+
+        // the parser separates fields & functions, so we only need to check one
+        const fields =
+          oldColumn.kind === 'function' ? result.tc.functions : result.tc.fields;
+
+        // for each field, add the text before it, then the new function and update index
+        // to be where we want to start again
+        for (const field of fields) {
+          if (
+            field.primary === existingColumn &&
+            lastIndex !== field.location.end.offset
+          ) {
+            newEquation +=
+              newColumn.field.substring(lastIndex, field.location.start.offset) +
+              updatedColumnString;
+            lastIndex = field.location.end.offset;
+          }
+        }
+
+        // Add whatever remains to be added from the equation, if existing field wasn't found
+        // add the entire equation
+        newEquation += newColumn.field.substring(lastIndex);
+        newColumns[i] = {
+          kind: 'equation',
+          field: newEquation,
+        };
+      }
+    }
   };
 
   removeColumn(index: number) {

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -17,7 +17,7 @@ import {
   Column,
   generateFieldAsString,
   hasDuplicate,
-  isEquationColumn,
+  isLegalEquationColumn,
 } from 'app/utils/discover/fields';
 import theme from 'app/utils/theme';
 import {getPointerPosition} from 'app/utils/touch';
@@ -165,7 +165,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     const oldColumn = newColumns[index];
     const existingColumn = generateFieldAsString(newColumns[index]);
     const updatedColumnString = generateFieldAsString(updatedColumn);
-    if (hasDuplicate(newColumns, oldColumn) || !isEquationColumn(updatedColumn)) {
+    if (!isLegalEquationColumn(updatedColumn) || hasDuplicate(newColumns, oldColumn)) {
       return;
     }
     // Find the equations in the list of columns
@@ -185,10 +185,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
         // for each field, add the text before it, then the new function and update index
         // to be where we want to start again
         for (const field of fields) {
-          if (
-            field.primary === existingColumn &&
-            lastIndex !== field.location.end.offset
-          ) {
+          if (field.term === existingColumn && lastIndex !== field.location.end.offset) {
             newEquation +=
               newColumn.field.substring(lastIndex, field.location.start.offset) +
               updatedColumnString;

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -359,6 +359,187 @@ describe('EventsV2 -> ColumnEditModal', function () {
     });
   });
 
+  describe('equation automatic update', function () {
+    let onApply;
+    beforeEach(function () {
+      onApply = jest.fn();
+    });
+    it('update simple equation columns when they change', function () {
+      const newWrapper = mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count_unique', 'user'],
+            },
+            {
+              kind: 'function',
+              function: ['p95', ''],
+            },
+            {
+              kind: 'equation',
+              field: '(p95() / count_unique(user)  ) *   100',
+            },
+          ],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+      selectByLabel(newWrapper, 'count_if(\u2026)', {
+        name: 'field',
+        at: 0,
+        control: true,
+      });
+
+      // Apply the changes so we can see the new columns.
+      newWrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['count_if', 'user', 'equals', '300']},
+        {kind: 'function', function: ['p95', '']},
+        {kind: 'equation', field: '(p95() / count_if(user,equals,300)  ) *   100'},
+      ]);
+    });
+    it('update equation with repeated columns when they change', function () {
+      const newWrapper = mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count_unique', 'user'],
+            },
+            {
+              kind: 'equation',
+              field:
+                'count_unique(user) +  (count_unique(user) - count_unique(user)) * 5',
+            },
+          ],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+      selectByLabel(newWrapper, 'count()', {
+        name: 'field',
+        at: 0,
+        control: true,
+      });
+
+      // Apply the changes so we can see the new columns.
+      newWrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['count', '', undefined, undefined]},
+        {kind: 'equation', field: 'count() +  (count() - count()) * 5'},
+      ]);
+    });
+    it('handles equations with duplicate fields', function () {
+      const newWrapper = mountModal(
+        {
+          columns: [
+            {
+              kind: 'field',
+              field: 'spans.db',
+            },
+            {
+              kind: 'field',
+              field: 'spans.db',
+            },
+            {
+              kind: 'equation',
+              field: 'spans.db - spans.db',
+            },
+          ],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+      selectByLabel(newWrapper, 'count()', {
+        name: 'field',
+        at: 0,
+        control: true,
+      });
+
+      // Apply the changes so we can see the new columns.
+      newWrapper.find('Button[priority="primary"]').simulate('click');
+      // Because spans.db is still a selected column it isn't swapped
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['count', '', undefined, undefined]},
+        {kind: 'field', field: 'spans.db'},
+        {kind: 'equation', field: 'spans.db - spans.db'},
+      ]);
+    });
+    it('handles equations with duplicate functions', function () {
+      const newWrapper = mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count', '', undefined, undefined],
+            },
+            {
+              kind: 'function',
+              function: ['count', '', undefined, undefined],
+            },
+            {
+              kind: 'equation',
+              field: 'count() - count()',
+            },
+          ],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+      selectByLabel(newWrapper, 'count_unique(\u2026)', {
+        name: 'field',
+        at: 0,
+        control: true,
+      });
+
+      // Apply the changes so we can see the new columns.
+      newWrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['count_unique', '', undefined, undefined]},
+        {kind: 'function', function: ['count', '', undefined, undefined]},
+        {kind: 'equation', field: 'count() - count()'},
+      ]);
+    });
+    it('handles incomplete equations', function () {
+      const newWrapper = mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: ['count', '', undefined, undefined],
+            },
+            {
+              kind: 'equation',
+              field: 'count() - count() arst count() ',
+            },
+          ],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+      expect(newWrapper.find('QueryField ArithmeticError')).toHaveLength(1);
+      selectByLabel(newWrapper, 'count_unique(\u2026)', {
+        name: 'field',
+        at: 0,
+        control: true,
+      });
+
+      // Apply the changes so we can see the new columns.
+      newWrapper.find('Button[priority="primary"]').simulate('click');
+      // With the way the parser works only tokens up to the error will be updated
+      expect(onApply).toHaveBeenCalledWith([
+        {kind: 'function', function: ['count_unique', '', undefined, undefined]},
+        {kind: 'equation', field: 'count_unique() - count_unique() arst count() '},
+      ]);
+    });
+  });
+
   describe('adding rows', function () {
     const wrapper = mountModal(
       {


### PR DESCRIPTION
- This automatically updates the equations that have already been added
  whenever a column changes, and that column was a part of the equation
  - eg. if the equation was `count() + 5` and `count()` changes to
    `count_unique(user)` the equation will become `count_unique(user) +
    5`
- The equation will only be updated as long as there doesn't exist the
  previous column anymore, which means if a column was selected more
  than once both will have to be changed for the equation to change
- This also fixes a bug in the autocomplete dropdown that would show
  duplicate keys, discovered it while trying to test the ability to skip
  this auto updating when duplicate fields exist