### PR TITLE
ref(notification platform): Show better unknown command help text

### DIFF
--- a/src/sentry/integrations/slack/endpoints/base.py
+++ b/src/sentry/integrations/slack/endpoints/base.py
@@ -53,7 +53,9 @@ class SlackDMEndpoint(Endpoint, abc.ABC):  # type: ignore
                 return self.unlink_team(request)
 
         # If we cannot interpret the command, print help text.
-        return self.respond(SlackHelpMessageBuilder(command).build())
+        request_data = request.data
+        unknown_command = request_data.get("text", "").lower()
+        return self.respond(SlackHelpMessageBuilder(unknown_command).build())
 
     def get_command_and_args(self, request: SlackRequest) -> Tuple[str, Sequence[str]]:
         raise NotImplementedError

--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -77,7 +77,8 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
             return self.respond()
         access_token = self._get_access_token(integration)
         headers = {"Authorization": "Bearer %s" % access_token}
-        payload = {"channel": channel, **SlackEventMessageBuilder(integration).build()}
+        command = request.data.get("event", {}).get("text", {}).lower()
+        payload = {"channel": channel, **SlackEventMessageBuilder(integration, command).build()}
         client = SlackClient()
         try:
             client.post("/chat.postMessage", headers=headers, data=payload, json=True)

--- a/src/sentry/integrations/slack/message_builder/event.py
+++ b/src/sentry/integrations/slack/message_builder/event.py
@@ -1,7 +1,12 @@
+from typing import Iterable, List, Optional
+
 from sentry.features.helpers import any_organization_has_feature
-from sentry.integrations.slack.message_builder import SlackBody
+from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.models import Integration
+from sentry.utils import metrics
+
+from .help import UNKNOWN_COMMAND_MESSAGE
 
 EVENT_MESSAGE = (
     "Want to learn more about configuring alerts in Sentry? Check out our documentation."
@@ -9,15 +14,30 @@ EVENT_MESSAGE = (
 
 
 class SlackEventMessageBuilder(SlackHelpMessageBuilder):
-    def __init__(self, integration: Integration) -> None:
+    def __init__(self, integration: Integration, command: Optional[str] = None) -> None:
         super().__init__()
         self.integration = integration
+        self.command = command
+
+    def get_header_block(self) -> Iterable[SlackBlock]:
+        blocks: List[SlackBlock] = []
+        if self.command != "help":
+            metrics.incr(
+                "slack.unknown_command",
+                sample_rate=1.0,
+                tags={"command": self.command},
+            )
+            blocks.append(
+                self.get_markdown_block(UNKNOWN_COMMAND_MESSAGE.format(command=self.command))
+            )
+        return blocks
 
     def build(self) -> SlackBody:
         if not any_organization_has_feature(
             "organizations:notification-platform", self.integration.organizations.all()
         ):
             return self._build_blocks(
+                *self.get_header_block(),
                 self.get_markdown_block(EVENT_MESSAGE),
                 self.get_docs_block(),
             )

--- a/src/sentry/integrations/slack/message_builder/event.py
+++ b/src/sentry/integrations/slack/message_builder/event.py
@@ -4,8 +4,8 @@ from sentry.features.helpers import any_organization_has_feature
 from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
 from sentry.integrations.slack.message_builder.help import SlackHelpMessageBuilder
 from sentry.models import Integration
-from sentry.utils import metrics
 
+from ..utils import logger
 from .help import UNKNOWN_COMMAND_MESSAGE
 
 EVENT_MESSAGE = (
@@ -22,11 +22,7 @@ class SlackEventMessageBuilder(SlackHelpMessageBuilder):
     def get_header_block(self) -> Iterable[SlackBlock]:
         blocks: List[SlackBlock] = []
         if self.command != "help":
-            metrics.incr(
-                "slack.unknown_command",
-                sample_rate=1.0,
-                tags={"command": self.command},
-            )
+            logger.info("slack.event.unknown-command", extra={"command": self.command})
             blocks.append(
                 self.get_markdown_block(UNKNOWN_COMMAND_MESSAGE.format(command=self.command))
             )

--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -2,6 +2,7 @@ from typing import Iterable, List, Mapping, Optional
 
 from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
+from sentry.utils import metrics
 
 UNKNOWN_COMMAND_MESSAGE = "Unknown command: `{command}`"
 HEADER_MESSAGE = "Here are the commands you can use. Commands not working? Re-install the app!"
@@ -53,7 +54,12 @@ class SlackHelpMessageBuilder(BlockSlackMessageBuilder):
 
     def get_header_blocks(self) -> Iterable[SlackBlock]:
         blocks: List[SlackBlock] = []
-        if self.command:
+        if self.command != "help":
+            metrics.incr(
+                "slack.unknown_command",
+                sample_rate=1.0,
+                tags={"command": self.command},
+            )
             blocks.append(
                 self.get_markdown_block(UNKNOWN_COMMAND_MESSAGE.format(command=self.command))
             )

--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -2,7 +2,8 @@ from typing import Iterable, List, Mapping, Optional
 
 from sentry.integrations.slack.message_builder import SlackBlock, SlackBody
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
-from sentry.utils import metrics
+
+from ..utils import logger
 
 UNKNOWN_COMMAND_MESSAGE = "Unknown command: `{command}`"
 HEADER_MESSAGE = "Here are the commands you can use. Commands not working? Re-install the app!"
@@ -55,11 +56,7 @@ class SlackHelpMessageBuilder(BlockSlackMessageBuilder):
     def get_header_blocks(self) -> Iterable[SlackBlock]:
         blocks: List[SlackBlock] = []
         if self.command != "help":
-            metrics.incr(
-                "slack.unknown_command",
-                sample_rate=1.0,
-                tags={"command": self.command},
-            )
+            logger.info("slack.event.unknown-command", extra={"command": self.command})
             blocks.append(
                 self.get_markdown_block(UNKNOWN_COMMAND_MESSAGE.format(command=self.command))
             )

--- a/tests/sentry/api/endpoints/test_integrations_slack_commands.py
+++ b/tests/sentry/api/endpoints/test_integrations_slack_commands.py
@@ -55,6 +55,12 @@ def assert_is_help_text(data: SlackBody, expected_command: Optional[str] = None)
         assert expected_command in text
 
 
+def assert_unknown_command_text(data: SlackBody, unknown_command: Optional[str] = None) -> None:
+    text = get_response_text(data)
+    assert f"Unknown command: `{unknown_command}`" in text
+    assert "Here are the commands you can use" in text
+
+
 class SlackCommandsTest(APITestCase, TestCase):
     endpoint = "sentry-integration-slack-commands"
     method = "post"
@@ -159,7 +165,7 @@ class SlackCommandsHelpTest(SlackCommandsTest):
 
     def test_invalid_command(self):
         data = self.send_slack_message("invalid command")
-        assert_is_help_text(data, "invalid")
+        assert_unknown_command_text(data, "invalid command")
 
     def test_help_command(self):
         data = self.send_slack_message("help")

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -193,10 +193,11 @@ class LinkSharedEventTest(BaseEventTest):
 class MessageIMEventTest(BaseEventTest):
     def get_block_type_text(self, block_type, data):
         block = filter(lambda x: x["type"] == block_type, data["blocks"])[0]
-        if block_type == "section":
-            return block["text"]["text"]
-
         return block["elements"][0]["text"]["text"]
+
+    def get_block_section_text(self, data):
+        blocks = data["blocks"]
+        return blocks[0]["text"]["text"], blocks[1]["text"]["text"]
 
     @responses.activate
     def test_user_message_im(self):
@@ -206,8 +207,10 @@ class MessageIMEventTest(BaseEventTest):
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
         data = json.loads(request.body)
+        heading, contents = self.get_block_section_text(data)
+        assert heading == "Unknown command: `helloo`"
         assert (
-            self.get_block_type_text("section", data)
+            contents
             == "Want to learn more about configuring alerts in Sentry? Check out our documentation."
         )
         assert self.get_block_type_text("actions", data) == "Sentry Docs"
@@ -221,8 +224,10 @@ class MessageIMEventTest(BaseEventTest):
         request = responses.calls[0].request
         assert request.headers["Authorization"] == "Bearer xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
         data = json.loads(request.body)
+        heading, contents = self.get_block_section_text(data)
+        assert heading == "Unknown command: `helloo`"
         assert (
-            self.get_block_type_text("section", data)
+            contents
             == "Here are the commands you can use. Commands not working? Re-install the app!"
         )
 


### PR DESCRIPTION
Update the "unknown command" help text to display the full text typed, rather than the "command" only (without arguments). For example, if a user typed "link team-sentry" before we'd reply with "Unknown command: link" and now will reply with "Unknown command: link team-sentry". This now works for `/sentry bad commands` and `just bad commands` (to a DM - we used to not show the unknown help text for non-slash commands). 
<img width="786" alt="Screen Shot 2021-07-28 at 1 49 22 PM" src="https://user-images.githubusercontent.com/29959063/127393919-7809e310-854b-434c-8b02-dcec41db4b49.png">

This PR also adds logging for when users type in unknown commands so we can see what they thought should have worked.