### PR TITLE
feat(growth): adding create sample transaction button

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -967,6 +967,8 @@ SENTRY_FEATURES = {
     "organizations:performance-events-page": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
+    # Allow the user to create a sample transaction while onboarding
+    "organizations:performance-create-sample-transaction": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -112,6 +112,9 @@ default_manager.add("organizations:performance-tag-page", OrganizationFeature, T
 default_manager.add("organizations:performance-events-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
+default_manager.add(
+    "organizations:performance-create-sample-transaction", OrganizationFeature, True
+)
 default_manager.add("organizations:project-transaction-threshold", OrganizationFeature, True)
 default_manager.add(
     "organizations:project-transaction-threshold-override", OrganizationFeature, True

--- a/static/app/utils/advancedAnalytics.tsx
+++ b/static/app/utils/advancedAnalytics.tsx
@@ -8,6 +8,10 @@ import {
   IntegrationEventParameters,
 } from 'app/utils/integrationEvents';
 import {issueEventMap, IssueEventParameters} from 'app/utils/issueEvents';
+import {
+  performanceEventMap,
+  PerformanceEventParameters,
+} from 'app/utils/performanceEvents';
 
 const ANALYTICS_SESSION = 'ANALYTICS_SESSION';
 
@@ -28,9 +32,15 @@ const hasAnalyticsDebug = () => window.localStorage.getItem('DEBUG_ANALYTICS') =
 
 export type EventParameters = IntegrationEventParameters &
   GrowthEventParameters &
-  IssueEventParameters;
+  IssueEventParameters &
+  PerformanceEventParameters;
 
-const allEventMap = {...integrationEventMap, ...growthEventMap, ...issueEventMap};
+const allEventMap = {
+  ...integrationEventMap,
+  ...growthEventMap,
+  ...issueEventMap,
+  ...performanceEventMap,
+};
 
 type AnalyticsKey = keyof EventParameters;
 

--- a/static/app/utils/growthAnalyticsEvents.tsx
+++ b/static/app/utils/growthAnalyticsEvents.tsx
@@ -34,6 +34,10 @@ type SampleEventParam = {
   platform?: PlatformKey;
 };
 
+type SampleTransactionParam = {
+  platform?: PlatformKey;
+};
+
 type InviteRequestParam = {
   member_id: number;
   invite_status: string;
@@ -59,6 +63,7 @@ export type GrowthEventParameters = {
   'growth.onboarding_take_to_error': {};
   'growth.onboarding_view_full_docs': {};
   'growth.onboarding_view_sample_event': SampleEventParam;
+  'growth.performance_sample_transaction': SampleTransactionParam;
   'invite_request.approved': InviteRequestParam;
   'invite_request.denied': InviteRequestParam;
 };
@@ -89,6 +94,7 @@ export const growthEventMap: Record<GrowthAnalyticsKey, string> = {
   'growth.onboarding_take_to_error': 'Growth: Onboarding Take to Error',
   'growth.onboarding_view_full_docs': 'Growth: Onboarding View Full Docs',
   'growth.onboarding_view_sample_event': 'Growth: Onboarding View Sample Event',
+  'growth.performance_sample_transaction': 'Growth: Performance Sample Transaction',
   'invite_request.approved': 'Invite Request Approved',
   'invite_request.denied': 'Invite Request Denied',
 };

--- a/static/app/utils/growthAnalyticsEvents.tsx
+++ b/static/app/utils/growthAnalyticsEvents.tsx
@@ -34,10 +34,6 @@ type SampleEventParam = {
   platform?: PlatformKey;
 };
 
-type SampleTransactionParam = {
-  platform?: PlatformKey;
-};
-
 type InviteRequestParam = {
   member_id: number;
   invite_status: string;
@@ -63,7 +59,6 @@ export type GrowthEventParameters = {
   'growth.onboarding_take_to_error': {};
   'growth.onboarding_view_full_docs': {};
   'growth.onboarding_view_sample_event': SampleEventParam;
-  'growth.performance_sample_transaction': SampleTransactionParam;
   'invite_request.approved': InviteRequestParam;
   'invite_request.denied': InviteRequestParam;
 };
@@ -94,7 +89,6 @@ export const growthEventMap: Record<GrowthAnalyticsKey, string> = {
   'growth.onboarding_take_to_error': 'Growth: Onboarding Take to Error',
   'growth.onboarding_view_full_docs': 'Growth: Onboarding View Full Docs',
   'growth.onboarding_view_sample_event': 'Growth: Onboarding View Sample Event',
-  'growth.performance_sample_transaction': 'Growth: Performance Sample Transaction',
   'invite_request.approved': 'Invite Request Approved',
   'invite_request.denied': 'Invite Request Denied',
 };

--- a/static/app/utils/performanceEvents.tsx
+++ b/static/app/utils/performanceEvents.tsx
@@ -1,0 +1,26 @@
+import {PlatformKey} from 'app/data/platformCategories';
+
+type SampleTransactionParam = {
+  platform?: PlatformKey;
+};
+
+type PerformanceTourParams = {
+  step: number;
+  duration: number;
+};
+
+export type PerformanceEventParameters = {
+  'performance_views.create_sample_transaction': SampleTransactionParam;
+  'performance_views.tour.start': {};
+  'performance_views.tour.advance': PerformanceTourParams;
+  'performance_views.tour.close': PerformanceTourParams;
+};
+
+export type PerformanceEventKey = keyof PerformanceEventParameters;
+
+export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
+  'performance_views.create_sample_transaction': 'Growth: Performance Sample Transaction',
+  'performance_views.tour.start': 'Performance Views: Tour Start',
+  'performance_views.tour.advance': 'Performance Views: Tour Advance',
+  'performance_views.tour.close': 'Performance Views: Tour Close',
+};

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -206,6 +206,8 @@ class PerformanceContent extends Component<Props, State> {
     const eventView = this.state.eventView;
     const showOnboarding = this.shouldShowOnboarding();
 
+    const project = projects && projects.length > 0 ? projects[0] : undefined;
+
     return (
       <PageContent>
         <LightWeightNoProjectMessage organization={organization}>
@@ -223,8 +225,8 @@ class PerformanceContent extends Component<Props, State> {
           </PageHeader>
           <GlobalSdkUpdateAlert />
           {this.renderError()}
-          {showOnboarding ? (
-            <Onboarding organization={organization} />
+          {showOnboarding && project ? (
+            <Onboarding organization={organization} project={project} />
           ) : (
             <LandingContent
               eventView={eventView}

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -206,8 +206,6 @@ class PerformanceContent extends Component<Props, State> {
     const eventView = this.state.eventView;
     const showOnboarding = this.shouldShowOnboarding();
 
-    const project = projects && projects.length > 0 ? projects[0] : undefined;
-
     return (
       <PageContent>
         <LightWeightNoProjectMessage organization={organization}>
@@ -225,8 +223,8 @@ class PerformanceContent extends Component<Props, State> {
           </PageHeader>
           <GlobalSdkUpdateAlert />
           {this.renderError()}
-          {showOnboarding && project ? (
-            <Onboarding organization={organization} project={project} />
+          {showOnboarding ? (
+            <Onboarding organization={organization} project={projects[0]} />
           ) : (
             <LandingContent
               eventView={eventView}

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -134,6 +134,7 @@ function Onboarding({organization, project, api}: Props) {
   );
   const secondaryBtn = showSampleTransactionBtn ? (
     <Button
+      data-test-id="create-sample-transaction-btn"
       onClick={async () => {
         trackAdvancedAnalyticsEvent(
           'performance_views.create_sample_transaction',

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -516,4 +516,46 @@ describe('Performance > Content', function () {
       expect(link).toHaveLength(1);
     }
   });
+
+  it('Display Create Sample Transaction Button with feature flag on', async function () {
+    const projects = [
+      TestStubs.Project({id: 1, firstTransactionEvent: false}),
+      TestStubs.Project({id: 2, firstTransactionEvent: false}),
+    ];
+    const data = initializeData(projects, {view: undefined}, [
+      'performance-create-sample-transaction',
+    ]);
+
+    const wrapper = mountWithTheme(
+      <PerformanceContent
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+
+    expect(
+      wrapper.find('Button[data-test-id="create-sample-transaction-btn"]').exists()
+    ).toBe(true);
+  });
+
+  it('Do not display Create Sample Transaction Button with feature flag turned off', async function () {
+    const projects = [
+      TestStubs.Project({id: 1, firstTransactionEvent: false}),
+      TestStubs.Project({id: 2, firstTransactionEvent: false}),
+    ];
+    const data = initializeData(projects, {view: undefined}, []);
+
+    const wrapper = mountWithTheme(
+      <PerformanceContent
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+
+    expect(
+      wrapper.find('Button[data-test-id="create-sample-transaction-btn"]').exists()
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Implement the design for button to create sample transactions. For now, only creates JS sample transactions.


![image](https://user-images.githubusercontent.com/8980455/127557320-aab91f44-0f1d-427d-898f-14bc16927616.png)
