### PR TITLE
feat(search): Allow partial IN list values

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -123,7 +123,7 @@ key                    = ~r"[a-zA-Z0-9_.-]+"
 quoted_key             = '"' ~r"[a-zA-Z0-9_.:-]+" '"'
 explicit_tag_key       = "tags" open_bracket search_key closed_bracket
 aggregate_key          = key open_paren spaces function_args? spaces closed_paren
-function_args          = aggregate_param (spaces comma spaces aggregate_param)*
+function_args          = aggregate_param (spaces comma spaces !comma aggregate_param?)*
 aggregate_param        = quoted_aggregate_param / raw_aggregate_param
 raw_aggregate_param    = ~r"[^()\t\n, \"]+"
 quoted_aggregate_param = '"' ('\\"' / ~r'[^\t\n\"]')* '"'
@@ -136,8 +136,8 @@ text_in_value          = quoted_value / in_value
 search_value           = quoted_value / value
 numeric_value          = "-"? numeric ~r"[kmb]"? &(end_value / comma / closed_bracket)
 boolean_value          = ~r"(true|1|false|0)"i &end_value
-text_in_list           = open_bracket text_in_value (spaces comma spaces text_in_value)* closed_bracket &end_value
-numeric_in_list        = open_bracket numeric_value (spaces comma spaces numeric_value)* closed_bracket &end_value
+text_in_list           = open_bracket text_in_value (spaces comma spaces !comma text_in_value?)* closed_bracket &end_value
+numeric_in_list        = open_bracket numeric_value (spaces comma spaces !comma numeric_value?)* closed_bracket &end_value
 
 # See: https://stackoverflow.com/a/39617181/790169
 in_value_termination = in_value_char (!in_value_end in_value_char)* in_value_end
@@ -258,9 +258,13 @@ def remove_space(children):
 
 
 def process_list(first, remaining):
+    # Empty values become blank nodes
+    if any(isinstance(item[4], Node) for item in remaining):
+        raise InvalidSearchQuery("Lists should not have empty values")
+
     return [
         first,
-        *[item[3] for item in remaining],
+        *[item[4][0] for item in remaining],
     ]
 
 

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -218,7 +218,7 @@ aggregate_key
 
 function_args
   = arg1:aggregate_param
-    args:(spaces comma spaces aggregate_param)* {
+    args:(spaces comma spaces !comma aggregate_param?)* {
       return tc.tokenKeyAggregateArgs(arg1, args);
     }
 
@@ -277,7 +277,7 @@ boolean_value
 text_in_list
   = open_bracket
     item1:text_in_value
-    items:(spaces comma spaces text_in_value)*
+    items:(spaces comma spaces !comma text_in_value?)*
     closed_bracket
     &end_value {
       return tc.tokenValueTextList(item1, items);
@@ -286,7 +286,7 @@ text_in_list
 numeric_in_list
   = open_bracket
     item1:numeric_value
-    items:(spaces comma spaces numeric_value)*
+    items:(spaces comma spaces !comma numeric_value?)*
     closed_bracket
     &end_value {
       return tc.tokenValueNumberList(item1, items);

--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -174,7 +174,7 @@ const ListToken = ({
   <InList>
     {token.items.map(({value, separator}) => [
       <ListComma key="comma">{separator}</ListComma>,
-      renderToken(value, cursor),
+      value && renderToken(value, cursor),
     ])}
   </InList>
 );

--- a/static/app/components/searchSyntax/utils.tsx
+++ b/static/app/components/searchSyntax/utils.tsx
@@ -69,7 +69,11 @@ export function treeResultLocator<T>({
 }: TreeResultLocatorOpts): T {
   const returnResult = (result: any) => new TokenResultFound(result);
 
-  const nodeVisitor = (token: TokenResult<Token>) => {
+  const nodeVisitor = (token: TokenResult<Token> | null) => {
+    if (token === null) {
+      return;
+    }
+
     const result = visitorTest({token, returnResult, skipToken: skipTokenMarker});
 
     // Bubble the result back up.
@@ -142,7 +146,11 @@ type TreeTransformerOpts = {
  * a transform to those nodes.
  */
 export function treeTransformer({tree, transform}: TreeTransformerOpts) {
-  const nodeVisitor = (token: TokenResult<Token>) => {
+  const nodeVisitor = (token: TokenResult<Token> | null) => {
+    if (token === null) {
+      return null;
+    }
+
     switch (token.type) {
       case Token.Filter:
         return transform({

--- a/tests/fixtures/search-syntax/numeric_in_filter.json
+++ b/tests/fixtures/search-syntax/numeric_in_filter.json
@@ -276,5 +276,47 @@
       },
       {"type": "spaces", "value": ""}
     ]
+  },
+  {
+    "query": "project_id:[500,501,]",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "numericIn",
+        "invalid": {"reason": "Lists should not have empty values"},
+        "negated": false,
+        "key": {"type": "keySimple", "value": "project_id", "quoted": false},
+        "operator": "",
+        "value": {
+          "type": "valueNumberList",
+          "items": [
+            {
+              "separator": "",
+              "value": {
+                "type": "valueNumber",
+                "value": "500",
+                "rawValue": 500,
+                "unit": null
+              }
+            },
+            {
+              "separator": ",",
+              "value": {
+                "type": "valueNumber",
+                "value": "501",
+                "rawValue": 501,
+                "unit": null
+              }
+            },
+            {
+              "separator": ",",
+              "value": null
+            }
+          ]
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
   }
 ]

--- a/tests/fixtures/search-syntax/simple_in.json
+++ b/tests/fixtures/search-syntax/simple_in.json
@@ -357,5 +357,33 @@
       },
       {"type": "spaces", "value": ""}
     ]
+  },
+  {
+    "query": "user.email:[test@test.com, ]",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "textIn",
+        "invalid": {"reason": "Lists should not have empty values"},
+        "negated": false,
+        "key": {"type": "keySimple", "value": "user.email", "quoted": false},
+        "operator": "",
+        "value": {
+          "type": "valueTextList",
+          "items": [
+            {
+              "separator": "",
+              "value": {"type": "valueText", "value": "test@test.com", "quoted": false}
+            },
+            {
+              "separator": ", ",
+              "value": null
+            }
+          ]
+        }
+      },
+      {"type": "spaces", "value": ""}
+    ]
   }
 ]


### PR DESCRIPTION
This allows values like `key:[one, ]` to match the parser, making it easier to complete values in the lists.

The token will be invalid if left like this.