### PR TITLE
feat(codeowners): Add a background color for badge

### DIFF
--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -136,6 +136,7 @@ const tagColors = {
   url: theme.green200,
   path: theme.purple300,
   tag: theme.blue300,
+  codeowners: theme.orange300,
 };
 
 const CommitIcon = styled(IconCommit)`
@@ -188,7 +189,6 @@ const OwnershipTag = styled(({tagType, ...props}) => <div {...props}>{tagType}</
   margin: ${space(0.25)} ${space(0.5)} ${space(0.25)} 0;
   border-radius: 2px;
   font-weight: bold;
-  min-width: 34px;
   text-align: center;
 `;
 


### PR DESCRIPTION
## Objective:
`codeowners` badge in the Suggested Assignees hovercard had a transparent background

![Screen Shot 2021-07-26 at 10 31 34 AM](https://user-images.githubusercontent.com/10491193/127038065-bc6431d7-529a-4916-9166-c6961bcb11af.png)


## UI:
![Screen Shot 2021-07-26 at 11 13 02 AM](https://user-images.githubusercontent.com/10491193/127038086-3a1df67c-b97b-4451-8c21-97f96b7980a4.png)
