### PR TITLE
feat(scim): don't use active field for azure members

### DIFF
--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -200,15 +200,15 @@ class OrganizationMemberSCIMSerializer(Serializer):  # type: ignore
         self, obj: OrganizationMember, attrs: Mapping[str, Any], user: Any, **kwargs: Any
     ) -> MutableMapping[str, JSONData]:
 
-        d = {
+        result = {
             "schemas": [SCIM_SCHEMA_USER],
             "id": str(obj.id),
-            "userName": obj.get_email(),  # TODO: does this get weird with secondary emails?
+            "userName": obj.get_email(),
             "name": {"givenName": "N/A", "familyName": "N/A"},
-            "emails": [
-                {"primary": True, "value": obj.get_email(), "type": "work"}
-            ],  # TODO: secondary emails?
-            "active": True,
+            "emails": [{"primary": True, "value": obj.get_email(), "type": "work"}],
             "meta": {"resourceType": "User"},
         }
-        return d
+        if "active" in self.expand:
+            result["active"] = True
+
+        return result

--- a/src/sentry/auth/providers/saml2/activedirectory/apps.py
+++ b/src/sentry/auth/providers/saml2/activedirectory/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
+ACTIVE_DIRECTORY_PROVIDER_NAME = "active-directory"
+
 
 class Config(AppConfig):
     name = "sentry.auth.providers.saml2.activedirectory"
@@ -9,4 +11,4 @@ class Config(AppConfig):
 
         from .provider import ActiveDirectorySAML2Provider
 
-        register("active-directory", ActiveDirectorySAML2Provider)
+        register(ACTIVE_DIRECTORY_PROVIDER_NAME, ActiveDirectorySAML2Provider)

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -11,7 +11,14 @@ from sentry.api.endpoints.organization_member_index import OrganizationMemberSer
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberSCIMSerializer
-from sentry.models import AuditLogEntryEvent, AuthIdentity, InviteStatus, OrganizationMember
+from sentry.auth.providers.saml2.activedirectory.apps import ACTIVE_DIRECTORY_PROVIDER_NAME
+from sentry.models import (
+    AuditLogEntryEvent,
+    AuthIdentity,
+    AuthProvider,
+    InviteStatus,
+    OrganizationMember,
+)
 from sentry.signals import member_invited
 from sentry.utils.cursors import SCIMCursor
 
@@ -28,6 +35,21 @@ ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization
 from rest_framework.exceptions import PermissionDenied
 
 from sentry.api.exceptions import ConflictError
+
+
+def _scim_member_serializer_with_expansion(organization):
+    """
+    For our Azure SCIM integration, we don't want to return the `active`
+    flag since we don't support soft deletes. Other integrations don't
+    care about this and rely on the behavior of setting "active" to false
+    to delete a member.
+    """
+    auth_provider = AuthProvider.objects.get(organization=organization)
+    expand = ["active"]
+
+    if auth_provider.provider == ACTIVE_DIRECTORY_PROVIDER_NAME:
+        expand = []
+    return OrganizationMemberSCIMSerializer(expand=expand)
 
 
 class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
@@ -62,7 +84,10 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
         return False
 
     def get(self, request, organization, member):
-        context = serialize(member, serializer=OrganizationMemberSCIMSerializer())
+        context = serialize(
+            member,
+            serializer=_scim_member_serializer_with_expansion(organization),
+        )
         return Response(context)
 
     def patch(self, request, organization, member):
@@ -77,7 +102,10 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
             else:
                 return Response(SCIM_400_INVALID_PATCH, status=400)
 
-        context = serialize(member, serializer=OrganizationMemberSCIMSerializer())
+        context = serialize(
+            member,
+            serializer=_scim_member_serializer_with_expansion(organization),
+        )
         return Response(context)
 
     def delete(self, request, organization, member):
@@ -114,7 +142,11 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
             return list(queryset[offset : offset + limit])
 
         def on_results(results):
-            results = serialize(results, None, OrganizationMemberSCIMSerializer())
+            results = serialize(
+                results,
+                None,
+                _scim_member_serializer_with_expansion(organization),
+            )
             return self.list_api_format(request, queryset.count(), results)
 
         return self.paginate(
@@ -180,5 +212,8 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                 referrer=request.data.get("referrer"),
             )
 
-        context = serialize(member, serializer=OrganizationMemberSCIMSerializer())
+        context = serialize(
+            member,
+            serializer=_scim_member_serializer_with_expansion(organization),
+        )
         return Response(context, status=201)

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1181,9 +1181,9 @@ class TestMigrations(TestCase):
 
 
 class SCIMTestCase(APITestCase):
-    def setUp(self):
+    def setUp(self, provider="dummy"):
         super().setUp()
-        self.auth_provider = AuthProviderModel(organization=self.organization, provider="dummy")
+        self.auth_provider = AuthProviderModel(organization=self.organization, provider=provider)
         with self.feature({"organizations:sso-scim": True}):
             self.auth_provider.enable_scim(self.user)
             self.auth_provider.save()

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -19,6 +19,7 @@ __all__ = (
     "SetRefsTestCase",
     "OrganizationDashboardWidgetTestCase",
     "SCIMTestCase",
+    "SCIMAzureTestCase",
 )
 
 import inspect
@@ -53,6 +54,7 @@ from rest_framework.test import APITestCase as BaseAPITestCase
 from sentry import auth, eventstore
 from sentry.auth.authenticators import TotpInterface
 from sentry.auth.providers.dummy import DummyProvider
+from sentry.auth.providers.saml2.activedirectory.apps import ACTIVE_DIRECTORY_PROVIDER_NAME
 from sentry.auth.superuser import COOKIE_DOMAIN as SU_COOKIE_DOMAIN
 from sentry.auth.superuser import COOKIE_NAME as SU_COOKIE_NAME
 from sentry.auth.superuser import COOKIE_PATH as SU_COOKIE_PATH
@@ -1188,3 +1190,10 @@ class SCIMTestCase(APITestCase):
             self.auth_provider.enable_scim(self.user)
             self.auth_provider.save()
         self.login_as(user=self.user)
+
+
+class SCIMAzureTestCase(SCIMTestCase):
+    def setUp(self):
+        auth.register(ACTIVE_DIRECTORY_PROVIDER_NAME, DummyProvider)
+        super().setUp(provider=ACTIVE_DIRECTORY_PROVIDER_NAME)
+        self.addCleanup(auth.unregister, ACTIVE_DIRECTORY_PROVIDER_NAME, DummyProvider)

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
 from sentry.models import OrganizationMember
-from sentry.testutils import SCIMTestCase
+from sentry.testutils import SCIMAzureTestCase, SCIMTestCase
 
 CREATE_USER_POST_DATA = {
     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -115,3 +115,29 @@ class SCIMMemberIndexTests(SCIMTestCase):
         assert response.data["totalResults"] == 151
         assert response.data["itemsPerPage"] == 51
         assert response.data["startIndex"] == 101
+
+
+class SCIMMemberIndexAzureTests(SCIMAzureTestCase):
+    def test_user_index_get_no_active(self):
+        member = self.create_member(organization=self.organization, email="test.user@okta.local")
+        url = reverse("sentry-api-0-organization-scim-member-index", args=[self.organization.slug])
+        response = self.client.get(
+            f"{url}?startIndex=1&count=100&filter=userName%20eq%20%22test.user%40okta.local%22"
+        )
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 1,
+            "startIndex": 1,
+            "itemsPerPage": 1,
+            "Resources": [
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+                    "id": str(member.id),
+                    "userName": "test.user@okta.local",
+                    "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+                    "name": {"familyName": "N/A", "givenName": "N/A"},
+                    "meta": {"resourceType": "User"},
+                }
+            ],
+        }

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -1,5 +1,8 @@
 from sentry.api.serializers import OrganizationMemberWithProjectsSerializer, serialize
-from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
+from sentry.api.serializers.models.organization_member import (
+    OrganizationMemberSCIMSerializer,
+    OrganizationMemberWithTeamsSerializer,
+)
 from sentry.testutils import TestCase
 
 
@@ -55,3 +58,21 @@ class OrganizationMemberWithTeamsSerializerTest(OrganizationMemberSerializerTest
         )
         expected_teams = [{self.team.slug, self.team_2.slug}, {self.team.slug}]
         assert [set(r["teams"]) for r in result] == expected_teams
+
+
+class OrganizationMemberSCIMSerializerTest(OrganizationMemberSerializerTest):
+    def test_simple(self):
+        result = serialize(
+            self._get_org_members()[0],
+            self.user_2,
+            OrganizationMemberSCIMSerializer(expand=["active"]),
+        )
+        assert "active" in result
+
+    def test_no_active(self):
+        result = serialize(
+            self._get_org_members()[0],
+            self.user_2,
+            OrganizationMemberSCIMSerializer(),
+        )
+        assert "active" not in result


### PR DESCRIPTION
Context:
- We don't support "soft" deletes by making an organization member inactive. 
- We still a boolean `"active" on the SCIM member response, as for other providers, they still rely on this active flag so we always just set it to true
- For Azure, they either need us to support soft deletes, or remove the active field from the SCIM Member response.

Changes:
- Supporting soft deletes (making an org member inactive) as it is a lot of work for little value added aside from conforming to SCIM, so instead, we remove the active field from members if the auth provider is Azure.