### PR TITLE
ref(models): Break up large file: `manager.py`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -16,7 +16,7 @@ files = src/sentry/api/bases/external_actor.py,
         src/sentry/api/serializers/models/team.py,
         src/sentry/api/validators/external_actor.py,
         src/sentry/api/validators/notifications.py,
-        src/sentry/db/models/manager.py,
+        src/sentry/db/models/manager/**/*.py,
         src/sentry/features/**/*.py,
         src/sentry/grouping/strategies/base.py,
         src/sentry/grouping/strategies/message.py,
@@ -66,6 +66,8 @@ no_implicit_reexport=True
 follow_imports = skip
 
 
+[mypy-celery.*]
+ignore_missing_imports = True
 [mypy-confluent_kafka.*]
 ignore_missing_imports = True
 [mypy-google.*]

--- a/src/sentry/db/models/manager/__init__.py
+++ b/src/sentry/db/models/manager/__init__.py
@@ -5,7 +5,7 @@ from django.utils.encoding import smart_text
 
 from sentry.utils.hashlib import md5_text
 
-__all__ = ("BaseManager", "OptionManager", "Value", "ValidateFunction")
+__all__ = ("BaseManager", "BaseQuerySet", "OptionManager", "Value", "ValidateFunction")
 
 M = TypeVar("M", bound=Model)
 Value = Any
@@ -38,4 +38,5 @@ def make_key(model: Any, prefix: str, kwargs: Mapping[str, Union[Model, int, str
 
 # Exporting these classes at the bottom to avoid circular dependencies.
 from .base import BaseManager
+from .base_query_set import BaseQuerySet
 from .option import OptionManager

--- a/src/sentry/db/models/manager/__init__.py
+++ b/src/sentry/db/models/manager/__init__.py
@@ -1,0 +1,41 @@
+from typing import Any, Callable, Mapping, TypeVar, Union
+
+from django.db.models import Model
+from django.utils.encoding import smart_text
+
+from sentry.utils.hashlib import md5_text
+
+__all__ = ("BaseManager", "OptionManager", "Value", "ValidateFunction")
+
+M = TypeVar("M", bound=Model)
+Value = Any
+ValidateFunction = Callable[[Value], bool]
+
+
+def __prep_value(model: Any, key: str, value: Union[Model, int, str]) -> str:
+    val = value
+    if isinstance(value, Model):
+        val = value.pk
+    return str(val)
+
+
+def __prep_key(model: Any, key: str) -> str:
+    if key == "pk":
+        return str(model._meta.pk.name)
+    return key
+
+
+def make_key(model: Any, prefix: str, kwargs: Mapping[str, Union[Model, int, str]]) -> str:
+    kwargs_bits = []
+    for k, v in sorted(kwargs.items()):
+        k = __prep_key(model, k)
+        v = smart_text(__prep_value(model, k, v))
+        kwargs_bits.append(f"{k}={v}")
+    kwargs_bits_str = ":".join(kwargs_bits)
+
+    return f"{prefix}:{model.__name__}:{md5_text(kwargs_bits_str).hexdigest()}"
+
+
+# Exporting these classes at the bottom to avoid circular dependencies.
+from .base import BaseManager
+from .option import OptionManager

--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -1,0 +1,22 @@
+import abc
+
+from django.db.models import QuerySet
+
+from sentry.utils.types import Any
+
+
+class BaseQuerySet(QuerySet, abc.ABC):  # type: ignore
+    # XXX(dcramer): we prefer values_list, but we can't disable values as Django uses it
+    # internally
+    # def values(self, *args, **kwargs):
+    #     raise NotImplementedError('Use ``values_list`` instead [performance].')
+
+    def defer(self, *args: Any, **kwargs: Any) -> "BaseQuerySet":
+        raise NotImplementedError("Use ``values_list`` instead [performance].")
+
+    def only(self, *args: Any, **kwargs: Any) -> "BaseQuerySet":
+        # In rare cases Django can use this if a field is unexpectedly deferred. This
+        # mostly can happen if a field is added to a model, and then an old pickle is
+        # passed to a process running the new code. So if you see this error after a
+        # deploy of a model with a new field, it'll likely fix itself post-deploy.
+        raise NotImplementedError("Use ``values_list`` instead [performance].")

--- a/src/sentry/db/models/manager/option.py
+++ b/src/sentry/db/models/manager/option.py
@@ -1,0 +1,30 @@
+from typing import Any, Dict, Union
+
+from celery.signals import task_postrun
+from django.core.signals import request_finished
+
+from sentry.db.models.manager import M
+from sentry.db.models.manager.base import BaseManager, _local_cache
+
+
+class OptionManager(BaseManager[M]):
+    @property
+    def _option_cache(self) -> Dict[str, Dict[str, Any]]:
+        if not hasattr(_local_cache, "option_cache"):
+            _local_cache.option_cache = {}
+
+        # Explicitly typing to satisfy mypy.
+        option_cache: Dict[str, Dict[str, Any]] = _local_cache.option_cache
+        return option_cache
+
+    def clear_local_cache(self, **kwargs: Any) -> None:
+        self._option_cache.clear()
+
+    def contribute_to_class(self, model: M, name: str) -> None:
+        super().contribute_to_class(model, name)
+        task_postrun.connect(self.clear_local_cache)
+        request_finished.connect(self.clear_local_cache)
+
+    def _make_key(self, instance_id: Union[int, str]) -> str:
+        assert instance_id
+        return f"{self.model._meta.db_table}:{instance_id}"


### PR DESCRIPTION
This PR splits up a large file into one file per class. It is a redo of:
- #27791 which got too difficult to rebase
- #27871 which failed CI on getsentry

