### PR TITLE
feat(plugins): Add deprecation date and alternative to serializer

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -48,6 +48,7 @@ class PluginSerializer(Serializer):
             "doc": doc,
             "firstPartyAlternative": obj.alternative if hasattr(obj, "alternative") else None,
             "deprecationDate": obj.deprecation_date if hasattr(obj, "deprecation_date") else None,
+            "altIsSentryApp": obj.alt_is_sentry_app if hasattr(obj, "alt_is_sentry_app") else None,
         }
         if self.project:
             d["enabled"] = obj.is_enabled(self.project)

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -46,6 +46,8 @@ class PluginSerializer(Serializer):
                 for asset in obj.get_assets()
             ],
             "doc": doc,
+            "firstPartyAlternative": obj.alternative if hasattr(obj, "alternative") else None,
+            "deprecationDate": obj.deprecation_date if hasattr(obj, "deprecation_date") else None,
         }
         if self.project:
             d["enabled"] = obj.is_enabled(self.project)

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -29,6 +29,9 @@ class PluginSerializer(Serializer):
         contexts = []
         if hasattr(obj, "get_custom_contexts"):
             contexts.extend(x.type for x in obj.get_custom_contexts() or ())
+
+        deprecation_date = getattr(obj, "deprecation_date", None)
+
         d = {
             "id": obj.slug,
             "name": str(obj.get_title()),
@@ -47,7 +50,9 @@ class PluginSerializer(Serializer):
             ],
             "doc": doc,
             "firstPartyAlternative": getattr(obj, "alternative", None),
-            "deprecationDate": getattr(obj, "deprecation_date", None),
+            "deprecationDate": deprecation_date.strftime("%b %-d, %Y")
+            if deprecation_date
+            else None,
             "altIsSentryApp": getattr(obj, "alt_is_sentry_app", None),
         }
         if self.project:

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -46,9 +46,9 @@ class PluginSerializer(Serializer):
                 for asset in obj.get_assets()
             ],
             "doc": doc,
-            "firstPartyAlternative": obj.alternative if hasattr(obj, "alternative") else None,
-            "deprecationDate": obj.deprecation_date if hasattr(obj, "deprecation_date") else None,
-            "altIsSentryApp": obj.alt_is_sentry_app if hasattr(obj, "alt_is_sentry_app") else None,
+            "firstPartyAlternative": getattr(obj, "alternative", None),
+            "deprecationDate": getattr(obj, "deprecation_date", None),
+            "altIsSentryApp": getattr(obj, "alt_is_sentry_app", None),
         }
         if self.project:
             d["enabled"] = obj.is_enabled(self.project)

--- a/src/sentry_plugins/clubhouse/plugin.py
+++ b/src/sentry_plugins/clubhouse/plugin.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.conf.urls import url
 from rest_framework.response import Response
 
@@ -33,7 +35,7 @@ class ClubhousePlugin(CorePluginMixin, IssuePlugin2):
             IntegrationFeatures.ISSUE_BASIC,
         ),
     ]
-    deprecation_date = "Sept 20, 2021"
+    deprecation_date = datetime(2021, 9, 20)
     alternative = "clubhouse"
     alt_is_sentry_app = True
 

--- a/src/sentry_plugins/clubhouse/plugin.py
+++ b/src/sentry_plugins/clubhouse/plugin.py
@@ -33,6 +33,9 @@ class ClubhousePlugin(CorePluginMixin, IssuePlugin2):
             IntegrationFeatures.ISSUE_BASIC,
         ),
     ]
+    deprecation_date = "Sept 20, 2021"
+    alternative = "clubhouse"
+    alt_is_sentry_app = True
 
     issue_fields = frozenset(["id", "title", "url"])
 

--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.plugins.bases.notify import NotifyPlugin
 from sentry.utils.http import absolute_uri
@@ -29,7 +31,8 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
             IntegrationFeatures.ALERT_RULE,
         ),
     ]
-    deprecation_date = "Sept 20, 2021"
+    deprecation_date = datetime(2021, 9, 20)
+
     alternative = "pagerduty"
     alt_is_sentry_app = False
 

--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -29,6 +29,9 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
             IntegrationFeatures.ALERT_RULE,
         ),
     ]
+    deprecation_date = "Sept 20, 2021"
+    alternative = "pagerduty"
+    alt_is_sentry_app = False
 
     def error_message_from_json(self, data):
         message = data.get("message", "unknown error")

--- a/src/sentry_plugins/teamwork/plugin.py
+++ b/src/sentry_plugins/teamwork/plugin.py
@@ -80,6 +80,9 @@ class TeamworkPlugin(CorePluginMixin, IssuePlugin):
             IntegrationFeatures.ISSUE_BASIC,
         ),
     ]
+    deprecation_date = "Sept 20, 2021"
+    alternative = "clubhouse"
+    alt_is_sentry_app = True
 
     conf_title = title
     conf_key = slug

--- a/src/sentry_plugins/teamwork/plugin.py
+++ b/src/sentry_plugins/teamwork/plugin.py
@@ -81,7 +81,7 @@ class TeamworkPlugin(CorePluginMixin, IssuePlugin):
         ),
     ]
     deprecation_date = "Sept 20, 2021"
-    alternative = "clubhouse"
+    alternative = "teamwork"
     alt_is_sentry_app = True
 
     conf_title = title

--- a/src/sentry_plugins/teamwork/plugin.py
+++ b/src/sentry_plugins/teamwork/plugin.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django import forms
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
@@ -80,7 +82,7 @@ class TeamworkPlugin(CorePluginMixin, IssuePlugin):
             IntegrationFeatures.ISSUE_BASIC,
         ),
     ]
-    deprecation_date = "Sept 20, 2021"
+    deprecation_date = datetime(2021, 9, 20)
     alternative = "teamwork"
     alt_is_sentry_app = True
 

--- a/src/sentry_plugins/vsts/plugin.py
+++ b/src/sentry_plugins/vsts/plugin.py
@@ -36,6 +36,9 @@ class VstsPlugin(VisualStudioMixin, IssueTrackingPlugin2):
             IntegrationFeatures.ISSUE_BASIC,
         ),
     ]
+    deprecation_date = "Sept 20, 2021"
+    alternative = "vsts"
+    alt_is_sentry_app = False
 
     issue_fields = frozenset(["id", "title", "url"])
 

--- a/src/sentry_plugins/vsts/plugin.py
+++ b/src/sentry_plugins/vsts/plugin.py
@@ -1,6 +1,7 @@
 """ A plugin to incorporate work-item creation in VSTS
 easily out of issues detected from Sentry.io """
 
+from datetime import datetime
 
 from mistune import markdown
 
@@ -36,7 +37,7 @@ class VstsPlugin(VisualStudioMixin, IssueTrackingPlugin2):
             IntegrationFeatures.ISSUE_BASIC,
         ),
     ]
-    deprecation_date = "Sept 20, 2021"
+    deprecation_date = datetime(2021, 9, 20)
     alternative = "vsts"
     alt_is_sentry_app = False
 


### PR DESCRIPTION
In preparation for deprecating some old plugins that have a 1st party or sentry app alternative, add `deprecationDate`, `firstPartyAlternative`, and `altIsSentryApp` fields to the serializer for the `OrganizationPluginsConfigsEndpoint`. If these fields are set on a plugin, the value will come through. If not, it will be null. This will be used to show a banner in the product warning users that we're going to get rid of it soon and they need to upgrade to the alternative to continue using it. `altIsSentryApp` is used because we want to provide the user with a link to install the "new" version of their plugin, and to do so we'll need to know if it's an integration or a sentry app, as the links are formed differently. 

The ticket I'm working off of said to also to this for the integration directory page, but that page just hits the integration, sentry app, and plugin endpoints and combines all the data - (https://github.com/getsentry/sentry/blob/master/static/app/views/organizationIntegrations/integrationListDirectory.tsx#L161)

This PR also sets the deprecation date for PagerDuty, Azure DevOps, Clubhouse, and Teamwork.

Front end piece here: https://github.com/getsentry/sentry/pull/28143