### PR TITLE
fix(post-process-forwarder): Skip dispatch attempt for non insert messages

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -283,10 +283,11 @@ class KafkaEventStream(SnubaProtocolEventStream):
                     ):
                         task_kwargs = get_task_kwargs_for_message_from_headers(message.headers())
 
-                    with metrics.timer(
-                        "eventstream.duration", instance="dispatch_post_process_group_task"
-                    ):
-                        self._dispatch_post_process_group_task(**task_kwargs)
+                    if task_kwargs is not None:
+                        with metrics.timer(
+                            "eventstream.duration", instance="dispatch_post_process_group_task"
+                        ):
+                            self._dispatch_post_process_group_task(**task_kwargs)
 
                 except Exception as error:
                     logger.error("Could not forward message: %s", error, exc_info=True)


### PR DESCRIPTION
The new implementation of dispatch events (using Kafka headers) was incorrectly
attempting (and failing) to dispatch all messages, even if task_kwargs was None.
This should be skipped like in the original implementation as we only want
to dispatch messages for "insert" events.

Fixes SENTRY-RWN