### PR TITLE
fix(integrations): VSTS `update_comment()`

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -332,6 +332,6 @@ class VstsIssueSync(IssueSyncMixin):
         quoted_comment = f"{attribution}<blockquote>{comment_text}</blockquote>"
         return quoted_comment
 
-    def update_comment(self, issue_id, user_id, external_comment_id, comment_text):
-        # Azure does not support updating comments
+    def update_comment(self, issue_id, user_id, group_note):
+        # Azure does not support updating comments.
         pass

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -2,6 +2,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
+from exam import mock
 
 from sentry.integrations.vsts import VstsIntegration, VstsIntegrationProvider
 from sentry.models import (
@@ -517,3 +518,15 @@ class VstsIntegrationTest(VstsIntegrationTestCase):
         )
         with pytest.raises(IntegrationError):
             installation.get_repositories()
+
+    def test_update_comment(self):
+        self.assert_installation()
+        integration = Integration.objects.get(provider="vsts")
+        installation = integration.get_installation(self.organization.id)
+
+        group_note = mock.Mock()
+        comment = "hello world\nThis is a comment.\n\n\n    I've changed it"
+        group_note.data = {"text": comment, "external_id": "123"}
+
+        # Does nothing.
+        installation.update_comment(1, self.user.id, group_note)


### PR DESCRIPTION
The noop function `update_comment()` has a bad signature.

Fixes [SENTRY-QXZ](https://sentry.io/organizations/sentry/issues/2473104343/activity).