### PR TITLE
feat(scim): move okta to GA

### DIFF
--- a/src/sentry/auth/providers/saml2/okta/provider.py
+++ b/src/sentry/auth/providers/saml2/okta/provider.py
@@ -1,11 +1,11 @@
 from sentry.auth.providers.saml2.forms import URLMetadataForm
-from sentry.auth.providers.saml2.provider import Attributes, SAML2Provider, SCIMMixin
+from sentry.auth.providers.saml2.provider import Attributes, SAML2Provider
 from sentry.auth.providers.saml2.views import make_simple_setup
 
 SelectIdP = make_simple_setup(URLMetadataForm, "sentry_auth_okta/select-idp.html")
 
 
-class OktaSAML2Provider(SCIMMixin, SAML2Provider):
+class OktaSAML2Provider(SAML2Provider):
     name = "Okta"
 
     def get_saml_setup_pipeline(self):
@@ -18,3 +18,6 @@ class OktaSAML2Provider(SCIMMixin, SAML2Provider):
             Attributes.FIRST_NAME: "firstName",
             Attributes.LAST_NAME: "lastName",
         }
+
+    def can_use_scim(self, organization, user):
+        return True


### PR DESCRIPTION
- removes SCIM enablement from being under a feature flag for orgs using the Okta Provider.
- Other providers still have a feature flag as we are still waiting on integration approval from partners.