### PR TITLE
fix(ui): Alert list sort by alert name should start by ascending

### DIFF
--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -179,7 +179,8 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
                         pathname: location.pathname,
                         query: {
                           ...currentQuery,
-                          asc: sort.field === 'name' && !sort.asc ? '1' : undefined,
+                          // sort by name should start by ascending on first click
+                          asc: sort.field === 'name' && sort.asc ? undefined : '1',
                           sort: 'name',
                         },
                       }}


### PR DESCRIPTION
This changes the initial sort order of the alerts list to ascending when you click on the name comn to sort by name, rather than descending.

Jira: [WOR-931](https://getsentry.atlassian.net/browse/WOR-931)