### PR TITLE
fix(group-assignment): Fixes bug in Group re-assignment

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -80,20 +80,29 @@ def handle_owner_assignment(project, group, event):
     from sentry.models import GroupAssignee, ProjectOwnership
 
     with metrics.timer("post_process.handle_owner_assignment"):
-        # Is the issue already assigned to a team or user?
-        key = "assignee_exists:1:%s" % group.id
-        owners_exists = cache.get(key)
+        owner_key = "owner_exists:1:%s" % group.id
+        owners_exists = cache.get(owner_key)
         if owners_exists is None:
-            owners_exists = group.assignee_set.exists() or group.groupowner_set.exists()
+            owners_exists = group.groupowner_set.exists()
             # Cache for an hour if it's assigned. We don't need to move that fast.
-            cache.set(key, owners_exists, 3600 if owners_exists else 60)
-        if owners_exists:
+            cache.set(owner_key, owners_exists, 3600 if owners_exists else 60)
+
+        # Is the issue already assigned to a team or user?
+        assignee_key = "assignee_exists:1:%s" % group.id
+        assignees_exists = cache.get(assignee_key)
+        if assignees_exists is None:
+            assignee_exists = group.assignee_set.exists()
+            # Cache for an hour if it's assigned. We don't need to move that fast.
+            cache.set(assignee_key, assignees_exists, 3600 if assignee_exists else 60)
+
+        if owners_exists and assignee_exists:
             return
 
         auto_assignment, owners, assigned_by_codeowners = ProjectOwnership.get_autoassign_owners(
             group.project_id, event.data
         )
-        if auto_assignment and owners:
+
+        if auto_assignment and owners and not assignee_exists:
             GroupAssignee.objects.assign(group, owners[0])
             if assigned_by_codeowners:
                 analytics.record(
@@ -103,7 +112,7 @@ def handle_owner_assignment(project, group, event):
                     group_id=group.id,
                 )
 
-        if owners:
+        if owners and not owners_exists:
             try:
                 handle_group_owners(project, group, owners)
             except Exception:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -91,18 +91,18 @@ def handle_owner_assignment(project, group, event):
         assignee_key = "assignee_exists:1:%s" % group.id
         assignees_exists = cache.get(assignee_key)
         if assignees_exists is None:
-            assignee_exists = group.assignee_set.exists()
+            assignees_exists = group.assignee_set.exists()
             # Cache for an hour if it's assigned. We don't need to move that fast.
-            cache.set(assignee_key, assignees_exists, 3600 if assignee_exists else 60)
+            cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
 
-        if owners_exists and assignee_exists:
+        if owners_exists and assignees_exists:
             return
 
         auto_assignment, owners, assigned_by_codeowners = ProjectOwnership.get_autoassign_owners(
             group.project_id, event.data
         )
 
-        if auto_assignment and owners and not assignee_exists:
+        if auto_assignment and owners and not assignees_exists:
             GroupAssignee.objects.assign(group, owners[0])
             if assigned_by_codeowners:
                 analytics.record(

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -539,15 +539,6 @@ class PostProcessGroupTest(TestCase):
 
 
 class PostProcessGroupAssignmentTest(TestCase):
-    def setUp(self):
-        self.cache_keys_to_delete = set()
-
-    def tearDown(self):
-        for key in self.cache_keys_to_delete:
-            cache.delete(key)
-
-        super().tearDown()
-
     def make_ownership(self, extra_rules=None):
         self.user_2 = self.create_user()
         rules = [
@@ -823,7 +814,6 @@ class PostProcessGroupAssignmentTest(TestCase):
 
         for key in [assignee_cache_key, owner_cache_key]:
             cache.set(key, True)
-            self.cache_keys_to_delete.add(key)
 
         post_process_group(
             is_new=False,


### PR DESCRIPTION
This PR:
- Fixes the bug that does not re-assign issue to group or user, when that user or team gets de-assigned.
- This also solves the issue when someone accidentally creates a bad rule assigning the issue to wrong team but does not re-assign when the rule is fixed