### PR TITLE
fix(auth): set test cookie if directing to confirm identity

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -464,6 +464,7 @@ class AuthIdentityHandler:
                 template = "sentry/auth-confirm-link.html"
                 context.update({"existing_user": self.user})
             else:
+                self.request.session.set_test_cookie()
                 template = "sentry/auth-confirm-identity.html"
                 context.update({"existing_user": acting_user, "login_form": login_form})
             return self._respond(template, context)


### PR DESCRIPTION
🍪 🍪 
We should set the test cookie if we're sending back a view where they can login in auth_helper. There is an edge case where an IDP initiated login will not have this test cookie set so the subsequent login fails.

Context is that we check to see that the test cookie was created when a user tries to log in.

I've tried to add a test to confirm behavior, but there's some complexity in testing a session value is created with our existing fixtures. (this flow of code is already tested however, so change risk is minor)

Random semi-confusing note: test cookie isn't actually a cookie -- its a value set in the session
