### PR TITLE
ref(gitlab): Handle IdentityNotValid error

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -1,5 +1,6 @@
 from sentry.api.bases.organization import OrganizationIntegrationsPermission
 from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
+from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.integrations.repositories import RepositoryMixin
 from sentry.shared_integrations.exceptions import IntegrationError
@@ -30,7 +31,7 @@ class OrganizationIntegrationReposEndpoint(OrganizationIntegrationBaseEndpoint):
         if isinstance(install, RepositoryMixin):
             try:
                 repositories = install.get_repositories(request.GET.get("search"))
-            except IntegrationError as e:
+            except (IntegrationError, IdentityNotValid) as e:
                 return self.respond({"detail": str(e)}, status=400)
 
             context = {"repos": repositories, "searchable": install.repo_search}

--- a/static/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/organizationIntegrations/integrationRepos.tsx
@@ -198,7 +198,7 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
       return (
         <Alert type="error" icon={<IconFlag size="md" />}>
           {t(
-            'We were unable to fetch repositories for this integration. Try again later, or reconnect this integration.'
+            'We were unable to fetch repositories for this integration. Try again later. If this error continues, please reconnect this integration by uninstalling and then reinstalling.'
           )}
         </Alert>
       );


### PR DESCRIPTION
**problem**
when an application on GitLab's end is removed, we still have the integration in Sentry, but now it's just a broken integration (because the auth token is no longer valid). The way this information gets surfaced in Sentry is not ideal - it 500's and gives the user:
> ![Screen Shot 2021-07-26 at 3 44 50 PM](https://user-images.githubusercontent.com/15368179/127069427-a755e6f8-62ee-4688-9e1a-6594ebb2036b.png)

**a lil better**
I would have liked to show existing repos along side an error, but I think for now catching and raising a 400 is an okay alternative. What's beneficial about this is that the network tab will show:

```json
detail: "HTTP 400 (invalid_grant): The provided authorization grant is invalid, expired, revoked,  \
does not match the redirection URI used in the authorization request, or was issued to another client."
```

in addition to the user seeing the following: 

![Screen Shot 2021-07-26 at 3 42 56 PM](https://user-images.githubusercontent.com/15368179/127069424-30a72745-fcbb-4eb5-a971-fc0eb3708737.png)

FIXES SENTRY-NT9
FIXES SENTRY-NCQ