### PR TITLE
ref(hackweek): inline list cast optimization pass #1

### DIFF
--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -57,9 +57,7 @@ class Map(Attribute):
             data[attr.name] = attr.extract(nv)
 
         if items:
-            raise ValueError(
-                "Unknown attributes: {}".format(", ".join(list(map(str, items.keys()))))
-            )
+            raise ValueError("Unknown attributes: {}".format(", ".join(map(str, items.keys()))))
 
         return data
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -165,7 +165,7 @@ class OrganizationEndpoint(Endpoint):
         permission checking, use ``get_projects``, instead.
         """
         try:
-            return set(list(map(int, request.GET.getlist("project"))))
+            return set(map(int, request.GET.getlist("project")))
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -283,7 +283,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         # If group ids specified, just ignore any query components
         try:
-            group_ids = set(list(map(int, request.GET.getlist("group"))))
+            group_ids = set(map(int, request.GET.getlist("group")))
         except ValueError:
             return Response({"detail": "Group ids must be integers"}, status=400)
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -59,7 +59,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
         project_ids = [p.id for p in projects]
 
         try:
-            group_ids = set(list(map(int, request.GET.getlist("groups"))))
+            group_ids = set(map(int, request.GET.getlist("groups")))
         except ValueError:
             raise ParseError(detail="Group ids must be integers")
 

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -23,7 +23,7 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :auth: required
         """
         is_member = request.GET.get("is_member")
-        project_ids = set(list(map(int, request.GET.getlist("project"))))
+        project_ids = set(map(int, request.GET.getlist("project")))
         queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
         if is_member:
             queryset = queryset.filter(teams__organizationmember__user=request.user)

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -50,7 +50,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
             raise ValueError("Invalid group: %s" % group)
 
         if "id" in request.GET:
-            id_filter_set = frozenset(list(map(int, request.GET.getlist("id"))))
+            id_filter_set = frozenset(map(int, request.GET.getlist("id")))
             keys = [k for k in keys if k in id_filter_set]
 
         if not keys:

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -357,7 +357,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
-        include = set(list(filter(bool, request.GET.get("include", "").split(","))))
+        include = set(filter(bool, request.GET.get("include", "").split(",")))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -352,7 +352,7 @@ class SearchFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
+        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
 
     @property
     def is_negation(self) -> bool:
@@ -379,7 +379,7 @@ class AggregateFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
+        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
 
 
 class AggregateKey(NamedTuple):

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -37,7 +37,7 @@ class DataExportQuerySerializer(serializers.Serializer):
             get_projects_by_id = self.context["get_projects_by_id"]
             # Coerce the query into a set
             if isinstance(project_query, list):
-                projects = get_projects_by_id(set(list(map(int, project_query))))
+                projects = get_projects_by_id(set(map(int, project_query)))
             else:
                 projects = get_projects_by_id({int(project_query)})
             query_info["project"] = [project.id for project in projects]

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -40,7 +40,7 @@ def get_package_version(module_name, app):
         return None
 
     if isinstance(version, (list, tuple)):
-        version = ".".join(list(map(str, version)))
+        version = ".".join(map(str, version))
 
     return str(version)
 

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -109,7 +109,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
         logger.info("discover1.request", extra={"organization_id": organization.id})
 
         try:
-            requested_projects = set(list(map(int, request.data.get("projects", []))))
+            requested_projects = set(map(int, request.data.get("projects", [])))
         except (ValueError, TypeError):
             raise ResourceDoesNotExist()
         projects = self._get_projects_by_id(requested_projects, request, organization)

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -45,7 +45,7 @@ def get_channel_id(organization, integration_id, name):
 
     # handle searching for channels first
     channel_list = client.get_channel_list(team_id)
-    filtered_channels = list(list(filter(lambda x: channel_filter(x, name), channel_list)))
+    filtered_channels = list(filter(lambda x: channel_filter(x, name), channel_list))
     if len(filtered_channels) > 0:
         return filtered_channels[0].get("id")
 
@@ -56,7 +56,7 @@ def get_channel_id(organization, integration_id, name):
         continuation_token = members.get("continuationToken")
 
         filtered_members = list(
-            list(filter(lambda x: x.get("name").lower() == name.lower(), member_list))
+            filter(lambda x: x.get("name").lower() == name.lower(), member_list)
         )
         if len(filtered_members) > 0:
             # TODO: handle duplicate username case

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -30,7 +30,7 @@ def load_registry(path):
 def get_highest_browser_sdk_version(versions):
     full_versions = [x for x in versions if _version_regexp.match(x)]
     return (
-        str(max(list(map(parse_version, full_versions))))
+        str(max(map(parse_version, full_versions)))
         if full_versions
         else settings.JS_SDK_LOADER_SDK_VERSION
     )

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -129,7 +129,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
             for instance in type.objects.filter(id__in=[a.id for a in _actors]):
                 results[(type, instance.id)] = instance
 
-        return list(list(filter(None, [results.get((actor.type, actor.id)) for actor in actors])))
+        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
 
     @classmethod
     def resolve_dict(cls, actor_dict):

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -44,7 +44,7 @@ class GroupOwner(Model):
         db_table = "sentry_groupowner"
 
     def save(self, *args, **kwargs):
-        keys = list(list(filter(None, [self.user_id, self.team_id])))
+        keys = list(filter(None, [self.user_id, self.team_id]))
         assert len(keys) == 1, "Must have team or user, not both"
         super().save(*args, **kwargs)
 

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -299,7 +299,7 @@ def _start_service(
 
     listening = ""
     if options["ports"]:
-        listening = "(listening: %s)" % ", ".join(list(map(str, options["ports"].values())))
+        listening = "(listening: %s)" % ", ".join(map(str, options["ports"].values()))
 
     # If a service is associated with the devserver, then do not run the created container.
     # This was mainly added since it was not desirable for nginx to occupy port 8000 on the

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -102,5 +102,5 @@ def organizations(metrics, since, until):
                 values.append(aggregate(results[metric][key]))
 
             stdout.write(
-                "{} {} {}\n".format(instance.id, instance.slug, " ".join(list(map(str, values))))
+                "{} {} {}\n".format(instance.id, instance.slug, " ".join(map(str, values)))
             )

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -273,7 +273,7 @@ def show_big_error(message):
         lines = message.strip().splitlines()
     else:
         lines = message
-    maxline = max(list(map(len, lines)))
+    maxline = max(map(len, lines))
     click.echo("", err=True)
     click.secho("!!!{}!!!".format("!" * min(maxline, 80)), err=True, fg="red")
     click.secho("!! %s !!" % "".center(maxline), err=True, fg="red")

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -415,7 +415,7 @@ def _semver_filter_converter(
     # the passed filter.
     order_by = Release.SEMVER_COLS
     if operator.startswith("<"):
-        order_by = list(list(map(_flip_field_sort, order_by)))
+        order_by = list(map(_flip_field_sort, order_by))
     qs = (
         Release.objects.filter_by_semver(
             organization_id,
@@ -1674,7 +1674,7 @@ class QueryFilter(QueryFields):
         # the passed filter.
         order_by = Release.SEMVER_COLS
         if operator.startswith("<"):
-            order_by = list(list(map(_flip_field_sort, order_by)))
+            order_by = list(map(_flip_field_sort, order_by))
         qs = (
             Release.objects.filter_by_semver(
                 organization_id,

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -37,7 +37,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
 
         arguments = []
         for bucket in band(self.bands, self.signature_builder(features)):
-            arguments.extend([1, ",".join(list(map("{}".format, bucket))), 1])
+            arguments.extend([1, ",".join(map("{}".format, bucket)), 1])
         return arguments
 
     def __index(self, scope, args):

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -22,7 +22,7 @@ class Encoder:
         elif isinstance(value, self.number_types):
             return str(value).encode("utf8")
         elif isinstance(value, Set):
-            return b"\x00".join(sorted(list(map(self.dumps, value))))
+            return b"\x00".join(sorted(map(self.dumps, value)))
         elif isinstance(value, Sequence):
             return b"\x01".join(list(map(self.dumps, value)))
         elif isinstance(value, Mapping):

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -24,10 +24,10 @@ class Encoder:
         elif isinstance(value, Set):
             return b"\x00".join(sorted(map(self.dumps, value)))
         elif isinstance(value, Sequence):
-            return b"\x01".join(list(map(self.dumps, value)))
+            return b"\x01".join(map(self.dumps, value))
         elif isinstance(value, Mapping):
             return b"\x02".join(
-                sorted(b"\x01".join(list(map(self.dumps, item))) for item in value.items())
+                sorted(b"\x01".join(map(self.dumps, item)) for item in value.items())
             )
         else:
             raise TypeError(f"Unsupported type: {type(value)}")

--- a/src/sentry/similarity/signatures.py
+++ b/src/sentry/similarity/signatures.py
@@ -10,7 +10,7 @@ class MinHashSignatureBuilder:
         return list(
             map(
                 lambda column: min(
-                    list(map(lambda feature: mmh3.hash(feature, column) % self.rows, features))
+                    map(lambda feature: mmh3.hash(feature, column) % self.rows, features)
                 ),
                 range(self.columns),
             )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1115,7 +1115,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if min_value is None:
         min_values = [row[get_function_alias(column)] for column in min_columns]
-        min_values = list(list(filter(lambda v: v is not None, min_values)))
+        min_values = list(filter(lambda v: v is not None, min_values))
         min_value = min(min_values) if min_values else None
         if max_value is not None and min_value is not None:
             # max_value was provided by the user, and min_value was queried.
@@ -1127,7 +1127,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if max_value is None:
         max_values = [row[get_function_alias(column)] for column in max_columns]
-        max_values = list(list(filter(lambda v: v is not None, max_values)))
+        max_values = list(filter(lambda v: v is not None, max_values))
         max_value = max(max_values) if max_values else None
 
         fences = []
@@ -1154,7 +1154,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         max_fence_value = max(fences) if fences else None
 
         candidates = [max_fence_value, max_value]
-        candidates = list(list(filter(lambda v: v is not None, candidates)))
+        candidates = list(filter(lambda v: v is not None, candidates))
         max_value = min(candidates) if candidates else None
         if max_value is not None and min_value is not None:
             # min_value may be either queried or provided by the user. max_value was queried.

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -255,7 +255,7 @@ class SnubaTSDB(BaseTSDB):
             TSDBModel.key_total_blacklisted,
             TSDBModel.key_total_rejected,
         ]:
-            keys = list(set(list(map(lambda x: int(x), keys))))
+            keys = list(set(map(lambda x: int(x), keys)))
 
         # 10s is the only rollup under an hour that we support
         if rollup and rollup == 10 and model in self.lower_rollup_query_settings:

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -56,7 +56,7 @@ COLOR_COUNT = len(LETTER_AVATAR_COLORS)
 
 def hash_user_identifier(identifier: str) -> int:
     identifier = force_text(identifier, errors="replace")
-    return sum(list(map(ord, identifier)))
+    return sum(map(ord, identifier))
 
 
 def get_letter_avatar_color(identifier: str) -> str:

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -225,7 +225,7 @@ class ListResolver:
                 f"Cannot generate mailing list identifier for {instance!r}"
             )
 
-        label = ".".join(list(map(str, handler(instance))))
+        label = ".".join(map(str, handler(instance)))
         assert is_valid_dot_atom(label)
 
         return f"<{label}.{self.__namespace}>"

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -79,7 +79,7 @@ def get_origins(project=None):
 
     # lowercase and strip the trailing slash from all origin values
     # filter out empty values
-    return frozenset(list(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result)))))
+    return frozenset(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result))))
 
 
 def parse_uri_match(value):

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -189,14 +189,14 @@ def get_cluster_from_options(setting, options, cluster_manager=clusters):
             raise InvalidConfiguration(
                 "Cannot provide both named cluster ({!r}) and cluster configuration ({}) options.".format(
                     cluster_option_name,
-                    ", ".join(list(map(repr, cluster_constructor_option_names))),
+                    ", ".join(map(repr, cluster_constructor_option_names)),
                 )
             )
         else:
             warnings.warn(
                 DeprecatedSettingWarning(
                     "{} parameter of {}".format(
-                        ", ".join(list(map(repr, cluster_constructor_option_names))), setting
+                        ", ".join(map(repr, cluster_constructor_option_names)), setting
                     ),
                     f'{setting}["{cluster_option_name}"]',
                     removed_in_version="8.5",

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -101,7 +101,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
     zero-width spaces after common delimiters, as well as soft-hyphenating long
     identifiers.
     """
-    delimiters = re.compile(r"([{}]+)".format("".join(list(map(re.escape, ",.$:/+@!?()<>[]{}")))))
+    delimiters = re.compile(r"([{}]+)".format("".join(map(re.escape, ",.$:/+@!?()<>[]{}"))))
 
     def soft_break_delimiter(match):
         results = []

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -7,7 +7,7 @@ from sentry.utils import warnings
 @python_2_unicode_compatible
 class Version(tuple):
     def __str__(self):
-        return ".".join(list(map(force_text, self)))
+        return ".".join(map(force_text, self))
 
 
 def summarize(sequence, max=3):
@@ -22,7 +22,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return "{service} {modality} be upgraded to {version} on {hosts}.".format(
-        hosts=",".join(list(map(force_text, summarize(list(hosts.keys()), 2)))),
+        hosts=",".join(map(force_text, summarize(list(hosts.keys()), 2))),
         modality=modality,
         service=service,
         version=version,

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -45,7 +45,7 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(list(filter(bool, re.split(r"\s*,\s*|\s+", data))))
+    return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
 
 
 class TwilioConfigurationForm(forms.Form):
@@ -84,7 +84,7 @@ class TwilioConfigurationForm(forms.Form):
         for phone in phones:
             if not validate_phone(phone):
                 raise forms.ValidationError(f"{phone} is not a valid phone number.")
-        return ",".join(sorted(set(list(map(clean_phone, phones)))))
+        return ",".join(sorted(set(map(clean_phone, phones))))
 
     def clean(self):
         # TODO: Ping Twilio and check credentials (?)

--- a/src/social_auth/__init__.py
+++ b/src/social_auth/__init__.py
@@ -1,3 +1,3 @@
 version = (0, 7, 28)
 
-__version__ = ".".join(list(map(str, version)))
+__version__ = ".".join(map(str, version))

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -272,7 +272,7 @@ class BaseAuth:
         return {
             "next": next_idx,
             "backend": self.AUTH_BACKEND.name,
-            "args": tuple(list(map(model_to_ctype, args))),
+            "args": tuple(map(model_to_ctype, args)),
             "kwargs": {key: model_to_ctype(val) for key, val in kwargs.items()},
         }
 
@@ -280,7 +280,7 @@ class BaseAuth:
         """Takes session saved data to continue pipeline and merges with any
         new extra argument needed. Returns tuple with next pipeline index
         entry, arguments and keyword arguments to continue the process."""
-        args = args[:] + tuple(list(map(ctype_to_model, session_data["args"])))
+        args = args[:] + tuple(map(ctype_to_model, session_data["args"]))
 
         kwargs = kwargs.copy()
         saved_kwargs = {key: ctype_to_model(val) for key, val in session_data["kwargs"].items()}

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -60,17 +60,14 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)
         assert (
-            list(list(filter(lambda x: x["slug"] == "webhooks", response.data)))[0]["projectList"]
-            == []
+            list(filter(lambda x: x["slug"] == "webhooks", response.data))[0]["projectList"] == []
         )
 
     def test_configured_not_enabled(self):
         plugins.get("trello").disable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ] == [
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -85,9 +82,7 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").enable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ] == [
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -104,19 +99,14 @@ class OrganizationPluginsTest(APITestCase):
         self.projectA.status = 1
         self.projectA.save()
         response = self.client.get(self.url)
-        assert (
-            list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0]["projectList"]
-            == []
-        )
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == []
 
     def test_configured_multiple_projects(self):
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         plugins.get("trello").set_option("key", "another_value", self.projectB)
         response = self.client.get(self.url)
-        projectList = list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ]
-        assert list(list(filter(lambda x: x["projectId"] == self.projectA.id, projectList)))[0] == {
+        projectList = list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"]
+        assert list(filter(lambda x: x["projectId"] == self.projectA.id, projectList))[0] == {
             "projectId": self.projectA.id,
             "projectSlug": self.projectA.slug,
             "projectName": self.projectA.name,
@@ -124,7 +114,7 @@ class OrganizationPluginsTest(APITestCase):
             "configured": True,
             "projectPlatform": None,
         }
-        assert list(list(filter(lambda x: x["projectId"] == self.projectB.id, projectList)))[0] == {
+        assert list(filter(lambda x: x["projectId"] == self.projectB.id, projectList))[0] == {
             "projectId": self.projectB.id,
             "projectSlug": self.projectB.slug,
             "projectName": self.projectB.name,

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -51,7 +51,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
     def run_test(self, expected_groups):
         response = self.get_valid_response(self.org.slug, self.project.slug, self.release.version)
         assert len(response.data) == len(expected_groups)
-        expected = set(list(map(str, [g.id for g in expected_groups])))
+        expected = set(map(str, [g.id for g in expected_groups]))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -88,7 +88,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
 
     def test_cannot_access_with_dsn_auth(self):
         project = self.create_project()
@@ -120,7 +120,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
 
     def test_environments(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -40,7 +40,7 @@ class ProjectUsersTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
             [str(self.euser1.id), str(self.euser2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -18,7 +18,7 @@ class TeamProjectIndexTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
             [str(project_1.id), str(project_2.id)]
         )
 

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -9,7 +9,7 @@ def psycopg2_version():
     import psycopg2
 
     version = psycopg2.__version__.split()[0].split(".")
-    return tuple(list(map(int, version)))
+    return tuple(map(int, version))
 
 
 @pytest.mark.skipif(psycopg2_version() < (2, 7), reason="Test requires psycopg 2.7+")

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -19,13 +19,11 @@ def test_is_rate_limited_script():
     # The item should not be rate limited by either key.
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [False, False]
@@ -34,13 +32,11 @@ def test_is_rate_limited_script():
     # The item should be rate limited by the first key (1).
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [True, False]
@@ -52,13 +48,11 @@ def test_is_rate_limited_script():
     # quota don't affect unrelated items that share a parent quota.
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [True, False]

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -357,7 +357,7 @@ class ReportTestCase(TestCase, SnubaTestCase):
         )
 
         assert any(
-            list(map(lambda x: x[1] == (2, 0), response))
+            map(lambda x: x[1] == (2, 0), response)
         ), "must show two issues resolved in one rollup window"
 
 

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -37,7 +37,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -173,7 +173,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -217,7 +217,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url + "?environment=production", format="json")
 
         assert response.status_code == 200, response.content
-        assert set(list(map(lambda x: x["eventID"], response.data))) == {
+        assert set(map(lambda x: x["eventID"], response.data)) == {
             str(events["production"].event_id)
         }
 
@@ -225,7 +225,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             url, data={"environment": ["production", "development"]}, format="json"
         )
         assert response.status_code == 200, response.content
-        assert set(list(map(lambda x: x["eventID"], response.data))) == {
+        assert set(map(lambda x: x["eventID"], response.data)) == {
             str(event.event_id) for event in events.values()
         }
 
@@ -258,9 +258,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
-            [str(event_2.event_id)]
-        )
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted([str(event_2.event_id)])
 
     def test_search_event_has_tags(self):
         self.login_as(user=self.user)
@@ -297,7 +295,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -63,7 +63,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
 
         response = self.get_valid_response(self.org.slug, self.release.version, **params)
         assert len(response.data) == len(expected_groups)
-        expected = set(list(map(str, [g.id for g in expected_groups])))
+        expected = set(map(str, [g.id for g in expected_groups]))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -24,7 +24,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [event_1.event_id, event_2.event_id]
         )
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -251,7 +251,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         merge_source, source, destination = list(Group.objects.all())
 
         assert len(events) == 3
-        assert sum(list(map(len, events.values()))) == 17
+        assert sum(map(len, events.values())) == 17
 
         production_environment = Environment.objects.get(
             organization_id=project.organization_id, name="production"


### PR DESCRIPTION
First pass after https://github.com/getsentry/sentry/pull/28080 that targets any single-argument calls to `frozenset list sum min all sorted any set max tuple` which contain a `list` call wrapping a `map filter list sorted`.

This is what's doing the work (libcst==0.3.19):

```
import gc
import os
import sys
from dataclasses import replace
from pathlib import Path

import libcst as cst
from libcst import Arg, Attribute, Call, CSTTransformer, Name, SimpleString

gc.disable()


def without_nested_list(node):
    nested = node.args[0].value

    if getattr(nested, "func", None) is None:
        return node

    if nested.func.value != "list":
        return node

    if len(nested.args) != 1:
        return node

    nested_nested = nested.args[0].value

    if nested_nested.func.value not in ("map", "filter", "list", "sorted"):
        return node

    # nodes are frozen dataclasses.
    updated_node = replace(node, args=[replace(node.args[0], value=nested_nested)])
    return updated_node


LIST_WRAPPED_ARG_NOT_NECESSARY_FOR = {
    "set",
    "frozenset",
    "sum",
    "list",
    "tuple",
    "sorted",
    "all",
    "any",
    "min",
    "max",
}


class GoodTransformer(CSTTransformer):
    def leave_Call(self, _, node):
        if isinstance(node.func, Name):
            if not (node.func.value in LIST_WRAPPED_ARG_NOT_NECESSARY_FOR and len(node.args) == 1):
                return node

            return without_nested_list(node)

        elif isinstance(node.func, Attribute):
            # str.join
            if not (
                isinstance(node.func.value, SimpleString)
                and node.func.attr.value == "join"
                and len(node.args) == 1
            ):
                return node

            return without_nested_list(node)

        return node


for fp in sys.argv[1:]:
    print(fp)
    m = cst.parse_module(Path(fp).read_text())
    Path(fp).write_text(m.visit(GoodTransformer()).code)
```

The files I'm passing to sys.argv are the files that were modified in https://github.com/getsentry/sentry/pull/28080 (therefore, the files that used to have the compat):

```
src/sentry/analytics/event.py
src/sentry/api/bases/organization.py
src/sentry/api/endpoints/assistant.py
src/sentry/api/endpoints/chunk.py
src/sentry/api/endpoints/group_similar_issues.py
src/sentry/api/endpoints/organization_code_mappings.py
src/sentry/api/endpoints/organization_config_integrations.py
src/sentry/api/endpoints/organization_group_index.py
src/sentry/api/endpoints/organization_group_index_stats.py
src/sentry/api/endpoints/organization_member_unreleased_commits.py
src/sentry/api/endpoints/organization_projects_sent_first_event.py
src/sentry/api/endpoints/organization_releases.py
src/sentry/api/endpoints/organization_stats.py
src/sentry/api/endpoints/project_details.py
src/sentry/api/endpoints/project_repo_path_parsing.py
src/sentry/api/endpoints/project_stacktrace_link.py
src/sentry/api/endpoints/prompts_activity.py
src/sentry/api/event_search.py
src/sentry/api/helpers/group_index.py
src/sentry/api/issue_search.py
src/sentry/api/paginator.py
src/sentry/api/serializers/models/activity.py
src/sentry/api/serializers/models/alert_rule.py
src/sentry/api/serializers/models/alert_rule_trigger.py
src/sentry/api/serializers/models/event.py
src/sentry/api/serializers/models/group.py
src/sentry/api/serializers/models/grouprelease.py
src/sentry/api/serializers/models/grouptombstone.py
src/sentry/api/serializers/models/project.py
src/sentry/api/serializers/models/release.py
src/sentry/api/serializers/models/rule.py
src/sentry/api/serializers/models/sentry_app.py
src/sentry/api/serializers/models/team.py
src/sentry/api/serializers/models/userreport.py
src/sentry/api/validators/monitor.py
src/sentry/auth/providers/google/views.py
src/sentry/data_export/endpoints/data_export.py
src/sentry/data_export/endpoints/data_export_details.py
src/sentry/data_export/processors/discover.py
src/sentry/db/deletion.py
src/sentry/db/models/fields/array.py
src/sentry/db/models/manager/base.py
src/sentry/debug/utils/packages.py
src/sentry/digests/backends/redis.py
src/sentry/discover/endpoints/discover_query.py
src/sentry/eventstore/models.py
src/sentry/grouping/enhancer/actions.py
src/sentry/identity/google/provider.py
src/sentry/incidents/endpoints/serializers.py
src/sentry/incidents/logic.py
src/sentry/incidents/subscription_processor.py
src/sentry/integrations/aws_lambda/integration.py
src/sentry/integrations/aws_lambda/utils.py
src/sentry/integrations/bitbucket_server/integration.py
src/sentry/integrations/issues.py
src/sentry/integrations/jira/integration.py
src/sentry/integrations/jira/search.py
src/sentry/integrations/msteams/card_builder.py
src/sentry/integrations/msteams/utils.py
src/sentry/integrations/msteams/webhook.py
src/sentry/integrations/pagerduty/integration.py
src/sentry/integrations/vercel/generic_webhook.py
src/sentry/integrations/vercel/integration.py
src/sentry/interfaces/http.py
src/sentry/lang/native/applecrashreport.py
src/sentry/lang/native/processing.py
src/sentry/loader/browsersdkversion.py
src/sentry/management/commands/collectstatic.py
src/sentry/middleware/health.py
src/sentry/models/actor.py
src/sentry/models/apikey.py
src/sentry/models/groupowner.py
src/sentry/notifications/notifications/activity/release.py
src/sentry/plugins/sentry_webhooks/plugin.py
src/sentry/quotas/redis.py
src/sentry/runner/__init__.py
src/sentry/runner/commands/devservices.py
src/sentry/runner/commands/tsdb.py
src/sentry/runner/initializer.py
src/sentry/sdk_updates.py
src/sentry/search/events/fields.py
src/sentry/search/events/filter.py
src/sentry/search/utils.py
src/sentry/similarity/__init__.py
src/sentry/similarity/backends/redis.py
src/sentry/similarity/encoder.py
src/sentry/similarity/features.py
src/sentry/similarity/signatures.py
src/sentry/snuba/discover.py
src/sentry/tasks/reports.py
src/sentry/tasks/sentry_apps.py
src/sentry/testutils/cases.py
src/sentry/tsdb/base.py
src/sentry/tsdb/inmemory.py
src/sentry/tsdb/redis.py
src/sentry/tsdb/snuba.py
src/sentry/utils/avatar.py
src/sentry/utils/committers.py
src/sentry/utils/email.py
src/sentry/utils/functional.py
src/sentry/utils/http.py
src/sentry/utils/iterators.py
src/sentry/utils/meta.py
src/sentry/utils/pytest/selenium.py
src/sentry/utils/redis.py
src/sentry/utils/safe.py
src/sentry/utils/snuba.py
src/sentry/utils/strings.py
src/sentry/utils/versioning.py
src/sentry/web/frontend/debug/debug_new_release_email.py
src/sentry_plugins/twilio/plugin.py
src/social_auth/__init__.py
src/social_auth/backends/__init__.py
tests/sentry/api/endpoints/test_organization_config_repositories.py
tests/sentry/api/endpoints/test_organization_dashboard_details.py
tests/sentry/api/endpoints/test_organization_dashboards.py
tests/sentry/api/endpoints/test_organization_member_details.py
tests/sentry/api/endpoints/test_organization_plugins_configs.py
tests/sentry/api/endpoints/test_project_details.py
tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
tests/sentry/api/endpoints/test_project_plugins.py
tests/sentry/api/endpoints/test_project_user_reports.py
tests/sentry/api/endpoints/test_project_users.py
tests/sentry/api/endpoints/test_team_projects.py
tests/sentry/db/postgres/test_base.py
tests/sentry/grouping/similarity/test_features.py
tests/sentry/incidents/test_subscription_processor.py
tests/sentry/integrations/aws_lambda/test_integration.py
tests/sentry/integrations/slack/test_event_endpoint.py
tests/sentry/lang/native/test_ignoredsourcesfiltering.py
tests/sentry/lang/native/test_symbolicator.py
tests/sentry/models/test_file.py
tests/sentry/models/test_project.py
tests/sentry/quotas/redis/tests.py
tests/sentry/similarity/test_signatures.py
tests/sentry/tasks/test_reports.py
tests/sentry/web/frontend/test_auth_saml2.py
tests/sentry_plugins/twilio/test_plugin.py
tests/snuba/api/endpoints/test_group_events.py
tests/snuba/api/endpoints/test_organization_events_stats.py
tests/snuba/api/endpoints/test_organization_events_v2.py
tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
tests/snuba/api/endpoints/test_project_events.py
tests/snuba/tasks/test_unmerge.py
```