### PR TITLE
fix(search): Do not allow operators on tags

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -818,6 +818,12 @@ class SearchVisitor(NodeVisitor):
         if not search_value.raw_value and not node.children[4].text:
             raise InvalidSearchQuery(f"Empty string after '{search_key.name}:'")
 
+        if operator not in ("=", "!=") and search_key.name not in self.config.text_operator_keys:
+            # Operators are not supported in text_filter.
+            # Push it back into the back before handing the negation.
+            search_value = search_value._replace(raw_value=f"{operator}{search_value.raw_value}")
+            operator = "="
+
         operator = handle_negation(negation, operator)
 
         return self._handle_text_filter(search_key, operator, search_value)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -820,7 +820,7 @@ class SearchVisitor(NodeVisitor):
 
         if operator not in ("=", "!=") and search_key.name not in self.config.text_operator_keys:
             # Operators are not supported in text_filter.
-            # Push it back into the back before handing the negation.
+            # Push it back into the value before handing the negation.
             search_value = search_value._replace(raw_value=f"{operator}{search_value.raw_value}")
             operator = "="
 

--- a/tests/fixtures/search-syntax/numeric_filter.json
+++ b/tests/fixtures/search-syntax/numeric_filter.json
@@ -16,6 +16,22 @@
     ]
   },
   {
+    "desc": "Numeric format should not negate operator if field isn't allowed",
+    "query": "!random_field:>500",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "text",
+        "negated": true,
+        "key": {"type": "keySimple", "value": "random_field", "quoted": false},
+        "operator": "",
+        "value": {"type": "valueText", "value": ">500", "quoted": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
     "query": "project_id:-500",
     "result": [
       {"type": "spaces", "value": ""},


### PR DESCRIPTION
Tags do no support comparison operators. This is causing an issue where if the
search filters for a tag value prefixed by an operator with negation, it was
negating the operator instead of treating the operator as a part of the value.