### PR TITLE
ref(js): Remove bootstrap/js/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "bootstrap": "3.4.1",
     "buffer": "^6.0.3",
     "classnames": "2.3.1",
     "color": "^3.1.3",

--- a/static/app/bootstrap/initializeApp.tsx
+++ b/static/app/bootstrap/initializeApp.tsx
@@ -1,6 +1,4 @@
-import 'bootstrap/js/alert';
-import 'bootstrap/js/tab';
-import 'bootstrap/js/dropdown';
+import './legacyTwitterBootstrap';
 import './exportGlobals';
 
 import routes from 'app/routes';

--- a/static/app/bootstrap/legacyTwitterBootstrap.tsx
+++ b/static/app/bootstrap/legacyTwitterBootstrap.tsx
@@ -1,0 +1,81 @@
+/**
+ * This is a re-implementation of some bootstrap functionality that we still
+ * depend on in some html templates.
+ */
+
+/**
+ * Similar to jQuery's `on`, adds an event listener to the root document which
+ * will only fire when the selector matches the element which triggered the
+ * event.
+ */
+const addSelectorEventListener = <K extends keyof DocumentEventMap>(
+  type: K,
+  selector: string,
+  listener: (ev: DocumentEventMap[K]) => any
+) =>
+  document.addEventListener(type, event => {
+    const {target} = event;
+
+    if (target === null) {
+      return;
+    }
+
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+
+    if (!target.matches(selector)) {
+      return;
+    }
+
+    listener(event);
+  });
+
+/**
+ * Tab toggle handlers.
+ *
+ * @deprecated
+ */
+addSelectorEventListener('click', '[data-toggle="tab"]', event => {
+  event.preventDefault();
+
+  const triggerElement = event.target as HTMLElement;
+  const targetSelector = triggerElement.getAttribute('href');
+
+  if (targetSelector === null) {
+    return;
+  }
+
+  const targetPanel = document.querySelector<HTMLElement>(targetSelector);
+
+  if (targetPanel === null) {
+    return;
+  }
+
+  const container = targetPanel.parentElement!;
+  const tabs = triggerElement.closest('ul');
+
+  const targetTab = triggerElement.closest('li');
+  const lastActiveTab = tabs?.querySelector(':scope > .active');
+
+  // Reset the old active tab
+  lastActiveTab?.classList?.remove('active');
+  lastActiveTab?.querySelector(':scope > a')?.setAttribute('aria-expanded', 'false');
+
+  container.querySelector<HTMLElement>(':scope > .active')?.classList?.remove('active');
+
+  // Activate the target
+  targetTab?.classList.add('active');
+  targetTab?.querySelector(':scope > a')?.setAttribute('aria-expanded', 'true');
+
+  targetPanel.classList.add('active');
+});
+
+/**
+ * Remove alerts when the close button is clicked
+ *
+ * @deprecated
+ */
+addSelectorEventListener('click', '[data-dismiss="alert"]', event => {
+  (event.target as HTMLElement).closest('.alert')?.remove();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,7 +2220,7 @@
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.3.6":
+"@storybook/addons@6.3.6", "@storybook/addons@^6.3.0":
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.6.tgz#330fd722bdae8abefeb029583e89e51e62c20b60"
   integrity sha512-tVV0vqaEEN9Md4bgScwfrnZYkN8iKZarpkIOFheLev+PHjSp8lgWMK5SNWDlbBYqfQfzrz9xbs+F07bMjfx9jQ==
@@ -2235,22 +2235,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@^6.3.0":
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.4.tgz#016c5c3e36c78a320eb8b022cf7fe556d81577c2"
-  integrity sha512-rf8K8X3JrB43gq5nw5SYgfucQkFg2QgUMWdByf7dQ4MyIl5zet+2MYiSXJ9lfbhGKJZ8orc81rmMtiocW4oBjg==
-  dependencies:
-    "@storybook/api" "6.3.4"
-    "@storybook/channels" "6.3.4"
-    "@storybook/client-logger" "6.3.4"
-    "@storybook/core-events" "6.3.4"
-    "@storybook/router" "6.3.4"
-    "@storybook/theming" "6.3.4"
-    core-js "^3.8.2"
-    global "^4.4.0"
-    regenerator-runtime "^0.13.7"
-
-"@storybook/api@6.3.4", "@storybook/api@^6.3.0":
+"@storybook/api@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.4.tgz#25b8b842104693000b018b3f64986e95fa032b45"
   integrity sha512-12q6dvSR4AtyuZbKAy3Xt+ZHzZ4ePPRV1q20xtgYBoiFEgB9vbh4XKEeeZD0yIeTamQ2x1Hn87R79Rs1GIdKRQ==
@@ -2276,7 +2261,7 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/api@6.3.6":
+"@storybook/api@6.3.6", "@storybook/api@^6.3.0":
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.6.tgz#b110688ae0a970c9443d47b87616a09456f3708e"
   integrity sha512-F5VuR1FrEwD51OO/EDDAZXNfF5XmJedYHJLwwCB4az2ZMrzG45TxGRmiEohrSTO6wAHGkAvjlEoX5jWOCqQ4pw==
@@ -2511,7 +2496,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.3.6":
+"@storybook/components@6.3.6", "@storybook/components@^6.3.0":
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.6.tgz#bc2fa1dbe59f42b5b2aeb9f84424072835d4ce8b"
   integrity sha512-aZkmtAY8b+LFXG6dVp6cTS6zGJuxkHRHcesRSWRQPxtgitaz1G58clRHxbKPRokfjPHNgYA3snogyeqxSA7YNQ==
@@ -2520,36 +2505,6 @@
     "@storybook/client-logger" "6.3.6"
     "@storybook/csf" "0.0.1"
     "@storybook/theming" "6.3.6"
-    "@types/color-convert" "^2.0.0"
-    "@types/overlayscrollbars" "^1.12.0"
-    "@types/react-syntax-highlighter" "11.0.5"
-    color-convert "^2.0.1"
-    core-js "^3.8.2"
-    fast-deep-equal "^3.1.3"
-    global "^4.4.0"
-    lodash "^4.17.20"
-    markdown-to-jsx "^7.1.3"
-    memoizerific "^1.11.3"
-    overlayscrollbars "^1.13.1"
-    polished "^4.0.5"
-    prop-types "^15.7.2"
-    react-colorful "^5.1.2"
-    react-popper-tooltip "^3.1.1"
-    react-syntax-highlighter "^13.5.3"
-    react-textarea-autosize "^8.3.0"
-    regenerator-runtime "^0.13.7"
-    ts-dedent "^2.0.0"
-    util-deprecate "^1.0.2"
-
-"@storybook/components@^6.3.0":
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.4.tgz#c872ec267edf315eaada505be8595c70eb6db09b"
-  integrity sha512-0hBKTkkQbW+daaA6nRedkviPr2bEzy1kwq0H5eaLKI1zYeXN3U5Z8fVhO137PPqH5LmLietrmTPkqiljUBk9ug==
-  dependencies:
-    "@popperjs/core" "^2.6.0"
-    "@storybook/client-logger" "6.3.4"
-    "@storybook/csf" "0.0.1"
-    "@storybook/theming" "6.3.4"
     "@types/color-convert" "^2.0.0"
     "@types/overlayscrollbars" "^1.12.0"
     "@types/react-syntax-highlighter" "11.0.5"
@@ -2648,14 +2603,14 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-events@6.3.4", "@storybook/core-events@^6.3.0":
+"@storybook/core-events@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.4.tgz#f841b8659a8729d334acd9a6dcfc470c88a2be8f"
   integrity sha512-6qI5bU5VcAoRfxkvpdRqO16eYrX5M0P2E3TakqUUDcgDo5Rfcwd1wTTcwiXslMIh7oiVGiisA+msKTlfzyKf9Q==
   dependencies:
     core-js "^3.8.2"
 
-"@storybook/core-events@6.3.6":
+"@storybook/core-events@6.3.6", "@storybook/core-events@^6.3.0":
   version "6.3.6"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.6.tgz#c4a09e2c703170995604d63e46e45adc3c9cd759"
   integrity sha512-Ut1dz96bJ939oSn5t1ckPXd3WcFejK96Sb3+R/z23vEHUWGBFtygGyw8r/SX/WNDVzGmQU8c+mzJJTZwCBJz8A==
@@ -3351,12 +3306,7 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
   integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
-  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
-
-"@types/json-schema@^7.0.8":
+"@types/json-schema@*", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
   version "7.0.8"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
@@ -4835,11 +4785,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-
-bootstrap@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
-  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 boxen@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
 - Tabs: I've re-implemented this in pure modern javascript in legacyTwitterBootstrap.tsx

 - Alerts: We only have 3 of these and can easily be re-implemented.

 - Dropdowns: Believe it or not, I could not find an actual usage of bootstrap controlled dropdowns. Everything seems to be just powered by newer style dropdown code.