### PR TITLE
ref(releases): Capture contents of broken zip file in sentry

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -512,9 +512,12 @@ def fetch_release_artifact(url, release, dist):
             archive = ReleaseArchive(archive_file)
         except Exception as exc:
             archive_file.seek(0)
-            # Assign to variable to make contents visible in Sentry:
-            contents = archive_file.read(n=256)  # NOQA
-            logger.error("Failed to initialize archive for release %s", release.id, exc_info=exc)
+            logger.error(
+                "Failed to initialize archive for release %s",
+                release.id,
+                exc_info=exc,
+                extra={"contents": archive_file.read(n=256)},
+            )
             # TODO(jjbayer): cache error and return here
         else:
             with archive:

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -511,6 +511,9 @@ def fetch_release_artifact(url, release, dist):
         try:
             archive = ReleaseArchive(archive_file)
         except Exception as exc:
+            archive_file.seek(0)
+            # Assign to variable to make contents visible in Sentry:
+            contents = archive_file.read(n=256)  # NOQA
             logger.error("Failed to initialize archive for release %s", release.id, exc_info=exc)
             # TODO(jjbayer): cache error and return here
         else:


### PR DESCRIPTION
Assign beginning of broken ZIP file to a variable so it becomes visible in Sentry.

See https://sentry.io/organizations/sentry/issues/2461965057.