### PR TITLE
ref(search): Rename QueryResults -> MutableSearch

### DIFF
--- a/static/app/components/deployBadge.tsx
+++ b/static/app/components/deployBadge.tsx
@@ -3,7 +3,7 @@ import Tag from 'app/components/tag';
 import {IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import {Deploy} from 'app/types';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 type Props = {
   deploy: Deploy;
@@ -39,7 +39,7 @@ const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) =>
         query: {
           project: projectId ?? null,
           environment: deploy.environment,
-          query: new QueryResults([`release:${version!}`]).formatString(),
+          query: new MutableSearch([`release:${version!}`]).formatString(),
         },
       }}
     >

--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -18,7 +18,7 @@ import {Sort} from 'app/utils/discover/fields';
 import BaselineQuery from 'app/utils/performance/baseline/baselineQuery';
 import {TrendsEventsDiscoverQuery} from 'app/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {Actions} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 import {decodeColumnOrder} from 'app/views/eventsV2/utils';
@@ -149,7 +149,7 @@ class TransactionsList extends React.Component<Props> {
 
     const sortedEventView = eventView.withSorts([selected.sort]);
     if (selected.query) {
-      const query = tokenizeSearch(sortedEventView.query);
+      const query = new MutableSearch(sortedEventView.query);
       selected.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       sortedEventView.query = query.formatString();
     }
@@ -343,7 +343,7 @@ class TransactionsList extends React.Component<Props> {
     sortedEventView.sorts = [selected.sort];
     sortedEventView.trendType = selected.trendType;
     if (selected.query) {
-      const query = tokenizeSearch(sortedEventView.query);
+      const query = new MutableSearch(sortedEventView.query);
       selected.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       sortedEventView.query = query.formatString();
     }

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -13,7 +13,7 @@ import {
   TraceError,
 } from 'app/utils/performance/quickTrace/types';
 import {getTraceTimeRangeFromEvent} from 'app/utils/performance/quickTrace/utils';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {getTransactionDetailsUrl} from 'app/views/performance/utils';
 
@@ -109,7 +109,7 @@ export function generateMultiTransactionsTarget(
   organization: OrganizationSummary,
   groupType: 'Ancestor' | 'Children' | 'Descendant'
 ): LocationDescriptor {
-  const queryResults = new QueryResults([]);
+  const queryResults = new MutableSearch([]);
   const eventIds = events.map(child => child.event_id);
   for (let i = 0; i < eventIds.length; i++) {
     queryResults.addOp(i === 0 ? '(' : 'OR');

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -41,7 +41,7 @@ import {SpanOperationBreakdownFilter} from 'app/views/performance/transactionSum
 import {EventsDisplayFilterName} from 'app/views/performance/transactionSummary/transactionEvents/utils';
 
 import {statsPeriodToDays} from '../dates';
-import {QueryResults, tokenizeSearch} from '../tokenizeSearch';
+import {MutableSearch} from '../tokenizeSearch';
 
 import {getSortField} from './fieldRenderers';
 import {
@@ -274,7 +274,7 @@ class EventView {
   interval: string | undefined;
   expired?: boolean;
   createdBy: User | undefined;
-  additionalConditions: QueryResults; // This allows views to always add additional conditins to the query to get specific data. It should not show up in the UI unless explicitly called.
+  additionalConditions: MutableSearch; // This allows views to always add additional conditins to the query to get specific data. It should not show up in the UI unless explicitly called.
 
   constructor(props: {
     id: string | undefined;
@@ -293,7 +293,7 @@ class EventView {
     interval?: string;
     expired?: boolean;
     createdBy: User | undefined;
-    additionalConditions: QueryResults;
+    additionalConditions: MutableSearch;
   }) {
     const fields: Field[] = Array.isArray(props.fields) ? props.fields : [];
     let sorts: Sort[] = Array.isArray(props.sorts) ? props.sorts : [];
@@ -340,7 +340,7 @@ class EventView {
     this.expired = props.expired;
     this.additionalConditions = props.additionalConditions
       ? props.additionalConditions.copy()
-      : new QueryResults([]);
+      : new MutableSearch([]);
   }
 
   static fromLocation(location: Location): EventView {
@@ -362,7 +362,7 @@ class EventView {
       display: decodeScalar(location.query.display),
       interval: decodeScalar(location.query.interval),
       createdBy: undefined,
-      additionalConditions: new QueryResults([]),
+      additionalConditions: new MutableSearch([]),
     });
   }
 
@@ -434,7 +434,7 @@ class EventView {
       display: saved.display,
       createdBy: saved.createdBy,
       expired: saved.expired,
-      additionalConditions: new QueryResults([]),
+      additionalConditions: new MutableSearch([]),
     });
   }
 
@@ -468,7 +468,7 @@ class EventView {
         interval: decodeScalar(location.query.interval),
         createdBy: saved.createdBy,
         expired: saved.expired,
-        additionalConditions: new QueryResults([]),
+        additionalConditions: new MutableSearch([]),
         // Always read team from location since they can be set by other parts
         // of the UI
         team: teams,
@@ -1310,7 +1310,7 @@ class EventView {
     if (this.additionalConditions.isEmpty()) {
       return query;
     }
-    const conditions = tokenizeSearch(query);
+    const conditions = new MutableSearch(query);
     Object.entries(this.additionalConditions.filters).forEach(([tag, tagValues]) => {
       const existingTagValues = conditions.getFilterValues(tag);
       const newTagValues = tagValues.filter(

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -33,10 +33,22 @@ function isParen(token: Token, character: '(' | ')') {
 // searchSyntax/parser. We should absolutely replace the internals of this API
 // with `parseSearch`.
 
-export class QueryResults {
+export class MutableSearch {
   tokens: Token[];
 
-  constructor(strTokens: string[]) {
+  /**
+   * Creates a MutableSearch from a string query
+   */
+  constructor(query: string);
+  /**
+   * Creates a mutable search query from a list of query parts
+   */
+  constructor(queries: string[]);
+  constructor(tokensOrQuery: string[] | string) {
+    const strTokens = Array.isArray(tokensOrQuery)
+      ? tokensOrQuery
+      : splitSearchIntoTokens(tokensOrQuery);
+
     this.tokens = [];
 
     for (let token of strTokens) {
@@ -286,7 +298,7 @@ export class QueryResults {
   }
 
   copy() {
-    const q = new QueryResults([]);
+    const q = new MutableSearch([]);
     q.tokens = [...this.tokens];
     return q;
   }
@@ -294,16 +306,6 @@ export class QueryResults {
   isEmpty() {
     return this.tokens.length === 0;
   }
-}
-
-/**
- * Tokenize a search into a QueryResult
- *
- * Should stay in sync with src.sentry.search.utils:tokenize_query
- */
-export function tokenizeSearch(query: string) {
-  const tokens = splitSearchIntoTokens(query);
-  return new QueryResults(tokens);
 }
 
 /**

--- a/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
+++ b/static/app/views/alerts/incidentRules/incidentRulePresets.tsx
@@ -2,7 +2,7 @@ import Link from 'app/components/links/link';
 import {t} from 'app/locale';
 import {Project} from 'app/types';
 import {DisplayModes} from 'app/utils/discover/types';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {Dataset, IncidentRule} from 'app/views/alerts/incidentRules/types';
 import {getIncidentRuleDiscoverUrl} from 'app/views/alerts/utils/getIncidentRuleDiscoverUrl';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
@@ -149,7 +149,7 @@ function makeGenericTransactionCta(opts: {
     return {to: '', buttonText: t('Alert rule details')};
   }
 
-  const query = tokenizeSearch(rule.query ?? '');
+  const query = new MutableSearch(rule.query ?? '');
   const transaction = query
     .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));
@@ -210,7 +210,7 @@ function makeFailureRateCta({orgSlug, rule, projects, start, end}: PresetCtaOpts
     return {to: '', buttonText: t('Alert rule details')};
   }
 
-  const query = tokenizeSearch(rule.query ?? '');
+  const query = new MutableSearch(rule.query ?? '');
   const transaction = query
     .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));

--- a/static/app/views/alerts/incidentRules/presets.tsx
+++ b/static/app/views/alerts/incidentRules/presets.tsx
@@ -2,7 +2,7 @@ import Link from 'app/components/links/link';
 import {t} from 'app/locale';
 import {Project} from 'app/types';
 import {DisplayModes} from 'app/utils/discover/types';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {Incident, IncidentStats} from 'app/views/alerts/types';
 import {getStartEndFromStats} from 'app/views/alerts/utils';
 import {getIncidentDiscoverUrl} from 'app/views/alerts/utils/getIncidentDiscoverUrl';
@@ -150,7 +150,7 @@ function makeGenericTransactionCta(opts: {
     return {to: '', buttonText: t('Incident details')};
   }
 
-  const query = tokenizeSearch(incident.discoverQuery ?? '');
+  const query = new MutableSearch(incident.discoverQuery ?? '');
   const transaction = query
     .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));
@@ -212,7 +212,7 @@ function makeFailureRateCta({orgSlug, incident, projects, stats}: PresetCtaOpts)
     return {to: '', buttonText: t('Incident details')};
   }
 
-  const query = tokenizeSearch(incident.discoverQuery ?? '');
+  const query = new MutableSearch(incident.discoverQuery ?? '');
   const transaction = query
     .getFilterValues('transaction')
     ?.find(filter => !filter.includes('*'));

--- a/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/statsRequest.tsx
@@ -10,7 +10,7 @@ import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
 import {GlobalSelection, Organization, Project, SessionApiResponse} from 'app/types';
 import {Series} from 'app/types/echarts';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {getInterval} from 'app/views/releases/detail/overview/chart/utils';
 import {roundDuration} from 'app/views/releases/utils';
 
@@ -109,7 +109,7 @@ function StatsRequest({
           .filter(tag => !!tag);
 
         if (!!tagsWithDoubleQuotes.length) {
-          query.query = new QueryResults(tagsWithDoubleQuotes).formatString();
+          query.query = new MutableSearch(tagsWithDoubleQuotes).formatString();
         }
       }
 

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -16,7 +16,7 @@ import {
   isRelativeSpanOperationBreakdownField,
 } from 'app/utils/discover/fields';
 import {getDuration} from 'app/utils/formatters';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 import {TableColumn} from './types';
 
@@ -32,7 +32,7 @@ export enum Actions {
 }
 
 export function updateQuery(
-  results: QueryResults,
+  results: MutableSearch,
   action: Actions,
   column: TableColumn<keyof TableDataRow>,
   value: React.ReactText | string[]

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -33,7 +33,7 @@ import {
 } from 'app/utils/discover/fields';
 import {DisplayModes, TOP_N} from 'app/utils/discover/types';
 import {eventDetailsRouteWithEventView, generateEventSlug} from 'app/utils/discover/urls';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
@@ -352,7 +352,7 @@ class TableView extends React.Component<TableViewProps> {
     return (action: Actions, value: React.ReactText) => {
       const {eventView, organization, projects} = this.props;
 
-      const query = tokenizeSearch(eventView.query);
+      const query = new MutableSearch(eventView.query);
 
       let nextView = eventView.clone();
 

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -29,7 +29,7 @@ import {
 } from 'app/utils/discover/fields';
 import {getTitle} from 'app/utils/events';
 import localStorage from 'app/utils/localStorage';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 import {FieldValue, FieldValueKind, TableColumn} from './table/types';
 import {ALL_VIEWS, TRANSACTION_VIEWS, WEB_VITALS_VIEWS} from './data';
@@ -374,7 +374,7 @@ function generateExpandedConditions(
   additionalConditions: Record<string, string>,
   dataRow?: TableDataRow | Event
 ): string {
-  const parsedQuery = tokenizeSearch(eventView.query);
+  const parsedQuery = new MutableSearch(eventView.query);
 
   // Remove any aggregates from the search conditions.
   // otherwise, it'll lead to an invalid query result.

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -20,7 +20,7 @@ import {GlobalSelection, Organization, Project} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {QueryResults, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -136,7 +136,7 @@ class PerformanceContent extends Component<Props, State> {
     };
 
     const query = decodeScalar(location.query.query, '');
-    const conditions = tokenizeSearch(query);
+    const conditions = new MutableSearch(query);
 
     trackAnalyticsEvent({
       eventKey: 'performance_views.change_view',
@@ -145,7 +145,7 @@ class PerformanceContent extends Component<Props, State> {
       view_name: 'TRENDS',
     });
 
-    const modifiedConditions = new QueryResults([]);
+    const modifiedConditions = new MutableSearch([]);
 
     if (conditions.hasFilter('tpm()')) {
       modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -6,7 +6,7 @@ import {t} from 'app/locale';
 import {LightWeightOrganization, NewQuery, Project, SelectValue} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from './landing/utils';
 import {
@@ -447,7 +447,7 @@ function generateGenericPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = tokenizeSearch(searchQuery);
+  const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
   if (!conditions.hasFilter('transaction.duration')) {
@@ -519,7 +519,7 @@ function generateBackendPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = tokenizeSearch(searchQuery);
+  const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
   if (!conditions.hasFilter('transaction.duration')) {
@@ -612,7 +612,7 @@ function generateMobilePerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = tokenizeSearch(searchQuery);
+  const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
   if (!conditions.hasFilter('transaction.duration')) {
@@ -682,7 +682,7 @@ function generateFrontendPageloadPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = tokenizeSearch(searchQuery);
+  const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
   if (!conditions.hasFilter('transaction.duration')) {
@@ -754,7 +754,7 @@ function generateFrontendOtherPerformanceEventView(
   savedQuery.orderby = decodeScalar(query.sort, '-tpm');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = tokenizeSearch(searchQuery);
+  const conditions = new MutableSearch(searchQuery);
 
   // This is not an override condition since we want the duration to appear in the search bar as a default.
   if (!conditions.hasFilter('transaction.duration')) {
@@ -847,7 +847,7 @@ export function generatePerformanceVitalDetailView(
   savedQuery.orderby = decodeScalar(query.sort, '-count');
 
   const searchQuery = decodeScalar(query.query, '');
-  const conditions = tokenizeSearch(searchQuery);
+  const conditions = new MutableSearch(searchQuery);
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.

--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -16,7 +16,7 @@ import EventView from 'app/utils/discover/eventView';
 import {generateAggregateFields} from 'app/utils/discover/fields';
 import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withTeams from 'app/utils/withTeams';
 
 import Charts from '../charts/index';
@@ -61,7 +61,7 @@ type Props = {
 type State = {};
 class LandingContent extends Component<Props, State> {
   getSummaryConditions(query: string) {
-    const parsed = tokenizeSearch(query);
+    const parsed = new MutableSearch(query);
     parsed.freeText = [];
 
     return parsed.formatString();
@@ -80,7 +80,7 @@ class LandingContent extends Component<Props, State> {
 
     // Transaction op can affect the display and show no results if it is explicitly set.
     const query = decodeScalar(location.query.query, '');
-    const searchConditions = tokenizeSearch(query);
+    const searchConditions = new MutableSearch(query);
     searchConditions.removeFilter('transaction.op');
 
     trackAnalyticsEvent({

--- a/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
+++ b/static/app/views/performance/landing/display/doubleAxisDisplay.tsx
@@ -8,7 +8,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 
 import _Footer from '../../charts/footer';
@@ -35,7 +35,7 @@ function DoubleAxisDisplay(props: Props) {
   const onFilterChange = (field: string) => (minValue, maxValue) => {
     const filterString = getTransactionSearchQuery(location);
 
-    const conditions = tokenizeSearch(filterString);
+    const conditions = new MutableSearch(filterString);
     conditions.setFilterValues(field, [
       `>=${Math.round(minValue)}`,
       `<${Math.round(maxValue)}`,

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -20,7 +20,7 @@ import DiscoverQuery, {TableData, TableDataRow} from 'app/utils/discover/discove
 import EventView, {EventData, isFieldSortable} from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {fieldAlignment, getAggregateAlias} from 'app/utils/discover/fields';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -141,7 +141,7 @@ class Table extends React.Component<Props, State> {
         return;
       }
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       searchConditions.removeFilter('event.type');

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -25,7 +25,7 @@ import {
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
@@ -121,7 +121,7 @@ class SummaryContent extends React.Component<Props, State> {
     return (action: Actions, value: React.ReactText) => {
       const {eventView, location} = this.props;
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       searchConditions.removeFilter('event.type');

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -24,7 +24,7 @@ import {
 } from 'app/utils/discover/fields';
 import {removeHistogramQueryStrings} from 'app/utils/performance/histogram';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
@@ -319,7 +319,7 @@ function generateSummaryEventView(
   // Use the user supplied query but overwrite any transaction or event type
   // conditions they applied.
   const query = decodeScalar(location.query.query, '');
-  const conditions = tokenizeSearch(query);
+  const conditions = new MutableSearch(query);
   conditions
     .setFilterValues('event.type', ['transaction'])
     .setFilterValues('transaction', [transactionName]);

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -16,7 +16,7 @@ import {OrganizationSummary} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {TRACING_FIELDS} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 type Props = {
   organization: OrganizationSummary;
@@ -47,7 +47,7 @@ class RelatedIssues extends Component<Props> {
       sort: 'new',
       ...pick(location.query, [...Object.values(URL_PARAM), 'cursor']),
     };
-    const currentFilter = tokenizeSearch(decodeScalar(location.query.query, ''));
+    const currentFilter = new MutableSearch(decodeScalar(location.query.query, ''));
     currentFilter.getFilterKeys().forEach(tagKey => {
       const searchKey = tagKey.startsWith('!') ? tagKey.substr(1) : tagKey;
       // Remove aggregates and transaction event fields

--- a/static/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -14,7 +14,7 @@ import {t} from 'app/locale';
 import {LightWeightOrganization} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {getTermHelp, PERFORMANCE_TERM} from 'app/views/performance/data';
 
 type Props = {
@@ -67,7 +67,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
             label: String(row['transaction.status']),
             value: parseInt(String(row.count), 10),
             onClick: () => {
-              const query = tokenizeSearch(eventView.query);
+              const query = new MutableSearch(eventView.query);
               query
                 .removeFilter('!transaction.status')
                 .setFilterValues('transaction.status', [row['transaction.status']]);

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -28,7 +28,7 @@ import SegmentExplorerQuery, {
   TableDataRow,
 } from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -283,7 +283,7 @@ class _TagExplorer extends React.Component<Props> {
     });
 
     const queryString = decodeScalar(location.query.query);
-    const conditions = tokenizeSearch(queryString || '');
+    const conditions = new MutableSearch(queryString ?? '');
 
     conditions.addFilterValues(tagKey, [tagValue]);
 
@@ -310,7 +310,7 @@ class _TagExplorer extends React.Component<Props> {
         organization_id: parseInt(organization.id, 10),
       });
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       searchConditions.removeFilter('event.type');

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -21,7 +21,7 @@ import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -61,7 +61,7 @@ class EventsPageContent extends React.Component<Props, State> {
     return (action: Actions, value: React.ReactText) => {
       const {eventView, location} = this.props;
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       searchConditions.removeFilter('event.type');

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -22,7 +22,7 @@ import {
   isSpanOperationBreakdownField,
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'app/utils/discover/fields';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -97,7 +97,7 @@ class EventsTable extends React.Component<Props, State> {
         action,
       });
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       searchConditions.removeFilter('event.type');

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -21,7 +21,7 @@ import {
 } from 'app/utils/discover/fields';
 import {removeHistogramQueryStrings} from 'app/utils/performance/histogram';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -157,7 +157,7 @@ class TransactionEvents extends Component<Props, State> {
     ];
     const filteredEventView = eventView?.clone();
     if (filteredEventView && filter?.query) {
-      const query = tokenizeSearch(filteredEventView.query);
+      const query = new MutableSearch(filteredEventView.query);
       filter.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       filteredEventView.query = query.formatString();
     }
@@ -307,7 +307,7 @@ function generateEventsEventView(
     return undefined;
   }
   const query = decodeScalar(location.query.query, '');
-  const conditions = tokenizeSearch(query);
+  const conditions = new MutableSearch(query);
   conditions
     .setFilterValues('event.type', ['transaction'])
     .setFilterValues('transaction', [transactionName]);

--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -13,7 +13,7 @@ import {PageContent} from 'app/styles/organization';
 import {GlobalSelection, Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -140,7 +140,7 @@ function generateTagsEventView(
     return undefined;
   }
   const query = decodeScalar(location.query.query, '');
-  const conditions = tokenizeSearch(query);
+  const conditions = new MutableSearch(query);
   const eventView = EventView.fromNewQueryWithLocation(
     {
       id: undefined,

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -22,7 +22,7 @@ import {
   TableDataRow,
 } from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -170,7 +170,7 @@ export class TagValueTable extends Component<Props, State> {
 
   handleTagValueClick = (location: Location, tagKey: string, tagValue: string) => {
     const queryString = decodeScalar(location.query.query);
-    const conditions = tokenizeSearch(queryString || '');
+    const conditions = new MutableSearch(queryString ?? '');
 
     conditions.addFilterValues(tagKey, [tagValue]);
 
@@ -193,7 +193,7 @@ export class TagValueTable extends Component<Props, State> {
       const {eventView, location, organization} = this.props;
       trackTagPageInteraction(organization);
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       searchConditions.removeFilter('event.type');
 
@@ -243,7 +243,7 @@ export class TagValueTable extends Component<Props, State> {
     }
 
     if (column.key === 'action') {
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
       const disabled = searchConditions.hasFilter(dataRow.tags_key);
       return (
         <Link

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
@@ -15,7 +15,7 @@ import EventView from 'app/utils/discover/eventView';
 import {isAggregateField, WebVital} from 'app/utils/discover/fields';
 import {WEB_VITAL_DETAILS} from 'app/utils/performance/vitals/constants';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -143,7 +143,7 @@ function generateRumEventView(
     return undefined;
   }
   const query = decodeScalar(location.query.query, '');
-  const conditions = tokenizeSearch(query);
+  const conditions = new MutableSearch(query);
   conditions
     .setFilterValues('event.type', ['transaction'])
     .setFilterValues('transaction.op', ['pageload'])

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -25,7 +25,7 @@ import {computeBuckets, formatHistogramData} from 'app/utils/performance/histogr
 import {Vital} from 'app/utils/performance/vitals/types';
 import {VitalData} from 'app/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {Theme} from 'app/utils/theme';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {EventsDisplayFilterName} from 'app/views/performance/transactionSummary/transactionEvents/utils';
 
 import {VitalBar} from '../../landing/vitalsCards';
@@ -193,7 +193,7 @@ class VitalCard extends Component<Props, State> {
         },
       ]);
 
-    const query = tokenizeSearch(newEventView.query ?? '');
+    const query = new MutableSearch(newEventView.query ?? '');
     query.addFilterValues('has', [column]);
     // add in any range constraints if any
     if (min !== undefined || max !== undefined) {

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -26,7 +26,7 @@ import {AvatarProject, Organization, Project} from 'app/types';
 import {formatPercentage, getDuration} from 'app/utils/formatters';
 import TrendsDiscoverQuery from 'app/utils/performance/trends/trendsDiscoverQuery';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -161,7 +161,7 @@ enum FilterSymbols {
 
 function handleFilterTransaction(location: Location, transaction: string) {
   const queryString = decodeScalar(location.query.query);
-  const conditions = tokenizeSearch(queryString || '');
+  const conditions = new MutableSearch(queryString ?? '');
 
   conditions.addFilterValues('!transaction', [transaction]);
 
@@ -179,7 +179,7 @@ function handleFilterTransaction(location: Location, transaction: string) {
 function handleFilterDuration(location: Location, value: number, symbol: FilterSymbols) {
   const durationTag = getCurrentTrendParameter(location).column;
   const queryString = decodeScalar(location.query.query);
-  const conditions = tokenizeSearch(queryString || '');
+  const conditions = new MutableSearch(queryString ?? '');
 
   const existingValues = conditions.getFilterValues(durationTag);
   const alternateSymbol = symbol === FilterSymbols.GREATER_THAN_EQUALS ? '>' : '<';

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -18,7 +18,7 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {generateAggregateFields} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import {getPerformanceLandingUrl, getTransactionSearchQuery} from '../utils';
@@ -147,7 +147,7 @@ class TrendsContent extends React.Component<Props, State> {
       ...location.query,
     };
     const query = decodeScalar(location.query.query, '');
-    const conditions = tokenizeSearch(query);
+    const conditions = new MutableSearch(query);
 
     // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
     conditions.removeFilter('tpm()');
@@ -314,7 +314,7 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
 
     const queryString = decodeScalar(location.query.query);
     const trendParameter = getCurrentTrendParameter(location);
-    const conditions = tokenizeSearch(queryString || '');
+    const conditions = new MutableSearch(queryString || '');
 
     if (queryString || this.hasPushedDefaults) {
       this.hasPushedDefaults = true;

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -19,7 +19,7 @@ import {
 } from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 import {
   NormalizedTrendsTransaction,
@@ -317,7 +317,7 @@ export function movingAverage(data, index, size) {
  * This function applies defaults for trend and count percentage, and adds the confidence limit to the query
  */
 function getLimitTransactionItems(query: string) {
-  const limitQuery = tokenizeSearch(query);
+  const limitQuery = new MutableSearch(query);
   if (!limitQuery.hasFilter('count_percentage()')) {
     limitQuery.addFilterValues('count_percentage()', ['>0.25', '<4']);
   }

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -10,7 +10,7 @@ import EventView from 'app/utils/discover/eventView';
 import {getDuration} from 'app/utils/formatters';
 import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 /**
  * Performance type can used to determine a default view or which specific field should be used by default on pages
@@ -66,7 +66,7 @@ export function platformAndConditionsToPerformanceType(
 ) {
   const performanceType = platformToPerformanceType(projects, eventView.project);
   if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
-    const conditions = tokenizeSearch(eventView.query);
+    const conditions = new MutableSearch(eventView.query);
     const ops = conditions.getFilterValues('!transaction.op');
     if (ops.some(op => op === 'pageload')) {
       return PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER;

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -24,7 +24,7 @@ import VitalsDetailsTableQuery, {
   TableData,
   TableDataRow,
 } from 'app/utils/performance/vitals/vitalsDetailsTableQuery';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
@@ -106,7 +106,7 @@ class Table extends React.Component<Props, State> {
         action,
       });
 
-      const searchConditions = tokenizeSearch(eventView.query);
+      const searchConditions = new MutableSearch(eventView.query);
 
       // remove any event.type queries since it is implied to apply to only transactions
       searchConditions.removeFilter('event.type');
@@ -176,7 +176,7 @@ class Table extends React.Component<Props, State> {
     if (field === 'transaction') {
       const projectID = getProjectID(dataRow, projects);
       const summaryView = eventView.clone();
-      const conditions = tokenizeSearch(summaryConditions);
+      const conditions = new MutableSearch(summaryConditions);
       conditions.addFilterValues('has', [`${vitalName}`]);
       summaryView.query = conditions.formatString();
 

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -22,7 +22,7 @@ import {generateQueryWithTag} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
 import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import withTeams from 'app/utils/withTeams';
 
@@ -53,7 +53,7 @@ type State = {
 };
 
 function getSummaryConditions(query: string) {
-  const parsed = tokenizeSearch(query);
+  const parsed = new MutableSearch(query);
   parsed.freeText = [];
 
   return parsed.formatString();

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -32,7 +32,7 @@ import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {decodeScalar} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import {
   getSessionTermDescription,
@@ -293,7 +293,7 @@ class ProjectCharts extends Component<Props, State> {
                 <ProjectBaseEventsChart
                   title={t('Apdex')}
                   help={getTermHelp(organization, apdexPerformanceTerm)}
-                  query={new QueryResults([
+                  query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',
                   ]).formatString()}
@@ -310,7 +310,7 @@ class ProjectCharts extends Component<Props, State> {
                 <ProjectBaseEventsChart
                   title={t('Failure Rate')}
                   help={getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE)}
-                  query={new QueryResults([
+                  query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',
                   ]).formatString()}
@@ -327,7 +327,7 @@ class ProjectCharts extends Component<Props, State> {
                 <ProjectBaseEventsChart
                   title={t('Transactions Per Minute')}
                   help={getTermHelp(organization, PERFORMANCE_TERM.TPM)}
-                  query={new QueryResults([
+                  query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',
                   ]).formatString()}
@@ -345,7 +345,7 @@ class ProjectCharts extends Component<Props, State> {
                 (hasDiscover ? (
                   <ProjectBaseEventsChart
                     title={t('Number of Errors')}
-                    query={new QueryResults([
+                    query={new MutableSearch([
                       '!event.type:transaction',
                       query ?? '',
                     ]).formatString()}
@@ -371,7 +371,7 @@ class ProjectCharts extends Component<Props, State> {
               {displayMode === DisplayModes.TRANSACTIONS && (
                 <ProjectBaseEventsChart
                   title={t('Number of Transactions')}
-                  query={new QueryResults([
+                  query={new MutableSearch([
                     'event.type:transaction',
                     query ?? '',
                   ]).formatString()}

--- a/static/app/views/projectDetail/projectQuickLinks.tsx
+++ b/static/app/views/projectDetail/projectQuickLinks.tsx
@@ -10,7 +10,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {DEFAULT_MAX_DURATION} from 'app/views/performance/trends/utils';
 import {
   getPerformanceLandingUrl,
@@ -28,7 +28,7 @@ type Props = {
 function ProjectQuickLinks({organization, project, location}: Props) {
   function getTrendsLink() {
     const queryString = decodeScalar(location.query.query);
-    const conditions = tokenizeSearch(queryString || '');
+    const conditions = new MutableSearch(queryString || '');
     conditions.setFilterValues('tpm()', ['>0.01']);
     conditions.setFilterValues('transaction.duration', [
       '>0',

--- a/static/app/views/releases/detail/overview/chart/utils.tsx
+++ b/static/app/views/releases/detail/overview/chart/utils.tsx
@@ -12,7 +12,7 @@ import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
 import {formatVersion} from 'app/utils/formatters';
 import {WEB_VITAL_DETAILS} from 'app/utils/performance/vitals/constants';
 import {Theme} from 'app/utils/theme';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {getCrashFreePercent} from 'app/views/releases/utils';
 import {sessionTerm} from 'app/views/releases/utils/sessionTerm';
 
@@ -85,7 +85,7 @@ export function getReleaseEventView(
       );
       return EventView.fromSavedQuery({
         ...baseQuery,
-        query: new QueryResults(
+        query: new MutableSearch(
           ['event.type:transaction', releaseFilter, ...statusFilters].filter(Boolean)
         ).formatString(),
       });
@@ -98,7 +98,7 @@ export function getReleaseEventView(
           : WEB_VITAL_DETAILS[vitalType].poorThreshold;
       return EventView.fromSavedQuery({
         ...baseQuery,
-        query: new QueryResults(
+        query: new MutableSearch(
           [
             'event.type:transaction',
             releaseFilter,
@@ -111,7 +111,7 @@ export function getReleaseEventView(
         eventType === EventType.ALL ? '' : `event.type:${eventType}`;
       return EventView.fromSavedQuery({
         ...baseQuery,
-        query: new QueryResults(
+        query: new MutableSearch(
           [releaseFilter, eventTypeFilter].filter(Boolean)
         ).formatString(),
       });
@@ -119,7 +119,7 @@ export function getReleaseEventView(
       return EventView.fromSavedQuery({
         ...baseQuery,
         fields: ['issue', 'title', 'count()', 'count_unique(user)', 'project'],
-        query: new QueryResults([
+        query: new MutableSearch([
           `release:${version}`,
           '!event.type:transaction',
         ]).formatString(),

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -19,7 +19,7 @@ import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization} from 'app/types';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import {IssueSortOptions} from 'app/views/issueList/utils';
@@ -144,7 +144,7 @@ class Issues extends Component<Props, State> {
     const {version, organization} = this.props;
     const {issuesType} = this.state;
     const {queryParams} = this.getIssuesEndpoint();
-    const query = new QueryResults([]);
+    const query = new MutableSearch([]);
 
     switch (issuesType) {
       case IssuesType.NEW:
@@ -194,7 +194,7 @@ class Issues extends Component<Props, State> {
           path: `/organizations/${organization.slug}/issues/`,
           queryParams: {
             ...queryParams,
-            query: new QueryResults([`${IssuesQuery.ALL}:${version}`]).formatString(),
+            query: new MutableSearch([`${IssuesQuery.ALL}:${version}`]).formatString(),
           },
         };
       case IssuesType.RESOLVED:
@@ -207,7 +207,7 @@ class Issues extends Component<Props, State> {
           path: `/organizations/${organization.slug}/issues/`,
           queryParams: {
             ...queryParams,
-            query: new QueryResults([
+            query: new MutableSearch([
               `${IssuesQuery.ALL}:${version}`,
               IssuesQuery.UNHANDLED,
             ]).formatString(),
@@ -219,7 +219,7 @@ class Issues extends Component<Props, State> {
           path: `/organizations/${organization.slug}/issues/`,
           queryParams: {
             ...queryParams,
-            query: new QueryResults([`${IssuesQuery.NEW}:${version}`]).formatString(),
+            query: new MutableSearch([`${IssuesQuery.NEW}:${version}`]).formatString(),
           },
         };
     }

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -35,7 +35,7 @@ import {formatPercentage} from 'app/utils/formatters';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
 import {getCount, getCrashFreeRate, getSessionStatusRate} from 'app/utils/sessions';
 import {Color} from 'app/utils/theme';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {
   displaySessionStatusPercent,
   getReleaseBounds,
@@ -159,7 +159,7 @@ function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['failure_rate()', 'count()'],
-            query: new QueryResults([
+            query: new MutableSearch([
               'event.type:transaction',
               `release:${release.version}`,
             ]).formatString(),
@@ -169,14 +169,14 @@ function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['failure_rate()', 'count()'],
-            query: new QueryResults(['event.type:transaction']).formatString(),
+            query: new MutableSearch(['event.type:transaction']).formatString(),
             ...commonQuery,
           },
         }),
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: new QueryResults([
+            query: new MutableSearch([
               'event.type:error',
               `release:${release.version}`,
             ]).formatString(),
@@ -186,7 +186,7 @@ function ReleaseComparisonChart({
         api.requestPromise(url, {
           query: {
             field: ['count()'],
-            query: new QueryResults(['event.type:error']).formatString(),
+            query: new MutableSearch(['event.type:error']).formatString(),
             ...commonQuery,
           },
         }),

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -20,7 +20,7 @@ import {
 } from 'app/types';
 import {tooltipFormatter} from 'app/utils/discover/charts';
 import {Theme} from 'app/utils/theme';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import {getTermHelp, PERFORMANCE_TERM} from 'app/views/performance/data';
@@ -81,14 +81,20 @@ function ReleaseEventsChart({
 
     switch (chartType) {
       case ReleaseComparisonChartType.ERROR_COUNT:
-        return new QueryResults([
+        return new MutableSearch([
           '!event.type:transaction',
           releaseFilter,
         ]).formatString();
       case ReleaseComparisonChartType.TRANSACTION_COUNT:
-        return new QueryResults(['event.type:transaction', releaseFilter]).formatString();
+        return new MutableSearch([
+          'event.type:transaction',
+          releaseFilter,
+        ]).formatString();
       case ReleaseComparisonChartType.FAILURE_RATE:
-        return new QueryResults(['event.type:transaction', releaseFilter]).formatString();
+        return new MutableSearch([
+          'event.type:transaction',
+          releaseFilter,
+        ]).formatString();
       default:
         return '';
     }

--- a/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/static/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -18,7 +18,7 @@ import {defined} from 'app/utils';
 import {WebVital} from 'app/utils/discover/fields';
 import {getExactDuration} from 'app/utils/formatters';
 import {Theme} from 'app/utils/theme';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 import {displayCrashFreePercent, roundDuration} from '../../utils';
 
@@ -111,7 +111,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
     const {version, organization, location, selection, defaultStatsPeriod} = this.props;
 
     return {
-      query: new QueryResults([`release:"${version}"`]).formatString(),
+      query: new MutableSearch([`release:"${version}"`]).formatString(),
       interval: getInterval(selection.datetime, {
         highFidelity: organization.features.includes('minute-resolution-sessions'),
       }),
@@ -203,7 +203,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
             ...this.baseQueryParams,
             field: 'sum(session)',
             groupBy: 'session.status',
-            query: new QueryResults([`!release:"${version}"`]).formatString(),
+            query: new MutableSearch([`!release:"${version}"`]).formatString(),
           },
         }),
       ]);
@@ -250,7 +250,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
             ...this.baseQueryParams,
             field: 'count_unique(user)',
             groupBy: 'session.status',
-            query: new QueryResults([`!release:"${version}"`]).formatString(),
+            query: new MutableSearch([`!release:"${version}"`]).formatString(),
           },
         }),
       ]);
@@ -297,7 +297,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
             ...this.baseQueryParams,
             field: ['sum(session)', 'count_unique(user)'],
             groupBy: 'session.status',
-            query: new QueryResults([`!release:"${version}"`]).formatString(),
+            query: new MutableSearch([`!release:"${version}"`]).formatString(),
           },
         }),
       ]);
@@ -365,7 +365,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
           query: {
             ...this.baseQueryParams,
             field: 'p50(session.duration)',
-            query: new QueryResults([`!release:"${version}"`]).formatString(),
+            query: new MutableSearch([`!release:"${version}"`]).formatString(),
           },
         }),
       ]);

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -20,7 +20,7 @@ import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
 import {decodeList} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {isProjectMobileForReleases} from 'app/views/releases/list';
 
 import {commonTermsDescription, SessionTerm} from '../utils/sessionTerm';
@@ -127,7 +127,7 @@ export function getReleaseEventView(
     version: 2,
     name: `${t('Release Apdex')}`,
     fields: [apdexField],
-    query: new QueryResults([
+    query: new MutableSearch([
       `release:${version}`,
       'event.type:transaction',
       'count():>0',

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -8,7 +8,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import {PAGE_URL_PARAM, URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {tn} from 'app/locale';
 import {Release, ReleaseStatus} from 'app/types';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {IssueSortOptions} from 'app/views/issueList/utils';
 
 import {DisplayOption} from '../list/utils';
@@ -81,7 +81,7 @@ export const getReleaseNewIssuesUrl = (
       statsPeriod: undefined,
       start: undefined,
       end: undefined,
-      query: new QueryResults([`firstRelease:${version}`]).formatString(),
+      query: new MutableSearch([`firstRelease:${version}`]).formatString(),
       sort: IssueSortOptions.FREQ,
     },
   };
@@ -98,7 +98,7 @@ export const getReleaseUnhandledIssuesUrl = (
     query: {
       ...dateTime,
       project: projectId,
-      query: new QueryResults([
+      query: new MutableSearch([
         `release:${version}`,
         'error.unhandled:true',
       ]).formatString(),
@@ -118,7 +118,7 @@ export const getReleaseHandledIssuesUrl = (
     query: {
       ...dateTime,
       project: projectId,
-      query: new QueryResults([
+      query: new MutableSearch([
         `release:${version}`,
         'error.handled:true',
       ]).formatString(),

--- a/static/app/views/releases/utils/releaseHealthRequest.tsx
+++ b/static/app/views/releases/utils/releaseHealthRequest.tsx
@@ -24,7 +24,7 @@ import {
   SessionApiResponse,
 } from 'app/types';
 import {defined, percent} from 'app/utils';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
 
 import {DisplayOption} from '../list/utils';
@@ -143,7 +143,7 @@ class ReleaseHealthRequest extends React.Component<Props, State> {
     const {location, selection, defaultStatsPeriod, releases} = this.props;
 
     return {
-      query: new QueryResults(
+      query: new MutableSearch(
         releases.reduce((acc, release, index, allReleases) => {
           acc.push(`release:"${release}"`);
           if (index < allReleases.length - 1) {

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -6,7 +6,7 @@ import Switch from 'app/components/switchButton';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {MemberRole} from 'app/types';
-import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 type Props = {
   className?: string;
@@ -34,7 +34,7 @@ const getBoolean = (list: string[]) =>
     : null;
 
 const MembersFilter = ({className, roles, query, onChange}: Props) => {
-  const search = tokenizeSearch(query);
+  const search = new MutableSearch(query);
 
   const filters = {
     roles: search.getFilterValues('role') || [],

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -1,7 +1,7 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import EventView from 'app/utils/discover/eventView';
-import {QueryResults} from 'app/utils/tokenizeSearch';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 
 const defaultData = {
@@ -374,7 +374,7 @@ describe('updateQuery()', function () {
   };
 
   it('modifies the query with has/!has', function () {
-    let results = new QueryResults([]);
+    let results = new MutableSearch([]);
     updateQuery(results, Actions.ADD, columnA, null);
     expect(results.formatString()).toEqual('!has:a');
     updateQuery(results, Actions.EXCLUDE, columnA, null);
@@ -382,13 +382,13 @@ describe('updateQuery()', function () {
     updateQuery(results, Actions.ADD, columnA, null);
     expect(results.formatString()).toEqual('!has:a');
 
-    results = new QueryResults([]);
+    results = new MutableSearch([]);
     updateQuery(results, Actions.ADD, columnA, [null]);
     expect(results.formatString()).toEqual('!has:a');
   });
 
   it('modifies the query with additions', function () {
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     updateQuery(results, Actions.ADD, columnA, '1');
     expect(results.formatString()).toEqual('a:1');
     updateQuery(results, Actions.ADD, columnB, '1');
@@ -400,7 +400,7 @@ describe('updateQuery()', function () {
   });
 
   it('modifies the query with exclusions', function () {
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     updateQuery(results, Actions.EXCLUDE, columnA, '1');
     expect(results.formatString()).toEqual('!a:1');
     updateQuery(results, Actions.EXCLUDE, columnB, '1');
@@ -412,7 +412,7 @@ describe('updateQuery()', function () {
   });
 
   it('modifies the query with a mix of additions and exclusions', function () {
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     updateQuery(results, Actions.ADD, columnA, '1');
     expect(results.formatString()).toEqual('a:1');
     updateQuery(results, Actions.ADD, columnB, '2');
@@ -428,7 +428,7 @@ describe('updateQuery()', function () {
   });
 
   it('modifies the query with greater/less than', function () {
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     updateQuery(results, Actions.SHOW_GREATER_THAN, columnA, 1);
     expect(results.formatString()).toEqual('a:>1');
     updateQuery(results, Actions.SHOW_GREATER_THAN, columnA, 2);
@@ -442,7 +442,7 @@ describe('updateQuery()', function () {
   it('modifies the query with greater/less than on duration fields', function () {
     const columnADuration = {...columnA, type: 'duration'};
 
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     updateQuery(results, Actions.SHOW_GREATER_THAN, columnADuration, 1);
     expect(results.formatString()).toEqual('a:>1.00ms');
     updateQuery(results, Actions.SHOW_GREATER_THAN, columnADuration, 2);
@@ -454,14 +454,14 @@ describe('updateQuery()', function () {
   });
 
   it('does not error for special actions', function () {
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     updateQuery(results, Actions.TRANSACTION, columnA, '');
     updateQuery(results, Actions.RELEASE, columnA, '');
     updateQuery(results, Actions.DRILLDOWN, columnA, '');
   });
 
   it('errors for unknown actions', function () {
-    const results = new QueryResults([]);
+    const results = new MutableSearch([]);
     expect(() => updateQuery(results, 'unknown', columnA, '')).toThrow();
   });
 });


### PR DESCRIPTION
The name `MutableSearch` is probably a bit more descriptive of what this object is.

Also removes the tokenizeSearch function and just replaces it with a overload of the constructor which accepts the full string