### PR TITLE
fix(grouping): Do not skip in-app code if sentinels exist

### DIFF
--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -23,7 +23,7 @@ def get_stacktrace_hierarchy(main_variant, components, frames, inverted_hierarch
         key = f"app-depth-{depth}"
         assert key not in all_variants
 
-        found_app_frame = False
+        found_sentinel = False
 
         for frame, component in frames_iter:
             if not component.contributes:
@@ -34,6 +34,7 @@ def get_stacktrace_hierarchy(main_variant, components, frames, inverted_hierarch
             # can't be sure that in-app is a good indicator of relevance.
 
             if component.is_sentinel_frame:
+                found_sentinel = True
                 break
 
             # In case we found an application frame before the first sentinel
@@ -43,12 +44,9 @@ def get_stacktrace_hierarchy(main_variant, components, frames, inverted_hierarch
             # grouping/inverted_hierarchy similar reasoning applies)
 
             if frame["in_app"]:
-                found_app_frame = True
                 break
-        else:
-            break
 
-        if found_app_frame:
+        if not found_sentinel:
             break
 
         add_to_layer = [component]

--- a/tests/sentry/grouping/grouping_inputs/in-app-in-ui.json
+++ b/tests/sentry/grouping/grouping_inputs/in-app-in-ui.json
@@ -1,0 +1,485 @@
+{
+  "platform": "cocoa",
+  "exception": {
+    "values": [
+      {
+        "type": "EXC_BREAKPOINT",
+        "value": "autoplayOption",
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "start",
+              "package": "libdyld.dylib",
+              "in_app": false
+            },
+            {
+              "function": "main",
+              "package": "Previouswindow",
+              "filename": "Previouswindow/Supporting Files/main.m",
+              "in_app": true
+            },
+            {
+              "function": "UIApplicationMain",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UIApplication _run]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "GSEventRunModal",
+              "package": "GraphicsServices",
+              "in_app": false
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "__CFRunLoopDoObservers",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "CA::Transaction::observer_callback",
+              "raw_function": "CA::Transaction::observer_callback(__CFRunLoopObserver*, unsigned long, void*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Transaction::commit",
+              "raw_function": "CA::Transaction::commit()",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Context::commit_transaction",
+              "raw_function": "CA::Context::commit_transaction(CA::Transaction*, double, double*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Layer::layout_and_display_if_needed",
+              "raw_function": "CA::Layer::layout_and_display_if_needed(CA::Transaction*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Layer::layout_if_needed",
+              "raw_function": "CA::Layer::layout_if_needed(CA::Transaction*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "-[CALayer layoutSublayers]",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "TableView.layoutSubviews",
+              "raw_function": "@objc TableView.layoutSubviews()",
+              "package": "ListKit",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "-[UITableView layoutSubviews]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UITableView _updateVisibleCellsNow:]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "AnyTableViewController.tableView",
+              "raw_function": "@objc AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)",
+              "package": "ListKit",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "AnyTableViewController.tableView",
+              "raw_function": "AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)",
+              "package": "ListKit",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "AnyTableViewController.tableView",
+              "raw_function": "specialized AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)",
+              "package": "ListKit",
+              "filename": "AnyTableViewController.swift",
+              "in_app": true
+            },
+            {
+              "function": "closure",
+              "raw_function": "thunk for closure",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "DailyDigestTableViewSection.photoCell",
+              "raw_function": "DailyDigestTableViewSection.photoCell(at: IndexPath, in: AnyTableViewController)",
+              "package": "Previouswindow",
+              "filename": "DailyDigestTableViewSection.swift",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSources",
+              "raw_function": "static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSources",
+              "raw_function": "specialized static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "MediaSlideshow+Extensions.swift",
+              "in_app": true
+            },
+            {
+              "function": "Sequence.compactMap<T>",
+              "raw_function": "specialized Sequence.compactMap<A>((A.Element))",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "closure",
+              "raw_function": "thunk for closure",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSources",
+              "raw_function": "closure #1 (FileAttachment) in static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "MediaSlideshow+Extensions.swift",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSource",
+              "raw_function": "static MediaSlideshow.toSource(_: FileAttachment, trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "MediaSlideshow+Extensions.swift",
+              "in_app": true
+            },
+            {
+              "function": "CurrentUserProfile.isVideoAutoplay.getter",
+              "raw_function": "@objc CurrentUserProfile.isVideoAutoplay.getter",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "CurrentUserProfile.isVideoAutoplay.getter",
+              "package": "Previouswindow",
+              "filename": "CurrentUserProfile.swift",
+              "in_app": true
+            },
+            {
+              "function": "value",
+              "raw_function": "Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value",
+              "package": "Previouswindow",
+              "filename": "CurrentUserProfile.swift",
+              "in_app": true
+            }
+          ],
+          "registers": {
+            "cpsr": "0x80000000",
+            "fp": "0x16f5b37c0",
+            "lr": "0x1011933b0",
+            "pc": "0x101193564",
+            "sp": "0x16f5b37a0",
+            "x0": "0x0",
+            "x1": "0x101611693",
+            "x10": "0x2836729e0",
+            "x11": "0xdae913",
+            "x12": "0xe",
+            "x13": "0x0",
+            "x14": "0x18",
+            "x15": "0x5",
+            "x16": "0x196b2073c",
+            "x17": "0x1008d6c20",
+            "x18": "0x1077b38fc",
+            "x19": "0x1e56f93a8",
+            "x2": "0xe900000000000035",
+            "x20": "0x143f0e790",
+            "x21": "0x0",
+            "x22": "0x283810000",
+            "x23": "0x3737373832353931",
+            "x24": "0xe900000000000035",
+            "x25": "0x281fe3600",
+            "x26": "0x0",
+            "x27": "0x101c132a0",
+            "x28": "0x0",
+            "x29": "0x16f5b37c0",
+            "x3": "0x0",
+            "x4": "0x0",
+            "x5": "0x4",
+            "x6": "0x35",
+            "x7": "0x0",
+            "x8": "0x1020a79a0",
+            "x9": "0x0"
+          }
+        },
+        "raw_stacktrace": {
+          "frames": [
+            {
+              "function": "start",
+              "package": "libdyld.dylib",
+              "in_app": false
+            },
+            {
+              "function": "main",
+              "package": "Previouswindow",
+              "filename": "Previouswindow/Supporting Files/main.m",
+              "in_app": true
+            },
+            {
+              "function": "UIApplicationMain",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UIApplication _run]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "GSEventRunModal",
+              "package": "GraphicsServices",
+              "in_app": false
+            },
+            {
+              "function": "CFRunLoopRunSpecific",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "__CFRunLoopRun",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "__CFRunLoopDoObservers",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__",
+              "package": "CoreFoundation",
+              "in_app": false
+            },
+            {
+              "function": "CA::Transaction::observer_callback",
+              "raw_function": "CA::Transaction::observer_callback(__CFRunLoopObserver*, unsigned long, void*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Transaction::commit",
+              "raw_function": "CA::Transaction::commit()",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Context::commit_transaction",
+              "raw_function": "CA::Context::commit_transaction(CA::Transaction*, double, double*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Layer::layout_and_display_if_needed",
+              "raw_function": "CA::Layer::layout_and_display_if_needed(CA::Transaction*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "CA::Layer::layout_if_needed",
+              "raw_function": "CA::Layer::layout_if_needed(CA::Transaction*)",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "-[CALayer layoutSublayers]",
+              "package": "QuartzCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "TableView.layoutSubviews",
+              "raw_function": "@objc TableView.layoutSubviews()",
+              "package": "ListKit",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "-[UITableView layoutSubviews]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UITableView _updateVisibleCellsNow:]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]",
+              "package": "UIKitCore",
+              "in_app": false
+            },
+            {
+              "function": "AnyTableViewController.tableView",
+              "raw_function": "@objc AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)",
+              "package": "ListKit",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "AnyTableViewController.tableView",
+              "raw_function": "AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)",
+              "package": "ListKit",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "AnyTableViewController.tableView",
+              "raw_function": "specialized AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)",
+              "package": "ListKit",
+              "filename": "AnyTableViewController.swift",
+              "in_app": true
+            },
+            {
+              "function": "thunk for closure",
+              "raw_function": "thunk for @escaping @callee_guaranteed (@in_guaranteed IndexPath, @guaranteed AnyTableViewController) -> (@owned UITableViewCell)",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "DailyDigestTableViewSection.photoCell",
+              "raw_function": "DailyDigestTableViewSection.photoCell(at: IndexPath, in: AnyTableViewController)",
+              "package": "Previouswindow",
+              "filename": "DailyDigestTableViewSection.swift",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSources",
+              "raw_function": "static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSources",
+              "raw_function": "specialized static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "MediaSlideshow+Extensions.swift",
+              "in_app": true
+            },
+            {
+              "function": "Sequence.compactMap<T>",
+              "raw_function": "specialized Sequence.compactMap<A>((A.Element))",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "thunk for closure",
+              "raw_function": "thunk for @callee_guaranteed (@guaranteed FileAttachment) -> (@out MediaSource?, @error @owned Error)",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSources",
+              "raw_function": "closure #1 (FileAttachment) in static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "MediaSlideshow+Extensions.swift",
+              "in_app": true
+            },
+            {
+              "function": "MediaSlideshow.toSource",
+              "raw_function": "static MediaSlideshow.toSource(_: FileAttachment, trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)",
+              "package": "Previouswindow",
+              "filename": "MediaSlideshow+Extensions.swift",
+              "in_app": true
+            },
+            {
+              "function": "CurrentUserProfile.isVideoAutoplay.getter",
+              "raw_function": "@objc CurrentUserProfile.isVideoAutoplay.getter",
+              "package": "Previouswindow",
+              "filename": "<compiler-generated>",
+              "in_app": true
+            },
+            {
+              "function": "CurrentUserProfile.isVideoAutoplay.getter",
+              "package": "Previouswindow",
+              "filename": "CurrentUserProfile.swift",
+              "in_app": true
+            },
+            {
+              "function": "value",
+              "raw_function": "Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value",
+              "package": "Previouswindow",
+              "filename": "CurrentUserProfile.swift",
+              "in_app": true
+            }
+          ]
+        },
+        "thread_id": 0,
+        "mechanism": {
+          "type": "mach",
+          "synthetic": true,
+          "handled": false,
+          "meta": {
+            "signal": {
+              "number": 5,
+              "code": 0,
+              "name": "SIGTRAP"
+            },
+            "mach_exception": {
+              "exception": 6,
+              "code": 18429284,
+              "subcode": 8,
+              "name": "EXC_BREAKPOINT"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/in_app_in_ui.pysnap
@@ -1,0 +1,49 @@
+---
+created: '2021-07-27T07:44:27.545732Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","AnyTableViewController.tableView"]],[["filename","anytableviewcontroller.swift"],["function","AnyTableViewController.tableView"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","CurrentUserProfile.isVideoAutoplay.getter"]],[["filename","currentuserprofile.swift"],["function","CurrentUserProfile.isVideoAutoplay.getter"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","MediaSlideshow.toSources"]],[["filename","mediaslideshow+extensions.swift"],["function","MediaSlideshow.toSources"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","Sequence.compactMap<T>"]],[["filename","<compiler-generated>"],["function","closure"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","TableView.layoutSubviews"]],[["filename","<compiler-generated>"],["function","AnyTableViewController.tableView"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","TableView.layoutSubviews"]],[["function","-[UITableView layoutSubviews]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","closure"]],[["filename","dailydigesttableviewsection.swift"],["function","DailyDigestTableViewSection.photoCell"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","<compiler-generated>"],["function","closure"]],[["filename","mediaslideshow+extensions.swift"],["function","MediaSlideshow.toSources"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","anytableviewcontroller.swift"],["function","AnyTableViewController.tableView"]],[["filename","<compiler-generated>"],["function","closure"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","currentuserprofile.swift"],["function","CurrentUserProfile.isVideoAutoplay.getter"]],[["filename","currentuserprofile.swift"],["function","value"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","dailydigesttableviewsection.swift"],["function","DailyDigestTableViewSection.photoCell"]],[["filename","<compiler-generated>"],["function","MediaSlideshow.toSources"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","main.m"],["function","main"]],[["filename","<compiler-generated>"],["function","TableView.layoutSubviews"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","main.m"],["function","main"]],[["function","UIApplicationMain"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","mediaslideshow+extensions.swift"],["function","MediaSlideshow.toSource"]],[["filename","<compiler-generated>"],["function","CurrentUserProfile.isVideoAutoplay.getter"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","mediaslideshow+extensions.swift"],["function","MediaSlideshow.toSources"]],[["filename","<compiler-generated>"],["function","Sequence.compactMap<T>"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","mediaslideshow+extensions.swift"],["function","MediaSlideshow.toSources"]],[["filename","mediaslideshow+extensions.swift"],["function","MediaSlideshow.toSource"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[CALayer layoutSublayers]"]],[["function","-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[UIApplication _run]"]],[["function","GSEventRunModal"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"]],[["filename","<compiler-generated>"],["function","AnyTableViewController.tableView"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[UITableView _updateVisibleCellsNow:]"]],[["function","-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[UITableView layoutSubviews]"]],[["function","-[UITableView _updateVisibleCellsNow:]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"]],[["filename","<compiler-generated>"],["function","TableView.layoutSubviews"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","CA::Context::commit_transaction"]],[["function","CA::Layer::layout_and_display_if_needed"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","CA::Layer::layout_and_display_if_needed"]],[["function","CA::Layer::layout_if_needed"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","CA::Layer::layout_if_needed"]],[["function","-[CALayer layoutSublayers]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","CA::Transaction::commit"]],[["function","CA::Context::commit_transaction"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","CA::Transaction::observer_callback"]],[["function","CA::Transaction::commit"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","CFRunLoopRunSpecific"]],[["function","__CFRunLoopRun"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","GSEventRunModal"]],[["function","CFRunLoopRunSpecific"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","UIApplicationMain"]],[["function","-[UIApplication _run]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"]],[["function","CA::Transaction::observer_callback"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","__CFRunLoopDoObservers"]],[["function","__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","__CFRunLoopRun"]],[["function","__CFRunLoopDoObservers"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","start"]],[["filename","main.m"],["function","main"]]]
+similarity:2020-07-23:value:character-5-shingle: "Optio"
+similarity:2020-07-23:value:character-5-shingle: "autop"
+similarity:2020-07-23:value:character-5-shingle: "ayOpt"
+similarity:2020-07-23:value:character-5-shingle: "layOp"
+similarity:2020-07-23:value:character-5-shingle: "oplay"
+similarity:2020-07-23:value:character-5-shingle: "playO"
+similarity:2020-07-23:value:character-5-shingle: "ption"
+similarity:2020-07-23:value:character-5-shingle: "topla"
+similarity:2020-07-23:value:character-5-shingle: "utopl"
+similarity:2020-07-23:value:character-5-shingle: "yOpti"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/in_app_in_ui.pysnap
@@ -1,0 +1,294 @@
+---
+created: '2021-07-26T19:38:19.001536Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "start"
+          frame*
+            filename* (stripped to basename)
+              "main.m"
+            function*
+              "main"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "UIApplicationMain"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "GSEventRunModal"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "__CFRunLoopDoObservers"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "CA::Transaction::observer_callback(__CFRunLoopObserver*, unsigned long, void*)"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "CA::Transaction::commit()"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "CA::Context::commit_transaction(CA::Transaction*, double, double*)"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "CA::Layer::layout_and_display_if_needed(CA::Transaction*)"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "CA::Layer::layout_if_needed(CA::Transaction*)"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "-[CALayer layoutSublayers]"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "@objc TableView.layoutSubviews()"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "-[UITableView layoutSubviews]"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (non app frame)
+            function (function name is not used if module or filename are available)
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "@objc AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)"
+          frame*
+            filename* (stripped to basename)
+              "AnyTableViewController.swift"
+            function*
+              "specialized AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "thunk for closure"
+          frame*
+            filename* (stripped to basename)
+              "DailyDigestTableViewSection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell(at: IndexPath, in: AnyTableViewController)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "MediaSlideshow+Extensions.swift"
+            function*
+              "specialized static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "specialized Sequence.compactMap<A>((A.Element))"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "thunk for closure"
+          frame*
+            filename* (stripped to basename)
+              "MediaSlideshow+Extensions.swift"
+            function*
+              "closure #1 (FileAttachment) in static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "MediaSlideshow+Extensions.swift"
+            function*
+              "static MediaSlideshow.toSource(_: FileAttachment, trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "@objc CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename* (stripped to basename)
+              "CurrentUserProfile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename* (stripped to basename)
+              "CurrentUserProfile.swift"
+            function*
+              "Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value"
+        type*
+          "EXC_BREAKPOINT"
+        value (stacktrace and type take precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+system:
+  hash: "c506663b9a1495d301bff1e82149d55e"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame
+            function (function name is not used if module or filename are available)
+              "start"
+          frame*
+            filename* (stripped to basename)
+              "main.m"
+            function*
+              "main"
+          frame
+            function (function name is not used if module or filename are available)
+              "UIApplicationMain"
+          frame
+            function (function name is not used if module or filename are available)
+              "-[UIApplication _run]"
+          frame
+            function (function name is not used if module or filename are available)
+              "GSEventRunModal"
+          frame
+            function (function name is not used if module or filename are available)
+              "CFRunLoopRunSpecific"
+          frame
+            function (function name is not used if module or filename are available)
+              "__CFRunLoopRun"
+          frame
+            function (function name is not used if module or filename are available)
+              "__CFRunLoopDoObservers"
+          frame
+            function (function name is not used if module or filename are available)
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame
+            function (function name is not used if module or filename are available)
+              "CA::Transaction::observer_callback(__CFRunLoopObserver*, unsigned long, void*)"
+          frame
+            function (function name is not used if module or filename are available)
+              "CA::Transaction::commit()"
+          frame
+            function (function name is not used if module or filename are available)
+              "CA::Context::commit_transaction(CA::Transaction*, double, double*)"
+          frame
+            function (function name is not used if module or filename are available)
+              "CA::Layer::layout_and_display_if_needed(CA::Transaction*)"
+          frame
+            function (function name is not used if module or filename are available)
+              "CA::Layer::layout_if_needed(CA::Transaction*)"
+          frame
+            function (function name is not used if module or filename are available)
+              "-[CALayer layoutSublayers]"
+          frame
+            function (function name is not used if module or filename are available)
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "@objc TableView.layoutSubviews()"
+          frame
+            function (function name is not used if module or filename are available)
+              "-[UITableView layoutSubviews]"
+          frame
+            function (function name is not used if module or filename are available)
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame
+            function (function name is not used if module or filename are available)
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "@objc AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)"
+          frame (ignored due to recursion)
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)"
+          frame*
+            filename* (stripped to basename)
+              "AnyTableViewController.swift"
+            function*
+              "specialized AnyTableViewController.tableView(_: UITableView, cellForRowAt: IndexPath)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "thunk for closure"
+          frame*
+            filename* (stripped to basename)
+              "DailyDigestTableViewSection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell(at: IndexPath, in: AnyTableViewController)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "MediaSlideshow+Extensions.swift"
+            function*
+              "specialized static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "specialized Sequence.compactMap<A>((A.Element))"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "thunk for closure"
+          frame*
+            filename* (stripped to basename)
+              "MediaSlideshow+Extensions.swift"
+            function*
+              "closure #1 (FileAttachment) in static MediaSlideshow.toSources(_: [FileAttachment], trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "MediaSlideshow+Extensions.swift"
+            function*
+              "static MediaSlideshow.toSource(_: FileAttachment, trackingContent: VideoTracker.Content, trackingScope: VideoTracker.Scope)"
+          frame*
+            filename* (stripped to basename)
+              "<compiler-generated>"
+            function*
+              "@objc CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename* (stripped to basename)
+              "CurrentUserProfile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename* (stripped to basename)
+              "CurrentUserProfile.swift"
+            function*
+              "Swift runtime failure: Unexpectedly found nil while implicitly unwrapping an Optional value"
+        type*
+          "EXC_BREAKPOINT"
+        value (stacktrace and type take precedence)
+          "autoplayOption"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-07-08T10:36:07.105939Z'
+created: '2021-07-26T19:40:57.788760Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,15 +24,28 @@ app-depth-1:
         stacktrace*
           frame*
             function*
-              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
-          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
-            function*
-              "-[UIApplication sendAction:to:from:forEvent:]"
+              "ViewController.captureError"
 --------------------------------------------------------------------------
 app-depth-2:
   hash: null
   component:
     app-depth-2 (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: null
+  component:
+    app-depth-3 (exception of app takes precedence)
       threads (exception of app takes precedence)
         stacktrace*
           frame*
@@ -47,6 +60,34 @@ app-depth-2:
           frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
             function*
               "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: null
+  component:
+    app-depth-4 (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
 --------------------------------------------------------------------------
 app-depth-max:
   hash: null

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/in_app_in_ui.pysnap
@@ -1,0 +1,431 @@
+---
+created: '2021-07-26T19:40:58.413847Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: "2063c1608d6e0baf80249c42e2be5804"
+  tree_label: "value"
+  component:
+    app-depth-1*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: "ce1bd3de2f794a0e1d6d33f5a32e6192"
+  tree_label: "value | CurrentUserProfile.isVideoAutoplay.getter"
+  component:
+    app-depth-2*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: "a058dabbac843ff84703c280824aa0b7"
+  tree_label: "value | CurrentUserProfile.isVideoAutoplay.getter | MediaSlideshow.toSource"
+  component:
+    app-depth-3*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+app-depth-4:
+  hash: "f0d4d3e4e53b6e74393e32aee11f6f1b"
+  tree_label: "value | CurrentUserProfile.isVideoAutoplay.getter | MediaSlideshow.toSource | MediaSlideshow.toSources"
+  component:
+    app-depth-4*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+app-depth-5:
+  hash: "db1e8fbcbf95edda89b571a3ce701048"
+  tree_label: "value | CurrentUserProfile.isVideoAutoplay.getter | MediaSlideshow.toSource | MediaSlideshow.toSources | MediaSlideshow.toSources"
+  component:
+    app-depth-5*
+      exception*
+        stacktrace*
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "80645b4c3dca9509556da849b8332986"
+  tree_label: "value | CurrentUserProfile.isVideoAutoplay.getter | MediaSlideshow.toSource | MediaSlideshow.toSources | MediaSlideshow.toSources | DailyDigestTableViewSection.photoCell | AnyTableViewController.tableView | -[UITableView layoutSubviews] | -[UIView(CALayerDelegate) layoutSublayersOfLayer:] | GSEventRunModal | -[UIApplication _run]"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "main.m"
+            function*
+              "main"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "UIApplicationMain"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "CFRunLoopRunSpecific"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopRun"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoObservers"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Transaction::observer_callback"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Transaction::commit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Context::commit_transaction"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Layer::layout_if_needed"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[CALayer layoutSublayers]"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+system:
+  hash: "97083c410d95190ef8b44a4917898dd1"
+  tree_label: "value | CurrentUserProfile.isVideoAutoplay.getter | MediaSlideshow.toSource | MediaSlideshow.toSources | MediaSlideshow.toSources | DailyDigestTableViewSection.photoCell | AnyTableViewController.tableView | -[UITableView layoutSubviews] | -[UIView(CALayerDelegate) layoutSublayersOfLayer:] | GSEventRunModal | -[UIApplication _run]"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            filename (discarded native filename for grouping stability)
+              "main.m"
+            function*
+              "main"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "UIApplicationMain"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "CFRunLoopRunSpecific"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopRun"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoObservers"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Transaction::observer_callback"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Transaction::commit"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Context::commit_transaction"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "CA::Layer::layout_if_needed"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[CALayer layoutSublayers]"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame (ignored by stack trace rule (category:internals -group))
+            filename (discarded native filename for grouping stability)
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename (discarded native filename for grouping stability)
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type*
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/in_app_in_ui.pysnap
@@ -1,0 +1,290 @@
+---
+created: '2021-07-26T19:38:33.015744Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoObservers"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (non app frame)
+            function* (isolated function)
+              "CA::Transaction::observer_callback"
+          frame (non app frame)
+            function* (isolated function)
+              "CA::Transaction::commit"
+          frame (non app frame)
+            function* (isolated function)
+              "CA::Context::commit_transaction"
+          frame (non app frame)
+            function* (isolated function)
+              "CA::Layer::layout_and_display_if_needed"
+          frame (non app frame)
+            function* (isolated function)
+              "CA::Layer::layout_if_needed"
+          frame (non app frame)
+            function*
+              "-[CALayer layoutSublayers]"
+          frame (non app frame)
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "TableView.layoutSubviews"
+          frame (non app frame)
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (non app frame)
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (non app frame)
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function* (isolated function)
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function* (isolated function)
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function* (isolated function)
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function* (isolated function)
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function* (isolated function)
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function* (isolated function)
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+--------------------------------------------------------------------------
+system:
+  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoObservers"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame*
+            function* (isolated function)
+              "CA::Transaction::observer_callback"
+          frame*
+            function* (isolated function)
+              "CA::Transaction::commit"
+          frame*
+            function* (isolated function)
+              "CA::Context::commit_transaction"
+          frame*
+            function* (isolated function)
+              "CA::Layer::layout_and_display_if_needed"
+          frame*
+            function* (isolated function)
+              "CA::Layer::layout_if_needed"
+          frame*
+            function*
+              "-[CALayer layoutSublayers]"
+          frame*
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "TableView.layoutSubviews"
+          frame*
+            function*
+              "-[UITableView layoutSubviews]"
+          frame*
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame*
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function* (isolated function)
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function* (isolated function)
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function* (isolated function)
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function* (isolated function)
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function* (isolated function)
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function* (isolated function)
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function* (isolated function)
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/in_app_in_ui.pysnap
@@ -1,0 +1,294 @@
+---
+created: '2021-07-26T19:38:36.313597Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoObservers"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (non app frame)
+            function*
+              "CA::Transaction::observer_callback"
+          frame (non app frame)
+            function*
+              "CA::Transaction::commit"
+          frame (non app frame)
+            function*
+              "CA::Context::commit_transaction"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_if_needed"
+          frame (non app frame)
+            function*
+              "-[CALayer layoutSublayers]"
+          frame (non app frame)
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame (non app frame)
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (non app frame)
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (non app frame)
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+system:
+  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoObservers"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame*
+            function*
+              "CA::Transaction::observer_callback"
+          frame*
+            function*
+              "CA::Transaction::commit"
+          frame*
+            function*
+              "CA::Context::commit_transaction"
+          frame*
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame*
+            function*
+              "CA::Layer::layout_if_needed"
+          frame*
+            function*
+              "-[CALayer layoutSublayers]"
+          frame*
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame*
+            function*
+              "-[UITableView layoutSubviews]"
+          frame*
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame*
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/in_app_in_ui.pysnap
@@ -1,0 +1,294 @@
+---
+created: '2021-07-26T19:38:22.762009Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoObservers"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (non app frame)
+            function*
+              "CA::Transaction::observer_callback"
+          frame (non app frame)
+            function*
+              "CA::Transaction::commit"
+          frame (non app frame)
+            function*
+              "CA::Context::commit_transaction"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_if_needed"
+          frame (non app frame)
+            function*
+              "-[CALayer layoutSublayers]"
+          frame (non app frame)
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame (non app frame)
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (non app frame)
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (non app frame)
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+system:
+  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoObservers"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame*
+            function*
+              "CA::Transaction::observer_callback"
+          frame*
+            function*
+              "CA::Transaction::commit"
+          frame*
+            function*
+              "CA::Context::commit_transaction"
+          frame*
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame*
+            function*
+              "CA::Layer::layout_if_needed"
+          frame*
+            function*
+              "-[CALayer layoutSublayers]"
+          frame*
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame*
+            function*
+              "-[UITableView layoutSubviews]"
+          frame*
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame*
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/in_app_in_ui.pysnap
@@ -1,0 +1,294 @@
+---
+created: '2021-07-26T19:38:26.157177Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoObservers"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (non app frame)
+            function*
+              "CA::Transaction::observer_callback"
+          frame (non app frame)
+            function*
+              "CA::Transaction::commit"
+          frame (non app frame)
+            function*
+              "CA::Context::commit_transaction"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_if_needed"
+          frame (non app frame)
+            function*
+              "-[CALayer layoutSublayers]"
+          frame (non app frame)
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame (non app frame)
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (non app frame)
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (non app frame)
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+system:
+  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoObservers"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame*
+            function*
+              "CA::Transaction::observer_callback"
+          frame*
+            function*
+              "CA::Transaction::commit"
+          frame*
+            function*
+              "CA::Context::commit_transaction"
+          frame*
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame*
+            function*
+              "CA::Layer::layout_if_needed"
+          frame*
+            function*
+              "-[CALayer layoutSublayers]"
+          frame*
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame*
+            function*
+              "-[UITableView layoutSubviews]"
+          frame*
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame*
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/in_app_in_ui.pysnap
@@ -1,0 +1,294 @@
+---
+created: '2021-07-26T19:38:39.646669Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "9b037f38798ea127aac3e8b8e1e1024a"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoObservers"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame (non app frame)
+            function*
+              "CA::Transaction::observer_callback"
+          frame (non app frame)
+            function*
+              "CA::Transaction::commit"
+          frame (non app frame)
+            function*
+              "CA::Context::commit_transaction"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame (non app frame)
+            function*
+              "CA::Layer::layout_if_needed"
+          frame (non app frame)
+            function*
+              "-[CALayer layoutSublayers]"
+          frame (non app frame)
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame (non app frame)
+            function*
+              "-[UITableView layoutSubviews]"
+          frame (non app frame)
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame (non app frame)
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"
+--------------------------------------------------------------------------
+system:
+  hash: "fe8b15fe322c91ede2fc48363fe43587"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            filename*
+              "main.m"
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoObservers"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__"
+          frame*
+            function*
+              "CA::Transaction::observer_callback"
+          frame*
+            function*
+              "CA::Transaction::commit"
+          frame*
+            function*
+              "CA::Context::commit_transaction"
+          frame*
+            function*
+              "CA::Layer::layout_and_display_if_needed"
+          frame*
+            function*
+              "CA::Layer::layout_if_needed"
+          frame*
+            function*
+              "-[CALayer layoutSublayers]"
+          frame*
+            function*
+              "-[UIView(CALayerDelegate) layoutSublayersOfLayer:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "TableView.layoutSubviews"
+          frame*
+            function*
+              "-[UITableView layoutSubviews]"
+          frame*
+            function*
+              "-[UITableView _updateVisibleCellsNow:]"
+          frame*
+            function*
+              "-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:]"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame (ignored due to recursion)
+            filename*
+              "<compiler-generated>"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "anytableviewcontroller.swift"
+            function*
+              "AnyTableViewController.tableView"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "dailydigesttableviewsection.swift"
+            function*
+              "DailyDigestTableViewSection.photoCell"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "Sequence.compactMap<T>"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "closure"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSources"
+          frame*
+            filename*
+              "mediaslideshow+extensions.swift"
+            function*
+              "MediaSlideshow.toSource"
+          frame*
+            filename*
+              "<compiler-generated>"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "CurrentUserProfile.isVideoAutoplay.getter"
+          frame*
+            filename*
+              "currentuserprofile.swift"
+            function*
+              "value"
+        type (ignored because exception is synthetic)
+          "EXC_BREAKPOINT"
+        value (ignored because stacktrace takes precedence)
+          "autoplayOption"


### PR DESCRIPTION
This logic is really getting contrived, but basically we identified a
bunch of cases where just relying on sentinel grouping does not really
work out well at all, and in fact regressed because instead of grouping
by perfectly fine app code (99% of the stack) we started grouping by
some random UI crap found near the threadbase.