### PR TITLE
ref(search): Bring tokenizeSearch naming inline

### DIFF
--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -150,7 +150,7 @@ class TransactionsList extends React.Component<Props> {
     const sortedEventView = eventView.withSorts([selected.sort]);
     if (selected.query) {
       const query = tokenizeSearch(sortedEventView.query);
-      selected.query.forEach(item => query.setTagValues(item[0], [item[1]]));
+      selected.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       sortedEventView.query = query.formatString();
     }
 
@@ -344,7 +344,7 @@ class TransactionsList extends React.Component<Props> {
     sortedEventView.trendType = selected.trendType;
     if (selected.query) {
       const query = tokenizeSearch(sortedEventView.query);
-      selected.query.forEach(item => query.setTagValues(item[0], [item[1]]));
+      selected.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       sortedEventView.query = query.formatString();
     }
     const cursor = decodeScalar(location.query?.[cursorName]);

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -113,7 +113,7 @@ export function generateMultiTransactionsTarget(
   const eventIds = events.map(child => child.event_id);
   for (let i = 0; i < eventIds.length; i++) {
     queryResults.addOp(i === 0 ? '(' : 'OR');
-    queryResults.addQuery(`id:${eventIds[i]}`);
+    queryResults.addFreeText(`id:${eventIds[i]}`);
     if (i === eventIds.length - 1) {
       queryResults.addOp(')');
     }

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1311,13 +1311,13 @@ class EventView {
       return query;
     }
     const conditions = tokenizeSearch(query);
-    Object.entries(this.additionalConditions.tagValues).forEach(([tag, tagValues]) => {
-      const existingTagValues = conditions.getTagValues(tag);
+    Object.entries(this.additionalConditions.filters).forEach(([tag, tagValues]) => {
+      const existingTagValues = conditions.getFilterValues(tag);
       const newTagValues = tagValues.filter(
         tagValue => !existingTagValues.includes(tagValue)
       );
       if (newTagValues.length) {
-        conditions.addTagValues(tag, newTagValues);
+        conditions.addFilterValues(tag, newTagValues);
       }
     });
     return conditions.formatString();

--- a/static/app/utils/performance/vitals/hasMeasurementsQuery.tsx
+++ b/static/app/utils/performance/vitals/hasMeasurementsQuery.tsx
@@ -7,7 +7,7 @@ import GenericDiscoverQuery, {
   DiscoverQueryProps,
   GenericChildrenProps,
 } from 'app/utils/discover/genericDiscoverQuery';
-import {escapeTagValue} from 'app/utils/tokenizeSearch';
+import {escapeFilterValue} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 
 type HasMeasurementsProps = {
@@ -29,7 +29,7 @@ type Props = RequestProps & {
 
 function getHasMeasurementsRequestPayload(props: RequestProps) {
   const {eventView, location, transaction, type} = props;
-  const escaped = escapeDoubleQuotes(escapeTagValue(transaction));
+  const escaped = escapeDoubleQuotes(escapeFilterValue(transaction));
   const baseApiPayload = {
     transaction: `"${escaped}"`,
     type,

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -1,9 +1,9 @@
 import {escapeDoubleQuotes} from 'app/utils';
 
 export enum TokenType {
-  OP,
-  TAG,
-  QUERY,
+  OPERATOR,
+  FILTER,
+  FREE_TEXT,
 }
 
 export type Token = {
@@ -13,7 +13,7 @@ export type Token = {
 };
 
 function isOp(t: Token) {
-  return t.type === TokenType.OP;
+  return t.type === TokenType.OPERATOR;
 }
 
 function isBooleanOp(value: string) {
@@ -34,14 +34,15 @@ function isParen(token: Token, character: '(' | ')') {
 // with `parseSearch`.
 
 export class QueryResults {
-  tagValues: Record<string, string[]>;
+  filters: Record<string, string[]>;
   tokens: Token[];
 
   constructor(strTokens: string[]) {
     this.tokens = [];
-    this.tagValues = {};
+    this.filters = {};
+
     for (let token of strTokens) {
-      let tokenState = TokenType.QUERY;
+      let tokenState = TokenType.FREE_TEXT;
 
       if (isBooleanOp(token)) {
         this.addOp(token.toUpperCase());
@@ -56,8 +57,7 @@ export class QueryResults {
         }
       }
 
-      // Traverse the token and determine if it is a tag
-      // condition or bare words.
+      // Traverse the token and check if it's a filter condition or free text
       for (let i = 0, len = token.length; i < len; i++) {
         const char = token[i];
 
@@ -65,13 +65,13 @@ export class QueryResults {
           break;
         }
 
-        // We may have entered a tag condition
+        // We may have entered a filter condition
         if (char === ':') {
           const nextChar = token[i + 1] || '';
           if ([':', ' '].includes(nextChar)) {
-            tokenState = TokenType.QUERY;
+            tokenState = TokenType.FREE_TEXT;
           } else {
-            tokenState = TokenType.TAG;
+            tokenState = TokenType.FILTER;
           }
           break;
         }
@@ -86,10 +86,10 @@ export class QueryResults {
         }
       }
 
-      if (tokenState === TokenType.QUERY && token.length) {
-        this.addQuery(token);
-      } else if (tokenState === TokenType.TAG) {
-        this.addStringTag(token, false);
+      if (tokenState === TokenType.FREE_TEXT && token.length) {
+        this.addFreeText(token);
+      } else if (tokenState === TokenType.FILTER) {
+        this.addStringFilter(token, false);
       }
 
       if (trailingParen !== '') {
@@ -102,7 +102,7 @@ export class QueryResults {
     const formattedTokens: string[] = [];
     for (const token of this.tokens) {
       switch (token.type) {
-        case TokenType.TAG:
+        case TokenType.FILTER:
           if (token.value === '' || token.value === null) {
             formattedTokens.push(`${token.key}:""`);
           } else if (/[\s\(\)\\"]/g.test(token.value)) {
@@ -111,7 +111,7 @@ export class QueryResults {
             formattedTokens.push(`${token.key}:${token.value}`);
           }
           break;
-        case TokenType.QUERY:
+        case TokenType.FREE_TEXT:
           if (/[\s\(\)\\"]/g.test(token.value)) {
             formattedTokens.push(`"${escapeDoubleQuotes(token.value)}"`);
           } else {
@@ -125,48 +125,48 @@ export class QueryResults {
     return formattedTokens.join(' ').trim();
   }
 
-  addStringTag(value: string, shouldEscape = true) {
-    const [key, tag] = formatTag(value);
-    this.addTagValues(key, [tag], shouldEscape);
+  addStringFilter(filter: string, shouldEscape = true) {
+    const [key, value] = parseFilter(filter);
+    this.addFilterValues(key, [value], shouldEscape);
     return this;
   }
 
-  addTagValues(tag: string, tagValues: string[], shouldEscape = true) {
-    for (const t of tagValues) {
-      // Tag values that we insert through the UI can contain special characters
+  addFilterValues(key: string, values: string[], shouldEscape = true) {
+    for (const value of values) {
+      // Filter values that we insert through the UI can contain special characters
       // that need to escaped. User entered filters should not be escaped.
-      const escaped = shouldEscape ? escapeTagValue(t) : t;
-      this.tagValues[tag] = Array.isArray(this.tagValues[tag])
-        ? [...this.tagValues[tag], escaped]
+      const escaped = shouldEscape ? escapeFilterValue(value) : value;
+      this.filters[key] = Array.isArray(this.filters[key])
+        ? [...this.filters[key], escaped]
         : [escaped];
-      const token: Token = {type: TokenType.TAG, key: tag, value: escaped};
+      const token: Token = {type: TokenType.FILTER, key, value: escaped};
       this.tokens.push(token);
     }
     return this;
   }
 
-  setTagValues(tag: string, tagValues: string[], shouldEscape = true) {
-    this.removeTag(tag);
-    this.addTagValues(tag, tagValues, shouldEscape);
+  setFilterValues(key: string, values: string[], shouldEscape = true) {
+    this.removeFilter(key);
+    this.addFilterValues(key, values, shouldEscape);
     return this;
   }
 
-  getTagValues(tag: string) {
-    return this.tagValues[tag] ?? [];
+  getFilterValues(key: string) {
+    return this.filters[key] ?? [];
   }
 
-  getTagKeys() {
-    return Object.keys(this.tagValues);
+  getFilterKeys() {
+    return Object.keys(this.filters);
   }
 
-  hasTag(tag: string): boolean {
-    const tags = this.getTagValues(tag);
-    return !!(tags && tags.length);
+  hasFilter(key: string): boolean {
+    const filters = this.getFilterValues(key);
+    return !!(filters && filters.length);
   }
 
-  removeTag(key: string) {
+  removeFilter(key: string) {
     this.tokens = this.tokens.filter(token => token.key !== key);
-    delete this.tagValues[key];
+    delete this.filters[key];
 
     // Now the really complicated part: removing parens that only have one element in them.
     // Since parens are themselves tokens, this gets tricky. In summary, loop through the
@@ -246,42 +246,42 @@ export class QueryResults {
     return this;
   }
 
-  removeTagValue(key: string, value: string) {
-    const values = this.getTagValues(key);
+  removeFilterValue(key: string, value: string) {
+    const values = this.getFilterValues(key);
     if (Array.isArray(values) && values.length) {
-      this.setTagValues(
+      this.setFilterValues(
         key,
         values.filter(item => item !== value)
       );
     }
   }
 
-  addQuery(value: string) {
-    const token: Token = {type: TokenType.QUERY, value: formatQuery(value)};
+  addFreeText(value: string) {
+    const token: Token = {type: TokenType.FREE_TEXT, value: formatQuery(value)};
     this.tokens.push(token);
     return this;
   }
 
   addOp(value: string) {
-    const token: Token = {type: TokenType.OP, value};
+    const token: Token = {type: TokenType.OPERATOR, value};
     this.tokens.push(token);
     return this;
   }
 
-  get query(): string[] {
-    return this.tokens.filter(t => t.type === TokenType.QUERY).map(t => t.value);
+  get freeText(): string[] {
+    return this.tokens.filter(t => t.type === TokenType.FREE_TEXT).map(t => t.value);
   }
 
-  set query(values: string[]) {
-    this.tokens = this.tokens.filter(t => t.type !== TokenType.QUERY);
+  set freeText(values: string[]) {
+    this.tokens = this.tokens.filter(t => t.type !== TokenType.FREE_TEXT);
     for (const v of values) {
-      this.addQuery(v);
+      this.addFreeText(v);
     }
   }
 
   copy() {
     const q = new QueryResults([]);
-    q.tagValues = {...this.tagValues};
+    q.filters = {...this.filters};
     q.tokens = [...this.tokens];
     return q;
   }
@@ -293,7 +293,6 @@ export class QueryResults {
 
 /**
  * Tokenize a search into a QueryResult
- *
  *
  * Should stay in sync with src.sentry.search.utils:tokenize_query
  */
@@ -359,13 +358,13 @@ function isSpace(s: string) {
 }
 
 /**
- * Splits tags on ':' and removes enclosing quotes if present, and returns both
- * sides of the split as strings.
+ * Splits a filter on ':' and removes enclosing quotes if present, and returns
+ * both sides of the split as strings.
  */
-function formatTag(tag: string) {
-  const idx = tag.indexOf(':');
-  const key = removeSurroundingQuotes(tag.slice(0, idx));
-  const value = removeSurroundingQuotes(tag.slice(idx + 1));
+function parseFilter(filter: string) {
+  const idx = filter.indexOf(':');
+  const key = removeSurroundingQuotes(filter.slice(0, idx));
+  const value = removeSurroundingQuotes(filter.slice(idx + 1));
 
   return [key, value];
 }
@@ -401,11 +400,10 @@ function formatQuery(query: string) {
 }
 
 /**
- * Some characters have special meaning in a tag value. So when they
- * are directly added as a tag value, we have to escape them to mean
- * the literal.
+ * Some characters have special meaning in a filter value. So when they are
+ * directly added as a value, we have to escape them to mean the literal.
  */
-export function escapeTagValue(value: string) {
+export function escapeFilterValue(value: string) {
   // TODO(txiao): The types here are definitely wrong.
   // Need to dig deeper to see where exactly it's wrong.
   //

--- a/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
+++ b/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
@@ -151,7 +151,7 @@ function makeGenericTransactionCta(opts: {
 
   const query = tokenizeSearch(rule.query ?? '');
   const transaction = query
-    .getTagValues('transaction')
+    .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));
 
   // CASE 1
@@ -212,7 +212,7 @@ function makeFailureRateCta({orgSlug, rule, projects, start, end}: PresetCtaOpts
 
   const query = tokenizeSearch(rule.query ?? '');
   const transaction = query
-    .getTagValues('transaction')
+    .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));
 
   const extraQueryParams =

--- a/static/app/views/alerts/incidentRules/presets.tsx
+++ b/static/app/views/alerts/incidentRules/presets.tsx
@@ -152,7 +152,7 @@ function makeGenericTransactionCta(opts: {
 
   const query = tokenizeSearch(incident.discoverQuery ?? '');
   const transaction = query
-    .getTagValues('transaction')
+    .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));
 
   // CASE 1
@@ -214,7 +214,7 @@ function makeFailureRateCta({orgSlug, incident, projects, stats}: PresetCtaOpts)
 
   const query = tokenizeSearch(incident.discoverQuery ?? '');
   const transaction = query
-    .getTagValues('transaction')
+    .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));
 
   const extraQueryParams =

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -58,48 +58,48 @@ export function updateQuery(
       if (value === null || value === undefined) {
         // Adding a null value is the same as excluding truthy values.
         // Remove inclusion if it exists.
-        results.removeTagValue('has', key);
-        results.addTagValues('!has', [key]);
+        results.removeFilterValue('has', key);
+        results.addFilterValues('!has', [key]);
       } else {
         // Remove exclusion if it exists.
-        results.removeTag(`!${key}`);
+        results.removeFilter(`!${key}`);
 
         if (Array.isArray(value)) {
           // For array values, add to existing filters
-          const currentFilters = results.getTagValues(key);
+          const currentFilters = results.getFilterValues(key);
           value = [...new Set([...currentFilters, ...value])];
         } else {
           value = [String(value)];
         }
 
-        results.setTagValues(key, value);
+        results.setFilterValues(key, value);
       }
       break;
     case Actions.EXCLUDE:
       if (value === null || value === undefined) {
         // Excluding a null value is the same as including truthy values.
         // Remove exclusion if it exists.
-        results.removeTagValue('!has', key);
-        results.addTagValues('has', [key]);
+        results.removeFilterValue('!has', key);
+        results.addFilterValues('has', [key]);
       } else {
         // Remove positive if it exists.
-        results.removeTag(key);
+        results.removeFilter(key);
         // Negations should stack up.
         const negation = `!${key}`;
         value = Array.isArray(value) ? value : [String(value)];
-        const currentNegations = results.getTagValues(negation);
+        const currentNegations = results.getFilterValues(negation);
         value = [...new Set([...currentNegations, ...value])];
-        results.setTagValues(negation, value);
+        results.setFilterValues(negation, value);
       }
       break;
     case Actions.SHOW_GREATER_THAN: {
       // Remove query token if it already exists
-      results.setTagValues(key, [`>${value}`]);
+      results.setFilterValues(key, [`>${value}`]);
       break;
     }
     case Actions.SHOW_LESS_THAN: {
       // Remove query token if it already exists
-      results.setTagValues(key, [`<${value}`]);
+      results.setFilterValues(key, [`<${value}`]);
       break;
     }
     // these actions do not modify the query in any way,

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -378,10 +378,10 @@ function generateExpandedConditions(
 
   // Remove any aggregates from the search conditions.
   // otherwise, it'll lead to an invalid query result.
-  for (const key in parsedQuery.tagValues) {
+  for (const key in parsedQuery.filters) {
     const column = explodeFieldString(key);
     if (column.kind === 'function') {
-      parsedQuery.removeTag(key);
+      parsedQuery.removeFilter(key);
     }
   }
 
@@ -396,7 +396,7 @@ function generateExpandedConditions(
     const value = conditions[key];
 
     if (Array.isArray(value)) {
-      parsedQuery.setTagValues(key, value);
+      parsedQuery.setFilterValues(key, value);
       continue;
     }
 
@@ -416,7 +416,7 @@ function generateExpandedConditions(
       continue;
     }
 
-    parsedQuery.setTagValues(key, [value]);
+    parsedQuery.setFilterValues(key, [value]);
   }
 
   return parsedQuery.formatString();

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -147,18 +147,18 @@ class PerformanceContent extends Component<Props, State> {
 
     const modifiedConditions = new QueryResults([]);
 
-    if (conditions.hasTag('tpm()')) {
-      modifiedConditions.setTagValues('tpm()', conditions.getTagValues('tpm()'));
+    if (conditions.hasFilter('tpm()')) {
+      modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));
     } else {
-      modifiedConditions.setTagValues('tpm()', ['>0.01']);
+      modifiedConditions.setFilterValues('tpm()', ['>0.01']);
     }
-    if (conditions.hasTag('transaction.duration')) {
-      modifiedConditions.setTagValues(
+    if (conditions.hasFilter('transaction.duration')) {
+      modifiedConditions.setFilterValues(
         'transaction.duration',
-        conditions.getTagValues('transaction.duration')
+        conditions.getFilterValues('transaction.duration')
       );
     } else {
-      modifiedConditions.setTagValues('transaction.duration', [
+      modifiedConditions.setFilterValues('transaction.duration', [
         '>0',
         `<${DEFAULT_MAX_DURATION}`,
       ]);

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -450,21 +450,25 @@ function generateGenericPerformanceEventView(
   const conditions = tokenizeSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasTag('transaction.duration')) {
-    conditions.setTagValues('transaction.duration', ['<15m']);
+  if (!conditions.hasFilter('transaction.duration')) {
+    conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.query.length > 0) {
+  if (conditions.freeText.length > 0) {
     // the query here is a user entered condition, no need to escape it
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
-    conditions.query = [];
+    conditions.setFilterValues(
+      'transaction',
+      [`*${conditions.freeText.join(' ')}*`],
+      false
+    );
+    conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
-  eventView.additionalConditions.addTagValues('event.type', ['transaction']);
+  eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
   return eventView;
 }
 
@@ -518,21 +522,25 @@ function generateBackendPerformanceEventView(
   const conditions = tokenizeSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasTag('transaction.duration')) {
-    conditions.setTagValues('transaction.duration', ['<15m']);
+  if (!conditions.hasFilter('transaction.duration')) {
+    conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.query.length > 0) {
+  if (conditions.freeText.length > 0) {
     // the query here is a user entered condition, no need to escape it
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
-    conditions.query = [];
+    conditions.setFilterValues(
+      'transaction',
+      [`*${conditions.freeText.join(' ')}*`],
+      false
+    );
+    conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
-  eventView.additionalConditions.addTagValues('event.type', ['transaction']);
+  eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
   return eventView;
 }
 
@@ -607,21 +615,25 @@ function generateMobilePerformanceEventView(
   const conditions = tokenizeSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasTag('transaction.duration')) {
-    conditions.setTagValues('transaction.duration', ['<15m']);
+  if (!conditions.hasFilter('transaction.duration')) {
+    conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.query.length > 0) {
+  if (conditions.freeText.length > 0) {
     // the query here is a user entered condition, no need to escape it
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
-    conditions.query = [];
+    conditions.setFilterValues(
+      'transaction',
+      [`*${conditions.freeText.join(' ')}*`],
+      false
+    );
+    conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
-  eventView.additionalConditions.addTagValues('event.type', ['transaction']);
+  eventView.additionalConditions.addFilterValues('event.type', ['transaction']);
   return eventView;
 }
 
@@ -673,23 +685,27 @@ function generateFrontendPageloadPerformanceEventView(
   const conditions = tokenizeSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasTag('transaction.duration')) {
-    conditions.setTagValues('transaction.duration', ['<15m']);
+  if (!conditions.hasFilter('transaction.duration')) {
+    conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.query.length > 0) {
+  if (conditions.freeText.length > 0) {
     // the query here is a user entered condition, no need to escape it
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
-    conditions.query = [];
+    conditions.setFilterValues(
+      'transaction',
+      [`*${conditions.freeText.join(' ')}*`],
+      false
+    );
+    conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions
-    .addTagValues('event.type', ['transaction'])
-    .addTagValues('transaction.op', ['pageload']);
+    .addFilterValues('event.type', ['transaction'])
+    .addFilterValues('transaction.op', ['pageload']);
   return eventView;
 }
 
@@ -741,23 +757,27 @@ function generateFrontendOtherPerformanceEventView(
   const conditions = tokenizeSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
-  if (!conditions.hasTag('transaction.duration')) {
-    conditions.setTagValues('transaction.duration', ['<15m']);
+  if (!conditions.hasFilter('transaction.duration')) {
+    conditions.setFilterValues('transaction.duration', ['<15m']);
   }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.query.length > 0) {
+  if (conditions.freeText.length > 0) {
     // the query here is a user entered condition, no need to escape it
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
-    conditions.query = [];
+    conditions.setFilterValues(
+      'transaction',
+      [`*${conditions.freeText.join(' ')}*`],
+      false
+    );
+    conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions
-    .addTagValues('event.type', ['transaction'])
-    .addTagValues('!transaction.op', ['pageload']);
+    .addFilterValues('event.type', ['transaction'])
+    .addFilterValues('!transaction.op', ['pageload']);
   return eventView;
 }
 
@@ -831,16 +851,20 @@ export function generatePerformanceVitalDetailView(
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
-  if (conditions.query.length > 0) {
+  if (conditions.freeText.length > 0) {
     // the query here is a user entered condition, no need to escape it
-    conditions.setTagValues('transaction', [`*${conditions.query.join(' ')}*`], false);
-    conditions.query = [];
+    conditions.setFilterValues(
+      'transaction',
+      [`*${conditions.freeText.join(' ')}*`],
+      false
+    );
+    conditions.freeText = [];
   }
   savedQuery.query = conditions.formatString();
 
   const eventView = EventView.fromNewQueryWithLocation(savedQuery, location);
   eventView.additionalConditions
-    .addTagValues('event.type', ['transaction'])
-    .addTagValues('has', [vitalName]);
+    .addFilterValues('event.type', ['transaction'])
+    .addFilterValues('has', [vitalName]);
   return eventView;
 }

--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -62,7 +62,7 @@ type State = {};
 class LandingContent extends Component<Props, State> {
   getSummaryConditions(query: string) {
     const parsed = tokenizeSearch(query);
-    parsed.query = [];
+    parsed.freeText = [];
 
     return parsed.formatString();
   }
@@ -81,7 +81,7 @@ class LandingContent extends Component<Props, State> {
     // Transaction op can affect the display and show no results if it is explicitly set.
     const query = decodeScalar(location.query.query, '');
     const searchConditions = tokenizeSearch(query);
-    searchConditions.removeTag('transaction.op');
+    searchConditions.removeFilter('transaction.op');
 
     trackAnalyticsEvent({
       eventKey: 'performance_views.landingv2.display_change',

--- a/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
+++ b/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
@@ -36,7 +36,7 @@ function DoubleAxisDisplay(props: Props) {
     const filterString = getTransactionSearchQuery(location);
 
     const conditions = tokenizeSearch(filterString);
-    conditions.setTagValues(field, [
+    conditions.setFilterValues(field, [
       `>=${Math.round(minValue)}`,
       `<${Math.round(maxValue)}`,
     ]);

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -144,7 +144,7 @@ class Table extends React.Component<Props, State> {
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       updateQuery(searchConditions, action, column, value);
 
@@ -190,7 +190,7 @@ class Table extends React.Component<Props, State> {
       const projectID = getProjectID(dataRow, projects);
       const summaryView = eventView.clone();
       if (dataRow['http.method']) {
-        summaryView.additionalConditions.setTagValues('http.method', [
+        summaryView.additionalConditions.setFilterValues('http.method', [
           dataRow['http.method'] as string,
         ]);
       }

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -124,10 +124,10 @@ class SummaryContent extends React.Component<Props, State> {
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       // no need to include transaction as its already in the query params
-      searchConditions.removeTag('transaction');
+      searchConditions.removeFilter('transaction');
 
       updateQuery(searchConditions, action, column, value);
 

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -321,11 +321,11 @@ function generateSummaryEventView(
   const query = decodeScalar(location.query.query, '');
   const conditions = tokenizeSearch(query);
   conditions
-    .setTagValues('event.type', ['transaction'])
-    .setTagValues('transaction', [transactionName]);
+    .setFilterValues('event.type', ['transaction'])
+    .setFilterValues('transaction', [transactionName]);
 
-  Object.keys(conditions.tagValues).forEach(field => {
-    if (isAggregateField(field)) conditions.removeTag(field);
+  Object.keys(conditions.filters).forEach(field => {
+    if (isAggregateField(field)) conditions.removeFilter(field);
   });
 
   const fields = ['id', 'user.display', 'transaction.duration', 'trace', 'timestamp'];

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -48,7 +48,7 @@ class RelatedIssues extends Component<Props> {
       ...pick(location.query, [...Object.values(URL_PARAM), 'cursor']),
     };
     const currentFilter = tokenizeSearch(decodeScalar(location.query.query, ''));
-    currentFilter.getTagKeys().forEach(tagKey => {
+    currentFilter.getFilterKeys().forEach(tagKey => {
       const searchKey = tagKey.startsWith('!') ? tagKey.substr(1) : tagKey;
       // Remove aggregates and transaction event fields
       if (
@@ -59,10 +59,12 @@ class RelatedIssues extends Component<Props> {
         // tags that we don't want to pass to pass to issue search
         EXCLUDE_TAG_KEYS.has(searchKey)
       ) {
-        currentFilter.removeTag(tagKey);
+        currentFilter.removeFilter(tagKey);
       }
     });
-    currentFilter.addQuery('is:unresolved').setTagValues('transaction', [transaction]);
+    currentFilter
+      .addFreeText('is:unresolved')
+      .setFilterValues('transaction', [transaction]);
 
     return {
       path: `/organizations/${organization.slug}/issues/`,

--- a/static/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -69,8 +69,8 @@ function StatusBreakdown({eventView, location, organization}: Props) {
             onClick: () => {
               const query = tokenizeSearch(eventView.query);
               query
-                .removeTag('!transaction.status')
-                .setTagValues('transaction.status', [row['transaction.status']]);
+                .removeFilter('!transaction.status')
+                .setFilterValues('transaction.status', [row['transaction.status']]);
               browserHistory.push({
                 pathname: location.pathname,
                 query: {

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -285,7 +285,7 @@ class _TagExplorer extends React.Component<Props> {
     const queryString = decodeScalar(location.query.query);
     const conditions = tokenizeSearch(queryString || '');
 
-    conditions.addTagValues(tagKey, [tagValue]);
+    conditions.addFilterValues(tagKey, [tagValue]);
 
     const query = conditions.formatString();
     browserHistory.push({
@@ -313,7 +313,7 @@ class _TagExplorer extends React.Component<Props> {
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       updateQuery(searchConditions, action, {...column, name: actionRow.id}, tagValue);
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -64,10 +64,10 @@ class EventsPageContent extends React.Component<Props, State> {
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       // no need to include transaction as its already in the query params
-      searchConditions.removeTag('transaction');
+      searchConditions.removeFilter('transaction');
 
       updateQuery(searchConditions, action, column, value);
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -100,7 +100,7 @@ class EventsTable extends React.Component<Props, State> {
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       updateQuery(searchConditions, action, column, value);
 

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -158,7 +158,7 @@ class TransactionEvents extends Component<Props, State> {
     const filteredEventView = eventView?.clone();
     if (filteredEventView && filter?.query) {
       const query = tokenizeSearch(filteredEventView.query);
-      filter.query.forEach(item => query.setTagValues(item[0], [item[1]]));
+      filter.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       filteredEventView.query = query.formatString();
     }
     return filteredEventView;
@@ -309,11 +309,11 @@ function generateEventsEventView(
   const query = decodeScalar(location.query.query, '');
   const conditions = tokenizeSearch(query);
   conditions
-    .setTagValues('event.type', ['transaction'])
-    .setTagValues('transaction', [transactionName]);
+    .setFilterValues('event.type', ['transaction'])
+    .setFilterValues('transaction', [transactionName]);
 
-  Object.keys(conditions.tagValues).forEach(field => {
-    if (isAggregateField(field)) conditions.removeTag(field);
+  Object.keys(conditions.filters).forEach(field => {
+    if (isAggregateField(field)) conditions.removeFilter(field);
   });
 
   // Default fields for relative span view

--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -149,7 +149,7 @@ const InnerContent = (
     return changeTagSelected(tag);
   };
   if (tagSelected) {
-    eventView.additionalConditions.setTagValues('has', [tagSelected]);
+    eventView.additionalConditions.setFilterValues('has', [tagSelected]);
   }
 
   const query = decodeScalar(location.query.query, '');

--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -153,8 +153,8 @@ function generateTagsEventView(
     location
   );
 
-  eventView.additionalConditions.setTagValues('event.type', ['transaction']);
-  eventView.additionalConditions.setTagValues('transaction', [transactionName]);
+  eventView.additionalConditions.setFilterValues('event.type', ['transaction']);
+  eventView.additionalConditions.setFilterValues('transaction', [transactionName]);
   return eventView;
 }
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -172,7 +172,7 @@ export class TagValueTable extends Component<Props, State> {
     const queryString = decodeScalar(location.query.query);
     const conditions = tokenizeSearch(queryString || '');
 
-    conditions.addTagValues(tagKey, [tagValue]);
+    conditions.addFilterValues(tagKey, [tagValue]);
 
     const query = conditions.formatString();
     browserHistory.push({
@@ -195,7 +195,7 @@ export class TagValueTable extends Component<Props, State> {
 
       const searchConditions = tokenizeSearch(eventView.query);
 
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       updateQuery(searchConditions, action, {...column, name: actionRow.id}, tagValue);
 
@@ -244,7 +244,7 @@ export class TagValueTable extends Component<Props, State> {
 
     if (column.key === 'action') {
       const searchConditions = tokenizeSearch(eventView.query);
-      const disabled = searchConditions.hasTag(dataRow.tags_key);
+      const disabled = searchConditions.hasFilter(dataRow.tags_key);
       return (
         <Link
           disabled={disabled}

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -295,13 +295,13 @@ const TagsHeatMap = (
                 const currentBucketEnd =
                   currentBucketStart + histogramBucketInfo.bucketSize;
 
-                newTransactionEventView.additionalConditions.setTagValues(
+                newTransactionEventView.additionalConditions.setFilterValues(
                   aggregateColumn,
                   [`>=${currentBucketStart}`, `<${currentBucketEnd}`]
                 );
               }
 
-              newTransactionEventView.additionalConditions.setTagValues(tagKey, [
+              newTransactionEventView.additionalConditions.setFilterValues(tagKey, [
                 tagValue,
               ]);
 

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
@@ -145,12 +145,12 @@ function generateRumEventView(
   const query = decodeScalar(location.query.query, '');
   const conditions = tokenizeSearch(query);
   conditions
-    .setTagValues('event.type', ['transaction'])
-    .setTagValues('transaction.op', ['pageload'])
-    .setTagValues('transaction', [transactionName]);
+    .setFilterValues('event.type', ['transaction'])
+    .setFilterValues('transaction.op', ['pageload'])
+    .setFilterValues('transaction', [transactionName]);
 
-  Object.keys(conditions.tagValues).forEach(field => {
-    if (isAggregateField(field)) conditions.removeTag(field);
+  Object.keys(conditions.filters).forEach(field => {
+    if (isAggregateField(field)) conditions.removeFilter(field);
   });
 
   const vitals = VITAL_GROUPS.reduce((allVitals: WebVital[], group) => {

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -194,14 +194,14 @@ class VitalCard extends Component<Props, State> {
       ]);
 
     const query = tokenizeSearch(newEventView.query ?? '');
-    query.addTagValues('has', [column]);
+    query.addFilterValues('has', [column]);
     // add in any range constraints if any
     if (min !== undefined || max !== undefined) {
       if (min !== undefined) {
-        query.addTagValues(column, [`>=${min}`]);
+        query.addFilterValues(column, [`>=${min}`]);
       }
       if (max !== undefined) {
-        query.addTagValues(column, [`<=${max}`]);
+        query.addFilterValues(column, [`<=${max}`]);
       }
     }
     newEventView.query = query.formatString();

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -163,7 +163,7 @@ function handleFilterTransaction(location: Location, transaction: string) {
   const queryString = decodeScalar(location.query.query);
   const conditions = tokenizeSearch(queryString || '');
 
-  conditions.addTagValues('!transaction', [transaction]);
+  conditions.addFilterValues('!transaction', [transaction]);
 
   const query = conditions.formatString();
 
@@ -181,18 +181,18 @@ function handleFilterDuration(location: Location, value: number, symbol: FilterS
   const queryString = decodeScalar(location.query.query);
   const conditions = tokenizeSearch(queryString || '');
 
-  const existingValues = conditions.getTagValues(durationTag);
+  const existingValues = conditions.getFilterValues(durationTag);
   const alternateSymbol = symbol === FilterSymbols.GREATER_THAN_EQUALS ? '>' : '<';
 
   if (existingValues) {
     existingValues.forEach(existingValue => {
       if (existingValue.startsWith(symbol) || existingValue.startsWith(alternateSymbol)) {
-        conditions.removeTagValue(durationTag, existingValue);
+        conditions.removeFilterValue(durationTag, existingValue);
       }
     });
   }
 
-  conditions.addTagValues(durationTag, [`${symbol}${value}`]);
+  conditions.addFilterValues(durationTag, [`${symbol}${value}`]);
 
   const query = conditions.formatString();
 

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -150,9 +150,9 @@ class TrendsContent extends React.Component<Props, State> {
     const conditions = tokenizeSearch(query);
 
     // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
-    conditions.removeTag('tpm()');
-    conditions.removeTag('confidence()');
-    conditions.removeTag('transaction.duration');
+    conditions.removeFilter('tpm()');
+    conditions.removeFilter('confidence()');
+    conditions.removeFilter('transaction.duration');
     newQuery.query = conditions.formatString();
     return {
       pathname: getPerformanceLandingUrl(this.props.organization),
@@ -321,8 +321,11 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
       return <React.Fragment>{children}</React.Fragment>;
     } else {
       this.hasPushedDefaults = true;
-      conditions.setTagValues('tpm()', ['>0.01']);
-      conditions.setTagValues(trendParameter.column, ['>0', `<${DEFAULT_MAX_DURATION}`]);
+      conditions.setFilterValues('tpm()', ['>0.01']);
+      conditions.setFilterValues(trendParameter.column, [
+        '>0',
+        `<${DEFAULT_MAX_DURATION}`,
+      ]);
     }
 
     const query = conditions.formatString();

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -318,14 +318,14 @@ export function movingAverage(data, index, size) {
  */
 function getLimitTransactionItems(query: string) {
   const limitQuery = tokenizeSearch(query);
-  if (!limitQuery.hasTag('count_percentage()')) {
-    limitQuery.addTagValues('count_percentage()', ['>0.25', '<4']);
+  if (!limitQuery.hasFilter('count_percentage()')) {
+    limitQuery.addFilterValues('count_percentage()', ['>0.25', '<4']);
   }
-  if (!limitQuery.hasTag('trend_percentage()')) {
-    limitQuery.addTagValues('trend_percentage()', ['>0%']);
+  if (!limitQuery.hasFilter('trend_percentage()')) {
+    limitQuery.addFilterValues('trend_percentage()', ['>0%']);
   }
-  if (!limitQuery.hasTag('confidence()')) {
-    limitQuery.addTagValues('confidence()', ['>6']);
+  if (!limitQuery.hasFilter('confidence()')) {
+    limitQuery.addFilterValues('confidence()', ['>6']);
   }
   return limitQuery.formatString();
 }

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -67,7 +67,7 @@ export function platformAndConditionsToPerformanceType(
   const performanceType = platformToPerformanceType(projects, eventView.project);
   if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
     const conditions = tokenizeSearch(eventView.query);
-    const ops = conditions.getTagValues('!transaction.op');
+    const ops = conditions.getFilterValues('!transaction.op');
     if (ops.some(op => op === 'pageload')) {
       return PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER;
     }

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -109,7 +109,7 @@ class Table extends React.Component<Props, State> {
       const searchConditions = tokenizeSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
-      searchConditions.removeTag('event.type');
+      searchConditions.removeFilter('event.type');
 
       updateQuery(searchConditions, action, column, value);
 
@@ -177,7 +177,7 @@ class Table extends React.Component<Props, State> {
       const projectID = getProjectID(dataRow, projects);
       const summaryView = eventView.clone();
       const conditions = tokenizeSearch(summaryConditions);
-      conditions.addTagValues('has', [`${vitalName}`]);
+      conditions.addFilterValues('has', [`${vitalName}`]);
       summaryView.query = conditions.formatString();
 
       const target = transactionSummaryRouteWithQuery({

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -54,7 +54,7 @@ type State = {
 
 function getSummaryConditions(query: string) {
   const parsed = tokenizeSearch(query);
-  parsed.query = [];
+  parsed.freeText = [];
 
   return parsed.formatString();
 }

--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -29,8 +29,11 @@ function ProjectQuickLinks({organization, project, location}: Props) {
   function getTrendsLink() {
     const queryString = decodeScalar(location.query.query);
     const conditions = tokenizeSearch(queryString || '');
-    conditions.setTagValues('tpm()', ['>0.01']);
-    conditions.setTagValues('transaction.duration', ['>0', `<${DEFAULT_MAX_DURATION}`]);
+    conditions.setFilterValues('tpm()', ['>0.01']);
+    conditions.setFilterValues('transaction.duration', [
+      '>0',
+      `<${DEFAULT_MAX_DURATION}`,
+    ]);
 
     return {
       pathname: getPerformanceTrendsUrl(organization),

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -148,16 +148,16 @@ class Issues extends Component<Props, State> {
 
     switch (issuesType) {
       case IssuesType.NEW:
-        query.setTagValues('firstRelease', [version]);
+        query.setFilterValues('firstRelease', [version]);
         break;
       case IssuesType.UNHANDLED:
-        query.setTagValues('release', [version]);
-        query.setTagValues('error.handled', ['0']);
+        query.setFilterValues('release', [version]);
+        query.setFilterValues('error.handled', ['0']);
         break;
       case IssuesType.RESOLVED:
       case IssuesType.ALL:
       default:
-        query.setTagValues('release', [version]);
+        query.setFilterValues('release', [version]);
     }
 
     return {

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -37,15 +37,15 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
   const search = tokenizeSearch(query);
 
   const filters = {
-    roles: search.getTagValues('role') || [],
-    isInvited: getBoolean(search.getTagValues('isInvited')),
-    ssoLinked: getBoolean(search.getTagValues('ssoLinked')),
-    has2fa: getBoolean(search.getTagValues('has2fa')),
+    roles: search.getFilterValues('role') || [],
+    isInvited: getBoolean(search.getFilterValues('isInvited')),
+    ssoLinked: getBoolean(search.getFilterValues('ssoLinked')),
+    has2fa: getBoolean(search.getFilterValues('has2fa')),
   };
 
   const handleRoleFilter = (id: string) => () => {
     const roleList = new Set(
-      search.getTagValues('role') ? [...search.getTagValues('role')] : []
+      search.getFilterValues('role') ? [...search.getFilterValues('role')] : []
     );
 
     if (roleList.has(id)) {
@@ -55,15 +55,15 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
     }
 
     const newSearch = search.copy();
-    newSearch.setTagValues('role', [...roleList]);
+    newSearch.setFilterValues('role', [...roleList]);
     onChange(newSearch.formatString());
   };
 
   const handleBoolFilter = (key: keyof Filters) => (value: boolean | null) => {
     const newQueryObject = search.copy();
-    newQueryObject.removeTag(key);
+    newQueryObject.removeFilter(key);
     if (value !== null) {
-      newQueryObject.setTagValues(key, [Boolean(value).toString()]);
+      newQueryObject.setFilterValues(key, [Boolean(value).toString()]);
     }
 
     onChange(newQueryObject.formatString());

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2265,7 +2265,7 @@ describe('EventView.getQueryWithAdditionalConditions', function () {
       query: 'event.type:transaction foo:bar',
     });
 
-    eventView.additionalConditions.setTagValues('event.type', ['transaction']);
+    eventView.additionalConditions.setFilterValues('event.type', ['transaction']);
 
     expect(eventView.getQueryWithAdditionalConditions()).toEqual(
       'event.type:transaction foo:bar'

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -7,8 +7,8 @@ describe('utils/tokenizeSearch', function () {
         name: 'should convert a basic query string to a query object',
         string: 'is:unresolved',
         object: {
-          tokens: [{type: TokenType.TAG, key: 'is', value: 'unresolved'}],
-          tagValues: {is: ['unresolved']},
+          tokens: [{type: TokenType.FILTER, key: 'is', value: 'unresolved'}],
+          filters: {is: ['unresolved']},
         },
       },
       {
@@ -16,10 +16,10 @@ describe('utils/tokenizeSearch', function () {
         string: 'is:unresolved browser:"Chrome 36"',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'is', value: 'unresolved'},
-            {type: TokenType.TAG, key: 'browser', value: 'Chrome 36'},
+            {type: TokenType.FILTER, key: 'is', value: 'unresolved'},
+            {type: TokenType.FILTER, key: 'browser', value: 'Chrome 36'},
           ],
-          tagValues: {is: ['unresolved'], browser: ['Chrome 36']},
+          filters: {is: ['unresolved'], browser: ['Chrome 36']},
         },
       },
       {
@@ -27,11 +27,11 @@ describe('utils/tokenizeSearch', function () {
         string: 'python is:unresolved browser:"Chrome 36"',
         object: {
           tokens: [
-            {type: TokenType.QUERY, value: 'python'},
-            {type: TokenType.TAG, key: 'is', value: 'unresolved'},
-            {type: TokenType.TAG, key: 'browser', value: 'Chrome 36'},
+            {type: TokenType.FREE_TEXT, value: 'python'},
+            {type: TokenType.FILTER, key: 'is', value: 'unresolved'},
+            {type: TokenType.FILTER, key: 'browser', value: 'Chrome 36'},
           ],
-          tagValues: {is: ['unresolved'], browser: ['Chrome 36']},
+          filters: {is: ['unresolved'], browser: ['Chrome 36']},
         },
       },
       {
@@ -39,10 +39,10 @@ describe('utils/tokenizeSearch', function () {
         string: 'python   exception',
         object: {
           tokens: [
-            {type: TokenType.QUERY, value: 'python'},
-            {type: TokenType.QUERY, value: 'exception'},
+            {type: TokenType.FREE_TEXT, value: 'python'},
+            {type: TokenType.FREE_TEXT, value: 'exception'},
           ],
-          tagValues: {},
+          filters: {},
         },
       },
       {
@@ -50,10 +50,10 @@ describe('utils/tokenizeSearch', function () {
         string: 'has:user has:browser',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'has', value: 'user'},
-            {type: TokenType.TAG, key: 'has', value: 'browser'},
+            {type: TokenType.FILTER, key: 'has', value: 'user'},
+            {type: TokenType.FILTER, key: 'has', value: 'browser'},
           ],
-          tagValues: {has: ['user', 'browser']},
+          filters: {has: ['user', 'browser']},
         },
       },
       {
@@ -61,10 +61,10 @@ describe('utils/tokenizeSearch', function () {
         string: '!has:user has:browser',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: '!has', value: 'user'},
-            {type: TokenType.TAG, key: 'has', value: 'browser'},
+            {type: TokenType.FILTER, key: '!has', value: 'user'},
+            {type: TokenType.FILTER, key: 'has', value: 'browser'},
           ],
-          tagValues: {'!has': ['user'], has: ['browser']},
+          filters: {'!has': ['user'], has: ['browser']},
         },
       },
       {
@@ -72,11 +72,11 @@ describe('utils/tokenizeSearch', function () {
         string: 'python  is:unresolved exception',
         object: {
           tokens: [
-            {type: TokenType.QUERY, value: 'python'},
-            {type: TokenType.TAG, key: 'is', value: 'unresolved'},
-            {type: TokenType.QUERY, value: 'exception'},
+            {type: TokenType.FREE_TEXT, value: 'python'},
+            {type: TokenType.FILTER, key: 'is', value: 'unresolved'},
+            {type: TokenType.FREE_TEXT, value: 'exception'},
           ],
-          tagValues: {is: ['unresolved']},
+          filters: {is: ['unresolved']},
         },
       },
       {
@@ -84,10 +84,14 @@ describe('utils/tokenizeSearch', function () {
         string: 'event.type:error title:"QueryExecutionError: Code: 141."',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'event.type', value: 'error'},
-            {type: TokenType.TAG, key: 'title', value: 'QueryExecutionError: Code: 141.'},
+            {type: TokenType.FILTER, key: 'event.type', value: 'error'},
+            {
+              type: TokenType.FILTER,
+              key: 'title',
+              value: 'QueryExecutionError: Code: 141.',
+            },
           ],
-          tagValues: {
+          filters: {
             'event.type': ['error'],
             title: ['QueryExecutionError: Code: 141.'],
           },
@@ -97,8 +101,8 @@ describe('utils/tokenizeSearch', function () {
         name: 'should tokenize words with :: in them',
         string: 'key:Resque::DirtyExit',
         object: {
-          tokens: [{type: TokenType.TAG, key: 'key', value: 'Resque::DirtyExit'}],
-          tagValues: {key: ['Resque::DirtyExit']},
+          tokens: [{type: TokenType.FILTER, key: 'key', value: 'Resque::DirtyExit'}],
+          filters: {key: ['Resque::DirtyExit']},
         },
       },
       {
@@ -106,10 +110,10 @@ describe('utils/tokenizeSearch', function () {
         string: 'country:canada :unresolved',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'country', value: 'canada'},
-            {type: TokenType.QUERY, value: ':unresolved'},
+            {type: TokenType.FILTER, key: 'country', value: 'canada'},
+            {type: TokenType.FREE_TEXT, value: ':unresolved'},
           ],
-          tagValues: {country: ['canada']},
+          filters: {country: ['canada']},
         },
       },
       {
@@ -117,11 +121,11 @@ describe('utils/tokenizeSearch', function () {
         string: 'country:canada Or country:newzealand',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'country', value: 'canada'},
-            {type: TokenType.OP, value: 'OR'},
-            {type: TokenType.TAG, key: 'country', value: 'newzealand'},
+            {type: TokenType.FILTER, key: 'country', value: 'canada'},
+            {type: TokenType.OPERATOR, value: 'OR'},
+            {type: TokenType.FILTER, key: 'country', value: 'newzealand'},
           ],
-          tagValues: {country: ['canada', 'newzealand']},
+          filters: {country: ['canada', 'newzealand']},
         },
       },
       {
@@ -129,15 +133,15 @@ describe('utils/tokenizeSearch', function () {
         string: '(country:canada Or country:newzealand) AnD province:pei',
         object: {
           tokens: [
-            {type: TokenType.OP, value: '('},
-            {type: TokenType.TAG, key: 'country', value: 'canada'},
-            {type: TokenType.OP, value: 'OR'},
-            {type: TokenType.TAG, key: 'country', value: 'newzealand'},
-            {type: TokenType.OP, value: ')'},
-            {type: TokenType.OP, value: 'AND'},
-            {type: TokenType.TAG, key: 'province', value: 'pei'},
+            {type: TokenType.OPERATOR, value: '('},
+            {type: TokenType.FILTER, key: 'country', value: 'canada'},
+            {type: TokenType.OPERATOR, value: 'OR'},
+            {type: TokenType.FILTER, key: 'country', value: 'newzealand'},
+            {type: TokenType.OPERATOR, value: ')'},
+            {type: TokenType.OPERATOR, value: 'AND'},
+            {type: TokenType.FILTER, key: 'province', value: 'pei'},
           ],
-          tagValues: {country: ['canada', 'newzealand'], province: ['pei']},
+          filters: {country: ['canada', 'newzealand'], province: ['pei']},
         },
       },
       {
@@ -145,22 +149,22 @@ describe('utils/tokenizeSearch', function () {
         string: '(a:a OR (b:b AND c d e)) OR f g:g',
         object: {
           tokens: [
-            {type: TokenType.OP, value: '('},
-            {type: TokenType.TAG, key: 'a', value: 'a'},
-            {type: TokenType.OP, value: 'OR'},
-            {type: TokenType.OP, value: '('},
-            {type: TokenType.TAG, key: 'b', value: 'b'},
-            {type: TokenType.OP, value: 'AND'},
-            {type: TokenType.QUERY, value: 'c'},
-            {type: TokenType.QUERY, value: 'd'},
-            {type: TokenType.QUERY, value: 'e'},
-            {type: TokenType.OP, value: ')'},
-            {type: TokenType.OP, value: ')'},
-            {type: TokenType.OP, value: 'OR'},
-            {type: TokenType.QUERY, value: 'f'},
-            {type: TokenType.TAG, key: 'g', value: 'g'},
+            {type: TokenType.OPERATOR, value: '('},
+            {type: TokenType.FILTER, key: 'a', value: 'a'},
+            {type: TokenType.OPERATOR, value: 'OR'},
+            {type: TokenType.OPERATOR, value: '('},
+            {type: TokenType.FILTER, key: 'b', value: 'b'},
+            {type: TokenType.OPERATOR, value: 'AND'},
+            {type: TokenType.FREE_TEXT, value: 'c'},
+            {type: TokenType.FREE_TEXT, value: 'd'},
+            {type: TokenType.FREE_TEXT, value: 'e'},
+            {type: TokenType.OPERATOR, value: ')'},
+            {type: TokenType.OPERATOR, value: ')'},
+            {type: TokenType.OPERATOR, value: 'OR'},
+            {type: TokenType.FREE_TEXT, value: 'f'},
+            {type: TokenType.FILTER, key: 'g', value: 'g'},
           ],
-          tagValues: {a: ['a'], b: ['b'], g: ['g']},
+          filters: {a: ['a'], b: ['b'], g: ['g']},
         },
       },
       {
@@ -168,19 +172,19 @@ describe('utils/tokenizeSearch', function () {
         string: 'country:>canada OR coronaFree():<newzealand',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'country', value: '>canada'},
-            {type: TokenType.OP, value: 'OR'},
-            {type: TokenType.TAG, key: 'coronaFree()', value: '<newzealand'},
+            {type: TokenType.FILTER, key: 'country', value: '>canada'},
+            {type: TokenType.OPERATOR, value: 'OR'},
+            {type: TokenType.FILTER, key: 'coronaFree()', value: '<newzealand'},
           ],
-          tagValues: {country: ['>canada'], 'coronaFree()': ['<newzealand']},
+          filters: {country: ['>canada'], 'coronaFree()': ['<newzealand']},
         },
       },
       {
         name: 'correctly preserves leading/trailing escaped quotes',
         string: 'a:"\\"a\\""',
         object: {
-          tokens: [{type: TokenType.TAG, key: 'a', value: '\\"a\\"'}],
-          tagValues: {a: ['\\"a\\"']},
+          tokens: [{type: TokenType.FILTER, key: 'a', value: '\\"a\\"'}],
+          filters: {a: ['\\"a\\"']},
         },
       },
       {
@@ -188,11 +192,11 @@ describe('utils/tokenizeSearch', function () {
         string: 'a:"i \\" quote" b:"b\\"bb" c:"cc"',
         object: {
           tokens: [
-            {type: TokenType.TAG, key: 'a', value: 'i \\" quote'},
-            {type: TokenType.TAG, key: 'b', value: 'b\\"bb'},
-            {type: TokenType.TAG, key: 'c', value: 'cc'},
+            {type: TokenType.FILTER, key: 'a', value: 'i \\" quote'},
+            {type: TokenType.FILTER, key: 'b', value: 'b\\"bb'},
+            {type: TokenType.FILTER, key: 'c', value: 'cc'},
           ],
-          tagValues: {a: ['i \\" quote'], b: ['b\\"bb'], c: ['cc']},
+          filters: {a: ['i \\" quote'], b: ['b\\"bb'], c: ['cc']},
         },
       },
     ];
@@ -206,22 +210,22 @@ describe('utils/tokenizeSearch', function () {
     it('add tokens to query object', function () {
       const results = new QueryResults([]);
 
-      results.addStringTag('a:a');
+      results.addStringFilter('a:a');
       expect(results.formatString()).toEqual('a:a');
 
-      results.addTagValues('b', ['b']);
+      results.addFilterValues('b', ['b']);
       expect(results.formatString()).toEqual('a:a b:b');
 
-      results.addTagValues('c', ['c1', 'c2']);
+      results.addFilterValues('c', ['c1', 'c2']);
       expect(results.formatString()).toEqual('a:a b:b c:c1 c:c2');
 
-      results.addTagValues('d', ['d']);
+      results.addFilterValues('d', ['d']);
       expect(results.formatString()).toEqual('a:a b:b c:c1 c:c2 d:d');
 
-      results.addTagValues('e', ['e1*e2\\e3']);
+      results.addFilterValues('e', ['e1*e2\\e3']);
       expect(results.formatString()).toEqual('a:a b:b c:c1 c:c2 d:d e:"e1\\*e2\\e3"');
 
-      results.addStringTag('d:d2');
+      results.addStringFilter('d:d2');
       expect(results.formatString()).toEqual(
         'a:a b:b c:c1 c:c2 d:d e:"e1\\*e2\\e3" d:d2'
       );
@@ -230,31 +234,31 @@ describe('utils/tokenizeSearch', function () {
     it('add text searches to query object', function () {
       const results = new QueryResults(['a:a']);
 
-      results.addQuery('b');
+      results.addFreeText('b');
       expect(results.formatString()).toEqual('a:a b');
-      expect(results.query).toEqual(['b']);
+      expect(results.freeText).toEqual(['b']);
 
-      results.addQuery('c');
+      results.addFreeText('c');
       expect(results.formatString()).toEqual('a:a b c');
-      expect(results.query).toEqual(['b', 'c']);
+      expect(results.freeText).toEqual(['b', 'c']);
 
-      results.addStringTag('d:d').addQuery('e');
+      results.addStringFilter('d:d').addFreeText('e');
       expect(results.formatString()).toEqual('a:a b c d:d e');
-      expect(results.query).toEqual(['b', 'c', 'e']);
+      expect(results.freeText).toEqual(['b', 'c', 'e']);
 
-      results.query = ['x', 'y'];
+      results.freeText = ['x', 'y'];
       expect(results.formatString()).toEqual('a:a d:d x y');
-      expect(results.query).toEqual(['x', 'y']);
+      expect(results.freeText).toEqual(['x', 'y']);
 
-      results.query = ['a b c'];
+      results.freeText = ['a b c'];
       expect(results.formatString()).toEqual('a:a d:d "a b c"');
-      expect(results.query).toEqual(['a b c']);
+      expect(results.freeText).toEqual(['a b c']);
 
-      results.query = ['invalid literal for int() with base'];
+      results.freeText = ['invalid literal for int() with base'];
       expect(results.formatString()).toEqual(
         'a:a d:d "invalid literal for int() with base"'
       );
-      expect(results.query).toEqual(['invalid literal for int() with base']);
+      expect(results.freeText).toEqual(['invalid literal for int() with base']);
     });
 
     it('add ops to query object', function () {
@@ -263,24 +267,29 @@ describe('utils/tokenizeSearch', function () {
       results.addOp('OR');
       expect(results.formatString()).toEqual('x a:a y OR');
 
-      results.addQuery('z');
+      results.addFreeText('z');
       expect(results.formatString()).toEqual('x a:a y OR z');
 
-      results.addOp('(').addStringTag('b:b').addOp('AND').addStringTag('c:c').addOp(')');
+      results
+        .addOp('(')
+        .addStringFilter('b:b')
+        .addOp('AND')
+        .addStringFilter('c:c')
+        .addOp(')');
       expect(results.formatString()).toEqual('x a:a y OR z ( b:b AND c:c )');
     });
 
     it('adds tags to query', function () {
       const results = new QueryResults(['tag:value']);
 
-      results.addStringTag('new:too');
+      results.addStringFilter('new:too');
       expect(results.formatString()).toEqual('tag:value new:too');
     });
 
     it('setTag() replaces tags', function () {
       const results = new QueryResults(['tag:value']);
 
-      results.setTagValues('tag', ['too']);
+      results.setFilterValues('tag', ['too']);
       expect(results.formatString()).toEqual('tag:too');
     });
 
@@ -293,11 +302,11 @@ describe('utils/tokenizeSearch', function () {
         ')',
       ]);
 
-      results.setTagValues('transaction', ['def']);
+      results.setFilterValues('transaction', ['def']);
       expect(results.formatString()).toEqual('transaction:def');
 
       results = new QueryResults(['(transaction:xyz', 'OR', 'transaction:abc)']);
-      results.setTagValues('transaction', ['def']);
+      results.setFilterValues('transaction', ['def']);
       expect(results.formatString()).toEqual('transaction:def');
     });
 
@@ -316,7 +325,7 @@ describe('utils/tokenizeSearch', function () {
         ')',
       ]);
 
-      results.setTagValues('transaction', ['def']);
+      results.setFilterValues('transaction', ['def']);
       expect(results.formatString()).toEqual(
         '( start:xyz AND end:abc ) OR ( start:abc AND end:xyz ) transaction:def'
       );
@@ -324,46 +333,46 @@ describe('utils/tokenizeSearch', function () {
 
     it('removes tags from query object', function () {
       let results = new QueryResults(['x', 'a:a', 'b:b']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('x b:b');
 
       results = new QueryResults(['a:a']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('');
 
       results = new QueryResults(['x', 'a:a', 'a:a2']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('x');
 
       results = new QueryResults(['a:a', 'OR', 'b:b']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('b:b');
 
       results = new QueryResults(['a:a', 'OR', 'a:a1', 'AND', 'b:b']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('b:b');
 
       results = new QueryResults(['(a:a', 'OR', 'b:b)']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('b:b');
 
       results = new QueryResults(['(a:a', 'OR', 'b:b', 'OR', 'y)']);
-      results.removeTag('a');
+      results.removeFilter('a');
       expect(results.formatString()).toEqual('( b:b OR y )');
 
       results = new QueryResults(['(a:a', 'OR', '(b:b1', 'OR', '(c:c', 'OR', 'b:b2)))']);
-      results.removeTag('b');
+      results.removeFilter('b');
       expect(results.formatString()).toEqual('( a:a OR c:c )');
 
       results = new QueryResults(['(((a:a', 'OR', 'b:b1)', 'OR', 'c:c)', 'OR', 'b:b2)']);
-      results.removeTag('b');
+      results.removeFilter('b');
       expect(results.formatString()).toEqual('( ( a:a OR c:c ) )');
     });
 
     it('can return the tag keys', function () {
       const results = new QueryResults(['tag:value', 'other:value', 'additional text']);
 
-      expect(results.getTagKeys()).toEqual(['tag', 'other']);
+      expect(results.getFilterKeys()).toEqual(['tag', 'other']);
     });
 
     it('getTagValues', () => {
@@ -373,9 +382,9 @@ describe('utils/tokenizeSearch', function () {
         'tag:value2',
         'additional text',
       ]);
-      expect(results.getTagValues('tag')).toEqual(['value', 'value2']);
+      expect(results.getFilterValues('tag')).toEqual(['value', 'value2']);
 
-      expect(results.getTagValues('nonexistent')).toEqual([]);
+      expect(results.getFilterValues('nonexistent')).toEqual([]);
     });
   });
 


### PR DESCRIPTION
This refactors the QueryResult class to use the words 'filter' and 'freeText' over 'tag', which puts the whole module more inline with the newly implemented search syntax parser.