### PR TITLE
fix(grouping): Sort subgroups by descending event count

### DIFF
--- a/src/sentry/api/endpoints/grouping_level_new_issues.py
+++ b/src/sentry/api/endpoints/grouping_level_new_issues.py
@@ -130,7 +130,14 @@ def _query_snuba(group: Group, id: int, offset=None, limit=None):
             ]
         )
         .set_groupby([Column("new_materialized_hash")])
-        .set_orderby([OrderBy(Column("latest_event_timestamp"), Direction.DESC)])
+        .set_orderby(
+            [
+                OrderBy(Column("event_count"), Direction.DESC),
+                # Completely useless sorting key, only there to achieve stable sort
+                # order in tests.
+                OrderBy(Column("latest_event_timestamp"), Direction.DESC),
+            ]
+        )
     )
 
     levels_overview = get_levels_overview(group)

--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -195,12 +195,12 @@ group: ZeroDivisionError | foo
 level 0*
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (4)
 level 1
-64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
 c8ef2dd3dedeed29b4b74b9c579eea1a: ZeroDivisionError | foo | bar2 (2)
+64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
 aa1c4037371150958f9ea22adb110bbc: ZeroDivisionError | foo | bar (1)
 level 2
-64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
 8c0bbfebc194c7aa3e77e95436fd61e5: ZeroDivisionError | foo | bar2 | baz2 (2)
+64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)
 b8d08a573c62ca8c84de14c12c0e19fe: ZeroDivisionError | foo | bar | baz (1)
 level 3
 64686dcd59e0cf97f34113e9d360541a: ZeroDivisionError | foo | bar3 (1)


### PR DESCRIPTION
That's slightly more interesting than ordering by last_seen (pure
assumption, no data-driven-ness)