### PR TITLE
build(ci): Always run "check migration" workflow

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -77,5 +77,5 @@ migrations_modified:
 migration_lockfile:
   - *backend_dependencies
   - *backend_lintable
-  # - .github/workflows/check-if-migration-is-required.yml
+  - .github/workflows/check-if-migration-is-required.yml
   - .github/workflows/scripts/migration-check.sh

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -71,3 +71,11 @@ migrations_added:
 
 migrations_modified:
   - modified: 'src/sentry/migrations/*'
+
+# These files will trigger our wokrflow to check if lockfile
+# updates are needed
+migration_lockfile:
+  - *backend_dependencies
+  - *backend_lintable
+  # - .github/workflows/check-if-migration-is-required.yml
+  - .github/workflows/scripts/migration-check.sh

--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -1,20 +1,34 @@
 name: check migration
-on:
-  pull_request:
-    paths:
-      # Matches all python files regardless of directory depth.
-      - '**.py'
-      - requirements*.txt
-      - .github/workflows/check-if-migration-is-required.yml
-      - .github/workflows/scripts/migration-check.sh
+on: pull_request
 
 jobs:
+  should-check:
+    name: check if migration is needed
+    runs-on: ubuntu-20.04
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      changed: ${{ steps.changes.outputs.migration_lockfile }}
+    steps:
+      - name: Checkout sentry
+        uses: actions/checkout@v2
+
+      - name: check if files have changed
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+
   main:
     name: check migration
+    if: needs.should-check.outputs.changed == 'true'
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sentry
+        uses: actions/checkout@v2
 
       - name: Set python version output
         id: python-version

--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -23,8 +23,9 @@ jobs:
 
   main:
     name: check migration
-    if: needs.should-check.outputs.changed == 'true'
     runs-on: ubuntu-20.04
+    needs: [should-check]
+    if: needs.should-check.outputs.changed == 'true'
 
     steps:
       - name: Checkout sentry

--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   should-check:
-    name: check if migration is needed
+    name: did files change
     runs-on: ubuntu-20.04
     timeout-minutes: 3
     # Map a step output to a job output


### PR DESCRIPTION
Previously this workflow only ran when certain files were modified. This meant that we could not use GH to mark the job as "required" because the check would be missing. Changed this to always run, but skip job if relevant files were not changed.

Closes #27044 