### PR TITLE
Revert "Revert "perf(post-process-forwarder): Skip parsing Kafka mess…

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -1,13 +1,17 @@
 import logging
 import signal
-from typing import Any
+from typing import Any, Mapping, Optional, Tuple
 
 from confluent_kafka import OFFSET_INVALID, TopicPartition
 from django.conf import settings
 from django.utils.functional import cached_property
 
+from sentry import options
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
-from sentry.eventstream.kafka.protocol import get_task_kwargs_for_message
+from sentry.eventstream.kafka.protocol import (
+    get_task_kwargs_for_message,
+    get_task_kwargs_for_message_from_headers,
+)
 from sentry.eventstream.snuba import SnubaProtocolEventStream
 from sentry.utils import json, kafka, metrics
 
@@ -26,13 +30,73 @@ class KafkaEventStream(SnubaProtocolEventStream):
         if error is not None:
             logger.warning("Could not publish message (error: %s): %r", error, message)
 
+    def _get_headers_for_insert(
+        self,
+        group,
+        event,
+        is_new,
+        is_regression,
+        is_new_group_environment,
+        primary_hash,
+        received_timestamp: float,
+        skip_consume,
+    ) -> Mapping[str, str]:
+
+        # HACK: We are putting all this extra information that is required by the
+        # post process forwarder into the headers so we can skip parsing entire json
+        # messages. The post process forwarder is currently bound to a single core.
+        # Once we are able to parallelize the JSON parsing and other transformation
+        # steps being done there we may want to remove this hack.
+        def encode_bool(value: Optional[bool]) -> str:
+            if value is None:
+                value = False
+            return str(int(value))
+
+        # WARNING: We must remove all None headers. There is a bug in confluent-kafka-python
+        # (used by both Sentry and Snuba) that incorrectly decrements the reference count of
+        # Python's None on any attempt to read header values containing null values, leading
+        # None to eventually get deallocated and crash the interpreter. The bug exists in the
+        # version we are using (1.5) as well as in the latest (at the time of writing) 1.7 version.
+        def strip_none_values(value: Mapping[str, Optional[str]]) -> Mapping[str, str]:
+            return {key: value for key, value in value.items() if value is not None}
+
+        send_new_headers = options.get("eventstream:kafka-headers")
+
+        if send_new_headers is True:
+            return strip_none_values(
+                {
+                    "Received-Timestamp": str(received_timestamp),
+                    "event_id": str(event.event_id),
+                    "project_id": str(event.project_id),
+                    "group_id": str(event.group_id) if event.group_id is not None else None,
+                    "primary_hash": str(primary_hash) if primary_hash is not None else None,
+                    "is_new": encode_bool(is_new),
+                    "is_new_group_environment": encode_bool(is_new_group_environment),
+                    "is_regression": encode_bool(is_regression),
+                    "version": str(self.EVENT_PROTOCOL_VERSION),
+                    "operation": "insert",
+                    "skip_consume": encode_bool(skip_consume),
+                }
+            )
+        else:
+            return super()._get_headers_for_insert(
+                group,
+                event,
+                is_new,
+                is_regression,
+                is_new_group_environment,
+                primary_hash,
+                received_timestamp,
+                skip_consume,
+            )
+
     def _send(
         self,
-        project_id,
-        _type,
-        extra_data=(),
-        asynchronous=True,
-        headers=None,  # Optional[Mapping[str, str]]
+        project_id: int,
+        _type: str,
+        extra_data: Tuple[Any, ...] = (),
+        asynchronous: bool = True,
+        headers: Optional[Mapping[str, str]] = None,
     ):
         if headers is None:
             headers = {}
@@ -210,14 +274,26 @@ class KafkaEventStream(SnubaProtocolEventStream):
             i = i + 1
             owned_partition_offsets[key] = message.offset() + 1
 
-            with metrics.timer("eventstream.duration", instance="get_task_kwargs_for_message"):
-                task_kwargs = get_task_kwargs_for_message(message.value())
+            use_kafka_headers = options.get("post-process-forwarder:kafka-headers")
 
-            if task_kwargs is not None:
-                with metrics.timer(
-                    "eventstream.duration", instance="dispatch_post_process_group_task"
-                ):
-                    self._dispatch_post_process_group_task(**task_kwargs)
+            if use_kafka_headers is True:
+                try:
+                    with metrics.timer(
+                        "eventstream.duration", instance="get_task_kwargs_for_message_from_headers"
+                    ):
+                        task_kwargs = get_task_kwargs_for_message_from_headers(message.headers())
+
+                    with metrics.timer(
+                        "eventstream.duration", instance="dispatch_post_process_group_task"
+                    ):
+                        self._dispatch_post_process_group_task(**task_kwargs)
+
+                except Exception:
+                    metrics.incr("eventstream.parsing-error")
+                    self._get_task_kwargs_and_dispatch(message)
+
+            else:
+                self._get_task_kwargs_and_dispatch(message)
 
             if i % commit_batch_size == 0:
                 commit_offsets()
@@ -226,3 +302,11 @@ class KafkaEventStream(SnubaProtocolEventStream):
         commit_offsets()
 
         consumer.close()
+
+    def _get_task_kwargs_and_dispatch(self, message) -> None:
+        with metrics.timer("eventstream.duration", instance="get_task_kwargs_for_message"):
+            task_kwargs = get_task_kwargs_for_message(message.value())
+
+        if task_kwargs is not None:
+            with metrics.timer("eventstream.duration", instance="dispatch_post_process_group_task"):
+                self._dispatch_post_process_group_task(**task_kwargs)

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional, Sequence, Tuple
 
 from sentry.utils import json, metrics
 
@@ -96,3 +97,75 @@ def get_task_kwargs_for_message(value):
         )
 
     return handler(*payload[1:])
+
+
+def get_task_kwargs_for_message_from_headers(headers: Sequence[Tuple[str, Optional[bytes]]]):
+    """
+    Same as get_task_kwargs_for_message but gets the required information from
+    the kafka message headers.
+    """
+    try:
+        header_data = {k: v for k, v in headers}
+        if "group_id" not in header_data:
+            header_data["group_id"] = None
+        if "primary_hash" not in header_data:
+            header_data["primary_hash"] = None
+
+        def decode_str(value: Optional[bytes]) -> str:
+            assert isinstance(value, bytes)
+            return value.decode("utf-8")
+
+        def decode_optional_str(value: Optional[bytes]) -> Optional[str]:
+            if value is None:
+                return None
+            return decode_str(value)
+
+        def decode_int(value: Optional[bytes]) -> int:
+            assert isinstance(value, bytes)
+            return int(value)
+
+        def decode_optional_int(value: Optional[bytes]) -> Optional[int]:
+            if value is None:
+                return None
+            return decode_int(value)
+
+        def decode_bool(value: bytes) -> bool:
+            return bool(int(decode_str(value)))
+
+        version = decode_int(header_data["version"])
+        operation = decode_str(header_data["operation"])
+        primary_hash = decode_optional_str(header_data["primary_hash"])
+        event_id = decode_str(header_data["event_id"])
+        group_id = decode_optional_int(header_data["group_id"])
+        project_id = decode_int(header_data["project_id"])
+
+        event_data = {
+            "event_id": event_id,
+            "group_id": group_id,
+            "project_id": project_id,
+            "primary_hash": primary_hash,
+        }
+
+        skip_consume = decode_bool(header_data["skip_consume"])
+        is_new = decode_bool(header_data["is_new"])
+        is_regression = decode_bool(header_data["is_regression"])
+        is_new_group_environment = decode_bool(header_data["is_new_group_environment"])
+
+        task_state = {
+            "skip_consume": skip_consume,
+            "is_new": is_new,
+            "is_regression": is_regression,
+            "is_new_group_environment": is_new_group_environment,
+        }
+
+    except Exception:
+        raise InvalidPayload("Received event payload with unexpected structure")
+
+    try:
+        handler = version_handlers[version]
+    except (ValueError, KeyError):
+        raise InvalidVersion(
+            f"Received event payload with unexpected version identifier: {version}"
+        )
+
+    return handler(operation, event_data, task_state)

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from typing import Any, Mapping, Optional, Tuple
 from uuid import uuid4
 
 import pytz
@@ -73,6 +74,19 @@ class SnubaProtocolEventStream(EventStream):
     # non-prefixed variations occur in a response.
     UNEXPECTED_TAG_KEYS = frozenset(["dist", "release", "user"])
 
+    def _get_headers_for_insert(
+        self,
+        group,
+        event,
+        is_new,
+        is_regression,
+        is_new_group_environment,
+        primary_hash,
+        received_timestamp,  # type: float
+        skip_consume,
+    ) -> Mapping[str, str]:
+        return {"Received-Timestamp": str(received_timestamp)}
+
     def insert(
         self,
         group,
@@ -97,6 +111,17 @@ class SnubaProtocolEventStream(EventStream):
         }
         if unexpected_tags:
             logger.error("%r received unexpected tags: %r", self, unexpected_tags)
+
+        headers = self._get_headers_for_insert(
+            group,
+            event,
+            is_new,
+            is_regression,
+            is_new_group_environment,
+            primary_hash,
+            received_timestamp,
+            skip_consume,
+        )
 
         self._send(
             project.id,
@@ -123,7 +148,7 @@ class SnubaProtocolEventStream(EventStream):
                     "skip_consume": skip_consume,
                 },
             ),
-            headers={"Received-Timestamp": str(received_timestamp)},
+            headers=headers,
         )
 
     def start_delete_groups(self, project_id, group_ids):
@@ -276,11 +301,11 @@ class SnubaProtocolEventStream(EventStream):
 
     def _send(
         self,
-        project_id,
-        _type,
-        extra_data=(),
-        asynchronous=True,
-        headers=None,  # Optional[Mapping[str, str]]
+        project_id: int,
+        _type: str,
+        extra_data: Tuple[Any, ...] = (),
+        asynchronous: bool = True,
+        headers: Optional[Mapping[str, str]] = None,
     ):
         raise NotImplementedError
 
@@ -288,11 +313,11 @@ class SnubaProtocolEventStream(EventStream):
 class SnubaEventStream(SnubaProtocolEventStream):
     def _send(
         self,
-        project_id,
-        _type,
-        extra_data=(),
-        asynchronous=True,
-        headers=None,  # Optional[Mapping[str, str]]
+        project_id: int,
+        _type: str,
+        extra_data: Tuple[Any, ...] = (),
+        asynchronous: bool = True,
+        headers: Optional[Mapping[str, str]] = None,
     ):
         if headers is None:
             headers = {}


### PR DESCRIPTION
…ages - take 2 (#27659)" (#27809)"

This reverts commit f3f2a0dde5e3e613b3319cec5a386f59d19691f2.

This brings back https://github.com/getsentry/sentry/pull/27659 (it's
exactly the same as the original PR).
The original change was first reverted because it caused consumer lag in
the post process forwarder. We suspect that this was caused by uncached
options in production resulting in cache miss on every option lookup.
Now we have set both "eventstream:kafka-headers" and
"post-process-forwarder:kafka-headers" to false (their defaults) in
production, let's try this again.