### PR TITLE
ref(ui): Add option to GlobalModal to prevent click outs from closing them

### DIFF
--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -32,6 +32,12 @@ type ModalOptions = {
    * Set to true (the default) to show a translucent backdrop
    */
   backdrop?: 'static' | boolean;
+  /**
+   * Set to `false` to disable the ability to click outside the modal to
+   * close it. This is useful for modals containing user input which will
+   * disappear on an accidental click. Defaults to `true`.
+   */
+  allowClickClose?: boolean;
 };
 
 type ModalRenderProps = {
@@ -152,10 +158,13 @@ function GlobalModal({visible = false, options = {}, children, onClose}: Props) 
   // Default to enabled backdrop
   const backdrop = options.backdrop ?? true;
 
+  // Default to enabled click close
+  const allowClickClose = options.allowClickClose ?? true;
+
   // Only close when we directly click outside of the modal.
   const containerRef = React.useRef<HTMLDivElement>(null);
   const clickClose = (e: React.MouseEvent) =>
-    containerRef.current === e.target && closeModal();
+    containerRef.current === e.target && allowClickClose && closeModal();
 
   return ReactDOM.createPortal(
     <React.Fragment>

--- a/static/app/components/group/externalIssueActions.tsx
+++ b/static/app/components/group/externalIssueActions.tsx
@@ -65,9 +65,10 @@ const ExternalIssueActions = ({configurations, group, onChange, api}: Props) => 
   };
 
   const doOpenModal = (integration: GroupIntegration) =>
-    openModal(deps => (
-      <ExternalIssueForm {...deps} {...{group, onChange, integration}} />
-    ));
+    openModal(
+      deps => <ExternalIssueForm {...deps} {...{group, onChange, integration}} />,
+      {allowClickClose: false}
+    );
 
   return (
     <Fragment>

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -69,13 +69,16 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
     );
 
     e?.preventDefault();
-    openModal(deps => (
-      <SentryAppExternalIssueModal
-        {...deps}
-        {...{group, event, sentryAppComponent, sentryAppInstallation}}
-        onSubmitSuccess={this.onSubmitSuccess}
-      />
-    ));
+    openModal(
+      deps => (
+        <SentryAppExternalIssueModal
+          {...deps}
+          {...{group, event, sentryAppComponent, sentryAppInstallation}}
+          onSubmitSuccess={this.onSubmitSuccess}
+        />
+      ),
+      {allowClickClose: false}
+    );
   };
 
   deleteIssue = () => {

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -116,7 +116,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
           }}
         />
       ),
-      {}
+      {allowClickClose: false}
     );
   };
 

--- a/tests/js/spec/components/globalModal.spec.jsx
+++ b/tests/js/spec/components/globalModal.spec.jsx
@@ -66,4 +66,35 @@ describe('GlobalModal', function () {
     wrapper.update();
     expect(closeSpy).toHaveBeenCalled();
   });
+
+  it('calls ignores click out when the allowClickClose option is false', async function () {
+    const wrapper = mountWithTheme(
+      <div id="outside-test">
+        <GlobalModal />
+      </div>
+    );
+
+    openModal(
+      ({Header}) => (
+        <div id="modal-test">
+          <Header closeButton>Header</Header>Hi
+        </div>
+      ),
+      {allowClickClose: false}
+    );
+
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('GlobalModal').prop('visible')).toBe(true);
+
+    wrapper.find('#outside-test').simulate('click');
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('GlobalModal').prop('visible')).toBe(true);
+
+    wrapper.find('CloseButton').simulate('click');
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('GlobalModal').prop('visible')).toBe(false);
+  });
 });


### PR DESCRIPTION
See [API-1683](https://getsentry.atlassian.net/browse/API-1683)

Throughout the app there are a few modals that contain fields where users can provide a decent amount of input. Clicking outside any modal in the app will close it and wipe any of the data within, which is especially frustrating after typing a bunch of stuff out manually. Ideally this would be solved by maintaining the state of the forms after the modal closes, but with how stores are kept right now, that is a bit difficult.

As a working solution, this PR adds the option to prevent modals from closing for indirect clicks (`allowClickClose`). It is enabled by default to maintain the existing behavior, but is disabled in this PR for:

- Linked Issue modal form
- Sentry App modal form
- Plugins modal form

**Before**
![before](https://user-images.githubusercontent.com/35509934/130123176-6b50c40f-168b-4125-8678-7c3ece2d8b0a.gif)

**After**
![after](https://user-images.githubusercontent.com/35509934/130122908-463d8599-cb8d-4b4b-8b55-91143c23ec2a.gif)
