### PR TITLE
fix(mail): Fix bug when email context misses timezone

### DIFF
--- a/src/sentry/notifications/rules.py
+++ b/src/sentry/notifications/rules.py
@@ -65,18 +65,21 @@ class AlertRuleNotification(BaseNotification):
     def get_user_context(
         self, user: User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
+        user_context = {"timezone": pytz.timezone("UTC")}
         try:
             # AlertRuleNotification is shared among both email and slack notifications, and in slack
             # notifications, the `user` arg could be of type `Team` which is why we need this check
             if isinstance(user, User):
-                return {
-                    "timezone": pytz.timezone(
-                        UserOption.objects.get_value(user=user, key="timezone", default="UTC")
-                    )
-                }
+                user_context.update(
+                    {
+                        "timezone": pytz.timezone(
+                            UserOption.objects.get_value(user=user, key="timezone", default="UTC")
+                        )
+                    }
+                )
         except pytz.UnknownTimeZoneError:
             ...
-        return super().get_user_context(user, extra_context)
+        return user_context
 
     def get_context(self) -> MutableMapping[str, Any]:
         environment = self.event.get_tag("environment")

--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -47,7 +47,11 @@
     {% if enhanced_privacy %}
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-        <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+          {% if timezone %}
+            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+          {% else %}
+            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
+          {% endif %}
       </div>
 
       <div class="notice">Details about this issue are not shown in this notification since enhanced privacy
@@ -111,7 +115,11 @@
 
       <div class="event">
         <div class="event-id">ID: {{ event.event_id }}</div>
-        <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+        {% if timezone %}
+            <div class="event-date">{{ event.datetime|timezone:timezone|date:"N j, Y, g:i:s a e"}}</div>
+        {% else %}
+            <div class="event-date">{{ event.datetime|date:"N j, Y, g:i:s a e"}}</div>
+        {% endif %}
       </div>
 
       {% if commits %}


### PR DESCRIPTION
Fixes bug that breaks sending emails when the context sent to `error.html` is missing a timezone context variable