### PR TITLE
feat(semver): Set `current_release_version` on Activity model

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1288,7 +1288,17 @@ def _handle_regression(group, event, release):
                 # XXX: handle missing data, as its not overly important
                 pass
             else:
-                activity.update(data={"version": release.version})
+                try:
+                    # We should only update last activity version prior to the regression in the
+                    # case where we have "Resolved in upcoming release" i.e. version == ""
+                    # We also should not override the `data` attribute here because it might have
+                    # a `current_release_version` for semver releases and we wouldn't want to
+                    # lose that
+                    if activity.data["version"] == "":
+                        activity.update(data={**activity.data, "version": release.version})
+                except KeyError:
+                    # Safeguard in case there is no "version" key. However, should not happen
+                    activity.update(data={"version": release.version})
 
     if is_regression:
         activity = Activity.objects.create(

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -373,6 +373,119 @@ class EventManagerTest(TestCase):
 
         mock_send_activity_notifications_delay.assert_called_once_with(activity.id)
 
+    @mock.patch("sentry.tasks.activity.send_activity_notifications.delay")
+    @mock.patch("sentry.event_manager.plugin_is_regression")
+    def test_that_release_in_latest_activity_prior_to_regression_is_not_overridden(
+        self, plugin_is_regression, mock_send_activity_notifications_delay
+    ):
+        """
+        Test that ensures in the case where a regression occurs, the release prior to the latest
+        activity to that regression is not overridden.
+        It should only be overridden if the activity was awaiting the upcoming release
+        """
+        plugin_is_regression.return_value = True
+
+        # Create a release and a group associated with it
+        old_release = self.create_release(
+            version="foobar", date_added=timezone.now() - timedelta(minutes=30)
+        )
+        manager = EventManager(
+            make_event(
+                event_id="a" * 32,
+                checksum="a" * 32,
+                timestamp=time() - 50000,  # need to work around active_at
+                release=old_release.version,
+            )
+        )
+        event = manager.save(1)
+        group = event.group
+        group.update(status=GroupStatus.RESOLVED)
+
+        # Resolve the group in old_release
+        resolution = GroupResolution.objects.create(release=old_release, group=group)
+        activity = Activity.objects.create(
+            group=group,
+            project=group.project,
+            type=Activity.SET_RESOLVED_IN_RELEASE,
+            ident=resolution.id,
+            data={"version": "foobar"},
+        )
+
+        # Create a regression
+        manager = EventManager(
+            make_event(event_id="c" * 32, checksum="a" * 32, timestamp=time(), release="b")
+        )
+        event = manager.save(1)
+        assert event.group_id == group.id
+
+        group = Group.objects.get(id=group.id)
+        assert group.status == GroupStatus.UNRESOLVED
+
+        activity = Activity.objects.get(id=activity.id)
+        assert activity.data["version"] == "foobar"
+
+        regressed_activity = Activity.objects.get(group=group, type=Activity.SET_REGRESSION)
+        assert regressed_activity.data["version"] == "b"
+
+        mock_send_activity_notifications_delay.assert_called_once_with(regressed_activity.id)
+
+    @mock.patch("sentry.tasks.activity.send_activity_notifications.delay")
+    @mock.patch("sentry.event_manager.plugin_is_regression")
+    def test_current_release_version_in_latest_activity_prior_to_regression_is_not_overridden(
+        self, plugin_is_regression, mock_send_activity_notifications_delay
+    ):
+        """
+        Test that ensures in the case where a regression occurs, the release prior to the latest
+        activity to that regression is overridden with the release regression occurred in but the
+        value of `current_release_version` used for semver is not lost in the update.
+        """
+        plugin_is_regression.return_value = True
+
+        # Create a release and a group associated with it
+        old_release = self.create_release(
+            version="a", date_added=timezone.now() - timedelta(minutes=30)
+        )
+        manager = EventManager(
+            make_event(
+                event_id="a" * 32,
+                checksum="a" * 32,
+                timestamp=time() - 50000,  # need to work around active_at
+                release=old_release.version,
+            )
+        )
+        event = manager.save(1)
+        group = event.group
+        group.update(status=GroupStatus.RESOLVED)
+
+        # Resolve the group in old_release
+        resolution = GroupResolution.objects.create(release=old_release, group=group)
+        activity = Activity.objects.create(
+            group=group,
+            project=group.project,
+            type=Activity.SET_RESOLVED_IN_RELEASE,
+            ident=resolution.id,
+            data={"version": "", "current_release_version": "pre foobar"},
+        )
+
+        # Create a regression
+        manager = EventManager(
+            make_event(event_id="c" * 32, checksum="a" * 32, timestamp=time(), release="b")
+        )
+        event = manager.save(1)
+        assert event.group_id == group.id
+
+        group = Group.objects.get(id=group.id)
+        assert group.status == GroupStatus.UNRESOLVED
+
+        activity = Activity.objects.get(id=activity.id)
+        assert activity.data["version"] == "b"
+        assert activity.data["current_release_version"] == "pre foobar"
+
+        regressed_activity = Activity.objects.get(group=group, type=Activity.SET_REGRESSION)
+        assert regressed_activity.data["version"] == "b"
+
+        mock_send_activity_notifications_delay.assert_called_once_with(regressed_activity.id)
+
     def test_has_pending_commit_resolution(self):
         project_id = 1
         event = self.make_release_event("1.0", project_id)


### PR DESCRIPTION
This PR:-
- Sets `current_release_version` on `Activity` when `ResolvedInNextRelease` is clicked on the UI for semver releases. 
- Also, updates `GroupResolution` to be of type `in_release` instead of `in_next_release` because since we are using `current_release_version` as an expression (i.e. `>current_release_version`), we pretty much know that we already have a `GroupResolution` of status resolved. Technically, there is no need to run `clear_expired_resolutions` as we are not awaiting any upcoming release
- Fix bug that was overriding the `release` version in the last activity prior to a regression activity

Follow up: 
- UI will use this `current_release_version` to say something like `This issue was resolved in versions >1.0.0` for example
- Will also change this for date based releases. Currently with date based releases and `ResolvedInNextRelease`, there is basically two scenarios

Scenario 1:
```
release 1 is created
issue 1 happens in release 1
release 2 is created
```

Clicking `ResolvedInNextRelease` resolves this issue in release 2 onwards, and so we know that release 2 is the release that resolves the issue
=> We can store the `release 2` in the `release` field for both `GroupResolution` and `Activity` + treat this resolve case as `ResolvedIn` release 2 (thereby updating relevant `GroupResolution` fields status and type to have `Resolved` and `in_release` respectively) => Hence, also not running `clear_expired_resolutions`

Scenario 2:

```
release 1 is created
issue 1 happens in release 1
```

Clicking `ResolvedInNextRelease` resolves this issue in the upcoming release that we do not know yet, and so we fallback to the model we have + `clear_expired_resolutions` runs updating all these fields once a new release is created