### PR TITLE
feat(discover): Add User ID to discover urls

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -13,6 +13,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import {DEFAULT_PER_PAGE} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
+import ConfigStore from 'app/stores/configStore';
 import {GlobalSelection, NewQuery, SavedQuery, SelectValue, User} from 'app/types';
 import {
   aggregateOutputType,
@@ -1109,14 +1110,16 @@ class EventView {
   }
 
   getResultsViewUrlTarget(slug: string): {pathname: string; query: Query} {
+    const user = ConfigStore.get('user');
     return {
       pathname: `/organizations/${slug}/discover/results/`,
-      query: this.generateQueryStringObject(),
+      query: {...this.generateQueryStringObject(), user: user.id},
     };
   }
 
   getResultsViewShortUrlTarget(slug: string): {pathname: string; query: Query} {
-    const output = {id: this.id};
+    const user = ConfigStore.get('user');
+    const output = {id: this.id, user: user.id};
     for (const field of [...Object.values(URL_PARAM), 'cursor']) {
       if (this[field] && this[field].length) {
         output[field] = this[field];

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -617,6 +617,7 @@ class EventView {
   }
 
   generateQueryStringObject(): Query {
+    const user = ConfigStore.get('user');
     const output = {
       id: this.id,
       name: this.name,
@@ -629,6 +630,7 @@ class EventView {
       yAxis: this.yAxis,
       display: this.display,
       interval: this.interval,
+      user: user.id,
     };
 
     for (const field of EXTERNAL_QUERY_STRING_KEYS) {
@@ -1110,10 +1112,9 @@ class EventView {
   }
 
   getResultsViewUrlTarget(slug: string): {pathname: string; query: Query} {
-    const user = ConfigStore.get('user');
     return {
       pathname: `/organizations/${slug}/discover/results/`,
-      query: {...this.generateQueryStringObject(), user: user.id},
+      query: {...this.generateQueryStringObject()},
     };
   }
 

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1114,7 +1114,7 @@ class EventView {
   getResultsViewUrlTarget(slug: string): {pathname: string; query: Query} {
     return {
       pathname: `/organizations/${slug}/discover/results/`,
-      query: {...this.generateQueryStringObject()},
+      query: this.generateQueryStringObject(),
     };
   }
 

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -23,6 +23,7 @@ import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {MAX_QUERY_LENGTH} from 'app/constants';
 import {IconFlag} from 'app/icons';
 import {t, tct} from 'app/locale';
+import ConfigStore from 'app/stores/configStore';
 import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization, SavedQuery} from 'app/types';
@@ -550,6 +551,17 @@ function ResultsContainer(props: Props) {
    * you no longer need to enforce a project if it is empty. We assume an empty project is
    * the desired behavior because saved queries can contain a project filter.
    */
+
+  const {location, router} = props;
+  const user = ConfigStore.get('user');
+
+  if (user.id !== location.query.user) {
+    router.push({
+      pathname: location.pathname,
+      query: {...location.query, user: user.id},
+    });
+  }
+
   return (
     <GlobalSelectionHeader
       skipLoadLastUsed={props.organization.features.includes('global-views')}

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -889,6 +889,7 @@ describe('EventView.generateQueryStringObject()', function () {
       project: [],
       environment: [],
       display: 'previous',
+      user: '1',
     };
 
     expect(eventView.generateQueryStringObject()).toEqual(expected);
@@ -931,6 +932,7 @@ describe('EventView.generateQueryStringObject()', function () {
       yAxis: 'count()',
       display: 'releases',
       interval: '1m',
+      user: '1',
     };
 
     expect(eventView.generateQueryStringObject()).toEqual(expected);

--- a/tests/js/spec/views/eventsV2/queryList.spec.jsx
+++ b/tests/js/spec/views/eventsV2/queryList.spec.jsx
@@ -159,6 +159,7 @@ describe('EventsV2 > QueryList', function () {
     expect(link.query).toEqual({
       id: '2',
       statsPeriod: '14d',
+      user: '1',
     });
   });
 

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -196,6 +196,52 @@ describe('EventsV2 > Results', function () {
     expect(eventResultsMock).toHaveBeenCalled();
   });
 
+  it('pushes to router when user id is wrong', async function () {
+    const organization = TestStubs.Organization({
+      features,
+      projects: [TestStubs.Project()],
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {...generateFields(), cursor: '0%3A50%3A0', user: '2'}},
+      },
+    });
+
+    ProjectsStore.loadInitialData(initialData.organization.projects);
+
+    const wrapper = mountWithTheme(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      initialData.routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(initialData.router.location).toEqual({
+      query: {
+        ...generateFields(),
+        cursor: '0%3A50%3A0',
+        user: '2',
+      },
+    });
+
+    expect(initialData.router.push).toHaveBeenCalledWith({
+      pathname: undefined,
+      query: {
+        ...generateFields(),
+        cursor: '0%3A50%3A0',
+        user: '1',
+      },
+    });
+    wrapper.unmount();
+  });
+
   it('pagination cursor should be cleared when making a search', async function () {
     const organization = TestStubs.Organization({
       features,

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -222,6 +222,7 @@ describe('pushEventViewToLocation', function () {
   const location = {
     query: {
       bestCountry: 'canada',
+      user: '1',
     },
   };
 
@@ -246,6 +247,7 @@ describe('pushEventViewToLocation', function () {
         end: '2019-10-02T00:00:00',
         statsPeriod: '14d',
         environment: ['staging'],
+        user: '1',
       },
     });
   });
@@ -275,6 +277,7 @@ describe('pushEventViewToLocation', function () {
         statsPeriod: '14d',
         environment: ['staging'],
         cursor: 'some cursor',
+        user: '1',
       },
     });
   });

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -151,6 +151,7 @@ describe('Release Issues', function () {
         display: undefined,
         interval: undefined,
         statsPeriod: props.selection.datetime.period,
+        user: '1',
       },
     });
 


### PR DESCRIPTION
Add User ID to Discover chart links. This will allow
us to resolve project ids during chart unfurl with
my projects.