### PR TITLE
chore(mobile-vitals): Remove frame slow/frozen from react-native for now

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -568,6 +568,10 @@ function generateMobilePerformanceEventView(
       selectedProjects.length > 0 &&
       selectedProjects.every(project => project.platform === 'react-native')
     ) {
+      // TODO(tonyx): remove these once the SDKs are ready
+      fields.pop();
+      fields.pop();
+
       fields.push('p75(measurements.stall_percentage)');
     }
   }

--- a/static/app/views/performance/landing/data.tsx
+++ b/static/app/views/performance/landing/data.tsx
@@ -56,8 +56,9 @@ export const REACT_NATIVE_COLUMN_TITLES = [
   'tpm',
   'cold start',
   'warm start',
-  'slow frame %',
-  'frozen frame %',
+  // TODO(tonyx): add these back in once the SDKs are ready
+  // 'slow frame %',
+  // 'frozen frame %',
   'stall %',
   'users',
   'user misery',

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -283,19 +283,21 @@ function _MobileCards(props: MobileCardsProps) {
       kind: 'function',
       function: ['p75', 'measurements.app_start_warm', undefined, undefined],
     },
-    {
-      kind: 'function',
-      function: ['p75', 'measurements.frames_slow_rate', undefined, undefined],
-    },
-    {
-      kind: 'function',
-      function: ['p75', 'measurements.frames_frozen_rate', undefined, undefined],
-    },
   ];
   if (props.showStallPercentage) {
     functions.push({
       kind: 'function',
       function: ['p75', 'measurements.stall_percentage', undefined, undefined],
+    });
+  } else {
+    // TODO(tonyx): add these by default once the SDKs are ready
+    functions.push({
+      kind: 'function',
+      function: ['p75', 'measurements.frames_slow_rate', undefined, undefined],
+    });
+    functions.push({
+      kind: 'function',
+      function: ['p75', 'measurements.frames_frozen_rate', undefined, undefined],
     });
   }
   return <GenericCards {...props} functions={functions} />;


### PR DESCRIPTION
The react-native SDK is not ready yet and does not include the frames slow and
frames frozen measurement right now. This change removes these from the mobile
landing page for react-native projects for the time being. They will be added
back once the SDKs are ready.