### PR TITLE
chore(performance): Remove Status Breakdown from FE txn summary

### DIFF
--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -35,7 +35,7 @@ import {
   VITAL_GROUPS,
 } from 'app/views/performance/transactionSummary/transactionVitals/constants';
 
-import {isSummaryViewFrontendPageLoad} from '../utils';
+import {isSummaryViewFrontend, isSummaryViewFrontendPageLoad} from '../utils';
 
 import TransactionSummaryCharts from './charts';
 import Filter, {
@@ -240,6 +240,8 @@ class SummaryContent extends React.Component<Props, State> {
           })
         ));
 
+    const isFrontendView = isSummaryViewFrontend(eventView, projects);
+
     const transactionsListTitles = [
       t('event id'),
       t('user'),
@@ -419,11 +421,13 @@ class SummaryContent extends React.Component<Props, State> {
               transactionName={transactionName}
               eventView={eventView}
             />
-            <StatusBreakdown
-              eventView={eventView}
-              organization={organization}
-              location={location}
-            />
+            {!isFrontendView && (
+              <StatusBreakdown
+                eventView={eventView}
+                organization={organization}
+                location={location}
+              />
+            )}
             <SidebarSpacer />
             <SidebarCharts
               organization={organization}

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -85,6 +85,15 @@ export function isSummaryViewFrontendPageLoad(eventView: EventView, projects: Pr
   );
 }
 
+export function isSummaryViewFrontend(eventView: EventView, projects: Project[]) {
+  return (
+    platformAndConditionsToPerformanceType(projects, eventView) ===
+      PROJECT_PERFORMANCE_TYPE.FRONTEND ||
+    platformAndConditionsToPerformanceType(projects, eventView) ===
+      PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER
+  );
+}
+
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
   return `/organizations/${organization.slug}/performance/`;
 }


### PR DESCRIPTION
Removed Status Breakdown from Frontend Transaction Summary
since it only reports "unknown" and "cancelled" statuses
which may not be useful to the user.