### PR TITLE
fix(slack): Don't reply to empty commands

### DIFF
--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -73,11 +73,11 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
         self, request: Request, integration: Integration, token: str, data: Mapping[str, Any]
     ) -> Response:
         channel = data["channel"]
-        if self.is_bot(data):
+        command = request.data.get("event", {}).get("text", "").lower()
+        if self.is_bot(data) or not command:
             return self.respond()
         access_token = self._get_access_token(integration)
         headers = {"Authorization": "Bearer %s" % access_token}
-        command = request.data.get("event", {}).get("text", {}).lower()
         payload = {"channel": channel, **SlackEventMessageBuilder(integration, command).build()}
         client = SlackClient()
         try:

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -48,6 +48,13 @@ MESSAGE_IM_EVENT = """{
     "message_ts": "123456789.9875"
 }"""
 
+MESSAGE_IM_EVENT_NO_TEXT = """{
+    "type": "message",
+    "channel": "DOxxxxxx",
+    "user": "Uxxxxxxx",
+    "message_ts": "123456789.9875"
+}"""
+
 MESSAGE_IM_EVENT_UNLINK = """{
         "type": "message",
         "text": "unlink",
@@ -312,3 +319,10 @@ class MessageIMEventTest(BaseEventTest):
     def test_bot_message_im(self):
         resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_BOT_EVENT))
         assert resp.status_code == 200, resp.content
+
+    @responses.activate
+    def test_user_message_im_no_text(self):
+        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
+        resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT_NO_TEXT))
+        assert resp.status_code == 200, resp.content
+        assert len(responses.calls) == 0


### PR DESCRIPTION
Sometimes Slack sends messages to users about the app being downgraded soon - "{name of workspace} is scheduled to switch from slack's pro plan to the free plan on {date}, which means you may find that some of your features are no longer available.". We hadn't anticipated the "text" field in a command not existing, and were accidentally putting the default value as an empty dictionary if nothing was there, and then trying to lowercase it. We don't want to reply with help text in this case since it's just a bot. I don't fully understand why this wasn't stopped by the `is_bot` check since it does seem to have a `bot_id` in `data`, but this should fix the issue. 

Fixes [SENTRY-RS8](https://sentry.io/organizations/sentry/issues/2541819665/events/abcccf598137436bb763850763b8f8b4/?project=1&referrer=slack)