### PR TITLE
chore(discover): Clean up args for SnQL count_miserable

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -117,6 +117,7 @@ SNQL_FIELD_ALLOWLIST = {
     "stack.module",
     "stack.package",
     "stack.stack_level",
+    "user",
 }
 
 OPERATOR_NEGATION_MAP = {


### PR DESCRIPTION
We'd initially just used FunctionArgs, cleaning that a
bit to be able to resolve the field outside of the
count_miserable specific function resolution.