### PR TITLE
feat(growth): add more sample transactions

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -11,6 +11,19 @@ from sentry.utils import json
 from sentry.utils.dates import to_timestamp
 from sentry.utils.samples import create_sample_event_basic
 
+base_platforms_with_transactions = ["javascript", "python", "apple-ios"]
+
+
+def get_json_name(project):
+    for base_platform in base_platforms_with_transactions:
+        if project.platform and project.platform.startswith(base_platform):
+            # special case for javascript
+            if base_platform == "javascript":
+                return "react-transaction.json"
+            return f"{base_platform}-transaction.json"
+    # default
+    return "react-transaction.json"
+
 
 class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
     # Members should be able to create sample events.
@@ -19,7 +32,7 @@ class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
 
     def post(self, request, project):
         samples_root = os.path.join(DATA_ROOT, "samples")
-        with open(os.path.join(samples_root, "react-transaction.json")) as fp:
+        with open(os.path.join(samples_root, get_json_name(project))) as fp:
             data = json.load(fp)
 
         timestamp = datetime.utcnow() - timedelta(minutes=1)

--- a/src/sentry/data/samples/apple-ios-transaction.json
+++ b/src/sentry/data/samples/apple-ios-transaction.json
@@ -1,0 +1,284 @@
+{
+  "event_id": "c5313ca3dc5b4ccf8956d81d4b9154bd",
+  "project": 6426,
+  "release": "checkout-app@3.1",
+  "dist": "1",
+  "platform": "other",
+  "message": "",
+  "tags": [
+    ["app.device", "2421fae1ac9237a8131e74883e52b0f7034a143f"],
+    ["device", "iPad13,2"],
+    ["device.family", "iOS"],
+    ["environment", "debug"],
+    ["level", "info"],
+    ["os", "iOS 14.5"],
+    ["os.name", "iOS"],
+    ["dist", "1"],
+    ["release", "checkout-app@3.1"],
+    ["user", "id:2017"],
+    ["transaction", "iOS_Swift.ViewController"]
+  ],
+  "_meta": {"platform": {"": {"val": "apple-ios"}}},
+  "_metrics": {"bytes.ingested.event": 5867, "bytes.stored.event": 7590},
+  "breadcrumbs": {
+    "values": [
+      {
+        "timestamp": 1623159181.144,
+        "type": "debug",
+        "category": "started",
+        "level": "info",
+        "message": "Breadcrumb Tracking"
+      },
+      {
+        "timestamp": 1623159181.146,
+        "type": "navigation",
+        "category": "device.orientation",
+        "level": "info",
+        "data": {"position": "portrait"}
+      },
+      {
+        "timestamp": 1623159181.164,
+        "type": "navigation",
+        "category": "device.orientation",
+        "level": "info",
+        "data": {"position": "portrait"}
+      },
+      {
+        "timestamp": 1623159181.164,
+        "type": "navigation",
+        "category": "device.orientation",
+        "level": "info",
+        "data": {"position": "portrait"}
+      },
+      {
+        "timestamp": 1623159181.165,
+        "type": "navigation",
+        "category": "app.lifecycle",
+        "level": "info",
+        "data": {"state": "foreground"}
+      },
+      {
+        "timestamp": 1623159181.181,
+        "type": "navigation",
+        "category": "ui.lifecycle",
+        "level": "info",
+        "data": {"screen": "iOS_Swift.ViewController"}
+      }
+    ]
+  },
+  "breakdowns": {"span_ops": {"total.time": {"value": 1770.999909}}},
+  "contexts": {
+    "app": {
+      "device_app_hash": "2421fae1ac9237a8131e74883e52b0f7034a143f",
+      "build_type": "test",
+      "app_identifier": "io.sentry.sample.iOS-Swift",
+      "app_name": "iOS-Swift",
+      "app_version": "7.1.3",
+      "app_build": "1",
+      "app_id": "3145EA1A-0EAE-3F8C-969A-13A01394D3EA",
+      "type": "app"
+    },
+    "device": {"family": "iOS", "model": "iPad13,2", "type": "device"},
+    "os": {"name": "iOS", "version": "14.5", "type": "os"},
+    "trace": {
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "span_id": "f8480676bfcc4054",
+      "op": "ui.rendering",
+      "status": "ok",
+      "data": {},
+      "start_timestamp": "2021-06-08T13:32:59.397Z",
+      "tags": {},
+      "timestamp": "2021-06-08T13:33:01.181Z",
+      "type": "trace"
+    }
+  },
+  "culprit": "iOS_Swift.ViewController",
+  "environment": "debug",
+  "extra": {"currentViewController": "<iOS_Swift.ViewController: 0x109a19b80>"},
+  "level": "info",
+  "logger": "",
+  "metadata": {},
+  "received": 1627581906.141836,
+  "spans": [
+    {
+      "timestamp": 1627470286.678385,
+      "start_timestamp": 1627470286.170839,
+      "description": "loadView",
+      "op": "ui.rendering",
+      "span_id": "3a357b62c04a4ea1",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.5075462924980586, "offset": 0},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470286.856404,
+      "start_timestamp": 1627470286.678385,
+      "description": "viewDidLoad",
+      "op": "ui.rendering",
+      "span_id": "d6a880e6ea8a487f",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.17801861513010295, "offset": 0.5075462924980586},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.008342,
+      "start_timestamp": 1627470286.856404,
+      "description": "viewWillAppear",
+      "op": "ui.rendering",
+      "span_id": "dec1a2d3281a4024",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.15193771479875243, "offset": 0.6855649076281616},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.334908,
+      "start_timestamp": 1627470287.008342,
+      "description": "viewWillLayoutSubviews",
+      "op": "ui.rendering",
+      "span_id": "2a585c4b845948f4",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.3265664340503061, "offset": 0.837502622426914},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.54576,
+      "start_timestamp": 1627470287.334908,
+      "description": "Warm Start",
+      "op": "app start",
+      "span_id": "7c6fa168c6484737",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.2108517470513121, "offset": 1.16406905647722},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.449167,
+      "start_timestamp": 1627470287.334908,
+      "description": "Pre main",
+      "op": "app start",
+      "span_id": "0e9e0e8adf314828",
+      "parent_span_id": "7c6fa168c6484737",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.11425881401474564, "offset": 1.16406905647722},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.528189,
+      "start_timestamp": 1627470287.449167,
+      "description": "UIKit and Application Init",
+      "op": "app start",
+      "span_id": "c0bcab9b382f4cef",
+      "parent_span_id": "7c6fa168c6484737",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.0790219541156238, "offset": 1.2783278704919656},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.54576,
+      "start_timestamp": 1627470287.528189,
+      "description": "Initial Frame Render",
+      "op": "app start",
+      "span_id": "b640ca2a35e74e08",
+      "parent_span_id": "7c6fa168c6484737",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.017570978920942615, "offset": 1.3573498246075897},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470287.559551,
+      "start_timestamp": 1627470287.54576,
+      "description": "layoutSubViews",
+      "op": "ui.rendering",
+      "span_id": "58221997279344b2",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.013791052931103024, "offset": 1.374920803528532},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470288.078139,
+      "start_timestamp": 1627470287.559551,
+      "description": "viewDidLayoutSubviews",
+      "op": "ui.rendering",
+      "span_id": "ddcceb7115cf404e",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.5185876340005693, "offset": 1.388711856459635},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470288.123004,
+      "start_timestamp": 1627470288.078139,
+      "description": "viewWillLayoutSubviews",
+      "op": "ui.rendering",
+      "span_id": "1eecd595ac1c41cb",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.04486567334362931, "offset": 1.9072994904602043},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470288.415961,
+      "start_timestamp": 1627470288.123004,
+      "description": "layoutSubViews",
+      "op": "ui.rendering",
+      "span_id": "b9ae9c1d401b425e",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.29295699390787355, "offset": 1.9521651638038335},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470288.700872,
+      "start_timestamp": 1627470288.415961,
+      "description": "viewDidLayoutSubviews",
+      "op": "ui.rendering",
+      "span_id": "14d523e595744518",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.284910737108978, "offset": 2.245122157711707},
+      "type": "trace"
+    },
+    {
+      "timestamp": 1627470289.672761,
+      "start_timestamp": 1627470288.700872,
+      "description": "viewDidAppear",
+      "op": "ui.rendering",
+      "span_id": "db28b921dafd4211",
+      "parent_span_id": "f8480676bfcc4054",
+      "trace_id": "9a35bef060494dcaa89ad70fcdaf59d9",
+      "tags": {},
+      "data": {"duration": 0.9718889973454528, "offset": 2.530032894820685},
+      "type": "trace"
+    }
+  ],
+  "start_timestamp": 1627470286.170839,
+  "timestamp": 1627470289.672761,
+  "transaction": "iOS_Swift.ViewController",
+  "type": "transaction",
+  "user": {
+    "id": "2017",
+    "email": "gloria@example.com",
+    "ip_address": "25.151.64.144",
+    "name": "Gloria",
+    "geo": {"country_code": "AU", "city": "Melbourne", "region": "VIC"}
+  },
+  "version": "5"
+}

--- a/src/sentry/data/samples/python-transaction.json
+++ b/src/sentry/data/samples/python-transaction.json
@@ -1,0 +1,124 @@
+{
+  "event_id": "00043830bf0f487392d51c698d42f4f6",
+  "project": 6422,
+  "release": "checkout-app@3.2",
+  "dist": null,
+  "platform": "python",
+  "message": "",
+  "tags": [
+    ["browser", "Chrome 86.0.4240"],
+    ["browser.name", "Chrome"],
+    ["client_os", "Mac OS X 10.11.6"],
+    ["client_os.name", "Mac OS X"],
+    ["environment", "prod"],
+    ["level", "info"],
+    ["os", "Mac OS X 10.15.6"],
+    ["os.name", "Mac OS X"],
+    ["runtime", "CPython 2.7.18"],
+    ["runtime.name", "CPython"],
+    ["release", "checkout-app@3.2"],
+    ["user", "id:4292"],
+    ["transaction", "getProductList"],
+    ["url", "https://app.example.com/products"]
+  ],
+  "_metrics": {"bytes.ingested.event": 3448, "bytes.stored.event": 3591},
+  "contexts": {
+    "browser": {"name": "Chrome", "version": "86.0.4240", "type": "browser"},
+    "client_os": {"name": "Mac OS X", "version": "10.11.6", "type": "os"},
+    "os": {"name": "Mac OS X", "version": "10.15.6", "type": "os"},
+    "runtime": {
+      "name": "CPython",
+      "version": "2.7.18",
+      "build": "2.7.18 (default, Apr 20 2020, 19:34:11) \n[GCC 8.3.0]",
+      "type": "runtime"
+    },
+    "trace": {
+      "trace_id": "10d0b72df0fe4392a6788bce71ec2028",
+      "span_id": "1756e116945a4360",
+      "parent_span_id": "d71f841b69164c33",
+      "op": "http.server",
+      "status": "ok",
+      "type": "trace"
+    }
+  },
+  "culprit": "getProductList",
+  "environment": "prod",
+  "extra": {
+    "inventory": {"hammer": 1, "nails": 1, "wrench": 0},
+    "sys.argv": ["/usr/local/bin/flask", "run", "--host=0.0.0.0", "-p", "8080"]
+  },
+  "level": "info",
+  "logger": "",
+  "metadata": {},
+  "received": 1627581737.872369,
+  "request": {
+    "url": "https://app.example.com/products",
+    "method": "GET",
+    "env": {"SERVER_NAME": "0.0.0.0", "SERVER_PORT": "8080"}
+  },
+  "spans": [
+    {
+      "timestamp": 1627579982.301401,
+      "start_timestamp": 1627579979.397719,
+      "op": "db function: get all products",
+      "span_id": "99bbfb48193a4ddb",
+      "parent_span_id": "1756e116945a4360",
+      "trace_id": "10d0b72df0fe4392a6788bce71ec2028",
+      "data": {"duration": 2.903681993484497, "offset": 0},
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1627579980.383624,
+      "start_timestamp": 1627579979.397719,
+      "op": "connect to db",
+      "span_id": "a3c3c7064e6d4fba",
+      "parent_span_id": "99bbfb48193a4ddb",
+      "trace_id": "10d0b72df0fe4392a6788bce71ec2028",
+      "data": {"duration": 0.9859052112667244, "offset": 0},
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1627579982.059427,
+      "start_timestamp": 1627579980.383624,
+      "op": "run query",
+      "span_id": "65d005a5b31d4614",
+      "parent_span_id": "99bbfb48193a4ddb",
+      "trace_id": "10d0b72df0fe4392a6788bce71ec2028",
+      "data": {"duration": 1.6758032827607312, "offset": 0.9859052112667244},
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1627579982.059427,
+      "start_timestamp": 1627579980.383624,
+      "description": "SELECT * FROM products",
+      "op": "db",
+      "span_id": "b501702695634df2",
+      "parent_span_id": "65d005a5b31d4614",
+      "trace_id": "10d0b72df0fe4392a6788bce71ec2028",
+      "data": {"duration": 1.675803282760731, "offset": 0.9859052112667244},
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1627579982.301401,
+      "start_timestamp": 1627579982.059427,
+      "op": "format results",
+      "span_id": "500c7624ca2c4df6",
+      "parent_span_id": "99bbfb48193a4ddb",
+      "trace_id": "10d0b72df0fe4392a6788bce71ec2028",
+      "data": {"duration": 0.24197349945704172, "offset": 2.6617084940274554},
+      "same_process_as_parent": true
+    }
+  ],
+  "start_timestamp": 1627579979.397719,
+  "timestamp": 1627579982.301401,
+  "transaction": "getProductList",
+  "type": "transaction",
+  "user": {
+    "id": "4292",
+    "email": "selia@example.com",
+    "ip_address": "185.196.94.82",
+    "name": "Selia",
+    "geo": {"country_code": "AU", "city": "Melbourne", "region": "VIC"}
+  },
+  "version": "5"
+}

--- a/tests/sentry/api/endpoints/test_project_create_sample_transaction.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample_transaction.py
@@ -19,7 +19,6 @@ class ProjectCreateSampleTransactionTest(APITestCase):
         response = self.client.post(url, format="json")
 
         assert response.status_code == 200
-        print("keys", response.data)
         assert response.data["title"] == "/productstore"
 
     def test_react(self):

--- a/tests/sentry/api/endpoints/test_project_create_sample_transaction.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample_transaction.py
@@ -9,8 +9,8 @@ class ProjectCreateSampleTransactionTest(APITestCase):
         self.login_as(user=self.user)
         self.team = self.create_team()
 
-    def test_simple(self):
-        project = self.create_project(teams=[self.team], name="foo")
+    def test_no_platform(self):
+        project = self.create_project(teams=[self.team], name="foo", platform=None)
 
         url = reverse(
             "sentry-api-0-project-create-sample-transaction",
@@ -18,4 +18,54 @@ class ProjectCreateSampleTransactionTest(APITestCase):
         )
         response = self.client.post(url, format="json")
 
-        assert response.status_code == 200, response.content
+        assert response.status_code == 200
+        print("keys", response.data)
+        assert response.data["title"] == "/productstore"
+
+    def test_react(self):
+        project = self.create_project(teams=[self.team], name="foo", platform="javascript-react")
+
+        url = reverse(
+            "sentry-api-0-project-create-sample-transaction",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.post(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["title"] == "/productstore"
+
+    def test_django(self):
+        project = self.create_project(teams=[self.team], name="foo", platform="python-django")
+
+        url = reverse(
+            "sentry-api-0-project-create-sample-transaction",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.post(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["title"] == "getProductList"
+
+    def test_ios(self):
+        project = self.create_project(teams=[self.team], name="foo", platform="apple-ios")
+
+        url = reverse(
+            "sentry-api-0-project-create-sample-transaction",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.post(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["title"] == "iOS_Swift.ViewController"
+
+    def test_other_platform(self):
+        project = self.create_project(teams=[self.team], name="foo", platform="other")
+
+        url = reverse(
+            "sentry-api-0-project-create-sample-transaction",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.post(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["title"] == "/productstore"


### PR DESCRIPTION
This PR adds two new sample transactions: one for python and another for IOS.

![Screen Shot 2021-07-29 at 3 31 55 PM](https://user-images.githubusercontent.com/8533851/127576045-833e0897-428e-45d3-82b7-063b81120e71.png)
![Screen Shot 2021-07-29 at 3 37 12 PM](https://user-images.githubusercontent.com/8533851/127576052-8ed613a1-56bc-4924-ab51-408f0fe2dd97.png)


