### PR TITLE
refs(db): Remove `attach_foreignkey` and replace with `prefetch_related_objects`

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import (
@@ -13,7 +15,6 @@ from sentry.incidents.models import (
 from sentry.models import ACTOR_TYPES, Rule, actor_type_to_class, actor_type_to_string
 from sentry.snuba.models import SnubaQueryEventType
 from sentry.utils.compat import zip
-from sentry.utils.db import attach_foreignkey
 
 
 @register(AlertRule)
@@ -23,7 +24,7 @@ class AlertRuleSerializer(Serializer):
 
     def get_attrs(self, item_list, user, **kwargs):
         alert_rules = {item.id: item for item in item_list}
-        attach_foreignkey(item_list, AlertRule.snuba_query, related=("environment",))
+        prefetch_related_objects(item_list, "snuba_query__environment")
 
         result = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import (
     AlertRuleTrigger,
@@ -7,13 +9,12 @@ from sentry.incidents.models import (
     AlertRuleTriggerExclusion,
 )
 from sentry.utils.compat import zip
-from sentry.utils.db import attach_foreignkey
 
 
 @register(AlertRuleTrigger)
 class AlertRuleTriggerSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        attach_foreignkey(item_list, AlertRuleTrigger.alert_rule)
+        prefetch_related_objects(item_list, "alert_rule")
 
         triggers = {item.id: item for item in item_list}
         result = defaultdict(dict)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -7,7 +7,7 @@ from typing import Iterable, Mapping, Optional, Tuple
 import pytz
 import sentry_sdk
 from django.conf import settings
-from django.db.models import Min
+from django.db.models import Min, prefetch_related_objects
 from django.utils import timezone
 
 from sentry import tagstore, tsdb
@@ -57,7 +57,6 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip
-from sentry.utils.db import attach_foreignkey
 from sentry.utils.safe import safe_execute
 from sentry.utils.snuba import Dataset, aliased_query, raw_query
 
@@ -225,7 +224,7 @@ class GroupSerializerBase(Serializer):
 
         # Note that organization is necessary here for use in `_get_permalink` to avoid
         # making unnecessary queries.
-        attach_foreignkey(item_list, Group.project, related=("organization",))
+        prefetch_related_objects(item_list, "project__organization")
 
         if user.is_authenticated and item_list:
             bookmarks = set(

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
 
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.incidents.models import (
@@ -11,7 +13,6 @@ from sentry.incidents.models import (
 )
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.tasks import apply_dataset_query_conditions
-from sentry.utils.db import attach_foreignkey
 
 
 @register(Incident)
@@ -20,7 +21,7 @@ class IncidentSerializer(Serializer):
         self.expand = expand or []
 
     def get_attrs(self, item_list, user, **kwargs):
-        attach_foreignkey(item_list, Incident.alert_rule, related=("snuba_query",))
+        prefetch_related_objects(item_list, "alert_rule__snuba_query")
         incident_projects = defaultdict(list)
         for incident_project in IncidentProject.objects.filter(
             incident__in=item_list

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -1,14 +1,15 @@
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.incidents.models import IncidentActivity
-from sentry.utils.db import attach_foreignkey
 
 
 @register(IncidentActivity)
 class IncidentActivitySerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        attach_foreignkey(item_list, IncidentActivity.incident, related=("organization",))
-        attach_foreignkey(item_list, IncidentActivity.user)
+        prefetch_related_objects(item_list, "incident__organization")
+        prefetch_related_objects(item_list, "user")
         user_serializer = UserSerializer()
         serialized_users = serialize(
             {item.user for item in item_list if item.user_id},

--- a/src/sentry/api/serializers/models/incidentseen.py
+++ b/src/sentry/api/serializers/models/incidentseen.py
@@ -1,12 +1,13 @@
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import IncidentSeen
-from sentry.utils.db import attach_foreignkey
 
 
 @register(IncidentSeen)
 class IncidentSeenSerializer(Serializer):
     def get_attrs(self, item_list, user):
-        attach_foreignkey(item_list, IncidentSeen.user)
+        prefetch_related_objects(item_list, "user")
         user_map = {d["id"]: d for d in serialize({i.user for i in item_list}, user)}
 
         result = {}

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -1,10 +1,11 @@
+from django.db.models import prefetch_related_objects
+
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.repository_project_path_config import (
     RepositoryProjectPathConfigSerializer,
 )
 from sentry.models import ProjectCodeOwners
 from sentry.ownership.grammar import convert_schema_to_rules_text
-from sentry.utils.db import attach_foreignkey
 
 
 @register(ProjectCodeOwners)
@@ -16,10 +17,9 @@ class ProjectCodeOwnersSerializer(Serializer):
         self.expand = expand or []
 
     def get_attrs(self, item_list, user, **kwargs):
-        attach_foreignkey(
+        prefetch_related_objects(
             item_list,
-            ProjectCodeOwners.repository_project_path_config,
-            related=("organization_integration",),
+            "repository_project_path_config__organization_integration",
         )
 
         return {

--- a/src/sentry/utils/db.py
+++ b/src/sentry/utils/db.py
@@ -3,7 +3,6 @@ from typing import Sequence, Union
 
 import sentry_sdk
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
-from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor
 from sentry_sdk.integrations import Integration
 
 
@@ -54,66 +53,6 @@ class DjangoAtomicIntegration(Integration):
 
         Atomic.__enter__ = _enter
         Atomic.__exit__ = _exit
-
-
-def attach_foreignkey(objects, field, related=(), database=None):
-    """
-    Shortcut method which handles a pythonic LEFT OUTER JOIN.
-
-    ``attach_foreignkey(posts, Post.thread)``
-
-    Works with both ForeignKey and OneToOne (reverse) lookups.
-    """
-
-    if not objects:
-        return
-
-    if database is None:
-        database = list(objects)[0]._state.db
-
-    is_foreignkey = isinstance(field, ReverseOneToOneDescriptor)
-
-    if not is_foreignkey:
-        field = field.field
-        accessor = "_%s_cache" % field.name
-        model = field.remote_field.model
-        lookup = "pk"
-        column = field.column
-        key = lookup
-    else:
-        accessor = field.cache_name
-        field = field.related.field
-        model = field.model
-        lookup = field.name
-        column = "pk"
-        key = field.column
-
-    objects = [o for o in objects if (related or getattr(o, accessor, False) is False)]
-
-    if not objects:
-        return
-
-    # Ensure values are unique, do not contain already present values, and are not missing
-    # values specified in select_related
-    values = {_f for _f in (getattr(o, column) for o in objects) if _f}
-    if values:
-        qs = model._default_manager
-        if database:
-            qs = qs.using(database)
-        if related:
-            qs = qs.select_related(*related)
-
-        if len(values) > 1:
-            qs = qs.filter(**{"%s__in" % lookup: values})
-        else:
-            qs = [qs.get(**{lookup: next(iter(values))})]
-
-        queryset = {getattr(o, key): o for o in qs}
-    else:
-        queryset = {}
-
-    for o in objects:
-        setattr(o, accessor, queryset.get(getattr(o, column)))
 
 
 def table_exists(name, using=DEFAULT_DB_ALIAS):


### PR DESCRIPTION
`attach_foreignkey` was broken as part of the Django 2.0 upgrade. Instead of fixing it, we'll
migrate over to using `prefetch_related_objects` instead, since it provides the same functionality
and is part of the Django core library.

It still supports fetching related relations via `__`. So

`prefetch_related_objects(Group.objects.all(), "project__organization")` would fetch all `Groups`,
then make two additional queries. One to fetch all projects related to those groups, and one to
fetch all orgnizations related to those projects.