### PR TITLE
fix(ci): Increase e2e-test timeout to 600s

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -65,7 +65,7 @@ steps:
           docker-compose logs;
           exit $test_return;
         fi
-    timeout: 450s
+    timeout: 600s
   - name: 'gcr.io/cloud-builders/docker'
     id: docker-push
     waitFor:


### PR DESCRIPTION
Fix the failure seen in Snuba at https://github.com/getsentry/snuba/runs/3365123915
by increasing the timeout.