### PR TITLE
fix(ui): Unexpected linebreaks on table

### DIFF
--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -126,7 +126,7 @@ export const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: repeat(5, auto);
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: auto repeat(4, 100px);
+    grid-template-columns: 1fr repeat(4, minmax(0, auto));
   }
 `;
 export const CellStat = styled('div')`


### PR DESCRIPTION
Discovered this while doing some research for QM

### Before
<img width="480" alt="Screen Shot 2021-08-19 at 12 28 33 PM" src="https://user-images.githubusercontent.com/1748388/130132315-f7c67de6-a231-4d28-9707-962876f1c0ed.png">



### After
<img width="480" alt="Screen Shot 2021-08-19 at 12 29 08 PM" src="https://user-images.githubusercontent.com/1748388/130132318-0b809c77-8b7b-463e-afdf-84bcd2f95063.png">


