### PR TITLE
fix(search): 'is' and 'has' marked as invalid for empty text

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -588,6 +588,10 @@ export class TokenConverter {
       );
     }
 
+    if (filter === FilterType.Is || filter === FilterType.Has) {
+      return this.checkInvalidTextValue(value as TextFilter['value']);
+    }
+
     if ([FilterType.TextIn, FilterType.NumericIn].includes(filter)) {
       return this.checkInvalidInFilter(value as InFilter['value']);
     }

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -665,14 +665,16 @@ describe('SmartSearchBar', function () {
 
     it('shows errors on incorrect tokens', async function () {
       const props = {
-        query: 'tag: ',
+        query: 'tag: is: has: ',
         organization,
         location,
         supportedTags,
       };
       jest.useRealTimers();
       const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      expect(wrapper.find('Filter').prop('invalid')).toBe(true);
+      wrapper.find('Filter').forEach(filter => {
+        expect(filter.prop('invalid')).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/9372512/129983567-e689fee3-0fa0-4c4a-a6d1-4895c4e9c6bc.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/129983551-8437e491-5b68-4dba-a277-f48bbb3d09fb.png)
