### PR TITLE
fix(notification platform): Handle no response URL

### DIFF
--- a/src/sentry/integrations/slack/views/__init__.py
+++ b/src/sentry/integrations/slack/views/__init__.py
@@ -1,10 +1,17 @@
+from typing import Mapping
+
 from django.urls import reverse
 from django.views.decorators.cache import never_cache as django_never_cache
 
+from sentry.models import Integration
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 from sentry.utils.types import Any
 from sentry.web.decorators import EndpointFunc
+
+from ..client import SlackClient
+from ..utils import logger
 
 
 def never_cache(view_func: EndpointFunc) -> EndpointFunc:
@@ -17,3 +24,46 @@ def build_linking_url(endpoint: str, **kwargs: Any) -> str:
     """TODO(mgaeta): Remove cast once sentry/utils/http.py is typed."""
     url: str = absolute_uri(reverse(endpoint, kwargs={"signed_params": sign(**kwargs)}))
     return url
+
+
+def send_slack_response(
+    integration: Integration, text: str, params: Mapping[str, str], command: str
+) -> None:
+    payload = {
+        "replace_original": False,
+        "response_type": "ephemeral",
+        "text": text,
+    }
+
+    client = SlackClient()
+    if params["response_url"]:
+        path = params["response_url"]
+        headers = {}
+
+    else:
+        # Command has been invoked in a DM, not as a slash command
+        # we do not have a response URL in this case
+        token = (
+            integration.metadata.get("user_access_token") or integration.metadata["access_token"]
+        )
+        headers = {"Authorization": f"Bearer {token}"}
+        payload["token"] = token
+        payload["channel"] = params["slack_id"]
+        path = "/chat.postMessage"
+
+    try:
+        client.post(path, headers=headers, data=payload, json=True)
+    except ApiError as e:
+        message = str(e)
+        # If the user took their time to link their slack account, we may no
+        # longer be able to respond, and we're not guaranteed able to post into
+        # the channel. Ignore Expired url errors.
+        #
+        # XXX(epurkhiser): Yes the error string has a space in it.
+        if message != "Expired url":
+            log_message = (
+                "slack.link-notify.response-error"
+                if command == "link"
+                else "slack.unlink-notify.response-error"
+            )
+            logger.error(log_message, extra={"error": message})

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -76,8 +76,24 @@ class SlackLinkIdentityView(BaseView):  # type: ignore
         }
 
         client = SlackClient()
+        if params["response_url"]:
+            path = params["response_url"]
+            headers = {}
+
+        else:
+            # command has been invoked in a DM, not as a slash command
+            # we do not have a response URL in this case
+            token = (
+                integration.metadata.get("user_access_token")
+                or integration.metadata["access_token"]
+            )
+            headers = {"Authorization": f"Bearer {token}"}
+            payload["token"] = token
+            payload["channel"] = params["slack_id"]
+            path = "/chat.postMessage"
+
         try:
-            client.post(params["response_url"], data=payload, json=True)
+            client.post(path, headers=headers, data=payload, json=True)
         except ApiError as e:
             message = str(e)
             # If the user took their time to link their slack account, we may no

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -4,16 +4,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.models import Identity
-from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
-from ..client import SlackClient
 from ..utils import get_identity, logger
 from . import build_linking_url as base_build_linking_url
-from . import never_cache
+from . import never_cache, send_slack_response
 
 SUCCESS_UNLINKED_MESSAGE = "Your Slack identity has been unlinked from your Sentry account."
 
@@ -56,40 +54,7 @@ class SlackUnlinkIdentityView(BaseView):  # type: ignore
             logger.error("slack.unlink.integrity-error", extra=e)
             raise Http404
 
-        payload = {
-            "replace_original": False,
-            "response_type": "ephemeral",
-            "text": SUCCESS_UNLINKED_MESSAGE,
-        }
-
-        client = SlackClient()
-        if params["response_url"]:
-            path = params["response_url"]
-            headers = {}
-
-        else:
-            # command has been invoked in a DM, not as a slash command
-            # we do not have a response URL in this case
-            token = (
-                integration.metadata.get("user_access_token")
-                or integration.metadata["access_token"]
-            )
-            headers = {"Authorization": f"Bearer {token}"}
-            payload["token"] = token
-            payload["channel"] = params["slack_id"]
-            path = "/chat.postMessage"
-
-        try:
-            client.post(path, headers=headers, data=payload, json=True)
-        except ApiError as e:
-            message = str(e)
-            # If the user took their time to link their slack account, we may no
-            # longer be able to respond, and we're not guaranteed able to post into
-            # the channel. Ignore Expired url errors.
-            #
-            # XXX(epurkhiser): Yes the error string has a space in it.
-            if message != "Expired url":
-                logger.error("slack.unlink-notify.response-error", extra={"error": message})
+        send_slack_response(integration, SUCCESS_UNLINKED_MESSAGE, params, command="unlink")
 
         return render_to_response(
             "sentry/integrations/slack-unlinked.html",


### PR DESCRIPTION
If a user types `link` or `unlink` to the Sentry Slack app (instead of using the slash commands `/sentry link` or `/sentry unlink`) we do not have a response URL to reply to. Since we know it was typed directly to the app in this case, we can pass the user's Slack ID as the channel and reply that way. 

Fixes [SENTRY-RP7](https://sentry.io/organizations/sentry/issues/2530053574/)