### PR TITLE
fix(discover-snql): Adding project_threshold when needed

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2657,7 +2657,10 @@ class QueryFields(QueryBase):
             "count_miserable(user)",
             "user_misery()",
         }:
-            if PROJECT_THRESHOLD_CONFIG_ALIAS not in stripped_columns:
+            if (
+                column in stripped_columns
+                and PROJECT_THRESHOLD_CONFIG_ALIAS not in stripped_columns
+            ):
                 stripped_columns.append(PROJECT_THRESHOLD_CONFIG_ALIAS)
                 break
 


### PR DESCRIPTION
- Existing query functionality automatically adds `project_threshold_config_alias` when there's a function that depends on
  it
- Also noticed the dedupe of columns was being done incorrectly
- Skipping tests for now, this is checked in our eventsv2 tests