### PR TITLE
Revert "feat(activity): Add current_release_version to Activity"

### DIFF
--- a/src/sentry/tasks/clear_expired_resolutions.py
+++ b/src/sentry/tasks/clear_expired_resolutions.py
@@ -46,8 +46,4 @@ def clear_expired_resolutions(release_id):
         except IndexError:
             continue
 
-        data = {"version": release.version}
-        if resolution.current_release_version:
-            data.update({"current_release_version": resolution.current_release_version})
-
-        activity.update(data=data)
+        activity.update(data={"version": release.version})

--- a/tests/sentry/tasks/test_clear_expired_resolutions.py
+++ b/tests/sentry/tasks/test_clear_expired_resolutions.py
@@ -21,10 +21,7 @@ class ClearExpiredResolutionsTest(TestCase):
             project=project, status=GroupStatus.RESOLVED, active_at=timezone.now()
         )
         resolution1 = GroupResolution.objects.create(
-            group=group1,
-            release=old_release,
-            current_release_version=old_release.version,
-            type=GroupResolution.Type.in_next_release,
+            group=group1, release=old_release, type=GroupResolution.Type.in_next_release
         )
         activity1 = Activity.objects.create(
             group=group1,
@@ -43,10 +40,7 @@ class ClearExpiredResolutionsTest(TestCase):
 
         group2 = self.create_group(status=GroupStatus.UNRESOLVED, active_at=timezone.now())
         resolution2 = GroupResolution.objects.create(
-            group=group2,
-            release=new_release,
-            current_release_version=new_release.version,
-            type=GroupResolution.Type.in_next_release,
+            group=group2, release=new_release, type=GroupResolution.Type.in_next_release
         )
         activity2 = Activity.objects.create(
             group=group2,
@@ -68,15 +62,12 @@ class ClearExpiredResolutionsTest(TestCase):
         assert resolution1.status == GroupResolution.Status.resolved
         assert resolution1.release == new_release
         assert resolution1.type == GroupResolution.Type.in_release
-        assert resolution1.current_release_version == old_release.version
 
         resolution2 = GroupResolution.objects.get(id=resolution2.id)
         assert resolution2.status == GroupResolution.Status.pending
 
         activity1 = Activity.objects.get(id=activity1.id)
         assert activity1.data["version"] == new_release.version
-        assert activity1.data["current_release_version"] == old_release.version
 
         activity2 = Activity.objects.get(id=activity2.id)
         assert activity2.data["version"] == ""
-        assert "current_release_version" not in activity2.data


### PR DESCRIPTION
Reverts getsentry/sentry#27741

We have decided to take a different approach where we:-
- Set `current_release_version` only for semver releases and instantly on the click of `Resolved in next release`
- Set `release` to the actual next release if it exists on clicking `Resolved in next release` for date based releases