### PR TITLE
fix(scim): use name instead of slug for SCIM teams

### DIFF
--- a/api-docs/paths/scim/team_details.json
+++ b/api-docs/paths/scim/team_details.json
@@ -124,7 +124,7 @@
             "required": true
         },
         "responses": {
-            "200": {
+            "204": {
                 "description": "Success"
             },
             "401": {

--- a/api-docs/paths/scim/team_details.json
+++ b/api-docs/paths/scim/team_details.json
@@ -124,7 +124,7 @@
             "required": true
         },
         "responses": {
-            "204": {
+            "200": {
                 "description": "Success"
             },
             "401": {

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -261,7 +261,7 @@ class TeamSCIMSerializer(Serializer):  # type: ignore
         return {
             "schemas": [SCIM_SCHEMA_GROUP],
             "id": str(obj.id),
-            "displayName": obj.slug,
+            "displayName": obj.name,
             "members": attrs["members"],
             "meta": {"resourceType": "Group"},
         }

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -36,9 +36,6 @@ from .utils import OrganizationSCIMTeamPermission, SCIMEndpoint, parse_filter_co
 delete_logger = logging.getLogger("sentry.deletions.api")
 
 
-CONFLICTING_SLUG_ERROR = "A team with this slug already exists."
-
-
 def _team_expand(query):
     return None if "members" in query.get("excludedAttributes", []) else ["members"]
 
@@ -61,9 +58,8 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
         queryset = Team.objects.filter(
             organization=organization, status=TeamStatus.VISIBLE
         ).order_by("slug")
-
         if filter_val:
-            queryset = queryset.filter(slug=slugify(filter_val))
+            queryset = queryset.filter(name=filter_val[0])
 
         def data_fn(offset, limit):
             return list(queryset[offset : offset + limit])
@@ -82,9 +78,9 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
         )
 
     def post(self, request, organization):
-        # shim displayName from SCIM api to "slug" in order to work with
+        # shim displayName from SCIM api in order to work with
         # our regular team index POST
-        request.data.update({"slug": slugify(request.data["displayName"])})
+        request.data.update({"name": request.data["displayName"]})
         return super().post(request, organization)
 
 
@@ -163,9 +159,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
     def _rename_team_operation(self, request, new_name, team):
         serializer = TeamSerializer(
             team,
-            data={
-                "slug": slugify(new_name),
-            },
+            data={"name": new_name, "slug": slugify(new_name)},
             partial=True,
         )
         if serializer.is_valid():

--- a/tests/sentry/api/endpoints/test_scim_team_details.py
+++ b/tests/sentry/api/endpoints/test_scim_team_details.py
@@ -74,11 +74,12 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
             "id": str(team.id),
-            "displayName": "newname",  # we slugify the name passed in
+            "displayName": "newName",
             "members": None,
             "meta": {"resourceType": "Group"},
         }
         assert Team.objects.get(id=team.id).slug == "newname"
+        assert Team.objects.get(id=team.id).name == "newName"
 
     def test_scim_team_details_patch_add(self):
         team = self.create_team(organization=self.organization)
@@ -109,7 +110,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
             "id": str(team.id),
-            "displayName": team.slug,
+            "displayName": team.name,
             "members": None,
             "meta": {"resourceType": "Group"},
         }
@@ -142,7 +143,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
             "id": str(team.id),
-            "displayName": team.slug,
+            "displayName": team.name,
             "members": None,
             "meta": {"resourceType": "Group"},
         }
@@ -187,7 +188,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
             "id": str(team.id),
-            "displayName": team.slug,
+            "displayName": team.name,
             "members": None,
             "meta": {"resourceType": "Group"},
         }
@@ -310,7 +311,7 @@ class SCIMTeamDetailsTests(SCIMTestCase):
         assert response.data == {
             "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
             "id": str(self.team.id),
-            "displayName": "thenewname",
+            "displayName": "theNewName",
             "members": None,
             "meta": {"resourceType": "Group"},
         }

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -199,7 +199,7 @@ class TeamSCIMSerializerTest(TestCase):
 
         result = serialize(team, user, TeamSCIMSerializer(expand=["members"]))
         assert result == {
-            "displayName": team.slug,
+            "displayName": team.name,
             "id": str(team.id),
             "members": [
                 {"display": user.email, "value": str(team.member_set[0].id)},
@@ -215,7 +215,7 @@ class TeamSCIMSerializerTest(TestCase):
         team = self.create_team(organization=organization, members=[user])
         result = serialize(team, user, TeamSCIMSerializer())
         assert result == {
-            "displayName": team.slug,
+            "displayName": team.name,
             "id": str(team.id),
             "members": None,
             "meta": {"resourceType": "Group"},


### PR DESCRIPTION
- Azure's SCIM integration expects the same value for team name passed in to be returned, so we can't slugify and use the slug as the primary displayName for the Team API responses. in the Sentry app, we'll still use the slug everywhere, so this doesn't change that.
- From what I understand the name field is basically deprecated, but this seemed like a good use for the field.

TODO:

- [ ] follow up with a PR to always change the name when the slug is changed in the sentry app (as of right now, the name is never changed when the slug is changed).