### PR TITLE
fix(releases): Check adoption stage label for undefined stages

### DIFF
--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -18,6 +18,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Release, ReleaseProject} from 'app/types';
 import {defined} from 'app/utils';
+import {Theme} from 'app/utils/theme';
 import {isProjectMobileForReleases} from 'app/views/releases/list';
 
 import {getReleaseNewIssuesUrl, getReleaseUnhandledIssuesUrl} from '../../utils';
@@ -30,7 +31,7 @@ import {DisplayOption} from '../utils';
 import Header from './header';
 import ProjectLink from './projectLink';
 
-const ADOPTION_STAGE_LABELS = {
+const ADOPTION_STAGE_LABELS: Record<string, {name: string; type: keyof Theme['tag']}> = {
   low_adoption: {
     name: t('Low Adoption'),
     type: 'warning',

--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -144,8 +144,9 @@ const Content = ({
               adoptionStages?.[project.slug].stage;
 
             const isMobileProject = isProjectMobileForReleases(project.platform);
-            const hasAdoptionStagesLabel =
-              get24hCountByProject && adoptionStage && isMobileProject;
+            const adoptionStageLabel =
+              Boolean(get24hCountByProject && adoptionStage && isMobileProject) &&
+              ADOPTION_STAGE_LABELS[adoptionStage];
 
             return (
               <ProjectRow key={`${releaseVersion}-${slug}-health`}>
@@ -156,9 +157,9 @@ const Content = ({
 
                   {hasAdoptionStagesColumn && (
                     <AdoptionStageColumn>
-                      {hasAdoptionStagesLabel ? (
-                        <Tag type={ADOPTION_STAGE_LABELS[adoptionStage].type}>
-                          {ADOPTION_STAGE_LABELS[adoptionStage].name}
+                      {adoptionStageLabel ? (
+                        <Tag type={adoptionStageLabel.type}>
+                          {adoptionStageLabel.name}
                         </Tag>
                       ) : (
                         <NotAvailable />


### PR DESCRIPTION
This fixes the guard for adoption stage labels in the release list for the adoption stage labels. There are cases when the old guard was evaluating to true but the stage wasn't one of the label object stages, with the explicit boolean and checking the label object this won't happen anymore.

Fixes: JAVASCRIPT-253X