### PR TITLE
fix(grouping): Separate featureflag for group title

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -894,6 +894,9 @@ SENTRY_FEATURES = {
     # Enable experimental new version of stacktrace component where additional
     # data related to grouping is shown on each frame
     "organizations:grouping-stacktrace-ui": False,
+    # Enable tweaks to group title in relation to hierarchical
+    # grouping.
+    "organizations:grouping-title-ui": False,
     # Lets organizations manage grouping configs
     "organizations:set-grouping-config": False,
     # Lets organizations set a custom title through fingerprinting

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -76,6 +76,7 @@ default_manager.add("organizations:filters-and-sampling", OrganizationFeature, T
 default_manager.add("organizations:global-views", OrganizationFeature)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
+default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)
 default_manager.add("organizations:images-loaded-v2", OrganizationFeature)
 default_manager.add("organizations:issue-percent-filters", OrganizationFeature, True)
 default_manager.add("organizations:improved-search", OrganizationFeature, True)

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -58,11 +58,7 @@ function EventOrGroupTitle({
           disablePreview={!withStackTracePreview}
           hasGroupingStacktraceUI={hasGroupingStacktraceUI}
         >
-          {treeLabel && hasGroupingTreeUI ? (
-            <EventTitleTreeLabel treeLabel={treeLabel} />
-          ) : (
-            title
-          )}
+          {treeLabel ? <EventTitleTreeLabel treeLabel={treeLabel} /> : title}
         </StyledStacktracePreview>
       </GuideAnchor>
       {subtitle && (

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -69,7 +69,7 @@ export function getTreeLabelPartDetails(part: TreeLabelPart) {
 
 function computeTitleWithTreeLabel(metadata: EventMetadata, features: string[] = []) {
   const {type, current_tree_label, finest_tree_label} = metadata;
-  const treeLabel = features.includes('grouping-tree-ui')
+  const treeLabel = features.includes('grouping-title-ui')
     ? current_tree_label || finest_tree_label
     : undefined;
   const formattedTreeLabel = treeLabel


### PR DESCRIPTION
We want to ship the grouping tab independently of the title tweaks