### PR TITLE
Revert "perf(post-process-forwarder): Skip parsing Kafka messages - t…

### DIFF
--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional, Sequence, Tuple
 
 from sentry.utils import json, metrics
 
@@ -97,75 +96,3 @@ def get_task_kwargs_for_message(value):
         )
 
     return handler(*payload[1:])
-
-
-def get_task_kwargs_for_message_from_headers(headers: Sequence[Tuple[str, Optional[bytes]]]):
-    """
-    Same as get_task_kwargs_for_message but gets the required information from
-    the kafka message headers.
-    """
-    try:
-        header_data = {k: v for k, v in headers}
-        if "group_id" not in header_data:
-            header_data["group_id"] = None
-        if "primary_hash" not in header_data:
-            header_data["primary_hash"] = None
-
-        def decode_str(value: Optional[bytes]) -> str:
-            assert isinstance(value, bytes)
-            return value.decode("utf-8")
-
-        def decode_optional_str(value: Optional[bytes]) -> Optional[str]:
-            if value is None:
-                return None
-            return decode_str(value)
-
-        def decode_int(value: Optional[bytes]) -> int:
-            assert isinstance(value, bytes)
-            return int(value)
-
-        def decode_optional_int(value: Optional[bytes]) -> Optional[int]:
-            if value is None:
-                return None
-            return decode_int(value)
-
-        def decode_bool(value: bytes) -> bool:
-            return bool(int(decode_str(value)))
-
-        version = decode_int(header_data["version"])
-        operation = decode_str(header_data["operation"])
-        primary_hash = decode_optional_str(header_data["primary_hash"])
-        event_id = decode_str(header_data["event_id"])
-        group_id = decode_optional_int(header_data["group_id"])
-        project_id = decode_int(header_data["project_id"])
-
-        event_data = {
-            "event_id": event_id,
-            "group_id": group_id,
-            "project_id": project_id,
-            "primary_hash": primary_hash,
-        }
-
-        skip_consume = decode_bool(header_data["skip_consume"])
-        is_new = decode_bool(header_data["is_new"])
-        is_regression = decode_bool(header_data["is_regression"])
-        is_new_group_environment = decode_bool(header_data["is_new_group_environment"])
-
-        task_state = {
-            "skip_consume": skip_consume,
-            "is_new": is_new,
-            "is_regression": is_regression,
-            "is_new_group_environment": is_new_group_environment,
-        }
-
-    except Exception:
-        raise InvalidPayload("Received event payload with unexpected structure")
-
-    try:
-        handler = version_handlers[version]
-    except (ValueError, KeyError):
-        raise InvalidVersion(
-            f"Received event payload with unexpected version identifier: {version}"
-        )
-
-    return handler(operation, event_data, task_state)

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from typing import Any, Mapping, Optional, Tuple
 from uuid import uuid4
 
 import pytz
@@ -74,19 +73,6 @@ class SnubaProtocolEventStream(EventStream):
     # non-prefixed variations occur in a response.
     UNEXPECTED_TAG_KEYS = frozenset(["dist", "release", "user"])
 
-    def _get_headers_for_insert(
-        self,
-        group,
-        event,
-        is_new,
-        is_regression,
-        is_new_group_environment,
-        primary_hash,
-        received_timestamp,  # type: float
-        skip_consume,
-    ) -> Mapping[str, str]:
-        return {"Received-Timestamp": str(received_timestamp)}
-
     def insert(
         self,
         group,
@@ -111,17 +97,6 @@ class SnubaProtocolEventStream(EventStream):
         }
         if unexpected_tags:
             logger.error("%r received unexpected tags: %r", self, unexpected_tags)
-
-        headers = self._get_headers_for_insert(
-            group,
-            event,
-            is_new,
-            is_regression,
-            is_new_group_environment,
-            primary_hash,
-            received_timestamp,
-            skip_consume,
-        )
 
         self._send(
             project.id,
@@ -148,7 +123,7 @@ class SnubaProtocolEventStream(EventStream):
                     "skip_consume": skip_consume,
                 },
             ),
-            headers=headers,
+            headers={"Received-Timestamp": str(received_timestamp)},
         )
 
     def start_delete_groups(self, project_id, group_ids):
@@ -301,11 +276,11 @@ class SnubaProtocolEventStream(EventStream):
 
     def _send(
         self,
-        project_id: int,
-        _type: str,
-        extra_data: Tuple[Any, ...] = (),
-        asynchronous: bool = True,
-        headers: Optional[Mapping[str, str]] = None,
+        project_id,
+        _type,
+        extra_data=(),
+        asynchronous=True,
+        headers=None,  # Optional[Mapping[str, str]]
     ):
         raise NotImplementedError
 
@@ -313,11 +288,11 @@ class SnubaProtocolEventStream(EventStream):
 class SnubaEventStream(SnubaProtocolEventStream):
     def _send(
         self,
-        project_id: int,
-        _type: str,
-        extra_data: Tuple[Any, ...] = (),
-        asynchronous: bool = True,
-        headers: Optional[Mapping[str, str]] = None,
+        project_id,
+        _type,
+        extra_data=(),
+        asynchronous=True,
+        headers=None,  # Optional[Mapping[str, str]]
     ):
         if headers is None:
             headers = {}

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -5,7 +5,6 @@ from sentry.eventstream.kafka.protocol import (
     InvalidVersion,
     UnexpectedOperation,
     get_task_kwargs_for_message,
-    get_task_kwargs_for_message_from_headers,
 )
 from sentry.testutils.helpers import override_options
 from sentry.utils import json
@@ -72,27 +71,3 @@ def test_get_task_kwargs_for_message_version_1_unsupported_operation():
 def test_get_task_kwargs_for_message_version_1_unexpected_operation():
     with pytest.raises(UnexpectedOperation):
         get_task_kwargs_for_message(json.dumps([1, "invalid", {}, {}]))
-
-
-@pytest.mark.django_db
-def test_get_task_kwargs_for_message_version_1_kafka_headers():
-    kafka_headers = [
-        ("Received-Timestamp", b"1626301534.910839"),
-        ("event_id", b"00000000000010008080808080808080"),
-        ("project_id", b"1"),
-        ("is_new", b"1"),
-        ("is_new_group_environment", b"1"),
-        ("is_regression", b"0"),
-        ("version", b"2"),
-        ("operation", b"insert"),
-        ("skip_consume", b"0"),
-    ]
-
-    kwargs = get_task_kwargs_for_message_from_headers(kafka_headers)
-    assert kwargs["project_id"] == 1
-    assert kwargs["event_id"] == "00000000000010008080808080808080"
-    assert kwargs["group_id"] is None
-    assert kwargs["primary_hash"] is None
-    assert kwargs["is_new"] is True
-    assert kwargs["is_regression"] is False
-    assert kwargs["is_new_group_environment"] is True


### PR DESCRIPTION
…ake 2 (#27659)"

This reverts commit 441373544f98f668b8a8524212af4d9e163a2fdd.

This change actually caused CPU usage to increase (even with options off).
Reverting until further investigation is done.