### PR TITLE
fix(grouping): Fix broken featureflagging

### DIFF
--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -37,6 +37,9 @@ function EventOrGroupTitle({
   const groupingCurrentLevel = (data as BaseGroup).metadata?.current_level;
 
   const hasGroupingTreeUI = !!organization?.features.includes('grouping-tree-ui');
+  const hasGroupingStacktraceUI = !!organization?.features.includes(
+    'grouping-stacktrace-ui'
+  );
   const {id, eventID, groupID, projectID} = event;
 
   const {title, subtitle, treeLabel} = getTitle(event, organization?.features);
@@ -53,9 +56,13 @@ function EventOrGroupTitle({
           eventId={eventID}
           projectSlug={eventID ? ProjectsStore.getById(projectID)?.slug : undefined}
           disablePreview={!withStackTracePreview}
-          hasGroupingTreeUI={hasGroupingTreeUI}
+          hasGroupingStacktraceUI={hasGroupingStacktraceUI}
         >
-          {treeLabel ? <EventTitleTreeLabel treeLabel={treeLabel} /> : title}
+          {treeLabel && hasGroupingTreeUI ? (
+            <EventTitleTreeLabel treeLabel={treeLabel} />
+          ) : (
+            title
+          )}
         </StyledStacktracePreview>
       </GuideAnchor>
       {subtitle && (
@@ -83,9 +90,11 @@ const Subtitle = styled('em')`
   font-style: normal;
 `;
 
-const StyledStacktracePreview = styled(StacktracePreview)<{hasGroupingTreeUI: boolean}>`
+const StyledStacktracePreview = styled(StacktracePreview)<{
+  hasGroupingStacktraceUI: boolean;
+}>`
   ${p =>
-    p.hasGroupingTreeUI &&
+    p.hasGroupingStacktraceUI &&
     `
       display: inline-flex;
       > span:first-child {

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -69,7 +69,9 @@ export function getTreeLabelPartDetails(part: TreeLabelPart) {
 
 function computeTitleWithTreeLabel(metadata: EventMetadata, features: string[] = []) {
   const {type, current_tree_label, finest_tree_label} = metadata;
-  const treeLabel = features.includes('grouping-tree-ui') ? (current_tree_label || finest_tree_label) : undefined;
+  const treeLabel = features.includes('grouping-tree-ui')
+    ? current_tree_label || finest_tree_label
+    : undefined;
   const formattedTreeLabel = treeLabel
     ? treeLabel.map(labelPart => getTreeLabelPartDetails(labelPart).label).join(' | ')
     : undefined;

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -67,9 +67,9 @@ export function getTreeLabelPartDetails(part: TreeLabelPart) {
   };
 }
 
-function computeTitleWithTreeLabel(metadata: EventMetadata) {
+function computeTitleWithTreeLabel(metadata: EventMetadata, features: string[] = []) {
   const {type, current_tree_label, finest_tree_label} = metadata;
-  const treeLabel = current_tree_label || finest_tree_label;
+  const treeLabel = features.includes('grouping-tree-ui') ? (current_tree_label || finest_tree_label) : undefined;
   const formattedTreeLabel = treeLabel
     ? treeLabel.map(labelPart => getTreeLabelPartDetails(labelPart).label).join(' | ')
     : undefined;
@@ -111,7 +111,7 @@ export function getTitle(event: Event | BaseGroup, features: string[] = []) {
 
       return {
         subtitle: culprit,
-        ...computeTitleWithTreeLabel(metadata),
+        ...computeTitleWithTreeLabel(metadata, features),
       };
     }
     case EventOrGroupType.CSP:


### PR DESCRIPTION
Group titles are a bit buggy and we want to avoid showing them if the
grouping-tree-ui featureflag is disabled.

Stacktrace rendering was attached to the wrong featureflag