### PR TITLE
ref(react-router): Normalize react-router/lib/* imports

### DIFF
--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -1,4 +1,4 @@
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import {Location} from 'history';
 
 import {openModal} from 'app/actionCreators/modal';

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import * as Router from 'react-router';
+import * as ReactRouter from 'react-router';
 import * as Sentry from '@sentry/react';
 import jQuery from 'jquery';
 import moment from 'moment';
@@ -15,9 +15,9 @@ const globals = {
   PropTypes,
   React,
   Reflux,
-  Router,
   Sentry,
   moment,
+  Router: ReactRouter,
   ReactDOM: {
     findDOMNode: ReactDOM.findDOMNode,
     render: ReactDOM.render,

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -1,4 +1,4 @@
-import * as Router from 'react-router';
+import * as ReactRouter from 'react-router';
 import {ExtraErrorData} from '@sentry/integrations';
 import * as Sentry from '@sentry/react';
 import SentryRRWeb from '@sentry/rrweb';
@@ -25,9 +25,9 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
       ...(typeof routes === 'function'
         ? {
             routingInstrumentation: Sentry.reactRouterV3Instrumentation(
-              Router.browserHistory as any,
-              Router.createRoutes(routes()),
-              Router.match
+              ReactRouter.browserHistory as any,
+              ReactRouter.createRoutes(routes()),
+              ReactRouter.match
             ),
           }
         : {}),

--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {RouteComponentProps} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {RouteComponentProps, WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {WithRouterProps} from 'react-router';
 import {EChartOption} from 'echarts/lib/echarts';
 import moment from 'moment';
 import * as qs from 'query-string';

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import {withTheme} from '@emotion/react';
 import {EChartOption} from 'echarts/lib/echarts';
 import {Query} from 'history';

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import {EChartOption} from 'echarts/lib/echarts';
 import {Query} from 'history';

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import {
   AutoSizer,
   CellMeasurer,

--- a/static/app/components/modals/emailVerificationModal.tsx
+++ b/static/app/components/modals/emailVerificationModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import {Client} from 'app/api';

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';

--- a/static/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/static/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 

--- a/static/app/types/react-router.d.ts
+++ b/static/app/types/react-router.d.ts
@@ -1,17 +1,15 @@
 import {ComponentClass, ComponentType, StatelessComponent} from 'react';
-import {PlainRoute} from 'react-router/lib/Route';
-import {InjectedRouter, Params} from 'react-router/lib/Router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {InjectedRouter, PlainRoute, WithRouterProps} from 'react-router';
 import {Location} from 'history';
 
 declare module 'react-router' {
-  interface InjectedRouter<P = Params, Q = any> {
+  interface InjectedRouter<P = Record<string, string>, Q = any> {
     location: Location<Q>;
     params: P;
     routes: PlainRoute[];
   }
 
-  interface WithRouterProps<P = Params, Q = any> {
+  interface WithRouterProps<P = Record<string, string>, Q = any> {
     location: Location<Q>;
     params: P;
     router: InjectedRouter<P, Q>;

--- a/static/app/utils/getRouteStringFromRoutes.tsx
+++ b/static/app/utils/getRouteStringFromRoutes.tsx
@@ -1,4 +1,4 @@
-import {PlainRoute} from 'react-router/lib/Route';
+import {PlainRoute} from 'react-router';
 import findLastIndex from 'lodash/findLastIndex';
 
 type RouteWithPath = Omit<PlainRoute, 'path'> & Required<Pick<PlainRoute, 'path'>>;

--- a/static/app/views/alerts/details/activity/index.tsx
+++ b/static/app/views/alerts/details/activity/index.tsx
@@ -1,5 +1,5 @@
 import {PureComponent} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 
 import {
   createIncidentNote,
@@ -28,11 +28,10 @@ import Activity from './activity';
 
 type Activities = Array<ActivityType | ActivityType>;
 
-type Props = {
+type Props = Pick<RouteComponentProps<{alertId: string; orgId: string}, {}>, 'params'> & {
   api: Client;
   incident?: Incident;
   incidentStatus: IncidentStatus | null;
-  params: Params;
 };
 
 type State = {

--- a/static/app/views/alerts/details/header.tsx
+++ b/static/app/views/alerts/details/header.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import moment from 'moment';
@@ -27,14 +27,13 @@ import Status from '../status';
 import {Incident, IncidentStats} from '../types';
 import {isOpen} from '../utils';
 
-type Props = {
+type Props = Pick<RouteComponentProps<{orgId: string}, {}>, 'params'> & {
   className?: string;
   hasIncidentDetailsError: boolean;
   incident?: Incident;
   stats?: IncidentStats;
   onSubscriptionChange: (event: React.MouseEvent) => void;
   onStatusChange: (eventKey: any) => void;
-  params: Params;
 };
 
 export default class DetailsHeader extends React.Component<Props> {

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {RouteComponentProps} from 'react-router';
-import {PlainRoute} from 'react-router/lib/Route';
+import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {

--- a/static/app/views/alerts/list/header.tsx
+++ b/static/app/views/alerts/list/header.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 
 import {navigateTo} from 'app/actionCreators/navigation';

--- a/static/app/views/alerts/rules/details/header.tsx
+++ b/static/app/views/alerts/rules/details/header.tsx
@@ -1,4 +1,4 @@
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -13,10 +13,9 @@ import {IncidentRule} from 'app/views/alerts/incidentRules/types';
 
 import {isIssueAlert} from '../../utils';
 
-type Props = {
+type Props = Pick<RouteComponentProps<{orgId: string}, {}>, 'params'> & {
   hasIncidentRuleDetailsError: boolean;
   rule?: IncidentRule;
-  params: Params;
 };
 
 function DetailsHeader({hasIncidentRuleDetailsError, rule, params}: Props) {

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import color from 'color';
 import moment from 'moment';

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import {closestCenter, DndContext} from '@dnd-kit/core';
 import {arrayMove, rectSortingStrategy, SortableContext} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';

--- a/static/app/views/dashboardsV2/widget/metricWidget/card.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/card.tsx
@@ -1,4 +1,4 @@
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
@@ -1,4 +1,4 @@
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import {components, OptionProps, SingleValueProps} from 'react-select';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import Feature from 'app/components/acl/feature';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -51,10 +50,8 @@ import LinkedIssue from './linkedIssue';
  */
 const EXCLUDED_TAG_KEYS = new Set(['release']);
 
-type Props = {
+type Props = Pick<RouteComponentProps<{eventSlug: string}, {}>, 'params' | 'location'> & {
   organization: Organization;
-  location: Location;
-  params: Params;
   eventSlug: string;
   eventView: EventView;
 };

--- a/static/app/views/eventsV2/eventDetails/index.tsx
+++ b/static/app/views/eventsV2/eventDetails/index.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -13,10 +12,8 @@ import withOrganization from 'app/utils/withOrganization';
 
 import EventDetailsContent from './content';
 
-type Props = {
+type Props = RouteComponentProps<{eventSlug: string}, {}> & {
   organization: Organization;
-  location: Location;
-  params: Params;
 };
 
 class EventDetails extends Component<Props> {

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -1,7 +1,6 @@
 import * as ReactRouter from 'react-router';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import {stringify} from 'query-string';
@@ -42,10 +41,8 @@ const SORT_OPTIONS: SelectValue<string>[] = [
 
 type Props = {
   organization: Organization;
-  location: Location;
-  router: ReactRouter.InjectedRouter;
-  params: Params;
-} & AsyncComponent['props'];
+} & RouteComponentProps<{}, {}> &
+  AsyncComponent['props'];
 
 type State = {
   savedQueries: SavedQuery[] | null;
@@ -118,7 +115,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       }
     }
 
-    const queryParams: Location['query'] = {
+    const queryParams: Props['location']['query'] = {
       cursor,
       query: `version:2 name:"${searchQuery}"`,
       per_page: perPage.toString(),

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import DocumentTitle from 'react-document-title';
-import {RouteComponentProps} from 'react-router';
-import {PlainRoute} from 'react-router/lib/Route';
+import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -1,5 +1,4 @@
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 import xor from 'lodash/xor';

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import debounce from 'lodash/debounce';

--- a/static/app/views/organizationJoinRequest.tsx
+++ b/static/app/views/organizationJoinRequest.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -11,9 +11,7 @@ import {trackAdhocEvent} from 'app/utils/analytics';
 import EmailField from 'app/views/settings/components/forms/emailField';
 import Form from 'app/views/settings/components/forms/form';
 
-type Props = {
-  params: Params;
-};
+type Props = RouteComponentProps<{orgId: string}, {}>;
 
 type State = {
   submitSuccess: boolean | null;

--- a/static/app/views/performance/compare/content.tsx
+++ b/static/app/views/performance/compare/content.tsx
@@ -1,7 +1,6 @@
 import {Component, Fragment} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import * as Layout from 'app/components/layouts/thirds';
 import {Panel} from 'app/components/panels';
@@ -14,10 +13,11 @@ import TraceView from './traceView';
 import TransactionSummary from './transactionSummary';
 import {isTransactionEvent} from './utils';
 
-type Props = {
+type Props = Pick<
+  RouteComponentProps<{baselineEventSlug: string; regressionEventSlug: string}, {}>,
+  'params' | 'location'
+> & {
   organization: Organization;
-  location: Location;
-  params: Params;
   baselineEvent: Event;
   regressionEvent: Event;
 };

--- a/static/app/views/performance/compare/index.tsx
+++ b/static/app/views/performance/compare/index.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import {Location} from 'history';
 
 import NotFound from 'app/components/errors/notFound';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
@@ -22,9 +21,10 @@ type ComparedEventSlugs = {
   regressionEventSlug: string | undefined;
 };
 
-type Props = {
-  location: Location;
-  params: Params;
+type Props = RouteComponentProps<
+  {baselineEventSlug: string; regressionEventSlug: string},
+  {}
+> & {
   organization: Organization;
 };
 

--- a/static/app/views/performance/compare/transactionSummary.tsx
+++ b/static/app/views/performance/compare/transactionSummary.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import {parseTrace} from 'app/components/events/interfaces/spans/utils';
 import Link from 'app/components/links/link';
@@ -15,10 +14,11 @@ import {getTransactionDetailsUrl} from '../utils';
 
 import {isTransactionEvent} from './utils';
 
-type Props = {
+type Props = Pick<
+  RouteComponentProps<{baselineEventSlug: string; regressionEventSlug: string}, {}>,
+  'location' | 'params'
+> & {
   organization: Organization;
-  location: Location;
-  params: Params;
   baselineEvent: Event;
   regressionEvent: Event;
 };

--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import * as Sentry from '@sentry/react';
-import {Location} from 'history';
 
 import Alert from 'app/components/alert';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
@@ -61,10 +60,8 @@ type AccType = {
   numberOfHiddenTransactionsAbove: number;
 };
 
-type Props = {
-  location: Location;
+type Props = Pick<RouteComponentProps<{traceSlug: string}, {}>, 'params' | 'location'> & {
   organization: Organization;
-  params: Params;
   traceSlug: string;
   traceEventView: EventView;
   dateSelected: boolean;

--- a/static/app/views/performance/traceDetails/index.tsx
+++ b/static/app/views/performance/traceDetails/index.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import {Client} from 'app/api';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
@@ -21,11 +20,9 @@ import withOrganization from 'app/utils/withOrganization';
 
 import TraceDetailsContent from './content';
 
-type Props = {
+type Props = RouteComponentProps<{traceSlug: string}, {}> & {
   api: Client;
-  location: Location;
   organization: Organization;
-  params: Params;
 };
 
 class TraceSummary extends Component<Props> {

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-import {Params} from 'react-router/lib/Router';
-import {Location} from 'history';
+import {RouteComponentProps} from 'react-router';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
@@ -34,10 +33,8 @@ import {getTransactionDetailsUrl} from '../utils';
 
 import EventMetas from './eventMetas';
 
-type Props = {
+type Props = Pick<RouteComponentProps<{eventSlug: string}, {}>, 'params' | 'location'> & {
   organization: Organization;
-  location: Location;
-  params: Params;
   eventSlug: string;
 };
 

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -14,10 +13,8 @@ import withOrganization from 'app/utils/withOrganization';
 import EventDetailsContent from './content';
 import FinishSetupAlert from './finishSetupAlert';
 
-type Props = {
+type Props = RouteComponentProps<{eventSlug: string}, {}> & {
   organization: Organization;
-  location: Location;
-  params: Params;
 };
 
 class EventDetails extends Component<Props> {

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-import {browserHistory} from 'react-router';
-import {Params} from 'react-router/lib/Router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
@@ -45,10 +44,8 @@ import {
 import {ZOOM_END, ZOOM_START} from './latencyChart';
 import {TransactionThresholdMetric} from './transactionThresholdModal';
 
-type Props = {
+type Props = RouteComponentProps<{}, {}> & {
   api: Client;
-  location: Location;
-  params: Params;
   organization: Organization;
   projects: Project[];
   selection: GlobalSelection;

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-import {browserHistory, withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 
 import {Client} from 'app/api';

--- a/static/app/views/performance/trends/index.tsx
+++ b/static/app/views/performance/trends/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {Params} from 'react-router/lib/Router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import {Client} from 'app/api';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
@@ -19,13 +18,11 @@ import {generatePerformanceEventView} from '../data';
 
 import TrendsContent from './content';
 
-type Props = {
+type Props = RouteComponentProps<{}, {}> & {
   api: Client;
-  location: Location;
   selection: GlobalSelection;
   organization: Organization;
   projects: Project[];
-  params: Params;
 };
 
 type State = {

--- a/static/app/views/performance/vitalDetail/index.tsx
+++ b/static/app/views/performance/vitalDetail/index.tsx
@@ -1,8 +1,6 @@
 import {Component} from 'react';
-import {browserHistory, InjectedRouter} from 'react-router';
-import {Params} from 'react-router/lib/Router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {loadOrganizationTags} from 'app/actionCreators/tags';
@@ -26,15 +24,12 @@ import {addRoutePerformanceContext, getTransactionName} from '../utils';
 
 import VitalDetailContent from './vitalDetailContent';
 
-type Props = {
+type Props = RouteComponentProps<{}, {}> & {
   api: Client;
-  location: Location;
-  params: Params;
   organization: Organization;
   projects: Project[];
   selection: GlobalSelection;
   loadingProjects: boolean;
-  router: InjectedRouter;
 };
 
 type State = {

--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -1,5 +1,5 @@
 import {Component, Fragment} from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import {withTheme} from '@emotion/react';
 import isEqual from 'lodash/isEqual';
 

--- a/static/app/views/releases/detail/overview/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/releaseAdoption.tsx
@@ -1,5 +1,4 @@
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import {EChartOption} from 'echarts';
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {withRouter} from 'react-router';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import round from 'lodash/round';
 

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.tsx
@@ -1,5 +1,5 @@
 import {Component} from 'react';
-import {PlainRoute} from 'react-router/lib/Route';
+import {PlainRoute} from 'react-router';
 
 import SettingsBreadcrumbActions from 'app/actions/settingsBreadcrumbActions';
 

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-import {RouteComponentProps} from 'react-router';
-import {PlainRoute} from 'react-router/lib/Route';
+import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import AlertLink from 'app/components/alertLink';

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/index.tsx
@@ -1,5 +1,5 @@
 import {useContext, useEffect} from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 

--- a/static/app/views/settings/projectDebugFiles/externalSources/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/index.tsx
@@ -1,5 +1,5 @@
 import {Fragment} from 'react';
-import {InjectedRouter} from 'react-router/lib/Router';
+import {InjectedRouter} from 'react-router';
 import {Location} from 'history';
 
 import {Client} from 'app/api';

--- a/static/app/views/settings/projectPlugins/index.tsx
+++ b/static/app/views/settings/projectPlugins/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {WithRouterProps} from 'react-router/lib/withRouter';
+import {WithRouterProps} from 'react-router';
 
 import {disablePlugin, enablePlugin, fetchPlugins} from 'app/actionCreators/plugins';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';


### PR DESCRIPTION
Don't use `/lib` imports.

Replaces many `Params` with `RouteComponentProps`