### PR TITLE
feat(codeowners): Set default to not show prompt

### DIFF
--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -38,7 +38,7 @@ class SuggestedOwners extends React.Component<Props, State> {
     rules: null,
     owners: [],
     codeowners: [],
-    isDismissed: false,
+    isDismissed: true,
   };
 
   componentDidMount() {


### PR DESCRIPTION
## Objective:
Currently the prompt is flashing and rendering while loading the states. This PR sets the default to true and will render the prompt once the prompt settings have loaded.