### PR TITLE
fix(discover): Previous Period Chart Rendering

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -375,10 +375,16 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
       : {};
     const timeframe =
       response.start && response.end
-        ? {
-            start: response.start * 1000,
-            end: response.end * 1000,
-          }
+        ? !previous
+          ? {
+              start: response.start * 1000,
+              end: response.end * 1000,
+            }
+          : {
+              // Find the midpoint of start & end since previous includes 2x data
+              start: (response.start + response.end) * 500,
+              end: response.end * 1000,
+            }
         : undefined;
     return {
       data: transformedData,


### PR DESCRIPTION
- Previous period was rendering the previous day since start is the
  start of data retrieved, which meant that it was twice as wide as it
  should be
  - This sets start as the midpoint between start&end when previous is
    selected