### PR TITLE
feat(suspect-spans): Add feature flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -989,6 +989,10 @@ SENTRY_FEATURES = {
     "organizations:performance-events-page": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
+    # Enable ingestion for suspect spans
+    "organizations:performance-suspect-spans-ingestion": False,
+    # Enable views for suspect tags
+    "organizations:performance-suspect-spans-view": False,
     # Allow the user to create a sample transaction while onboarding
     "organizations:performance-create-sample-transaction": False,
     # Enable the new Related Events feature

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -117,6 +117,8 @@ default_manager.add("organizations:performance-tag-explorer", OrganizationFeatur
 default_manager.add("organizations:performance-tag-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-events-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
+default_manager.add("organizations:performance-suspect-spans-ingestion", OrganizationFeature)
+default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add(
     "organizations:performance-create-sample-transaction", OrganizationFeature, True


### PR DESCRIPTION
This adds in two new feature flags for suspect spans.
- `performance-suspect-spans-ingestion` will enable the ingestion related code
- `performance-suspect-spans-view` will enable the suspect spans tab