### PR TITLE
fix(scim): dont allow dupe team names

### DIFF
--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -64,7 +64,7 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
             organization=organization, status=TeamStatus.VISIBLE
         ).order_by("slug")
         if filter_val:
-            queryset = queryset.filter(name=filter_val)
+            queryset = queryset.filter(name__iexact=filter_val)
 
         def data_fn(offset, limit):
             return list(queryset[offset : offset + limit])
@@ -85,7 +85,9 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
     def post(self, request, organization):
         # shim displayName from SCIM api in order to work with
         # our regular team index POST
-        request.data.update({"name": request.data["displayName"]})
+        request.data.update(
+            {"name": request.data["displayName"], "slug": slugify(request.data["displayName"])}
+        ),
         return super().post(request, organization)
 
 

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -153,6 +153,28 @@ class SCIMGroupIndexTests(SCIMTestCase):
             ],
         }
 
+    def test_team_filter_case_insensitive(self):
+        url = reverse("sentry-api-0-organization-scim-team-index", args=[self.organization.slug])
+        team = self.create_team(organization=self.organization, name="Name WithASpace")
+        response = self.client.get(
+            f"{url}?startIndex=1&count=100&filter=displayName eq %22{team.name.upper()}%22"
+        )
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:ListResponse"],
+            "totalResults": 1,
+            "startIndex": 1,
+            "itemsPerPage": 1,
+            "Resources": [
+                {
+                    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+                    "id": str(team.id),
+                    "displayName": team.name,
+                    "members": [],
+                    "meta": {"resourceType": "Group"},
+                }
+            ],
+        }
+
     def test_team_exclude_members_param(self):
         url = reverse("sentry-api-0-organization-scim-team-index", args=[self.organization.slug])
         response = self.client.get(
@@ -181,3 +203,12 @@ class SCIMGroupIndexTests(SCIMTestCase):
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
             "scimType": "invalidFilter",
         }
+
+    def test_scim_team_no_duplicate_names(self):
+        self.create_team(organization=self.organization, name=CREATE_TEAM_POST_DATA["displayName"])
+        url = reverse(
+            "sentry-api-0-organization-scim-team-index",
+            args=[self.organization.slug],
+        )
+        response = self.client.post(url, CREATE_TEAM_POST_DATA)
+        assert response.status_code == 409, response.content


### PR DESCRIPTION
if you don't pass a slug to team creation it will not check that there are not duplicates and instead generate a unique slug, which was causing teams with duplicate names to be allowed by SCIM. The rename operation was already passing a slug, so we are good there.

- This is fixed by passing a slug as a parameter.
- This PR also makes team name search filtering case insensitive by using iexact.

