### PR TITLE
chore(js-sdk): Reduce idleTimeout to 3000

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 4000,
+      idleTimeout: 3000,
     }),
   ];
   if (hasReplays) {


### PR DESCRIPTION
Day 3 of increasing idleTimeout. Reduced by 1000 ms over 500ms as last decrease didn't really have a big impact.

See Day 2 here: https://github.com/getsentry/getsentry/commit/9ae0fcedf30780c4aba898f25a1affd324d99c01