### PR TITLE
feat(codeowners): Record analytics on changes to assignment

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -961,14 +961,14 @@ def update_groups(request, group_ids, projects, organization_id, search_fn):
             for group in group_list:
                 resolved_actor = assigned_actor.resolve()
 
-                created = GroupAssignee.objects.assign(group, resolved_actor, acting_user)
+                assignment = GroupAssignee.objects.assign(group, resolved_actor, acting_user)
                 analytics.record(
                     "manual.issue_assignment",
                     organization_id=project_lookup[group.project_id].organization_id,
                     project_id=group.project_id,
                     group_id=group.id,
                     assigned_by=assigned_by,
-                    had_to_deassign=(not created),
+                    had_to_deassign=assignment["updated_assignment"],
                 )
             result["assignedTo"] = serialize(
                 assigned_actor.resolve(), acting_user, ActorSerializer()

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -179,7 +179,7 @@ class GroupAssigneeManager(BaseManager):
             ):
                 sync_group_assignee_outbound(group, assigned_to.id, assign=True)
 
-        return created
+        return {"new_assignment": created, "updated_assignment": bool(not created and affected)}
 
     def deassign(self, group, acting_user=None):
         from sentry import features

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -103,17 +103,10 @@ def handle_owner_assignment(project, group, event):
         )
 
         if auto_assignment and owners and not assignees_exists:
-            GroupAssignee.objects.assign(group, owners[0])
-            if assigned_by_codeowners:
+            assignment = GroupAssignee.objects.assign(group, owners[0])
+            if assignment["new_assignment"] or assignment["updated_assignment"]:
                 analytics.record(
-                    "codeowners.assignment",
-                    organization_id=project.organization_id,
-                    project_id=project.id,
-                    group_id=group.id,
-                )
-            else:
-                analytics.record(
-                    "issueowners.assignment",
+                    "codeowners.assignment" if assigned_by_codeowners else "issueowners.assignment",
                     organization_id=project.organization_id,
                     project_id=project.id,
                     group_id=group.id,


### PR DESCRIPTION
## Objective:
Currently, we recalculate issue assignment on every new event for a group. However, this is skewing our metrics from outlier issues that have an outsized number of events. This PR, allows us to record only when there is a change in assignment (new or updated) for an issue. We still expect the number of assignments to be greater than the number of distinct issues that have assignments. However, the magnitude in difference should decrease.