### PR TITLE
test(ui): Add test coverage for utils/sessions

### DIFF
--- a/tests/js/spec/utils/sessions.spec.tsx
+++ b/tests/js/spec/utils/sessions.spec.tsx
@@ -1,6 +1,13 @@
-import {filterSessionsInTimeWindow} from 'app/utils/sessions';
+import {SessionField, SessionStatus} from 'app/types';
+import {
+  filterSessionsInTimeWindow,
+  getCount,
+  getCrashFreeRate,
+  getSessionsInterval,
+  getSessionStatusRate,
+} from 'app/utils/sessions';
 
-const apiResponse = {
+const sessionsApiResponse = {
   start: '2021-07-09T23:00:00Z',
   end: '2021-07-11T14:51:00Z',
   query: '',
@@ -109,121 +116,226 @@ const apiResponse = {
   ],
 };
 
-describe('filterSessionsInTimeWindow', function () {
-  it('filters out intervals/series out of bounds', function () {
-    const filtered = filterSessionsInTimeWindow(
-      apiResponse,
-      '2021-07-09T23:12:57.265410Z',
-      '2021-07-11T14:49:59Z'
-    );
+describe('utils/sessions', () => {
+  describe('getCount', () => {
+    const groups = [sessionsApiResponse.groups[1], sessionsApiResponse.groups[2]];
+    it('returns sessions count', () => {
+      expect(getCount(groups, SessionField.SESSIONS)).toBe(1942);
+    });
+    it('returns users count', () => {
+      expect(getCount(groups, SessionField.USERS)).toBe(720);
+    });
+  });
 
-    expect(filtered).toEqual({
-      start: '2021-07-10T00:00:00Z',
-      end: '2021-07-11T14:00:00Z',
-      query: '',
-      intervals: [
-        '2021-07-10T00:00:00Z',
-        '2021-07-10T01:00:00Z',
-        '2021-07-10T02:00:00Z',
-        '2021-07-10T03:00:00Z',
-        '2021-07-10T04:00:00Z',
-        '2021-07-10T05:00:00Z',
-        '2021-07-10T06:00:00Z',
-        '2021-07-10T07:00:00Z',
-        '2021-07-10T08:00:00Z',
-        '2021-07-10T09:00:00Z',
-        '2021-07-10T10:00:00Z',
-        '2021-07-10T11:00:00Z',
-        '2021-07-10T12:00:00Z',
-        '2021-07-10T13:00:00Z',
-        '2021-07-10T14:00:00Z',
-        '2021-07-10T15:00:00Z',
-        '2021-07-10T16:00:00Z',
-        '2021-07-10T17:00:00Z',
-        '2021-07-10T18:00:00Z',
-        '2021-07-10T19:00:00Z',
-        '2021-07-10T20:00:00Z',
-        '2021-07-10T21:00:00Z',
-        '2021-07-10T22:00:00Z',
-        '2021-07-10T23:00:00Z',
-        '2021-07-11T00:00:00Z',
-        '2021-07-11T01:00:00Z',
-        '2021-07-11T02:00:00Z',
-        '2021-07-11T03:00:00Z',
-        '2021-07-11T04:00:00Z',
-        '2021-07-11T05:00:00Z',
-        '2021-07-11T06:00:00Z',
-        '2021-07-11T07:00:00Z',
-        '2021-07-11T08:00:00Z',
-        '2021-07-11T09:00:00Z',
-        '2021-07-11T10:00:00Z',
-        '2021-07-11T11:00:00Z',
-        '2021-07-11T12:00:00Z',
-        '2021-07-11T13:00:00Z',
-        '2021-07-11T14:00:00Z',
-      ],
-      groups: [
-        {
-          by: {'session.status': 'abnormal'},
-          totals: {'count_unique(user)': 0, 'sum(session)': 0},
-          series: {
-            'count_unique(user)': [
-              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-            'sum(session)': [
-              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-              0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
+  describe('getCrashFreeRate', () => {
+    const {groups} = sessionsApiResponse;
+    it('returns crash free sessions', () => {
+      expect(getCrashFreeRate(groups, SessionField.SESSIONS)).toBe(98.751);
+    });
+    it('returns crash free users', () => {
+      expect(getCrashFreeRate(groups, SessionField.USERS)).toBe(95.332);
+    });
+  });
+
+  describe('getSessionStatusRate', () => {
+    const {groups} = sessionsApiResponse;
+    it('returns errored sessions rate', () => {
+      expect(
+        getSessionStatusRate(groups, SessionField.SESSIONS, SessionStatus.ERRORED)
+      ).toBe(0.10153484522890543);
+    });
+    it('returns healthy users rate', () => {
+      expect(
+        getSessionStatusRate(groups, SessionField.USERS, SessionStatus.HEALTHY)
+      ).toBe(90.14373716632443);
+    });
+  });
+
+  describe('getSessionsInterval', () => {
+    describe('with high fidelity', () => {
+      it('greater than 14 days', () => {
+        expect(getSessionsInterval({period: '15d'}, {highFidelity: true})).toBe('1d');
+      });
+
+      it('greater than 7 days', () => {
+        expect(getSessionsInterval({period: '8d'}, {highFidelity: true})).toBe('6h');
+      });
+
+      it('30 minutes or less', () => {
+        expect(getSessionsInterval({period: '28m'}, {highFidelity: true})).toBe('1m');
+      });
+
+      it('between one week and six hours', () => {
+        expect(getSessionsInterval({period: '1d'}, {highFidelity: true})).toBe('1h');
+      });
+
+      it('between 6 hours and 30 minutes', () => {
+        expect(getSessionsInterval({period: '31m'}, {highFidelity: true})).toBe('5m');
+      });
+
+      it('less or equal to 30 minutes', () => {
+        expect(getSessionsInterval({period: '30m'}, {highFidelity: true})).toBe('1m');
+      });
+
+      it('ignores high fidelity flag if start is older than 30d', () => {
+        expect(
+          getSessionsInterval(
+            {start: '2017-09-15T02:41:20Z', end: '2017-09-15T02:42:20Z'},
+            {highFidelity: true}
+          )
+        ).toBe('1h');
+      });
+    });
+
+    describe('with low fidelity', () => {
+      it('greater than 14 days', () => {
+        expect(getSessionsInterval({period: '15d'})).toBe('1d');
+        expect(
+          getSessionsInterval(
+            {start: '2021-07-19T15:14:23Z', end: '2021-08-03T15:13:32Z'},
+            {highFidelity: true}
+          )
+        ).toBe('1d');
+      });
+
+      it('greater than 7 days', () => {
+        expect(getSessionsInterval({period: '8d'})).toBe('6h');
+      });
+
+      it('30 minutes or less', () => {
+        expect(getSessionsInterval({period: '28m'})).toBe('1h');
+      });
+
+      it('between one week and six hours', () => {
+        expect(getSessionsInterval({period: '1d'})).toBe('1h');
+      });
+
+      it('between 6 hours and 30 minutes', () => {
+        expect(getSessionsInterval({period: '31m'})).toBe('1h');
+      });
+
+      it('less or equal to 30 minutes', () => {
+        expect(getSessionsInterval({period: '30m'})).toBe('1h');
+      });
+    });
+  });
+
+  describe('filterSessionsInTimeWindow', () => {
+    it('filters out intervals/series out of bounds', () => {
+      const filtered = filterSessionsInTimeWindow(
+        sessionsApiResponse,
+        '2021-07-09T23:12:57.265410Z',
+        '2021-07-11T14:49:59Z'
+      );
+
+      expect(filtered).toEqual({
+        start: '2021-07-10T00:00:00Z',
+        end: '2021-07-11T14:00:00Z',
+        query: '',
+        intervals: [
+          '2021-07-10T00:00:00Z',
+          '2021-07-10T01:00:00Z',
+          '2021-07-10T02:00:00Z',
+          '2021-07-10T03:00:00Z',
+          '2021-07-10T04:00:00Z',
+          '2021-07-10T05:00:00Z',
+          '2021-07-10T06:00:00Z',
+          '2021-07-10T07:00:00Z',
+          '2021-07-10T08:00:00Z',
+          '2021-07-10T09:00:00Z',
+          '2021-07-10T10:00:00Z',
+          '2021-07-10T11:00:00Z',
+          '2021-07-10T12:00:00Z',
+          '2021-07-10T13:00:00Z',
+          '2021-07-10T14:00:00Z',
+          '2021-07-10T15:00:00Z',
+          '2021-07-10T16:00:00Z',
+          '2021-07-10T17:00:00Z',
+          '2021-07-10T18:00:00Z',
+          '2021-07-10T19:00:00Z',
+          '2021-07-10T20:00:00Z',
+          '2021-07-10T21:00:00Z',
+          '2021-07-10T22:00:00Z',
+          '2021-07-10T23:00:00Z',
+          '2021-07-11T00:00:00Z',
+          '2021-07-11T01:00:00Z',
+          '2021-07-11T02:00:00Z',
+          '2021-07-11T03:00:00Z',
+          '2021-07-11T04:00:00Z',
+          '2021-07-11T05:00:00Z',
+          '2021-07-11T06:00:00Z',
+          '2021-07-11T07:00:00Z',
+          '2021-07-11T08:00:00Z',
+          '2021-07-11T09:00:00Z',
+          '2021-07-11T10:00:00Z',
+          '2021-07-11T11:00:00Z',
+          '2021-07-11T12:00:00Z',
+          '2021-07-11T13:00:00Z',
+          '2021-07-11T14:00:00Z',
+        ],
+        groups: [
+          {
+            by: {'session.status': 'abnormal'},
+            totals: {'count_unique(user)': 0, 'sum(session)': 0},
+            series: {
+              'count_unique(user)': [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+              ],
+              'sum(session)': [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+              ],
+            },
           },
-        },
-        {
-          by: {'session.status': 'errored'},
-          totals: {'count_unique(user)': 414, 'sum(session)': 226},
-          series: {
-            'count_unique(user)': [
-              6, 5, 7, 11, 5, 6, 8, 12, 14, 9, 16, 15, 22, 28, 11, 14, 16, 9, 11, 11, 7,
-              7, 4, 3, 7, 6, 12, 3, 6, 6, 4, 8, 14, 23, 16, 14, 18, 12, 8,
-            ],
-            'sum(session)': [
-              3, 0, 0, 11, 0, 0, 0, 0, 1, 2, 5, 1, 16, 40, 0, 5, 0, 1, 13, 3, 0, 0, 5, 0,
-              0, 3, 14, 0, 3, 2, 0, 3, 9, 16, 6, 0, 31, 20, 13,
-            ],
+          {
+            by: {'session.status': 'errored'},
+            totals: {'count_unique(user)': 414, 'sum(session)': 226},
+            series: {
+              'count_unique(user)': [
+                6, 5, 7, 11, 5, 6, 8, 12, 14, 9, 16, 15, 22, 28, 11, 14, 16, 9, 11, 11, 7,
+                7, 4, 3, 7, 6, 12, 3, 6, 6, 4, 8, 14, 23, 16, 14, 18, 12, 8,
+              ],
+              'sum(session)': [
+                3, 0, 0, 11, 0, 0, 0, 0, 1, 2, 5, 1, 16, 40, 0, 5, 0, 1, 13, 3, 0, 0, 5,
+                0, 0, 3, 14, 0, 3, 2, 0, 3, 9, 16, 6, 0, 31, 20, 13,
+              ],
+            },
           },
-        },
-        {
-          by: {'session.status': 'crashed'},
-          totals: {'count_unique(user)': 462, 'sum(session)': 1763},
-          series: {
-            'count_unique(user)': [
-              10, 5, 6, 6, 12, 9, 16, 24, 16, 11, 13, 20, 16, 12, 18, 18, 17, 12, 8, 8,
-              19, 15, 5, 4, 9, 4, 7, 5, 7, 4, 12, 13, 11, 15, 9, 21, 20, 14, 11,
-            ],
-            'sum(session)': [
-              32, 31, 36, 30, 78, 56, 60, 95, 55, 52, 47, 53, 43, 61, 68, 43, 71, 47, 29,
-              38, 65, 55, 14, 14, 34, 30, 32, 23, 20, 21, 53, 40, 39, 56, 34, 60, 61, 62,
-              25,
-            ],
+          {
+            by: {'session.status': 'crashed'},
+            totals: {'count_unique(user)': 462, 'sum(session)': 1763},
+            series: {
+              'count_unique(user)': [
+                10, 5, 6, 6, 12, 9, 16, 24, 16, 11, 13, 20, 16, 12, 18, 18, 17, 12, 8, 8,
+                19, 15, 5, 4, 9, 4, 7, 5, 7, 4, 12, 13, 11, 15, 9, 21, 20, 14, 11,
+              ],
+              'sum(session)': [
+                32, 31, 36, 30, 78, 56, 60, 95, 55, 52, 47, 53, 43, 61, 68, 43, 71, 47,
+                29, 38, 65, 55, 14, 14, 34, 30, 32, 23, 20, 21, 53, 40, 39, 56, 34, 60,
+                61, 62, 25,
+              ],
+            },
           },
-        },
-        {
-          by: {'session.status': 'healthy'},
-          totals: {'count_unique(user)': 11347, 'sum(session)': 136419},
-          series: {
-            'count_unique(user)': [
-              351, 261, 239, 229, 250, 296, 329, 337, 336, 347, 368, 351, 372, 370, 391,
-              323, 358, 348, 307, 266, 224, 201, 168, 156, 133, 146, 164, 168, 151, 184,
-              276, 341, 354, 351, 379, 395, 400, 394, 333,
-            ],
-            'sum(session)': [
-              3999, 2632, 2624, 2587, 3525, 3666, 3783, 4059, 3882, 4022, 4490, 4052,
-              4157, 4166, 4502, 4260, 4713, 4474, 3802, 3199, 2296, 2737, 2259, 1560,
-              1659, 1997, 1975, 1777, 1897, 2783, 3310, 4414, 4012, 4230, 4618, 4773,
-              4814, 4821, 3893,
-            ],
+          {
+            by: {'session.status': 'healthy'},
+            totals: {'count_unique(user)': 11347, 'sum(session)': 136419},
+            series: {
+              'count_unique(user)': [
+                351, 261, 239, 229, 250, 296, 329, 337, 336, 347, 368, 351, 372, 370, 391,
+                323, 358, 348, 307, 266, 224, 201, 168, 156, 133, 146, 164, 168, 151, 184,
+                276, 341, 354, 351, 379, 395, 400, 394, 333,
+              ],
+              'sum(session)': [
+                3999, 2632, 2624, 2587, 3525, 3666, 3783, 4059, 3882, 4022, 4490, 4052,
+                4157, 4166, 4502, 4260, 4713, 4474, 3802, 3199, 2296, 2737, 2259, 1560,
+                1659, 1997, 1975, 1777, 1897, 2783, 3310, 4414, 4012, 4230, 4618, 4773,
+                4814, 4821, 3893,
+              ],
+            },
           },
-        },
-      ],
+        ],
+      });
     });
   });
 });


### PR DESCRIPTION
Adding tests for `app/utils/sessions`.

Integration tests should cover basic scenarios, but I wanted to catch some edge cases with unit tests.