### PR TITLE
ref(killswitches): Skip steps instead of dropping event

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -53,7 +53,7 @@ ALL_KILLSWITCH_OPTIONS = {
         },
     ),
     "store.load-shed-process-event-projects": KillswitchInfo(
-        description="Drop events in process_event.",
+        description="Skip event process_event and forward to save_event",
         fields={
             "project_id": "A project ID to filter events by.",
             "event_id": "An event ID as given in the event payload.",
@@ -61,11 +61,20 @@ ALL_KILLSWITCH_OPTIONS = {
         },
     ),
     "store.load-shed-symbolicate-event-projects": KillswitchInfo(
-        description="Drop events in symbolicate_event.",
+        description="Skip symbolicating events in symbolicate_event (event gets fwd to process_event)",
         fields={
             "project_id": "A project ID to filter events by.",
             "event_id": "An event ID as given in the event payload.",
             "platform": "The event platform as defined in the event payload's platform field.",
+            "symbolication_function": "process_minidump, process_applecrashreport, or process_payload",
+        },
+    ),
+    "store.load-shed-save-event-projects": KillswitchInfo(
+        description="Drop events in save_event",
+        fields={
+            "project_id": "A project ID to filter events by.",
+            "event_type": "transaction, csp, hpkp, expectct, expectstaple, transaction, default or null",
+            "platform": "The event platform as defined in the event payload's platform field, or 'none'",
         },
     ),
 }

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -336,10 +336,10 @@ register("store.background-grouping-before", default=False)
 # Killswitch for dropping events in ingest consumer (after parsing them)
 register("store.load-shed-parsed-pipeline-projects", type=Any, default=[])
 
-# Killswitch for dropping events in process_event
+# Killswitch for skipping processing events in process_event
 register("store.load-shed-process-event-projects", type=Any, default=[])
 
-# Killswitch for dropping events in symbolicate_event
+# Killswitch for skipping processing events in symbolicate_event
 register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
 
 # Store release files bundled as zip files
@@ -360,3 +360,6 @@ register("eventstream:kafka-headers", default=False)
 
 # Post process forwarder gets data from Kafka headers
 register("post-process-forwarder:kafka-headers", default=False)
+
+# Killswitch for dropping events in save_event
+register("store.load-shed-save-event-projects", type=Any, default=[])

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -315,11 +315,15 @@ register("store.reprocessing-force-disable", default=False)
 register("store.race-free-group-creation-force-disable", default=False)
 
 
-# Killswitch for dropping events if they were to create groups
+# ## sentry.killswitches
+#
+# The following options are documented in sentry.killswitches in more detail
 register("store.load-shed-group-creation-projects", type=Any, default=[])
-
-# Killswitch for dropping events in ingest consumer
 register("store.load-shed-pipeline-projects", type=Any, default=[])
+register("store.load-shed-parsed-pipeline-projects", type=Any, default=[])
+register("store.load-shed-save-event-projects", type=Any, default=[])
+register("store.load-shed-process-event-projects", type=Any, default=[])
+register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
 
 # Switch for more performant project counter incr
 register("store.projectcounter-modern-upsert-sample-rate", default=0.0)
@@ -332,15 +336,6 @@ register("store.background-grouping-sample-rate", default=0.0)
 
 # True if background grouping should run before secondary and primary grouping
 register("store.background-grouping-before", default=False)
-
-# Killswitch for dropping events in ingest consumer (after parsing them)
-register("store.load-shed-parsed-pipeline-projects", type=Any, default=[])
-
-# Killswitch for skipping processing events in process_event
-register("store.load-shed-process-event-projects", type=Any, default=[])
-
-# Killswitch for skipping processing events in symbolicate_event
-register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
 
 # Store release files bundled as zip files
 register("processing.save-release-archives", default=False)  # unused
@@ -360,6 +355,3 @@ register("eventstream:kafka-headers", default=False)
 
 # Post process forwarder gets data from Kafka headers
 register("post-process-forwarder:kafka-headers", default=False)
-
-# Killswitch for dropping events in save_event
-register("store.load-shed-save-event-projects", type=Any, default=[])

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -233,8 +233,7 @@ def _do_symbolicate_event(cache_key, start_time, event_id, symbolicate_task, dat
             "symbolication_function": symbolication_function_name,
         },
     ):
-        _continue_to_process_event()
-        return
+        return _continue_to_process_event()
 
     has_changed = False
 
@@ -319,7 +318,7 @@ def _do_symbolicate_event(cache_key, start_time, event_id, symbolicate_task, dat
     if has_changed:
         cache_key = event_processing_store.store(data)
 
-    _continue_to_process_event()
+    return _continue_to_process_event()
 
 
 @instrumented_task(
@@ -425,8 +424,7 @@ def _do_process_event(
             "platform": data.get("platform") or "null",
         },
     ):
-        _continue_to_save_event()
-        return
+        return _continue_to_save_event()
 
     with sentry_sdk.start_span(op="tasks.store.process_event.get_project_from_cache"):
         project = Project.objects.get_from_cache(id=project_id)
@@ -550,7 +548,7 @@ def _do_process_event(
 
         cache_key = event_processing_store.store(data)
 
-    _continue_to_save_event()
+    return _continue_to_save_event()
 
 
 @instrumented_task(


### PR DESCRIPTION
Rewrite existing killswitches in process_event and symbolicate_event to
skip the pipeline stage instead of naively dropping the event and
leaking processingstore that way. Because currently they're just leaking
payloads into Redis those killswitches are basically useless.

In compensation, add another killswitch to save_event