### PR TITLE
ref(growth): moving organization argument for analytics events

### DIFF
--- a/static/app/components/demo/demoHeader.tsx
+++ b/static/app/components/demo/demoHeader.tsx
@@ -52,7 +52,9 @@ export default function DemoHeader() {
       <StyledLogoSentry />
       <ButtonBar gap={4}>
         <StyledExternalLink
-          onClick={() => trackAdvancedAnalyticsEvent('growth.demo_click_docs', {}, null)}
+          onClick={() =>
+            trackAdvancedAnalyticsEvent('growth.demo_click_docs', {organization: null})
+          }
           href={`https://docs.sentry.io/${extraParameter}`}
         >
           {t('Documentation')}
@@ -60,7 +62,9 @@ export default function DemoHeader() {
         <BaseButton
           priority="form"
           onClick={() =>
-            trackAdvancedAnalyticsEvent('growth.demo_click_request_demo', {}, null)
+            trackAdvancedAnalyticsEvent('growth.demo_click_request_demo', {
+              organization: null,
+            })
           }
           href={`https://sentry.io/_/demo/${extraParameter}`}
         >
@@ -68,13 +72,10 @@ export default function DemoHeader() {
         </BaseButton>
         <GetStarted
           onClick={() =>
-            trackAdvancedAnalyticsEvent(
-              'growth.demo_click_get_started',
-              {
-                is_upgrade: !!saasOrgSlug,
-              },
-              null
-            )
+            trackAdvancedAnalyticsEvent('growth.demo_click_get_started', {
+              is_upgrade: !!saasOrgSlug,
+              organization: null,
+            })
           }
           href={getStartedUrl}
         >

--- a/static/app/components/events/eventCauseEmpty.tsx
+++ b/static/app/components/events/eventCauseEmpty.tsx
@@ -146,14 +146,11 @@ class EventCauseEmpty extends Component<Props, State> {
   trackAnalytics(eventKey: IssueEventKey) {
     const {project, organization} = this.props;
 
-    trackAdvancedAnalyticsEvent(
-      eventKey,
-      {
-        project_id: project.id,
-        platform: project.platform,
-      },
-      organization
-    );
+    trackAdvancedAnalyticsEvent(eventKey, {
+      project_id: project.id,
+      platform: project.platform,
+      organization,
+    });
   }
 
   render() {

--- a/static/app/components/modals/demoSignUp.tsx
+++ b/static/app/components/modals/demoSignUp.tsx
@@ -34,7 +34,9 @@ const DemoSignUpModal = ({closeModal}: Props) => {
             priority="primary"
             href={signupUrl}
             onClick={() =>
-              trackAdvancedAnalyticsEvent('growth.demo_modal_clicked_signup', {}, null)
+              trackAdvancedAnalyticsEvent('growth.demo_modal_clicked_signup', {
+                organization: null,
+              })
             }
           >
             {t('Sign up now')}
@@ -42,7 +44,9 @@ const DemoSignUpModal = ({closeModal}: Props) => {
           <Button
             priority="default"
             onClick={() => {
-              trackAdvancedAnalyticsEvent('growth.demo_modal_clicked_continue', {}, null);
+              trackAdvancedAnalyticsEvent('growth.demo_modal_clicked_continue', {
+                organization: null,
+              });
               closeModal();
             }}
           >

--- a/static/app/components/modals/suggestProjectModal.tsx
+++ b/static/app/components/modals/suggestProjectModal.tsx
@@ -41,21 +41,19 @@ class SuggestProjectModal extends Component<Props, State> {
 
   handleGetStartedClick = () => {
     const {matchedUserAgentString, organization} = this.props;
-    trackAdvancedAnalyticsEvent(
-      'growth.clicked_mobile_prompt_setup_project',
-      {matchedUserAgentString},
-      organization
-    );
+    trackAdvancedAnalyticsEvent('growth.clicked_mobile_prompt_setup_project', {
+      matchedUserAgentString,
+      organization,
+    });
   };
 
   handleAskTeammate = () => {
     const {matchedUserAgentString, organization} = this.props;
     this.setState({askTeammate: true});
-    trackAdvancedAnalyticsEvent(
-      'growth.clicked_mobile_prompt_ask_teammate',
-      {matchedUserAgentString},
-      organization
-    );
+    trackAdvancedAnalyticsEvent('growth.clicked_mobile_prompt_ask_teammate', {
+      matchedUserAgentString,
+      organization,
+    });
   };
 
   goBack = () => {
@@ -65,11 +63,10 @@ class SuggestProjectModal extends Component<Props, State> {
   handleSubmitSuccess = () => {
     const {matchedUserAgentString, organization, closeModal} = this.props;
     addSuccessMessage('Notified teammate successfully');
-    trackAdvancedAnalyticsEvent(
-      'growth.submitted_mobile_prompt_ask_teammate',
-      {matchedUserAgentString},
-      organization
-    );
+    trackAdvancedAnalyticsEvent('growth.submitted_mobile_prompt_ask_teammate', {
+      matchedUserAgentString,
+      organization,
+    });
     closeModal();
   };
 

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -80,15 +80,12 @@ class PlatformPicker extends React.Component<Props, State> {
 
   logSearch = debounce(() => {
     if (this.state.filter) {
-      trackAdvancedAnalyticsEvent(
-        'growth.platformpicker_search',
-        {
-          search: this.state.filter.toLowerCase(),
-          num_results: this.platformList.length,
-          source: this.props.source,
-        },
-        this.props.organization ?? null
-      );
+      trackAdvancedAnalyticsEvent('growth.platformpicker_search', {
+        search: this.state.filter.toLowerCase(),
+        num_results: this.platformList.length,
+        source: this.props.source,
+        organization: this.props.organization ?? null,
+      });
     }
   }, 300);
 
@@ -115,11 +112,11 @@ class PlatformPicker extends React.Component<Props, State> {
               <ListLink
                 key={id}
                 onClick={(e: React.MouseEvent) => {
-                  trackAdvancedAnalyticsEvent(
-                    'growth.platformpicker_category',
-                    {category: id, source: this.props.source},
-                    this.props.organization ?? null
-                  );
+                  trackAdvancedAnalyticsEvent('growth.platformpicker_category', {
+                    category: id,
+                    source: this.props.source,
+                    organization: this.props.organization ?? null,
+                  });
                   this.setState({category: id, filter: ''});
                   e.preventDefault();
                 }}
@@ -153,14 +150,11 @@ class PlatformPicker extends React.Component<Props, State> {
                 e.stopPropagation();
               }}
               onClick={() => {
-                trackAdvancedAnalyticsEvent(
-                  'growth.select_platform',
-                  {
-                    platform_id: platform.id,
-                    source: this.props.source,
-                  },
-                  this.props.organization ?? null
-                );
+                trackAdvancedAnalyticsEvent('growth.select_platform', {
+                  platform_id: platform.id,
+                  source: this.props.source,
+                  organization: this.props.organization ?? null,
+                });
                 setPlatform(platform.id as PlatformKey);
               }}
             />

--- a/static/app/components/suggestProjectCTA.tsx
+++ b/static/app/components/suggestProjectCTA.tsx
@@ -126,8 +126,8 @@ class SuggestProjectCTA extends Component<Props, State> {
               matchedUserAgentString,
               mobileEventBrowserName: mobileEventResult?.browserName || '',
               mobileEventClientOsName: mobileEventResult?.clientOsName || '',
+              organization: this.props.organization,
             },
-            this.props.organization,
             {startSession: true}
           );
         }
@@ -160,13 +160,10 @@ class SuggestProjectCTA extends Component<Props, State> {
 
   handleCTAClose = () => {
     const {api, organization} = this.props;
-    trackAdvancedAnalyticsEvent(
-      'growth.dismissed_mobile_prompt_banner',
-      {
-        matchedUserAgentString: this.matchedUserAgentString,
-      },
-      this.props.organization
-    );
+    trackAdvancedAnalyticsEvent('growth.dismissed_mobile_prompt_banner', {
+      matchedUserAgentString: this.matchedUserAgentString,
+      organization,
+    });
 
     promptsUpdate(api, {
       organizationId: organization.id,
@@ -178,13 +175,10 @@ class SuggestProjectCTA extends Component<Props, State> {
   };
 
   openModal = () => {
-    trackAdvancedAnalyticsEvent(
-      'growth.opened_mobile_project_suggest_modal',
-      {
-        matchedUserAgentString: this.matchedUserAgentString,
-      },
-      this.props.organization
-    );
+    trackAdvancedAnalyticsEvent('growth.opened_mobile_project_suggest_modal', {
+      matchedUserAgentString: this.matchedUserAgentString,
+      organization: this.props.organization,
+    });
     openModal(deps => (
       <SuggestProjectModal
         organization={this.props.organization}

--- a/static/app/utils/advancedAnalytics.tsx
+++ b/static/app/utils/advancedAnalytics.tsx
@@ -1,4 +1,4 @@
-import {Organization} from 'app/types';
+import {LightWeightOrganization} from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import {trackAnalyticsEventV2} from 'app/utils/analytics';
 import {growthEventMap, GrowthEventParameters} from 'app/utils/growthAnalyticsEvents';
@@ -44,6 +44,8 @@ const allEventMap = {
 
 type AnalyticsKey = keyof EventParameters;
 
+type OptionalOrg = {organization: LightWeightOrganization | null};
+
 /**
  * Tracks an event for analytics.
  * Must be tied to an organization.
@@ -53,17 +55,18 @@ type AnalyticsKey = keyof EventParameters;
  */
 export function trackAdvancedAnalyticsEvent<T extends AnalyticsKey>(
   eventKey: T,
-  analyticsParams: EventParameters[T],
-  org: Organization | null, // if org is undefined, event won't be recorded
+  analyticsParams: EventParameters[T] & OptionalOrg,
   options?: Parameters<Hooks['analytics:track-event-v2']>[1]
 ) {
   const eventName = allEventMap[eventKey];
 
+  // need to destructure the org here to make TS happy
+  const {organization, ...rest} = analyticsParams;
   const params = {
     eventKey,
     eventName,
-    organization: org,
-    ...analyticsParams,
+    organization,
+    ...rest,
   };
 
   // could put this into a debug method or for the main trackAnalyticsEvent event

--- a/static/app/utils/growthAnalyticsEvents.tsx
+++ b/static/app/utils/growthAnalyticsEvents.tsx
@@ -47,7 +47,7 @@ export type GrowthEventParameters = {
   'growth.clicked_mobile_prompt_setup_project': MobilePromptBannerParams;
   'growth.clicked_mobile_prompt_ask_teammate': MobilePromptBannerParams;
   'growth.submitted_mobile_prompt_ask_teammate': MobilePromptBannerParams;
-  'growth.demo_click_get_started': {};
+  'growth.demo_click_get_started': {is_upgrade: boolean};
   'growth.demo_click_docs': {};
   'growth.demo_click_request_demo': {};
   'growth.onboarding_load_choose_platform': {};

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -41,11 +41,12 @@ export function trackIntegrationEvent<T extends IntegrationAnalyticsKey>(
   eventKey: T,
   analyticsParams: EventParameters[T],
   org: Organization, // integration events should always be tied to an org
-  options?: Parameters<typeof trackAdvancedAnalyticsEvent>[3]
+  options?: Parameters<typeof trackAdvancedAnalyticsEvent>[2]
 ) {
   options = options || {};
   options.mapValuesFn = mapIntegrationParams;
-  return trackAdvancedAnalyticsEvent(eventKey, analyticsParams, org, options);
+  const params = {organization: org, ...analyticsParams};
+  return trackAdvancedAnalyticsEvent(eventKey, params, options);
 }
 
 /**

--- a/static/app/views/onboarding/components/firstEventIndicator.tsx
+++ b/static/app/views/onboarding/components/firstEventIndicator.tsx
@@ -36,11 +36,9 @@ const FirstEventIndicator = ({children, ...props}: Props) => (
             disabled={!firstIssue}
             priority="primary"
             onClick={() =>
-              trackAdvancedAnalyticsEvent(
-                'growth.onboarding_take_to_error',
-                {},
-                props.organization
-              )
+              trackAdvancedAnalyticsEvent('growth.onboarding_take_to_error', {
+                organization: props.organization,
+              })
             }
             to={`/organizations/${props.organization.slug}/issues/${
               firstIssue !== true && firstIssue !== null ? `${firstIssue.id}/` : ''

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -103,11 +103,10 @@ class CreateSampleEventButton extends React.Component<Props, State> {
       return;
     }
 
-    trackAdvancedAnalyticsEvent(
-      'growth.onboarding_view_sample_event',
-      {platform: project.platform},
-      organization
-    );
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_sample_event', {
+      platform: project.platform,
+      organization,
+    });
 
     addLoadingMessage(t('Processing sample event...'), {
       duration: EVENT_POLL_RETRIES * EVENT_POLL_INTERVAL,

--- a/static/app/views/onboarding/documentationSetup.tsx
+++ b/static/app/views/onboarding/documentationSetup.tsx
@@ -81,7 +81,7 @@ class DocumentationSetup extends React.Component<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {organization});
   };
 
   /**

--- a/static/app/views/onboarding/integrationSetup.tsx
+++ b/static/app/views/onboarding/integrationSetup.tsx
@@ -95,7 +95,7 @@ class IntegrationSetup extends Component<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {organization});
   };
 
   trackSwitchToManual = () => {

--- a/static/app/views/onboarding/otherSetup.tsx
+++ b/static/app/views/onboarding/otherSetup.tsx
@@ -44,7 +44,7 @@ class OtherSetup extends AsyncComponent<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {organization});
   };
 
   render() {

--- a/static/app/views/onboarding/platform.tsx
+++ b/static/app/views/onboarding/platform.tsx
@@ -47,11 +47,9 @@ class OnboardingPlatform extends Component<Props, State> {
   };
 
   componentDidMount() {
-    trackAdvancedAnalyticsEvent(
-      'growth.onboarding_load_choose_platform',
-      {},
-      this.props.organization ?? null
-    );
+    trackAdvancedAnalyticsEvent('growth.onboarding_load_choose_platform', {
+      organization: this.props.organization ?? null,
+    });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -111,11 +109,10 @@ class OnboardingPlatform extends Component<Props, State> {
     if (platform === null) {
       return;
     }
-    trackAdvancedAnalyticsEvent(
-      'growth.onboarding_set_up_your_project',
-      {platform},
-      this.props.organization ?? null
-    );
+    trackAdvancedAnalyticsEvent('growth.onboarding_set_up_your_project', {
+      platform,
+      organization: this.props.organization ?? null,
+    });
 
     // Create their first project if they don't already have one. This is a
     // no-op if they already have a project.

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -40,11 +40,9 @@ class OnboardingWelcome extends Component<Props> {
     // icons). Keep things smooth by prefetching them. Preload a bit late to
     // avoid jank on welcome animations.
     setTimeout(preloadIcons, 1500);
-    trackAdvancedAnalyticsEvent(
-      'growth.onboarding_start_onboarding',
-      {},
-      this.props.organization ?? null
-    );
+    trackAdvancedAnalyticsEvent('growth.onboarding_start_onboarding', {
+      organization: this.props.organization ?? null,
+    });
   }
 
   render() {

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -94,19 +94,19 @@ type Props = {
 
 function Onboarding({organization, project, api}: Props) {
   function handleAdvance(step: number, duration: number) {
-    trackAdvancedAnalyticsEvent(
-      'performance_views.tour.advance',
-      {step, duration},
-      organization
-    );
+    trackAdvancedAnalyticsEvent('performance_views.tour.advance', {
+      step,
+      duration,
+      organization,
+    });
   }
 
   function handleClose(step: number, duration: number) {
-    trackAdvancedAnalyticsEvent(
-      'performance_views.tour.close',
-      {step, duration},
-      organization
-    );
+    trackAdvancedAnalyticsEvent('performance_views.tour.close', {
+      step,
+      duration,
+      organization,
+    });
   }
   const showSampleTransactionBtn = organization.features.includes(
     'performance-create-sample-transaction'
@@ -123,7 +123,7 @@ function Onboarding({organization, project, api}: Props) {
         <Button
           priority={showSampleTransactionBtn ? 'link' : 'default'}
           onClick={() => {
-            trackAdvancedAnalyticsEvent('performance_views.tour.start', {}, organization);
+            trackAdvancedAnalyticsEvent('performance_views.tour.start', {organization});
             showModal();
           }}
         >
@@ -136,11 +136,10 @@ function Onboarding({organization, project, api}: Props) {
     <Button
       data-test-id="create-sample-transaction-btn"
       onClick={async () => {
-        trackAdvancedAnalyticsEvent(
-          'performance_views.create_sample_transaction',
-          {platform: project.platform},
-          organization
-        );
+        trackAdvancedAnalyticsEvent('performance_views.create_sample_transaction', {
+          platform: project.platform,
+          organization,
+        });
         addLoadingMessage(t('Processing sample event...'), {
           duration: 15000,
         });

--- a/static/app/views/performance/transactionDetails/finishSetupAlert.tsx
+++ b/static/app/views/performance/transactionDetails/finishSetupAlert.tsx
@@ -29,13 +29,10 @@ export default function FinishSetupAlert({
         external
         href="https://docs.sentry.io/performance-monitoring/getting-started/"
         onClick={() =>
-          trackAdvancedAnalyticsEvent(
-            'growth.sample_transaction_docs_link_clicked',
-            {
-              project_id: project.id,
-            },
-            organization
-          )
+          trackAdvancedAnalyticsEvent('growth.sample_transaction_docs_link_clicked', {
+            project_id: project.id,
+            organization,
+          })
         }
       >
         {t('Get Started')}

--- a/static/app/views/projectInstall/platformIntegrationSetup.tsx
+++ b/static/app/views/projectInstall/platformIntegrationSetup.tsx
@@ -78,7 +78,7 @@ class PlatformIntegrationSetup extends AsyncComponent<Props, State> {
 
   handleFullDocsClick = () => {
     const {organization} = this.props;
-    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
+    trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {organization});
   };
 
   redirectToNeutralDocs() {

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -188,14 +188,11 @@ class OrganizationMembersList extends AsyncView<Props, State> {
 
       this.removeInviteRequest(inviteRequest.id);
       addSuccessMessage(successMessage);
-      trackAdvancedAnalyticsEvent(
-        eventKey,
-        {
-          member_id: parseInt(inviteRequest.id, 10),
-          invite_status: inviteRequest.inviteStatus,
-        },
-        organization
-      );
+      trackAdvancedAnalyticsEvent(eventKey, {
+        member_id: parseInt(inviteRequest.id, 10),
+        invite_status: inviteRequest.inviteStatus,
+        organization,
+      });
     } catch {
       addErrorMessage(errorMessage);
     }

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -490,8 +490,8 @@ describe('OrganizationMembersList', function () {
         {
           invite_status: inviteRequest.inviteStatus,
           member_id: parseInt(inviteRequest.id, 10),
-        },
-        org
+          organization: org,
+        }
       );
     });
 
@@ -534,14 +534,11 @@ describe('OrganizationMembersList', function () {
 
       expect(wrapper.find('InviteRequestRow').exists()).toBe(false);
 
-      expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledWith(
-        'invite_request.denied',
-        {
-          invite_status: joinRequest.inviteStatus,
-          member_id: parseInt(joinRequest.id, 10),
-        },
-        org
-      );
+      expect(trackAdvancedAnalyticsEvent).toHaveBeenCalledWith('invite_request.denied', {
+        invite_status: joinRequest.inviteStatus,
+        member_id: parseInt(joinRequest.id, 10),
+        organization: org,
+      });
     });
 
     it('can update invite requests', async function () {


### PR DESCRIPTION
In order to unify the APIs for analytics between Sentry and Getsentry, I am moving the organization argument in Sentry from the third argument to the payload of the second argument. This more closely matches the hook we have: https://github.com/getsentry/sentry/blob/53dc400b37443f465414dc8529f937151d2c9db8/static/app/types/hooks.tsx#L256-L272

The API is also slightly more clean for events without extra event properties (assuming you've destructured the organization).

Before:
```
trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {}, organization);
```
After:
```
trackAdvancedAnalyticsEvent('growth.onboarding_view_full_docs', {organization});
```

After this, I will update the API for `trackAdvancedAnalyticsEvent` to match better.