### PR TITLE
feat(ui): Custom Storybook Docs styles

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,49 @@
+<style>
+	body {
+		--font-size: 16px;
+		--font-color: #2B1D38;
+		font-family: 'Rubik', 'Avenir Next', 'Helvetica Neue', sans-serif;
+		font-size: var(--font-size);
+		color: var(--font-color);
+	}
+	code {
+		font-family: 'IBM Plex', Consolas, 'Courier New', monospace;
+		font-size: 1rem;
+		color: var(--font-color);
+	}
+	.sbdocs.sbdocs-p,
+	.sbdocs.sbdocs-li {
+		font-family: inherit;
+		font-size: 1em;
+		color: var(--font-color);
+	}
+	.sbdocs.sbdocs-h1,
+	.sbdocs.sbdocs-h2,
+	.sbdocs.sbdocs-h3,
+	.sbdocs.sbdocs-h4,
+	.sbdocs.sbdocs-h5,
+	.sbdocs.sbdocs-h6 {
+		font-family: inherit;
+		font-weight: 600;
+		color: var(--font-color);
+	}
+	.sbdocs.sbdocs-h1 {
+		font-size: 2.25em;
+		letter-spacing: -1px;
+		margin-top: 0.4em;
+	}
+	.sbdocs.sbdocs-h2,
+	.sbdocs.sbdocs-h2:first-of-type {
+		font-size: 1.625em;
+		letter-spacing: -0.5px;
+		margin-top: 1em;
+	}
+	.sbdocs.sbdocs-h3,
+	.sbdocs.sbdocs-h3:first-of-type {
+		font-size: 1.25em;
+		margin-top: 1em;
+	}
+	.sbdocs.sbdocs-content {
+		max-width: 48em;
+	}
+</style>


### PR DESCRIPTION
Added custom styles as [CSS escape hatches](https://storybook.js.org/docs/react/configure/theming#css-escape-hatches) to make Storybook Docs more readable and on-brand. This mostly affects documentation pages like CORE > Overview.
<img width="1229" alt="Screen Shot 2021-07-30 at 9 34 10 AM" src="https://user-images.githubusercontent.com/44172267/127693249-b3e53e1d-43d8-4127-9936-e9a2bdb02148.png">
