### PR TITLE
feat(search): Fix search tests for improved search

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1288,10 +1288,13 @@ class SmartSearchBar extends React.Component<Props, State> {
             ? this.cursorPosition
             : valueToken.location.end.offset;
         } else {
-          // Include everything after the ':'
           const keyLocation = cursorToken.key.location;
           clauseStart = keyLocation.end.offset + 1;
           clauseEnd = location.end.offset + 1;
+          // The user tag often contains : within its value and we need to quote it.
+          if (getKeyName(cursorToken.key) === 'user') {
+            replaceToken = `"${replaceText.trim()}"`;
+          }
           // handle using autocomplete with key:[]
           if (valueToken.text === '[]') {
             clauseStart += 1;
@@ -1309,7 +1312,8 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     if (cursorToken.type === Token.FreeText) {
-      clauseStart = cursorToken.location.start.offset;
+      const startPos = cursorToken.location.start.offset;
+      clauseStart = cursorToken.text.startsWith('!') ? startPos + 1 : startPos;
       clauseEnd = cursorToken.location.end.offset;
     }
 

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1313,7 +1313,9 @@ class SmartSearchBar extends React.Component<Props, State> {
 
     if (cursorToken.type === Token.FreeText) {
       const startPos = cursorToken.location.start.offset;
-      clauseStart = cursorToken.text.startsWith('!') ? startPos + 1 : startPos;
+      clauseStart = cursorToken.text.startsWith(NEGATION_OPERATOR)
+        ? startPos + 1
+        : startPos;
       clauseEnd = cursorToken.location.end.offset;
     }
 

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -26,7 +26,7 @@ describe('SmartSearchBar', function () {
       key: 'firstRelease',
       name: 'firstRelease',
     };
-    organization = TestStubs.Organization({id: '123'});
+    organization = TestStubs.Organization({id: '123', features: ['improved-search']});
 
     location = {
       pathname: '/organizations/org-slug/recent-searches/',
@@ -495,6 +495,7 @@ describe('SmartSearchBar', function () {
       jest.useRealTimers();
       const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = wrapper.instance();
+      wrapper.find('textarea').simulate('focus');
       searchBar.updateAutoCompleteItems();
       await tick();
       wrapper.update();
@@ -515,6 +516,7 @@ describe('SmartSearchBar', function () {
       jest.useRealTimers();
       const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = wrapper.instance();
+      wrapper.find('textarea').simulate('focus');
       searchBar.updateAutoCompleteItems();
       await tick();
       wrapper.update();
@@ -598,6 +600,7 @@ describe('SmartSearchBar', function () {
         <SmartSearchBar {...props} api={new Client()} />,
         options
       ).instance();
+      mockCursorPosition(searchBar, 13);
       searchBar.updateAutoCompleteItems();
 
       jest.advanceTimersByTime(301);
@@ -611,6 +614,65 @@ describe('SmartSearchBar', function () {
           },
         })
       );
+    });
+
+    it('shows operator autocompletion', async function () {
+      const props = {
+        query: 'is:unresolved',
+        organization,
+        location,
+        supportedTags,
+      };
+      jest.useRealTimers();
+      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
+      // Cursor is at end of line
+      mockCursorPosition(searchBar, 3);
+      searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
+      // two search groups because of operator suggestions
+      expect(searchBar.state.searchGroups).toHaveLength(2);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    });
+
+    it('responds to cursor changes', async function () {
+      const props = {
+        query: 'is:unresolved',
+        organization,
+        location,
+        supportedTags,
+      };
+      jest.useRealTimers();
+      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = wrapper.instance();
+      // Cursor is at end of line
+      mockCursorPosition(searchBar, 3);
+      searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
+      // two search groups tags and values
+      expect(searchBar.state.searchGroups).toHaveLength(2);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
+      mockCursorPosition(searchBar, 1);
+      searchBar.updateAutoCompleteItems();
+      await tick();
+      wrapper.update();
+      // one search group because only showing tags now
+      expect(searchBar.state.searchGroups).toHaveLength(1);
+      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    });
+
+    it('shows errors on incorrect tokens', async function () {
+      const props = {
+        query: 'tag: ',
+        organization,
+        location,
+        supportedTags,
+      };
+      jest.useRealTimers();
+      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
+      expect(wrapper.find('Filter').prop('invalid')).toBe(true);
     });
   });
 
@@ -691,32 +753,6 @@ describe('SmartSearchBar', function () {
       expect(searchBar.state.query).toEqual('event.type:error !title:');
     });
 
-    it('removes wildcard', function () {
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      // leading wildcard
-      textarea.simulate('change', {target: {value: 'event.type:*err'}});
-      mockCursorPosition(searchBar, 20);
-      // use autocompletion to do the rest
-      searchBar.onAutoComplete('error', {});
-      expect(searchBar.state.query).toEqual('event.type:error');
-
-      // trailing wildcard
-      textarea.simulate('change', {target: {value: 'event.type:err*'}});
-      mockCursorPosition(searchBar, 20);
-      // use autocompletion to do the rest
-      searchBar.onAutoComplete('error', {});
-      expect(searchBar.state.query).toEqual('event.type:error');
-    });
-
     it('handles special case for user tag', function () {
       const props = {
         query: '',
@@ -731,13 +767,7 @@ describe('SmartSearchBar', function () {
       textarea.simulate('change', {target: {value: 'user:'}});
       mockCursorPosition(searchBar, 5);
       searchBar.onAutoComplete('id:1', {});
-      expect(searchBar.state.query).toEqual('user:"id:1"');
-
-      // try it with the SEARCH_WILDCARD
-      textarea.simulate('change', {target: {value: 'user:1*'}});
-      mockCursorPosition(searchBar, 5);
-      searchBar.onAutoComplete('ip:127.0.0.1', {});
-      expect(searchBar.state.query).toEqual('user:"ip:127.0.0.1"');
+      expect(searchBar.state.query).toEqual('user:"id:1" ');
     });
   });
 });

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -626,7 +626,7 @@ describe('SmartSearchBar', function () {
       jest.useRealTimers();
       const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = wrapper.instance();
-      // Cursor is at end of line
+      // Cursor is on ':'
       mockCursorPosition(searchBar, 3);
       searchBar.updateAutoCompleteItems();
       await tick();
@@ -646,7 +646,7 @@ describe('SmartSearchBar', function () {
       jest.useRealTimers();
       const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = wrapper.instance();
-      // Cursor is at end of line
+      // Cursor is on ':'
       mockCursorPosition(searchBar, 3);
       searchBar.updateAutoCompleteItems();
       await tick();


### PR DESCRIPTION
Made the old tests work with the new search and added a few new tests for the additional functionality we have now with autocomplete and invalid tokens.

After this I will make a follow-up PR to delete the old code, disable the improved-search experiment, thus turning on improved-search for everyone