### PR TITLE
build(ci): Tweak usage of `actions/cache`

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -40,13 +40,10 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -102,21 +99,16 @@ jobs:
           echo "::set-output name=dist-path::src/sentry/static/sentry/dist"
 
       - name: yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         with:
           path: ${{ steps.config.outputs.yarn-path }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: webpack cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.config.outputs.webpack-path }}
-          key: ${{ runner.os }}-webpack-cache-${{ hashFiles('webpack.config.ts') }}
-          restore-keys: |
-            ${{ runner.os }}-webpack-cache-
+          key: ${{ runner.os }}-v2-webpack-cache-${{ hashFiles('webpack.config.ts') }}
 
       - name: Install Javascript Dependencies
         run: |
@@ -179,8 +171,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry python env
         uses: ./.github/actions/setup-sentry
@@ -263,8 +253,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
@@ -273,13 +261,10 @@ jobs:
           chartcuterie: true
 
       - name: yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         with:
           path: ${{ steps.setup.outputs.yarn-cache-dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: Install Javascript Dependencies
         run: |

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -261,7 +261,7 @@ jobs:
           chartcuterie: true
 
       - name: yarn cache
-      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+        uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         with:
           path: ${{ steps.setup.outputs.yarn-cache-dir }}
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}

--- a/.github/workflows/api-docs-test.yml
+++ b/.github/workflows/api-docs-test.yml
@@ -50,8 +50,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry python env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -64,8 +64,6 @@ jobs:
           # Note this uses a different cache key than other backend-based workflows because this workflows dependencies are different
           key: |
             precommit-${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ hashFiles('requirements-pre-commit.txt') }}
-          restore-keys: |
-            precommit-${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}
 
       - name: Setup pre-commit
         if: steps.changes.outputs.backend == 'true'

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -65,8 +65,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -53,8 +53,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       # Since we don't call the setup-sentry action we need to install libxmlsec1-dev
       - name: Setup backend typing

--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/command-line-test.yml
+++ b/.github/workflows/command-line-test.yml
@@ -43,8 +43,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -61,25 +61,18 @@ jobs:
         with:
           path: ~/.pyenv
           key: devenv-${{ matrix.os }}-pyenv-${{ hashFiles('.python-version') }}
-          restore-keys: |
-            devenv-${{ matrix.os }}-pyenv-
 
       - name: Cache (pip)
         uses: actions/cache@v2
         with:
           path: ${{ steps.info.outputs.pip-cache-dir }}
           key: devenv-${{ matrix.os }}-py${{ steps.info.outputs.python-version }}-pip${{ steps.info.outputs.pip-version }}-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            devenv-${{ matrix.os }}-py${{ steps.info.outputs.python-version }}-pip${{ steps.info.outputs.pip-version }}-
 
       - name: Cache (yarn)
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         with:
           path: ${{ steps.info.outputs.yarn-cache-dir }}
-          key: devenv-${{ matrix.os }}-yarn-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            devenv-${{ matrix.os }}-yarn-
+          key: devenv-${{ matrix.os }}-v2-yarn-${{ hashFiles('yarn.lock') }}
 
       - name: Set up development environment (mostly as per docs)
         run: |

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -40,14 +40,11 @@ jobs:
         if: steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         if: steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: Install dependencies
         if: steps.changes.outputs.frontend == 'true'
@@ -137,14 +134,11 @@ jobs:
         if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
         if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: Install dependencies
         if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -68,8 +68,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/plugins-test.yml
+++ b/.github/workflows/plugins-test.yml
@@ -44,8 +44,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -46,8 +46,6 @@ jobs:
             ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             python-deps-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements-*.txt') }}
-          restore-keys: |
-            python-deps-${{ matrix.os }}-py${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/relay-integration-test.yml
+++ b/.github/workflows/relay-integration-test.yml
@@ -49,8 +49,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/snuba-integration-test.yml
+++ b/.github/workflows/snuba-integration-test.yml
@@ -66,8 +66,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/symbolicator-integration-test.yml
+++ b/.github/workflows/symbolicator-integration-test.yml
@@ -50,8 +50,6 @@ jobs:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry


### PR DESCRIPTION
* Remove usage of `restore-keys` as it can continuously grow the cache size and cause restoring cache to be slow. The trade-off is that cache misses will be slower. This is acceptable as these dependencies should not change often.
* Requires further investigation, but I believe `actions/cache@v2` has a perf regression when GHA logging is enabled. See some tests here: [v1: 14s](https://github.com/getsentry/sentry/runs/3235769855#step:7:1) vs [v2 - 36s](https://github.com/getsentry/sentry/pull/27917/checks?check_run_id=3235884831#step:7:1)

Other things to note in regards to `yarn install`:
* [bahmutov/npm-install action](https://github.com/bahmutov/npm-install) can be useful as it abstracts the caching (less yaml boilerplate)
  * the new `action/setup-node` action from GH also does this (but we use volta to setup node)
  * [pnpm is fast af](https://github.com/getsentry/sentry/runs/3235769953)


The combination of starting with a new cache (our previous cache snowballed from around 180MB to nearly 600MB) and switching from `v2` -> `v1` should bring an improvement from around 90 seconds down to 15-20 seconds.