### PR TITLE
build(webpack): Remove `clean-webpack-plugin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "bootstrap": "3.4.1",
     "buffer": "^6.0.3",
     "classnames": "2.3.1",
-    "clean-webpack-plugin": "^3.0.0",
     "color": "^3.1.3",
     "compression-webpack-plugin": "7.0.0",
     "copy-text-to-clipboard": "2.2.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,7 +4,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import {CleanWebpackPlugin} from 'clean-webpack-plugin';
 import CompressionPlugin from 'compression-webpack-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
@@ -303,8 +302,6 @@ let appConfig: Configuration = {
     ],
   },
   plugins: [
-    new CleanWebpackPlugin(),
-
     // Do not bundle moment's locale files as we will lazy load them using
     // dynamic imports in the application code
     new webpack.IgnorePlugin({
@@ -424,6 +421,7 @@ let appConfig: Configuration = {
     extensions: ['.jsx', '.js', '.json', '.ts', '.tsx', '.less'],
   },
   output: {
+    clean: true, // Clean the output directory before emit.
     path: distPath,
     publicPath: '',
     filename: 'entrypoints/[name].js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3567,7 +3567,7 @@
     "@types/source-list-map" "*"
     source-map "^0.6.1"
 
-"@types/webpack@^4", "@types/webpack@^4.4.31", "@types/webpack@^4.41.26":
+"@types/webpack@^4", "@types/webpack@^4.41.26":
   version "4.41.30"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.30.tgz#fd3db6d0d41e145a8eeeafcd3c4a7ccde9068ddc"
   integrity sha512-GUHyY+pfuQ6haAfzu4S14F+R5iGRwN6b2FRNJY7U0NilmFAqbsOfK6j1HwuLBAqwRIT+pVdNDJGJ6e8rpp0KHA==
@@ -5199,14 +5199,6 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-clean-webpack-plugin@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz#a99d8ec34c1c628a4541567aa7b457446460c62b"
-  integrity sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==
-  dependencies:
-    "@types/webpack" "^4.4.31"
-    del "^4.1.1"
 
 cli-boxes@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
This is no longer necessary as it [comes with webpack now](https://webpack.js.org/configuration/output/#outputclean).