### PR TITLE
fix(scim): add excludeAttributes to team details routes

### DIFF
--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -36,6 +36,23 @@ class SCIMGroupDetailsTests(SCIMTestCase):
             "meta": {"resourceType": "Group"},
         }
 
+    def test_scim_team_details_excluded_attributes(self):
+        team = self.create_team(organization=self.organization, name="test-scimv2")
+        # test team details GET
+        url = reverse(
+            "sentry-api-0-organization-scim-team-details",
+            args=[self.organization.slug, team.id],
+        )
+        response = self.client.get(f"{url}?excludedAttributes=members")
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": str(team.id),
+            "displayName": "test-scimv2",
+            "members": None,
+            "meta": {"resourceType": "Group"},
+        }
+
     def test_scim_team_details_patch_replace_rename_team(self):
         team = self.create_team(organization=self.organization)
         # rename a team with the replace op

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -4,9 +4,8 @@ from sentry.models import OrganizationMemberTeam, Team, TeamStatus
 from sentry.testutils import SCIMTestCase
 
 
-class SCIMGroupDetailsTests(SCIMTestCase):
-    def test_group_details_404(self):
-        # test team route 404s
+class SCIMTeamDetailsTests(SCIMTestCase):
+    def test_team_details_404(self):
         url = reverse(
             "sentry-api-0-organization-scim-team-details",
             args=[self.organization.slug, 2],
@@ -21,7 +20,6 @@ class SCIMGroupDetailsTests(SCIMTestCase):
 
     def test_scim_team_details_basic(self):
         team = self.create_team(organization=self.organization, name="test-scimv2")
-        # test team details GET
         url = reverse(
             "sentry-api-0-organization-scim-team-details",
             args=[self.organization.slug, team.id],
@@ -38,7 +36,6 @@ class SCIMGroupDetailsTests(SCIMTestCase):
 
     def test_scim_team_details_excluded_attributes(self):
         team = self.create_team(organization=self.organization, name="test-scimv2")
-        # test team details GET
         url = reverse(
             "sentry-api-0-organization-scim-team-details",
             args=[self.organization.slug, team.id],
@@ -55,7 +52,6 @@ class SCIMGroupDetailsTests(SCIMTestCase):
 
     def test_scim_team_details_patch_replace_rename_team(self):
         team = self.create_team(organization=self.organization)
-        # rename a team with the replace op
         url = reverse(
             "sentry-api-0-organization-scim-team-details", args=[self.organization.slug, team.id]
         )
@@ -120,8 +116,6 @@ class SCIMGroupDetailsTests(SCIMTestCase):
         assert OrganizationMemberTeam.objects.filter(
             team_id=str(team.id), organizationmember_id=member1.id
         ).exists()
-
-        # remove a member from a team
 
     def test_scim_team_details_patch_remove(self):
         team = self.create_team(organization=self.organization)


### PR DESCRIPTION
- We'd like to support the `excludedAttributes` query param on the team details route (already supported on the team index route).

