### PR TITLE
fix(ui): Skip last point in adoption chart if releases at 0

### DIFF
--- a/static/app/views/releases/list/releaseAdoptionChart.tsx
+++ b/static/app/views/releases/list/releaseAdoptionChart.tsx
@@ -203,6 +203,9 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
 
     const interval = this.getInterval();
     const numDataPoints = releasesSeries[0].data.length;
+    const xAxisData = releasesSeries[0].data.map(point => point.name);
+    const hideLastPoint =
+      releasesSeries.findIndex(series => series.data[numDataPoints - 1].value > 0) === -1;
 
     return (
       <Panel>
@@ -217,7 +220,10 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
                 <LineChart
                   {...zoomRenderProps}
                   grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
-                  series={releasesSeries}
+                  series={releasesSeries.map(series => ({
+                    ...series,
+                    data: hideLastPoint ? series.data.slice(0, -1) : series.data,
+                  }))}
                   yAxis={{
                     min: 0,
                     max: 100,
@@ -228,6 +234,13 @@ class ReleaseAdoptionChart extends AsyncComponent<Props, State> {
                     axisLabel: {
                       formatter: '{value}%',
                     },
+                  }}
+                  xAxis={{
+                    show: true,
+                    min: xAxisData[0],
+                    max: xAxisData[numDataPoints - 1],
+                    type: 'time',
+                    data: xAxisData,
                   }}
                   tooltip={{
                     formatter: seriesParams => {


### PR DESCRIPTION
This changes the release adoption chart series to ignore the last point, if all session counts for releases a project to be plotted went down to 0. This happens when there is no data for a time bucket yet(the current time bucket), it looks like all the releases went to 0 because there is a massive error. To avoid this we don't plot the last point in the graph.

Jira: [WOR-1127](https://getsentry.atlassian.net/browse/WOR-1127)

Before:
![before](https://user-images.githubusercontent.com/15015880/129322484-51d14b79-599a-471b-b538-296ebc19a2e8.png)

After:
![after](https://user-images.githubusercontent.com/15015880/129322523-ebf7ce3b-e539-4de3-a00d-e88c63e9efd5.png)
