### PR TITLE
feat(growth): randomize ids for sample transactions

### DIFF
--- a/src/sentry/api/endpoints/project_create_sample_transaction.py
+++ b/src/sentry/api/endpoints/project_create_sample_transaction.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta
+from uuid import uuid4
 
 import pytz
 from rest_framework.response import Response
@@ -25,6 +26,42 @@ def get_json_name(project):
     return "react-transaction.json"
 
 
+def fix_event_data(data):
+    """
+    This function will fix timestamps for sample events and generate
+    random ids for traces, spans, and the event id.
+    Largely based on sentry.utils.samples.load_data but more simple
+    """
+    timestamp = datetime.utcnow() - timedelta(minutes=1)
+    timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
+    timestamp = timestamp.replace(tzinfo=pytz.utc)
+    data["timestamp"] = to_timestamp(timestamp)
+
+    start_timestamp = timestamp - timedelta(seconds=3)
+    data["start_timestamp"] = to_timestamp(start_timestamp)
+
+    trace = uuid4().hex
+    span_id = uuid4().hex[:16]
+    data["event_id"] = uuid4().hex
+
+    data["contexts"]["trace"]["trace_id"] = trace
+    data["contexts"]["trace"]["span_id"] = span_id
+
+    for span in data.get("spans", []):
+        # Use data to generate span timestamps consistently and based
+        # on event timestamp
+        duration = span.get("data", {}).get("duration", 10.0)
+        offset = span.get("data", {}).get("offset", 0)
+        span_start = data["start_timestamp"] + offset
+        span["start_timestamp"] = span_start
+        span["timestamp"] = span_start + duration
+
+        span["parent_span_id"] = span_id
+        span["span_id"] = uuid4().hex[:16]
+        span["trace_id"] = trace
+    return data
+
+
 class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
     # Members should be able to create sample events.
     # This is the same scope that allows members to view all issues for a project.
@@ -35,22 +72,7 @@ class ProjectCreateSampleTransactionEndpoint(ProjectEndpoint):
         with open(os.path.join(samples_root, get_json_name(project))) as fp:
             data = json.load(fp)
 
-        timestamp = datetime.utcnow() - timedelta(minutes=1)
-        timestamp = timestamp - timedelta(microseconds=timestamp.microsecond % 1000)
-        timestamp = timestamp.replace(tzinfo=pytz.utc)
-        data["timestamp"] = to_timestamp(timestamp)
-
-        start_timestamp = timestamp - timedelta(seconds=3)
-        data["start_timestamp"] = to_timestamp(start_timestamp)
-        for span in data.get("spans", []):
-            # Use data to generate span timestamps consistently and based
-            # on event timestamp
-            duration = span.get("data", {}).get("duration", 10.0)
-            offset = span.get("data", {}).get("offset", 0)
-            span_start = data["start_timestamp"] + offset
-            span["start_timestamp"] = span_start
-            span["timestamp"] = span_start + duration
-
+        data = fix_event_data(data)
         event = create_sample_event_basic(
             data, project.id, raw=True, skip_send_first_transaction=True
         )


### PR DESCRIPTION
Since it is possible to create multiple sample transactions, we should uniquify the IDs so they don't conflict.