### PR TITLE
feat(growth): change discover to performance in link

### DIFF
--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -238,7 +238,7 @@ def get_one_transaction(org: Organization, project_slug: Optional[str]):
 
     transaction_id = result["data"][0]["id"]
 
-    return f"/organizations/{org.slug}/discover/{project.slug}:{transaction_id}/"
+    return f"/organizations/{org.slug}/performance/{project.slug}:{transaction_id}/"
 
 
 def get_one_discover_query(org: Organization):

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -125,7 +125,7 @@ class DemoStartTest(TestCase):
             ("oneIssue", base_issue_url),
             ("oneBreadcrumb", base_issue_url + "#breadcrumbs"),
             ("oneStackTrace", base_issue_url + "#exception"),
-            ("oneTransaction", f"/organizations/{org.slug}/discover/"),
+            ("oneTransaction", f"/organizations/{org.slug}/performance/"),
             (
                 "oneWebVitals",
                 f"/organizations/{org.slug}/performance/summary/vitals/?project={project.id}",


### PR DESCRIPTION
We can see the same transaction event detail from the performance page instead discover. Better to link to performance since the context is generally with performance on our marketing page.