### PR TITLE
ref(notification platform): Add referrer to note issue link

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -80,7 +80,7 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
 
         return self._build(
             title=build_attachment_title(group),
-            title_link=get_title_link(group, None, False, False, self.notification),
+            title_link=get_title_link(group, None, False, True, self.notification),
             text=self.notification.get_message_description(),
             footer=build_notification_footer(self.notification, self.recipient),
             color="info",

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -434,7 +434,7 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         assert attachment["title"] == f"{self.group.title}"
         assert (
             attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=slack"
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=NoteActivitySlack"
         )
         assert attachment["text"] == notification.activity.data["text"]
         assert (

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -119,7 +119,7 @@ class ActivityNotificationTest(APITestCase):
         assert attachment["title"] == f"{self.group.title}"
         assert (
             attachment["title_link"]
-            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=slack"
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=NoteActivitySlack"
         )
         assert attachment["text"] == "blah blah"
         assert (


### PR DESCRIPTION
The link to the issue that was commented on didn't have a more specific referrer than just "slack" so this PR adds the type of notification to it for tracking. 