### PR TITLE
fix(growth): Adds query parameters to demo header links 

### DIFF
--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -27,6 +27,7 @@ ACCEPTED_TRACKING_COOKIE = "accepted_tracking"
 MEMBER_ID_COOKIE = "demo_member_id"
 SKIP_EMAIL_COOKIE = "skip_email"
 SAAS_ORG_SLUG = "saas_org_slug"
+EXTRA_QUERY_STRING = "extra_query_string"
 
 
 class DemoStartView(BaseView):
@@ -113,6 +114,9 @@ class DemoStartView(BaseView):
         saas_org_slug = request.POST.get("saasOrgSlug")
         if saas_org_slug:
             resp.set_cookie(SAAS_ORG_SLUG, saas_org_slug)
+
+        if extra_query_string:
+            resp.set_cookie(EXTRA_QUERY_STRING, extra_query_string)
 
         # set the member id
         resp.set_signed_cookie(MEMBER_ID_COOKIE, member.id)

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -16,12 +16,15 @@ type Preferences = typeof PreferencesStore.prefs;
 export default function DemoHeader() {
   // if the user came from a SaaS org, we should send them back to upgrade when they leave the sandbox
   const saasOrgSlug = getCookie('saas_org_slug');
+  const extraQueryString = getCookie('extra_query_string');
+  const extraQueryParameter = extraQueryString?.replaceAll('"', '');
   const email = localStorage.getItem('email');
   const queryParameter = email ? `?email=${email}` : '';
+  const extraQuerySeparator = email ? '&' : '?';
   const getStartedText = saasOrgSlug ? t('Upgrade Now') : t('Sign Up for Free');
   const getStartedUrl = saasOrgSlug
     ? `https://sentry.io/settings/${saasOrgSlug}/billing/checkout/`
-    : `https://sentry.io/signup/${queryParameter}`;
+    : `https://sentry.io/signup/${queryParameter}${extraQuerySeparator}${extraQueryParameter}`;
 
   const [collapsed, setCollapsed] = useState(PreferencesStore.prefs.collapsed);
 
@@ -49,7 +52,7 @@ export default function DemoHeader() {
       <ButtonBar gap={4}>
         <StyledExternalLink
           onClick={() => trackAdvancedAnalyticsEvent('growth.demo_click_docs', {}, null)}
-          href="https://docs.sentry.io"
+          href={`https://docs.sentry.io/?${extraQueryParameter}`}
         >
           {t('Documentation')}
         </StyledExternalLink>
@@ -58,7 +61,7 @@ export default function DemoHeader() {
           onClick={() =>
             trackAdvancedAnalyticsEvent('growth.demo_click_request_demo', {}, null)
           }
-          href="https://sentry.io/_/demo/"
+          href={`https://sentry.io/_/demo/?${extraQueryParameter}`}
         >
           {t('Request a Demo')}
         </BaseButton>

--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -17,14 +17,17 @@ export default function DemoHeader() {
   // if the user came from a SaaS org, we should send them back to upgrade when they leave the sandbox
   const saasOrgSlug = getCookie('saas_org_slug');
   const extraQueryString = getCookie('extra_query_string');
-  const extraQueryParameter = extraQueryString?.replaceAll('"', '');
+  // cookies that have = sign are quotes so extra quotes need to be removed
+  const extraQuery = extraQueryString ? extraQueryString.replaceAll('"', '') : '';
   const email = localStorage.getItem('email');
   const queryParameter = email ? `?email=${email}` : '';
-  const extraQuerySeparator = email ? '&' : '?';
+  const emailSeparator = email ? '&' : '?';
+  const getStartedSeparator = extraQueryString ? emailSeparator : '';
+  const extraQueryParameter = extraQueryString ? `?${extraQuery}` : '';
   const getStartedText = saasOrgSlug ? t('Upgrade Now') : t('Sign Up for Free');
   const getStartedUrl = saasOrgSlug
     ? `https://sentry.io/settings/${saasOrgSlug}/billing/checkout/`
-    : `https://sentry.io/signup/${queryParameter}${extraQuerySeparator}${extraQueryParameter}`;
+    : `https://sentry.io/signup/${queryParameter}${getStartedSeparator}${extraQuery}`;
 
   const [collapsed, setCollapsed] = useState(PreferencesStore.prefs.collapsed);
 
@@ -52,7 +55,7 @@ export default function DemoHeader() {
       <ButtonBar gap={4}>
         <StyledExternalLink
           onClick={() => trackAdvancedAnalyticsEvent('growth.demo_click_docs', {}, null)}
-          href={`https://docs.sentry.io/?${extraQueryParameter}`}
+          href={`https://docs.sentry.io/${extraQueryParameter}`}
         >
           {t('Documentation')}
         </StyledExternalLink>
@@ -61,7 +64,7 @@ export default function DemoHeader() {
           onClick={() =>
             trackAdvancedAnalyticsEvent('growth.demo_click_request_demo', {}, null)
           }
-          href={`https://sentry.io/_/demo/?${extraQueryParameter}`}
+          href={`https://sentry.io/_/demo/${extraQueryParameter}`}
         >
           {t('Request a Demo')}
         </BaseButton>


### PR DESCRIPTION
This PR adds the extra query parameters from marketing to the demo header links. previously, the query parameters were only present on the Sandbox page that was initially loaded. 

GRW-216