### PR TITLE
fix(ui): Remove circular import used to style icon w/ search

### DIFF
--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -7,7 +7,6 @@ import {IconInput, IconLink, IconSettings} from 'app/icons';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
 import highlightFuseMatches from 'app/utils/highlightFuseMatches';
-import {StyledSettingsSearch} from 'app/views/settings/components/settingsSearch';
 
 import {Result} from './sources/types';
 
@@ -102,7 +101,7 @@ class SearchResult extends Component<Props> {
     return (
       <Wrapper>
         <Content>{this.renderContent()}</Content>
-        <IconWrapper>{this.renderResultType()}</IconWrapper>
+        <div>{this.renderResultType()}</div>
       </Wrapper>
     );
   }
@@ -140,12 +139,6 @@ const Wrapper = styled('div')`
 const Content = styled('div')`
   display: flex;
   flex-direction: column;
-`;
-
-const IconWrapper = styled('div')`
-  ${/* sc-selector */ StyledSettingsSearch} & {
-    color: inherit;
-  }
 `;
 
 const StyledPluginIcon = styled(PluginIcon)`

--- a/static/app/views/settings/components/settingsSearch/index.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.tsx
@@ -50,12 +50,7 @@ class SettingsSearch extends React.Component<Props> {
   }
 }
 
-// This is so we can use this as a selector for emotion
-const StyledSettingsSearch = styled(SettingsSearch)``;
-
-export default StyledSettingsSearch;
-// We use named export for StyledSettingsSearch to prevent circular import in `app/components/search/searchResult`
-export {SettingsSearch, StyledSettingsSearch};
+export default SettingsSearch;
 
 const SearchInputWrapper = styled('div')`
   position: relative;

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -2,7 +2,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {navigateTo} from 'app/actionCreators/navigation';
 import FormSearchStore from 'app/stores/formSearchStore';
-import {SettingsSearch} from 'app/views/settings/components/settingsSearch';
+import SettingsSearch from 'app/views/settings/components/settingsSearch';
 
 jest.mock('app/actionCreators/formSearch');
 jest.mock('app/actionCreators/navigation');


### PR DESCRIPTION
unblocks #27346

I don't believe this style is required. The colors are still inherited.
![image](https://user-images.githubusercontent.com/1400464/127244249-1a5abb89-dc59-4dbb-ba6f-70e758aa3522.png)
