### PR TITLE
feat(cdc_search): Implement cdc search for `is:unresolved` query.

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from dataclasses import replace
 from datetime import datetime, timedelta
 from hashlib import md5
-from typing import Mapping
+from typing import Any, Mapping, Sequence
 
 import sentry_sdk
 from django.db.models import QuerySet
@@ -22,7 +22,6 @@ from sentry.search.events.fields import DateArg
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.utils import json, metrics, snuba
 from sentry.utils.cursors import Cursor, CursorResult
-from sentry.utils.types import Any, Sequence
 
 
 def get_search_filter(search_filters, name, operator):

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1,19 +1,28 @@
 import logging
 import time
 from abc import ABCMeta, abstractmethod, abstractproperty
+from dataclasses import replace
 from datetime import datetime, timedelta
 from hashlib import md5
+from typing import Mapping
 
 import sentry_sdk
+from django.db.models import QuerySet
 from django.utils import timezone
+from snuba_sdk import Direction, Op
+from snuba_sdk.query import Column, Condition, Entity, Function, Join, Limit, OrderBy, Query
+from snuba_sdk.relationships import Relationship
 
 from sentry import options
+from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.api.paginator import DateTimePaginator, Paginator, SequencePaginator
 from sentry.constants import ALLOWED_FUTURE_DELTA
-from sentry.models import Environment, Group
+from sentry.models import Environment, Group, Optional, Project
 from sentry.search.events.fields import DateArg
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.utils import json, metrics, snuba
+from sentry.utils.cursors import Cursor, CursorResult
+from sentry.utils.types import Any, Sequence
 
 
 def get_search_filter(search_filters, name, operator):
@@ -619,4 +628,219 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
 
 
 class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
-    pass
+    sort_strategies = {
+        "date": "last_seen",
+        "freq": "times_seen",
+        "new": "first_seen",
+        "priority": "priority",
+        "user": "user_count",
+    }
+
+    entities = {
+        "event": Entity("events", alias="e"),
+        "group": Entity("groupedmessage", alias="g"),
+    }
+
+    aggregation_defs = {
+        "times_seen": Function("count", [Column("group_id", entities["event"])]),
+        "first_seen": Function(
+            "multiply",
+            [
+                Function("toUInt64", [Function("min", [Column("timestamp", entities["event"])])]),
+                1000,
+            ],
+        ),
+        "last_seen": Function(
+            "multiply",
+            [
+                Function("toUInt64", [Function("max", [Column("timestamp", entities["event"])])]),
+                1000,
+            ],
+        ),
+        # https://github.com/getsentry/sentry/blob/804c85100d0003cfdda91701911f21ed5f66f67c/src/sentry/event_manager.py#L241-L271
+        "priority": Function(
+            "toUInt64",
+            [
+                Function(
+                    "plus",
+                    [
+                        Function(
+                            "multiply",
+                            [
+                                Function(
+                                    "log",
+                                    [Function("count", [Column("group_id", entities["event"])])],
+                                ),
+                                600,
+                            ],
+                        ),
+                        Function(
+                            "multiply",
+                            [
+                                Function(
+                                    "toUInt64",
+                                    [
+                                        Function(
+                                            "toUInt64",
+                                            [
+                                                Function(
+                                                    "max", [Column("timestamp", entities["event"])]
+                                                )
+                                            ],
+                                        )
+                                    ],
+                                ),
+                                1000,
+                            ],
+                        ),
+                    ],
+                )
+            ],
+        ),
+        "user_count": Function("uniq", [Column("tags[sentry:user]", entities["event"])]),
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.postres_executor = PostgresSnubaQueryExecutor()
+
+    def calculate_start_end(
+        self,
+        retention_window_start: Optional[datetime],
+        search_filters: Sequence[SearchFilter],
+        date_from: Optional[datetime],
+        date_to: Optional[datetime],
+    ):
+        now = timezone.now()
+        end = None
+        end_params = [_f for _f in [date_to, get_search_filter(search_filters, "date", "<")] if _f]
+        if end_params:
+            end = min(end_params)
+
+        if not end:
+            end = now + ALLOWED_FUTURE_DELTA
+
+        retention_date = max(_f for _f in [retention_window_start, now - timedelta(days=90)] if _f)
+        start_params = [date_from, retention_date, get_search_filter(search_filters, "date", ">")]
+        start = max(_f for _f in start_params if _f)
+        end = max([retention_date, end])
+        return start, end, retention_date
+
+    def query(
+        self,
+        projects: Sequence[Project],
+        retention_window_start: Optional[datetime],
+        group_queryset: QuerySet,
+        environments: Sequence[Environment],
+        sort_by: str,
+        limit: int,
+        cursor: Optional[Cursor],
+        count_hits: bool,
+        paginator_options: Mapping[str, Any],
+        search_filters: Sequence[SearchFilter],
+        date_from: Optional[datetime],
+        date_to: Optional[datetime],
+        max_hits=None,
+    ) -> CursorResult:
+        # TODO: For the moment, the assumption is that this backend will only ever be passed
+        # search_filters derived from `is:unresolved`. We'll hardcode that case and handle more
+        # later.
+
+        if search_filters != [SearchFilter(SearchKey("status"), "IN", SearchValue([0]))]:
+            logging.error(
+                "Received invalid search_filters in `CdcPostgresSnubaQueryExecutor`, "
+                "passing through to base class",
+                extra={"search_filters": search_filters},
+            )
+            return self.postres_executor.query(
+                projects,
+                retention_window_start,
+                group_queryset,
+                environments,
+                sort_by,
+                limit,
+                cursor,
+                count_hits,
+                paginator_options,
+                search_filters,
+                date_from,
+                date_to,
+                max_hits=None,
+            )
+
+        start, end, retention_date = self.calculate_start_end(
+            retention_window_start, search_filters, date_from, date_to
+        )
+
+        if start == retention_date and end == retention_date:
+            # Both `start` and `end` must have been trimmed to `retention_date`,
+            # so this entire search was against a time range that is outside of
+            # retention. We'll return empty results to maintain backwards compatibility
+            # with Django search (for now).
+            return self.empty_result
+
+        if start >= end:
+            # TODO: This maintains backwards compatibility with Django search, but
+            # in the future we should find a way to notify the user that their search
+            # is invalid.
+            return self.empty_result
+
+        e_event = self.entities["event"]
+        e_group = self.entities["group"]
+
+        where_conditions = [
+            Condition(Column("project_id", e_event), Op.IN, [p.id for p in projects]),
+            Condition(Column("timestamp", e_event), Op.GTE, start),
+            Condition(Column("timestamp", e_event), Op.LT, end),
+            Condition(Column("status", e_group), Op.IN, [0]),
+        ]
+        if environments:
+            # TODO: Should this be handled via filter_keys, once we have a snql compatible version?
+            where_conditions.append(
+                Condition(Column("environment", e_event), Op.IN, [e.name for e in environments])
+            )
+
+        sort_func = self.aggregation_defs[self.sort_strategies[sort_by]]
+
+        having = []
+        if cursor is not None:
+            op = Op.GTE if cursor.is_prev else Op.LTE
+            having.append(Condition(sort_func, op, cursor.value))
+
+        query = Query(
+            "events",
+            match=Join([Relationship(e_event, "grouped", e_group)]),
+            select=[
+                Column("id", e_group),
+                replace(sort_func, alias="score"),
+            ],
+            where=where_conditions,
+            groupby=[Column("id", e_group)],
+            having=having,
+            orderby=[OrderBy(sort_func, direction=Direction.DESC)],
+            limit=Limit(limit + 1),
+        )
+
+        data = snuba.raw_snql_query(query, referrer="search.snuba.cdc_search.query")["data"]
+
+        hits_query = Query(
+            "events",
+            match=Join([Relationship(e_event, "grouped", e_group)]),
+            select=[
+                Function("uniq", [Column("id", e_group)], alias="count"),
+            ],
+            where=where_conditions,
+        )
+        hits = len(data)
+        if count_hits:
+            hits = snuba.raw_snql_query(hits_query, referrer="search.snuba.cdc_search.hits")[
+                "data"
+            ][0]["count"]
+
+        paginator_results = SequencePaginator(
+            [(row["score"], row["g.id"]) for row in data], reverse=True, **paginator_options
+        ).get_result(limit, cursor, known_hits=hits, max_hits=max_hits)
+        groups = Group.objects.in_bulk(paginator_results.results)
+        paginator_results.results = [groups[k] for k in paginator_results.results if k in groups]
+
+        return paginator_results

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -688,10 +688,6 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "user_count": Function("uniq", [Column("tags[sentry:user]", entities["event"])]),
     }
 
-    def __init__(self):
-        super().__init__()
-        self.postres_executor = PostgresSnubaQueryExecutor()
-
     def calculate_start_end(
         self,
         retention_window_start: Optional[datetime],
@@ -733,7 +729,6 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         # TODO: For the moment, the assumption is that this backend will only ever be passed
         # search_filters derived from `is:unresolved`. We'll hardcode that case and handle more
         # later.
-
         if search_filters != [SearchFilter(SearchKey("status"), "IN", SearchValue([0]))]:
             raise InvalidQueryForExecutor("Search filters invalid for this query executor")
 


### PR DESCRIPTION
This implements the basics of `CdcPostgresSnubaQueryExecutor` to handle a single query -
`is:unresolved`. This should work correctly for all existing sorts, filtering by projects,
environments, etc. The results should be equivalent to the existing executor, but we can test that
in the `ServiceDelegator` callback.

This is reasonably rough. As we start to implement more features I'll work to factor this into
methods.