### PR TITLE
feat(api): Add endpoint to retrieve group activities

### DIFF
--- a/src/sentry/api/endpoints/group_activities.py
+++ b/src/sentry/api/endpoints/group_activities.py
@@ -1,0 +1,19 @@
+from rest_framework.response import Response
+
+from sentry.api.base import EnvironmentMixin
+from sentry.api.bases import GroupEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import Activity
+
+
+class GroupActivitiesEndpoint(GroupEndpoint, EnvironmentMixin):
+    def get(self, request, group):
+        """
+        Retrieve all the Activities for a Group
+        """
+        activity = Activity.get_activities_for_group(group, num=100)
+        return Response(
+            {
+                "activity": serialize(activity, request.user),
+            }
+        )

--- a/src/sentry/api/endpoints/group_activities.py
+++ b/src/sentry/api/endpoints/group_activities.py
@@ -11,7 +11,7 @@ class GroupActivitiesEndpoint(GroupEndpoint, EnvironmentMixin):
         """
         Retrieve all the Activities for a Group
         """
-        activity = Activity.get_activities_for_group(group, num=self.get_per_page(request))
+        activity = Activity.get_activities_for_group(group, num=100)
         return Response(
             {
                 "activity": serialize(activity, request.user),

--- a/src/sentry/api/endpoints/group_activities.py
+++ b/src/sentry/api/endpoints/group_activities.py
@@ -11,7 +11,7 @@ class GroupActivitiesEndpoint(GroupEndpoint, EnvironmentMixin):
         """
         Retrieve all the Activities for a Group
         """
-        activity = Activity.get_activities_for_group(group, num=100)
+        activity = Activity.get_activities_for_group(group, num=self.get_per_page(request))
         return Response(
             {
                 "activity": serialize(activity, request.user),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -90,6 +90,7 @@ from .endpoints.external_team_details import ExternalTeamDetailsEndpoint
 from .endpoints.external_user import ExternalUserEndpoint
 from .endpoints.external_user_details import ExternalUserDetailsEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
+from .endpoints.group_activities import GroupActivitiesEndpoint
 from .endpoints.group_attachments import GroupAttachmentsEndpoint
 from .endpoints.group_current_release import GroupCurrentReleaseEndpoint
 from .endpoints.group_details import GroupDetailsEndpoint
@@ -422,6 +423,7 @@ from .endpoints.useravatar import UserAvatarEndpoint
 # to the organization (and queryable via short ID)
 GROUP_URLS = [
     url(r"^(?P<issue_id>[^\/]+)/$", GroupDetailsEndpoint.as_view()),
+    url(r"^(?P<issue_id>[^\/]+)/activities/$", GroupActivitiesEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/events/$", GroupEventsEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/events/latest/$", GroupEventsLatestEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/events/oldest/$", GroupEventsOldestEndpoint.as_view()),

--- a/tests/sentry/api/endpoints/test_group_activities.py
+++ b/tests/sentry/api/endpoints/test_group_activities.py
@@ -1,0 +1,40 @@
+from sentry.models import Activity, GroupStatus
+from sentry.testutils import APITestCase
+
+
+class GroupActivitiesEndpointTest(APITestCase):
+    def test_endpoint_with_no_group_activities(self):
+        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group.id}/"
+        response = self.client.get(
+            url,
+            format="json",
+        )
+
+        assert "activity" in response.data
+        assert len(response.data["activity"]) == 1
+
+    def test_endpoint_with_group_activities(self):
+        group = self.create_group(checksum="a" * 32, status=GroupStatus.UNRESOLVED)
+
+        for i in range(0, 4):
+            Activity.objects.create(
+                group=group,
+                project=group.project,
+                type=Activity.NOTE,
+                data={"text": "hello world"},
+            )
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{group.id}/"
+        response = self.client.get(
+            url,
+            format="json",
+        )
+
+        assert "activity" in response.data
+        assert len(response.data["activity"]) == 5

--- a/tests/sentry/api/endpoints/test_group_activities.py
+++ b/tests/sentry/api/endpoints/test_group_activities.py
@@ -8,7 +8,7 @@ class GroupActivitiesEndpointTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/issues/{group.id}/activities/"
         response = self.client.get(
             url,
             format="json",
@@ -30,7 +30,7 @@ class GroupActivitiesEndpointTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = f"/api/0/issues/{group.id}/"
+        url = f"/api/0/issues/{group.id}/activities/"
         response = self.client.get(
             url,
             format="json",


### PR DESCRIPTION
This PR:- 
- Adds end point that basically retrieves all activities related to a Group

Follow up on: 
https://github.com/getsentry/sentry/pull/27860#pullrequestreview-721606035