### PR TITLE
fix(grouping): New logic for showing sentinel frames

### DIFF
--- a/static/app/components/events/interfaces/frame/lineV2/groupingBadges.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/groupingBadges.tsx
@@ -14,11 +14,11 @@ type Props = {
 function GroupingBadges({isPrefix, isSentinel, isUsedForGrouping}: Props) {
   const badges: React.ReactElement[] = [];
 
-  if (isSentinel) {
+  if (isUsedForGrouping && isSentinel) {
     badges.push(<GroupingBadge key={FrameBadge.SENTINEL} badge={FrameBadge.SENTINEL} />);
   }
 
-  if (isPrefix) {
+  if (isUsedForGrouping && isPrefix) {
     badges.push(<GroupingBadge key={FrameBadge.PREFIX} badge={FrameBadge.PREFIX} />);
   }
 

--- a/static/app/components/events/interfaces/stacktraceContentV2.tsx
+++ b/static/app/components/events/interfaces/stacktraceContentV2.tsx
@@ -184,8 +184,9 @@ function StackTraceContent({
           nRepeats++;
         }
 
-        const isVisible =
-          includeSystemFrames || frame.inApp || frame.minGroupingLevel !== undefined;
+        const isUsedForGrouping = isFrameUsedForGrouping(frame);
+
+        const isVisible = includeSystemFrames || frame.inApp || isUsedForGrouping;
 
         if (isVisible && !repeatedFrame) {
           const lineProps = {
@@ -207,7 +208,7 @@ function StackTraceContent({
             isHoverPreviewed,
             isPrefix: !!frame.isPrefix,
             isSentinel: !!frame.isSentinel,
-            isUsedForGrouping: isFrameUsedForGrouping(frame),
+            isUsedForGrouping,
             haveFramesAtLeastOneExpandedFrame,
             haveFramesAtLeastOneGroupingBadge,
           };


### PR DESCRIPTION
Now that we've seen how the current logic plays out, we changed our
minds.

- Don't show sentinel markers unless the frame is currently being
  grouped by. There's nothing interesting about a sentinel that is
  currently irrelevant for grouping.

- Don't show frames that one would only potentially group by.

Later we can improve the rendering of grouping labels to adapt a new design, but right now we need to fix the logic.