### PR TITLE
fix(workflow): Manually end overview navigation transactions

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
+import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 import Cookies from 'js-cookie';
 import isEqual from 'lodash/isEqual';
@@ -463,6 +464,13 @@ class IssueListOverview extends React.Component<Props, State> {
       },
       complete: () => {
         this._lastStatsRequest = null;
+
+        // End navigation transaction to prevent additional page requests from impacting page metrics.
+        // Other transactions include stacktrace preview request
+        const currentTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+        if (currentTransaction?.op === 'navigation') {
+          currentTransaction.finish();
+        }
       },
     });
   };


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/WOR-989

on navigation transactions to the issues page we're seeing requests to `/api/0/issues/{issue_id}/events/latest/` impact our metrics. This request is made when a user hovers an issue group. This will attempt to end the transaction at what is normally the full page load.


[example](https://sentry.io/organizations/sentry/performance/javascript:476258786cc14a6f9bfbd232b4156401/?project=11276&query=transaction.duration%3A%3C15m+event.type%3Atransaction+transaction.op%3Anavigation+organization.slug%3Asentry&statsPeriod=24h&transaction=%2Forganizations%2F%3AorgId%2Fissues%2F&unselectedSeries=p100%28%29)

![image](https://user-images.githubusercontent.com/1400464/127071348-a1134acb-59b9-491b-b34f-792f65b6bb4e.png)
