### PR TITLE
ref(perf): Replace beta badge with new for tag explorer

### DIFF
--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -559,7 +559,7 @@ function TagsHeader(props: HeaderProps) {
     <Header>
       <div>
         <SectionHeading>{t('Suspect Tags')}</SectionHeading>
-        <FeatureBadge type="beta" />
+        <FeatureBadge type="new" />
       </div>
       <Feature features={['performance-tag-page']} organization={organization}>
         <Button


### PR DESCRIPTION
### Summary
This will change the tag explorer badge to 'new' as well.