### PR TITLE
ref(integrations): Remove call to action on code mappings page

### DIFF
--- a/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -5,7 +5,6 @@ import * as qs from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
-import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
@@ -17,7 +16,7 @@ import RepositoryProjectPathConfigRow, {
   NameRepoColumn,
   OutputPathColumn,
 } from 'app/components/repositoryProjectPathConfigRow';
-import {IconAdd, IconInfo} from 'app/icons';
+import {IconAdd} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -178,11 +177,6 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
 
     return (
       <Fragment>
-        <Alert type="info" icon={<IconInfo />}>
-          {tct('Got feedback? Email [email:ecosystem-feedback@sentry.io].', {
-            email: <a href="mailto:ecosystem-feedback@sentry.io" />,
-          })}
-        </Alert>
         <TextBlock>
           {tct(
             `Code Mappings are used to map stack trace file paths to source code file paths. These mappings are the basis for features like Stack Trace Linking. To learn more, [link: read the docs].`,


### PR DESCRIPTION
See: [API-2024](https://getsentry.atlassian.net/browse/API-2024)

Small PR to remove the alert call to action atop the code-mappings tab to contact the ecosystems team. 

**Before**:
![image](https://user-images.githubusercontent.com/35509934/129977524-ea8f17b1-7000-477b-b3e1-6a426b6c48e0.png)

**After**:
![image](https://user-images.githubusercontent.com/35509934/129977561-5dbf4a91-70f6-4a5c-ae75-fad223942482.png)
_i learned how to set up local github integrations for this screenshot :)_