### PR TITLE
feat(growth): adds show_onboarding event param for Transaction overview view event

### DIFF
--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -76,6 +76,7 @@ class PerformanceContent extends Component<Props, State> {
       eventKey: 'performance_views.overview.view',
       eventName: 'Performance Views: Transaction overview view',
       organization_id: parseInt(organization.id, 10),
+      show_onboarding: this.shouldShowOnboarding(),
     });
   }
 


### PR DESCRIPTION
We want to track views on the performance empty state which we can do by adding an event parameter to the existing event (`show_onboarding`).