### PR TITLE
meta(codeowners): Split some visibility codeownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,62 +104,66 @@ build-utils/        @getsentry/owners-js-build
 /tests/sentry/snuba/test_subscriptions.py                       @getsentry/workflow
 /tests/sentry/snuba/test_tasks.py                               @getsentry/workflow
 /tests/snuba/snuba/test_query_subscription_consumer.py          @getsentry/workflow
+/src/sentry/api/issue_search.py                                 @getsentry/workflow
+/tests/sentry/api/test_issue_search.py                          @getsentry/workflow
 ### Endof Issue/Metric Alerts ###
 
 
-### Perfomance/Discover ###
-/src/sentry/snuba/                                              @getsentry/visibility
-/tests/sentry/snuba/test_discover.py                            @getsentry/visibility
-
-/src/sentry/discover/                                           @getsentry/visibility
-
-/src/sentry/utils/snuba.py                                      @getsentry/visibility
-
-/src/sentry/api/event_search.py                                 @getsentry/visibility
-/src/sentry/api/issue_search.py                                 @getsentry/visibility
-/tests/sentry/api/test_event_search.py                          @getsentry/visibility
-/tests/sentry/api/test_issue_search.py                          @getsentry/visibility
-
-/src/sentry/api/bases/organization_events.py                    @getsentry/visibility
-/src/sentry/api/endpoints/organization_event_details.py         @getsentry/visibility
-/src/sentry/api/endpoints/organization_events.py                @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_facets.py         @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_meta.py           @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_stats.py          @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_trace.py          @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_tends.py          @getsentry/visibility
-/src/sentry/api/endpoints/organization_events_vitals.py         @getsentry/visibility
-
+### Visibility ###
 /src/sentry/api/endpoints/organization_tags.py                  @getsentry/visibility
 /tests/snuba/api/endpoints/                                     @getsentry/visibility
-
 /src/sentry/api/serializers/snuba.py                            @getsentry/visibility
+/src/sentry/snuba/                                              @getsentry/visibility
+/src/sentry/utils/snuba.py                                      @getsentry/visibility
 
 /src/sentry/search/                                             @getsentry/visibility
 /tests/snuba/search/test_backend.py                             @getsentry/visibility
-
-/src/sentry/data_export/                                        @getsentry/visibility
-/tests/sentry/data_export/                                      @getsentry/visibility
-
-/static/app/views/eventsV2/                                     @getsentry/visibility
-/tests/js/spec/views/eventsV2/                                  @getsentry/visibility
-/static/app/views/discover/                                     @getsentry/visibility
-/tests/js/spec/views/discover/                                  @getsentry/visibility
-/static/app/views/performance/                                  @getsentry/visibility
-/tests/js/spec/views/performance/                               @getsentry/visibility
 /static/app/utils/discover/                                     @getsentry/visibility
 /tests/js/spec/utils/discover/                                  @getsentry/visibility
-/static/app/utils/performance/                                  @getsentry/visibility
-/tests/js/spec/utils/performance/                               @getsentry/visibility
-/static/app/views/dashboards/                                   @getsentry/visibility
-/tests/js/spec/views/dashboards/                                @getsentry/visibility
-/static/app/views/dashboardsV2/                                 @getsentry/visibility
-/tests/js/spec/views/dashboardsV2/                              @getsentry/visibility
-/static/app/components/events/interfaces/spans/                 @getsentry/visibility
-/static/app/components/performance/                             @getsentry/visibility
-/static/app/components/quickTrace/                              @getsentry/visibility
-### Endof Perfomance/Discover ###
+### Endof Visibility ###
+
+
+### Perfomance ###
+/src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/performance
+
+/src/sentry/api/endpoints/organization_events_trace.py          @getsentry/performance
+/src/sentry/api/endpoints/organization_events_trends.py         @getsentry/performance
+/src/sentry/api/endpoints/organization_events_vitals.py         @getsentry/performance
+
+/static/app/views/performance/                                  @getsentry/performance
+/tests/js/spec/views/performance/                               @getsentry/performance
+/static/app/utils/performance/                                  @getsentry/performance
+/tests/js/spec/utils/performance/                               @getsentry/performance
+/static/app/components/events/interfaces/spans/                 @getsentry/performance
+/static/app/components/performance/                             @getsentry/performance
+/static/app/components/quickTrace/                              @getsentry/performance
+### Endof Perfomance ###
+
+
+### Discover/Dashboards ###
+/src/sentry/api/bases/organization_events.py                    @getsentry/discover-n-dashboards
+/src/sentry/api/endpoints/organization_event_details.py         @getsentry/discover-n-dashboards
+/src/sentry/api/endpoints/organization_events.py                @getsentry/discover-n-dashboards
+/src/sentry/api/endpoints/organization_events_facets.py         @getsentry/discover-n-dashboards
+/src/sentry/api/endpoints/organization_events_meta.py           @getsentry/discover-n-dashboards
+/src/sentry/api/endpoints/organization_events_stats.py          @getsentry/discover-n-dashboards
+
+/src/sentry/discover/                                           @getsentry/discover-n-dashboards
+/tests/sentry/snuba/test_discover.py                            @getsentry/discover-n-dashboards
+
+/src/sentry/api/event_search.py                                 @getsentry/discover-n-dashboards
+/tests/sentry/api/test_event_search.py                          @getsentry/discover-n-dashboards
+
+/src/sentry/data_export/                                        @getsentry/discover-n-dashboards
+/tests/sentry/data_export/                                      @getsentry/discover-n-dashboards
+
+/static/app/views/eventsV2/                                     @getsentry/discover-n-dashboards
+/tests/js/spec/views/eventsV2/                                  @getsentry/discover-n-dashboards
+/static/app/views/discover/                                     @getsentry/discover-n-dashboards
+/tests/js/spec/views/discover/                                  @getsentry/discover-n-dashboards
+/static/app/views/dashboardsV2/                                 @getsentry/discover-n-dashboards
+/tests/js/spec/views/dashboardsV2/                              @getsentry/discover-n-dashboards
+### Endof Discover/Dashboards ###
 
 
 ### Ecosystem ###

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,7 +123,7 @@ build-utils/        @getsentry/owners-js-build
 ### Endof Visibility ###
 
 
-### Perfomance ###
+### Performance ###
 /src/sentry/api/endpoints/organization_events_facets_performance.py         @getsentry/performance
 
 /src/sentry/api/endpoints/organization_events_trace.py          @getsentry/performance
@@ -137,7 +137,7 @@ build-utils/        @getsentry/owners-js-build
 /static/app/components/events/interfaces/spans/                 @getsentry/performance
 /static/app/components/performance/                             @getsentry/performance
 /static/app/components/quickTrace/                              @getsentry/performance
-### Endof Perfomance ###
+### Endof Performance ###
 
 
 ### Discover/Dashboards ###

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # Snuba
 /src/sentry/eventstream/        @getsentry/owners-snuba
-/src/sentry/utils/snuba.py      @getsentry/owners-snuba
+/src/sentry/utils/snuba.py      @getsentry/owners-snuba @getsentry/visibility
 /src/sentry/utils/snql.py       @getsentry/owners-snuba
 /src/sentry/tsdb/snuba.py       @getsentry/owners-snuba
 /src/sentry/tsdb/redissnuba.py  @getsentry/owners-snuba
@@ -114,7 +114,6 @@ build-utils/        @getsentry/owners-js-build
 /tests/snuba/api/endpoints/                                     @getsentry/visibility
 /src/sentry/api/serializers/snuba.py                            @getsentry/visibility
 /src/sentry/snuba/                                              @getsentry/visibility
-/src/sentry/utils/snuba.py                                      @getsentry/visibility
 
 /src/sentry/search/                                             @getsentry/visibility
 /tests/snuba/search/test_backend.py                             @getsentry/visibility


### PR DESCRIPTION
- Just a first pass of moving some files to the individual performance &
  discover-dashboards teams.
- Also moving issue search to workflow