### PR TITLE
ref(analytics): modify trackIntegrationEvent args

### DIFF
--- a/static/app/components/events/interfaces/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/stacktraceLink.tsx
@@ -110,13 +110,10 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       status: 'dismissed',
     });
 
-    trackIntegrationEvent(
-      'integrations.stacktrace_link_cta_dismissed',
-      {
-        view: 'stacktrace_issue_details',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.stacktrace_link_cta_dismissed', {
+      view: 'stacktrace_issue_details',
+      organization,
+    });
 
     this.setState({isDismissed: true});
   }
@@ -164,8 +161,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
         {
           view: 'stacktrace_issue_details',
           provider: provider.key,
+          organization: this.props.organization,
         },
-        this.props.organization,
         {startSession: true}
       );
     }
@@ -181,8 +178,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
           view: 'stacktrace_issue_details',
           provider: provider.key,
           error_reason: error,
+          organization: this.props.organization,
         },
-        this.props.organization,
         {startSession: true}
       );
     }
@@ -222,8 +219,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
                           {
                             view: 'stacktrace_issue_details',
                             platform,
+                            organization,
                           },
-                          this.props.organization,
                           {startSession: true}
                         );
                         openModal(

--- a/static/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -40,28 +40,22 @@ class StacktraceLinkModal extends Component<Props, State> {
   }
 
   onManualSetup(provider: string) {
-    trackIntegrationEvent(
-      'integrations.stacktrace_manual_option_clicked',
-      {
-        view: 'stacktrace_issue_details',
-        setup_type: 'manual',
-        provider,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.stacktrace_manual_option_clicked', {
+      view: 'stacktrace_issue_details',
+      setup_type: 'manual',
+      provider,
+      organization: this.props.organization,
+    });
   }
 
   handleSubmit = async () => {
     const {sourceCodeInput} = this.state;
     const {api, closeModal, filename, onSubmit, organization, project} = this.props;
-    trackIntegrationEvent(
-      'integrations.stacktrace_submit_config',
-      {
-        setup_type: 'automatic',
-        view: 'stacktrace_issue_details',
-      },
-      organization
-    );
+    trackIntegrationEvent('integrations.stacktrace_submit_config', {
+      setup_type: 'automatic',
+      view: 'stacktrace_issue_details',
+      organization,
+    });
 
     const parsingEndpoint = `/projects/${organization.slug}/${project.slug}/repo-path-parsing/`;
     try {
@@ -84,15 +78,12 @@ class StacktraceLinkModal extends Component<Props, State> {
       });
 
       addSuccessMessage(t('Stack trace configuration saved.'));
-      trackIntegrationEvent(
-        'integrations.stacktrace_complete_setup',
-        {
-          setup_type: 'automatic',
-          provider: configData.config?.provider.key,
-          view: 'stacktrace_issue_details',
-        },
-        organization
-      );
+      trackIntegrationEvent('integrations.stacktrace_complete_setup', {
+        setup_type: 'automatic',
+        provider: configData.config?.provider.key,
+        view: 'stacktrace_issue_details',
+        organization,
+      });
       closeModal();
       onSubmit();
     } catch (err) {

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -56,8 +56,8 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
         already_installed: isInstalled,
         view: 'external_install',
         integration_status: sentryApp.status,
+        organization,
       },
-      organization,
       {startSession: true}
     );
   }

--- a/static/app/components/repositoryProjectPathConfigForm.tsx
+++ b/static/app/components/repositoryProjectPathConfigForm.tsx
@@ -93,15 +93,12 @@ export default class RepositoryProjectPathConfigForm extends Component<Props> {
   }
 
   handlePreSubmit() {
-    trackIntegrationEvent(
-      'integrations.stacktrace_submit_config',
-      {
-        setup_type: 'manual',
-        view: 'integration_configuration_detail',
-        provider: this.props.integration.provider.key,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.stacktrace_submit_config', {
+      setup_type: 'manual',
+      view: 'integration_configuration_detail',
+      provider: this.props.integration.provider.key,
+      organization: this.props.organization,
+    });
   }
 
   render() {

--- a/static/app/plugins/components/settings.tsx
+++ b/static/app/plugins/components/settings.tsx
@@ -50,16 +50,13 @@ class PluginSettings<
   }
 
   trackPluginEvent = (eventKey: IntegrationAnalyticsKey) => {
-    trackIntegrationEvent(
-      eventKey,
-      {
-        integration: this.props.plugin.id,
-        integration_type: 'plugin',
-        view: 'plugin_details',
-        already_installed: this.state.wasConfiguredOnPageLoad,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent(eventKey, {
+      integration: this.props.plugin.id,
+      integration_type: 'plugin',
+      view: 'plugin_details',
+      already_installed: this.state.wasConfiguredOnPageLoad,
+      organization: this.props.organization,
+    });
   };
 
   componentDidMount() {

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -16,7 +16,7 @@ import {
   IntegrationFeature,
   IntegrationInstallationStatus,
   IntegrationType,
-  Organization,
+  LightWeightOrganization,
   PluginWithProjectList,
   SentryApp,
   SentryAppInstallation,
@@ -39,14 +39,12 @@ const mapIntegrationParams = analyticsParams => {
 // data massaging above
 export function trackIntegrationEvent<T extends IntegrationAnalyticsKey>(
   eventKey: T,
-  analyticsParams: EventParameters[T],
-  org: Organization, // integration events should always be tied to an org
+  analyticsParams: EventParameters[T] & {organization: LightWeightOrganization}, // integration events should always be tied to an org
   options?: Parameters<typeof trackAdvancedAnalyticsEvent>[2]
 ) {
   options = options || {};
   options.mapValuesFn = mapIntegrationParams;
-  const params = {organization: org, ...analyticsParams};
-  return trackAdvancedAnalyticsEvent(eventKey, params, options);
+  return trackAdvancedAnalyticsEvent(eventKey, analyticsParams, options);
 }
 
 /**

--- a/static/app/views/integrationOrganizationLink.tsx
+++ b/static/app/views/integrationOrganizationLink.tsx
@@ -60,8 +60,8 @@ export default class IntegrationOrganizationLink extends AsyncView<Props, State>
         // We actually don't know if it's installed but neither does the user in the view and multiple installs is possible
         already_installed: false,
         view: 'external_install',
+        organization,
       },
-      organization,
       {startSession: !!startSession}
     );
   };

--- a/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -152,15 +152,12 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
 
   handleChangeShowInputs = () => {
     this.setState({showInputs: true});
-    trackIntegrationEvent(
-      'integrations.installation_input_value_changed',
-      {
-        integration: 'aws_lambda',
-        integration_type: 'first_party',
-        field_name: 'showInputs',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.installation_input_value_changed', {
+      integration: 'aws_lambda',
+      integration_type: 'first_party',
+      field_name: 'showInputs',
+      organization: this.props.organization,
+    });
   };
 
   get formValid() {
@@ -170,26 +167,20 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
 
   // debounce so we don't send a request on every input change
   debouncedTrackValueChanged = debounce((fieldName: string) => {
-    trackIntegrationEvent(
-      'integrations.installation_input_value_changed',
-      {
-        integration: 'aws_lambda',
-        integration_type: 'first_party',
-        field_name: fieldName,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.installation_input_value_changed', {
+      integration: 'aws_lambda',
+      integration_type: 'first_party',
+      field_name: fieldName,
+      organization: this.props.organization,
+    });
   }, 200);
 
   trackOpenCloudFormation = () => {
-    trackIntegrationEvent(
-      'integrations.cloudformation_link_clicked',
-      {
-        integration: 'aws_lambda',
-        integration_type: 'first_party',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.cloudformation_link_clicked', {
+      integration: 'aws_lambda',
+      integration_type: 'first_party',
+      organization: this.props.organization,
+    });
   };
 
   render = () => {

--- a/static/app/views/onboarding/integrationSetup.tsx
+++ b/static/app/views/onboarding/integrationSetup.tsx
@@ -100,15 +100,12 @@ class IntegrationSetup extends Component<Props, State> {
 
   trackSwitchToManual = () => {
     const {organization, integrationSlug} = this.props;
-    trackIntegrationEvent(
-      'integrations.switch_manual_sdk_setup',
-      {
-        integration_type: 'first_party',
-        integration: integrationSlug,
-        view: 'onboarding',
-      },
-      organization
-    );
+    trackIntegrationEvent('integrations.switch_manual_sdk_setup', {
+      integration_type: 'first_party',
+      integration: integrationSlug,
+      view: 'onboarding',
+      organization,
+    });
   };
 
   handleAddIntegration = () => {

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -200,9 +200,10 @@ class AbstractIntegrationDetailedView<
       integration: this.integrationSlug,
       integration_type: this.integrationType,
       already_installed: this.installationStatus !== 'Not Installed', // pending counts as installed here
+      organization: this.props.organization,
       ...options,
     };
-    trackIntegrationEvent(eventKey, params, this.props.organization);
+    trackIntegrationEvent(eventKey, params);
   };
 
   // Returns the props as needed by the hooks integrations:feature-gates

--- a/static/app/views/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/organizationIntegrations/addIntegration.tsx
@@ -63,15 +63,12 @@ export default class AddIntegration extends React.Component<Props> {
   }
 
   openDialog = (urlParams?: {[key: string]: string}) => {
-    trackIntegrationEvent(
-      'integrations.installation_start',
-      {
-        integration: this.props.provider.key,
-        integration_type: 'first_party',
-        ...this.props.analyticsParams,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.installation_start', {
+      integration: this.props.provider.key,
+      integration_type: 'first_party',
+      organization: this.props.organization,
+      ...this.props.analyticsParams,
+    });
     const name = 'sentryAddIntegration';
     const {url, width, height} = this.props.provider.setupDialog;
     const {left, top} = this.computeCenteredWindow(width, height);
@@ -113,15 +110,12 @@ export default class AddIntegration extends React.Component<Props> {
     if (!data) {
       return;
     }
-    trackIntegrationEvent(
-      'integrations.installation_complete',
-      {
-        integration: this.props.provider.key,
-        integration_type: 'first_party',
-        ...this.props.analyticsParams,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.installation_complete', {
+      integration: this.props.provider.key,
+      integration_type: 'first_party',
+      organization: this.props.organization,
+      ...this.props.analyticsParams,
+    });
     addSuccessMessage(t('%s added', this.props.provider.name));
     this.props.onInstall(data);
   };

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -99,8 +99,8 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
       {
         integration: this.props.integration.provider.key,
         integration_type: 'first_party',
+        organization: this.props.organization,
       },
-      this.props.organization,
       {startSession}
     );
   }
@@ -128,15 +128,12 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
   };
 
   handleSubmitSuccess = (pathConfig: RepositoryProjectPathConfig) => {
-    trackIntegrationEvent(
-      'integrations.stacktrace_complete_setup',
-      {
-        setup_type: 'manual',
-        view: 'integration_configuration_detail',
-        provider: this.props.integration.provider.key,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.stacktrace_complete_setup', {
+      setup_type: 'manual',
+      view: 'integration_configuration_detail',
+      provider: this.props.integration.provider.key,
+      organization: this.props.organization,
+    });
     let {pathConfigs} = this.state;
     pathConfigs = pathConfigs.filter(config => config.id !== pathConfig.id);
     // our getter handles the order of the configs
@@ -147,15 +144,12 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
 
   openModal = (pathConfig?: RepositoryProjectPathConfig) => {
     const {organization, integration} = this.props;
-    trackIntegrationEvent(
-      'integrations.stacktrace_start_setup',
-      {
-        setup_type: 'manual',
-        view: 'integration_configuration_detail',
-        provider: this.props.integration.provider.key,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.stacktrace_start_setup', {
+      setup_type: 'manual',
+      view: 'integration_configuration_detail',
+      provider: this.props.integration.provider.key,
+      organization: this.props.organization,
+    });
 
     openModal(({Body, Header, closeModal}) => (
       <Fragment>
@@ -226,14 +220,11 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
                     href={`https://docs.sentry.io/product/integrations/${integration.provider.key}/#stack-trace-linking`}
                     size="small"
                     onClick={() => {
-                      trackIntegrationEvent(
-                        'integrations.stacktrace_docs_clicked',
-                        {
-                          view: 'integration_configuration_detail',
-                          provider: this.props.integration.provider.key,
-                        },
-                        this.props.organization
-                      );
+                      trackIntegrationEvent('integrations.stacktrace_docs_clicked', {
+                        view: 'integration_configuration_detail',
+                        provider: this.props.integration.provider.key,
+                        organization: this.props.organization,
+                      });
                     }}
                   >
                     View Documentation

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -152,8 +152,8 @@ export class IntegrationListDirectory extends AsyncComponent<
       {
         integrations_installed: integrationsInstalled.size,
         view: 'integrations_directory',
+        organization: this.props.organization,
       },
-      this.props.organization,
       {startSession: true}
     );
   }
@@ -268,15 +268,12 @@ export class IntegrationListDirectory extends AsyncComponent<
   }
 
   debouncedTrackIntegrationSearch = debounce((search: string, numResults: number) => {
-    trackIntegrationEvent(
-      'integrations.directory_item_searched',
-      {
-        view: 'integrations_directory',
-        search_term: search,
-        num_results: numResults,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.directory_item_searched', {
+      view: 'integrations_directory',
+      search_term: search,
+      num_results: numResults,
+      organization: this.props.organization,
+    });
   }, TEXT_SEARCH_ANALYTICS_DEBOUNCE_IN_MS);
 
   /**
@@ -349,14 +346,11 @@ export class IntegrationListDirectory extends AsyncComponent<
       this.updateDisplayedList();
 
       if (category) {
-        trackIntegrationEvent(
-          'integrations.directory_category_selected',
-          {
-            view: 'integrations_directory',
-            category,
-          },
-          this.props.organization
-        );
+        trackIntegrationEvent('integrations.directory_category_selected', {
+          view: 'integrations_directory',
+          category,
+          organization: this.props.organization,
+        });
       }
     });
   };

--- a/static/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/static/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -37,14 +37,11 @@ export default class RequestIntegrationModal extends AsyncComponent<Props, State
     const {organization, slug, type} = this.props;
     const {message} = this.state;
 
-    trackIntegrationEvent(
-      'integrations.request_install',
-      {
-        integration_type: type,
-        integration: slug,
-      },
-      organization
-    );
+    trackIntegrationEvent('integrations.request_install', {
+      integration_type: type,
+      integration: slug,
+      organization,
+    });
 
     const endpoint = `/organizations/${organization.slug}/integration-requests/`;
     this.api.request(endpoint, {

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -103,14 +103,11 @@ const IntegrationRow = (props: Props) => {
               href={`${baseUrl}?tab=configurations&referrer=directory_resolve_now`}
               size="xsmall"
               onClick={() =>
-                trackIntegrationEvent(
-                  'integrations.resolve_now_clicked',
-                  {
-                    integration_type: convertIntegrationTypeToSnakeCase(type),
-                    integration: slug,
-                  },
-                  organization
-                )
+                trackIntegrationEvent('integrations.resolve_now_clicked', {
+                  integration_type: convertIntegrationTypeToSnakeCase(type),
+                  integration: slug,
+                  organization,
+                })
               }
             >
               {t('Resolve Now')}

--- a/static/app/views/organizationIntegrations/integrationServerlessFunctions.tsx
+++ b/static/app/views/organizationIntegrations/integrationServerlessFunctions.tsx
@@ -45,15 +45,12 @@ class IntegrationServerlessFunctions extends AsyncComponent<Props, State> {
   }
 
   onLoadAllEndpointsSuccess() {
-    trackIntegrationEvent(
-      'integrations.serverless_functions_viewed',
-      {
-        integration: this.props.integration.provider.key,
-        integration_type: 'first_party',
-        num_functions: this.serverlessFunctions.length,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.serverless_functions_viewed', {
+      integration: this.props.integration.provider.key,
+      integration_type: 'first_party',
+      num_functions: this.serverlessFunctions.length,
+      organization: this.props.organization,
+    });
   }
 
   handleFunctionUpdate = (

--- a/static/app/views/organizationIntegrations/integrationServerlessRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationServerlessRow.tsx
@@ -40,15 +40,12 @@ class IntegrationServerlessRow extends Component<Props, State> {
   }
 
   recordAction = (action: 'enable' | 'disable' | 'updateVersion') => {
-    trackIntegrationEvent(
-      'integrations.serverless_function_action',
-      {
-        integration: this.props.integration.provider.key,
-        integration_type: 'first_party',
-        action,
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.serverless_function_action', {
+      integration: this.props.integration.provider.key,
+      integration_type: 'first_party',
+      action,
+      organization: this.props.organization,
+    });
   };
   toggleEnable = async () => {
     const {serverlessFunction} = this.props;

--- a/static/app/views/projectInstall/platformIntegrationSetup.tsx
+++ b/static/app/views/projectInstall/platformIntegrationSetup.tsx
@@ -95,15 +95,12 @@ class PlatformIntegrationSetup extends AsyncComponent<Props, State> {
 
   trackSwitchToManual = () => {
     const {organization, integrationSlug} = this.props;
-    trackIntegrationEvent(
-      'integrations.switch_manual_sdk_setup',
-      {
-        integration_type: 'first_party',
-        integration: integrationSlug,
-        view: 'project_creation',
-      },
-      organization
-    );
+    trackIntegrationEvent('integrations.switch_manual_sdk_setup', {
+      integration_type: 'first_party',
+      integration: integrationSlug,
+      view: 'project_creation',
+      organization,
+    });
   };
 
   render() {

--- a/static/app/views/sentryAppExternalInstallation.tsx
+++ b/static/app/views/sentryAppExternalInstallation.tsx
@@ -96,30 +96,24 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
     if (!organization || !sentryApp) {
       return undefined;
     }
-    trackIntegrationEvent(
-      'integrations.installation_start',
-      {
-        integration_type: 'sentry_app',
-        integration: sentryApp.slug,
-        view: 'external_install',
-        integration_status: sentryApp.status,
-      },
-      organization
-    );
+    trackIntegrationEvent('integrations.installation_start', {
+      integration_type: 'sentry_app',
+      integration: sentryApp.slug,
+      view: 'external_install',
+      integration_status: sentryApp.status,
+      organization,
+    });
 
     const install = await installSentryApp(this.api, organization.slug, sentryApp);
     // installation is complete if the status is installed
     if (install.status === 'installed') {
-      trackIntegrationEvent(
-        'integrations.installation_complete',
-        {
-          integration_type: 'sentry_app',
-          integration: sentryApp.slug,
-          view: 'external_install',
-          integration_status: sentryApp.status,
-        },
-        organization
-      );
+      trackIntegrationEvent('integrations.installation_complete', {
+        integration_type: 'sentry_app',
+        integration: sentryApp.slug,
+        view: 'external_install',
+        integration_status: sentryApp.status,
+        organization,
+      });
     }
 
     if (sentryApp.redirectUrl) {

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -68,14 +68,11 @@ class ConfigureIntegration extends AsyncView<Props, State> {
     if (stateKey !== 'integration') {
       return;
     }
-    trackIntegrationEvent(
-      'integrations.details_viewed',
-      {
-        integration: data.provider.key,
-        integration_type: 'first_party',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.details_viewed', {
+      integration: data.provider.key,
+      integration_type: 'first_party',
+      organization: this.props.organization,
+    });
   }
 
   getTitle() {

--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -53,15 +53,12 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
   recordDetailsViewed() {
     const {pluginId} = this.props.params;
 
-    trackIntegrationEvent(
-      'integrations.details_viewed',
-      {
-        integration: pluginId,
-        integration_type: 'plugin',
-        view: 'plugin_details',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.details_viewed', {
+      integration: pluginId,
+      integration_type: 'plugin',
+      view: 'plugin_details',
+      organization: this.props.organization,
+    });
   }
 
   getTitle() {
@@ -86,15 +83,12 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
     const {projectId, orgId, pluginId} = this.props.params;
 
     addLoadingMessage(t('Saving changes\u2026'));
-    trackIntegrationEvent(
-      'integrations.uninstall_clicked',
-      {
-        integration: pluginId,
-        integration_type: 'plugin',
-        view: 'plugin_details',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent('integrations.uninstall_clicked', {
+      integration: pluginId,
+      integration_type: 'plugin',
+      view: 'plugin_details',
+      organization: this.props.organization,
+    });
 
     this.api.request(`/projects/${orgId}/${projectId}/plugins/${pluginId}/`, {
       method: 'POST',
@@ -102,15 +96,12 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
       success: pluginDetails => {
         this.setState({pluginDetails});
         addSuccessMessage(t('Plugin was reset'));
-        trackIntegrationEvent(
-          'integrations.uninstall_completed',
-          {
-            integration: pluginId,
-            integration_type: 'plugin',
-            view: 'plugin_details',
-          },
-          this.props.organization
-        );
+        trackIntegrationEvent('integrations.uninstall_completed', {
+          integration: pluginId,
+          integration_type: 'plugin',
+          view: 'plugin_details',
+          organization: this.props.organization,
+        });
       },
       error: () => {
         addErrorMessage(t('An error occurred'));
@@ -131,15 +122,12 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
   analyticsChangeEnableStatus = (enabled: boolean) => {
     const {pluginId} = this.props.params;
     const eventKey = enabled ? 'integrations.enabled' : 'integrations.disabled';
-    trackIntegrationEvent(
-      eventKey,
-      {
-        integration: pluginId,
-        integration_type: 'plugin',
-        view: 'plugin_details',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent(eventKey, {
+      integration: pluginId,
+      integration_type: 'plugin',
+      view: 'plugin_details',
+      organization: this.props.organization,
+    });
   };
 
   // Enabled state is handled via PluginsStore and not via plugins detail

--- a/static/app/views/settings/projectPlugins/index.tsx
+++ b/static/app/views/settings/projectPlugins/index.tsx
@@ -37,8 +37,8 @@ class ProjectPluginsContainer extends React.Component<Props> {
       {
         integrations_installed: installCount,
         view: 'legacy_integrations',
+        organization: this.props.organization,
       },
-      this.props.organization,
       {startSession: true}
     );
   };

--- a/static/app/views/settings/projectPlugins/projectPluginRow.tsx
+++ b/static/app/views/settings/projectPlugins/projectPluginRow.tsx
@@ -30,15 +30,12 @@ class ProjectPluginRow extends PureComponent<Props> {
     const {onChange, id, enabled} = this.props;
     onChange(id, !enabled);
     const eventKey = !enabled ? 'integrations.enabled' : 'integrations.disabled';
-    trackIntegrationEvent(
-      eventKey,
-      {
-        integration: id,
-        integration_type: 'plugin',
-        view: 'legacy_integrations',
-      },
-      this.props.organization
-    );
+    trackIntegrationEvent(eventKey, {
+      integration: id,
+      integration_type: 'plugin',
+      view: 'legacy_integrations',
+      organization: this.props.organization,
+    });
   };
 
   render() {


### PR DESCRIPTION
In order to unify the APIs for analytics between Sentry and Getsentry, I am moving the organization argument in Sentry from the third argument to the payload of the second argument. I already have done this with the base `trackAdvancedAnalyticsEvent` function (see https://github.com/getsentry/sentry/pull/27951) and now I'm extending it to `trackIntegrationEvent`.
This more closely matches the hook we have: https://github.com/getsentry/sentry/blob/53dc400b37443f465414dc8529f937151d2c9db8/static/app/types/hooks.tsx#L256-L272

The API is also slightly more clean if you've destructured the organization.

Before:
```
    trackIntegrationEvent(
      'integrations.stacktrace_submit_config',
      {
        setup_type: 'automatic',
        view: 'stacktrace_issue_details',
      },
      organization
    );
```
After:
```
    trackIntegrationEvent('integrations.stacktrace_submit_config', {
      setup_type: 'automatic',
      view: 'stacktrace_issue_details',
      organization,
    });
```
