### PR TITLE
fix(notifications): Use all providers in `is_subscribed`

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -47,7 +47,7 @@ from sentry.notifications.helpers import (
     get_user_subscriptions_for_groups,
     transform_to_notification_settings_by_scope,
 )
-from sentry.notifications.types import NotificationScopeType, NotificationSettingTypes
+from sentry.notifications.types import NotificationSettingTypes
 from sentry.reprocessing2 import get_progress
 from sentry.search.events.constants import RELEASE_STAGE_ALIAS
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
@@ -187,10 +187,7 @@ class GroupSerializerBase(Serializer):
                 groups_by_project.keys(),
             )
         )
-        query_groups = get_groups_for_query(
-            groups_by_project,
-            notification_settings_by_scope.get(NotificationScopeType.PROJECT, {}),
-        )
+        query_groups = get_groups_for_query(groups_by_project, notification_settings_by_scope, user)
         subscriptions = GroupSubscription.objects.filter(group__in=query_groups, user=user)
         subscriptions_by_group_id = {
             subscription.group_id: subscription for subscription in subscriptions

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -45,15 +45,14 @@ from sentry.notifications.helpers import (
     get_groups_for_query,
     get_subscription_from_attributes,
     get_user_subscriptions_for_groups,
-    transform_to_notification_settings_by_parent_id,
+    transform_to_notification_settings_by_scope,
 )
-from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.notifications.types import NotificationScopeType, NotificationSettingTypes
 from sentry.reprocessing2 import get_progress
 from sentry.search.events.constants import RELEASE_STAGE_ALIAS
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip
@@ -181,27 +180,16 @@ class GroupSerializerBase(Serializer):
             return {}
 
         groups_by_project = collect_groups_by_project(groups)
-        notification_settings = NotificationSetting.objects.get_for_user_by_projects(
-            NotificationSettingTypes.WORKFLOW,
-            user,
-            groups_by_project.keys(),
+        notification_settings_by_scope = transform_to_notification_settings_by_scope(
+            NotificationSetting.objects.get_for_user_by_projects(
+                NotificationSettingTypes.WORKFLOW,
+                user,
+                groups_by_project.keys(),
+            )
         )
-
-        (
-            notification_settings_by_project_id_by_provider,
-            default_subscribe_by_provider,
-        ) = transform_to_notification_settings_by_parent_id(
-            notification_settings, NotificationSettingOptionValues.SUBSCRIBE_ONLY
-        )
-        notification_settings_by_key = notification_settings_by_project_id_by_provider[
-            ExternalProviders.EMAIL
-        ]
-        global_default_workflow_option = default_subscribe_by_provider[ExternalProviders.EMAIL]
-
         query_groups = get_groups_for_query(
             groups_by_project,
-            notification_settings_by_key,
-            global_default_workflow_option,
+            notification_settings_by_scope.get(NotificationScopeType.PROJECT, {}),
         )
         subscriptions = GroupSubscription.objects.filter(group__in=query_groups, user=user)
         subscriptions_by_group_id = {
@@ -210,9 +198,9 @@ class GroupSerializerBase(Serializer):
 
         return get_user_subscriptions_for_groups(
             groups_by_project,
-            notification_settings_by_key,
+            notification_settings_by_scope,
             subscriptions_by_group_id,
-            global_default_workflow_option,
+            user,
         )
 
     def get_attrs(self, item_list, user):

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -302,8 +302,9 @@ def get_subscription_from_attributes(
 
 def get_groups_for_query(
     groups_by_project: Mapping["Project", Set["Group"]],
-    notification_settings_by_key: Mapping[int, NotificationSettingOptionValues],
-    global_default_workflow_option: NotificationSettingOptionValues,
+    notification_settings_by_provider_by_parent_id: Mapping[
+        int, Mapping[ExternalProviders, NotificationSettingOptionValues]
+    ],
 ) -> Set["Group"]:
     """
     If there is a subscription record associated with the group, we can just use
@@ -313,7 +314,9 @@ def get_groups_for_query(
     # Although this can be done with a comprehension, looping for clarity.
     output = set()
     for project, groups in groups_by_project.items():
-        value = notification_settings_by_key.get(project.id, global_default_workflow_option)
+        value = get_highest_notification_setting_value(
+            notification_settings_by_provider_by_parent_id.get(project.id, {})
+        )
         if value != NotificationSettingOptionValues.NEVER:
             output |= groups
     return output

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -288,9 +288,11 @@ def get_subscription_from_attributes(
 
 def get_groups_for_query(
     groups_by_project: Mapping["Project", Set["Group"]],
-    notification_settings_by_provider_by_parent_id: Mapping[
-        int, Mapping[ExternalProviders, NotificationSettingOptionValues]
+    notification_settings_by_scope: Mapping[
+        NotificationScopeType,
+        Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
+    user: "User",
 ) -> Set["Group"]:
     """
     If there is a subscription record associated with the group, we can just use
@@ -300,8 +302,11 @@ def get_groups_for_query(
     # Although this can be done with a comprehension, looping for clarity.
     output = set()
     for project, groups in groups_by_project.items():
-        value = get_highest_notification_setting_value(
-            notification_settings_by_provider_by_parent_id.get(project.id, {})
+        value = get_most_specific_notification_setting_value(
+            notification_settings_by_scope,
+            user=user,
+            parent_id=project.id,
+            type=NotificationSettingTypes.WORKFLOW,
         )
         if value != NotificationSettingOptionValues.NEVER:
             output |= groups

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -441,8 +441,11 @@ def get_highest_notification_setting_value(
 ) -> Optional[NotificationSettingOptionValues]:
     """
     Find the "most specific" notification setting value. Currently non-NEVER
-    values are locked together, but this might change. This is a HACK but if we
-    put an explicit ordering here I'd match the implicit ordering.
+    values are locked together (for example, you cannot have
+    `{"email": "always", "slack": "subscribe_only"}` but you can have
+    `{"email": "always", "slack": "never"}` and
+    `{"email": "always", "slack": "always"}`), but this might change. This is a
+    HACK but if we put an explicit ordering here It'd match the implicit ordering.
     """
     if not notification_settings_by_provider:
         return None

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -181,8 +181,8 @@ def transform_to_notification_settings_by_user(
     Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
 ]:
     """
-    Given a unorganized list of notification settings, create a mapping of
-    users to a map of notification scopes to setting values.
+    Given an unsorted list of notification settings, create a mapping of users
+    to a map of notification scopes to setting values.
     """
     actor_mapping = {user.actor_id: user for user in users}
     notification_settings_by_user: Dict[
@@ -204,6 +204,10 @@ def transform_to_notification_settings_by_scope(
     NotificationScopeType,
     Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],
 ]:
+    """
+    Given an unsorted list of notification settings, create a mapping of scopes
+    (user or parent) and their IDs to a map of provider to notifications setting values.
+    """
     notification_settings_by_scopes: Dict[
         NotificationScopeType, Dict[int, Dict[ExternalProviders, NotificationSettingOptionValues]]
     ] = defaultdict(lambda: defaultdict(lambda: dict()))
@@ -454,7 +458,10 @@ def get_most_specific_notification_setting_value(
     parent_id: int,
     type: NotificationSettingTypes,
 ) -> NotificationSettingOptionValues:
-    """If there are no setting, default to the default setting for EMAIL."""
+    """
+    Get the "most specific" notification setting value for a given user and
+    project. If there are no settings, default to the default setting for EMAIL.
+    """
     return (
         get_highest_notification_setting_value(
             notification_settings_by_scope.get(get_scope_type(type), {}).get(parent_id, {})

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -3,7 +3,6 @@ from sentry.notifications.helpers import (
     _get_setting_mapping_from_mapping,
     collect_groups_by_project,
     get_fallback_settings,
-    get_groups_for_query,
     get_scope_type,
     get_settings_by_provider,
     get_subscription_from_attributes,
@@ -231,17 +230,6 @@ class NotificationHelpersTest(TestCase):
 
         attrs = {"subscription": (True, False, None)}
         assert get_subscription_from_attributes(attrs) == (False, {"disabled": True})
-
-    def test_get_groups_for_query(self):
-        groups_by_project = {self.project: {self.group}}
-        notification_settings_by_key = {5: NotificationSettingOptionValues.ALWAYS}
-        global_default_workflow_option = NotificationSettingOptionValues.ALWAYS
-        query_groups = get_groups_for_query(
-            groups_by_project,
-            notification_settings_by_key,
-            global_default_workflow_option,
-        )
-        assert query_groups == {self.group}
 
     def test_collect_groups_by_project(self):
         assert collect_groups_by_project([self.group]) == {self.project: {self.group}}

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -7,7 +7,6 @@ from sentry.notifications.helpers import (
     get_settings_by_provider,
     get_subscription_from_attributes,
     get_target_id,
-    get_user_subscriptions_for_groups,
     get_values_by_provider_by_type,
     transform_to_notification_settings_by_parent_id,
     transform_to_notification_settings_by_user,
@@ -233,19 +232,6 @@ class NotificationHelpersTest(TestCase):
 
     def test_collect_groups_by_project(self):
         assert collect_groups_by_project([self.group]) == {self.project: {self.group}}
-
-    def test_get_user_subscriptions_for_groups(self):
-        groups_by_project = {self.project: {self.group}}
-        notification_settings_by_key = {5: NotificationSettingOptionValues.ALWAYS}
-        subscriptions_by_group_id = {2: None}
-        global_default_workflow_option = NotificationSettingOptionValues.ALWAYS
-        subscriptions = get_user_subscriptions_for_groups(
-            groups_by_project,
-            notification_settings_by_key,
-            subscriptions_by_group_id,
-            global_default_workflow_option,
-        )
-        assert subscriptions == {self.group.id: (False, True, None)}
 
     def test_get_settings_by_provider(self):
         settings = {

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -8,8 +8,6 @@ from sentry.notifications.helpers import (
     get_subscription_from_attributes,
     get_target_id,
     get_values_by_provider_by_type,
-    transform_to_notification_settings_by_parent_id,
-    transform_to_notification_settings_by_user,
     validate,
 )
 from sentry.notifications.notify import notification_providers
@@ -116,49 +114,6 @@ class NotificationHelpersTest(TestCase):
         assert values_by_provider == {
             ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
             ExternalProviders.SLACK: NotificationSettingOptionValues.COMMITTED_ONLY,
-        }
-
-    def test_transform_to_notification_settings_by_user(self):
-        notification_settings = NotificationSetting.objects.get_for_recipient_by_parent(
-            NotificationSettingTypes.WORKFLOW,
-            recipients=[self.user],
-            parent=self.group.project,
-        )
-        notification_settings_by_user = transform_to_notification_settings_by_user(
-            notification_settings, [self.user]
-        )
-        assert notification_settings_by_user == {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS
-                }
-            }
-        }
-
-    def test_transform_to_notification_settings_by_parent_id(self):
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.SLACK,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=self.user,
-            project=self.project,
-        )
-        notification_settings = NotificationSetting.objects.get_for_user_by_projects(
-            NotificationSettingTypes.WORKFLOW,
-            self.user,
-            [self.project],
-        )
-        (
-            notification_settings_by_project_id_by_provider,
-            default_subscribe_by_provider,
-        ) = transform_to_notification_settings_by_parent_id(
-            notification_settings, NotificationSettingOptionValues.ALWAYS
-        )
-        assert notification_settings_by_project_id_by_provider == {
-            ExternalProviders.SLACK: {self.project.id: NotificationSettingOptionValues.ALWAYS}
-        }
-        assert default_subscribe_by_provider == {
-            ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS
         }
 
     def test_validate(self):

--- a/tests/sentry/notifications/utils/test_get_groups_for_query.py
+++ b/tests/sentry/notifications/utils/test_get_groups_for_query.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+
+from sentry.models import Group, Project
+from sentry.notifications.helpers import get_groups_for_query
+from sentry.notifications.types import NotificationSettingOptionValues
+from sentry.types.integrations import ExternalProviders
+
+
+class GetGroupsForQueryTestCase(TestCase):
+    def setUp(self) -> None:
+        self.project = Project(id=123)
+        self.group = Group(id=456, project=self.project)
+
+    def test_get_groups_for_query_empty(self):
+        groups_by_project = {self.project: {self.group}}
+        notification_settings_by_provider_by_parent_id = {
+            self.project.id: {
+                ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            },
+        }
+
+        assert get_groups_for_query({}, {}) == set()
+        assert get_groups_for_query(groups_by_project, {}) == {self.group}
+        assert get_groups_for_query({}, notification_settings_by_provider_by_parent_id) == set()
+
+    def test_get_groups_for_query(self):
+        project_0 = Project(id=100)
+        project_1 = Project(id=101)
+        project_2 = Project(id=102)
+
+        groups_by_project = {
+            project_0: {Group(id=10, project=project_0), Group(id=11, project=project_0)},
+            project_1: {Group(id=12, project=project_0)},
+            project_2: {Group(id=13, project=project_0)},
+        }
+
+        notification_settings_by_provider_by_parent_id = {
+            project_0.id: {
+                ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            },
+            project_1.id: {
+                ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+            },
+        }
+        query_groups = get_groups_for_query(
+            groups_by_project,
+            notification_settings_by_provider_by_parent_id,
+        )
+        assert {group.id for group in query_groups} == {10, 11, 13}
+
+    def test_get_groups_for_query_simple(self):
+        assert (
+            get_groups_for_query(
+                {self.project: {self.group}},
+                {
+                    self.project.id: {
+                        ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                        ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                    },
+                },
+            )
+            == {self.group}
+        )
+
+    def test_get_groups_for_query_never(self):
+        assert (
+            get_groups_for_query(
+                {self.project: {self.group}},
+                {
+                    self.project.id: {
+                        ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                        ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+                    },
+                },
+            )
+            == set()
+        )

--- a/tests/sentry/notifications/utils/test_get_most_specific.py
+++ b/tests/sentry/notifications/utils/test_get_most_specific.py
@@ -1,0 +1,104 @@
+from unittest import TestCase
+
+from sentry.models import User
+from sentry.notifications.helpers import (
+    get_highest_notification_setting_value,
+    get_most_specific_notification_setting_value,
+)
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+from sentry.types.integrations import ExternalProviders
+
+
+class GetMostSpecificNotificationSettingValueTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User(id=1)
+
+    def test_get_most_specific_notification_setting_value_empty_workflow(self):
+        value = get_most_specific_notification_setting_value(
+            notification_settings_by_scope={},
+            user=self.user,
+            parent_id=1,
+            type=NotificationSettingTypes.WORKFLOW,
+        )
+        assert value == NotificationSettingOptionValues.SUBSCRIBE_ONLY
+
+    def test_get_most_specific_notification_setting_value_empty_alerts(self):
+        value = get_most_specific_notification_setting_value(
+            notification_settings_by_scope={},
+            user=self.user,
+            parent_id=1,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert value == NotificationSettingOptionValues.ALWAYS
+
+    def test_get_most_specific_notification_setting_value_user(self):
+        notification_settings_by_scope = {
+            NotificationScopeType.USER: {
+                self.user.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                },
+            },
+        }
+        value = get_most_specific_notification_setting_value(
+            notification_settings_by_scope,
+            user=self.user,
+            parent_id=1,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert value == NotificationSettingOptionValues.ALWAYS
+
+    def test_get_most_specific_notification_setting_value(self):
+        project_id = 1
+
+        notification_settings_by_scope = {
+            NotificationScopeType.USER: {
+                self.user.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                },
+            },
+            NotificationScopeType.PROJECT: {
+                project_id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+                },
+            },
+        }
+        value = get_most_specific_notification_setting_value(
+            notification_settings_by_scope,
+            user=self.user,
+            parent_id=project_id,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert value == NotificationSettingOptionValues.NEVER
+
+
+class GetHighestNotificationSettingValueTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User(id=1)
+
+    def test_get_highest_notification_setting_value_empty(self):
+        assert get_highest_notification_setting_value({}) is None
+
+    def test_get_highest_notification_setting_value(self):
+        value = get_highest_notification_setting_value(
+            {
+                ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            }
+        )
+        assert value == NotificationSettingOptionValues.ALWAYS
+
+    def test_get_highest_notification_setting_value_never(self):
+        value = get_highest_notification_setting_value(
+            {
+                ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+            }
+        )
+        assert value == NotificationSettingOptionValues.NEVER

--- a/tests/sentry/notifications/utils/test_get_user_subscriptions_for_groups.py
+++ b/tests/sentry/notifications/utils/test_get_user_subscriptions_for_groups.py
@@ -1,0 +1,99 @@
+from unittest import TestCase
+
+from sentry.models import Group, GroupSubscription, Project, User
+from sentry.notifications.helpers import get_user_subscriptions_for_groups
+from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
+from sentry.types.integrations import ExternalProviders
+
+
+class GetUserSubscriptionsForGroupsTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User(1)
+        self.project = Project(id=123)
+        self.group = Group(id=456, project=self.project)
+        self.group_subscription = GroupSubscription(is_active=True)
+
+    def test_get_user_subscriptions_for_groups_empty(self):
+        groups_by_project = {self.project: {self.group}}
+        notification_settings_by_scope = {
+            NotificationScopeType.USER: {
+                self.user.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                },
+            },
+            NotificationScopeType.PROJECT: {
+                self.project.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+                },
+            },
+        }
+
+        subscriptions_by_group_id = {self.group.id: self.group_subscription}
+        assert (
+            get_user_subscriptions_for_groups(
+                groups_by_project={},
+                notification_settings_by_scope={},
+                subscriptions_by_group_id={},
+                user=self.user,
+            )
+            == {}
+        )
+
+        assert (
+            get_user_subscriptions_for_groups(
+                groups_by_project={},
+                notification_settings_by_scope=notification_settings_by_scope,
+                subscriptions_by_group_id=subscriptions_by_group_id,
+                user=self.user,
+            )
+            == {}
+        )
+
+        assert (
+            get_user_subscriptions_for_groups(
+                groups_by_project=groups_by_project,
+                notification_settings_by_scope={},
+                subscriptions_by_group_id=subscriptions_by_group_id,
+                user=self.user,
+            )
+            == {self.group.id: (False, True, self.group_subscription)}
+        )
+
+        assert (
+            get_user_subscriptions_for_groups(
+                groups_by_project=groups_by_project,
+                notification_settings_by_scope=notification_settings_by_scope,
+                subscriptions_by_group_id={},
+                user=self.user,
+            )
+            == {self.group.id: (True, False, None)}
+        )
+
+    def test_get_user_subscriptions_for_groups(self):
+        groups_by_project = {self.project: {self.group}}
+        notification_settings_by_scope = {
+            NotificationScopeType.USER: {
+                self.user.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                },
+            },
+            NotificationScopeType.PROJECT: {
+                self.project.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+                },
+            },
+        }
+        subscriptions_by_group_id = {self.group.id: self.group_subscription}
+        assert (
+            get_user_subscriptions_for_groups(
+                groups_by_project,
+                notification_settings_by_scope,
+                subscriptions_by_group_id,
+                user=self.user,
+            )
+            == {self.group.id: (False, True, self.group_subscription)}
+        )

--- a/tests/sentry/notifications/utils/test_transforms.py
+++ b/tests/sentry/notifications/utils/test_transforms.py
@@ -1,0 +1,81 @@
+from unittest import TestCase
+
+from sentry.models import Group, NotificationSetting, Project, User
+from sentry.notifications.helpers import (
+    transform_to_notification_settings_by_scope,
+    transform_to_notification_settings_by_user,
+)
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+from sentry.types.integrations import ExternalProviders
+
+
+class TransformTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User(id=1)
+        self.project = Project(id=123)
+        self.group = Group(id=456, project=self.project)
+        self.notification_settings = [
+            NotificationSetting(
+                provider=ExternalProviders.SLACK.value,
+                type=NotificationSettingTypes.WORKFLOW.value,
+                value=NotificationSettingOptionValues.ALWAYS.value,
+                target=self.user.actor,
+                scope_type=NotificationScopeType.PROJECT.value,
+                scope_identifier=self.project.id,
+            ),
+            NotificationSetting(
+                provider=ExternalProviders.SLACK.value,
+                type=NotificationSettingTypes.WORKFLOW.value,
+                value=NotificationSettingOptionValues.ALWAYS.value,
+                target=self.user.actor,
+                scope_type=NotificationScopeType.USER.value,
+                scope_identifier=self.user.id,
+            ),
+        ]
+
+
+class TransformToNotificationSettingsByUserTestCase(TransformTestCase):
+    def test_transform_to_notification_settings_by_user_empty(self):
+        assert transform_to_notification_settings_by_user(notification_settings=[], users=[]) == {}
+
+        assert (
+            transform_to_notification_settings_by_user(notification_settings=[], users=[self.user])
+            == {}
+        )
+
+    def test_transform_to_notification_settings_by_user(self):
+        assert transform_to_notification_settings_by_user(
+            notification_settings=self.notification_settings, users=[self.user]
+        ) == {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS
+                },
+                NotificationScopeType.PROJECT: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS
+                },
+            }
+        }
+
+
+class TransformToNotificationSettingsByScopeTestCase(TransformTestCase):
+    def test_transform_to_notification_settings_by_scope_empty(self):
+        assert transform_to_notification_settings_by_scope(notification_settings=[]) == {}
+
+    def test_transform_to_notification_settings_by_scope(self):
+        assert transform_to_notification_settings_by_scope(
+            notification_settings=self.notification_settings,
+        ) == {
+            NotificationScopeType.USER: {
+                self.user.id: {ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS},
+            },
+            NotificationScopeType.PROJECT: {
+                self.project.id: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+                }
+            },
+        }


### PR DESCRIPTION
In the previous version, when trying to decide whether or not a user is subscribed to an issue, we only considers EMAIL notification settings:
```python
notification_settings_by_key = notification_settings_by_project_id_by_provider[ExternalProviders.EMAIL]
global_default_workflow_option = default_subscribe_by_provider[ExternalProviders.EMAIL]
```
When a user's notification settings are SLACK only, they should still be subscribed to a group. The best way to decide whether or not a user will be notified is to see if ANY of their notification setting are not NEVER. A simple way to check is by iterating over the notification settings by provider:
```python
max(notification_settings_by_provider.values(), key=lambda v: v.value)
```
Before: 
<img width="1004" alt="Screen Shot 2021-08-17 at 3 41 30 PM" src="https://user-images.githubusercontent.com/31750075/129810110-ff7a209e-9e73-4b51-aa3c-df83197bd0d9.png">
After:
<img width="955" alt="Screen Shot 2021-08-17 at 3 43 07 PM" src="https://user-images.githubusercontent.com/31750075/129810220-9ed92856-f248-4563-a186-fef3760b34a2.png">
