### PR TITLE
fix(discover): Push yAxis change to URL

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -776,6 +776,8 @@ class EventView {
       newEventView.sorts = newSort;
     }
 
+    newEventView.yAxis = newEventView.getYAxis();
+
     return newEventView;
   }
 
@@ -900,6 +902,8 @@ class EventView {
       }
     }
 
+    newEventView.yAxis = newEventView.getYAxis();
+
     return newEventView;
   }
 
@@ -964,6 +968,8 @@ class EventView {
         }
       }
     }
+
+    newEventView.yAxis = newEventView.getYAxis();
 
     return newEventView;
   }

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -1615,7 +1615,9 @@ describe('EventView.withColumns()', function () {
     fields: [
       {field: 'count()', width: 30},
       {field: 'project.id', width: 99},
+      {field: 'failure_count()', width: 30},
     ],
+    yAxis: 'failure_count()',
     sorts: generateSorts(['count']),
     query: 'event.type:error',
     project: [42],
@@ -1696,6 +1698,20 @@ describe('EventView.withColumns()', function () {
     const newView = eventView.withColumns([{kind: 'field', field: 'issue'}]);
     expect(newView.fields).toEqual([{field: 'issue', width: COL_WIDTH_UNDEFINED}]);
     expect(newView.sorts).toEqual([]);
+  });
+  it('updates yAxis if column is dropped', function () {
+    const newView = eventView.withColumns([
+      {kind: 'field', field: 'count()'},
+      {kind: 'field', field: 'project.id'},
+    ]);
+
+    expect(newView.fields).toEqual([
+      {field: 'count()', width: 30},
+      {field: 'project.id', width: 99},
+    ]);
+
+    expect(eventView.yAxis).toEqual('failure_count()');
+    expect(newView.yAxis).toEqual('count()');
   });
 });
 


### PR DESCRIPTION
Updating selected columns should update the url
params for yAxis if that column has been dropped.