### PR TITLE
ref(jira ac): Return 404s for all URL paths unless flagged in

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -974,6 +974,8 @@ SENTRY_FEATURES = {
     "organizations:invite-members": True,
     # Enable rate limits for inviting members.
     "organizations:invite-members-rate-limits": True,
+    # Enable Jira AC for select organizations.
+    "organizations:jira-ac-plugin": False,
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
     "organizations:org-subdomains": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -100,6 +100,7 @@ default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, 
 default_manager.add("organizations:issue-percent-display", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-use-cdc-secondary", OrganizationFeature, True)
+default_manager.add("organizations:jira-ac-plugin", OrganizationFeature, True)
 default_manager.add("organizations:large-debug-files", OrganizationFeature)
 default_manager.add("organizations:metric-alert-builder-aggregate", OrganizationFeature)
 default_manager.add("organizations:metrics", OrganizationFeature, True)

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -2,7 +2,7 @@ from typing import Any, Mapping, MutableMapping, Optional
 from urllib.parse import urlparse
 
 from django.forms.utils import ErrorList
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -10,7 +10,7 @@ from django.views.generic import View
 from jwt.exceptions import ExpiredSignatureError
 from rest_framework.request import Request
 
-from sentry import options
+from sentry import features, options
 from sentry.models import Organization
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -59,6 +59,8 @@ class BaseJiraWidgetView(View):
 class JiraUIWidgetView(BaseJiraWidgetView):
     @transaction_start("JiraUIWidgetView.get")
     def get(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+            raise Http404
         with configure_scope() as scope:
             try:
                 # make sure this exists and is valid
@@ -100,6 +102,8 @@ class JiraConfigView(BaseJiraWidgetView):
 
     @transaction_start("JiraConfigView.get")
     def get(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+            raise Http404
         try:
             jira_auth = self.get_jira_auth()
         except CATCHABLE_AUTH_ERRORS:
@@ -122,6 +126,8 @@ class JiraConfigView(BaseJiraWidgetView):
 
     @transaction_start("JiraConfigView.post")
     def post(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+            raise Http404
         try:
             jira_auth = self.get_jira_auth()
         except CATCHABLE_AUTH_ERRORS:
@@ -153,6 +159,8 @@ class JiraConfigView(BaseJiraWidgetView):
 class JiraDescriptorView(View):
     @transaction_start("JiraDescriptorView.get")
     def get(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+            raise Http404
         return HttpResponse(
             json.dumps(
                 {
@@ -194,6 +202,8 @@ class JiraInstalledCallback(View):
     @method_decorator(csrf_exempt)
     @transaction_start("JiraInstalledCallback.post")
     def post(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+            raise Http404
         registration_info = json.loads(request.body)
         JiraTenant.objects.create_or_update(
             client_key=registration_info["clientKey"],

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -10,7 +10,8 @@ from django.views.generic import View
 from jwt.exceptions import ExpiredSignatureError
 from rest_framework.request import Request
 
-from sentry import features, options
+from sentry import options
+from sentry.features.helpers import any_organization_has_feature
 from sentry.models import Organization
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -59,7 +60,9 @@ class BaseJiraWidgetView(View):
 class JiraUIWidgetView(BaseJiraWidgetView):
     @transaction_start("JiraUIWidgetView.get")
     def get(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+        if not any_organization_has_feature(
+            "organizations:jira-ac-plugin", request.user.get_orgs()
+        ):
             raise Http404
         with configure_scope() as scope:
             try:
@@ -102,7 +105,9 @@ class JiraConfigView(BaseJiraWidgetView):
 
     @transaction_start("JiraConfigView.get")
     def get(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+        if not any_organization_has_feature(
+            "organizations:jira-ac-plugin", request.user.get_orgs()
+        ):
             raise Http404
         try:
             jira_auth = self.get_jira_auth()
@@ -126,7 +131,9 @@ class JiraConfigView(BaseJiraWidgetView):
 
     @transaction_start("JiraConfigView.post")
     def post(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+        if not any_organization_has_feature(
+            "organizations:jira-ac-plugin", request.user.get_orgs()
+        ):
             raise Http404
         try:
             jira_auth = self.get_jira_auth()
@@ -159,7 +166,9 @@ class JiraConfigView(BaseJiraWidgetView):
 class JiraDescriptorView(View):
     @transaction_start("JiraDescriptorView.get")
     def get(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+        if not any_organization_has_feature(
+            "organizations:jira-ac-plugin", request.user.get_orgs()
+        ):
             raise Http404
         return HttpResponse(
             json.dumps(
@@ -202,7 +211,9 @@ class JiraInstalledCallback(View):
     @method_decorator(csrf_exempt)
     @transaction_start("JiraInstalledCallback.post")
     def post(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
-        if not features.has("organizations:jira-ac-plugin", request.user.get_orgs()):
+        if not any_organization_has_feature(
+            "organizations:jira-ac-plugin", request.user.get_orgs()
+        ):
             raise Http404
         registration_info = json.loads(request.body)
         JiraTenant.objects.create_or_update(


### PR DESCRIPTION
In preparation for nuking the Jira AC plugin, we're soft-nuking it first by returning 404s for all Jira AC URLs unless you are feature flagged in. 