### PR TITLE
feat(notification platform): Add tags and transactions to updating settings

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -42,6 +42,9 @@ SAMPLED_URL_NAMES = {
     "sentry-extensions-vercel-configure": settings.SAMPLED_DEFAULT_RATE,
     "sentry-extensions-vercel-ui-hook": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-group-integration-details": settings.SAMPLED_DEFAULT_RATE,
+    # notification platform
+    "sentry-api-0-user-notification-settings": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-api-0-team-notification-settings": settings.SAMPLED_DEFAULT_RATE,
     # releases
     "sentry-api-0-organization-releases": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-organization-release-details": settings.SAMPLED_DEFAULT_RATE,


### PR DESCRIPTION
We want to see how often users are updating their notification settings so this PR adds the user and team notification settings endpoints to be sampled, and adds tags so we can see what the setting being updated is.

<img width="1189" alt="Screen Shot 2021-07-27 at 4 11 10 PM" src="https://user-images.githubusercontent.com/29959063/127239054-06cbaa22-ef5b-4b90-a4e0-076aee804388.png">
