### PR TITLE
feat(mobile-vitals): Default to mobile landing as needed

### DIFF
--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -98,6 +98,7 @@ export function getDefaultDisplayFieldForPlatform(
     [PROJECT_PERFORMANCE_TYPE.ANY]: LandingDisplayField.ALL,
     [PROJECT_PERFORMANCE_TYPE.FRONTEND]: LandingDisplayField.FRONTEND_PAGELOAD,
     [PROJECT_PERFORMANCE_TYPE.BACKEND]: LandingDisplayField.BACKEND,
+    [PROJECT_PERFORMANCE_TYPE.MOBILE]: LandingDisplayField.MOBILE,
   };
   const performanceType = platformToPerformanceType(projects, projectIds);
   const landingField =

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -2,7 +2,7 @@ import {Location, LocationDescriptor, Query} from 'history';
 
 import Duration from 'app/components/duration';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
-import {backend, frontend} from 'app/data/platformCategories';
+import {backend, frontend, mobile} from 'app/data/platformCategories';
 import {GlobalSelection, OrganizationSummary, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {statsPeriodToDays} from 'app/utils/dates';
@@ -21,10 +21,12 @@ export enum PROJECT_PERFORMANCE_TYPE {
   FRONTEND = 'frontend',
   BACKEND = 'backend',
   FRONTEND_OTHER = 'frontend_other',
+  MOBILE = 'mobile',
 }
 
 const FRONTEND_PLATFORMS: string[] = [...frontend];
 const BACKEND_PLATFORMS: string[] = [...backend];
+const MOBILE_PLATFORMS: string[] = [...mobile];
 
 export function platformToPerformanceType(
   projects: Project[],
@@ -52,6 +54,14 @@ export function platformToPerformanceType(
     )
   ) {
     return PROJECT_PERFORMANCE_TYPE.BACKEND;
+  }
+
+  if (
+    selectedProjects.every(project =>
+      MOBILE_PLATFORMS.includes(project.platform as string)
+    )
+  ) {
+    return PROJECT_PERFORMANCE_TYPE.MOBILE;
   }
 
   return PROJECT_PERFORMANCE_TYPE.ANY;


### PR DESCRIPTION
When all selected projects are a mobile platform, we can default the landing
page to the tailored mobile view.