### PR TITLE
feat(grouping): Measure grouping time per platform

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1633,7 +1633,10 @@ def _calculate_event_grouping(project, event, grouping_config) -> CalculatedHash
     Main entrypoint for modifying/enhancing and grouping an event, writes
     hashes back into event payload.
     """
-    metric_tags = {"grouping_config": grouping_config["id"]}
+    metric_tags = {
+        "grouping_config": grouping_config["id"],
+        "platform": event.platform or "unknown",
+    }
 
     with metrics.timer("event_manager.normalize_stacktraces_for_grouping", tags=metric_tags):
         with sentry_sdk.start_span(op="event_manager.normalize_stacktraces_for_grouping"):


### PR DESCRIPTION
Add metric tag to limit comparison between hierarchical and newstyle grouping to native platforms.