### PR TITLE
fix(perf): Fix error on tags page when aggregate is zero

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -434,7 +434,7 @@ def query_facet_performance(
             offset=offset,
         )
 
-        results["meta"] = discover.transform_meta(results, {})
+        results = discover.transform_results(results, {}, translated_columns, snuba_filter)
 
         return results
 


### PR DESCRIPTION
### Summary
This fixes a divide by zero (nan) error that occurs when the aggregate (eg. transaction duration) turns out to be zero.

Refs SENTRY-RKM