### PR TITLE
fix(auth): set session cookie samesite to none

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -432,7 +432,14 @@ SOCIAL_AUTH_USER_MODEL = AUTH_USER_MODEL = "sentry.User"
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SESSION_COOKIE_NAME = "sentrysid"
+
+# setting SESSION_COOKIE_SAMESITE to None below for now because
+# Django's default in 2.1 now `Lax`.
+# this breaks certain IDP flows where we need cookies sent to us on a redirected POST
+# request, and `Lax` doesnt permit this.
+# See here: https://docs.djangoproject.com/en/2.1/ref/settings/#session-cookie-samesite
 SESSION_COOKIE_SAMESITE = None
+
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
 GOOGLE_OAUTH2_CLIENT_ID = ""

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -432,6 +432,7 @@ SOCIAL_AUTH_USER_MODEL = AUTH_USER_MODEL = "sentry.User"
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 SESSION_COOKIE_NAME = "sentrysid"
+SESSION_COOKIE_SAMESITE = None
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
 GOOGLE_OAUTH2_CLIENT_ID = ""


### PR DESCRIPTION
- Django 2.1 introduced [SESSION_COOKIE_SAMESITE](https://docs.djangoproject.com/en/2.1/ref/settings/#session-cookie-samesite) which sets the samesite policy by default of the session cookie to 'Lax'
- Unfortunately, some of our current SSO flows depend on the session cookie sent in a POST request redirect from auth providers, so this change breaks functionality for most modern browsers.
- This change sets the value to `None` makes the behavior the same prior to 2.1 (don't set a value)
- We can discuss if it's needed to move away from this pattern so we can have the value set to Lax, there is a bit of work to do on the auth side to make this happen though.

I've verified that this setting fixes the problem.