### PR TITLE
fix(grouping): Work around really long titles

### DIFF
--- a/src/sentry/api/endpoints/grouping_level_new_issues.py
+++ b/src/sentry/api/endpoints/grouping_level_new_issues.py
@@ -209,7 +209,9 @@ def _process_snuba_results(query_res, group: Group, id: int, user):
             event = Event(group.project_id, event_id, group_id=group.id, data=event_data)
             response_item["latestEvent"] = serialize(event, user, EventSerializer())
 
-            tree_label = get_path(event_data, "hierarchical_tree_labels", id)
+            tree_label = get_path(event_data, "hierarchical_tree_labels", id) or get_path(
+                event_data, "hierarchical_tree_labels", -1
+            )
 
             # Rough approximation of what happens with Group title
             event_type = get_event_type(event.data)

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -64,7 +64,7 @@ StrippedTreeLabel = Sequence[StrippedTreeLabelPart]
 MAX_ISSUE_TREE_LABELS = 4
 
 
-def _strip_tree_label(tree_label: TreeLabel) -> StrippedTreeLabel:
+def _strip_tree_label(tree_label: TreeLabel, trunchate=False) -> StrippedTreeLabel:
     rv = []
     for part in tree_label:
         stripped_part: StrippedTreeLabelPart = dict(part)  # type: ignore
@@ -73,7 +73,7 @@ def _strip_tree_label(tree_label: TreeLabel) -> StrippedTreeLabel:
         stripped_part.pop("datapath", None)  # type: ignore
         rv.append(stripped_part)
 
-        if len(rv) == MAX_ISSUE_TREE_LABELS:
+        if trunchate and len(rv) == MAX_ISSUE_TREE_LABELS:
             break
 
     return rv
@@ -142,7 +142,7 @@ class CalculatedHashes:
             tree_label = self.tree_labels[i]
             return {
                 "current_level": i,
-                "current_tree_label": tree_label and _strip_tree_label(tree_label),
+                "current_tree_label": tree_label and _strip_tree_label(tree_label, trunchate=True),
             }
         except (IndexError, ValueError):
             return {}

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -47,7 +47,7 @@ StrippedTreeLabel = Sequence[StrippedTreeLabelPart]
 # by all frames). That means that the system will produce extremely long tree
 # labels even though the user may not really want or understand any of them.
 #
-# To get around this, we trunchate the tree label down to some arbitrary
+# To get around this, we truncate the tree label down to some arbitrary
 # number of functions. This does not apply to the grouping breakdown, as in
 # grouping_level_new_issues endpoint we populate the tree labels not through
 # this function at all.
@@ -64,7 +64,7 @@ StrippedTreeLabel = Sequence[StrippedTreeLabelPart]
 MAX_ISSUE_TREE_LABELS = 4
 
 
-def _strip_tree_label(tree_label: TreeLabel, trunchate=False) -> StrippedTreeLabel:
+def _strip_tree_label(tree_label: TreeLabel, truncate=False) -> StrippedTreeLabel:
     rv = []
     for part in tree_label:
         stripped_part: StrippedTreeLabelPart = dict(part)  # type: ignore
@@ -73,7 +73,7 @@ def _strip_tree_label(tree_label: TreeLabel, trunchate=False) -> StrippedTreeLab
         stripped_part.pop("datapath", None)  # type: ignore
         rv.append(stripped_part)
 
-        if trunchate and len(rv) == MAX_ISSUE_TREE_LABELS:
+        if truncate and len(rv) == MAX_ISSUE_TREE_LABELS:
             break
 
     return rv
@@ -134,7 +134,7 @@ class CalculatedHashes:
             tree_label = self.tree_labels[-1]
             # Also do this for event title in discover because people may
             # expect to `groupby title` to basically groupby issue.
-            return tree_label and _strip_tree_label(tree_label, trunchate=True)
+            return tree_label and _strip_tree_label(tree_label, truncate=True)
         except IndexError:
             return None
 
@@ -144,7 +144,7 @@ class CalculatedHashes:
             tree_label = self.tree_labels[i]
             return {
                 "current_level": i,
-                "current_tree_label": tree_label and _strip_tree_label(tree_label, trunchate=True),
+                "current_tree_label": tree_label and _strip_tree_label(tree_label, truncate=True),
             }
         except (IndexError, ValueError):
             return {}

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -61,7 +61,7 @@ StrippedTreeLabel = Sequence[StrippedTreeLabelPart]
 # level), we may revisit this type of truncation and replace it with something
 # that only kicks in when the found hash is found via fallback grouping. But
 # that'd be harder to implement and doesn't need to be solved rn.
-MAX_ISSUE_TREE_LABELS = 4
+MAX_ISSUE_TREE_LABELS = 2
 
 
 def _strip_tree_label(tree_label: TreeLabel, truncate=False) -> StrippedTreeLabel:

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -41,6 +41,28 @@ StrippedTreeLabelPart = TypedDict(
 TreeLabel = Sequence[TreeLabelPart]
 StrippedTreeLabel = Sequence[StrippedTreeLabelPart]
 
+# XXX(markus): Because of fallback grouping, people who migrate to new grouping
+# algorithm will start grouping at the maximum level as for each issue there
+# will be likely one old system- or app-hash that matches the max level (=group
+# by all frames). That means that the system will produce extremely long tree
+# labels even though the user may not really want or understand any of them.
+#
+# To get around this, we trunchate the tree label down to some arbitrary
+# number of functions. This does not apply to the grouping breakdown, as in
+# grouping_level_new_issues endpoint we populate the tree labels not through
+# this function at all.
+#
+# The reason we do this on the backend instead of the frontend's title
+# component is because JIRA/Slack/Email titles suffer from the same issue:
+# After the user migrates to hierarchical grouping, all the issue titles are
+# really long, and any created JIRA ticket's title/summary is also really long.
+#
+# Once people are able to actually split up issues (i.e. set the grouping
+# level), we may revisit this type of truncation and replace it with something
+# that only kicks in when the found hash is found via fallback grouping. But
+# that'd be harder to implement and doesn't need to be solved rn.
+MAX_ISSUE_TREE_LABELS = 4
+
 
 def _strip_tree_label(tree_label: TreeLabel) -> StrippedTreeLabel:
     rv = []
@@ -50,6 +72,9 @@ def _strip_tree_label(tree_label: TreeLabel) -> StrippedTreeLabel:
         # title
         stripped_part.pop("datapath", None)  # type: ignore
         rv.append(stripped_part)
+
+        if len(rv) == MAX_ISSUE_TREE_LABELS:
+            break
 
     return rv
 

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -132,7 +132,9 @@ class CalculatedHashes:
     def finest_tree_label(self) -> Optional[StrippedTreeLabel]:
         try:
             tree_label = self.tree_labels[-1]
-            return tree_label and _strip_tree_label(tree_label)
+            # Also do this for event title in discover because people may
+            # expect to `groupby title` to basically groupby issue.
+            return tree_label and _strip_tree_label(tree_label, trunchate=True)
         except IndexError:
             return None
 

--- a/src/sentry/grouping/result.py
+++ b/src/sentry/grouping/result.py
@@ -64,7 +64,7 @@ StrippedTreeLabel = Sequence[StrippedTreeLabelPart]
 MAX_ISSUE_TREE_LABELS = 2
 
 
-def _strip_tree_label(tree_label: TreeLabel, truncate=False) -> StrippedTreeLabel:
+def _strip_tree_label(tree_label: TreeLabel, truncate: bool = False) -> StrippedTreeLabel:
     rv = []
     for part in tree_label:
         stripped_part: StrippedTreeLabelPart = dict(part)  # type: ignore

--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -156,9 +156,10 @@ def _assert_tree_labels(event, functions):
         for i, function in enumerate(functions)
     ]
 
-    assert event.data["metadata"]["finest_tree_label"] == [
-        {"function": function} for function in reversed(functions)
-    ]
+    assert (
+        event.data["metadata"]["finest_tree_label"]
+        == [{"function": function} for function in reversed(functions)][:2]
+    )
 
 
 @pytest.mark.django_db
@@ -173,9 +174,9 @@ def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_p
     ]
 
     assert [e.title for e in events] == [
-        "ZeroDivisionError | foo | bar2 | baz2 | bam",
-        "ZeroDivisionError | foo | bar | baz",
-        "ZeroDivisionError | foo | bar2 | baz2",
+        "ZeroDivisionError | foo | bar2",
+        "ZeroDivisionError | foo | bar",
+        "ZeroDivisionError | foo | bar2",
         "ZeroDivisionError | foo | bar3",
     ]
 
@@ -239,7 +240,7 @@ def test_upwards(default_project, store_stacktrace, reset_snuba, _render_all_pre
     assert (
         _render_all_previews(events[0].group)
         == """\
-group: ZeroDivisionError | foo | bar2 | baz
+group: ZeroDivisionError | foo | bar2
 level 0
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
@@ -251,7 +252,7 @@ level 2*
     assert (
         _render_all_previews(events[1].group)
         == """\
-group: ZeroDivisionError | foo | bar | baz
+group: ZeroDivisionError | foo | bar
 level 0
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
@@ -264,7 +265,7 @@ b8d08a573c62ca8c84de14c12c0e19fe: ZeroDivisionError | foo | bar | baz (1)\
     assert (
         _render_all_previews(events[2].group)
         == """\
-group: ZeroDivisionError | foo | bar | bam
+group: ZeroDivisionError | foo | bar
 level 0
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1


### PR DESCRIPTION
See code comment:

```
# XXX(markus): Because of fallback grouping, people who migrate to new grouping
# algorithm will start grouping at the maximum level as for each issue there
# will be likely one old system- or app-hash that matches the max level (=group
# by all frames). That means that the system will produce extremely long tree
# labels even though the user may not really want or understand any of them.
#
# To get around this, we trunchate the tree label down to some arbitrary
# number of functions. This does not apply to the grouping breakdown, as in
# grouping_level_new_issues endpoint we populate the tree labels not through
# this function at all.
#
# The reason we do this on the backend instead of the frontend's title
# component is because JIRA/Slack/Email titles suffer from the same issue:
# After the user migrates to hierarchical grouping, all the issue titles are
# really long, and any created JIRA ticket's title/summary is also really long.
#
# Once people are able to actually split up issues (i.e. set the grouping
# level), we may revisit this type of truncation and replace it with something
# that only kicks in when the found hash is found via fallback grouping. But
# that'd be harder to implement and doesn't need to be solved rn.
```