### PR TITLE
feat(growth): add nextjs as a popular platform

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -3,6 +3,7 @@ import {t} from 'app/locale';
 const popular = [
   'javascript',
   'javascript-react',
+  'javascript-nextjs',
   'python-django',
   'python',
   'python-flask',


### PR DESCRIPTION
Next.JS was the top search result for platforms during onboarding so we should add it to the list of popular platforms.


![Screen Shot 2021-08-02 at 4 19 08 PM](https://user-images.githubusercontent.com/8533851/127935356-722b761c-a393-4311-b079-03c6a56309b7.png)
