### PR TITLE
feat(growth): send onboarding events to marketing

### DIFF
--- a/static/app/views/onboarding/components/firstEventIndicator.tsx
+++ b/static/app/views/onboarding/components/firstEventIndicator.tsx
@@ -39,7 +39,8 @@ const FirstEventIndicator = ({children, ...props}: Props) => (
               trackAdvancedAnalyticsEvent(
                 'growth.onboarding_take_to_error',
                 {},
-                props.organization
+                props.organization,
+                {sendMarketing: true}
               )
             }
             to={`/organizations/${props.organization.slug}/issues/${

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -106,7 +106,8 @@ class CreateSampleEventButton extends React.Component<Props, State> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_view_sample_event',
       {platform: project.platform},
-      organization
+      organization,
+      {sendMarketing: true}
     );
 
     addLoadingMessage(t('Processing sample event...'), {

--- a/static/app/views/onboarding/documentationSetup.tsx
+++ b/static/app/views/onboarding/documentationSetup.tsx
@@ -81,7 +81,9 @@ class DocumentationSetup extends React.Component<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization, {
+      sendMarketing: true,
+    });
   };
 
   /**

--- a/static/app/views/onboarding/integrationSetup.tsx
+++ b/static/app/views/onboarding/integrationSetup.tsx
@@ -95,7 +95,9 @@ class IntegrationSetup extends Component<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization, {
+      sendMarketing: true,
+    });
   };
 
   trackSwitchToManual = () => {

--- a/static/app/views/onboarding/otherSetup.tsx
+++ b/static/app/views/onboarding/otherSetup.tsx
@@ -44,7 +44,9 @@ class OtherSetup extends AsyncComponent<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization, {
+      sendMarketing: true,
+    });
   };
 
   render() {

--- a/static/app/views/onboarding/platform.tsx
+++ b/static/app/views/onboarding/platform.tsx
@@ -50,7 +50,8 @@ class OnboardingPlatform extends Component<Props, State> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_load_choose_platform',
       {},
-      this.props.organization ?? null
+      this.props.organization ?? null,
+      {sendMarketing: true}
     );
   }
 
@@ -114,7 +115,8 @@ class OnboardingPlatform extends Component<Props, State> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_set_up_your_project',
       {platform},
-      this.props.organization ?? null
+      this.props.organization ?? null,
+      {sendMarketing: true}
     );
 
     // Create their first project if they don't already have one. This is a

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -43,7 +43,8 @@ class OnboardingWelcome extends Component<Props> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_start_onboarding',
       {},
-      this.props.organization ?? null
+      this.props.organization ?? null,
+      {sendMarketing: true}
     );
   }
 


### PR DESCRIPTION
We want to send onboarding analytics events to Google Analytics