### PR TITLE
fix(ui): Fix text overflow for issue tag pills

### DIFF
--- a/static/app/components/events/interfaces/exceptionMechanism.tsx
+++ b/static/app/components/events/interfaces/exceptionMechanism.tsx
@@ -80,7 +80,7 @@ class ExceptionMechanism extends Component<Props> {
 
     return (
       <Wrapper>
-        <Pills>{pills}</Pills>
+        <StyledPills>{pills}</StyledPills>
       </Wrapper>
     );
   }
@@ -107,6 +107,15 @@ const StyledExternalLink = styled(ExternalLink)`
 
 const Details = styled('span')`
   margin-right: ${space(1)};
+`;
+
+const StyledPills = styled(Pills)`
+  span:nth-of-type(2) {
+    display: inline;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 const StyledIconInfo = styled(IconInfo)`

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -122,11 +122,8 @@ const PillValue = styled(PillName)`
   border-radius: ${p =>
     `0 ${p.theme.button.borderRadius} ${p.theme.button.borderRadius} 0`};
   max-width: 100%;
-  align-self: flex-end;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-  display: inline-block;
+  display: flex;
+  align-items: center;
 
   > a {
     max-width: 100%;

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -122,7 +122,7 @@ const PillValue = styled(PillName)`
   border-radius: ${p =>
     `0 ${p.theme.button.borderRadius} ${p.theme.button.borderRadius} 0`};
   max-width: 100%;
-  align-items: center;
+  align-self: flex-end;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -122,8 +122,11 @@ const PillValue = styled(PillName)`
   border-radius: ${p =>
     `0 ${p.theme.button.borderRadius} ${p.theme.button.borderRadius} 0`};
   max-width: 100%;
-  display: flex;
   align-items: center;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  display: inline-block;
 
   > a {
     max-width: 100%;


### PR DESCRIPTION
Fix text overflow for issue tag pills.

FIXES [WOR-1154](https://getsentry.atlassian.net/browse/WOR-1154)
FIXES [GH-27737](https://github.com/getsentry/sentry/issues/27737)

# Before
<img width="1204" alt="Screen Shot 2021-08-02 at 7 37 44 PM" src="https://user-images.githubusercontent.com/20312973/127955962-fe0a5569-afd6-4d0a-a31f-1621276be30e.png">

# After
<img width="1198" alt="Screen Shot 2021-08-02 at 8 36 03 PM" src="https://user-images.githubusercontent.com/20312973/127955986-ab229b72-ce25-4bbc-9619-f05a9ca90f96.png">