### PR TITLE
feat(growth): remove sendMarketing option

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -272,10 +272,6 @@ type AnalyticsTrackEventV2 = (
   },
   options?: {
     /**
-     * If true, send the event to marketing analytics
-     */
-    sendMarketing?: boolean;
-    /**
      * If true, starts an analytics session. This session can be used
      * to construct funnels. The start of the funnel should have
      * startSession set to true.

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -26,7 +26,6 @@ import {Hooks} from 'app/types/hooks';
  * This should be with all analytics events regardless of the analytics destination
  * which includes Reload, Amplitude, and Google Analytics.
  * All events go to Reload. If eventName is defined, events also go to Amplitude.
- * If the sendMarketing option is true, we also send to Google Analytics.
  * For more details, refer to the API defined in hooks.
  */
 export const trackAnalyticsEventV2: Hooks['analytics:track-event-v2'] = (data, options) =>

--- a/static/app/views/onboarding/components/firstEventIndicator.tsx
+++ b/static/app/views/onboarding/components/firstEventIndicator.tsx
@@ -39,8 +39,7 @@ const FirstEventIndicator = ({children, ...props}: Props) => (
               trackAdvancedAnalyticsEvent(
                 'growth.onboarding_take_to_error',
                 {},
-                props.organization,
-                {sendMarketing: true}
+                props.organization
               )
             }
             to={`/organizations/${props.organization.slug}/issues/${

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -106,8 +106,7 @@ class CreateSampleEventButton extends React.Component<Props, State> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_view_sample_event',
       {platform: project.platform},
-      organization,
-      {sendMarketing: true}
+      organization
     );
 
     addLoadingMessage(t('Processing sample event...'), {

--- a/static/app/views/onboarding/documentationSetup.tsx
+++ b/static/app/views/onboarding/documentationSetup.tsx
@@ -81,9 +81,7 @@ class DocumentationSetup extends React.Component<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization, {
-      sendMarketing: true,
-    });
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
   };
 
   /**

--- a/static/app/views/onboarding/integrationSetup.tsx
+++ b/static/app/views/onboarding/integrationSetup.tsx
@@ -95,9 +95,7 @@ class IntegrationSetup extends Component<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization, {
-      sendMarketing: true,
-    });
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
   };
 
   trackSwitchToManual = () => {

--- a/static/app/views/onboarding/otherSetup.tsx
+++ b/static/app/views/onboarding/otherSetup.tsx
@@ -44,9 +44,7 @@ class OtherSetup extends AsyncComponent<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization, {
-      sendMarketing: true,
-    });
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
   };
 
   render() {

--- a/static/app/views/onboarding/platform.tsx
+++ b/static/app/views/onboarding/platform.tsx
@@ -50,8 +50,7 @@ class OnboardingPlatform extends Component<Props, State> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_load_choose_platform',
       {},
-      this.props.organization ?? null,
-      {sendMarketing: true}
+      this.props.organization ?? null
     );
   }
 
@@ -115,8 +114,7 @@ class OnboardingPlatform extends Component<Props, State> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_set_up_your_project',
       {platform},
-      this.props.organization ?? null,
-      {sendMarketing: true}
+      this.props.organization ?? null
     );
 
     // Create their first project if they don't already have one. This is a

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -43,8 +43,7 @@ class OnboardingWelcome extends Component<Props> {
     trackAdvancedAnalyticsEvent(
       'growth.onboarding_start_onboarding',
       {},
-      this.props.organization ?? null,
-      {sendMarketing: true}
+      this.props.organization ?? null
     );
   }
 


### PR DESCRIPTION
This PR removes the `sendMarketing` option for analytics events which determines whether or not they go to Google analytics. Instead, we just have a lookup table for event names and if the name matches, we send to Google Analytics.


Requires: https://github.com/getsentry/getsentry/pull/6010