### PR TITLE
fix(appconnect): Accept 201 Created when requesting SMS 2FA info during iTunes auth

### DIFF
--- a/src/sentry/utils/appleconnect/itunes_connect.py
+++ b/src/sentry/utils/appleconnect/itunes_connect.py
@@ -302,7 +302,7 @@ class ITunesClient:
             },
             timeout=REQUEST_TIMEOUT,
         )
-        if not response.ok():
+        if not response.ok:
             raise ITunesError(f"Unexpected response status: {response.status_code}")
 
         try:

--- a/src/sentry/utils/appleconnect/itunes_connect.py
+++ b/src/sentry/utils/appleconnect/itunes_connect.py
@@ -302,25 +302,18 @@ class ITunesClient:
             },
             timeout=REQUEST_TIMEOUT,
         )
-        # Fastlane actually doesn't check the response status in their implementation and simply
-        # checks whether the response returns the expected fields associated with 2FA. This is
-        # tries to be lenient in a similar way.
-        is_expected_status = (
-            response.status_code == HTTPStatus.OK or response.status_code == HTTPStatus.CREATED
-        )
+        if not response.ok():
+            raise ITunesError(f"Unexpected response status: {response.status_code}")
+
         try:
             info = response.json()["trustedPhoneNumber"]
+        except requests.exceptions.JSONDecodeError:
+            raise ITunesError(
+                f"Received unexpected response content, response status: {response.status_code}"
+            )
         except KeyError:
-            if is_expected_status:
-                raise ITunesError(
-                    f"Trusted phone info missing from response with status: {response.status_code}"
-                )
-            else:
-                raise ITunesError(f"Unexpected response status: {response.status_code}")
-        else:
-            sentry_sdk.capture_message(
-                f"Unexpected response status from Apple ({response.status_code}) while requesting trusted phone info but found trustedPhoneNumber in response payload, proceeding using response's contents",
-                level="warning",
+            raise ITunesError(
+                f"Trusted phone info missing from response with status: {response.status_code}"
             )
         self._trusted_phone = TrustedPhoneInfo(
             id=info["id"],

--- a/src/sentry/utils/appleconnect/itunes_connect.py
+++ b/src/sentry/utils/appleconnect/itunes_connect.py
@@ -307,7 +307,7 @@ class ITunesClient:
 
         try:
             info = response.json()["trustedPhoneNumber"]
-        except requests.exceptions.JSONDecodeError:
+        except ValueError:
             raise ITunesError(
                 f"Received unexpected response content, response status: {response.status_code}"
             )


### PR DESCRIPTION
We've been seeing a couple of instances where a user has received 201 Created in response to one of the SMS 2FA requests (sentry: SENTRY-RWG, jira: NATIVE-159).

[fastlane's implementation](https://github.com/fastlane/fastlane/blob/e874a47c6e2e0e61590a03d3b71e75e5a505d1ce/spaceship/lib/spaceship/two_step_or_factor_client.rb#L13-L21) doesn't appear to be strictly checking the status code and merely checks the contents of the response. Knowing that, I've changed our implementation to first check to see if `trustedPhone` is present in the payload, and to just emit a warning if the status was wrong but the data needed to continue with SMS 2FA was available.
