### PR TITLE
ref(gitlab): Handle IdentityNotValid in check_file

### DIFF
--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -1,5 +1,6 @@
 from sentry_sdk import configure_scope
 
+from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.models import Repository
 from sentry.shared_integrations.exceptions import ApiError
@@ -33,6 +34,8 @@ class RepositoryMixin:
             resp = self.get_client().check_file(repo, filepath, branch)
             if resp is None:
                 return None
+        except IdentityNotValid:
+            return None
         except ApiError as e:
             if e.code != 404:
                 raise

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -252,6 +252,41 @@ class GitlabIntegrationTest(IntegrationTestCase):
         assert not source_url
 
     @responses.activate
+    def test_get_stacktrace_link_file_identity_not_valid(self):
+        self.assert_setup_flow()
+        external_id = 4
+        integration = Integration.objects.get(provider=self.provider.key)
+        instance = integration.metadata["instance"]
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Get Sentry / Example Repo",
+            external_id=f"{instance}:{external_id}",
+            url="https://gitlab.example.com/getsentry/projects/example-repo",
+            config={"project_id": external_id, "path": "getsentry/example-repo"},
+            provider="integrations:gitlab",
+            integration_id=integration.id,
+        )
+        installation = integration.get_installation(self.organization.id)
+
+        filepath = "README.md"
+        ref = "master"
+        version = None
+        responses.add(
+            responses.HEAD,
+            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{filepath}?ref={ref}",
+            status=401,
+        )
+        # failed attempt to refresh auth token
+        responses.add(
+            responses.POST,
+            "https://example.gitlab.com/oauth/token",
+            status=401,
+            json={},
+        )
+        source_url = installation.get_stacktrace_link(repo, "README.md", ref, version)
+        assert not source_url
+
+    @responses.activate
     def test_get_stacktrace_link_use_default_if_version_404(self):
         self.assert_setup_flow()
         external_id = 4


### PR DESCRIPTION
Same problem as https://github.com/getsentry/sentry/pull/27765 but here we should just catch the error and return `None`.

FIXES SENTRY-NT9
(forreal this time)