### PR TITLE
ref(integrations): Handle missing default identity

### DIFF
--- a/src/sentry/integrations/jira_server/webhooks.py
+++ b/src/sentry/integrations/jira_server/webhooks.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry.api.base import Endpoint
@@ -62,7 +63,7 @@ class JiraIssueUpdatedWebhook(Endpoint):
         try:
             handle_assignee_change(integration, data)
             handle_status_change(integration, data)
-        except ApiError as err:
+        except (ApiError, ObjectDoesNotExist) as err:
             logger.info("sync-failed", extra={"token": token, "error": str(err)})
             return self.respond(status=400)
         else:

--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -2,6 +2,8 @@ import logging
 from datetime import timedelta
 from time import time
 
+from django.core.exceptions import ObjectDoesNotExist
+
 from sentry import analytics, features
 from sentry.models import (
     Activity,
@@ -331,7 +333,10 @@ def kickoff_vsts_subscription_check():
 def vsts_subscription_check(integration_id, organization_id, **kwargs):
     integration = Integration.objects.get(id=integration_id)
     installation = integration.get_installation(organization_id=organization_id)
-    client = installation.get_client()
+    try:
+        client = installation.get_client()
+    except ObjectDoesNotExist:
+        return
 
     try:
         subscription_id = integration.metadata["subscription"]["id"]

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -19,6 +19,9 @@ from .testutils import EXAMPLE_PRIVATE_KEY
 
 
 class JiraServerWebhookEndpointTest(APITestCase):
+    endpoint = "sentry-extensions-jiraserver-issue-updated"
+    method = "post"
+
     @fixture
     def integration(self):
         integration = Integration.objects.create(
@@ -86,10 +89,7 @@ class JiraServerWebhookEndpointTest(APITestCase):
             },
             "issue": {"project": {"key": "APP", "id": "10000"}, "key": "APP-1"},
         }
-        token = self.jwt_token
-        path = reverse("sentry-extensions-jiraserver-issue-updated", args=[token])
-        resp = self.client.post(path, data=payload)
-        assert resp.status_code == 400
+        self.get_error_response(self.jwt_token, **payload, status_code=400)
 
     def test_post_token_missing_id(self):
         integration = self.integration

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -106,5 +106,5 @@ class VstsSubscriptionCheckTest(TestCase):
             "subscription"
         ]
         assert subscription["id"] == "subscription1"
-        assert not subscription.get("check", None)
-        assert not subscription.get("secret", None)
+        assert "check" not in subscription
+        assert "secret" not in subscription

--- a/tests/sentry/tasks/test_integrations.py
+++ b/tests/sentry/tasks/test_integrations.py
@@ -85,3 +85,26 @@ class VstsSubscriptionCheckTest(TestCase):
         ]
         self.assert_subscription(subscription3, "subscription3")
         assert integration3_check_time == subscription3["check"]
+
+    @responses.activate
+    def test_kickoff_subscription_no_default_identity(self):
+        integration = Integration.objects.create(
+            provider="vsts",
+            name="vsts1",
+            external_id="vsts1",
+            metadata={
+                "domain_name": "https://vsts1.visualstudio.com/",
+                "subscription": {"id": "subscription1"},
+            },
+        )
+        integration.add_organization(self.organization, default_auth_id=None)
+
+        with self.tasks():
+            kickoff_vsts_subscription_check()
+
+        subscription = Integration.objects.get(provider="vsts", external_id="vsts1").metadata[
+            "subscription"
+        ]
+        assert subscription["id"] == "subscription1"
+        assert not subscription.get("check", None)
+        assert not subscription.get("secret", None)


### PR DESCRIPTION
Handle missing default identity errors and don't report them to Sentry. We have a huge number of events for these.

Fixes [SENTRY-RT4](https://sentry.io/organizations/sentry/issues/2545058125/?project=1&referrer=slack), [SENTRY-RTT](https://sentry.io/organizations/sentry/issues/2546924160/?project=1&referrer=slack), [SENTRY-N33](https://sentry.io/organizations/sentry/issues/2200343254/?project=1&query=is%3Aignored+Identity+matching+query+does+not+exist.&statsPeriod=14d), and [SENTRY-954](https://sentry.io/organizations/sentry/issues/854536313/?project=1&query=is%3Aignored+doesnotexist&statsPeriod=14d)