### PR TITLE
fix(spans): Factor any embedded transactions' trace bounds into the span view's trace bounds

### DIFF
--- a/static/app/components/events/interfaces/spans/header.tsx
+++ b/static/app/components/events/interfaces/spans/header.tsx
@@ -53,6 +53,7 @@ type PropType = {
   trace: ParsedTraceType;
   event: EventTransaction;
   operationNameFilters: ActiveOperationFilter;
+  rootSpan: RawSpanType;
 };
 
 type State = {
@@ -440,6 +441,7 @@ class TraceViewHeader extends React.Component<PropType, State> {
                 <ActualMinimap
                   trace={this.props.trace}
                   dividerPosition={dividerPosition}
+                  rootSpan={this.props.rootSpan}
                 />
                 <CursorGuideHandler.Consumer>
                   {({
@@ -508,9 +510,10 @@ class TraceViewHeader extends React.Component<PropType, State> {
 class ActualMinimap extends React.PureComponent<{
   trace: ParsedTraceType;
   dividerPosition: number;
+  rootSpan: RawSpanType;
 }> {
   renderRootSpan(): React.ReactNode {
-    const {trace} = this.props;
+    const {trace, rootSpan} = this.props;
 
     const generateBounds = boundsGenerator({
       traceStartTimestamp: trace.traceStartTimestamp,
@@ -518,15 +521,6 @@ class ActualMinimap extends React.PureComponent<{
       viewStart: 0,
       viewEnd: 1,
     });
-
-    const rootSpan: RawSpanType = {
-      trace_id: trace.traceID,
-      span_id: trace.rootSpanID,
-      start_timestamp: trace.traceStartTimestamp,
-      timestamp: trace.traceEndTimestamp,
-      op: trace.op,
-      data: {},
-    };
 
     return this.renderSpan({
       spanNumber: 0,

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -14,6 +14,7 @@ import {
   RawSpanType,
   SpanChildrenLookupType,
   SpanType,
+  TraceBound,
   TreeDepthType,
 } from './types';
 import {
@@ -180,6 +181,8 @@ class SpanTreeModel {
     spanGrouping: EnhancedSpan[] | undefined;
     toggleSpanGroup: (() => void) | undefined;
     showSpanGroup: boolean;
+    addTraceBounds: (bounds: TraceBound) => void;
+    removeTraceBounds: (eventSlug: string) => void;
   }): EnhancedProcessedSpanType[] => {
     const {
       operationNameFilters,
@@ -195,6 +198,8 @@ class SpanTreeModel {
       spanGrouping,
       toggleSpanGroup,
       showSpanGroup,
+      addTraceBounds,
+      removeTraceBounds,
     } = props;
     let {treeDepth, continuingTreeDepths} = props;
 
@@ -257,7 +262,10 @@ class SpanTreeModel {
       continuingTreeDepths,
       fetchEmbeddedChildrenState: this.fetchEmbeddedChildrenState,
       showEmbeddedChildren: this.showEmbeddedChildren,
-      toggleEmbeddedChildren: this.toggleEmbeddedChildren,
+      toggleEmbeddedChildren: this.toggleEmbeddedChildren({
+        addTraceBounds,
+        removeTraceBounds,
+      }),
       toggleSpanGroup:
         spanGroupingCriteria && toggleSpanGroup && !showSpanGroup
           ? toggleSpanGroup
@@ -323,6 +331,8 @@ class SpanTreeModel {
                 ? this.showSpanGroup
                 : showSpanGroup
               : false,
+            addTraceBounds,
+            removeTraceBounds,
           })
         );
 
@@ -428,18 +438,47 @@ class SpanTreeModel {
     return [wrappedSpan, ...descendants];
   };
 
-  toggleEmbeddedChildren = (props: {orgSlug: string; eventSlug: string}) => {
-    this.showEmbeddedChildren = !this.showEmbeddedChildren;
-    this.fetchEmbeddedChildrenState = 'idle';
+  toggleEmbeddedChildren =
+    ({
+      addTraceBounds,
+      removeTraceBounds,
+    }: {
+      addTraceBounds: (bounds: TraceBound) => void;
+      removeTraceBounds: (eventSlug: string) => void;
+    }) =>
+    (props: {orgSlug: string; eventSlug: string}) => {
+      this.showEmbeddedChildren = !this.showEmbeddedChildren;
+      this.fetchEmbeddedChildrenState = 'idle';
 
-    if (this.showEmbeddedChildren && this.embeddedChildren.length === 0) {
-      return this.fetchEmbeddedTransactions(props);
-    }
+      if (!this.showEmbeddedChildren) {
+        if (this.embeddedChildren.length > 0) {
+          this.embeddedChildren.forEach(child => {
+            removeTraceBounds(child.generateTraceBounds().spanId);
+          });
+        }
+      }
 
-    return Promise.resolve(undefined);
-  };
+      if (this.showEmbeddedChildren) {
+        if (this.embeddedChildren.length === 0) {
+          return this.fetchEmbeddedTransactions({...props, addTraceBounds});
+        }
+        this.embeddedChildren.forEach(child => {
+          addTraceBounds(child.generateTraceBounds());
+        });
+      }
 
-  fetchEmbeddedTransactions({orgSlug, eventSlug}: {orgSlug: string; eventSlug: string}) {
+      return Promise.resolve(undefined);
+    };
+
+  fetchEmbeddedTransactions({
+    orgSlug,
+    eventSlug,
+    addTraceBounds,
+  }: {
+    orgSlug: string;
+    eventSlug: string;
+    addTraceBounds: (bounds: TraceBound) => void;
+  }) {
     const url = `/organizations/${orgSlug}/events/${eventSlug}/`;
 
     this.fetchEmbeddedChildrenState = 'loading_embedded_transactions';
@@ -466,6 +505,7 @@ class SpanTreeModel {
 
           this.embeddedChildren = [parsedRootSpan];
           this.fetchEmbeddedChildrenState = 'idle';
+          addTraceBounds(parsedRootSpan.generateTraceBounds());
         })
       )
       .catch(
@@ -478,6 +518,14 @@ class SpanTreeModel {
 
   toggleSpanGroup = () => {
     this.showSpanGroup = !this.showSpanGroup;
+  };
+
+  generateTraceBounds = (): TraceBound => {
+    return {
+      spanId: this.span.span_id,
+      traceStartTimestamp: this.span.start_timestamp,
+      traceEndTimestamp: this.span.timestamp,
+    };
   };
 }
 

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -38,6 +38,7 @@ class TraceView extends PureComponent<Props> {
             event={waterfallModel.event}
             virtualScrollBarContainerRef={this.virtualScrollBarContainerRef}
             operationNameFilters={waterfallModel.operationNameFilters}
+            rootSpan={waterfallModel.rootSpan.span}
           />
         );
       }}

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -176,3 +176,9 @@ export type SpanFuseOptions = {
   distance: number;
   maxPatternLength: number;
 };
+
+export type TraceBound = {
+  spanId: string;
+  traceStartTimestamp: number;
+  traceEndTimestamp: number;
+};


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/27727

Embedding transactions may be out of bounds with respect to the current transaction's trace bounds. This pull request expands the trace bounds as necessary to accommodate the embedded transaction's span tree.

**Before:**


https://user-images.githubusercontent.com/139499/128424689-30c85758-b4b7-4b0e-bb39-e5b0b5f1cb8c.mp4




**After:**

https://user-images.githubusercontent.com/139499/128424683-d62c6e3e-ac0f-4a9e-a894-833cd3c5992e.mp4