### PR TITLE
ref(jest): Update Jest config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -59,10 +59,10 @@ const config: Config.InitialOptions = {
   setupFiles: [
     '<rootDir>/static/app/utils/silence-react-unsafe-warnings.ts',
     '<rootDir>/tests/js/throw-on-react-error.js',
-    '<rootDir>/tests/js/setup.js',
     'jest-canvas-mock',
   ],
   setupFilesAfterEnv: [
+    '<rootDir>/tests/js/setup.js',
     '<rootDir>/tests/js/setupFramework.ts',
     '@testing-library/jest-dom/extend-expect',
   ],

--- a/tests/js/spec/components/events/interfaces/frame/line.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/frame/line.spec.tsx
@@ -1,4 +1,4 @@
-import {cleanup, mountWithTheme, within} from 'sentry-test/reactTestingLibrary';
+import {mountWithTheme, within} from 'sentry-test/reactTestingLibrary';
 
 import Line from 'app/components/events/interfaces/frame/line';
 import {Frame} from 'app/types';
@@ -26,10 +26,6 @@ describe('Frame - Line', function () {
     trust: null,
     vars: null,
   };
-
-  afterEach(() => {
-    cleanup();
-  });
 
   describe('renderOriginalSourceInfo()', function () {
     it('should render the source map information as a HTML string', function () {

--- a/tests/js/spec/components/indicators.spec.jsx
+++ b/tests/js/spec/components/indicators.spec.jsx
@@ -1,10 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {
-  cleanup,
-  fireEvent,
-  mountWithTheme,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {
   addErrorMessage,
@@ -35,10 +30,6 @@ describe('Indicators', function () {
 
     clearIndicators();
     jest.runAllTimers();
-  });
-
-  afterEach(function () {
-    cleanup();
   });
 
   it('renders nothing by default', function () {

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -3,12 +3,7 @@ import selectEvent from 'react-select-event';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
-import {
-  cleanup,
-  fireEvent,
-  mountWithTheme,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as memberActionCreators from 'app/actionCreators/members';
 import ProjectsStore from 'app/stores/projectsStore';
@@ -113,7 +108,6 @@ describe('ProjectAlertsCreate', function () {
   });
 
   afterEach(function () {
-    cleanup();
     MockApiClient.clearMockResponses();
     trackAnalyticsEvent.mockClear();
   });

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -1,7 +1,7 @@
 import {browserHistory} from 'react-router';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {cleanup, mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
+import {mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import GlobalSelectionStore from 'app/stores/globalSelectionStore';
 import GroupStore from 'app/stores/groupStore';
@@ -106,7 +106,6 @@ describe('groupDetails', () => {
     });
   });
   afterEach(() => {
-    cleanup();
     ProjectsStore.reset();
     GroupStore.reset();
     GlobalSelectionStore.reset();

--- a/tests/js/spec/views/organizationGroupDetails/groupTagValues.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTagValues.spec.jsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {cleanup, fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import GroupTagValues from 'app/views/organizationGroupDetails/groupTagValues';
 
@@ -16,7 +16,6 @@ describe('GroupTagValues', () => {
   });
 
   afterEach(() => {
-    cleanup();
     MockApiClient.clearMockResponses();
   });
 

--- a/tests/js/spec/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/tests/js/spec/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -1,20 +1,11 @@
 import {browserHistory} from 'react-router';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {
-  cleanup,
-  fireEvent,
-  mountWithTheme,
-  screen,
-} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import ReleaseComparisonChart from 'app/views/releases/detail/overview/releaseComparisonChart';
 
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
-  afterEach(() => {
-    cleanup();
-  });
-
   const {routerContext, organization, project} = initializeOrg();
   // @ts-expect-error
   const api = new MockApiClient();


### PR DESCRIPTION
**Before:**
```
  setupFiles: [
    '<rootDir>/static/app/utils/silence-react-unsafe-warnings.ts',
    '<rootDir>/tests/js/throw-on-react-error.js',
    '<rootDir>/tests/js/setup.js',
    'jest-canvas-mock',
  ],
  setupFilesAfterEnv: [
    '<rootDir>/tests/js/setupFramework.ts',
    '@testing-library/jest-dom/extend-expect',
  ],
```

**After:** 

```
  setupFiles: [
    '<rootDir>/static/app/utils/silence-react-unsafe-warnings.ts',
    '<rootDir>/tests/js/throw-on-react-error.js',
    'jest-canvas-mock',
  ],
  setupFilesAfterEnv: [
    '<rootDir>/tests/js/setup.js',
    '<rootDir>/tests/js/setupFramework.ts',
    '@testing-library/jest-dom/extend-expect',
  ],
```

Moves `test/setup.js` to the `setupFilesAfterEnv` config because RTL requires the jest environment to be setup to get the auto-cleanup functionality working.

