### PR TITLE
build(ci): Add second snuba test instance

### DIFF
--- a/.github/workflows/snuba-integration-test.yml
+++ b/.github/workflows/snuba-integration-test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        instance: [0]
+        instance: [0, 1]
 
     env:
       USE_SNUBA: 1


### PR DESCRIPTION
Snuba tests are taking over 15 minutes, we are trying to keep all CI runs < 15 minutes, so adding another snuba test instance. This will bring the snuba test from ~18 minutes to ~9 minutes and ~13 minutes

Note: we will need to adjust the GitHub require checks to add `snuba test(1)`.