### PR TITLE
fix(ui): Fix session resolution on old short-lived releases

### DIFF
--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -144,6 +144,11 @@ export function getSessionsInterval(
 ) {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
 
+  if (moment(datetimeObj.start).isSameOrBefore(moment().subtract(30, 'days'))) {
+    // we cannot use sub-hour session resolution on buckets older than 30 days
+    highFidelity = false;
+  }
+
   if (diffInMinutes > TWO_WEEKS) {
     return '1d';
   }


### PR DESCRIPTION
There are two limitations to using sub-hour session resolution:
1. interval length must be 6 hours or less
2. start period must not be older than 30 days

This handles the second condition.