### PR TITLE
ref: revert liveserver monkeypatch

### DIFF
--- a/src/sentry/monkey/__init__.py
+++ b/src/sentry/monkey/__init__.py
@@ -32,61 +32,6 @@ def patch_httprequest_repr():
     HttpRequest.__repr__ = safe_httprequest_repr
 
 
-def patch_django_runserver():
-    # This patch from django@934acf1126995f6e6ccba5947ec8f7561633c27f is needed
-    # to fix symbolicator tests on Django 2.0. Otherwise, symbolicator will attempt
-    # to GET DebugFilesEndpoint and fail when django liveserver closes conns prematurely.
-    # Can be removed in Django >= 2.1.4.
-
-    try:
-        import django.core.servers.basehttp
-    except ImportError:
-        return
-
-    def _cleanup_headers(self):
-        super(django.core.servers.basehttp.ServerHandler, self).cleanup_headers()
-        if "Content-Length" not in self.headers:
-            self.headers["Connection"] = "close"
-        if self.headers.get("Connection") == "close":
-            self.request_handler.close_connection = True
-
-    django.core.servers.basehttp.ServerHandler.cleanup_headers = _cleanup_headers
-
-    import socket
-
-    def _handle_one_request(self):
-        self.raw_requestline = self.rfile.readline(65537)
-        if len(self.raw_requestline) > 65536:
-            self.requestline = ""
-            self.request_version = ""
-            self.command = ""
-            self.send_error(414)
-            return
-
-        if not self.parse_request():
-            return
-
-        handler = django.core.servers.basehttp.ServerHandler(
-            self.rfile, self.wfile, self.get_stderr(), self.get_environ()
-        )
-        handler.request_handler = self
-        handler.run(self.server.get_app())
-
-    django.core.servers.basehttp.WSGIRequestHandler.handle_one_request = _handle_one_request
-
-    def _handle(self):
-        self.close_connection = True
-        self.handle_one_request()
-        while not self.close_connection:
-            self.handle_one_request()
-        try:
-            self.connection.shutdown(socket.SHUT_WR)
-        except (OSError, AttributeError):
-            pass
-
-    django.core.servers.basehttp.WSGIRequestHandler.handle = _handle
-
-
 def patch_django_views_debug():
     # Prevent exposing any Django SETTINGS on our debug error page
     # This information is not useful for Sentry development
@@ -114,7 +59,6 @@ def patch_celery_imgcat():
 
 for patch in (
     patch_httprequest_repr,
-    patch_django_runserver,
     patch_django_views_debug,
     patch_celery_imgcat,
     patch_pickle_loaders,


### PR DESCRIPTION
Now that we're on Django 2.1, this isn't needed anymore.

Revert "fix(django 2.0): monkeypatch liveserver to fix symbolicator integration tests on Django 2.0 (#27382)"

This reverts commit d76fd35def6639c479518ba52bf7478560fa3b19.
