### PR TITLE
fix(chart-unfurl): Resolve My Projects from User ID

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -46,12 +46,11 @@ def unfurl_discover(data, integration, links: List[UnfurlableUrl]) -> UnfurledUr
         query_id = params.get("id", None)
         user_id = params.get("user", None)
 
-        projects = [
-            f"{project_id}"
-            for project_id in Project.objects.filter(
+        projects = list(
+            Project.objects.filter(
                 organization=org, teams__organizationmember__user_id=user_id
             ).values_list("id", flat=True)
-        ]
+        )
 
         saved_query = {}
         if query_id:

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -46,7 +46,11 @@ def unfurl_discover(data, integration, links: List[UnfurlableUrl]) -> UnfurledUr
         query_id = params.get("id", None)
 
         user_id = params.get("user", None)
-        user = User.objects.get(id=user_id) if user_id else None
+        user = (
+            User.objects.get(id=user_id, sentry_orgmember_set__organization=org)
+            if user_id
+            else None
+        )
 
         saved_query = {}
         if query_id:
@@ -79,10 +83,7 @@ def unfurl_discover(data, integration, links: List[UnfurlableUrl]) -> UnfurledUr
         params.setlist("field", params.getlist("field") or to_list(saved_query.get("fields")))
 
         params.setlist(
-            "project",
-            params.getlist("project") or to_list(saved_query.get("project"))
-            if saved_query.get("project")
-            else [],
+            "project", params.getlist("project") or to_list(saved_query.get("project") or [])
         )
 
         # Only override if key doesn't exist since we want to account for

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -72,9 +72,8 @@ def unfurl_discover(data, integration, links: List[UnfurlableUrl]) -> UnfurledUr
         # Override params from Discover Saved Query if they aren't in the URL
         params.setlist(
             "order",
-            params.getlist("sort") or to_list(saved_query.get("orderby"))
-            if saved_query.get("orderby")
-            else [],
+            params.getlist("sort")
+            or (to_list(saved_query.get("orderby")) if saved_query.get("orderby") else []),
         )
         params.setlist("name", params.getlist("name") or to_list(saved_query.get("name")))
         params.setlist(
@@ -83,7 +82,9 @@ def unfurl_discover(data, integration, links: List[UnfurlableUrl]) -> UnfurledUr
         params.setlist("field", params.getlist("field") or to_list(saved_query.get("fields")))
 
         params.setlist(
-            "project", params.getlist("project") or to_list(saved_query.get("project") or [])
+            "project",
+            params.getlist("project")
+            or (to_list(saved_query.get("project")) if saved_query.get("project") else []),
         )
 
         # Only override if key doesn't exist since we want to account for

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -79,7 +79,10 @@ def unfurl_discover(data, integration, links: List[UnfurlableUrl]) -> UnfurledUr
         params.setlist("field", params.getlist("field") or to_list(saved_query.get("fields")))
 
         params.setlist(
-            "project", params.getlist("project") or to_list(saved_query.get("project") or [])
+            "project",
+            params.getlist("project") or to_list(saved_query.get("project"))
+            if saved_query.get("project")
+            else [],
         )
 
         # Only override if key doesn't exist since we want to account for


### PR DESCRIPTION
Add user ID to query string params to resolve
My Projects.
Test:
`https://sentry.io/organizations/org_slug/discover/results/?id=2&statsPeriod=24h&user=1`

Discover Chart
![Screen Shot 2021-07-30 at 1 38 42 PM](https://user-images.githubusercontent.com/63818634/127691275-5c8113f8-4309-4cc7-aca2-a5e00c7888fc.png)

Resulting chart png:
![Screen Shot 2021-07-30 at 1 38 11 PM](https://user-images.githubusercontent.com/63818634/127691291-96d78d71-930a-48fb-ba9f-2f576b4ae4c9.png)
