### PR TITLE
fix(tests): Fix `--reuse-db` flag in pytest

### DIFF
--- a/src/sentry/db/postgres/base.py
+++ b/src/sentry/db/postgres/base.py
@@ -6,6 +6,7 @@ from django.db.backends.postgresql_psycopg2.base import DatabaseWrapper
 
 from sentry.utils.strings import strip_lone_surrogates
 
+from .creation import SentryDatabaseCreation
 from .decorators import (
     auto_reconnect_connection,
     auto_reconnect_cursor,
@@ -83,6 +84,8 @@ class CursorWrapper:
 
 
 class DatabaseWrapper(DatabaseWrapper):
+    creation_class = SentryDatabaseCreation
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ops = DatabaseOperations(self)

--- a/src/sentry/db/postgres/creation.py
+++ b/src/sentry/db/postgres/creation.py
@@ -1,0 +1,30 @@
+import sys
+
+from django.db.backends.postgresql.creation import DatabaseCreation
+from psycopg2 import errorcodes
+
+
+class SentryDatabaseCreation(DatabaseCreation):
+    def _execute_create_test_db(self, cursor, parameters, keepdb=False):
+        """
+        This is just copied from the base class and should behave the same. The only difference is
+        that as well as checking `pgcode` we also do string matching on the Exception. This is to
+        work around an issue where `pgcode` is missing when we run tests.
+        """
+        try:
+            # Explicitly skip the overriden `_execute_create_test_db` and just call the one from
+            # its superclass
+            super(DatabaseCreation, self)._execute_create_test_db(cursor, parameters, keepdb)
+        except Exception as e:
+            if (
+                getattr(e.__cause__, "pgcode", "") != errorcodes.DUPLICATE_DATABASE
+                and "DuplicateDatabase" not in str(e)
+                and "already exists" not in str(e)
+            ):
+                # All errors except "database already exists" cancel tests.
+                sys.stderr.write("Got an error creating the test database: %s\n" % e)
+                sys.exit(2)
+            elif not keepdb:
+                # If the database should be kept, ignore "database already
+                # exists".
+                raise e


### PR DESCRIPTION
This fixes the `--reuse-db` flag when using pytest. It was broken because Django checks `pgcode` to
determine whether database creation fails due to an existing database. In our setup, `pgcode` always
ends up being empty, and so isn't useful. I tried updating to a later `psycopg2` and it didn't help.
I couldn't find much on this, but it seems that if there's a problem with the connection it can
cause `pgcode` to be blank.

To work around this we just do string matching on the exception as well. This is actually what
Django used to do and it was changed to use `pgcode` more recently.

Using `--reuse-db` speeds up test startup time by around 10s. In a few tests I ran:
 - With --reuse-db, single test
   - Test took 3s, overall time to run was 8-9s
 - Without --reuse-db, single test
   - Test took 3s, overall time to run was 18-19s

The only downside to using this is that then running `pytest` without it later errors, since the db
is still in place. I also need to do some testing on how it interacts with migrations, syncdb, etc.
Ideally I'd like to enable this by default for everyone, but for now people who know about it can
use it.