### PR TITLE
feat(workflow): Adding `has_sessions` flag support to the Project serializer

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -352,6 +352,7 @@ class ProjectSerializer(Serializer):
             "dateCreated": obj.date_added,
             "firstEvent": obj.first_event,
             "firstTransactionEvent": True if obj.flags.has_transactions else False,
+            "hasSessions": True if obj.flags.has_sessions else False,
             "features": attrs["features"],
             "status": status_label,
             "platform": obj.platform,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -553,6 +553,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "features": attrs["features"],
             "firstEvent": obj.first_event,
             "firstTransactionEvent": True if obj.flags.has_transactions else False,
+            "hasSessions": True if obj.flags.has_sessions else False,
             "platform": obj.platform,
             "platforms": attrs["platforms"],
             "latestRelease": attrs["latest_release"],

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -553,7 +553,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "features": attrs["features"],
             "firstEvent": obj.first_event,
             "firstTransactionEvent": True if obj.flags.has_transactions else False,
-            "hasSessions": True if obj.flags.has_sessions else False,
+            "hasSessions": bool(obj.flags.has_sessions),
             "platform": obj.platform,
             "platforms": attrs["platforms"],
             "latestRelease": attrs["latest_release"],

--- a/src/sentry/tasks/releasemonitor.py
+++ b/src/sentry/tasks/releasemonitor.py
@@ -4,13 +4,14 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from django.db import IntegrityError
-from django.db.models import Q
+from django.db.models import F, Q
 from django.utils import timezone
 from sentry_sdk import capture_exception
 from snuba_sdk import Column, Condition, Direction, Entity, Granularity, Op, OrderBy, Query
 
 from sentry.models import (
     Environment,
+    Project,
     Release,
     ReleaseEnvironment,
     ReleaseProject,
@@ -103,6 +104,13 @@ def process_projects_with_sessions(org_id, project_ids):
     # Takes a single org id and a list of project ids
 
     with metrics.timer("sentry.tasks.monitor_release_adoption.process_projects_with_sessions.core"):
+        # Set the `has_sessions` flag for these projects
+        Project.objects.filter(
+            organization_id=org_id,
+            id__in=project_ids,
+            flags=F("flags").bitand(~Project.flags.has_sessions),
+        ).update(flags=F("flags").bitor(Project.flags.has_sessions))
+
         totals = sum_sessions_and_releases(org_id, project_ids)
 
         adopted_ids = adopt_releases(org_id, totals)

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -297,6 +297,16 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         result = serialize(self.project, self.user, ProjectSummarySerializer())
         assert result["hasUserReports"] is True
 
+    def test_has_sessions_flag(self):
+        result = serialize(self.project, self.user, ProjectSummarySerializer())
+        assert result["hasSessions"] is False
+
+        self.project.first_event = timezone.now()
+        self.project.update(flags=F("flags").bitor(Project.flags.has_sessions))
+
+        result = serialize(self.project, self.user, ProjectSummarySerializer())
+        assert result["hasSessions"] is True
+
     def test_no_environments(self):
         # remove environments and related models
         Deploy.objects.all().delete()

--- a/tests/sentry/tasks/test_releasemonitor.py
+++ b/tests/sentry/tasks/test_releasemonitor.py
@@ -126,6 +126,7 @@ class TestReleaseMonitor(TestCase, SnubaTestCase):
                 for i in range(1)
             ]
         )
+        assert self.project1.flags.has_sessions.is_set is False
         now = timezone.now()
         assert ReleaseProjectEnvironment.objects.filter(
             project_id=self.project1.id,
@@ -159,6 +160,8 @@ class TestReleaseMonitor(TestCase, SnubaTestCase):
             },
         ]
         process_projects_with_sessions(test_data[0]["org_id"][0], test_data[0]["project_id"])
+        self.project1.refresh_from_db()
+        assert self.project1.flags.has_sessions.is_set is True
 
         assert not ReleaseProjectEnvironment.objects.filter(
             project_id=self.project1.id,


### PR DESCRIPTION
Following up on the PR that added `has_sessions` to the project model, this PR returns the flag in the serializer and also populate it in the release monitor task.

This should mean the API call is fast and will serve the immedaite need of this feature well enough. Longer-term, we may want to think about making `has_sessions` more precise in certain cases. Perhaps a flag can be passed to the project serializer to force a recalculation. For now, `has_sessions` can be delayed up to an hour. 

I think a future optimization can also rely on `has_sessions` instead of `hasHealthData` and save some overhead in the project serializer.