### PR TITLE
fix(ui): Fix release comparison zooming timezone offset

### DIFF
--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -182,7 +182,9 @@ export function filterSessionsInTimeWindow(
   const filteredIndexes: number[] = [];
 
   const intervals = sessions.intervals.filter((interval, index) => {
-    const isBetween = moment(interval).isBetween(start, end, undefined, '[]');
+    const isBetween = moment
+      .utc(interval)
+      .isBetween(moment.utc(start), moment.utc(end), undefined, '[]');
     if (isBetween) {
       filteredIndexes.push(index);
     }


### PR DESCRIPTION
We need to convert all timestamps to UTC when filtering out chart points outside of range so that we are comparing apples to apples.