### PR TITLE
feat(ui): Add release marklines to event charts

### DIFF
--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -814,7 +814,8 @@ function ReleaseComparisonChart({
             ReleaseComparisonChartType.FAILURE_RATE,
           ].includes(activeChart) ? (
             <ReleaseEventsChart
-              version={release.version}
+              release={release}
+              project={project}
               chartType={activeChart}
               period={period ?? undefined}
               start={start}


### PR DESCRIPTION
Release mark lines used to be only on session-based charts, now we are also adding them to event-based charts (Event Count, Transaction Count, Failure Rate).

![Screenshot 2021-08-04 at 09 49 08](https://user-images.githubusercontent.com/9060071/128142785-0466fb8f-8ea5-41e3-918a-3a3844826a7c.png)
