### PR TITLE
fix(scim): format bearer token and remove trailing slash

### DIFF
--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -79,7 +79,9 @@ class AuthProvider(Model):
     def get_scim_url(self):
         if self.flags.scim_enabled:
             url_prefix = options.get("system.url-prefix")
-            return f"{url_prefix}/api/0/organizations/{self.organization.slug}/scim/v2/"
+            # the SCIM protocol doesn't use trailing slashes in URLs
+            return f"{url_prefix}/api/0/organizations/{self.organization.slug}/scim/v2"
+
         else:
             return None
 

--- a/src/sentry/templates/sentry/organization-auth-provider-settings.html
+++ b/src/sentry/templates/sentry/organization-auth-provider-settings.html
@@ -65,7 +65,7 @@
       </div>
       <div class="box-content with-padding">
         <b>Auth Token:</b>
-        <pre>{% if provider_name != "Active Directory" %}Bearer {% endif %}{{ scim_api_token }}</pre>
+        <pre>{{ scim_api_token }}</pre>
         <b>SCIM URL:</b>
         <pre>{{ scim_url }}</pre>
         <p>See provider specific SCIM documentation <a href="#TODO">here</a>.</p>


### PR DESCRIPTION
- removes trailing slash from the SCIM URL, was causing issues w/ okta.
- Removes the word "Bearer" from all tokens, our production application in Okta only takes the token.