### PR TITLE
hackweek: all compat inline

### DIFF
--- a/joshware3.py
+++ b/joshware3.py
@@ -92,14 +92,10 @@ class GoodTransformer(CSTTransformer):
 
         return node
 
-    # TODO dict(list(zip, though this should be turned into a literal by pyupgrade
+    def leave_CompFor(self, _, node):
+        return self.leave_For(_, node)
 
-    #      src/sentry/api/endpoints/organization_releases.py L197
-    # TODO: in inside comprehensions, like {a for a, b in list(zip(range(1), range(1)))}
-    # src/sentry/api/serializers/models/activity.py L22, L41
-    # src/sentry/api/serializers/models/event.py L174, L353
-    # ... lots more
-    # src/sentry/api/endpoints/project_stacktrace_link.py L53 - for inside a list comprehension
+    # TODO dict(list(zip, though this should be turned into a literal by pyupgrade
 
 
 for fp in sys.argv[1:]:

--- a/joshware3.py
+++ b/joshware3.py
@@ -1,0 +1,76 @@
+import gc
+import os
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import libcst as cst
+from libcst import Arg, Attribute, Call, CSTTransformer, Name, SimpleString
+
+gc.disable()
+
+
+def without_nested_list(node):
+    nested = node.args[0].value
+
+    if getattr(nested, "func", None) is None:
+        return node
+
+    if nested.func.value != "list":
+        return node
+
+    if len(nested.args) != 1:
+        return node
+
+    nested_nested = nested.args[0].value
+
+    if nested_nested.func.value not in ("map", "filter", "list", "sorted"):
+        return node
+
+    # nodes are frozen dataclasses.
+    updated_node = replace(node, args=[replace(node.args[0], value=nested_nested)])
+    return updated_node
+
+
+LIST_WRAPPED_ARG_NOT_NECESSARY_FOR = {
+    "set",
+    "frozenset",
+    "sum",
+    "list",
+    "tuple",
+    "sorted",
+    "all",
+    "any",
+}
+
+
+class GoodTransformer(CSTTransformer):
+    def leave_Call(self, _, node):
+        if isinstance(node.func, Name):
+            if not (node.func.value in LIST_WRAPPED_ARG_NOT_NECESSARY_FOR and len(node.args) == 1):
+                return node
+
+            return without_nested_list(node)
+
+        elif isinstance(node.func, Attribute):
+            # str.join(list(map|filter|list)) -> str.join(map|filter|list)
+            if not (
+                isinstance(node.func.value, SimpleString)
+                and node.func.attr.value == "join"
+                and len(node.args) == 1
+            ):
+                return node
+
+            return without_nested_list(node)
+
+        # TODO: for x in list(map|filter|list)
+
+        # TODO  for x, y in list(zip)
+
+        return node
+
+
+for fp in sys.argv[1:]:
+    print(fp)
+    m = cst.parse_module(Path(fp).read_text())
+    Path(fp).write_text(m.visit(GoodTransformer()).code)

--- a/joshware3.py
+++ b/joshware3.py
@@ -59,6 +59,8 @@ LIST_WRAPPED_ARG_NOT_NECESSARY_FOR = {
     "sorted",
     "all",
     "any",
+    "min",
+    "max",
 }
 
 

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -1,5 +1,3 @@
-from sentry.utils.compat import map
-
 __all__ = ("Attribute", "Event", "Map")
 
 from base64 import b64encode
@@ -59,7 +57,9 @@ class Map(Attribute):
             data[attr.name] = attr.extract(nv)
 
         if items:
-            raise ValueError("Unknown attributes: {}".format(", ".join(map(str, items.keys()))))
+            raise ValueError(
+                "Unknown attributes: {}".format(", ".join(list(map(str, items.keys()))))
+            )
 
         return data
 

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -57,9 +57,7 @@ class Map(Attribute):
             data[attr.name] = attr.extract(nv)
 
         if items:
-            raise ValueError(
-                "Unknown attributes: {}".format(", ".join(list(map(str, items.keys()))))
-            )
+            raise ValueError("Unknown attributes: {}".format(", ".join(map(str, items.keys()))))
 
         return data
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -22,7 +22,6 @@ from sentry.models import (
     ReleaseProject,
 )
 from sentry.utils import auth
-from sentry.utils.compat import map
 from sentry.utils.hashlib import hash_values
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.sdk import bind_organization_context
@@ -166,7 +165,7 @@ class OrganizationEndpoint(Endpoint):
         permission checking, use ``get_projects``, instead.
         """
         try:
-            return set(map(int, request.GET.getlist("project")))
+            return set(list(map(int, request.GET.getlist("project"))))
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -165,7 +165,7 @@ class OrganizationEndpoint(Endpoint):
         permission checking, use ``get_projects``, instead.
         """
         try:
-            return set(list(map(int, request.GET.getlist("project"))))
+            return set(map(int, request.GET.getlist("project")))
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
 

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -10,7 +10,6 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.assistant import manager
 from sentry.models import AssistantActivity
-from sentry.utils.compat import zip
 
 VALID_STATUSES = frozenset(("viewed", "dismissed"))
 
@@ -18,7 +17,7 @@ VALID_STATUSES = frozenset(("viewed", "dismissed"))
 class AssistantSerializer(serializers.Serializer):
     guide = serializers.CharField(required=False)
     guide_id = serializers.IntegerField(required=False)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES))
+    status = serializers.ChoiceField(choices=list(zip(VALID_STATUSES, VALID_STATUSES)))
     useful = serializers.BooleanField(required=False)
 
     def validate_guide_id(self, value):

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -11,7 +11,6 @@ from rest_framework.response import Response
 from sentry import options
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.models import FileBlob
-from sentry.utils.compat import zip
 from sentry.utils.files import get_max_file_size
 
 MAX_CHUNKS_PER_REQUEST = 64
@@ -115,7 +114,9 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             return Response({"error": "Too many chunks"}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            FileBlob.from_files(zip(files, checksums), organization=organization, logger=logger)
+            FileBlob.from_files(
+                list(zip(files, checksums)), organization=organization, logger=logger
+            )
         except OSError as err:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -114,9 +114,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             return Response({"error": "Too many chunks"}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            FileBlob.from_files(
-                list(zip(files, checksums)), organization=organization, logger=logger
-            )
+            FileBlob.from_files(zip(files, checksums), organization=organization, logger=logger)
         except OSError as err:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -53,7 +53,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
 
         # We need to preserve the ordering of the Redis results, as that
         # ordering is directly shown in the UI
-        for group_id, scores in list(zip(group_ids, group_scores)):
+        for group_id, scores in zip(group_ids, group_scores):
             group = serialized_groups.get(group_id)
             if group is None:
                 # TODO(tkaemming): This should log when we filter out a group that is

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -7,7 +7,6 @@ from sentry import similarity
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Group
-from sentry.utils.compat import zip
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +53,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
 
         # We need to preserve the ordering of the Redis results, as that
         # ordering is directly shown in the UI
-        for group_id, scores in zip(group_ids, group_scores):
+        for group_id, scores in list(zip(group_ids, group_scores)):
             group = serialized_groups.get(group_id)
             if group is None:
                 # TODO(tkaemming): This should log when we filter out a group that is

--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -6,7 +6,6 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationInte
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.models import OrganizationIntegration, Project, Repository, RepositoryProjectPathConfig
-from sentry.utils.compat import map
 
 
 def gen_path_regex_field():
@@ -154,7 +153,7 @@ class OrganizationCodeMappingsEndpoint(OrganizationEndpoint, NullableOrganizatio
 
         # front end handles ordering
         # TODO: Add pagination
-        data = map(lambda x: serialize(x, request.user), queryset)
+        data = list(map(lambda x: serialize(x, request.user), queryset))
         return self.respond(data)
 
     def post(self, request, organization):

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 from sentry import features, integrations
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import IntegrationProviderSerializer, serialize
-from sentry.utils.compat import filter
 
 
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
@@ -15,7 +14,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
             feature_flag_name = "organizations:integrations-%s" % provider_key
             return features.has(feature_flag_name, organization, actor=request.user)
 
-        providers = filter(is_provider_enabled, list(integrations.all()))
+        providers = list(filter(is_provider_enabled, list(integrations.all())))
 
         providers.sort(key=lambda i: i.key)
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -283,7 +283,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         # If group ids specified, just ignore any query components
         try:
-            group_ids = set(list(map(int, request.GET.getlist("group"))))
+            group_ids = set(map(int, request.GET.getlist("group")))
         except ValueError:
             return Response({"detail": "Group ids must be integers"}, status=400)
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -38,7 +38,6 @@ from sentry.search.events.constants import EQUALITY_OPERATORS
 from sentry.search.snuba.backend import assigned_or_suggested_filter
 from sentry.search.snuba.executors import get_search_filter
 from sentry.snuba import discover
-from sentry.utils.compat import map
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.validators import normalize_event_id
 
@@ -284,7 +283,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         # If group ids specified, just ignore any query components
         try:
-            group_ids = set(map(int, request.GET.getlist("group")))
+            group_ids = set(list(map(int, request.GET.getlist("group"))))
         except ValueError:
             return Response({"detail": "Group ids must be integers"}, status=400)
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -59,7 +59,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
         project_ids = [p.id for p in projects]
 
         try:
-            group_ids = set(list(map(int, request.GET.getlist("groups"))))
+            group_ids = set(map(int, request.GET.getlist("groups")))
         except ValueError:
             raise ParseError(detail="Group ids must be integers")
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -12,7 +12,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.models import Group
-from sentry.utils.compat import map
 
 
 class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
@@ -60,7 +59,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
         project_ids = [p.id for p in projects]
 
         try:
-            group_ids = set(map(int, request.GET.getlist("groups")))
+            group_ids = set(list(map(int, request.GET.getlist("groups"))))
         except ValueError:
             raise ParseError(detail="Group ids must be integers")
 

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -3,7 +3,6 @@ from django.db import connections
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Commit, Repository, UserEmail
-from sentry.utils.compat import zip
 
 # TODO(dcramer): once LatestRepoReleaseEnvironment is backfilled, change this query to use the new
 # schema [performance]
@@ -71,7 +70,7 @@ class OrganizationMemberUnreleasedCommitsEndpoint(OrganizationMemberEndpoint):
                     for c in results
                 ],
                 "repositories": {
-                    str(r.id): d for r, d in zip(repos, serialize(repos, request.user))
+                    str(r.id): d for r, d in list(zip(repos, serialize(repos, request.user)))
                 },
             }
         )

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -70,7 +70,7 @@ class OrganizationMemberUnreleasedCommitsEndpoint(OrganizationMemberEndpoint):
                     for c in results
                 ],
                 "repositories": {
-                    str(r.id): d for r, d in list(zip(repos, serialize(repos, request.user)))
+                    str(r.id): d for r, d in zip(repos, serialize(repos, request.user))
                 },
             }
         )

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
-from sentry.utils.compat import map
 
 
 class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
@@ -24,7 +23,7 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :auth: required
         """
         is_member = request.GET.get("is_member")
-        project_ids = set(map(int, request.GET.getlist("project")))
+        project_ids = set(list(map(int, request.GET.getlist("project"))))
         queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
         if is_member:
             queryset = queryset.filter(teams__organizationmember__user=request.user)

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -23,7 +23,7 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :auth: required
         """
         is_member = request.GET.get("is_member")
-        project_ids = set(list(map(int, request.GET.getlist("project"))))
+        project_ids = set(map(int, request.GET.getlist("project")))
         queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
         if is_member:
             queryset = queryset.filter(teams__organizationmember__user=request.user)

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -46,7 +46,6 @@ from sentry.snuba.sessions import (
     get_project_releases_by_stability,
 )
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip as izip
 from sentry.utils.sdk import bind_organization_context, configure_scope
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
@@ -146,7 +145,7 @@ def debounce_update_release_health_data(organization, project_ids):
     should_update = {}
     cache_keys = ["debounce-health:%d" % id for id in project_ids]
     cache_data = cache.get_many(cache_keys)
-    for project_id, cache_key in izip(project_ids, cache_keys):
+    for project_id, cache_key in list(zip(project_ids, cache_keys)):
         if cache_data.get(cache_key) is None:
             should_update[project_id] = cache_key
 
@@ -195,7 +194,7 @@ def debounce_update_release_health_data(organization, project_ids):
         release.add_project(project)
 
     # Debounce updates for a minute
-    cache.set_many(dict(izip(should_update.values(), [True] * len(should_update))), 60)
+    cache.set_many(dict(list(zip(should_update.values(), [True] * len(should_update)))), 60)
 
 
 class OrganizationReleasesEndpoint(

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -145,7 +145,7 @@ def debounce_update_release_health_data(organization, project_ids):
     should_update = {}
     cache_keys = ["debounce-health:%d" % id for id in project_ids]
     cache_data = cache.get_many(cache_keys)
-    for project_id, cache_key in list(zip(project_ids, cache_keys)):
+    for project_id, cache_key in zip(project_ids, cache_keys):
         if cache_data.get(cache_key) is None:
             should_update[project_id] = cache_key
 

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -5,7 +5,6 @@ from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import Environment, Project, Team
-from sentry.utils.compat import map
 
 
 class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMixin):
@@ -51,7 +50,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
             raise ValueError("Invalid group: %s" % group)
 
         if "id" in request.GET:
-            id_filter_set = frozenset(map(int, request.GET.getlist("id")))
+            id_filter_set = frozenset(list(map(int, request.GET.getlist("id"))))
             keys = [k for k in keys if k in id_filter_set]
 
         if not keys:

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -50,7 +50,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
             raise ValueError("Invalid group: %s" % group)
 
         if "id" in request.GET:
-            id_filter_set = frozenset(list(map(int, request.GET.getlist("id"))))
+            id_filter_set = frozenset(map(int, request.GET.getlist("id")))
             keys = [k for k in keys if k in id_filter_set]
 
         if not keys:

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -357,7 +357,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
-        include = set(list(filter(bool, request.GET.get("include", "").split(","))))
+        include = set(filter(bool, request.GET.get("include", "").split(",")))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}
 

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -42,7 +42,6 @@ from sentry.notifications.utils.legacy_mappings import get_option_value_from_boo
 from sentry.tasks.deletion import delete_project
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
-from sentry.utils.compat import filter
 
 delete_logger = logging.getLogger("sentry.deletions.api")
 
@@ -178,7 +177,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         return data
 
     def validate_allowedDomains(self, value):
-        value = filter(bool, value)
+        value = list(filter(bool, value))
         if len(value) == 0:
             raise serializers.ValidationError(
                 "Empty value will block all requests, use * to accept from all domains"
@@ -358,7 +357,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
-        include = set(filter(bool, request.GET.get("include", "").split(",")))
+        include = set(list(filter(bool, request.GET.get("include", "").split(","))))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}
 

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -5,7 +5,6 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations import IntegrationFeatures
 from sentry.models import Integration, Repository
-from sentry.utils.compat import filter, map
 
 
 def find_roots(stack_path, source_path):
@@ -41,10 +40,13 @@ class PathMappingSerializer(CamelSnakeSerializer):
 
     @property
     def providers(self):
-        providers = filter(
-            lambda x: x.has_feature(IntegrationFeatures.STACKTRACE_LINK), list(integrations.all())
+        providers = list(
+            filter(
+                lambda x: x.has_feature(IntegrationFeatures.STACKTRACE_LINK),
+                list(integrations.all()),
+            )
         )
-        return map(lambda x: x.key, providers)
+        return list(map(lambda x: x.key, providers))
 
     @property
     def org_id(self):
@@ -72,7 +74,7 @@ class PathMappingSerializer(CamelSnakeSerializer):
             organizations=self.org_id, provider__in=self.providers
         )
 
-        matching_integrations = filter(integration_match, integrations)
+        matching_integrations = list(filter(integration_match, integrations))
         if not matching_integrations:
             raise serializers.ValidationError("Could not find integration")
 
@@ -80,7 +82,7 @@ class PathMappingSerializer(CamelSnakeSerializer):
 
         # now find the matching repo
         repos = Repository.objects.filter(integration_id=self.integration.id)
-        matching_repos = filter(repo_match, repos)
+        matching_repos = list(filter(repo_match, repos))
         if not matching_repos:
             raise serializers.ValidationError("Could not find repo")
 

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -50,8 +50,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # no longer feature gated and is added as an IntegrationFeature
         result["integrations"] = [
             serialize(i, request.user)
-            for i in list(
-                filter(lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations)
+            for i in filter(
+                lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations
             )
         ]
 

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -6,7 +6,6 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.integrations import IntegrationFeatures
 from sentry.models import Integration, RepositoryProjectPathConfig
-from sentry.utils.compat import filter
 
 
 def get_link(config, filepath, default, version=None):
@@ -51,8 +50,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # no longer feature gated and is added as an IntegrationFeature
         result["integrations"] = [
             serialize(i, request.user)
-            for i in filter(
-                lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations
+            for i in list(
+                filter(lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations)
             )
         ]
 

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -9,7 +9,6 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.models import Organization, Project, PromptsActivity
-from sentry.utils.compat import zip
 from sentry.utils.prompts import prompt_config
 
 VALID_STATUSES = frozenset(("snoozed", "dismissed"))
@@ -17,7 +16,9 @@ VALID_STATUSES = frozenset(("snoozed", "dismissed"))
 
 class PromptsActivitySerializer(serializers.Serializer):
     feature = serializers.CharField(required=True)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES), required=True)
+    status = serializers.ChoiceField(
+        choices=list(zip(VALID_STATUSES, VALID_STATUSES)), required=True
+    )
 
     def validate_feature(self, value):
         if value is None:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -29,7 +29,6 @@ from sentry.search.utils import (
     parse_numeric_value,
     parse_percentage,
 )
-from sentry.utils.compat import filter, map
 from sentry.utils.snuba import is_duration_measurement, is_measurement, is_span_op_breakdown
 from sentry.utils.validators import is_event_id
 
@@ -247,14 +246,14 @@ def remove_optional_nodes(children):
     def is_not_optional(child):
         return not (isinstance(child, Node) and isinstance(child.expr, Optional))
 
-    return filter(is_not_optional, children)
+    return list(filter(is_not_optional, children))
 
 
 def remove_space(children):
     def is_not_space(text):
         return not (isinstance(text, str) and text == " " * len(text))
 
-    return filter(is_not_space, children)
+    return list(filter(is_not_space, children))
 
 
 def process_list(first, remaining):
@@ -264,7 +263,7 @@ def process_list(first, remaining):
 
     return [
         first,
-        *[item[4][0] for item in remaining],
+        *(item[4][0] for item in remaining),
     ]
 
 
@@ -353,7 +352,7 @@ class SearchFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
+        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
 
     @property
     def is_negation(self) -> bool:
@@ -380,7 +379,7 @@ class AggregateFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
+        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
 
 
 class AggregateKey(NamedTuple):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -352,7 +352,7 @@ class SearchFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
+        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
 
     @property
     def is_negation(self) -> bool:
@@ -379,7 +379,7 @@ class AggregateFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
+        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
 
 
 class AggregateKey(NamedTuple):

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -65,7 +65,6 @@ from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_groups
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry
-from sentry.utils.compat import zip
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.functional import extract_lazy_object
 from sentry.utils.hashlib import md5_text
@@ -248,7 +247,7 @@ class GroupValidator(serializers.Serializer):
     inbox = serializers.BooleanField()
     inboxDetails = InboxDetailsValidator()
     status = serializers.ChoiceField(
-        choices=zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys())
+        choices=list(zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys()))
     )
     statusDetails = StatusDetailsValidator()
     hasSeen = serializers.BooleanField()
@@ -1228,5 +1227,5 @@ def get_first_last_release_info(request, group, versions):
     # Default to a dictionary if the release object wasn't found and not serialized
     return [
         item if item is not None else {"version": version}
-        for item, version in zip(serialized_releases, versions)
+        for item, version in list(zip(serialized_releases, versions))
     ]

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -1227,5 +1227,5 @@ def get_first_last_release_info(request, group, versions):
     # Default to a dictionary if the release object wasn't found and not serialized
     return [
         item if item is not None else {"version": version}
-        for item, version in list(zip(serialized_releases, versions))
+        for item, version in zip(serialized_releases, versions)
     ]

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -13,7 +13,6 @@ from sentry.search.utils import (
     parse_status_value,
     parse_user_value,
 )
-from sentry.utils.compat import map
 
 is_filter_translation = {
     "assigned": ("unassigned", False),
@@ -129,4 +128,4 @@ def convert_query_values(search_filters, projects, user, environments):
             )
         return search_filter
 
-    return map(convert_search_filter, search_filters)
+    return list(map(convert_search_filter, search_filters))

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -361,7 +361,7 @@ def reverse_bisect_left(a, x, lo=0, hi=None):
 class SequencePaginator:
     def __init__(self, data, reverse=False, max_limit=MAX_LIMIT, on_results=None):
         self.scores, self.values = (
-            list(map(list, list(zip(*sorted(data, reverse=reverse))))) if data else ([], [])
+            map(list, zip(*sorted(data, reverse=reverse))) if data else ([], [])
         )
         self.reverse = reverse
         self.search = functools.partial(

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -9,7 +9,6 @@ from django.db.models.functions import Lower
 from django.db.models.sql.datastructures import EmptyResultSet
 from django.utils import timezone
 
-from sentry.utils.compat import map, zip
 from sentry.utils.cursors import Cursor, CursorResult, build_cursor
 
 quote_name = connections["default"].ops.quote_name
@@ -362,7 +361,7 @@ def reverse_bisect_left(a, x, lo=0, hi=None):
 class SequencePaginator:
     def __init__(self, data, reverse=False, max_limit=MAX_LIMIT, on_results=None):
         self.scores, self.values = (
-            map(list, zip(*sorted(data, reverse=reverse))) if data else ([], [])
+            list(map(list, list(zip(*sorted(data, reverse=reverse))))) if data else ([], [])
         )
         self.reverse = reverse
         self.search = functools.partial(

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -2,7 +2,6 @@ import functools
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Activity, Commit, Group, PullRequest
-from sentry.utils.compat import zip
 from sentry.utils.functional import apply_values
 
 
@@ -20,7 +19,9 @@ class ActivitySerializer(Serializer):
         }
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids))
-            commits_by_id = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
+            commits_by_id = {
+                c.id: d for c, d in list(zip(commit_list, serialize(commit_list, user)))
+            }
             commits = {
                 i: commits_by_id.get(i.data["commit"])
                 for i in item_list
@@ -37,7 +38,7 @@ class ActivitySerializer(Serializer):
         if pull_request_ids:
             pull_request_list = list(PullRequest.objects.filter(id__in=pull_request_ids))
             pull_requests_by_id = {
-                c.id: d for c, d in zip(pull_request_list, serialize(pull_request_list, user))
+                c.id: d for c, d in list(zip(pull_request_list, serialize(pull_request_list, user)))
             }
             pull_requests = {
                 i: pull_requests_by_id.get(i.data["pull_request"])

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -19,9 +19,7 @@ class ActivitySerializer(Serializer):
         }
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids))
-            commits_by_id = {
-                c.id: d for c, d in list(zip(commit_list, serialize(commit_list, user)))
-            }
+            commits_by_id = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
             commits = {
                 i: commits_by_id.get(i.data["commit"])
                 for i in item_list
@@ -38,7 +36,7 @@ class ActivitySerializer(Serializer):
         if pull_request_ids:
             pull_request_list = list(PullRequest.objects.filter(id__in=pull_request_ids))
             pull_requests_by_id = {
-                c.id: d for c, d in list(zip(pull_request_list, serialize(pull_request_list, user)))
+                c.id: d for c, d in zip(pull_request_list, serialize(pull_request_list, user))
             }
             pull_requests = {
                 i: pull_requests_by_id.get(i.data["pull_request"])

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -28,7 +28,7 @@ class AlertRuleSerializer(Serializer):
         result = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
         serialized_triggers = serialize(list(triggers))
-        for trigger, serialized in list(zip(triggers, serialized_triggers)):
+        for trigger, serialized in zip(triggers, serialized_triggers):
             alert_rule_triggers = result[alert_rules[trigger.alert_rule_id]].setdefault(
                 "triggers", []
             )

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -14,7 +14,6 @@ from sentry.incidents.models import (
 )
 from sentry.models import ACTOR_TYPES, Rule, actor_type_to_class, actor_type_to_string
 from sentry.snuba.models import SnubaQueryEventType
-from sentry.utils.compat import zip
 
 
 @register(AlertRule)
@@ -29,7 +28,7 @@ class AlertRuleSerializer(Serializer):
         result = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
         serialized_triggers = serialize(list(triggers))
-        for trigger, serialized in zip(triggers, serialized_triggers):
+        for trigger, serialized in list(zip(triggers, serialized_triggers)):
             alert_rule_triggers = result[alert_rules[trigger.alert_rule_id]].setdefault(
                 "triggers", []
             )

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -8,7 +8,6 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,
 )
-from sentry.utils.compat import zip
 
 
 @register(AlertRuleTrigger)
@@ -23,7 +22,7 @@ class AlertRuleTriggerSerializer(Serializer):
             "id"
         )
         serialized_actions = serialize(list(actions))
-        for trigger, serialized in zip(actions, serialized_actions):
+        for trigger, serialized in list(zip(actions, serialized_actions)):
             triggers_actions = result[triggers[trigger.alert_rule_trigger_id]].setdefault(
                 "actions", []
             )

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -22,7 +22,7 @@ class AlertRuleTriggerSerializer(Serializer):
             "id"
         )
         serialized_actions = serialize(list(actions))
-        for trigger, serialized in list(zip(actions, serialized_actions)):
+        for trigger, serialized in zip(actions, serialized_actions):
             triggers_actions = result[triggers[trigger.alert_rule_trigger_id]].setdefault(
                 "actions", []
             )

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -8,7 +8,6 @@ from sentry.eventstore.models import Event
 from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.sdk_updates import SdkSetupState, get_suggested_updates
 from sentry.search.utils import convert_user_tag_to_query
-from sentry.utils.compat import zip
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 
@@ -172,7 +171,7 @@ class EventSerializer(Serializer):
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized
-            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
+            for file, serialized in list(zip(crash_files, serialize(crash_files, user=user)))
         }
         results = {}
         for item in item_list:
@@ -351,7 +350,7 @@ class SimpleEventSerializer(EventSerializer):
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized
-            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
+            for file, serialized in list(zip(crash_files, serialize(crash_files, user=user)))
         }
         return {event: {"crash_file": serialized_files.get(event.event_id)} for event in item_list}
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -171,7 +171,7 @@ class EventSerializer(Serializer):
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized
-            for file, serialized in list(zip(crash_files, serialize(crash_files, user=user)))
+            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
         }
         results = {}
         for item in item_list:
@@ -350,7 +350,7 @@ class SimpleEventSerializer(EventSerializer):
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized
-            for file, serialized in list(zip(crash_files, serialize(crash_files, user=user)))
+            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
         }
         return {event: {"crash_file": serialized_files.get(event.event_id)} for event in item_list}
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -130,7 +130,7 @@ class GroupSerializerBase(Serializer):
             cache_keys.append("group-mechanism-handled:%d" % item.id)
 
         cache_data = cache.get_many(cache_keys)
-        for item, cache_key in list(zip(item_list, cache_keys)):
+        for item, cache_key in zip(item_list, cache_keys):
             unhandled[item.id] = cache_data.get(cache_key)
 
         filter_keys = {}

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -56,7 +56,6 @@ from sentry.tsdb.snuba import SnubaTSDB
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip
 from sentry.utils.safe import safe_execute
 from sentry.utils.snuba import Dataset, aliased_query, raw_query
 
@@ -131,7 +130,7 @@ class GroupSerializerBase(Serializer):
             cache_keys.append("group-mechanism-handled:%d" % item.id)
 
         cache_data = cache.get_many(cache_keys)
-        for item, cache_key in zip(item_list, cache_keys):
+        for item, cache_key in list(zip(item_list, cache_keys)):
             unhandled[item.id] = cache_data.get(cache_key)
 
         filter_keys = {}
@@ -278,7 +277,7 @@ class GroupSerializerBase(Serializer):
                 )
             )
             commit_resolutions = {
-                i.group_id: d for i, d in zip(commit_results, serialize(commit_results, user))
+                i.group_id: d for i, d in list(zip(commit_results, serialize(commit_results, user)))
             }
         else:
             release_resolutions = {}
@@ -288,7 +287,7 @@ class GroupSerializerBase(Serializer):
         actor_ids.update(r.actor_id for r in ignore_items.values())
         if actor_ids:
             users = list(User.objects.filter(id__in=actor_ids, is_active=True))
-            actors = {u.id: d for u, d in zip(users, serialize(users, user))}
+            actors = {u.id: d for u, d in list(zip(users, serialize(users, user)))}
         else:
             actors = {}
 
@@ -825,7 +824,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         )
         seen_data = {
             issue["group_id"]: fix_tag_value_data(
-                dict(filter(lambda key: key[0] != "group_id", issue.items()))
+                dict(list(filter(lambda key: key[0] != "group_id", issue.items())))
             )
             for issue in result["data"]
         }

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -277,7 +277,7 @@ class GroupSerializerBase(Serializer):
                 )
             )
             commit_resolutions = {
-                i.group_id: d for i, d in list(zip(commit_results, serialize(commit_results, user)))
+                i.group_id: d for i, d in zip(commit_results, serialize(commit_results, user))
             }
         else:
             release_resolutions = {}
@@ -287,7 +287,7 @@ class GroupSerializerBase(Serializer):
         actor_ids.update(r.actor_id for r in ignore_items.values())
         if actor_ids:
             users = list(User.objects.filter(id__in=actor_ids, is_active=True))
-            actors = {u.id: d for u, d in list(zip(users, serialize(users, user)))}
+            actors = {u.id: d for u, d in zip(users, serialize(users, user))}
         else:
             actors = {}
 

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -14,7 +14,7 @@ StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 class GroupReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user):
         release_list = list(Release.objects.filter(id__in=[i.release_id for i in item_list]))
-        releases = {r.id: d for r, d in list(zip(release_list, serialize(release_list, user)))}
+        releases = {r.id: d for r, d in zip(release_list, serialize(release_list, user))}
 
         result = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.app import tsdb
 from sentry.models import GroupRelease, Release
-from sentry.utils.compat import zip
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 
@@ -15,7 +14,7 @@ StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 class GroupReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user):
         release_list = list(Release.objects.filter(id__in=[i.release_id for i in item_list]))
-        releases = {r.id: d for r, d in zip(release_list, serialize(release_list, user))}
+        releases = {r.id: d for r, d in list(zip(release_list, serialize(release_list, user)))}
 
         result = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -7,7 +7,7 @@ from sentry.models import GroupTombstone, User
 class GroupTombstoneSerializer(Serializer):
     def get_attrs(self, item_list, user):
         user_list = list(User.objects.filter(id__in=[item.actor_id for item in item_list]))
-        users = {u.id: d for u, d in list(zip(user_list, serialize(user_list, user)))}
+        users = {u.id: d for u, d in zip(user_list, serialize(user_list, user))}
 
         attrs = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -1,14 +1,13 @@
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import LOG_LEVELS
 from sentry.models import GroupTombstone, User
-from sentry.utils.compat import zip
 
 
 @register(GroupTombstone)
 class GroupTombstoneSerializer(Serializer):
     def get_attrs(self, item_list, user):
         user_list = list(User.objects.filter(id__in=[item.actor_id for item in item_list]))
-        users = {u.id: d for u, d in zip(user_list, serialize(user_list, user))}
+        users = {u.id: d for u, d in list(zip(user_list, serialize(user_list, user)))}
 
         attrs = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -690,7 +690,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         latest_release_list = bulk_fetch_project_latest_releases(item_list)
         latest_releases = {
             r.actual_project_id: d
-            for r, d in list(zip(latest_release_list, serialize(latest_release_list, user)))
+            for r, d in zip(latest_release_list, serialize(latest_release_list, user))
         }
 
         for item in item_list:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -38,7 +38,6 @@ from sentry.notifications.types import NotificationSettingOptionValues, Notifica
 from sentry.snuba import discover
 from sentry.snuba.sessions import check_has_health_data, get_current_and_previous_crash_free_rates
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.compat import zip
 
 STATUS_LABELS = {
     ProjectStatus.VISIBLE: "active",
@@ -691,7 +690,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         latest_release_list = bulk_fetch_project_latest_releases(item_list)
         latest_releases = {
             r.actual_project_id: d
-            for r, d in zip(latest_release_list, serialize(latest_release_list, user))
+            for r, d in list(zip(latest_release_list, serialize(latest_release_list, user)))
         }
 
         for item in item_list:

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -158,7 +158,7 @@ class ReleaseSerializer(Serializer):
         commit_ids = {o.last_commit_id for o in item_list if o.last_commit_id}
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids).select_related("author"))
-            commits = {c.id: d for c, d in list(zip(commit_list, serialize(commit_list, user)))}
+            commits = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
         else:
             commits = {}
 
@@ -194,7 +194,7 @@ class ReleaseSerializer(Serializer):
         deploy_ids = {o.last_deploy_id for o in item_list if o.last_deploy_id}
         if deploy_ids:
             deploy_list = list(Deploy.objects.filter(id__in=deploy_ids))
-            deploys = {d.id: c for d, c in list(zip(deploy_list, serialize(deploy_list, user)))}
+            deploys = {d.id: c for d, c in zip(deploy_list, serialize(deploy_list, user))}
         else:
             deploys = {}
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -20,7 +20,6 @@ from sentry.models import (
 )
 from sentry.snuba.sessions import get_release_health_data_overview
 from sentry.utils import metrics
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import md5_text
 
 
@@ -159,7 +158,7 @@ class ReleaseSerializer(Serializer):
         commit_ids = {o.last_commit_id for o in item_list if o.last_commit_id}
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids).select_related("author"))
-            commits = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
+            commits = {c.id: d for c, d in list(zip(commit_list, serialize(commit_list, user)))}
         else:
             commits = {}
 
@@ -195,7 +194,7 @@ class ReleaseSerializer(Serializer):
         deploy_ids = {o.last_deploy_id for o in item_list if o.last_deploy_id}
         if deploy_ids:
             deploy_list = list(Deploy.objects.filter(id__in=deploy_ids))
-            deploys = {d.id: c for d, c in zip(deploy_list, serialize(deploy_list, user))}
+            deploys = {d.id: c for d, c in list(zip(deploy_list, serialize(deploy_list, user)))}
         else:
             deploys = {}
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -10,7 +10,6 @@ from sentry.models import (
     actor_type_to_class,
     actor_type_to_string,
 )
-from sentry.utils.compat import filter
 
 
 def _generate_rule_label(project, rule, data):
@@ -84,9 +83,9 @@ class RuleSerializer(Serializer):
             # as part of the rule editor
             "id": str(obj.id) if obj.id else None,
             # conditions pertain to criteria that can trigger an alert
-            "conditions": filter(lambda condition: not _is_filter(condition), all_conditions),
+            "conditions": list(filter(lambda condition: not _is_filter(condition), all_conditions)),
             # filters are not new conditions but are the subset of conditions that pertain to event attributes
-            "filters": filter(lambda condition: _is_filter(condition), all_conditions),
+            "filters": list(filter(lambda condition: _is_filter(condition), all_conditions)),
             "actions": [
                 dict(list(o.items()) + [("name", _generate_rule_label(obj.project, obj, o))])
                 for o in obj.data.get("actions", [])

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -4,7 +4,6 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.models import IntegrationFeature, SentryApp
 from sentry.models.sentryapp import MASKED_VALUE
-from sentry.utils.compat import map
 
 
 @register(SentryApp)
@@ -33,7 +32,7 @@ class SentryAppSerializer(Serializer):
 
         if obj.status != SentryAppStatus.INTERNAL:
             features = IntegrationFeature.objects.filter(sentry_app_id=obj.id)
-            data["featureData"] = map(lambda x: serialize(x, user), features)
+            data["featureData"] = list(map(lambda x: serialize(x, user), features))
 
         if obj.status == SentryAppStatus.PUBLISHED and obj.date_published:
             data.update({"datePublished": obj.date_published})

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -146,7 +146,7 @@ class TeamSerializer(Serializer):  # type: ignore
             projects = [pt.project for pt in project_teams]
 
             projects_by_id = {
-                project.id: data for project, data in list(zip(projects, serialize(projects, user)))
+                project.id: data for project, data in zip(projects, serialize(projects, user))
             }
 
             project_map = defaultdict(list)

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -29,7 +29,6 @@ from sentry.models import (
     User,
 )
 from sentry.scim.endpoints.constants import SCIM_SCHEMA_GROUP
-from sentry.utils.compat import zip
 from sentry.utils.json import JSONData
 from sentry.utils.query import RangeQuerySetWrapper
 
@@ -147,7 +146,7 @@ class TeamSerializer(Serializer):  # type: ignore
             projects = [pt.project for pt in project_teams]
 
             projects_by_id = {
-                project.id: data for project, data in zip(projects, serialize(projects, user))
+                project.id: data for project, data in list(zip(projects, serialize(projects, user)))
             }
 
             project_map = defaultdict(list)

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -11,7 +11,7 @@ class UserReportSerializer(Serializer):
         # for event_user_id to be None.
         if event_user_ids:
             queryset = list(EventUser.objects.filter(id__in=event_user_ids))
-            event_users = {e.id: d for e, d in list(zip(queryset, serialize(queryset, user)))}
+            event_users = {e.id: d for e, d in zip(queryset, serialize(queryset, user))}
         else:
             event_users = {}
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -1,6 +1,5 @@
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import EventUser, Group, UserReport
-from sentry.utils.compat import zip
 
 
 @register(UserReport)
@@ -12,7 +11,7 @@ class UserReportSerializer(Serializer):
         # for event_user_id to be None.
         if event_user_ids:
             queryset = list(EventUser.objects.filter(id__in=event_user_ids))
-            event_users = {e.id: d for e, d in zip(queryset, serialize(queryset, user))}
+            event_users = {e.id: d for e, d in list(zip(queryset, serialize(queryset, user)))}
         else:
             event_users = {}
 

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.models import MonitorStatus, MonitorType, ScheduleType
-from sentry.utils.compat import zip
 
 SCHEDULE_TYPES = OrderedDict(
     [("crontab", ScheduleType.CRONTAB), ("interval", ScheduleType.INTERVAL)]
@@ -39,7 +38,7 @@ class ObjectField(serializers.Field):
 
 class CronJobValidator(serializers.Serializer):
     schedule_type = serializers.ChoiceField(
-        choices=zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys())
+        choices=list(zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys()))
     )
     schedule = ObjectField()
     checkin_margin = EmptyIntegerField(required=False, default=None)
@@ -86,9 +85,9 @@ class MonitorValidator(serializers.Serializer):
     project = ProjectField()
     name = serializers.CharField()
     status = serializers.ChoiceField(
-        choices=zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys()), default="active"
+        choices=list(zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys())), default="active"
     )
-    type = serializers.ChoiceField(choices=zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys()))
+    type = serializers.ChoiceField(choices=list(zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys())))
     config = ObjectField()
 
     def validate(self, attrs):

--- a/src/sentry/auth/providers/google/views.py
+++ b/src/sentry/auth/providers/google/views.py
@@ -2,7 +2,6 @@ import logging
 
 from sentry.auth.view import AuthView, ConfigureView
 from sentry.utils import json
-from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
 
 from .constants import DOMAIN_BLOCKLIST, ERR_INVALID_DOMAIN, ERR_INVALID_RESPONSE
@@ -26,7 +25,7 @@ class FetchUser(AuthView):
             return helper.error(ERR_INVALID_RESPONSE)
 
         try:
-            _, payload, _ = map(urlsafe_b64decode, id_token.split(".", 2))
+            _, payload, _ = list(map(urlsafe_b64decode, id_token.split(".", 2)))
         except Exception as exc:
             logger.error("Unable to decode id_token: %s" % exc, exc_info=True)
             return helper.error(ERR_INVALID_RESPONSE)

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -14,7 +14,6 @@ from sentry.models import Environment
 from sentry.search.events.fields import resolve_field_list
 from sentry.search.events.filter import get_filter
 from sentry.utils import metrics
-from sentry.utils.compat import map
 from sentry.utils.snuba import MAX_FIELDS
 
 from ..base import ExportQueryType
@@ -38,7 +37,7 @@ class DataExportQuerySerializer(serializers.Serializer):
             get_projects_by_id = self.context["get_projects_by_id"]
             # Coerce the query into a set
             if isinstance(project_query, list):
-                projects = get_projects_by_id(set(map(int, project_query)))
+                projects = get_projects_by_id(set(list(map(int, project_query))))
             else:
                 projects = get_projects_by_id({int(project_query)})
             query_info["project"] = [project.id for project in projects]

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -37,7 +37,7 @@ class DataExportQuerySerializer(serializers.Serializer):
             get_projects_by_id = self.context["get_projects_by_id"]
             # Coerce the query into a set
             if isinstance(project_query, list):
-                projects = get_projects_by_id(set(list(map(int, project_query))))
+                projects = get_projects_by_id(set(map(int, project_query)))
             else:
                 projects = get_projects_by_id({int(project_query)})
             query_info["project"] = [project.id for project in projects]

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -7,7 +7,6 @@ from sentry.api.bases.organization import OrganizationDataExportPermission, Orga
 from sentry.api.serializers import serialize
 from sentry.models import Project
 from sentry.utils import metrics
-from sentry.utils.compat import map
 
 from ..models import ExportedData
 
@@ -28,7 +27,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
             # Check data export permissions
             if data_export.query_info.get("project"):
-                project_ids = map(int, data_export.query_info.get("project", []))
+                project_ids = list(map(int, data_export.query_info.get("project", [])))
                 projects = Project.objects.filter(organization=organization, id__in=project_ids)
                 if any(p for p in projects if not request.access.has_project_access(p)):
                     raise PermissionDenied(

--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -4,7 +4,6 @@ from sentry.api.utils import get_date_range_from_params
 from sentry.models import Environment, Group, Project
 from sentry.search.events.fields import get_function_alias
 from sentry.snuba import discover
-from sentry.utils.compat import map
 
 from ..base import ExportError
 
@@ -33,7 +32,7 @@ class DiscoverProcessor:
 
         equations = discover_query.get("equations", [])
         self.header_fields = (
-            map(lambda x: get_function_alias(x), discover_query["field"]) + equations
+            list(map(lambda x: get_function_alias(x), discover_query["field"])) + equations
         )
         self.equation_aliases = {
             f"equation[{index}]": equation for index, equation in enumerate(equations)

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -5,8 +5,6 @@ from uuid import uuid4
 from django.db import connections, router
 from django.utils import timezone
 
-from sentry.utils.compat import zip
-
 
 class BulkDeleteQuery:
     def __init__(self, model, project_id=None, dtfield=None, days=None, order_by=None):
@@ -109,7 +107,7 @@ class BulkDeleteQuery:
                         if position is not None:
                             where.append((f"{quote_name(order_field)} >= %s", [position]))
 
-                    conditions, parameters = zip(*where)
+                    conditions, parameters = list(zip(*where))
                     parameters = list(itertools.chain.from_iterable(parameters))
 
                     query = """

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -4,7 +4,6 @@ from django.db import models
 
 from sentry.db.models.utils import Creator
 from sentry.utils import json
-from sentry.utils.compat import map
 
 
 # Adapted from django-pgfields
@@ -60,4 +59,4 @@ class ArrayField(models.Field):
                 # This is to accomodate the erronous exports pre 21.4.0
                 # See getsentry/sentry#23843 for more details
                 value = ast.literal_eval(value)
-        return map(self.of.to_python, value)
+        return list(map(self.of.to_python, value))

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -345,7 +345,7 @@ class BaseManager(Manager, Generic[M]):  # type: ignore
         nested_lookup_cache_keys = []
         nested_lookup_values = []
 
-        for cache_key, value in list(zip(cache_lookup_cache_keys, cache_lookup_values)):
+        for cache_key, value in zip(cache_lookup_cache_keys, cache_lookup_values):
             cache_result = cache_results.get(cache_key)
             if cache_result is None:
                 db_lookup_cache_keys.append(cache_key)
@@ -391,7 +391,7 @@ class BaseManager(Manager, Generic[M]):  # type: ignore
         cache_writes = []
 
         db_results = {getattr(x, key): x for x in self.filter(**{key + "__in": db_lookup_values})}
-        for cache_key, value in list(zip(db_lookup_cache_keys, db_lookup_values)):
+        for cache_key, value in zip(db_lookup_cache_keys, db_lookup_values):
             db_result = db_results.get(value)
             if db_result is None:
                 continue  # This model ultimately does not exist

--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -14,7 +14,6 @@ from sentry.db.models.manager import M, make_key
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.models.query import create_or_update
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger("sentry")
@@ -346,7 +345,7 @@ class BaseManager(Manager, Generic[M]):  # type: ignore
         nested_lookup_cache_keys = []
         nested_lookup_values = []
 
-        for cache_key, value in zip(cache_lookup_cache_keys, cache_lookup_values):
+        for cache_key, value in list(zip(cache_lookup_cache_keys, cache_lookup_values)):
             cache_result = cache_results.get(cache_key)
             if cache_result is None:
                 db_lookup_cache_keys.append(cache_key)
@@ -392,7 +391,7 @@ class BaseManager(Manager, Generic[M]):  # type: ignore
         cache_writes = []
 
         db_results = {getattr(x, key): x for x in self.filter(**{key + "__in": db_lookup_values})}
-        for cache_key, value in zip(db_lookup_cache_keys, db_lookup_values):
+        for cache_key, value in list(zip(db_lookup_cache_keys, db_lookup_values)):
             db_result = db_results.get(value)
             if db_result is None:
                 continue  # This model ultimately does not exist

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -40,7 +40,7 @@ def get_package_version(module_name, app):
         return None
 
     if isinstance(version, (list, tuple)):
-        version = ".".join(list(map(str, version)))
+        version = ".".join(map(str, version))
 
     return str(version)
 

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -1,7 +1,5 @@
 import sys
 
-from sentry.utils.compat import map
-
 try:
     import pkg_resources
 except ImportError:
@@ -42,7 +40,7 @@ def get_package_version(module_name, app):
         return None
 
     if isinstance(version, (list, tuple)):
-        version = ".".join(map(str, version))
+        version = ".".join(list(map(str, version)))
 
     return str(version)
 

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -6,7 +6,6 @@ from redis.client import ResponseError
 
 from sentry.digests import Record, ScheduleEntry
 from sentry.digests.backends.base import Backend, InvalidState
-from sentry.utils.compat import map
 from sentry.utils.locking.backends.redis import RedisLockBackend
 from sentry.utils.locking.manager import LockManager
 from sentry.utils.redis import check_cluster_versions, get_cluster_from_options, load_script
@@ -202,15 +201,17 @@ class RedisBackend(Backend):
                 else:
                     raise
 
-            records = map(
-                lambda key__value__timestamp: Record(
-                    key__value__timestamp[0].decode("utf-8"),
-                    self.codec.decode(key__value__timestamp[1])
-                    if key__value__timestamp[1] is not None
-                    else None,
-                    float(key__value__timestamp[2]),
-                ),
-                response,
+            records = list(
+                map(
+                    lambda key__value__timestamp: Record(
+                        key__value__timestamp[0].decode("utf-8"),
+                        self.codec.decode(key__value__timestamp[1])
+                        if key__value__timestamp[1] is not None
+                        else None,
+                        float(key__value__timestamp[2]),
+                    ),
+                    response,
+                )
             )
 
             # If the record value is `None`, this means the record data was

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -109,7 +109,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
         logger.info("discover1.request", extra={"organization_id": organization.id})
 
         try:
-            requested_projects = set(list(map(int, request.data.get("projects", []))))
+            requested_projects = set(map(int, request.data.get("projects", [])))
         except (ValueError, TypeError):
             raise ResourceDoesNotExist()
         projects = self._get_projects_by_id(requested_projects, request, organization)

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -11,7 +11,6 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.utils import transform_aliases_and_query
 from sentry.utils import snuba
-from sentry.utils.compat import map
 
 from .serializers import DiscoverQuerySerializer
 
@@ -110,7 +109,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
         logger.info("discover1.request", extra={"organization_id": organization.id})
 
         try:
-            requested_projects = set(map(int, request.data.get("projects", [])))
+            requested_projects = set(list(map(int, request.data.get("projects", []))))
         except (ValueError, TypeError):
             raise ResourceDoesNotExist()
         projects = self._get_projects_by_id(requested_projects, request, organization)

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -125,7 +125,7 @@ class Event:
             keys = self._snuba_data[tags_key_column]
             values = self._snuba_data[tags_value_column]
             if keys and values and len(keys) == len(values):
-                return sorted(list(zip(keys, values)))
+                return sorted(zip(keys, values))
             else:
                 return []
         # Nodestore implementation

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -19,7 +19,6 @@ from sentry.snuba.events import Columns
 from sentry.utils import json
 from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyView
-from sentry.utils.compat import zip
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
 
@@ -126,7 +125,7 @@ class Event:
             keys = self._snuba_data[tags_key_column]
             values = self._snuba_data[tags_value_column]
             if keys and values and len(keys) == len(values):
-                return sorted(zip(keys, values))
+                return sorted(list(zip(keys, values)))
             else:
                 return []
         # Nodestore implementation
@@ -262,7 +261,7 @@ class Event:
         be saved under this key in nodestore so it can be retrieved using the
         same generated id when we only have project_id and event_id.
         """
-        return md5(f"{project_id}:{event_id}".encode("utf-8")).hexdigest()
+        return md5(f"{project_id}:{event_id}".encode()).hexdigest()
 
     # TODO We need a better way to cache these properties. functools
     # doesn't quite do the trick as there is a reference bug with unsaved

--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -109,7 +109,7 @@ class FlagAction(Action):
 
         sliced_components = self._slice_to_range(components, idx)
         sliced_frames = self._slice_to_range(frames, idx)
-        for component, frame in list(zip(sliced_components, sliced_frames)):
+        for component, frame in zip(sliced_components, sliced_frames):
             if self.key == "group" and self.flag != component.contributes:
                 component.update(
                     contributes=self.flag,

--- a/src/sentry/grouping/enhancer/actions.py
+++ b/src/sentry/grouping/enhancer/actions.py
@@ -1,6 +1,5 @@
 from sentry.grouping.utils import get_rule_bool
 from sentry.stacktraces.functions import set_in_app
-from sentry.utils.compat import zip
 from sentry.utils.safe import get_path, set_path
 
 from .exceptions import InvalidEnhancerConfig
@@ -99,7 +98,7 @@ class FlagAction(Action):
         if self.key == "group":
             return
         if self.key == "app":
-            for frame, match_frame in self._slice_to_range(zip(frames, match_frames), idx):
+            for frame, match_frame in self._slice_to_range(list(zip(frames, match_frames)), idx):
                 set_in_app(frame, self.flag)
                 match_frame["in_app"] = frame["in_app"]
 
@@ -110,7 +109,7 @@ class FlagAction(Action):
 
         sliced_components = self._slice_to_range(components, idx)
         sliced_frames = self._slice_to_range(frames, idx)
-        for component, frame in zip(sliced_components, sliced_frames):
+        for component, frame in list(zip(sliced_components, sliced_frames)):
             if self.key == "group" and self.flag != component.contributes:
                 component.update(
                     contributes=self.flag,

--- a/src/sentry/identity/google/provider.py
+++ b/src/sentry/identity/google/provider.py
@@ -3,7 +3,6 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.provider import MigratingIdentityId
 from sentry.identity.oauth2 import OAuth2Provider
 from sentry.utils import json
-from sentry.utils.compat import map
 from sentry.utils.signing import urlsafe_b64decode
 
 # When no hosted domain is in use for the authenticated user, we default to the
@@ -37,7 +36,7 @@ class GoogleIdentityProvider(OAuth2Provider):
             raise IdentityNotValid("Missing id_token in OAuth response: %s" % data)
 
         try:
-            _, payload, _ = map(urlsafe_b64decode, id_token.split(".", 2))
+            _, payload, _ = list(map(urlsafe_b64decode, id_token.split(".", 2)))
         except Exception as exc:
             raise IdentityNotValid("Unable to decode id_token: %s" % exc)
 

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -44,7 +44,6 @@ from sentry.models.user import User
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.snuba.tasks import build_snuba_filter
-from sentry.utils.compat import zip
 from sentry.utils.snuba import raw_query
 
 logger = logging.getLogger(__name__)
@@ -474,7 +473,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             )
 
         for i, (trigger, expected_label) in enumerate(
-            zip(triggers, (CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL))
+            list(zip(triggers, (CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL)))
         ):
             if trigger.get("label", None) != expected_label:
                 raise serializers.ValidationError(

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -48,7 +48,6 @@ from sentry.snuba.subscriptions import (
     update_snuba_query,
 )
 from sentry.snuba.tasks import build_snuba_filter
-from sentry.utils.compat import zip
 from sentry.utils.dates import to_timestamp
 from sentry.utils.snuba import SnubaQueryParams, SnubaTSResult, bulk_raw_query, is_measurement
 
@@ -487,9 +486,9 @@ def get_incident_event_stats(incident, start=None, end=None, windowed_stats=Fals
     results = bulk_raw_query(snuba_params, referrer="incidents.get_incident_event_stats")
     # Once we receive the results, if we requested extra buckets we now need to label
     # them with timestamp data, since the query we ran only returns the count.
-    for extra_start, result in zip(extra_buckets, results[1:]):
+    for extra_start, result in list(zip(extra_buckets, results[1:])):
         result["data"][0]["time"] = int(to_timestamp(extra_start))
-    merged_data = list(chain(*[r["data"] for r in results]))
+    merged_data = list(chain(*(r["data"] for r in results)))
     merged_data.sort(key=lambda row: row["time"])
     results[0]["data"] = merged_data
     # When an incident has just been created it's possible for the actual incident start

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -486,7 +486,7 @@ def get_incident_event_stats(incident, start=None, end=None, windowed_stats=Fals
     results = bulk_raw_query(snuba_params, referrer="incidents.get_incident_event_stats")
     # Once we receive the results, if we requested extra buckets we now need to label
     # them with timestamp data, since the query we ran only returns the count.
-    for extra_start, result in list(zip(extra_buckets, results[1:])):
+    for extra_start, result in zip(extra_buckets, results[1:]):
         result["data"][0]["time"] = int(to_timestamp(extra_start))
     merged_data = list(chain(*(r["data"] for r in results)))
     merged_data.sort(key=lambda row: row["time"])

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -467,7 +467,9 @@ def get_alert_rule_stats(alert_rule, subscription, triggers):
     trigger_results = results[1:]
     trigger_alert_counts = {}
     trigger_resolve_counts = {}
-    for trigger, trigger_result in zip(triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS))):
+    for trigger, trigger_result in zip(
+        triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS))
+    ):
         trigger_alert_counts[trigger.id] = trigger_result[0]
         trigger_resolve_counts[trigger.id] = trigger_result[1]
 

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -29,7 +29,6 @@ from sentry.incidents.models import (
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.models import Project
 from sentry.utils import metrics, redis
-from sentry.utils.compat import zip
 from sentry.utils.dates import to_datetime, to_timestamp
 
 logger = logging.getLogger(__name__)
@@ -445,7 +444,7 @@ def partition(iterable, n):
     """
     assert len(iterable) % n == 0
     args = [iter(iterable)] * n
-    return zip(*args)
+    return list(zip(*args))
 
 
 def get_alert_rule_stats(alert_rule, subscription, triggers):
@@ -468,8 +467,8 @@ def get_alert_rule_stats(alert_rule, subscription, triggers):
     trigger_results = results[1:]
     trigger_alert_counts = {}
     trigger_resolve_counts = {}
-    for trigger, trigger_result in zip(
-        triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS))
+    for trigger, trigger_result in list(
+        zip(triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS)))
     ):
         trigger_alert_counts[trigger.id] = trigger_result[0]
         trigger_resolve_counts[trigger.id] = trigger_result[1]
@@ -483,7 +482,7 @@ def update_alert_rule_stats(alert_rule, subscription, last_update, alert_counts,
     """
     pipeline = get_redis_client().pipeline()
 
-    counts_with_stat_keys = zip(ALERT_RULE_TRIGGER_STAT_KEYS, (alert_counts, resolve_counts))
+    counts_with_stat_keys = list(zip(ALERT_RULE_TRIGGER_STAT_KEYS, (alert_counts, resolve_counts)))
     for stat_key, trigger_counts in counts_with_stat_keys:
         for trigger_id, alert_count in trigger_counts.items():
             pipeline.set(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -467,9 +467,7 @@ def get_alert_rule_stats(alert_rule, subscription, triggers):
     trigger_results = results[1:]
     trigger_alert_counts = {}
     trigger_resolve_counts = {}
-    for trigger, trigger_result in list(
-        zip(triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS)))
-    ):
+    for trigger, trigger_result in zip(triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS))):
         trigger_alert_counts[trigger.id] = trigger_result[0]
         trigger_resolve_counts[trigger.id] = trigger_result[1]
 

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -17,7 +17,6 @@ from sentry.integrations.serverless import ServerlessMixin
 from sentry.models import OrganizationIntegration, Project, ProjectStatus
 from sentry.pipeline import PipelineView
 from sentry.utils import json
-from sentry.utils.compat import map
 from sentry.utils.sdk import capture_exception
 
 from .client import ConfigurationError, gen_aws_client
@@ -131,7 +130,7 @@ class AwsLambdaIntegration(IntegrationInstallation, ServerlessMixin):
         functions = get_supported_functions(self.client)
         functions.sort(key=lambda x: x["FunctionName"].lower())
 
-        return map(self.serialize_lambda_function, functions)
+        return list(map(self.serialize_lambda_function, functions))
 
     @wrap_lambda_updater()
     def enable_function(self, target):
@@ -248,7 +247,7 @@ class AwsLambdaProjectSelectPipelineView(PipelineView):
             pipeline.bind_state("project_id", projects[0].id)
             return pipeline.next_step()
 
-        serialized_projects = map(lambda x: serialize(x, request.user), projects)
+        serialized_projects = list(map(lambda x: serialize(x, request.user), projects))
         return self.render_react_view(
             request, "awsLambdaProjectSelect", {"projects": serialized_projects}
         )
@@ -363,7 +362,7 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
             # check to see if the user wants to enable this function
             return enabled_lambdas.get(name)
 
-        lambda_functions = filter(is_lambda_enabled, lambda_functions)
+        lambda_functions = list(filter(is_lambda_enabled, lambda_functions))
 
         def _enable_lambda(function):
             try:

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -9,7 +9,6 @@ from sentry import options
 from sentry.models import Project, ProjectKey
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.release_registry import LAYER_INDEX_CACHE_KEY
-from sentry.utils.compat import filter, map
 
 SUPPORTED_RUNTIMES = [
     "nodejs14.x",
@@ -104,7 +103,7 @@ def get_option_value(function, option):
     # special lookup for the version since it depends on the region
     if option == OPTION_VERSION:
         region_release_list = cache_value.get("regions", [])
-        matched_regions = filter(lambda x: x["region"] == region, region_release_list)
+        matched_regions = list(filter(lambda x: x["region"] == region, region_release_list))
         # see if there is the specific region in our list
         if matched_regions:
             version = matched_regions[0]["version"]
@@ -136,7 +135,7 @@ def _get_arn_from_layer(layer):
 
 def get_function_layer_arns(function):
     layers = function.get("Layers", [])
-    return map(_get_arn_from_layer, layers)
+    return list(map(_get_arn_from_layer, layers))
 
 
 def get_latest_layer_for_function(function):
@@ -176,9 +175,11 @@ def get_supported_functions(lambda_client):
     for page in response_iterator:
         functions += page["Functions"]
 
-    return filter(
-        lambda x: x.get("Runtime") in SUPPORTED_RUNTIMES,
-        functions,
+    return list(
+        filter(
+            lambda x: x.get("Runtime") in SUPPORTED_RUNTIMES,
+            functions,
+        )
     )
 
 

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -20,7 +20,6 @@ from sentry.models.repository import Repository
 from sentry.pipeline import PipelineView
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.tasks.integrations import migrate_repo
-from sentry.utils.compat import filter
 from sentry.web.helpers import render_to_response
 
 from .client import BitbucketServer, BitbucketServerSetupClient
@@ -275,7 +274,7 @@ class BitbucketServerIntegration(IntegrationInstallation, RepositoryMixin):
 
         accessible_repos = [r["identifier"] for r in self.get_repositories()]
 
-        return filter(lambda repo: repo.name not in accessible_repos, repos)
+        return list(filter(lambda repo: repo.name not in accessible_repos, repos))
 
     def reinstall(self):
         self.reinstall_repositories()

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -5,7 +5,6 @@ from sentry import features
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.models.useroption import UserOption
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
@@ -266,7 +265,7 @@ class IssueBasicMixin:
         # group annotations by group id
         annotations_by_group_id = defaultdict(list)
         for group_link in group_links:
-            issues_for_group = filter(lambda x: x.id == group_link.linked_id, external_issues)
+            issues_for_group = list(filter(lambda x: x.id == group_link.linked_id, external_issues))
             annotations = self.map_external_issues_to_annotations(issues_for_group)
             annotations_by_group_id[group_link.group_id].extend(annotations)
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -22,7 +22,6 @@ from sentry.shared_integrations.exceptions import (
     IntegrationError,
     IntegrationFormError,
 )
-from sentry.utils.compat import filter
 from sentry.utils.decorators import classproperty
 from sentry.utils.http import absolute_uri
 
@@ -245,8 +244,10 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             # accidentally use newlines, so we explicitly handle that case. On page
             # refresh, they will see how it got interpreted as `get_config_data` will
             # re-serialize the config as a comma-separated list.
-            ignored_fields_list = filter(
-                None, [field.strip() for field in re.split(r"[,\n\r]+", ignored_fields_text)]
+            ignored_fields_list = list(
+                filter(
+                    None, [field.strip() for field in re.split(r"[,\n\r]+", ignored_fields_text)]
+                )
             )
             data[self.issues_ignored_fields_key] = ignored_fields_list
 

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
-from sentry.utils.compat import filter
 
 from .utils import build_user_choice
 
@@ -55,8 +54,11 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             except (ApiUnauthorized, ApiError):
                 return Response({"detail": "Unable to fetch users from Jira"}, status=400)
 
-            user_tuples = filter(
-                None, [build_user_choice(user, jira_client.user_id_field()) for user in response]
+            user_tuples = list(
+                filter(
+                    None,
+                    [build_user_choice(user, jira_client.user_id_field()) for user in response],
+                )
             )
             users = [{"value": user_id, "label": display} for user_id, display in user_tuples]
             return Response(users)

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -1,7 +1,6 @@
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models import GroupAssignee, GroupStatus, Project, Team
 from sentry.utils.assets import get_asset_url
-from sentry.utils.compat import map
 from sentry.utils.http import absolute_uri
 
 from .utils import ACTION_TYPE
@@ -15,7 +14,7 @@ logo = {
 
 
 def generate_action_payload(action_type, event, rules, integration):
-    rule_ids = map(lambda x: x.id, rules)
+    rule_ids = list(map(lambda x: x.id, rules))
     # we need nested data or else Teams won't handle the payload correctly
     return {
         "payload": {

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -5,7 +5,6 @@ from django.http import Http404
 
 from sentry.models import IdentityProvider, Integration, Organization
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils.compat import filter
 
 from .client import MsTeamsClient, MsTeamsPreInstallClient, get_token_data
 
@@ -46,7 +45,7 @@ def get_channel_id(organization, integration_id, name):
 
     # handle searching for channels first
     channel_list = client.get_channel_list(team_id)
-    filtered_channels = list(filter(lambda x: channel_filter(x, name), channel_list))
+    filtered_channels = list(list(filter(lambda x: channel_filter(x, name), channel_list)))
     if len(filtered_channels) > 0:
         return filtered_channels[0].get("id")
 
@@ -57,7 +56,7 @@ def get_channel_id(organization, integration_id, name):
         continuation_token = members.get("continuationToken")
 
         filtered_members = list(
-            filter(lambda x: x.get("name").lower() == name.lower(), member_list)
+            list(filter(lambda x: x.get("name").lower() == name.lower(), member_list))
         )
         if len(filtered_members) > 0:
             # TODO: handle duplicate username case

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -45,7 +45,7 @@ def get_channel_id(organization, integration_id, name):
 
     # handle searching for channels first
     channel_list = client.get_channel_list(team_id)
-    filtered_channels = list(list(filter(lambda x: channel_filter(x, name), channel_list)))
+    filtered_channels = list(filter(lambda x: channel_filter(x, name), channel_list))
     if len(filtered_channels) > 0:
         return filtered_channels[0].get("id")
 
@@ -56,7 +56,7 @@ def get_channel_id(organization, integration_id, name):
         continuation_token = members.get("continuationToken")
 
         filtered_members = list(
-            list(filter(lambda x: x.get("name").lower() == name.lower(), member_list))
+            filter(lambda x: x.get("name").lower() == name.lower(), member_list)
         )
         if len(filtered_members) > 0:
             # TODO: handle duplicate username case

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -19,7 +19,6 @@ from sentry.models import (
 )
 from sentry.utils import json, jwt
 from sentry.utils.audit import create_audit_entry
-from sentry.utils.compat import filter
 from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 
@@ -175,7 +174,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
     def handle_personal_member_add(self, request):
         data = request.data
         # only care if our bot is the new member added
-        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"])
+        matches = list(filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"]))
         if not matches:
             return self.respond(status=204)
 
@@ -190,7 +189,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
         data = request.data
         channel_data = data["channelData"]
         # only care if our bot is the new member added
-        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"])
+        matches = list(filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"]))
         if not matches:
             return self.respond(status=204)
 
@@ -216,7 +215,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
         data = request.data
         channel_data = data["channelData"]
         # only care if our bot is the new member removed
-        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersRemoved"])
+        matches = list(filter(lambda x: x["id"] == data["recipient"]["id"], data["membersRemoved"]))
         if not matches:
             return self.respond(status=204)
 
@@ -420,9 +419,11 @@ class MsTeamsWebhookEndpoint(Endpoint):
             # check the ids of the mentions in the entities
             mentioned = (
                 len(
-                    filter(
-                        lambda x: x.get("mentioned", {}).get("id") == recipient_id,
-                        data.get("entities", []),
+                    list(
+                        filter(
+                            lambda x: x.get("mentioned", {}).get("id") == recipient_id,
+                            data.get("entities", []),
+                        )
                     )
                 )
                 > 0

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -13,7 +13,6 @@ from sentry.models import OrganizationIntegration, PagerDutyService
 from sentry.pipeline import PipelineView
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils import json
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 
 from .client import PagerDutyClient
@@ -79,7 +78,9 @@ class PagerDutyIntegration(IntegrationInstallation):
         if "service_table" in data:
             service_rows = data["service_table"]
             # validate fields
-            bad_rows = filter(lambda x: not x["service"] or not x["integration_key"], service_rows)
+            bad_rows = list(
+                filter(lambda x: not x["service"] or not x["integration_key"], service_rows)
+            )
             if bad_rows:
                 raise IntegrationError("Name and key are required")
 
@@ -90,7 +91,7 @@ class PagerDutyIntegration(IntegrationInstallation):
 
                 for service_item in existing_service_items:
                     # find the matching row from the input
-                    matched_rows = filter(lambda x: x["id"] == service_item.id, service_rows)
+                    matched_rows = list(filter(lambda x: x["id"] == service_item.id, service_rows))
                     if matched_rows:
                         matched_row = matched_rows[0]
                         service_item.integration_key = matched_row["integration_key"]
@@ -100,7 +101,7 @@ class PagerDutyIntegration(IntegrationInstallation):
                         service_item.delete()
 
                 # new rows don't have an id
-                new_rows = filter(lambda x: not x["id"], service_rows)
+                new_rows = list(filter(lambda x: not x["id"], service_rows))
                 for row in new_rows:
                     service_name = row["service"]
                     key = row["integration_key"]

--- a/src/sentry/integrations/vercel/generic_webhook.py
+++ b/src/sentry/integrations/vercel/generic_webhook.py
@@ -20,7 +20,6 @@ from sentry.models import (
 )
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.audit import create_audit_entry
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.integrations.vercel.uninstall")
@@ -301,7 +300,7 @@ class VercelGenericWebhookEndpoint(Endpoint):
         # for each org integration, search the configs to find one that matches the vercel project of the webhook
         for org_integration in org_integrations:
             project_mappings = org_integration.config.get("project_mappings") or []
-            matched_mappings = filter(lambda x: x[1] == vercel_project_id, project_mappings)
+            matched_mappings = list(filter(lambda x: x[1] == vercel_project_id, project_mappings))
             if matched_mappings:
                 organization = org_integration.organization
                 sentry_project_id = matched_mappings[0][0]

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -25,7 +25,6 @@ from sentry.models import (
 )
 from sentry.pipeline import NestedPipelineView
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
-from sentry.utils.compat import map
 from sentry.utils.http import absolute_uri
 
 from .client import VercelClient
@@ -153,15 +152,17 @@ class VercelIntegration(IntegrationInstallation):
         ]
 
         proj_fields = ["id", "platform", "name", "slug"]
-        sentry_projects = map(
-            lambda proj: {key: proj[key] for key in proj_fields},
-            (
-                Project.objects.filter(
-                    organization_id=self.organization_id, status=ObjectStatus.VISIBLE
-                )
-                .order_by("slug")
-                .values(*proj_fields)
-            ),
+        sentry_projects = list(
+            map(
+                lambda proj: {key: proj[key] for key in proj_fields},
+                (
+                    Project.objects.filter(
+                        organization_id=self.organization_id, status=ObjectStatus.VISIBLE
+                    )
+                    .order_by("slug")
+                    .values(*proj_fields)
+                ),
+            )
         )
 
         fields = [

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -1,5 +1,3 @@
-from sentry.utils.compat import map
-
 __all__ = ("Http",)
 
 import re
@@ -56,7 +54,7 @@ def format_cookies(value):
     if isinstance(value, dict):
         value = value.items()
 
-    return [map(fix_broken_encoding, (k.strip(), v)) for k, v in value]
+    return [list(map(fix_broken_encoding, (k.strip(), v))) for k, v in value]
 
 
 def fix_broken_encoding(value):

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -5,7 +5,6 @@ from symbolic import parse_addr
 from sentry.constants import NATIVE_UNKNOWN_STRING
 from sentry.interfaces.exception import upgrade_legacy_mechanism
 from sentry.lang.native.utils import image_name
-from sentry.utils.compat import map
 from sentry.utils.safe import get_path
 
 REPORT_VERSION = "104"
@@ -160,9 +159,11 @@ class AppleCrashReport:
         # We don't need binary images on symbolicated crashreport
         if self.symbolicated or self.debug_images is None:
             return ""
-        binary_images = map(
-            lambda i: self._convert_debug_meta_to_binary_image_row(debug_image=i),
-            sorted(self.debug_images, key=lambda i: parse_addr(i["image_addr"])),
+        binary_images = list(
+            map(
+                lambda i: self._convert_debug_meta_to_binary_image_row(debug_image=i),
+                sorted(self.debug_images, key=lambda i: parse_addr(i["image_addr"])),
+            )
         )
         return "Binary Images:\n" + "\n".join(binary_images)
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -373,12 +373,12 @@ def process_payload(data):
 
     sdk_info = get_sdk_from_event(data)
 
-    for raw_image, complete_image in list(zip(modules, response["modules"])):
+    for raw_image, complete_image in zip(modules, response["modules"]):
         _merge_image(raw_image, complete_image, sdk_info, data)
 
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
 
-    for sinfo, complete_stacktrace in list(zip(stacktrace_infos, response["stacktraces"])):
+    for sinfo, complete_stacktrace in zip(stacktrace_infos, response["stacktraces"]):
         complete_frames_by_idx = {}
         for complete_frame in complete_stacktrace.get("frames") or ():
             complete_frames_by_idx.setdefault(complete_frame["original_index"], []).append(

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -20,7 +20,6 @@ from sentry.lang.native.utils import (
 from sentry.models import EventError, Project
 from sentry.stacktraces.functions import trim_function_name
 from sentry.stacktraces.processing import find_stacktraces_in_data
-from sentry.utils.compat import zip
 from sentry.utils.in_app import is_known_third_party, is_optional_package
 from sentry.utils.safe import get_path, set_path, setdefault_path, trim
 
@@ -374,12 +373,12 @@ def process_payload(data):
 
     sdk_info = get_sdk_from_event(data)
 
-    for raw_image, complete_image in zip(modules, response["modules"]):
+    for raw_image, complete_image in list(zip(modules, response["modules"])):
         _merge_image(raw_image, complete_image, sdk_info, data)
 
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
 
-    for sinfo, complete_stacktrace in zip(stacktrace_infos, response["stacktraces"]):
+    for sinfo, complete_stacktrace in list(zip(stacktrace_infos, response["stacktraces"])):
         complete_frames_by_idx = {}
         for complete_frame in complete_stacktrace.get("frames") or ():
             complete_frames_by_idx.setdefault(complete_frame["original_index"], []).append(

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -8,7 +8,6 @@ from pkg_resources import parse_version
 
 import sentry
 from sentry.utils import json
-from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry")
 
@@ -31,7 +30,7 @@ def load_registry(path):
 def get_highest_browser_sdk_version(versions):
     full_versions = [x for x in versions if _version_regexp.match(x)]
     return (
-        str(max(map(parse_version, full_versions)))
+        str(max(list(map(parse_version, full_versions))))
         if full_versions
         else settings.JS_SDK_LOADER_SDK_VERSION
     )

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -30,7 +30,7 @@ def load_registry(path):
 def get_highest_browser_sdk_version(versions):
     full_versions = [x for x in versions if _version_regexp.match(x)]
     return (
-        str(max(list(map(parse_version, full_versions))))
+        str(max(map(parse_version, full_versions)))
         if full_versions
         else settings.JS_SDK_LOADER_SDK_VERSION
     )

--- a/src/sentry/management/commands/collectstatic.py
+++ b/src/sentry/management/commands/collectstatic.py
@@ -6,8 +6,6 @@ from operator import itemgetter
 from click import echo
 from django.contrib.staticfiles.management.commands.collectstatic import Command as BaseCommand
 
-from sentry.utils.compat import map, zip
-
 BUFFER_SIZE = 65536
 VERSION_PATH = "version"
 
@@ -24,9 +22,9 @@ def checksum(file_):
 
 def get_bundle_version(files):
     hasher = md5()
-    for (short, _), sum in zip(files, map(checksum, files)):
+    for (short, _), sum in list(zip(files, list(map(checksum, files)))):
         echo(f"{sum}  {short}")
-        hasher.update(f"{sum}  {short}\n".encode("utf-8"))
+        hasher.update(f"{sum}  {short}\n".encode())
     return hasher.hexdigest()
 
 
@@ -39,8 +37,8 @@ class Command(BaseCommand):
 
         collected = super().collect()
         paths = sorted(set(chain(*itemgetter(*collected.keys())(collected))))
-        abs_paths = map(self.storage.path, paths)
-        version = get_bundle_version(zip(paths, abs_paths))
+        abs_paths = list(map(self.storage.path, paths))
+        version = get_bundle_version(list(zip(paths, abs_paths)))
         echo("-----------------")
         echo(version)
         with open(self.storage.path(VERSION_PATH), "wb") as fp:

--- a/src/sentry/management/commands/collectstatic.py
+++ b/src/sentry/management/commands/collectstatic.py
@@ -22,7 +22,7 @@ def checksum(file_):
 
 def get_bundle_version(files):
     hasher = md5()
-    for (short, _), sum in list(zip(files, list(map(checksum, files)))):
+    for (short, _), sum in zip(files, list(map(checksum, files))):
         echo(f"{sum}  {short}")
         hasher.update(f"{sum}  {short}\n".encode())
     return hasher.hexdigest()

--- a/src/sentry/middleware/health.py
+++ b/src/sentry/middleware/health.py
@@ -3,8 +3,6 @@ import itertools
 from django.http import HttpResponse
 from django.utils.deprecation import MiddlewareMixin
 
-from sentry.utils.compat import filter
-
 
 class HealthCheck(MiddlewareMixin):
     def process_request(self, request):
@@ -24,7 +22,9 @@ class HealthCheck(MiddlewareMixin):
         from sentry.utils import json
 
         threshold = Problem.threshold(Problem.SEVERITY_CRITICAL)
-        results = {check: filter(threshold, problems) for check, problems in check_all().items()}
+        results = {
+            check: list(filter(threshold, problems)) for check, problems in check_all().items()
+        }
         problems = list(itertools.chain.from_iterable(results.values()))
 
         return HttpResponse(

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -129,7 +129,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
             for instance in type.objects.filter(id__in=[a.id for a in _actors]):
                 results[(type, instance.id)] = instance
 
-        return list(list(filter(None, [results.get((actor.type, actor.id)) for actor in actors])))
+        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
 
     @classmethod
     def resolve_dict(cls, actor_dict):

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -6,7 +6,6 @@ from django.db.models.signals import pre_save
 from rest_framework import serializers
 
 from sentry.db.models import Model
-from sentry.utils.compat import filter
 
 ACTOR_TYPES = {"team": 0, "user": 1}
 
@@ -130,7 +129,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
             for instance in type.objects.filter(id__in=[a.id for a in _actors]):
                 results[(type, instance.id)] = instance
 
-        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
+        return list(list(filter(None, [results.get((actor.type, actor.id)) for actor in actors])))
 
     @classmethod
     def resolve_dict(cls, actor_dict):

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -13,7 +13,6 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
-from sentry.utils.compat import filter
 
 
 # TODO(dcramer): pull in enum library
@@ -84,7 +83,7 @@ class ApiKey(Model):
     def get_allowed_origins(self):
         if not self.allowed_origins:
             return []
-        return filter(bool, self.allowed_origins.split("\n"))
+        return list(filter(bool, self.allowed_origins.split("\n")))
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from hashlib import sha1
 from threading import Semaphore
+from typing import Container
 from uuid import uuid4
 
 from django.conf import settings
@@ -118,7 +119,7 @@ class FileBlob(Model):
         db_table = "sentry_fileblob"
 
     @classmethod
-    def from_files(cls, files, organization=None, logger=nooplogger):
+    def from_files(cls, files: Container, organization=None, logger=nooplogger):
         """A faster version of `from_file` for multiple files at the time.
         If an organization is provided it will also create `FileBlobOwner`
         entries.  Files can be a list of files or tuples of file and checksum.

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -44,7 +44,7 @@ class GroupOwner(Model):
         db_table = "sentry_groupowner"
 
     def save(self, *args, **kwargs):
-        keys = list(list(filter(None, [self.user_id, self.team_id])))
+        keys = list(filter(None, [self.user_id, self.team_id]))
         assert len(keys) == 1, "Must have team or user, not both"
         super().save(*args, **kwargs)
 

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, Model
-from sentry.utils.compat import filter
 
 
 class GroupOwnerType(Enum):
@@ -45,7 +44,7 @@ class GroupOwner(Model):
         db_table = "sentry_groupowner"
 
     def save(self, *args, **kwargs):
-        keys = list(filter(None, [self.user_id, self.team_id]))
+        keys = list(list(filter(None, [self.user_id, self.team_id])))
         assert len(keys) == 1, "Must have team or user, not both"
         super().save(*args, **kwargs)
 

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -14,7 +14,6 @@ from sentry.notifications.utils import (
 )
 from sentry.notifications.utils.participants import get_participants_for_release
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.compat import zip
 from sentry.utils.http import absolute_uri
 
 from .base import ActivityNotification
@@ -96,7 +95,7 @@ class ReleaseActivityNotification(ActivityNotification):
         resolved_issue_counts = [self.group_counts_by_project.get(p.id, 0) for p in projects]
         return {
             **super().get_user_context(user, extra_context),
-            "projects": zip(projects, release_links, resolved_issue_counts),
+            "projects": list(zip(projects, release_links, resolved_issue_counts)),
             "project_count": len(projects),
         }
 

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -10,7 +10,6 @@ from sentry.exceptions import PluginError
 from sentry.http import is_valid_url, safe_urlopen
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.plugins.bases import notify
-from sentry.utils.compat import filter
 from sentry.utils.safe import safe_execute
 
 DESCRIPTION = """
@@ -24,7 +23,7 @@ Note: To configure webhooks over multiple projects, we recommend setting up an
 def split_urls(value):
     if not value:
         return ()
-    return filter(bool, (url.strip() for url in value.splitlines()))
+    return list(filter(bool, (url.strip() for url in value.splitlines())))
 
 
 def validate_urls(value, **kwargs):

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -248,7 +248,7 @@ class RedisQuota(Quota):
             return NotRateLimited()
 
         worst_case = (0, None)
-        for quota, rejected in list(zip(quotas, rejections)):
+        for quota, rejected in zip(quotas, rejections):
             if not rejected:
                 continue
 

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -3,7 +3,6 @@ from time import time
 
 from sentry.constants import DataCategory
 from sentry.quotas.base import NotRateLimited, Quota, QuotaConfig, QuotaScope, RateLimited
-from sentry.utils.compat import map, zip
 from sentry.utils.redis import (
     get_dynamic_cluster_from_options,
     load_script,
@@ -133,12 +132,16 @@ class RedisQuota(Quota):
             return int(result.value or 0) - int(refund_result.value or 0)
 
         if self.is_redis_cluster:
-            results = map(functools.partial(get_usage_for_quota, self.cluster), quotas)
+            results = list(map(functools.partial(get_usage_for_quota, self.cluster), quotas))
         else:
             with self.cluster.fanout() as client:
-                results = map(
-                    functools.partial(get_usage_for_quota, client.target_key(str(organization_id))),
-                    quotas,
+                results = list(
+                    map(
+                        functools.partial(
+                            get_usage_for_quota, client.target_key(str(organization_id))
+                        ),
+                        quotas,
+                    )
                 )
 
         return [get_value_for_result(*r) for r in results]
@@ -245,7 +248,7 @@ class RedisQuota(Quota):
             return NotRateLimited()
 
         worst_case = (0, None)
-        for quota, rejected in zip(quotas, rejections):
+        for quota, rejected in list(zip(quotas, rejections)):
             if not rejected:
                 continue
 

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -47,35 +47,33 @@ def cli(ctx, config):
 
 # TODO(mattrobenolt): Autodiscover commands?
 list(
-    list(
-        map(
-            lambda cmd: cli.add_command(import_string(cmd)),
-            (
-                "sentry.runner.commands.backup.export",
-                "sentry.runner.commands.backup.import_",
-                "sentry.runner.commands.cleanup.cleanup",
-                "sentry.runner.commands.config.config",
-                "sentry.runner.commands.createuser.createuser",
-                "sentry.runner.commands.devserver.devserver",
-                "sentry.runner.commands.django.django",
-                "sentry.runner.commands.exec.exec_",
-                "sentry.runner.commands.execfile.execfile",
-                "sentry.runner.commands.files.files",
-                "sentry.runner.commands.help.help",
-                "sentry.runner.commands.init.init",
-                "sentry.runner.commands.killswitches.killswitches",
-                "sentry.runner.commands.migrations.migrations",
-                "sentry.runner.commands.plugins.plugins",
-                "sentry.runner.commands.queues.queues",
-                "sentry.runner.commands.repair.repair",
-                "sentry.runner.commands.run.run",
-                "sentry.runner.commands.start.start",
-                "sentry.runner.commands.tsdb.tsdb",
-                "sentry.runner.commands.upgrade.upgrade",
-                "sentry.runner.commands.permissions.permissions",
-                "sentry.runner.commands.devservices.devservices",
-            ),
-        )
+    map(
+        lambda cmd: cli.add_command(import_string(cmd)),
+        (
+            "sentry.runner.commands.backup.export",
+            "sentry.runner.commands.backup.import_",
+            "sentry.runner.commands.cleanup.cleanup",
+            "sentry.runner.commands.config.config",
+            "sentry.runner.commands.createuser.createuser",
+            "sentry.runner.commands.devserver.devserver",
+            "sentry.runner.commands.django.django",
+            "sentry.runner.commands.exec.exec_",
+            "sentry.runner.commands.execfile.execfile",
+            "sentry.runner.commands.files.files",
+            "sentry.runner.commands.help.help",
+            "sentry.runner.commands.init.init",
+            "sentry.runner.commands.killswitches.killswitches",
+            "sentry.runner.commands.migrations.migrations",
+            "sentry.runner.commands.plugins.plugins",
+            "sentry.runner.commands.queues.queues",
+            "sentry.runner.commands.repair.repair",
+            "sentry.runner.commands.run.run",
+            "sentry.runner.commands.start.start",
+            "sentry.runner.commands.tsdb.tsdb",
+            "sentry.runner.commands.upgrade.upgrade",
+            "sentry.runner.commands.permissions.permissions",
+            "sentry.runner.commands.devservices.devservices",
+        ),
     )
 )
 
@@ -103,11 +101,9 @@ def make_django_command(name, django_command=None, help=None):
 
 
 list(
-    list(
-        map(
-            cli.add_command,
-            (make_django_command("shell", help="Run a Python interactive interpreter."),),
-        )
+    map(
+        cli.add_command,
+        (make_django_command("shell", help="Run a Python interactive interpreter."),),
     )
 )
 

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -7,7 +7,6 @@ import click
 import sentry_sdk
 
 import sentry
-from sentry.utils.compat import map
 from sentry.utils.imports import import_string
 
 # We need to run this here because of a concurrency bug in Python's locale
@@ -48,33 +47,35 @@ def cli(ctx, config):
 
 # TODO(mattrobenolt): Autodiscover commands?
 list(
-    map(
-        lambda cmd: cli.add_command(import_string(cmd)),
-        (
-            "sentry.runner.commands.backup.export",
-            "sentry.runner.commands.backup.import_",
-            "sentry.runner.commands.cleanup.cleanup",
-            "sentry.runner.commands.config.config",
-            "sentry.runner.commands.createuser.createuser",
-            "sentry.runner.commands.devserver.devserver",
-            "sentry.runner.commands.django.django",
-            "sentry.runner.commands.exec.exec_",
-            "sentry.runner.commands.execfile.execfile",
-            "sentry.runner.commands.files.files",
-            "sentry.runner.commands.help.help",
-            "sentry.runner.commands.init.init",
-            "sentry.runner.commands.killswitches.killswitches",
-            "sentry.runner.commands.migrations.migrations",
-            "sentry.runner.commands.plugins.plugins",
-            "sentry.runner.commands.queues.queues",
-            "sentry.runner.commands.repair.repair",
-            "sentry.runner.commands.run.run",
-            "sentry.runner.commands.start.start",
-            "sentry.runner.commands.tsdb.tsdb",
-            "sentry.runner.commands.upgrade.upgrade",
-            "sentry.runner.commands.permissions.permissions",
-            "sentry.runner.commands.devservices.devservices",
-        ),
+    list(
+        map(
+            lambda cmd: cli.add_command(import_string(cmd)),
+            (
+                "sentry.runner.commands.backup.export",
+                "sentry.runner.commands.backup.import_",
+                "sentry.runner.commands.cleanup.cleanup",
+                "sentry.runner.commands.config.config",
+                "sentry.runner.commands.createuser.createuser",
+                "sentry.runner.commands.devserver.devserver",
+                "sentry.runner.commands.django.django",
+                "sentry.runner.commands.exec.exec_",
+                "sentry.runner.commands.execfile.execfile",
+                "sentry.runner.commands.files.files",
+                "sentry.runner.commands.help.help",
+                "sentry.runner.commands.init.init",
+                "sentry.runner.commands.killswitches.killswitches",
+                "sentry.runner.commands.migrations.migrations",
+                "sentry.runner.commands.plugins.plugins",
+                "sentry.runner.commands.queues.queues",
+                "sentry.runner.commands.repair.repair",
+                "sentry.runner.commands.run.run",
+                "sentry.runner.commands.start.start",
+                "sentry.runner.commands.tsdb.tsdb",
+                "sentry.runner.commands.upgrade.upgrade",
+                "sentry.runner.commands.permissions.permissions",
+                "sentry.runner.commands.devservices.devservices",
+            ),
+        )
     )
 )
 
@@ -102,9 +103,11 @@ def make_django_command(name, django_command=None, help=None):
 
 
 list(
-    map(
-        cli.add_command,
-        (make_django_command("shell", help="Run a Python interactive interpreter."),),
+    list(
+        map(
+            cli.add_command,
+            (make_django_command("shell", help="Run a Python interactive interpreter."),),
+        )
     )
 )
 

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -4,8 +4,6 @@ import time
 
 import click
 
-from sentry.utils.compat import map
-
 # Work around a stupid docker issue: https://github.com/docker/for-mac/issues/5025
 RAW_SOCKET_HACK_PATH = os.path.expanduser(
     "~/Library/Containers/com.docker.docker/Data/docker.raw.sock"
@@ -301,7 +299,7 @@ def _start_service(
 
     listening = ""
     if options["ports"]:
-        listening = "(listening: %s)" % ", ".join(map(str, options["ports"].values()))
+        listening = "(listening: %s)" % ", ".join(list(map(str, options["ports"].values())))
 
     # If a service is associated with the devserver, then do not run the created container.
     # This was mainly added since it was not desirable for nginx to occupy port 8000 on the

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -299,7 +299,7 @@ def _start_service(
 
     listening = ""
     if options["ports"]:
-        listening = "(listening: %s)" % ", ".join(list(map(str, options["ports"].values())))
+        listening = "(listening: %s)" % ", ".join(map(str, options["ports"].values()))
 
     # If a service is associated with the devserver, then do not run the created container.
     # This was mainly added since it was not desirable for nginx to occupy port 8000 on the

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -6,7 +6,6 @@ import pytz
 from dateutil.parser import parse
 
 from sentry.runner.decorators import configuration
-from sentry.utils.compat import map
 from sentry.utils.iterators import chunked
 
 
@@ -103,5 +102,5 @@ def organizations(metrics, since, until):
                 values.append(aggregate(results[metric][key]))
 
             stdout.write(
-                "{} {} {}\n".format(instance.id, instance.slug, " ".join(map(str, values)))
+                "{} {} {}\n".format(instance.id, instance.slug, " ".join(list(map(str, values))))
             )

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -102,5 +102,5 @@ def organizations(metrics, since, until):
                 values.append(aggregate(results[metric][key]))
 
             stdout.write(
-                "{} {} {}\n".format(instance.id, instance.slug, " ".join(list(map(str, values))))
+                "{} {} {}\n".format(instance.id, instance.slug, " ".join(map(str, values)))
             )

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -6,7 +6,6 @@ import click
 from django.conf import settings
 
 from sentry.utils import metrics, warnings
-from sentry.utils.compat import map
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -274,7 +273,7 @@ def show_big_error(message):
         lines = message.strip().splitlines()
     else:
         lines = message
-    maxline = max(map(len, lines))
+    maxline = max(list(map(len, lines)))
     click.echo("", err=True)
     click.secho("!!!{}!!!".format("!" * min(maxline, 80)), err=True, fg="red")
     click.secho("!! %s !!" % "".center(maxline), err=True, fg="red")

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -273,7 +273,7 @@ def show_big_error(message):
         lines = message.strip().splitlines()
     else:
         lines = message
-    maxline = max(list(map(len, lines)))
+    maxline = max(map(len, lines))
     click.echo("", err=True)
     click.secho("!!!{}!!!".format("!" * min(maxline, 80)), err=True, fg="red")
     click.secho("!! %s !!" % "".center(maxline), err=True, fg="red")

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -432,7 +432,7 @@ def get_suggested_updates(
         rv.append(suggestion)
         new_setup_states.append(new_setup_state)
 
-    for new_setup_state, suggestion in list(zip(new_setup_states, rv)):
+    for new_setup_state, suggestion in zip(new_setup_states, rv):
         json = suggestion.to_json()
         json["enables"] = list(
             get_suggested_updates(

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.core.cache import cache
 
 from sentry.tasks.release_registry import SDK_INDEX_CACHE_KEY
-from sentry.utils.compat import zip
 from sentry.utils.safe import get_path
 
 logger = logging.getLogger(__name__)
@@ -433,7 +432,7 @@ def get_suggested_updates(
         rv.append(suggestion)
         new_setup_states.append(new_setup_state)
 
-    for new_setup_state, suggestion in zip(new_setup_states, rv):
+    for new_setup_state, suggestion in list(zip(new_setup_states, rv)):
         json = suggestion.to_json()
         json["enables"] = list(
             get_suggested_updates(

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -1470,7 +1470,7 @@ class DiscoverFunction:
         arguments = {}
 
         # normalize the arguments before putting them in a dict
-        for argument, column in list(zip(self.args, columns)):
+        for argument, column in zip(self.args, columns):
             try:
                 normalized_value = argument.normalize(column, params)
                 if not isinstance(self, SnQLFunction) and isinstance(argument, NumericColumn):

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -51,7 +51,6 @@ from sentry.search.events.constants import (
 )
 from sentry.search.events.types import ParamsType, SelectType
 from sentry.search.utils import InvalidQuery, parse_duration
-from sentry.utils.compat import zip
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.snuba import (
     Dataset,
@@ -1471,7 +1470,7 @@ class DiscoverFunction:
         arguments = {}
 
         # normalize the arguments before putting them in a dict
-        for argument, column in zip(self.args, columns):
+        for argument, column in list(zip(self.args, columns)):
             try:
                 normalized_value = argument.normalize(column, params)
                 if not isinstance(self, SnQLFunction) and isinstance(argument, NumericColumn):

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -415,7 +415,7 @@ def _semver_filter_converter(
     # the passed filter.
     order_by = Release.SEMVER_COLS
     if operator.startswith("<"):
-        order_by = list(list(map(_flip_field_sort, order_by)))
+        order_by = list(map(_flip_field_sort, order_by))
     qs = (
         Release.objects.filter_by_semver(
             organization_id,
@@ -1674,7 +1674,7 @@ class QueryFilter(QueryFields):
         # the passed filter.
         order_by = Release.SEMVER_COLS
         if operator.startswith("<"):
-            order_by = list(list(map(_flip_field_sort, order_by)))
+            order_by = list(map(_flip_field_sort, order_by))
         qs = (
             Release.objects.filter_by_semver(
                 organization_id,

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -50,7 +50,6 @@ from sentry.search.events.constants import (
 from sentry.search.events.fields import FIELD_ALIASES, FUNCTIONS, QueryFields, resolve_field
 from sentry.search.events.types import ParamsType, WhereType
 from sentry.search.utils import parse_release
-from sentry.utils.compat import filter
 from sentry.utils.dates import outside_retention_with_modified_start, to_timestamp
 from sentry.utils.snuba import (
     FUNCTION_TO_OPERATOR,
@@ -416,7 +415,7 @@ def _semver_filter_converter(
     # the passed filter.
     order_by = Release.SEMVER_COLS
     if operator.startswith("<"):
-        order_by = list(map(_flip_field_sort, order_by))
+        order_by = list(list(map(_flip_field_sort, order_by)))
     qs = (
         Release.objects.filter_by_semver(
             organization_id,
@@ -439,7 +438,7 @@ def _semver_filter_converter(
         # include it even though we don't really care about order for this query
         qs_flipped = (
             Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
-            .order_by(*map(_flip_field_sort, order_by))
+            .order_by(*list(map(_flip_field_sort, order_by)))
             .values_list("version", flat=True)[:MAX_SEARCH_RELEASES]
         )
 
@@ -810,7 +809,7 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
 
     condition, having = None, None
     if lhs_condition or rhs_condition:
-        args = filter(None, [lhs_condition, rhs_condition])
+        args = list(filter(None, [lhs_condition, rhs_condition]))
         if not args:
             condition = None
         elif len(args) == 1:
@@ -819,7 +818,7 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
             condition = [operator, args]
 
     if lhs_having or rhs_having:
-        args = filter(None, [lhs_having, rhs_having])
+        args = list(filter(None, [lhs_having, rhs_having]))
         if not args:
             having = None
         elif len(args) == 1:
@@ -1675,7 +1674,7 @@ class QueryFilter(QueryFields):
         # the passed filter.
         order_by = Release.SEMVER_COLS
         if operator.startswith("<"):
-            order_by = list(map(_flip_field_sort, order_by))
+            order_by = list(list(map(_flip_field_sort, order_by)))
         qs = (
             Release.objects.filter_by_semver(
                 organization_id,
@@ -1698,7 +1697,7 @@ class QueryFilter(QueryFields):
             # include it even though we don't really care about order for this query
             qs_flipped = (
                 Release.objects.filter_by_semver(organization_id, parse_semver(version, operator))
-                .order_by(*map(_flip_field_sort, order_by))
+                .order_by(*list(map(_flip_field_sort, order_by)))
                 .values_list("version", flat=True)[:MAX_SEARCH_RELEASES]
             )
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -8,7 +8,6 @@ from sentry.models import KEYWORD_MAP, EventUser, Release, Team, User
 from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.search.base import ANY
 from sentry.utils.auth import find_users
-from sentry.utils.compat import map
 
 
 class InvalidQuery(Exception):
@@ -368,7 +367,7 @@ def tokenize_query(query):
         query_params[state].append(token)
 
     if "query" in query_params:
-        result["query"] = map(format_query, query_params["query"])
+        result["query"] = list(map(format_query, query_params["query"]))
     for tag in query_params["tags"]:
         key, value = format_tag(tag)
         result[key].append(value)

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -18,7 +18,6 @@ from sentry.similarity.features import (
 from sentry.similarity.featuresv2 import GroupingBasedFeatureSet
 from sentry.similarity.signatures import MinHashSignatureBuilder
 from sentry.utils import redis
-from sentry.utils.compat import map
 from sentry.utils.datastructures import BidirectionalMapping
 from sentry.utils.iterators import shingle
 
@@ -26,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def text_shingle(n, value):
-    return map("".join, shingle(n, value))
+    return list(map("".join, shingle(n, value)))
 
 
 class FrameEncodingError(ValueError):

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -210,7 +210,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
 
             responses = self.__index(scope, arguments + flatten(requests))
 
-            for (idx, _, _), (cursor, chunk) in list(zip(requests, responses)):
+            for (idx, _, _), (cursor, chunk) in zip(requests, responses):
                 cursor = int(cursor)
                 if cursor == 0:
                     del cursors[idx]

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -75,7 +75,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
                 key,  # lexicographical sort on key, ascending
             )
 
-        return sorted(list(map(decode_search_result, results)), key=get_comparison_key)
+        return sorted(map(decode_search_result, results), key=get_comparison_key)
 
     def classify(self, scope, items, limit=None, timestamp=None):
         if timestamp is None:

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -37,7 +37,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
 
         arguments = []
         for bucket in band(self.bands, self.signature_builder(features)):
-            arguments.extend([1, ",".join(list(map("{}".format, bucket))), 1])
+            arguments.extend([1, ",".join(map("{}".format, bucket)), 1])
         return arguments
 
     def __index(self, scope, args):

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -22,12 +22,12 @@ class Encoder:
         elif isinstance(value, self.number_types):
             return str(value).encode("utf8")
         elif isinstance(value, Set):
-            return b"\x00".join(sorted(list(map(self.dumps, value))))
+            return b"\x00".join(sorted(map(self.dumps, value)))
         elif isinstance(value, Sequence):
-            return b"\x01".join(list(map(self.dumps, value)))
+            return b"\x01".join(map(self.dumps, value))
         elif isinstance(value, Mapping):
             return b"\x02".join(
-                sorted(b"\x01".join(list(map(self.dumps, item))) for item in value.items())
+                sorted(b"\x01".join(map(self.dumps, item)) for item in value.items())
             )
         else:
             raise TypeError(f"Unsupported type: {type(value)}")

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -1,7 +1,5 @@
 from collections import Mapping, Sequence, Set
 
-from sentry.utils.compat import map
-
 
 class Encoder:
     try:
@@ -24,12 +22,12 @@ class Encoder:
         elif isinstance(value, self.number_types):
             return str(value).encode("utf8")
         elif isinstance(value, Set):
-            return b"\x00".join(sorted(map(self.dumps, value)))
+            return b"\x00".join(sorted(list(map(self.dumps, value))))
         elif isinstance(value, Sequence):
-            return b"\x01".join(map(self.dumps, value))
+            return b"\x01".join(list(map(self.dumps, value)))
         elif isinstance(value, Mapping):
             return b"\x02".join(
-                sorted(b"\x01".join(map(self.dumps, item)) for item in value.items())
+                sorted(b"\x01".join(list(map(self.dumps, item))) for item in value.items())
             )
         else:
             raise TypeError(f"Unsupported type: {type(value)}")

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -2,7 +2,6 @@ import functools
 import itertools
 import logging
 
-from sentry.utils.compat import map, zip
 from sentry.utils.dates import to_timestamp
 
 logger = logging.getLogger("sentry.similarity")
@@ -14,12 +13,14 @@ def get_application_chunks(exception):
     better align similar logical application paths. This returns a sequence of
     application code "chunks": blocks of contiguously called application code.
     """
-    return map(
-        lambda in_app__frames: list(in_app__frames[1]),
-        itertools.ifilter(
-            lambda in_app__frames: in_app__frames[0],
-            itertools.groupby(exception.stacktrace.frames, key=lambda frame: frame.in_app),
-        ),
+    return list(
+        map(
+            lambda in_app__frames: list(in_app__frames[1]),
+            itertools.ifilter(
+                lambda in_app__frames: in_app__frames[0],
+                itertools.groupby(exception.stacktrace.frames, key=lambda frame: frame.in_app),
+            ),
+        )
     )
 
 
@@ -122,7 +123,7 @@ class FeatureSet:
                     ), "all events must be associated with the same group"
 
                 try:
-                    features = map(self.encoder.dumps, features)
+                    features = list(map(self.encoder.dumps, features))
                 except Exception as error:
                     log = (
                         logger.debug
@@ -162,7 +163,7 @@ class FeatureSet:
                     ), "all events must be associated with the same project"
 
                 try:
-                    features = map(self.encoder.dumps, features)
+                    features = list(map(self.encoder.dumps, features))
                 except Exception as error:
                     log = (
                         logger.debug
@@ -180,11 +181,13 @@ class FeatureSet:
                         items.append((self.aliases[label], thresholds.get(label, 0), features))
                         labels.append(label)
 
-        return map(
-            lambda key__scores: (int(key__scores[0]), dict(zip(labels, key__scores[1]))),
-            self.index.classify(
-                scope, items, limit=limit, timestamp=int(to_timestamp(event.datetime))
-            ),
+        return list(
+            map(
+                lambda key__scores: (int(key__scores[0]), dict(list(zip(labels, key__scores[1])))),
+                self.index.classify(
+                    scope, items, limit=limit, timestamp=int(to_timestamp(event.datetime))
+                ),
+            )
         )
 
     def compare(self, group, limit=None, thresholds=None):
@@ -195,11 +198,16 @@ class FeatureSet:
 
         items = [(self.aliases[label], thresholds.get(label, 0)) for label in features]
 
-        return map(
-            lambda key__scores: (int(key__scores[0]), dict(zip(features, key__scores[1]))),
-            self.index.compare(
-                self.__get_scope(group.project), self.__get_key(group), items, limit=limit
-            ),
+        return list(
+            map(
+                lambda key__scores: (
+                    int(key__scores[0]),
+                    dict(list(zip(features, key__scores[1]))),
+                ),
+                self.index.compare(
+                    self.__get_scope(group.project), self.__get_key(group), items, limit=limit
+                ),
+            )
         )
 
     def merge(self, destination, sources, allow_unsafe=False):
@@ -231,7 +239,7 @@ class FeatureSet:
             if source_scope != destination_scope:
                 imports = [
                     (alias, destination_key, data)
-                    for (alias, _), data in zip(items, self.index.export(source_scope, items))
+                    for (alias, _), data in list(zip(items, self.index.export(source_scope, items)))
                 ]
                 self.index.delete(source_scope, items)
                 self.index.import_(destination_scope, imports)

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -239,7 +239,7 @@ class FeatureSet:
             if source_scope != destination_scope:
                 imports = [
                     (alias, destination_key, data)
-                    for (alias, _), data in list(zip(items, self.index.export(source_scope, items)))
+                    for (alias, _), data in zip(items, self.index.export(source_scope, items))
                 ]
                 self.index.delete(source_scope, items)
                 self.index.import_(destination_scope, imports)

--- a/src/sentry/similarity/signatures.py
+++ b/src/sentry/similarity/signatures.py
@@ -10,7 +10,7 @@ class MinHashSignatureBuilder:
         return list(
             map(
                 lambda column: min(
-                    list(map(lambda feature: mmh3.hash(feature, column) % self.rows, features))
+                    map(lambda feature: mmh3.hash(feature, column) % self.rows, features)
                 ),
                 range(self.columns),
             )

--- a/src/sentry/similarity/signatures.py
+++ b/src/sentry/similarity/signatures.py
@@ -1,7 +1,5 @@
 import mmh3
 
-from sentry.utils.compat import map
-
 
 class MinHashSignatureBuilder:
     def __init__(self, columns, rows):
@@ -9,9 +7,11 @@ class MinHashSignatureBuilder:
         self.rows = rows
 
     def __call__(self, features):
-        return map(
-            lambda column: min(
-                map(lambda feature: mmh3.hash(feature, column) % self.rows, features)
-            ),
-            range(self.columns),
+        return list(
+            map(
+                lambda column: min(
+                    list(map(lambda feature: mmh3.hash(feature, column) % self.rows, features))
+                ),
+                range(self.columns),
+            )
         )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1115,7 +1115,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if min_value is None:
         min_values = [row[get_function_alias(column)] for column in min_columns]
-        min_values = list(list(filter(lambda v: v is not None, min_values)))
+        min_values = list(filter(lambda v: v is not None, min_values))
         min_value = min(min_values) if min_values else None
         if max_value is not None and min_value is not None:
             # max_value was provided by the user, and min_value was queried.
@@ -1127,7 +1127,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if max_value is None:
         max_values = [row[get_function_alias(column)] for column in max_columns]
-        max_values = list(list(filter(lambda v: v is not None, max_values)))
+        max_values = list(filter(lambda v: v is not None, max_values))
         max_value = max(max_values) if max_values else None
 
         fences = []
@@ -1154,7 +1154,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         max_fence_value = max(fences) if fences else None
 
         candidates = [max_fence_value, max_value]
-        candidates = list(list(filter(lambda v: v is not None, candidates)))
+        candidates = list(filter(lambda v: v is not None, candidates))
         max_value = min(candidates) if candidates else None
         if max_value is not None and min_value is not None:
             # min_value may be either queried or provided by the user. max_value was queried.

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -20,7 +20,6 @@ from sentry.search.events.fields import (
 )
 from sentry.search.events.filter import get_filter
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
-from sentry.utils.compat import filter
 from sentry.utils.math import mean, nice_int
 from sentry.utils.snuba import (
     SNUBA_AND,
@@ -1116,7 +1115,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if min_value is None:
         min_values = [row[get_function_alias(column)] for column in min_columns]
-        min_values = list(filter(lambda v: v is not None, min_values))
+        min_values = list(list(filter(lambda v: v is not None, min_values)))
         min_value = min(min_values) if min_values else None
         if max_value is not None and min_value is not None:
             # max_value was provided by the user, and min_value was queried.
@@ -1128,7 +1127,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if max_value is None:
         max_values = [row[get_function_alias(column)] for column in max_columns]
-        max_values = list(filter(lambda v: v is not None, max_values))
+        max_values = list(list(filter(lambda v: v is not None, max_values)))
         max_value = max(max_values) if max_values else None
 
         fences = []
@@ -1155,7 +1154,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         max_fence_value = max(fences) if fences else None
 
         candidates = [max_fence_value, max_value]
-        candidates = list(filter(lambda v: v is not None, candidates))
+        candidates = list(list(filter(lambda v: v is not None, candidates)))
         max_value = min(candidates) if candidates else None
         if max_value is not None and min_value is not None:
             # min_value may be either queried or provided by the user. max_value was queried.

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -967,7 +967,7 @@ def to_calendar(organization, interval, series):
 
     calendar = Calendar(6)
     sheets = []
-    for year, month in list(map(index_to_month, range(start, stop + 1))):
+    for year, month in map(index_to_month, range(start, stop + 1)):
         weeks = []
 
         for week in calendar.monthdatescalendar(year, month):

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -185,7 +185,7 @@ def merge_sequences(target, other, function=operator.add):
     if rt_type == range:
         rt_type = list
 
-    return rt_type([function(x, y) for x, y in list(zip(target, other))])
+    return rt_type([function(x, y) for x, y in zip(target, other)])
 
 
 def merge_mappings(target, other, function=operator.add):

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -27,7 +27,6 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
@@ -175,9 +174,11 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
             id=Project.objects.get_from_cache(id=instance.project_id).organization_id
         )
 
-    installations = filter(
-        lambda i: event in i.sentry_app.events,
-        SentryAppInstallation.get_installed_for_org(org.id).select_related("sentry_app"),
+    installations = list(
+        filter(
+            lambda i: event in i.sentry_app.events,
+            SentryAppInstallation.get_installed_for_org(org.id).select_related("sentry_app"),
+        )
     )
 
     for installation in installations:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,5 +1,3 @@
-from sentry.utils.compat import zip
-
 __all__ = (
     "TestCase",
     "TransactionTestCase",
@@ -1084,7 +1082,7 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
 
     def assert_widget_queries(self, widget_id, data):
         result_queries = DashboardWidgetQuery.objects.filter(widget_id=widget_id).order_by("order")
-        for ds, expected_ds in zip(result_queries, data):
+        for ds, expected_ds in list(zip(result_queries, data)):
             assert ds.name == expected_ds["name"]
             assert ds.fields == expected_ds["fields"]
             assert ds.conditions == expected_ds["conditions"]

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1082,7 +1082,7 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
 
     def assert_widget_queries(self, widget_id, data):
         result_queries = DashboardWidgetQuery.objects.filter(widget_id=widget_id).order_by("order")
-        for ds, expected_ds in list(zip(result_queries, data)):
+        for ds, expected_ds in zip(result_queries, data):
             assert ds.name == expected_ds["name"]
             assert ds.fields == expected_ds["fields"]
             assert ds.conditions == expected_ds["conditions"]

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -6,7 +6,6 @@ from enum import Enum
 from django.conf import settings
 from django.utils import timezone
 
-from sentry.utils.compat import map
 from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.services import Service
 
@@ -265,7 +264,7 @@ class BaseTSDB(Service):
                 end,
                 rollup=rollup,
             )
-            rollups[rollup] = map(to_datetime, series)
+            rollups[rollup] = list(map(to_datetime, series))
         return rollups
 
     def make_series(self, default, start, end=None, rollup=None):

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -3,7 +3,6 @@ from collections import Counter, defaultdict
 from django.utils import timezone
 
 from sentry.tsdb.base import BaseTSDB
-from sentry.utils.compat import map
 from sentry.utils.dates import to_datetime, to_timestamp
 
 
@@ -69,7 +68,7 @@ class InMemoryTSDB(BaseTSDB):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = []
-        for timestamp in map(to_datetime, series):
+        for timestamp in list(map(to_datetime, series)):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
 
             for key in keys:

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -68,7 +68,7 @@ class InMemoryTSDB(BaseTSDB):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = []
-        for timestamp in list(map(to_datetime, series)):
+        for timestamp in map(to_datetime, series):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
 
             for key in keys:

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -12,7 +12,7 @@ from django.utils.encoding import force_bytes
 from pkg_resources import resource_string
 
 from sentry.tsdb.base import BaseTSDB
-from sentry.utils.compat import crc32, map, zip
+from sentry.utils.compat import crc32
 from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.redis import SentryScript, check_cluster_versions, get_cluster_from_options
 from sentry.utils.versioning import Version
@@ -279,7 +279,7 @@ class RedisTSDB(BaseTSDB):
         self.validate_arguments([model], [environment_id])
 
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
-        series = map(to_datetime, series)
+        series = list(map(to_datetime, series))
 
         results = []
         cluster, _ = self.get_cluster(environment_id)
@@ -505,7 +505,9 @@ class RedisTSDB(BaseTSDB):
             client = cluster.get_local_client(host)
             with client.pipeline(transaction=False) as pipeline:
                 pipeline.execute_command(
-                    "PFMERGE", destination, *itertools.chain.from_iterable(map(expand_key, keys))
+                    "PFMERGE",
+                    destination,
+                    *itertools.chain.from_iterable(list(map(expand_key, keys))),
                 )
                 pipeline.get(destination)
                 pipeline.delete(destination)
@@ -644,7 +646,7 @@ class RedisTSDB(BaseTSDB):
 
     def make_frequency_table_keys(self, model, rollup, timestamp, key, environment_id):
         prefix = self.make_key(model, rollup, timestamp, key, environment_id)
-        return map(operator.methodcaller("format", prefix), ("{}:i", "{}:e"))
+        return list(map(operator.methodcaller("format", prefix), ("{}:i", "{}:e")))
 
     def record_frequency_multi(self, requests, timestamp=None, environment_id=None):
         self.validate_arguments([model for model, request in requests], [environment_id])
@@ -758,7 +760,7 @@ class RedisTSDB(BaseTSDB):
         results = {}
         cluster, _ = self.get_cluster(environment_id)
         for key, responses in cluster.execute_commands(commands).items():
-            results[key] = zip(series, map(unpack_response, responses))
+            results[key] = list(zip(series, list(map(unpack_response, responses))))
 
         return results
 
@@ -796,8 +798,8 @@ class RedisTSDB(BaseTSDB):
             members = items[key]
 
             chunk = results[key] = []
-            for timestamp, scores in zip(series, responses[0].value):
-                chunk.append((timestamp, dict(zip(members, map(float, scores)))))
+            for timestamp, scores in list(zip(series, responses[0].value)):
+                chunk.append((timestamp, dict(list(zip(members, list(map(float, scores)))))))
 
         return results
 
@@ -836,7 +838,7 @@ class RedisTSDB(BaseTSDB):
                 end=None,
                 rollup=rollup,
             )
-            rollups.append((rollup, map(to_datetime, series)))
+            rollups.append((rollup, list(map(to_datetime, series))))
 
         for (cluster, durable), environment_ids in self.get_cluster_groups(environment_ids):
             exports = defaultdict(list)
@@ -868,7 +870,9 @@ class RedisTSDB(BaseTSDB):
                 results = iter(results)
                 for rollup, series in rollups:
                     for timestamp in series:
-                        for environment_id, payload in zip(environment_ids, next(results).value):
+                        for environment_id, payload in list(
+                            zip(environment_ids, next(results).value)
+                        ):
                             imports.append(
                                 (
                                     CountMinScript,

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -798,7 +798,7 @@ class RedisTSDB(BaseTSDB):
             members = items[key]
 
             chunk = results[key] = []
-            for timestamp, scores in list(zip(series, responses[0].value)):
+            for timestamp, scores in zip(series, responses[0].value):
                 chunk.append((timestamp, dict(list(zip(members, list(map(float, scores)))))))
 
         return results
@@ -870,9 +870,7 @@ class RedisTSDB(BaseTSDB):
                 results = iter(results)
                 for rollup, series in rollups:
                     for timestamp in series:
-                        for environment_id, payload in list(
-                            zip(environment_ids, next(results).value)
-                        ):
+                        for environment_id, payload in zip(environment_ids, next(results).value):
                             imports.append(
                                 (
                                     CountMinScript,

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -6,7 +6,6 @@ from sentry.constants import DataCategory
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.tsdb.base import BaseTSDB, TSDBModel
 from sentry.utils import outcomes, snuba
-from sentry.utils.compat import map, zip
 from sentry.utils.dates import to_datetime
 
 SnubaModelQuerySettings = collections.namedtuple(
@@ -256,7 +255,7 @@ class SnubaTSDB(BaseTSDB):
             TSDBModel.key_total_blacklisted,
             TSDBModel.key_total_rejected,
         ]:
-            keys = list(set(map(lambda x: int(x), keys)))
+            keys = list(set(list(map(lambda x: int(x), keys))))
 
         # 10s is the only rollup under an hour that we support
         if rollup and rollup == 10 and model in self.lower_rollup_query_settings:
@@ -282,7 +281,7 @@ class SnubaTSDB(BaseTSDB):
             model_aggregate = None
 
         columns = (model_query_settings.groupby, model_query_settings.aggregate)
-        keys_map = dict(zip(columns, self.flatten_keys(keys)))
+        keys_map = dict(list(zip(columns, self.flatten_keys(keys))))
         keys_map = {k: v for k, v in keys_map.items() if k is not None and v is not None}
         if environment_ids is not None:
             keys_map["environment"] = environment_ids

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -255,7 +255,7 @@ class SnubaTSDB(BaseTSDB):
             TSDBModel.key_total_blacklisted,
             TSDBModel.key_total_rejected,
         ]:
-            keys = list(set(list(map(lambda x: int(x), keys))))
+            keys = list(set(map(lambda x: int(x), keys)))
 
         # 10s is the only rollup under an hour that we support
         if rollup and rollup == 10 and model in self.lower_rollup_query_settings:

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -12,7 +12,6 @@ from django.utils.encoding import force_text
 from django.utils.html import escape
 
 from sentry.http import safe_urlopen
-from sentry.utils.compat import map
 from sentry.utils.hashlib import md5_text
 
 
@@ -57,7 +56,7 @@ COLOR_COUNT = len(LETTER_AVATAR_COLORS)
 
 def hash_user_identifier(identifier: str) -> int:
     identifier = force_text(identifier, errors="replace")
-    return sum(map(ord, identifier))
+    return sum(list(map(ord, identifier)))
 
 
 def get_letter_avatar_color(identifier: str) -> str:

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -56,7 +56,7 @@ COLOR_COUNT = len(LETTER_AVATAR_COLORS)
 
 def hash_user_identifier(identifier: str) -> int:
     identifier = force_text(identifier, errors="replace")
-    return sum(list(map(ord, identifier)))
+    return sum(map(ord, identifier))
 
 
 def get_letter_avatar_color(identifier: str) -> str:

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -9,7 +9,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.commit import CommitSerializer, get_users_for_commits
 from sentry.models import Commit, CommitFileChange, Group, Release, ReleaseCommit
 from sentry.utils import metrics
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import get_path
 
@@ -28,7 +27,7 @@ def tokenize_path(path):
 
 def score_path_match_length(path_a, path_b):
     score = 0
-    for a, b in zip(tokenize_path(path_a), tokenize_path(path_b)):
+    for a, b in list(zip(tokenize_path(path_a), tokenize_path(path_b))):
         if a.lower() != b.lower():
             break
         score += 1
@@ -272,7 +271,7 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
 
     serialized_commits_by_id = {}
 
-    for (commit, score), serialized_commit in zip(commits, serialized_commits):
+    for (commit, score), serialized_commit in list(zip(commits, serialized_commits)):
         serialized_commit["score"] = score
         serialized_commits_by_id[commit.id] = serialized_commit
 

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -27,7 +27,7 @@ def tokenize_path(path):
 
 def score_path_match_length(path_a, path_b):
     score = 0
-    for a, b in list(zip(tokenize_path(path_a), tokenize_path(path_b))):
+    for a, b in zip(tokenize_path(path_a), tokenize_path(path_b)):
         if a.lower() != b.lower():
             break
         score += 1
@@ -271,7 +271,7 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
 
     serialized_commits_by_id = {}
 
-    for (commit, score), serialized_commit in list(zip(commits, serialized_commits)):
+    for (commit, score), serialized_commit in zip(commits, serialized_commits):
         serialized_commit["score"] = score
         serialized_commits_by_id[commit.id] = serialized_commit
 

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -1,23 +1,3 @@
-_builtin_map = map
-_builtin_filter = filter
-_builtin_zip = zip
-
-
-def map(a, b, *c):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_map(a, b, *c))
-
-
-def filter(a, b):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_filter(a, b))
-
-
-def zip(*a):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_zip(*a))
-
-
 from binascii import crc32 as _crc32
 
 

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -23,7 +23,6 @@ from sentry import options
 from sentry.logging import LoggingFormat
 from sentry.models import Activity, Group, GroupEmailThread, Project, User, UserOption
 from sentry.utils import metrics
-from sentry.utils.compat import map
 from sentry.utils.safe import safe_execute
 from sentry.utils.strings import is_valid_dot_atom
 from sentry.web.helpers import render_to_string
@@ -226,7 +225,7 @@ class ListResolver:
                 f"Cannot generate mailing list identifier for {instance!r}"
             )
 
-        label = ".".join(map(str, handler(instance)))
+        label = ".".join(list(map(str, handler(instance))))
         assert is_valid_dot_atom(label)
 
         return f"<{label}.{self.__namespace}>"

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -225,7 +225,7 @@ class ListResolver:
                 f"Cannot generate mailing list identifier for {instance!r}"
             )
 
-        label = ".".join(list(map(str, handler(instance))))
+        label = ".".join(map(str, handler(instance)))
         assert is_valid_dot_atom(label)
 
         return f"<{label}.{self.__namespace}>"

--- a/src/sentry/utils/functional.py
+++ b/src/sentry/utils/functional.py
@@ -1,7 +1,5 @@
 from django.utils.functional import empty
 
-from sentry.utils.compat import zip
-
 
 def extract_lazy_object(lo):
     """
@@ -32,8 +30,8 @@ def apply_values(function, mapping):
     if not mapping:
         return {}
 
-    keys, values = zip(*mapping.items())
-    return dict(zip(keys, function(values)))
+    keys, values = list(zip(*mapping.items()))
+    return dict(list(zip(keys, function(values))))
 
 
 def compact(seq):

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -7,7 +7,6 @@ from django.conf import settings
 
 from sentry import options
 from sentry.utils import json
-from sentry.utils.compat import filter, map
 
 ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 
@@ -80,7 +79,7 @@ def get_origins(project=None):
 
     # lowercase and strip the trailing slash from all origin values
     # filter out empty values
-    return frozenset(filter(bool, map(lambda x: (x or "").lower().rstrip("/"), result)))
+    return frozenset(list(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result)))))
 
 
 def parse_uri_match(value):

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -79,7 +79,7 @@ def get_origins(project=None):
 
     # lowercase and strip the trailing slash from all origin values
     # filter out empty values
-    return frozenset(list(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result)))))
+    return frozenset(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result))))
 
 
 def parse_uri_match(value):

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -1,7 +1,5 @@
 import itertools
 
-from sentry.utils.compat import map, zip
-
 
 def advance(n, iterator):
     """Advances an iterator n places."""
@@ -16,10 +14,14 @@ def shingle(n, iterator):
     >>> list(shingle(2, ('foo', 'bar', 'baz')))
     [('foo', 'bar'), ('bar', 'baz')]
     """
-    return zip(
-        *map(
-            lambda i__iterator: advance(i__iterator[0], i__iterator[1]),
-            enumerate(itertools.tee(iterator, n)),
+    return list(
+        zip(
+            *list(
+                map(
+                    lambda i__iterator: advance(i__iterator[0], i__iterator[1]),
+                    enumerate(itertools.tee(iterator, n)),
+                )
+            )
         )
     )
 

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -1,7 +1,5 @@
 import collections
 
-from sentry.utils.compat import map
-
 
 class Meta:
     """
@@ -26,7 +24,7 @@ class Meta:
         Enters into sub meta data at the specified path. This always returns a
         new ``Meta`` object, regardless whether the path already exists.
         """
-        return Meta(self._meta, path=self._path + map(str, path))
+        return Meta(self._meta, path=self._path + list(map(str, path)))
 
     @property
     def path(self):

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -20,7 +20,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
-from sentry.utils.compat import map
 from sentry.utils.retries import TimedRetryPolicy
 
 logger = logging.getLogger("sentry.testutils")
@@ -472,7 +471,7 @@ def start_chrome(**chrome_args):
 @pytest.fixture(scope="function")
 def browser(request, live_server):
     window_size = request.config.getoption("window_size")
-    window_width, window_height = map(int, window_size.split("x", 1))
+    window_width, window_height = list(map(int, window_size.split("x", 1)))
 
     driver_type = request.config.getoption("selenium_driver")
     headless = not request.config.getoption("no_headless")

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -16,7 +16,6 @@ from rediscluster.exceptions import ClusterError
 from sentry import options
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
-from sentry.utils.compat import map
 from sentry.utils.versioning import Version, check_versions
 from sentry.utils.warnings import DeprecatedSettingWarning
 
@@ -189,14 +188,15 @@ def get_cluster_from_options(setting, options, cluster_manager=clusters):
         if cluster_option_name in options:
             raise InvalidConfiguration(
                 "Cannot provide both named cluster ({!r}) and cluster configuration ({}) options.".format(
-                    cluster_option_name, ", ".join(map(repr, cluster_constructor_option_names))
+                    cluster_option_name,
+                    ", ".join(list(map(repr, cluster_constructor_option_names))),
                 )
             )
         else:
             warnings.warn(
                 DeprecatedSettingWarning(
                     "{} parameter of {}".format(
-                        ", ".join(map(repr, cluster_constructor_option_names)), setting
+                        ", ".join(list(map(repr, cluster_constructor_option_names))), setting
                     ),
                     f'{setting}["{cluster_option_name}"]',
                     removed_in_version="8.5",
@@ -246,7 +246,7 @@ def check_cluster_versions(cluster, required, recommended=None, label=None):
         # NOTE: This assumes there is no routing magic going on here, and
         # all requests to this host are being served by the same database.
         key = f"{host.host}:{host.port}"
-        versions[key] = Version(map(int, info["redis_version"].split(".", 3)))
+        versions[key] = Version(list(map(int, info["redis_version"].split(".", 3))))
 
     check_versions(
         "Redis" if label is None else f"Redis ({label})", versions, required, recommended

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -189,14 +189,14 @@ def get_cluster_from_options(setting, options, cluster_manager=clusters):
             raise InvalidConfiguration(
                 "Cannot provide both named cluster ({!r}) and cluster configuration ({}) options.".format(
                     cluster_option_name,
-                    ", ".join(list(map(repr, cluster_constructor_option_names))),
+                    ", ".join(map(repr, cluster_constructor_option_names)),
                 )
             )
         else:
             warnings.warn(
                 DeprecatedSettingWarning(
                     "{} parameter of {}".format(
-                        ", ".join(list(map(repr, cluster_constructor_option_names))), setting
+                        ", ".join(map(repr, cluster_constructor_option_names)), setting
                     ),
                     f'{setting}["{cluster_option_name}"]',
                     removed_in_version="8.5",

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -6,7 +6,6 @@ from django.db import transaction
 from django.utils.encoding import force_text
 
 from sentry.utils import json
-from sentry.utils.compat import filter
 from sentry.utils.strings import truncatechars
 
 
@@ -144,7 +143,7 @@ def get_path(data, *path, **kwargs):
             return default
 
     if f and data and isinstance(data, (list, tuple)):
-        data = filter((lambda x: x is not None) if f is True else f, data)
+        data = list(filter((lambda x: x is not None) if f is True else f, data))
 
     return data if data is not None else default
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -717,7 +717,7 @@ def _apply_cache_and_build_results(
         cache_keys = [get_cache_key(query_params) for _, query_params in query_param_list]
         cache_data = cache.get_many(cache_keys)
         to_query: List[Tuple[int, SnubaQueryBody, Optional[str]]] = []
-        for (query_pos, query_params), cache_key in list(zip(query_param_list, cache_keys)):
+        for (query_pos, query_params), cache_key in zip(query_param_list, cache_keys):
             cached_result = cache_data.get(cache_key)
             metric_tags = {"referrer": referrer} if referrer else None
             if cached_result is None:
@@ -731,7 +731,7 @@ def _apply_cache_and_build_results(
 
     if to_query:
         query_results = _bulk_snuba_query(list(map(itemgetter(1), to_query)), headers, use_snql)
-        for result, (query_pos, _, cache_key) in list(zip(query_results, to_query)):
+        for result, (query_pos, _, cache_key) in zip(query_results, to_query):
             if cache_key:
                 cache.set(cache_key, json.dumps(result), settings.SENTRY_SNUBA_CACHE_TTL_SECONDS)
             results.append((query_pos, result))

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -37,7 +37,6 @@ from sentry.net.http import connection_from_url
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
 from sentry.utils import json, metrics
-from sentry.utils.compat import map
 from sentry.utils.dates import outside_retention_with_modified_start, to_timestamp
 from sentry.utils.snql import should_use_snql
 
@@ -422,7 +421,7 @@ def get_query_params_to_update_for_projects(query_params, with_org=False):
                 get_related_project_ids(k, query_params.filter_keys[k])
                 for k in query_params.filter_keys
             ]
-            project_ids = list(set.union(*map(set, ids)))
+            project_ids = list(set.union(*list(map(set, ids))))
     elif query_params.conditions:
         project_ids = []
         for cond in query_params.conditions:
@@ -693,7 +692,7 @@ def bulk_raw_query(
     use_cache: Optional[bool] = False,
     use_snql: Optional[bool] = None,
 ) -> ResultSet:
-    params = map(_prepare_query_params, snuba_param_list)
+    params = list(map(_prepare_query_params, snuba_param_list))
     return _apply_cache_and_build_results(
         params, referrer=referrer, use_cache=use_cache, use_snql=use_snql
     )
@@ -718,7 +717,7 @@ def _apply_cache_and_build_results(
         cache_keys = [get_cache_key(query_params) for _, query_params in query_param_list]
         cache_data = cache.get_many(cache_keys)
         to_query: List[Tuple[int, SnubaQueryBody, Optional[str]]] = []
-        for (query_pos, query_params), cache_key in zip(query_param_list, cache_keys):
+        for (query_pos, query_params), cache_key in list(zip(query_param_list, cache_keys)):
             cached_result = cache_data.get(cache_key)
             metric_tags = {"referrer": referrer} if referrer else None
             if cached_result is None:
@@ -731,8 +730,8 @@ def _apply_cache_and_build_results(
         to_query = [(query_pos, query_params, None) for query_pos, query_params in query_param_list]
 
     if to_query:
-        query_results = _bulk_snuba_query(map(itemgetter(1), to_query), headers, use_snql)
-        for result, (query_pos, _, cache_key) in zip(query_results, to_query):
+        query_results = _bulk_snuba_query(list(map(itemgetter(1), to_query)), headers, use_snql)
+        for result, (query_pos, _, cache_key) in list(zip(query_results, to_query)):
             if cache_key:
                 cache.set(cache_key, json.dumps(result), settings.SENTRY_SNUBA_CACHE_TTL_SECONDS)
             results.append((query_pos, result))
@@ -740,7 +739,7 @@ def _apply_cache_and_build_results(
     # Sort so that we get the results back in the original param list order
     results.sort()
     # Drop the sort order val
-    return map(itemgetter(1), results)
+    return list(map(itemgetter(1), results))
 
 
 def _bulk_snuba_query(

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -6,8 +6,6 @@ import zlib
 
 from django.utils.encoding import force_text, smart_text
 
-from sentry.utils.compat import map
-
 _word_sep_re = re.compile(r"[\s.;,_-]+", re.UNICODE)
 _camelcase_re = re.compile(r"(?:[A-Z]{2,}(?=[A-Z]))|(?:[A-Z][a-z0-9]+)|(?:[a-z0-9]+)")
 _letters_re = re.compile(r"[A-Z]+")
@@ -103,7 +101,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
     zero-width spaces after common delimiters, as well as soft-hyphenating long
     identifiers.
     """
-    delimiters = re.compile(r"([{}]+)".format("".join(map(re.escape, ",.$:/+@!?()<>[]{}"))))
+    delimiters = re.compile(r"([{}]+)".format("".join(list(map(re.escape, ",.$:/+@!?()<>[]{}")))))
 
     def soft_break_delimiter(match):
         results = []

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -101,7 +101,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
     zero-width spaces after common delimiters, as well as soft-hyphenating long
     identifiers.
     """
-    delimiters = re.compile(r"([{}]+)".format("".join(list(map(re.escape, ",.$:/+@!?()<>[]{}")))))
+    delimiters = re.compile(r"([{}]+)".format("".join(map(re.escape, ",.$:/+@!?()<>[]{}"))))
 
     def soft_break_delimiter(match):
         results = []

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -2,13 +2,12 @@ from django.utils.encoding import force_text, python_2_unicode_compatible
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
-from sentry.utils.compat import map
 
 
 @python_2_unicode_compatible
 class Version(tuple):
     def __str__(self):
-        return ".".join(map(force_text, self))
+        return ".".join(list(map(force_text, self)))
 
 
 def summarize(sequence, max=3):
@@ -23,7 +22,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return "{service} {modality} be upgraded to {version} on {hosts}.".format(
-        hosts=",".join(map(force_text, summarize(list(hosts.keys()), 2))),
+        hosts=",".join(list(map(force_text, summarize(list(hosts.keys()), 2)))),
         modality=modality,
         service=service,
         version=version,

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -7,7 +7,7 @@ from sentry.utils import warnings
 @python_2_unicode_compatible
 class Version(tuple):
     def __str__(self):
-        return ".".join(list(map(force_text, self)))
+        return ".".join(map(force_text, self))
 
 
 def summarize(sequence, max=3):
@@ -22,7 +22,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return "{service} {modality} be upgraded to {version} on {hosts}.".format(
-        hosts=",".join(list(map(force_text, summarize(list(hosts.keys()), 2)))),
+        hosts=",".join(map(force_text, summarize(list(hosts.keys()), 2))),
         modality=modality,
         service=service,
         version=version,

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -5,7 +5,6 @@ from django.views.generic import View
 
 from sentry.models import Commit, CommitAuthor, Deploy, Organization, Project, Release, User
 from sentry.notifications.types import GroupSubscriptionReason
-from sentry.utils.compat import zip
 from sentry.utils.http import absolute_uri
 
 from .mail import MailPreview
@@ -96,7 +95,7 @@ class DebugNewReleaseEmailView(View):
             text_template="sentry/emails/activity/release.txt",
             context={
                 "release": release,
-                "projects": zip(projects, release_links, [6, 1, 0]),
+                "projects": list(zip(projects, release_links, [6, 1, 0])),
                 "repos": repos,
                 "reason": GroupSubscriptionReason.descriptions[GroupSubscriptionReason.committed],
                 "project_count": len(projects),

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -7,7 +7,6 @@ from django.utils.translation import ugettext_lazy as _
 import sentry
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.plugins.bases.notify import NotificationPlugin
-from sentry.utils.compat import filter, map
 from sentry_plugins.base import CorePluginMixin
 
 from .client import TwilioApiClient
@@ -46,7 +45,7 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
+    return set(list(filter(bool, re.split(r"\s*,\s*|\s+", data))))
 
 
 class TwilioConfigurationForm(forms.Form):
@@ -85,7 +84,7 @@ class TwilioConfigurationForm(forms.Form):
         for phone in phones:
             if not validate_phone(phone):
                 raise forms.ValidationError(f"{phone} is not a valid phone number.")
-        return ",".join(sorted(set(map(clean_phone, phones))))
+        return ",".join(sorted(set(list(map(clean_phone, phones)))))
 
     def clean(self):
         # TODO: Ping Twilio and check credentials (?)

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -45,7 +45,7 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(list(filter(bool, re.split(r"\s*,\s*|\s+", data))))
+    return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
 
 
 class TwilioConfigurationForm(forms.Form):
@@ -84,7 +84,7 @@ class TwilioConfigurationForm(forms.Form):
         for phone in phones:
             if not validate_phone(phone):
                 raise forms.ValidationError(f"{phone} is not a valid phone number.")
-        return ",".join(sorted(set(list(map(clean_phone, phones)))))
+        return ",".join(sorted(set(map(clean_phone, phones))))
 
     def clean(self):
         # TODO: Ping Twilio and check credentials (?)

--- a/src/social_auth/__init__.py
+++ b/src/social_auth/__init__.py
@@ -1,3 +1,3 @@
 version = (0, 7, 28)
 
-__version__ = ".".join(list(map(str, version)))
+__version__ = ".".join(map(str, version))

--- a/src/social_auth/__init__.py
+++ b/src/social_auth/__init__.py
@@ -1,5 +1,3 @@
-from sentry.utils.compat import map
-
 version = (0, 7, 28)
 
-__version__ = ".".join(map(str, version))
+__version__ = ".".join(list(map(str, version)))

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -272,7 +272,7 @@ class BaseAuth:
         return {
             "next": next_idx,
             "backend": self.AUTH_BACKEND.name,
-            "args": tuple(list(map(model_to_ctype, args))),
+            "args": tuple(map(model_to_ctype, args)),
             "kwargs": {key: model_to_ctype(val) for key, val in kwargs.items()},
         }
 
@@ -280,7 +280,7 @@ class BaseAuth:
         """Takes session saved data to continue pipeline and merges with any
         new extra argument needed. Returns tuple with next pipeline index
         entry, arguments and keyword arguments to continue the process."""
-        args = args[:] + tuple(list(map(ctype_to_model, session_data["args"])))
+        args = args[:] + tuple(map(ctype_to_model, session_data["args"]))
 
         kwargs = kwargs.copy()
         saved_kwargs = {key: ctype_to_model(val) for key, val in session_data["kwargs"].items()}

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -22,7 +22,6 @@ from django.utils.crypto import constant_time_compare, get_random_string
 from requests_oauthlib import OAuth1
 
 from sentry.utils import json
-from sentry.utils.compat import map
 from social_auth.exceptions import (
     AuthCanceled,
     AuthFailed,
@@ -273,7 +272,7 @@ class BaseAuth:
         return {
             "next": next_idx,
             "backend": self.AUTH_BACKEND.name,
-            "args": tuple(map(model_to_ctype, args)),
+            "args": tuple(list(map(model_to_ctype, args))),
             "kwargs": {key: model_to_ctype(val) for key, val in kwargs.items()},
         }
 
@@ -281,7 +280,7 @@ class BaseAuth:
         """Takes session saved data to continue pipeline and merges with any
         new extra argument needed. Returns tuple with next pipeline index
         entry, arguments and keyword arguments to continue the process."""
-        args = args[:] + tuple(map(ctype_to_model, session_data["args"]))
+        args = args[:] + tuple(list(map(ctype_to_model, session_data["args"])))
 
         kwargs = kwargs.copy()
         saved_kwargs = {key: ctype_to_model(val) for key, val in session_data["kwargs"].items()}

--- a/tests/sentry/api/endpoints/test_organization_config_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_config_repositories.py
@@ -1,7 +1,6 @@
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
-from sentry.utils.compat import filter
 
 
 class OrganizationConfigRepositoriesTest(APITestCase):
@@ -14,6 +13,6 @@ class OrganizationConfigRepositoriesTest(APITestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        provider = filter(lambda x: x["id"] == "dummy", response.data["providers"])[0]
+        provider = list(filter(lambda x: x["id"] == "dummy", response.data["providers"]))[0]
         assert provider["name"] == "Example"
         assert provider["config"]

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -189,7 +189,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         widgets = self.get_widgets(self.dashboard)
         assert len(widgets) == len(list(widget_ids))
 
-        for widget, id in list(zip(widgets, widget_ids)):
+        for widget, id in zip(widgets, widget_ids):
             assert widget.id == id
 
     def test_dashboard_does_not_exist(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -8,7 +8,6 @@ from sentry.models import (
     DashboardWidgetQuery,
 )
 from sentry.testutils import OrganizationDashboardWidgetTestCase
-from sentry.utils.compat import zip
 
 
 class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
@@ -190,7 +189,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         widgets = self.get_widgets(self.dashboard)
         assert len(widgets) == len(list(widget_ids))
 
-        for widget, id in zip(widgets, widget_ids):
+        for widget, id in list(zip(widgets, widget_ids)):
             assert widget.id == id
 
     def test_dashboard_does_not_exist(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -7,7 +7,6 @@ from sentry.models import (
     DashboardWidgetDisplayTypes,
 )
 from sentry.testutils import OrganizationDashboardWidgetTestCase
-from sentry.utils.compat import zip
 
 
 class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
@@ -167,11 +166,11 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         widgets = self.get_widgets(dashboard.id)
         assert len(widgets) == 2
 
-        for expected_widget, actual_widget in zip(data["widgets"], widgets):
+        for expected_widget, actual_widget in list(zip(data["widgets"], widgets)):
             self.assert_serialized_widget(expected_widget, actual_widget)
 
             queries = actual_widget.dashboardwidgetquery_set.all()
-            for expected_query, actual_query in zip(expected_widget["queries"], queries):
+            for expected_query, actual_query in list(zip(expected_widget["queries"], queries)):
                 self.assert_serialized_widget_query(expected_query, actual_query)
 
     def test_invalid_data(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -166,11 +166,11 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         widgets = self.get_widgets(dashboard.id)
         assert len(widgets) == 2
 
-        for expected_widget, actual_widget in list(zip(data["widgets"], widgets)):
+        for expected_widget, actual_widget in zip(data["widgets"], widgets):
             self.assert_serialized_widget(expected_widget, actual_widget)
 
             queries = actual_widget.dashboardwidgetquery_set.all()
-            for expected_query, actual_query in list(zip(expected_widget["queries"], queries)):
+            for expected_query, actual_query in zip(expected_widget["queries"], queries):
                 self.assert_serialized_widget_query(expected_query, actual_query)
 
     def test_invalid_data(self):

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -12,7 +12,6 @@ from sentry.models import (
     OrganizationMemberTeam,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 from sentry.utils.compat.mock import patch
 
 
@@ -260,13 +259,13 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase):
         self.get_success_response(self.organization.slug, member_om.id, teams=[foo.slug, bar.slug])
 
         member_teams = OrganizationMemberTeam.objects.filter(organizationmember=member_om)
-        team_ids = map(lambda x: x.team_id, member_teams)
+        team_ids = list(map(lambda x: x.team_id, member_teams))
         assert foo.id in team_ids
         assert bar.id in team_ids
 
         member_om = OrganizationMember.objects.get(id=member_om.id)
 
-        teams = map(lambda team: team.slug, member_om.teams.all())
+        teams = list(map(lambda team: team.slug, member_om.teams.all()))
         assert foo.slug in teams
         assert bar.slug in teams
 
@@ -281,7 +280,7 @@ class UpdateOrganizationMemberTest(OrganizationMemberTestBase):
         )
 
         member_om = OrganizationMember.objects.get(id=member_om.id)
-        teams = map(lambda team: team.slug, member_om.teams.all())
+        teams = list(map(lambda team: team.slug, member_om.teams.all()))
         assert len(teams) == 0
 
     def test_can_update_role(self):

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -60,17 +60,14 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)
         assert (
-            list(list(filter(lambda x: x["slug"] == "webhooks", response.data)))[0]["projectList"]
-            == []
+            list(filter(lambda x: x["slug"] == "webhooks", response.data))[0]["projectList"] == []
         )
 
     def test_configured_not_enabled(self):
         plugins.get("trello").disable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ] == [
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -85,9 +82,7 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").enable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ] == [
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -104,19 +99,14 @@ class OrganizationPluginsTest(APITestCase):
         self.projectA.status = 1
         self.projectA.save()
         response = self.client.get(self.url)
-        assert (
-            list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0]["projectList"]
-            == []
-        )
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == []
 
     def test_configured_multiple_projects(self):
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         plugins.get("trello").set_option("key", "another_value", self.projectB)
         response = self.client.get(self.url)
-        projectList = list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ]
-        assert list(list(filter(lambda x: x["projectId"] == self.projectA.id, projectList)))[0] == {
+        projectList = list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"]
+        assert list(filter(lambda x: x["projectId"] == self.projectA.id, projectList))[0] == {
             "projectId": self.projectA.id,
             "projectSlug": self.projectA.slug,
             "projectName": self.projectA.name,
@@ -124,7 +114,7 @@ class OrganizationPluginsTest(APITestCase):
             "configured": True,
             "projectPlatform": None,
         }
-        assert list(list(filter(lambda x: x["projectId"] == self.projectB.id, projectList)))[0] == {
+        assert list(filter(lambda x: x["projectId"] == self.projectB.id, projectList))[0] == {
             "projectId": self.projectB.id,
             "projectSlug": self.projectB.slug,
             "projectName": self.projectB.name,

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class OrganizationPluginsTest(APITestCase):
@@ -51,7 +50,7 @@ class OrganizationPluginsTest(APITestCase):
             "webhooks",
         ]
         for plugin in expected_plugins:
-            assert filter(lambda x: x["slug"] == plugin, response.data)
+            assert list(filter(lambda x: x["slug"] == plugin, response.data))
 
     def test_only_configuable_plugins(self):
         response = self.client.get(self.url)
@@ -61,14 +60,17 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)
         assert (
-            list(filter(lambda x: x["slug"] == "webhooks", response.data))[0]["projectList"] == []
+            list(list(filter(lambda x: x["slug"] == "webhooks", response.data)))[0]["projectList"]
+            == []
         )
 
     def test_configured_not_enabled(self):
         plugins.get("trello").disable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
+        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
+            "projectList"
+        ] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -83,7 +85,9 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").enable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
+        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
+            "projectList"
+        ] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -100,14 +104,19 @@ class OrganizationPluginsTest(APITestCase):
         self.projectA.status = 1
         self.projectA.save()
         response = self.client.get(self.url)
-        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == []
+        assert (
+            list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0]["projectList"]
+            == []
+        )
 
     def test_configured_multiple_projects(self):
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         plugins.get("trello").set_option("key", "another_value", self.projectB)
         response = self.client.get(self.url)
-        projectList = list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"]
-        assert list(filter(lambda x: x["projectId"] == self.projectA.id, projectList))[0] == {
+        projectList = list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
+            "projectList"
+        ]
+        assert list(list(filter(lambda x: x["projectId"] == self.projectA.id, projectList)))[0] == {
             "projectId": self.projectA.id,
             "projectSlug": self.projectA.slug,
             "projectName": self.projectA.name,
@@ -115,7 +124,7 @@ class OrganizationPluginsTest(APITestCase):
             "configured": True,
             "projectPlatform": None,
         }
-        assert list(filter(lambda x: x["projectId"] == self.projectB.id, projectList))[0] == {
+        assert list(list(filter(lambda x: x["projectId"] == self.projectB.id, projectList)))[0] == {
             "projectId": self.projectB.id,
             "projectSlug": self.projectB.slug,
             "projectName": self.projectB.name,
@@ -143,7 +152,7 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").set_option("key", "some_value", another)
         url = self.url + "?plugins=trello"
         response = self.client.get(url)
-        assert map(lambda x: x["projectSlug"], response.data[0]["projectList"]) == [
+        assert list(map(lambda x: x["projectSlug"], response.data[0]["projectList"])) == [
             "another",
             "proj_a",
             "proj_b",

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -809,7 +809,7 @@ class CopyProjectSettingsTest(APITestCase):
         assert ownership.schema == self.ownership.schema
 
         rules = Rule.objects.filter(project_id=project.id).order_by("label")
-        for rule, other_rule in list(zip(rules, self.rules)):
+        for rule, other_rule in zip(rules, self.rules):
             assert rule.label == other_rule.label
 
     def assert_settings_not_copied(self, project, teams=()):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -28,7 +28,7 @@ from sentry.models import (
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.compat import mock, zip
+from sentry.utils.compat import mock
 
 
 def _dyn_sampling_data():
@@ -809,7 +809,7 @@ class CopyProjectSettingsTest(APITestCase):
         assert ownership.schema == self.ownership.schema
 
         rules = Rule.objects.filter(project_id=project.id).order_by("label")
-        for rule, other_rule in zip(rules, self.rules):
+        for rule, other_rule in list(zip(rules, self.rules)):
             assert rule.label == other_rule.label
 
     def assert_settings_not_copied(self, project, teams=()):

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -51,7 +51,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
     def run_test(self, expected_groups):
         response = self.get_valid_response(self.org.slug, self.project.slug, self.release.version)
         assert len(response.data) == len(expected_groups)
-        expected = set(list(map(str, [g.id for g in expected_groups])))
+        expected = set(map(str, [g.id for g in expected_groups]))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -2,7 +2,6 @@ from uuid import uuid1
 
 from sentry.models import Commit, GroupLink, GroupResolution, ReleaseCommit, Repository
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
@@ -52,7 +51,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
     def run_test(self, expected_groups):
         response = self.get_valid_response(self.org.slug, self.project.slug, self.release.version)
         assert len(response.data) == len(expected_groups)
-        expected = set(map(str, [g.id for g in expected_groups]))
+        expected = set(list(map(str, [g.id for g in expected_groups])))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase
-from sentry.utils.compat import filter
 from sentry.utils.compat.mock import patch
 
 
@@ -26,13 +25,13 @@ class ProjectPluginsTest(APITestCase):
         assert response.status_code == 200, (response.status_code, response.content)
         assert len(response.data) >= 9
 
-        auto_tag = filter(lambda p: p["slug"] == "browsers", response.data)[0]
+        auto_tag = list(filter(lambda p: p["slug"] == "browsers", response.data))[0]
         assert auto_tag["name"] == "Auto Tag: Browsers"
         assert auto_tag["enabled"] is True
         assert auto_tag["isHidden"] is False
         self.assert_plugin_shape(auto_tag)
 
-        issues = filter(lambda p: p["slug"] == "issuetrackingplugin2", response.data)[0]
+        issues = list(filter(lambda p: p["slug"] == "issuetrackingplugin2", response.data))[0]
         assert issues["name"] == "IssueTrackingPlugin2"
         assert issues["enabled"] is False
         assert issues["isHidden"] is True

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 from sentry.models import EventUser, GroupStatus, UserReport
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import map
 
 
 class ProjectUserReportListTest(APITestCase, SnubaTestCase):
@@ -89,7 +88,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
 
     def test_cannot_access_with_dsn_auth(self):
         project = self.create_project()
@@ -121,7 +120,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
 
     def test_environments(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -88,7 +88,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
 
     def test_cannot_access_with_dsn_auth(self):
         project = self.create_project()
@@ -120,7 +120,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
 
     def test_environments(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -40,7 +40,7 @@ class ProjectUsersTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
             [str(self.euser1.id), str(self.euser2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.models import EventUser
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class ProjectUsersTest(APITestCase):
@@ -41,7 +40,7 @@ class ProjectUsersTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
             [str(self.euser1.id), str(self.euser2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -18,7 +18,7 @@ class TeamProjectIndexTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
             [str(project_1.id), str(project_2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.models import Project, Rule
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class TeamProjectIndexTest(APITestCase):
@@ -19,7 +18,7 @@ class TeamProjectIndexTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
             [str(project_1.id), str(project_2.id)]
         )
 

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -3,14 +3,13 @@ from django.utils.encoding import force_bytes, force_text
 
 from sentry.constants import MAX_CULPRIT_LENGTH
 from sentry.testutils import TestCase
-from sentry.utils.compat import map
 
 
 def psycopg2_version():
     import psycopg2
 
     version = psycopg2.__version__.split()[0].split(".")
-    return tuple(map(int, version))
+    return tuple(list(map(int, version)))
 
 
 @pytest.mark.skipif(psycopg2_version() < (2, 7), reason="Test requires psycopg 2.7+")

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -9,7 +9,7 @@ def psycopg2_version():
     import psycopg2
 
     version = psycopg2.__version__.split()[0].split(".")
-    return tuple(list(map(int, version)))
+    return tuple(map(int, version))
 
 
 @pytest.mark.skipif(psycopg2_version() < (2, 7), reason="Test requires psycopg 2.7+")

--- a/tests/sentry/grouping/similarity/test_features.py
+++ b/tests/sentry/grouping/similarity/test_features.py
@@ -7,7 +7,6 @@ from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
 from sentry.models import Group, Project
 from sentry.utils import json
-from sentry.utils.compat import zip
 from tests.sentry.grouping import with_fingerprint_input, with_grouping_input
 
 
@@ -88,7 +87,7 @@ def test_similarity_extract_fingerprinting(fingerprint_input, insta_snapshot):
 def _get_configurations():
     # Sort configurations by ascending date
     strategies = sorted(CONFIGURATIONS.keys(), key=lambda x: x.split(":")[-1])
-    return list(zip(strategies, strategies[1:]))
+    return list(list(zip(strategies, strategies[1:])))
 
 
 @pytest.mark.parametrize("config,next_config", _get_configurations())

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -32,7 +32,6 @@ from sentry.incidents.subscription_processor import (
 )
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils import TestCase
-from sentry.utils.compat import map
 from sentry.utils.compat.mock import Mock, call
 from sentry.utils.dates import to_timestamp
 
@@ -886,17 +885,19 @@ class TestUpdateAlertRuleStats(TestCase):
         date = datetime.utcnow().replace(tzinfo=pytz.utc)
         update_alert_rule_stats(alert_rule, sub, date, {3: 20, 4: 3}, {3: 10, 4: 15})
         client = get_redis_client()
-        results = map(
-            int,
-            client.mget(
-                [
-                    "{alert_rule:1:project:2}:last_update",
-                    "{alert_rule:1:project:2}:trigger:3:alert_triggered",
-                    "{alert_rule:1:project:2}:trigger:3:resolve_triggered",
-                    "{alert_rule:1:project:2}:trigger:4:alert_triggered",
-                    "{alert_rule:1:project:2}:trigger:4:resolve_triggered",
-                ]
-            ),
+        results = list(
+            map(
+                int,
+                client.mget(
+                    [
+                        "{alert_rule:1:project:2}:last_update",
+                        "{alert_rule:1:project:2}:trigger:3:alert_triggered",
+                        "{alert_rule:1:project:2}:trigger:3:resolve_triggered",
+                        "{alert_rule:1:project:2}:trigger:4:alert_triggered",
+                        "{alert_rule:1:project:2}:trigger:4:resolve_triggered",
+                    ]
+                ),
+            )
         )
 
         assert results == [int(to_timestamp(date)), 20, 10, 3, 15]

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -10,7 +10,6 @@ from sentry.models import Integration, OrganizationIntegration, ProjectKey
 from sentry.pipeline import PipelineView
 from sentry.testutils import IntegrationTestCase
 from sentry.testutils.helpers.faux import Mock
-from sentry.utils.compat import map
 from sentry.utils.compat.mock import ANY, MagicMock, patch
 
 arn = (
@@ -34,7 +33,9 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
     def test_project_select(self, mock_react_view):
         resp = self.client.get(self.setup_path)
         assert resp.status_code == 200
-        serialized_projects = map(lambda x: serialize(x, self.user), [self.projectA, self.projectB])
+        serialized_projects = list(
+            map(lambda x: serialize(x, self.user), [self.projectA, self.projectB])
+        )
         mock_react_view.assert_called_with(
             ANY, "awsLambdaProjectSelect", {"projects": serialized_projects}
         )

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -13,7 +13,6 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.utils import json
-from sentry.utils.compat import filter
 from sentry.utils.compat.mock import Mock, patch
 
 UNSET = object()
@@ -199,7 +198,7 @@ class LinkSharedEventTest(BaseEventTest):
 
 class MessageIMEventTest(BaseEventTest):
     def get_block_type_text(self, block_type, data):
-        block = filter(lambda x: x["type"] == block_type, data["blocks"])[0]
+        block = list(filter(lambda x: x["type"] == block_type, data["blocks"]))[0]
         return block["elements"][0]["text"]["text"]
 
     def get_block_section_text(self, data):

--- a/tests/sentry/lang/native/test_ignoredsourcesfiltering.py
+++ b/tests/sentry/lang/native/test_ignoredsourcesfiltering.py
@@ -2,7 +2,6 @@ import pytest
 
 from sentry.lang.native.symbolicator import filter_ignored_sources
 from sentry.testutils.helpers import override_options
-from sentry.utils.compat import map
 
 
 class TestIgnoredSourcesFiltering:
@@ -53,7 +52,7 @@ class TestIgnoredSourcesFiltering:
     def test_sources_ignored_unset(self, sources):
         sources = filter_ignored_sources(sources)
 
-        source_ids = map(lambda s: s["id"], sources)
+        source_ids = list(map(lambda s: s["id"], sources))
         assert source_ids == [
             "sentry:microsoft",
             "sentry:electron",
@@ -66,7 +65,7 @@ class TestIgnoredSourcesFiltering:
         with override_options({"symbolicator.ignored_sources": []}):
             sources = filter_ignored_sources(sources)
 
-            source_ids = map(lambda s: s["id"], sources)
+            source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == [
                 "sentry:microsoft",
                 "sentry:electron",
@@ -79,7 +78,7 @@ class TestIgnoredSourcesFiltering:
         with override_options({"symbolicator.ignored_sources": ["sentry:microsoft"]}):
             sources = filter_ignored_sources(sources)
 
-            source_ids = map(lambda s: s["id"], sources)
+            source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == [
                 "sentry:electron",
                 "sentry:ios-source",
@@ -91,14 +90,14 @@ class TestIgnoredSourcesFiltering:
         with override_options({"symbolicator.ignored_sources": ["sentry:ios"]}):
             sources = filter_ignored_sources(sources, reversed_alias_map)
 
-            source_ids = map(lambda s: s["id"], sources)
+            source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == ["sentry:microsoft", "sentry:electron", "custom"]
 
     def test_sources_ignored_bypass_alias(self, sources, reversed_alias_map):
         with override_options({"symbolicator.ignored_sources": ["sentry:ios-source"]}):
             sources = filter_ignored_sources(sources, reversed_alias_map)
 
-            source_ids = map(lambda s: s["id"], sources)
+            source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == [
                 "sentry:microsoft",
                 "sentry:electron",
@@ -110,7 +109,7 @@ class TestIgnoredSourcesFiltering:
         with override_options({"symbolicator.ignored_sources": ["custom"]}):
             sources = filter_ignored_sources(sources)
 
-            source_ids = map(lambda s: s["id"], sources)
+            source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == [
                 "sentry:microsoft",
                 "sentry:electron",
@@ -122,7 +121,7 @@ class TestIgnoredSourcesFiltering:
         with override_options({"symbolicator.ignored_sources": ["honk"]}):
             sources = filter_ignored_sources(sources)
 
-            source_ids = map(lambda s: s["id"], sources)
+            source_ids = list(map(lambda s: s["id"], sources))
             assert source_ids == [
                 "sentry:microsoft",
                 "sentry:electron",

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -5,7 +5,6 @@ import pytest
 from sentry.lang.native import symbolicator
 from sentry.lang.native.symbolicator import get_sources_for_project, redact_internal_sources
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat import map
 
 CUSTOM_SOURCE_CONFIG = """
 [{
@@ -39,7 +38,7 @@ def test_sources_builtin(default_project):
         sources = get_sources_for_project(default_project)
 
     # XXX: The order matters here! Project is always first, then builtin sources
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project", "sentry:microsoft"]
 
 
@@ -54,7 +53,7 @@ def test_sources_builtin_unknown(default_project):
     with Feature(features):
         sources = get_sources_for_project(default_project)
 
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project"]
 
 
@@ -69,7 +68,7 @@ def test_sources_builtin_disabled(default_project):
     with Feature(features):
         sources = get_sources_for_project(default_project)
 
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project"]
 
 
@@ -85,7 +84,7 @@ def test_sources_custom(default_project):
         sources = get_sources_for_project(default_project)
 
     # XXX: The order matters here! Project is always first, then custom sources
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project", "custom"]
 
 
@@ -101,7 +100,7 @@ def test_sources_custom_disabled(default_project):
     with Feature(features):
         sources = get_sources_for_project(default_project)
 
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project"]
 
 

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -7,7 +7,6 @@ from django.db import DatabaseError
 
 from sentry.models import File, FileBlob, FileBlobIndex
 from sentry.testutils import TestCase
-from sentry.utils.compat import map
 
 
 class FileBlobTest(TestCase):
@@ -32,7 +31,7 @@ class FileBlobTest(TestCase):
 
         parts = path.split("/")
         assert len(parts) == 3
-        assert map(len, parts) == [2, 4, 26]
+        assert list(map(len, parts)) == [2, 4, 26]
 
         # Check uniqueness
         path2 = FileBlob.generate_unique_path()

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -256,7 +256,7 @@ class CopyProjectSettingsTest(TestCase):
         assert ownership.schema == self.ownership.schema
 
         rules = Rule.objects.filter(project_id=project.id).order_by("label")
-        for rule, other_rule in list(zip(rules, self.rules)):
+        for rule, other_rule in zip(rules, self.rules):
             assert rule.label == other_rule.label
 
     def assert_settings_not_copied(self, project, teams=()):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -18,7 +18,6 @@ from sentry.models import (
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.compat import zip
 
 
 class ProjectTest(TestCase):
@@ -257,7 +256,7 @@ class CopyProjectSettingsTest(TestCase):
         assert ownership.schema == self.ownership.schema
 
         rules = Rule.objects.filter(project_id=project.id).order_by("label")
-        for rule, other_rule in zip(rules, self.rules):
+        for rule, other_rule in list(zip(rules, self.rules)):
             assert rule.label == other_rule.label
 
     def assert_settings_not_copied(self, project, teams=()):

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -19,13 +19,11 @@ def test_is_rate_limited_script():
     # The item should not be rate limited by either key.
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [False, False]
@@ -34,13 +32,11 @@ def test_is_rate_limited_script():
     # The item should be rate limited by the first key (1).
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [True, False]
@@ -52,13 +48,11 @@ def test_is_rate_limited_script():
     # quota don't affect unrelated items that share a parent quota.
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [True, False]

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -6,7 +6,7 @@ from sentry.constants import DataCategory
 from sentry.quotas.base import QuotaConfig, QuotaScope
 from sentry.quotas.redis import RedisQuota, is_rate_limited
 from sentry.testutils import TestCase
-from sentry.utils.compat import map, mock
+from sentry.utils.compat import mock
 from sentry.utils.redis import clusters
 
 
@@ -19,11 +19,13 @@ def test_is_rate_limited_script():
     # The item should not be rate limited by either key.
     assert (
         list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
+            list(
+                map(
+                    bool,
+                    is_rate_limited(
+                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                    ),
+                )
             )
         )
         == [False, False]
@@ -32,11 +34,13 @@ def test_is_rate_limited_script():
     # The item should be rate limited by the first key (1).
     assert (
         list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
+            list(
+                map(
+                    bool,
+                    is_rate_limited(
+                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                    ),
+                )
             )
         )
         == [True, False]
@@ -48,11 +52,13 @@ def test_is_rate_limited_script():
     # quota don't affect unrelated items that share a parent quota.
     assert (
         list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
+            list(
+                map(
+                    bool,
+                    is_rate_limited(
+                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                    ),
+                )
             )
         )
         == [True, False]
@@ -73,9 +79,9 @@ def test_is_rate_limited_script():
     # increment
     is_rate_limited(client, ("orange", "baz"), (1, now + 60))
     # test that it's rate limited without refund
-    assert map(bool, is_rate_limited(client, ("orange", "baz"), (1, now + 60))) == [True]
+    assert list(map(bool, is_rate_limited(client, ("orange", "baz"), (1, now + 60)))) == [True]
     # test that refund key is used
-    assert map(bool, is_rate_limited(client, ("orange", "apple"), (1, now + 60))) == [False]
+    assert list(map(bool, is_rate_limited(client, ("orange", "apple"), (1, now + 60)))) == [False]
 
 
 class RedisQuotaTest(TestCase):

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -2,7 +2,6 @@ from collections import Counter
 from unittest import TestCase
 
 from sentry.similarity.signatures import MinHashSignatureBuilder
-from sentry.utils.compat import map, zip
 
 
 class MinHashSignatureBuilderTestCase(TestCase):
@@ -20,7 +19,9 @@ class MinHashSignatureBuilderTestCase(TestCase):
         b = set("the quick brown fox jumps over the lazy dog".split())
 
         results = Counter(
-            map(lambda l__r: l__r[0] == l__r[1], zip(get_signature(a), get_signature(b)))
+            list(
+                map(lambda l__r: l__r[0] == l__r[1], list(zip(get_signature(a), get_signature(b))))
+            )
         )
 
         similarity = len(a & b) / float(len(a | b))

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -37,7 +37,7 @@ from sentry.tasks.reports import (
 from sentry.testutils.cases import OutcomesSnubaTest, SnubaTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
-from sentry.utils.compat import map, mock
+from sentry.utils.compat import mock
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
 from sentry.utils.outcomes import Outcome
 
@@ -357,7 +357,7 @@ class ReportTestCase(TestCase, SnubaTestCase):
         )
 
         assert any(
-            map(lambda x: x[1] == (2, 0), response)
+            list(map(lambda x: x[1] == (2, 0), response))
         ), "must show two issues resolved in one rollup window"
 
 

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -357,7 +357,7 @@ class ReportTestCase(TestCase, SnubaTestCase):
         )
 
         assert any(
-            list(map(lambda x: x[1] == (2, 0), response))
+            map(lambda x: x[1] == (2, 0), response)
         ), "must show two issues resolved in one rollup window"
 
 

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -12,7 +12,7 @@ from sentry.auth.providers.saml2.provider import HAS_SAML2, Attributes, SAML2Pro
 from sentry.models import AuditLogEntry, AuditLogEntryEvent, AuthProvider, Organization
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat import map, mock
+from sentry.utils.compat import mock
 
 dummy_provider_config = {
     "idp": {
@@ -133,7 +133,7 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         auth = self.accept_auth(follow=True)
 
-        messages = map(lambda m: str(m), auth.context["messages"])
+        messages = list(map(lambda m: str(m), auth.context["messages"]))
 
         assert len(messages) == 2
         assert messages[0] == "You have successfully linked your account to your SSO provider."
@@ -157,7 +157,7 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         assert auth.status_code == 200
 
-        messages = map(lambda m: str(m), auth.context["messages"])
+        messages = list(map(lambda m: str(m), auth.context["messages"]))
         assert len(messages) == 1
         assert messages[0] == "The organization does not exist or does not have SAML SSO enabled."
 

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -6,7 +6,6 @@ from exam import fixture
 from sentry.models import Rule
 from sentry.plugins.base import Notification
 from sentry.testutils import PluginTestCase, TestCase
-from sentry.utils.compat import map
 from sentry_plugins.twilio.plugin import TwilioConfigurationForm, TwilioPlugin
 
 
@@ -40,7 +39,7 @@ class TwilioConfigurationFormTest(TestCase):
         # extracting the message from django.forms.ValidationError
         # is the easiest and simplest way I've found to assert as_data
         for e in errors:
-            errors[e] = map(lambda x: x.message, errors[e])
+            errors[e] = list(map(lambda x: x.message, errors[e]))
 
         self.assertDictEqual(
             errors,

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import map
 
 
 class GroupEventsTest(APITestCase, SnubaTestCase):
@@ -38,7 +37,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -174,7 +173,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -218,7 +217,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url + "?environment=production", format="json")
 
         assert response.status_code == 200, response.content
-        assert set(map(lambda x: x["eventID"], response.data)) == {
+        assert set(list(map(lambda x: x["eventID"], response.data))) == {
             str(events["production"].event_id)
         }
 
@@ -226,7 +225,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             url, data={"environment": ["production", "development"]}, format="json"
         )
         assert response.status_code == 200, response.content
-        assert set(map(lambda x: x["eventID"], response.data)) == {
+        assert set(list(map(lambda x: x["eventID"], response.data))) == {
             str(event.event_id) for event in events.values()
         }
 
@@ -259,7 +258,9 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted([str(event_2.event_id)])
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+            [str(event_2.event_id)]
+        )
 
     def test_search_event_has_tags(self):
         self.login_as(user=self.user)
@@ -296,7 +297,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -350,4 +351,4 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content
             assert len(response.data) == 1, response.data
-            assert map(lambda x: x["eventID"], response.data) == [str(event.event_id)]
+            assert list(map(lambda x: x["eventID"], response.data)) == [str(event.event_id)]

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -37,7 +37,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -173,7 +173,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -217,7 +217,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url + "?environment=production", format="json")
 
         assert response.status_code == 200, response.content
-        assert set(list(map(lambda x: x["eventID"], response.data))) == {
+        assert set(map(lambda x: x["eventID"], response.data)) == {
             str(events["production"].event_id)
         }
 
@@ -225,7 +225,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             url, data={"environment": ["production", "development"]}, format="json"
         )
         assert response.status_code == 200, response.content
-        assert set(list(map(lambda x: x["eventID"], response.data))) == {
+        assert set(map(lambda x: x["eventID"], response.data)) == {
             str(event.event_id) for event in events.values()
         }
 
@@ -258,9 +258,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
-            [str(event_2.event_id)]
-        )
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted([str(event_2.event_id)])
 
     def test_search_event_has_tags(self):
         self.login_as(user=self.user)
@@ -297,7 +295,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -10,7 +10,7 @@ from pytz import utc
 from sentry.models.transaction_threshold import ProjectTransactionThreshold, TransactionMetric
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock, zip
+from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 
 
@@ -383,7 +383,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert len(data) == 6
 
             rows = data[0:6]
-            for test in zip(event_counts, rows):
+            for test in list(zip(event_counts, rows)):
                 assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
     def test_throughput_epm_day_rollup(self):
@@ -461,7 +461,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert len(data) == 6
 
             rows = data[0:6]
-            for test in zip(event_counts, rows):
+            for test in list(zip(event_counts, rows)):
                 assert test[1][1][0]["count"] == test[0] / 60.0
 
     def test_throughput_eps_no_rollup(self):
@@ -1780,7 +1780,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         timestamp_hours = [timestamp.replace(minute=0, second=0) for timestamp in timestamps]
         timestamp_days = [timestamp.replace(hour=0, minute=0, second=0) for timestamp in timestamps]
 
-        for ts, ts_hr, ts_day in zip(timestamps, timestamp_hours, timestamp_days):
+        for ts, ts_hr, ts_day in list(zip(timestamps, timestamp_hours, timestamp_days)):
             key = f"{iso_format(ts)}+00:00,{iso_format(ts_day)}+00:00,{iso_format(ts_hr)}+00:00"
             count = sum(
                 e["count"] for e in self.event_data if e["data"]["timestamp"] == iso_format(ts)

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -383,7 +383,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert len(data) == 6
 
             rows = data[0:6]
-            for test in list(zip(event_counts, rows)):
+            for test in zip(event_counts, rows):
                 assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
     def test_throughput_epm_day_rollup(self):
@@ -461,7 +461,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert len(data) == 6
 
             rows = data[0:6]
-            for test in list(zip(event_counts, rows)):
+            for test in zip(event_counts, rows):
                 assert test[1][1][0]["count"] == test[0] / 60.0
 
     def test_throughput_eps_no_rollup(self):
@@ -1780,7 +1780,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         timestamp_hours = [timestamp.replace(minute=0, second=0) for timestamp in timestamps]
         timestamp_days = [timestamp.replace(hour=0, minute=0, second=0) for timestamp in timestamps]
 
-        for ts, ts_hr, ts_day in list(zip(timestamps, timestamp_hours, timestamp_days)):
+        for ts, ts_hr, ts_day in zip(timestamps, timestamp_hours, timestamp_days):
             key = f"{iso_format(ts)}+00:00,{iso_format(ts_day)}+00:00,{iso_format(ts_hr)}+00:00"
             count = sum(
                 e["count"] for e in self.event_data if e["data"]["timestamp"] == iso_format(ts)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -3565,7 +3565,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             results = response.data["data"]
             assert results[0]["count"] == 1, datum
 
-            for (field, exp) in list(zip(fields, expected)):
+            for (field, exp) in zip(fields, expected):
                 assert results[0][field] == exp, field + str(datum)
 
     def test_failure_count_alias_field(self):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -27,7 +27,7 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat import mock, zip
+from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import QueryExecutionError, QueryIllegalTypeOfArgument, RateLimitExceeded
 
@@ -78,7 +78,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             url,
             query,
             format="json",
-            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode()),
         )
 
         assert response.status_code == 200, response.content
@@ -3565,7 +3565,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             results = response.data["data"]
             assert results[0]["count"] == 1, datum
 
-            for (field, exp) in zip(fields, expected):
+            for (field, exp) in list(zip(fields, expected)):
                 assert results[0][field] == exp, field + str(datum)
 
     def test_failure_count_alias_field(self):

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -63,7 +63,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
 
         response = self.get_valid_response(self.org.slug, self.release.version, **params)
         assert len(response.data) == len(expected_groups)
-        expected = set(list(map(str, [g.id for g in expected_groups])))
+        expected = set(map(str, [g.id for g in expected_groups]))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -2,7 +2,6 @@ from uuid import uuid1
 
 from sentry.models import Commit, GroupLink, GroupResolution, ReleaseCommit, Repository
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.utils.compat import map
 
 
 class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase):
@@ -64,7 +63,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
 
         response = self.get_valid_response(self.org.slug, self.release.version, **params)
         assert len(response.data) == len(expected_groups)
-        expected = set(map(str, [g.id for g in expected_groups]))
+        expected = set(list(map(str, [g.id for g in expected_groups])))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -24,7 +24,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [event_1.event_id, event_2.event_id]
         )
 

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import map
 
 
 class ProjectEventsTest(APITestCase, SnubaTestCase):
@@ -25,7 +24,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [event_1.event_id, event_2.event_id]
         )
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -26,7 +26,6 @@ from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import redis
-from sentry.utils.compat import map
 from sentry.utils.compat.mock import patch
 from sentry.utils.dates import to_timestamp
 
@@ -252,7 +251,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         merge_source, source, destination = list(Group.objects.all())
 
         assert len(events) == 3
-        assert sum(map(len, events.values())) == 17
+        assert sum(list(map(len, events.values()))) == 17
 
         production_environment = Environment.objects.get(
             organization_id=project.organization_id, name="production"
@@ -304,7 +303,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         assert source.id != destination.id
         assert source.project == destination.project
 
-        destination_event_ids = map(lambda event: event.event_id, list(events.values())[1])
+        destination_event_ids = list(map(lambda event: event.event_id, list(events.values())[1]))
 
         assert set(
             UserReport.objects.filter(group_id=source.id).values_list("event_id", flat=True)
@@ -327,8 +326,8 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             )
         } == {("red", 4), ("green", 3), ("blue", 3)}
 
-        destination_event_ids = map(
-            lambda event: event.event_id, list(events.values())[0] + list(events.values())[2]
+        destination_event_ids = list(
+            map(lambda event: event.event_id, list(events.values())[0] + list(events.values())[2])
         )
 
         assert set(

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -251,7 +251,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         merge_source, source, destination = list(Group.objects.all())
 
         assert len(events) == 3
-        assert sum(list(map(len, events.values()))) == 17
+        assert sum(map(len, events.values())) == 17
 
         production_environment = Environment.objects.get(
             organization_id=project.organization_id, name="production"


### PR DESCRIPTION
As part of the Python 3 upgrade we went the easy and fast way and just casted all map, filter and zip calls in lists.

Firstly, this does a brute force inline pass which saves a function call everywhere.

- https://github.com/getsentry/sentry/pull/28080 (TODO: merge)

Then, I'm using a custom libcst-based rewriter to take care of any case that doesn't need manual inspection. In the end, it should be mostly args, value assignments and return values remaining - you can `diff origin/master` and see what's remaining. Currently I have:

- https://github.com/getsentry/sentry/pull/28081
- https://github.com/getsentry/sentry/pull/28082

I may ship the brute force inline pass first, save the file list, then ship individual classes of these rewrites for easier reviewing.  I'll have to line it all up ideally as fast as I can. For now I'm just putting all fixes in here to run tests and will remerge iteratively so I can keep diffing origin/master.
