### PR TITLE
ref(settings): Remove SENTRY_SCRAPE_JAVASCRIPT_CONTEXT

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1193,9 +1193,6 @@ SENTRY_ENABLE_INVITES = True
 # Origins allowed for session-based API access (via the Access-Control-Allow-Origin header)
 SENTRY_ALLOW_ORIGIN = None
 
-# Enable scraping of javascript context for source code
-SENTRY_SCRAPE_JAVASCRIPT_CONTEXT = True
-
 # Buffer backend
 SENTRY_BUFFER = "sentry.buffer.Buffer"
 SENTRY_BUFFER_OPTIONS = {}

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -830,7 +830,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
 
     def handles_frame(self, frame, stacktrace_info):
         platform = frame.get("platform") or self.data.get("platform")
-        return settings.SENTRY_SCRAPE_JAVASCRIPT_CONTEXT and platform in ("javascript", "node")
+        return platform in ("javascript", "node")
 
     def preprocess_frame(self, processable_frame):
         # Stores the resolved token.  This is used to cross refer to other


### PR DESCRIPTION
This flag is obsolete for quite a while so remove it to avoid confusing behavior like https://forum.sentry.io/t/the-content-of-sourcemaps-is-not-displayed-in-the-error/14697/2
