### PR TITLE
fix(chart-unfurl): Suport empty series for top 5 charts

### DIFF
--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -127,14 +127,25 @@ discover_top5 = {
     }
 }
 
+discover_empty = {
+    "seriesName": "Discover empty",
+    "stats": {
+        "data": [],
+    },
+}
+
 
 class DebugChartRendererView(View):
     def get(self, request):
         charts = []
 
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_total_period))
+        charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOTAL_PERIOD, discover_empty))
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_total_daily))
+        charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOTAL_DAILY, discover_empty))
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_top5))
+        charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_empty))
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_top5))
+        charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_empty))
 
         return render_to_response("sentry/debug/chart-renderer.html", context={"charts": charts})

--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -1,3 +1,5 @@
+import isArray from 'lodash/isArray';
+
 import XAxis from 'app/components/charts/components/xAxis';
 import AreaSeries from 'app/components/charts/series/areaSeries';
 import BarSeries from 'app/components/charts/series/barSeries';
@@ -71,7 +73,23 @@ discoverCharts.push({
 
 discoverCharts.push({
   key: ChartType.SLACK_DISCOVER_TOP5_PERIOD,
-  getOption: (data: {stats: Record<string, EventsStats>}) => {
+  getOption: (
+    data: {stats: Record<string, EventsStats>} | {seriesName?: string; stats: EventsStats}
+  ) => {
+    if (isArray(data.stats.data)) {
+      const color = theme.charts.getColorPalette(data.stats.data.length - 2);
+      const areaSeries = AreaSeries({
+        name: data.hasOwnProperty('seriesName') ? data.seriesName : undefined,
+        data: [],
+      });
+      return {
+        ...slackChartDefaults,
+        color,
+        useUTC: true,
+        series: [areaSeries],
+      };
+    }
+
     const stats = Object.values(data.stats);
     const color = theme.charts.getColorPalette(stats.length - 2);
 
@@ -102,7 +120,23 @@ discoverCharts.push({
 
 discoverCharts.push({
   key: ChartType.SLACK_DISCOVER_TOP5_DAILY,
-  getOption: (data: {stats: Record<string, EventsStats>}) => {
+  getOption: (
+    data: {stats: Record<string, EventsStats>} | {seriesName?: string; stats: EventsStats}
+  ) => {
+    if (isArray(data.stats.data)) {
+      const color = theme.charts.getColorPalette(data.stats.data.length - 2);
+      const areaSeries = AreaSeries({
+        name: data.hasOwnProperty('seriesName') ? data.seriesName : undefined,
+        data: [],
+      });
+      return {
+        ...slackChartDefaults,
+        color,
+        useUTC: true,
+        series: [areaSeries],
+      };
+    }
+
     const stats = Object.values(data.stats);
     const color = theme.charts.getColorPalette(stats.length - 2);
 

--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -77,16 +77,10 @@ discoverCharts.push({
     data: {stats: Record<string, EventsStats>} | {seriesName?: string; stats: EventsStats}
   ) => {
     if (isArray(data.stats.data)) {
-      const color = theme.charts.getColorPalette(data.stats.data.length - 2);
-      const areaSeries = AreaSeries({
-        name: data.hasOwnProperty('seriesName') ? data.seriesName : undefined,
-        data: [],
-      });
       return {
         ...slackChartDefaults,
-        color,
         useUTC: true,
-        series: [areaSeries],
+        series: [],
       };
     }
 
@@ -124,16 +118,10 @@ discoverCharts.push({
     data: {stats: Record<string, EventsStats>} | {seriesName?: string; stats: EventsStats}
   ) => {
     if (isArray(data.stats.data)) {
-      const color = theme.charts.getColorPalette(data.stats.data.length - 2);
-      const areaSeries = AreaSeries({
-        name: data.hasOwnProperty('seriesName') ? data.seriesName : undefined,
-        data: [],
-      });
       return {
         ...slackChartDefaults,
-        color,
         useUTC: true,
-        series: [areaSeries],
+        series: [],
       };
     }
 

--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -76,7 +76,7 @@ discoverCharts.push({
   getOption: (
     data: {stats: Record<string, EventsStats>} | {seriesName?: string; stats: EventsStats}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (isArray(data.stats.data) && data.stats.data.length === 0) {
       return {
         ...slackChartDefaults,
         useUTC: true,
@@ -117,7 +117,7 @@ discoverCharts.push({
   getOption: (
     data: {stats: Record<string, EventsStats>} | {seriesName?: string; stats: EventsStats}
   ) => {
-    if (isArray(data.stats.data)) {
+    if (isArray(data.stats.data) && data.stats.data.length === 0) {
       return {
         ...slackChartDefaults,
         useUTC: true,


### PR DESCRIPTION
The data structure was different than expected when there
were no series for a top 5 type chart, which resulted in a 500.
Updated to handle empty state.

Screenshots:
<img width="458" alt="Screen Shot 2021-08-06 at 11 18 03 AM" src="https://user-images.githubusercontent.com/63818634/128533228-749ccabe-d361-463a-9514-1019cc9178c1.png">
<img width="467" alt="Screen Shot 2021-08-06 at 11 18 11 AM" src="https://user-images.githubusercontent.com/63818634/128533232-94485ced-4565-49b3-83da-593ee5c85b3f.png">
