### PR TITLE
fix(slack): Don't show unknown command message when there is no command

### DIFF
--- a/src/sentry/integrations/slack/message_builder/help.py
+++ b/src/sentry/integrations/slack/message_builder/help.py
@@ -55,7 +55,7 @@ class SlackHelpMessageBuilder(BlockSlackMessageBuilder):
 
     def get_header_blocks(self) -> Iterable[SlackBlock]:
         blocks: List[SlackBlock] = []
-        if self.command != "help":
+        if self.command and self.command != "help":
             logger.info("slack.event.unknown-command", extra={"command": self.command})
             blocks.append(
                 self.get_markdown_block(UNKNOWN_COMMAND_MESSAGE.format(command=self.command))


### PR DESCRIPTION
When the user types `/sentry` with no args they see:
<img width="581" alt="Screen Shot 2021-08-09 at 2 43 48 PM" src="https://user-images.githubusercontent.com/31750075/128778396-888f1887-435f-4f4a-80fe-03ad936b2ef4.png">
This PR removes the unknown command message when there is no command.