### PR TITLE
feat(transaction-summary): Use has measurements endpoint for web vita…

### DIFF
--- a/static/app/utils/performance/vitals/hasMeasurementsQuery.tsx
+++ b/static/app/utils/performance/vitals/hasMeasurementsQuery.tsx
@@ -1,0 +1,66 @@
+import omit from 'lodash/omit';
+import pick from 'lodash/pick';
+
+import {Client} from 'app/api';
+import {escapeDoubleQuotes} from 'app/utils';
+import GenericDiscoverQuery, {
+  DiscoverQueryProps,
+  GenericChildrenProps,
+} from 'app/utils/discover/genericDiscoverQuery';
+import {escapeTagValue} from 'app/utils/tokenizeSearch';
+import withApi from 'app/utils/withApi';
+
+type HasMeasurementsProps = {
+  transaction: string;
+  type: 'web' | 'mobile';
+};
+
+type RequestProps = DiscoverQueryProps & HasMeasurementsProps;
+
+type HasMeasurements = {measurements: boolean};
+
+type ChildrenProps = Omit<GenericChildrenProps<HasMeasurementsProps>, 'tableData'> & {
+  hasMeasurements: boolean | null;
+};
+
+type Props = RequestProps & {
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+function getHasMeasurementsRequestPayload(props: RequestProps) {
+  const {eventView, location, transaction, type} = props;
+  const escaped = escapeDoubleQuotes(escapeTagValue(transaction));
+  const baseApiPayload = {
+    transaction: `"${escaped}"`,
+    type,
+  };
+  const additionalApiPayload = pick(eventView.getEventsAPIPayload(location), [
+    'project',
+    'environment',
+  ]);
+  return Object.assign(baseApiPayload, additionalApiPayload);
+}
+
+function beforeFetch(api: Client) {
+  api.clear();
+}
+
+function HasMeasurementsQuery(props: Props) {
+  return (
+    <GenericDiscoverQuery<HasMeasurements, HasMeasurementsProps>
+      route="events-has-measurements"
+      getRequestPayload={getHasMeasurementsRequestPayload}
+      beforeFetch={beforeFetch}
+      {...omit(props, 'children')}
+    >
+      {({tableData, ...rest}) => {
+        return props.children({
+          hasMeasurements: tableData?.measurements ?? null,
+          ...rest,
+        });
+      }}
+    </GenericDiscoverQuery>
+  );
+}
+
+export default withApi(HasMeasurementsQuery);

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -405,7 +405,7 @@ function formatQuery(query: string) {
  * are directly added as a tag value, we have to escape them to mean
  * the literal.
  */
-function escapeTagValue(value: string) {
+export function escapeTagValue(value: string) {
   // TODO(txiao): The types here are definitely wrong.
   // Need to dig deeper to see where exactly it's wrong.
   //

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -322,7 +322,7 @@ class SummaryContent extends React.Component<Props, State> {
           projects={projects}
           transactionName={transactionName}
           currentTab={Tab.TransactionSummary}
-          hasWebVitals={hasWebVitals ? 'yes' : 'no'}
+          hasWebVitals="maybe"
           handleIncompatibleQuery={this.handleIncompatibleQuery}
           onChangeThreshold={onChangeThreshold}
         />

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -322,7 +322,7 @@ class SummaryContent extends React.Component<Props, State> {
           projects={projects}
           transactionName={transactionName}
           currentTab={Tab.TransactionSummary}
-          hasWebVitals={hasWebVitals}
+          hasWebVitals={hasWebVitals ? 'yes' : 'no'}
           handleIncompatibleQuery={this.handleIncompatibleQuery}
           onChangeThreshold={onChangeThreshold}
         />

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -25,7 +25,6 @@ import {tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
-import {getCurrentLandingDisplay, LandingDisplayField} from '../../landing/utils';
 import Filter, {filterToSearchConditions, SpanOperationBreakdownFilter} from '../filter';
 import TransactionHeader, {Tab} from '../header';
 
@@ -124,10 +123,7 @@ class EventsPageContent extends React.Component<Props, State> {
           projects={projects}
           transactionName={transactionName}
           currentTab={Tab.Events}
-          hasWebVitals={
-            getCurrentLandingDisplay(location, projects, eventView).field ===
-            LandingDisplayField.FRONTEND_PAGELOAD
-          }
+          hasWebVitals="maybe"
           handleIncompatibleQuery={this.handleIncompatibleQuery}
         />
         <Layout.Body>

--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -19,7 +19,6 @@ import SegmentExplorerQuery, {
 import {decodeScalar} from 'app/utils/queryString';
 import {SidebarSpacer} from 'app/views/performance/transactionSummary/utils';
 
-import {getCurrentLandingDisplay, LandingDisplayField} from '../../landing/utils';
 import {SpanOperationBreakdownFilter} from '../filter';
 import TransactionHeader, {Tab} from '../header';
 import {getTransactionField} from '../tagExplorer';
@@ -57,10 +56,7 @@ const TagsPageContent = (props: Props) => {
         projects={projects}
         transactionName={transactionName}
         currentTab={Tab.Tags}
-        hasWebVitals={
-          getCurrentLandingDisplay(location, projects, eventView).field ===
-          LandingDisplayField.FRONTEND_PAGELOAD
-        }
+        hasWebVitals="maybe"
         handleIncompatibleQuery={handleIncompatibleQuery}
       />
 

--- a/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/content.tsx
@@ -80,7 +80,7 @@ class VitalsContent extends React.Component<Props, State> {
           projects={projects}
           transactionName={transactionName}
           currentTab={Tab.RealUserMonitoring}
-          hasWebVitals
+          hasWebVitals="yes"
           handleIncompatibleQuery={this.handleIncompatibleQuery}
         />
         <Histogram location={location} zoomKeys={ZOOM_KEYS}>

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -12,6 +12,7 @@ type Data = {
     webVital?: WebVital;
   };
 };
+
 function initializeData({features: additionalFeatures = [], query = {}}: Data = {}) {
   const features = ['discover-basic', 'performance-view', ...additionalFeatures];
   // @ts-expect-error
@@ -139,6 +140,11 @@ describe('Performance > TransactionSummary', function () {
         },
       }
     );
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
   });
 
   afterEach(function () {

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -243,6 +243,10 @@ describe('Performance > TransactionSummary', function () {
         keyed: [],
       })),
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
   });
 
   afterEach(function () {

--- a/tests/js/spec/views/performance/transactionSummary/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/content.spec.tsx
@@ -54,41 +54,51 @@ describe('Transaction Summary Content', function () {
       url: '/prompts-activity/',
       body: {},
     });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sdk-updates/',
+      body: [],
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {data: [{'event.type': 'error'}], meta: {'event.type': 'string'}},
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [],
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/?limit=5&query=is%3Aunresolved%20transaction%3Aexample-transaction&sort=new&statsPeriod=14d',
+      body: [],
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-facets/',
+      body: [],
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
   });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/sdk-updates/',
-    body: [],
-  });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/eventsv2/',
-    body: {data: [{'event.type': 'error'}], meta: {'event.type': 'string'}},
-  });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/users/',
-    body: [],
-  });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/issues/?limit=5&query=is%3Aunresolved%20transaction%3Aexample-transaction&sort=new&statsPeriod=14d',
-    body: [],
-  });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/events-facets/',
-    body: [],
-  });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/releases/stats/',
-    body: [],
-  });
-  // @ts-expect-error
-  MockApiClient.addMockResponse({
-    url: '/organizations/org-slug/events-stats/',
-    body: [],
+
+  afterEach(function () {
+    // @ts-expect-error
+    MockApiClient.clearMockResponses();
   });
 
   it('Basic Rendering', async function () {

--- a/tests/js/spec/views/performance/transactionSummary/header.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/header.spec.tsx
@@ -43,6 +43,8 @@ describe('Performance > Transaction Summary Header', function () {
   let wrapper;
 
   afterEach(function () {
+    // @ts-expect-error
+    MockApiClient.clearMockResponses();
     wrapper.unmount();
   });
 

--- a/tests/js/spec/views/performance/transactionSummary/header.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/header.spec.tsx
@@ -1,0 +1,177 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import EventView from 'app/utils/discover/eventView';
+import TransactionHeader, {Tab} from 'app/views/performance/transactionSummary/header';
+
+function initializeData(opts?: {platform?: string}) {
+  // @ts-expect-error
+  const project = TestStubs.Project({platform: opts?.platform});
+  // @ts-expect-error
+  const organization = TestStubs.Organization({
+    projects: [project],
+  });
+  const initialData = initializeOrg({
+    organization,
+    router: {
+      location: {
+        query: {
+          project: project.id,
+        },
+      },
+    },
+    project: project.id,
+    projects: [],
+  });
+  const router = initialData.router;
+  const eventView = EventView.fromSavedQuery({
+    id: undefined,
+    version: 2,
+    name: '',
+    fields: ['transaction.status'], // unused fields
+    projects: [parseInt(project.id, 10)],
+  });
+  return {
+    project,
+    organization,
+    router,
+    eventView,
+  };
+}
+
+describe('Performance > Transaction Summary Header', function () {
+  let wrapper;
+
+  afterEach(function () {
+    wrapper.unmount();
+  });
+
+  it('should render web vitals tab when yes', async function () {
+    const {project, organization, router, eventView} = initializeData();
+
+    wrapper = mountWithTheme(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="yes"
+        handleIncompatibleQuery={() => {}}
+      />
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('ListLink[data-test-id="web-vitals-tab"]').exists()).toBeTruthy();
+  });
+
+  it('should not render web vitals tab when no', async function () {
+    const {project, organization, router, eventView} = initializeData();
+
+    wrapper = mountWithTheme(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="no"
+        handleIncompatibleQuery={() => {}}
+      />
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('ListLink[data-test-id="web-vitals-tab"]').exists()).toBeFalsy();
+  });
+
+  it('should render web vitals tab when maybe and is frontend platform', async function () {
+    const {project, organization, router, eventView} = initializeData({
+      platform: 'javascript',
+    });
+
+    wrapper = mountWithTheme(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="maybe"
+        handleIncompatibleQuery={() => {}}
+      />
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('ListLink[data-test-id="web-vitals-tab"]').exists()).toBeTruthy();
+  });
+
+  it('should render web vitals tab when maybe and has measurements', async function () {
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: true},
+    });
+
+    const {project, organization, router, eventView} = initializeData();
+
+    wrapper = mountWithTheme(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="maybe"
+        handleIncompatibleQuery={() => {}}
+      />
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('ListLink[data-test-id="web-vitals-tab"]').exists()).toBeTruthy();
+  });
+
+  it('should not render web vitals tab when maybe and has no measurements', async function () {
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
+
+    const {project, organization, router, eventView} = initializeData();
+
+    wrapper = mountWithTheme(
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="maybe"
+        handleIncompatibleQuery={() => {}}
+      />
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('ListLink[data-test-id="web-vitals-tab"]').exists()).toBeFalsy();
+  });
+});

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -152,6 +152,11 @@ describe('Performance Transaction Events Content', function () {
         },
       }
     );
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
     initialData = initializeData({features: ['performance-events-page']});
     eventView = EventView.fromNewQueryWithLocation(
       {

--- a/tests/js/spec/views/performance/transactionTags/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.jsx
@@ -103,6 +103,10 @@ describe('Performance > Transaction Tags', function () {
         ],
       },
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-has-measurements/',
+      body: {measurements: false},
+    });
   });
 
   afterEach(function () {


### PR DESCRIPTION
…ls tab

This will use the new has-measurements endpoint to render the web vitals tab in
a more consistent way.