### PR TITLE
fix(discover): Add yAxis to discover URL

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -627,7 +627,7 @@ class EventView {
       environment: this.environment,
       project: this.project,
       query: this.query,
-      yAxis: this.yAxis,
+      yAxis: this.yAxis || this.getYAxis(),
       display: this.display,
       interval: this.interval,
       user: user.id,

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -890,6 +890,7 @@ describe('EventView.generateQueryStringObject()', function () {
       environment: [],
       display: 'previous',
       user: '1',
+      yAxis: 'count()',
     };
 
     expect(eventView.generateQueryStringObject()).toEqual(expected);

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -248,6 +248,7 @@ describe('pushEventViewToLocation', function () {
         statsPeriod: '14d',
         environment: ['staging'],
         user: '1',
+        yAxis: 'count()',
       },
     });
   });
@@ -278,6 +279,7 @@ describe('pushEventViewToLocation', function () {
         environment: ['staging'],
         cursor: 'some cursor',
         user: '1',
+        yAxis: 'count()',
       },
     });
   });

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -147,7 +147,7 @@ describe('Release Issues', function () {
         environment: [],
         project: [],
         query: `release:${props.version} !event.type:transaction`,
-        yAxis: undefined,
+        yAxis: 'count()',
         display: undefined,
         interval: undefined,
         statsPeriod: props.selection.datetime.period,


### PR DESCRIPTION
Without the yAxis qs param, the chart unfurling defaults
to count() as the yAxis. So if a discover query defaulted
to a count_if(...) yAxis, the chart unfurl will show count()
as the yAxis. This bug manifests in chart unfurling only
when the default yAxis is not count(). If the user changes
the yAxis, it gets added to the url qs params, so that use
case is not broken.