### PR TITLE
ref(grouping): Label not showing in breakdown

### DIFF
--- a/static/app/components/events/interfaces/frame/lineV2/default.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/default.tsx
@@ -8,7 +8,6 @@ import {Frame} from 'app/types';
 import {defined} from 'app/utils';
 
 import DefaultTitle from '../defaultTitle';
-import GroupingIndicator from '../groupingIndicator';
 
 import Expander from './expander';
 import LeadHint from './leadHint';
@@ -64,7 +63,6 @@ function Default({
           isUsedForGrouping={isUsedForGrouping}
         />
         {renderRepeats()}
-        {isUsedForGrouping && <GroupingIndicator />}
       </VertCenterWrapper>
       <Expander
         isExpanded={isExpanded}

--- a/static/app/components/events/interfaces/frame/lineV2/default.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/default.tsx
@@ -8,6 +8,7 @@ import {Frame} from 'app/types';
 import {defined} from 'app/utils';
 
 import DefaultTitle from '../defaultTitle';
+import GroupingIndicator from '../groupingIndicator';
 
 import Expander from './expander';
 import LeadHint from './leadHint';
@@ -63,6 +64,7 @@ function Default({
           isUsedForGrouping={isUsedForGrouping}
         />
         {renderRepeats()}
+        {isUsedForGrouping && <GroupingIndicator />}
       </VertCenterWrapper>
       <Expander
         isExpanded={isExpanded}

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -237,7 +237,10 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
                     key={hash}
                     sampleEvent={{
                       ...latestEvent,
-                      metadata: metadata || latestEvent.metadata,
+                      metadata: {
+                        ...(metadata || latestEvent.metadata),
+                        current_level: activeGroupingLevel,
+                      },
                       title: title || latestEvent.title,
                     }}
                     eventCount={eventCount}


### PR DESCRIPTION
Grouping indicator was not being shown in the stack trace preview in the grouping breakdown. 
closes: INGEST-209