### PR TITLE
feat(codeowners): Support multiple CODEOWNERS per project

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -154,7 +154,7 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectC
         expand = request.GET.getlist("expand", [])
         expand.append("errors")
 
-        codeowners = list(ProjectCodeOwners.objects.filter(project=project))
+        codeowners = list(ProjectCodeOwners.objects.filter(project=project).order_by("-date_added"))
 
         return Response(
             serialize(

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -188,14 +188,6 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectC
             data={**request.data},
         )
 
-        # TODO(nisanthan): Revisit for supporting multiple CODEOWNERS.
-        # For now we will prevent adding multiple CODEOWNERS for a project.
-        if ProjectCodeOwners.objects.filter(project=project).exists():
-            return Response(
-                data={"details": "There exists a CODEOWNERS file for this project."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
         if serializer.is_valid():
             project_codeowners = serializer.save()
             self.track_response_code("create", status.HTTP_201_CREATED)

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -47,16 +47,13 @@ class ProjectCodeOwners(DefaultFieldsModel):
         don't have CODEOWNERS.
         """
         cache_key = self.get_cache_key(project_id)
-        codeowners = cache.get(cache_key)
-        if codeowners is None:
-            # TODO(nisanthan): Revisit for supporting multiple CODEOWNERS.
-            # For now we support the first CODEOWNERS uploaded.
-            codeowners = (
-                self.objects.filter(project_id=project_id).order_by("-date_added").first() or False
-            )
+        code_owners = cache.get(cache_key)
+        if code_owners is None:
+            query = self.objects.filter(project_id=project_id).order_by("-date_added") or False
+            code_owners = self.merge_code_owners_list(codeowners_list=query) if query else query
+            cache.set(cache_key, code_owners, READ_CACHE_DURATION)
 
-            cache.set(cache_key, codeowners, READ_CACHE_DURATION)
-        return codeowners or None
+        return code_owners or None
 
     @classmethod
     def validate_codeowners_associations(self, codeowners, project):
@@ -109,6 +106,24 @@ class ProjectCodeOwners(DefaultFieldsModel):
             "teams_without_access": teams_without_access,
         }
         return associations, errors
+
+    @classmethod
+    def merge_code_owners_list(self, code_owners_list):
+        """
+        Merge list of code_owners into a single code_owners object concating all the rules. We assume schema version is constant.
+        """
+        merged_code_owners = None
+        for code_owners in code_owners_list:
+            if code_owners.schema:
+                if merged_code_owners is None:
+                    merged_code_owners = code_owners
+                    continue
+                merged_code_owners.schema["rules"] = [
+                    *merged_code_owners.schema["rules"],
+                    *code_owners.schema["rules"],
+                ]
+
+        return merged_code_owners
 
     def update_schema(self):
         """

--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -50,7 +50,7 @@ class ProjectCodeOwners(DefaultFieldsModel):
         code_owners = cache.get(cache_key)
         if code_owners is None:
             query = self.objects.filter(project_id=project_id).order_by("-date_added") or False
-            code_owners = self.merge_code_owners_list(codeowners_list=query) if query else query
+            code_owners = self.merge_code_owners_list(code_owners_list=query) if query else query
             cache.set(cache_key, code_owners, READ_CACHE_DURATION)
 
         return code_owners or None

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -113,7 +113,7 @@ tags.sku_class:enterprise #enterprise`;
 
   handleCodeOwnerAdded = (data: CodeOwner) => {
     const {codeowners} = this.state;
-    const newCodeowners = (codeowners || []).concat(data);
+    const newCodeowners = [data, ...(codeowners || [])];
     this.setState({codeowners: newCodeowners});
   };
 

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -238,8 +238,6 @@ tags.sku_class:enterprise #enterprise`;
                   size="small"
                   priority="primary"
                   data-test-id="add-codeowner-button"
-                  // TODO(nisanthan): Remove disabled logic when implementing support for multiple CODEOWNERS
-                  disabled={codeowners && codeowners.length > 0}
                 >
                   {t('Add CODEOWNERS File')}
                 </CodeOwnerButton>

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -234,7 +234,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             assert response.status_code == 201, response.content
             response = self.client.post(self.url, self.data)
             assert response.status_code == 400
-            assert response.data == {"details": "There exists a CODEOWNERS file for this project."}
+            assert response.data == {"codeMappingId": ["This code mapping is already in use."]}
 
     def test_schema_is_correct(self):
         with self.feature({"organizations:integrations-codeowners": True}):
@@ -321,5 +321,4 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         self.create_codeowners(code_mapping=code_mapping_2)
         with self.feature({"organizations:integrations-codeowners": True}):
             response = self.client.post(self.url, self.data)
-        assert response.status_code == 400
-        assert response.data == {"details": "There exists a CODEOWNERS file for this project."}
+        assert response.status_code == 201

--- a/tests/sentry/models/test_projectcodeowners.py
+++ b/tests/sentry/models/test_projectcodeowners.py
@@ -1,0 +1,95 @@
+from sentry.models import Integration, ProjectCodeOwners
+from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
+from sentry.testutils import TestCase
+from sentry.utils.cache import cache
+
+
+class ProjectCodeOwnersTestCase(TestCase):
+    def tearDown(self):
+        cache.delete(ProjectCodeOwners.get_cache_key(self.project.id))
+
+        super().tearDown()
+
+    def setUp(self):
+        self.login_as(user=self.user)
+        self.integration = Integration.objects.create(
+            provider="github", name="GitHub", external_id="github:1"
+        )
+        self.oi = self.integration.add_organization(self.organization, self.user)
+
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+
+        self.project = self.project = self.create_project(
+            organization=self.organization, teams=[self.team], slug="bengal"
+        )
+        self.code_mapping = self.create_code_mapping(
+            project=self.project,
+            organization_integration=self.oi,
+        )
+
+        self.external_team = self.create_external_team(integration=self.integration)
+        self.external_user = self.create_external_user(
+            self.user,
+            self.organization,
+            integration=self.integration,
+            external_name="@NisanthanNanthakumar",
+        )
+
+        self.data = {
+            "raw": "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem\n",
+        }
+
+    def test_merge_codeowners(self):
+        self.code_mapping_2 = self.create_code_mapping(
+            project=self.project,
+            organization_integration=self.oi,
+            stack_root="stack/root/",
+        )
+
+        code_owners_1_rule = Rule(
+            Matcher("codeowners", "docs/*"),
+            [Owner("user", self.user.email), Owner("team", self.team.slug)],
+        )
+        code_owners_2_rule = Rule(
+            Matcher("codeowners", "stack/root/docs/*"),
+            [Owner("user", self.user.email), Owner("team", self.team.slug)],
+        )
+
+        self.code_owners = self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw=self.data["raw"],
+            schema=dump_schema([code_owners_1_rule]),
+        )
+
+        self.code_owners_2 = self.create_codeowners(
+            self.project,
+            self.code_mapping_2,
+            raw=self.data["raw"],
+            schema=dump_schema([code_owners_2_rule]),
+        )
+
+        code_owners = ProjectCodeOwners.objects.filter(project=self.project)
+        merged = ProjectCodeOwners.merge_code_owners_list(code_owners_list=code_owners)
+
+        assert merged.schema == {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"type": "codeowners", "pattern": "docs/*"},
+                    "owners": [
+                        {"type": "user", "identifier": "admin@localhost"},
+                        {"type": "team", "identifier": "tiger-team"},
+                    ],
+                },
+                {
+                    "matcher": {"type": "codeowners", "pattern": "stack/root/docs/*"},
+                    "owners": [
+                        {"type": "user", "identifier": "admin@localhost"},
+                        {"type": "team", "identifier": "tiger-team"},
+                    ],
+                },
+            ],
+        }


### PR DESCRIPTION
## Objective:
We want to support multiple Code Owners per project. We will order by `date_added` DESC during evaluation for auto-assignment. 

Rather than refactoring all logic to evaluate an array of CodeOwners, we will merge the rules into 1 object's schema. We are making the assumption that the schema $version will stay constant at `1`. If that assumption changes, we will need to refactor the `merge_code_owners_list` method.

This PR also removes logic added in https://github.com/getsentry/sentry/pull/27808 for the POST endpoint and UI to prevent multiple CODEOWNER uploads per project.

## Tests:
Tests were added for the `merge_code_owners_list` method.