### PR TITLE
fix(post-process-forwarder): Fix parsing of non insert messages

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -73,8 +73,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
                     "is_new": encode_bool(is_new),
                     "is_new_group_environment": encode_bool(is_new_group_environment),
                     "is_regression": encode_bool(is_regression),
-                    "version": str(self.EVENT_PROTOCOL_VERSION),
-                    "operation": "insert",
                     "skip_consume": encode_bool(skip_consume),
                 }
             )
@@ -100,6 +98,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
     ):
         if headers is None:
             headers = {}
+        headers["operation"] = _type
+        headers["version"] = str(self.EVENT_PROTOCOL_VERSION)
 
         # Polling the producer is required to ensure callbacks are fired. This
         # means that the latency between a message being delivered (or failing


### PR DESCRIPTION
This change ensures that `operation` and `version` are present on
all messages sent on the events topic (not just the "insert" messages).

Now `get_task_kwargs_for_message_from_headers` should not throw an exception
on non insert messages that are missing expected headers and fall back to the
previous implementation. Since we don't need event_data or task_state for
other message types, we can also skip parsing the message values for these types.

Fixes SENTRY-RWM