### PR TITLE
hackweek: Make "Merged" a terminating PR status

### DIFF
--- a/src/sentry/utils/groupreference.py
+++ b/src/sentry/utils/groupreference.py
@@ -11,7 +11,7 @@ def find_referenced_groups(text, org_id):
     from sentry.models import Group
 
     if not text:
-        return []
+        return set()
 
     results = set()
     for fmatch in _fixes_re.finditer(text):
@@ -35,7 +35,7 @@ def find_referenced_groups_in_branch(branch_name, org_id):
     from sentry.models import Group
 
     if not branch_name:
-        return []
+        return set()
 
     results = set()
     for smatch in branch_re.finditer(branch_name):

--- a/static/app/components/group/gitActivity/activity.tsx
+++ b/static/app/components/group/gitActivity/activity.tsx
@@ -88,11 +88,7 @@ function Activity({gitActivity, onUnlink}: Props) {
               )}
               <MenuItemActionLink
                 onAction={() => onUnlink(gitActivity)}
-                message={t(
-                  'Are you sure you want to unlink this Pull Request from the issue?'
-                )}
                 title={t('Unlink Pull Request')}
-                shouldConfirm
               >
                 {t('Unlink Pull Request')}
               </MenuItemActionLink>
@@ -113,9 +109,7 @@ function Activity({gitActivity, onUnlink}: Props) {
               </MenuItemActionLink>
               <MenuItemActionLink
                 onAction={() => onUnlink(gitActivity)}
-                message={t('Are you sure you want to unlink this Branch from the issue?')}
                 title={t('Unlink Branch')}
-                shouldConfirm
               >
                 {t('Unlink Branch')}
               </MenuItemActionLink>

--- a/static/app/components/group/gitActivity/index.tsx
+++ b/static/app/components/group/gitActivity/index.tsx
@@ -5,7 +5,6 @@ import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
 import Alert from 'app/components/alert';
 import Clipboard from 'app/components/clipboard';
-import LoadingIndicator from 'app/components/loadingIndicator';
 import TextOverflow from 'app/components/textOverflow';
 import Tooltip from 'app/components/tooltip';
 import {IconCopy, IconRefresh} from 'app/icons';
@@ -37,7 +36,6 @@ type Props = {
 function GitActivity({api, issueId}: Props) {
   const [linkedActivities, setLinkedActivities] = useState<GitActivity[]>([]);
   const [unlinkedActivities, setUnlinkedActivities] = useState<GitActivity[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<undefined | string>(undefined);
   const [branchName, setBranchName] = useState('');
 
@@ -46,23 +44,16 @@ function GitActivity({api, issueId}: Props) {
     fetchActivities();
   }, []);
 
-  async function fetchBranchName(reload = true) {
-    if (reload) {
-      setIsLoading(true);
-    }
-
+  async function fetchBranchName() {
     try {
       const response = await api.requestPromise(`/issues/${issueId}/branch-name/`);
       setBranchName(response.branchName);
-      setIsLoading(false);
     } catch {
-      setIsLoading(false);
       setError(t('An error occurred while fetching the branch name'));
     }
   }
 
   async function fetchActivities() {
-    setIsLoading(true);
     setError(undefined);
     try {
       const response: GitActivity[] = await api.requestPromise(
@@ -72,9 +63,11 @@ function GitActivity({api, issueId}: Props) {
       setLinkedActivities(activities);
       const unlinked = response.filter(gitActivity => !gitActivity.visible);
       setUnlinkedActivities(unlinked);
-      setIsLoading(false);
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      await fetchActivities();
     } catch {
-      setIsLoading(false);
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      await fetchActivities();
       setError(t('An error occurred while fetching Git Activity'));
     }
   }
@@ -121,10 +114,6 @@ function GitActivity({api, issueId}: Props) {
       return <Alert type="error">{error}</Alert>;
     }
 
-    if (isLoading) {
-      return <LoadingIndicator mini />;
-    }
-
     return (
       <Fragment>
         <IssueId>
@@ -142,7 +131,7 @@ function GitActivity({api, issueId}: Props) {
               title={t('Refresh to get a new branch name')}
               containerDisplayMode="inline-flex"
             >
-              <StyledIconRefresh onClick={() => fetchBranchName(false)} />
+              <StyledIconRefresh onClick={() => fetchBranchName()} />
             </Tooltip>
           </BranchNameAndActions>
         </IssueId>


### PR DESCRIPTION
1. Make "Merged" a terminating PR status - so don't
update the status of the branch after it's been merged
to set "closed" or "deleted" status.
2. Also remove the confirmation dialogue to unlink PR
since we can easily relink it.
3. Initially skipped checking the PR description if the
branch had matches, but now always checking both.