### PR TITLE
feat(performance): Enable the performance-view feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -886,7 +886,7 @@ SENTRY_FEATURES = {
     # Enable discover 2 custom queries and saved queries
     "organizations:discover-query": True,
     # Enable Performance view
-    "organizations:performance-view": False,
+    "organizations:performance-view": True,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -168,6 +168,9 @@ def pytest_configure(config):
     # this isn't the real secret
     settings.SENTRY_OPTIONS["github.integration-hook-secret"] = "b3002c3e321d4b7880360d397db2ccfd"
 
+    # This is so tests can assume this feature is off by default
+    settings.SENTRY_FEATURES["organizations:performance-view"] = False
+
     # django mail uses socket.getfqdn which doesn't play nice if our
     # networking isn't stable
     patcher = mock.patch("socket.getfqdn", return_value="localhost")


### PR DESCRIPTION
- Going to just manually keep this off in tests so we don't need to
  update all the tests that require it to be off by default
- Second attempt at https://github.com/getsentry/sentry/pull/26178 after it closed from staleness