### PR TITLE
fix(trace-navigator): Trace not found alert dismiss button

### DIFF
--- a/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
@@ -42,8 +42,11 @@ class IssueQuickTrace extends Component<Props, State> {
     this.promptsCheck();
   }
 
-  shouldComponentUpdate(nextProps) {
-    return this.props.event !== nextProps.event;
+  shouldComponentUpdate(nextProps, nextState: State) {
+    return (
+      this.props.event !== nextProps.event ||
+      this.state.shouldShow !== nextState.shouldShow
+    );
   }
 
   async promptsCheck() {


### PR DESCRIPTION
The component is not updating when the state changes. This ensures to check that
when the state changes from the dismiss button, the alert is removed.