### PR TITLE
fix(discover): Improve experience when there are only a few columns

### DIFF
--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -369,9 +369,10 @@ class ColumnEditCollection extends React.Component<Props, State> {
     i: number,
     {
       canDelete = true,
+      canDrag = true,
       isGhost = false,
       gridColumns = 2,
-    }: {canDelete?: boolean; isGhost?: boolean; gridColumns: number}
+    }: {canDelete?: boolean; canDrag?: boolean; isGhost?: boolean; gridColumns: number}
   ) {
     const {columns, fieldOptions} = this.props;
     const {isDragging, draggingTargetIndex, draggingIndex} = this.state;
@@ -402,7 +403,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
       <React.Fragment key={`${i}:${this.keyForColumn(col, isGhost)}`}>
         {position === PlaceholderPosition.TOP && placeholder}
         <RowContainer className={isGhost ? '' : DRAG_CLASS}>
-          {canDelete ? (
+          {canDrag ? (
             <Button
               aria-label={t('Drag to reorder')}
               onMouseDown={event => this.startDrag(event, i)}
@@ -423,7 +424,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
             takeFocus={i === this.props.columns.length - 1}
             otherColumns={columns}
           />
-          {canDelete ? (
+          {canDelete || col.kind === 'equation' ? (
             <Button
               aria-label={t('Remove column')}
               onClick={() => this.removeColumn(i)}
@@ -441,11 +442,8 @@ class ColumnEditCollection extends React.Component<Props, State> {
 
   render() {
     const {className, columns, organization} = this.props;
-    const canDelete =
-      columns.filter(
-        field =>
-          field.kind === 'function' || (field.kind === 'field' && field.field !== '')
-      ).length > 1;
+    const canDelete = columns.filter(field => field.kind !== 'equation').length > 1;
+    const canDrag = columns.length > 1;
     const canAdd = columns.length < MAX_COL_COUNT;
     const title = canAdd
       ? undefined
@@ -471,7 +469,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
           </Heading>
         </RowContainer>
         {columns.map((col: Column, i: number) =>
-          this.renderItem(col, i, {canDelete, gridColumns})
+          this.renderItem(col, i, {canDelete, canDrag, gridColumns})
         )}
         <RowContainer>
           <Actions>

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -610,13 +610,14 @@ describe('EventsV2 -> ColumnEditModal', function () {
 
       expect(newWrapper.find('QueryField')).toHaveLength(2);
 
-      // Last row cannot be removed or dragged.
+      // Can still remove the equation
       expect(
         newWrapper.find('RowContainer button[aria-label="Remove column"]')
-      ).toHaveLength(0);
+      ).toHaveLength(1);
+      // And both are draggable
       expect(
         newWrapper.find('RowContainer button[aria-label="Drag to reorder"]')
-      ).toHaveLength(0);
+      ).toHaveLength(2);
     });
     it('handles equations being deleted', function () {
       const newWrapper = mountModal(


### PR DESCRIPTION
- This re-introduces a potential edge case where only an equation is
  left with an empty field, going to fix this in a follow up PR, where
  `apply` will be disabled if columns have errors.
- This allows dragging when there's at least two columns of any kind
- This allows equations to be deleted even if the only other leftover
  column is an unselected field