### PR TITLE
fix(grouping): Also apply prefix for level 1

### DIFF
--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -176,16 +176,24 @@ def _accumulate_frame_levels(values, blaming_frame_idx, depth, direction):
     # subtract depth by one to count blaming frame
     depth -= 1
 
-    idx = blaming_frame_idx + direction
-    while 0 <= idx < len(values) and depth > 0:
-        component = values[idx]
-        idx += direction
+    start = blaming_frame_idx + direction
+    if start < 0:
+        return rv
 
+    added = 0
+    prev_was_prefix = values[blaming_frame_idx].is_prefix_frame
+    for component in values[start:None:direction]:
         if not component.contributes:
             continue
 
-        rv.append(component)
-        if not component.is_prefix_frame:
-            depth -= 1
+        if prev_was_prefix:
+            rv.append(component)
+        else:
+            if added == depth:
+                break
+            rv.append(component)
+            added += 1
+
+        prev_was_prefix = component.is_prefix_frame
 
     return rv

--- a/tests/sentry/grouping/grouping_inputs/fallback-prefix-level-1.json
+++ b/tests/sentry/grouping/grouping_inputs/fallback-prefix-level-1.json
@@ -1,0 +1,47 @@
+{
+    "platform": "cocoa",
+    "exception": {
+        "values": [
+            {
+                "type": "EXC_BAD_ACCESS",
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "function": "start",
+                            "symbol": "start",
+                            "package": "libdyld.dylib",
+                            "in_app": false
+                        },
+                        {
+                            "function": "stripped_application_code"
+                        },
+                        {
+                            "function": "UIApplicationMain",
+                            "symbol": "UIApplicationMain",
+                            "package": "UIKitCore",
+                            "in_app": false
+                        },
+                        {
+                            "function": "-[UIApplication _run]",
+                            "symbol": "-[UIApplication _run]",
+                            "package": "UIKitCore",
+                            "in_app": false
+                        },
+                        {
+                            "function": "GSEventRunModal",
+                            "symbol": "GSEventRunModal",
+                            "package": "GraphicsServices",
+                            "in_app": false
+                        },
+                        {
+                            "function": "objc_release",
+                            "symbol": "objc_release",
+                            "package": "libobjc.A.dylib",
+                            "in_app": false
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/fallback_prefix_level_1.pysnap
@@ -1,0 +1,11 @@
+---
+created: '2021-07-30T14:36:17.078158Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","-[UIApplication _run]"]],[["function","GSEventRunModal"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","GSEventRunModal"]],[["function","objc_release"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","UIApplicationMain"]],[["function","-[UIApplication _run]"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","start"]],[["function","stripped_application_code"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","stripped_application_code"]],[["function","UIApplicationMain"]]]
+similarity:2020-07-23:type:ident-shingle: "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/fallback_prefix_level_1.pysnap
@@ -1,0 +1,78 @@
+---
+created: '2021-07-30T14:13:50.908037Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because hash matches system variant)
+        stacktrace
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "start"
+            function (function name is not used if module or filename are available)
+              "start"
+          frame (frame considered in-app because no frame is in-app)
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "UIApplicationMain"
+            function (function name is not used if module or filename are available)
+              "UIApplicationMain"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "-[UIApplication _run]"
+            function (function name is not used if module or filename are available)
+              "-[UIApplication _run]"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "GSEventRunModal"
+            function (function name is not used if module or filename are available)
+              "GSEventRunModal"
+          frame (frame considered in-app because no frame is in-app)
+            symbol (symbol is not used if module or filename are available)
+              "objc_release"
+            function (function name is not used if module or filename are available)
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "b0d6c60d82e250da178402493260c2f2"
+  component:
+    system*
+      exception*
+        stacktrace
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "start"
+            function (function name is not used if module or filename are available)
+              "start"
+          frame
+            function (function name is not used if module or filename are available)
+              "stripped_application_code"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "UIApplicationMain"
+            function (function name is not used if module or filename are available)
+              "UIApplicationMain"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "-[UIApplication _run]"
+            function (function name is not used if module or filename are available)
+              "-[UIApplication _run]"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "GSEventRunModal"
+            function (function name is not used if module or filename are available)
+              "GSEventRunModal"
+          frame
+            symbol (symbol is not used if module or filename are available)
+              "objc_release"
+            function (function name is not used if module or filename are available)
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/fallback_prefix_level_1.pysnap
@@ -1,0 +1,76 @@
+---
+created: '2021-07-30T14:13:52.088912Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-1:
+  hash: "87497299851e09febfecf4e84e0d45ba"
+  tree_label: "objc_release | -[UIApplication _run]"
+  component:
+    app-depth-1*
+      exception*
+        stacktrace*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication _run]"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+app-depth-max:
+  hash: "87497299851e09febfecf4e84e0d45ba"
+  tree_label: "objc_release | -[UIApplication _run]"
+  component:
+    app-depth-max*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "UIApplicationMain"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication _run]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "GSEventRunModal"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "87497299851e09febfecf4e84e0d45ba"
+  tree_label: "objc_release | -[UIApplication _run]"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "start"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "stripped_application_code"
+          frame (ignored by stack trace rule (category:threadbase -group v-group))
+            function*
+              "UIApplicationMain"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication _run]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "GSEventRunModal"
+          frame* (marked as prefix frame by stack trace rule (category:free +prefix))
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/fallback_prefix_level_1.pysnap
@@ -1,0 +1,58 @@
+---
+created: '2021-07-30T14:13:53.586018Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "b85897bf204fd8e90ff495b47502f281"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/fallback_prefix_level_1.pysnap
@@ -1,0 +1,58 @@
+---
+created: '2021-07-30T14:13:54.082575Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "b85897bf204fd8e90ff495b47502f281"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/fallback_prefix_level_1.pysnap
@@ -1,0 +1,58 @@
+---
+created: '2021-07-30T14:13:51.282688Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "b85897bf204fd8e90ff495b47502f281"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/fallback_prefix_level_1.pysnap
@@ -1,0 +1,58 @@
+---
+created: '2021-07-30T14:13:52.212124Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "b85897bf204fd8e90ff495b47502f281"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/fallback_prefix_level_1.pysnap
@@ -1,0 +1,58 @@
+---
+created: '2021-07-30T14:13:55.020183Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app (exception of system takes precedence)
+      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
+        stacktrace
+          frame (non app frame)
+            function*
+              "start"
+          frame (non app frame)
+            function*
+              "stripped_application_code"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"
+--------------------------------------------------------------------------
+system:
+  hash: "b85897bf204fd8e90ff495b47502f281"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "stripped_application_code"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "objc_release"
+        type*
+          "EXC_BAD_ACCESS"


### PR DESCRIPTION
Change fallback tree for hierarchical grouping such that prefix frames are considered also for `app-depth-1`, and not just for higher levels.