### PR TITLE
ref(routes): Do not apply errorHandler to lazyLoad components

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -56,7 +56,7 @@ const IndexRoute = BaseIndexRoute as React.ComponentClass<IndexRouteProps & Cust
 const lazyLoad =
   (load: () => Promise<any>): RouteProps['getComponent'] =>
   (_loc, cb) =>
-    load().then(module => cb(null, errorHandler(module.default)));
+    load().then(module => cb(null, module.default));
 
 const hook = (name: HookName) => HookStore.get(name).map(cb => cb());
 


### PR DESCRIPTION
For whatever reason this is causing some weird component re-mounting issues.

Need to investigate more what was wrong here, but this fixes some pages that reload their components on any route change