### PR TITLE
perf(auditlogs): replace attach_foreign_key with prefetch_related_objs

### DIFF
--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -1,6 +1,7 @@
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import AuditLogEntry
-from sentry.utils.db import attach_foreignkey
 
 
 def fix(data):
@@ -18,8 +19,8 @@ def fix(data):
 class AuditLogEntrySerializer(Serializer):
     def get_attrs(self, item_list, user):
         # TODO(dcramer); assert on relations
-        attach_foreignkey(item_list, AuditLogEntry.actor)
-        attach_foreignkey(item_list, AuditLogEntry.target_user)
+        prefetch_related_objects(item_list, "actor")
+        prefetch_related_objects(item_list, "target_user")
 
         users = {
             d["id"]: d


### PR DESCRIPTION
- confirmed it replaces N+1 queries pattern with a single SQL `SELECT` that uses a `WHERE IN ...` clause