### PR TITLE
feat(search): Enable improved search for all users

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -20,12 +20,6 @@ export const experimentList = [
     assignments: [0, 1],
   },
   {
-    key: 'ImprovedSearchExperiment',
-    type: ExperimentType.Organization,
-    parameter: 'exposed',
-    assignments: [0, 1],
-  },
-  {
     key: 'TrialConfirmationExperiment',
     type: ExperimentType.Organization,
     parameter: 'exposed',

--- a/tests/js/spec/components/events/searchBar.spec.jsx
+++ b/tests/js/spec/components/events/searchBar.spec.jsx
@@ -5,11 +5,11 @@ import SearchBar from 'app/components/events/searchBar';
 import TagStore from 'app/stores/tagStore';
 
 const focusTextarea = el => el.find('textarea[name="query"]').simulate('focus');
-const selectFirstAutocompleteItem = async el => {
+const selectNthAutocompleteItem = async (el, index) => {
   focusTextarea(el);
 
   el.find('SearchListItem[data-test-id="search-autocomplete-item"]')
-    .first()
+    .at(index)
     .simulate('click');
   const textarea = el.find('textarea');
   textarea
@@ -122,9 +122,9 @@ describe('Events > SearchBar', function () {
     await wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
-    expect(wrapper.find('SearchDropdown Description').first().text()).toEqual('gpu');
+    expect(wrapper.find('SearchDropdown Description').at(2).text()).toEqual('gpu');
 
-    selectFirstAutocompleteItem(wrapper);
+    selectNthAutocompleteItem(wrapper, 2);
     await wrapper.update();
     // the trailing space is important here as without it, autocomplete suggestions will
     // try to complete `has:gpu` thinking the token has not ended yet
@@ -147,11 +147,11 @@ describe('Events > SearchBar', function () {
     await wrapper.update();
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
-    expect(wrapper.find('SearchDropdown Description').first().text()).toEqual(
+    expect(wrapper.find('SearchDropdown Description').at(2).text()).toEqual(
       '"Nvidia 1080ti"'
     );
 
-    selectFirstAutocompleteItem(wrapper);
+    selectNthAutocompleteItem(wrapper, 2);
     await wrapper.update();
     expect(wrapper.find('textarea').prop('value')).toBe('gpu:"Nvidia 1080ti" ');
   });
@@ -178,9 +178,10 @@ describe('Events > SearchBar', function () {
     );
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('');
-    expect(wrapper.find('SearchDropdown Description').first().text()).toEqual(
+    expect(wrapper.find('SearchDropdown Description').at(2).text()).toEqual(
       '"Nvidia 1080ti"'
     );
+    selectNthAutocompleteItem(wrapper, 2);
 
     wrapper.find('textarea').simulate('keydown', {key: 'Enter'});
 
@@ -296,7 +297,7 @@ describe('Events > SearchBar', function () {
         query: {project: ['1', '2'], statsPeriod: '14d', includeTransactions: '1'},
       })
     );
-    selectFirstAutocompleteItem(wrapper);
+    selectNthAutocompleteItem(wrapper, 0);
     expect(wrapper.find('textarea').prop('value')).toBe('!gpu:"Nvidia 1080ti" ');
   });
 

--- a/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
@@ -15,7 +15,6 @@ jest.mock('app/utils/analytics', () => ({
     })),
     endTransaction: jest.fn(),
   },
-  logExperiment: jest.fn(),
 }));
 
 describe('Incident Rules Details', function () {

--- a/tests/js/spec/views/alerts/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/ruleForm.spec.jsx
@@ -15,7 +15,6 @@ jest.mock('app/utils/analytics', () => ({
     })),
     endTransaction: jest.fn(),
   },
-  logExperiment: jest.fn(),
 }));
 
 describe('Incident Rules Form', function () {

--- a/tests/js/spec/views/issueList/searchBar.spec.jsx
+++ b/tests/js/spec/views/issueList/searchBar.spec.jsx
@@ -16,6 +16,15 @@ describe('IssueListSearchBar', function () {
   const clickInput = searchBar =>
     searchBar.find('textarea[name="query"]').simulate('click');
 
+  const mockCursorPosition = (wrapper, pos) => {
+    const component = wrapper.find('SmartSearchBar').instance();
+    delete component.cursorPosition;
+    Object.defineProperty(component, 'cursorPosition', {
+      get: jest.fn().mockReturnValue(pos),
+      configurable: true,
+    });
+  };
+
   beforeEach(function () {
     TagStore.reset();
     TagStore.onLoadTagsSuccess(TestStubs.Tags());
@@ -64,6 +73,7 @@ describe('IssueListSearchBar', function () {
         onSearch: jest.fn(),
       };
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
+      mockCursorPosition(searchBar, 5);
       clickInput(searchBar);
       jest.advanceTimersByTime(301);
       expect(searchBar.find('SearchDropdown').prop('searchSubstring')).toEqual('"fu"');
@@ -87,6 +97,7 @@ describe('IssueListSearchBar', function () {
       };
 
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
+      mockCursorPosition(searchBar, 5);
       clickInput(searchBar);
       expect(searchBar.state.searchTerm).toEqual();
       expect(searchBar.find('SearchDropdown').prop('searchSubstring')).toEqual(
@@ -137,6 +148,7 @@ describe('IssueListSearchBar', function () {
         supportedTags,
       };
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
+      mockCursorPosition(searchBar, 5);
       clickInput(searchBar);
       jest.advanceTimersByTime(301);
       expect(searchBar.find('SearchDropdown').prop('searchSubstring')).toEqual('"fu"');

--- a/tests/js/spec/views/projectDetail/projectFilters.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectFilters.spec.jsx
@@ -47,7 +47,7 @@ describe('ProjectDetail > ProjectFilters', () => {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('[data-test-id="search-autocomplete-item"]').at(0).text()).toBe(
+    expect(wrapper.find('[data-test-id="search-autocomplete-item"]').at(4).text()).toBe(
       'sentry@0.5.3'
     );
   });

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -435,7 +435,7 @@ describe('ReleasesList', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('[data-test-id="search-autocomplete-item"]').at(0).text()).toBe(
+    expect(wrapper.find('[data-test-id="search-autocomplete-item"]').at(4).text()).toBe(
       'sentry@0.5.3'
     );
   });


### PR DESCRIPTION
This PR removes the experiment for improved-search and fixes related tests. Most tests were failing because they were not accounting for 
- New operator autocomplete items
- Cursor-responsive autocomplete
- Inability to search when query is invalid

Dependent on https://github.com/getsentry/sentry/pull/27947