### PR TITLE
feat(plugins): Add deprecation warning in UI

### DIFF
--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -32,7 +32,6 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
         ),
     ]
     deprecation_date = datetime(2021, 9, 20)
-
     alternative = "pagerduty"
     alt_is_sentry_app = False
 

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -595,13 +595,13 @@ export type PluginNoProject = {
   author?: {name: string; url: string};
   description?: string;
   resourceLinks?: Array<{title: string; url: string}>;
+  altIsSentryApp?: boolean;
+  deprecationDate?: string;
+  firstPartyAlternative?: string;
 };
 
 export type Plugin = PluginNoProject & {
   enabled: boolean;
-  altIsSentryApp?: boolean;
-  deprecationDate?: string;
-  firstPartyAlternative?: string;
 };
 
 export type PluginProjectItem = {

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -612,6 +612,9 @@ export type PluginProjectItem = {
 
 export type PluginWithProjectList = PluginNoProject & {
   projectList: PluginProjectItem[];
+  altIsSentryApp: boolean;
+  deprecationDate: string;
+  firstPartyAlternative: string;
 };
 
 export type AppOrProviderOrPlugin =

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -599,6 +599,9 @@ export type PluginNoProject = {
 
 export type Plugin = PluginNoProject & {
   enabled: boolean;
+  altIsSentryApp?: boolean;
+  deprecationDate?: string;
+  firstPartyAlternative?: string;
 };
 
 export type PluginProjectItem = {
@@ -612,9 +615,6 @@ export type PluginProjectItem = {
 
 export type PluginWithProjectList = PluginNoProject & {
   projectList: PluginProjectItem[];
-  altIsSentryApp: boolean;
-  deprecationDate: string;
-  firstPartyAlternative: string;
 };
 
 export type AppOrProviderOrPlugin =

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -394,9 +394,9 @@ export class IntegrationListDirectory extends AsyncComponent<
     const isLegacy = plugin.isHidden;
     const displayName = `${plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
     // hide legacy integrations if we don't have any projects with them
-    // if (isLegacy && !plugin.projectList.length) {
-    //   return null;
-    // }
+    if (isLegacy && !plugin.projectList.length) {
+      return null;
+    }
     return (
       <IntegrationRow
         key={`row-plugin-${plugin.id}`}

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -380,13 +380,23 @@ export class IntegrationListDirectory extends AsyncComponent<
 
   renderPlugin = (plugin: PluginWithProjectList) => {
     const {organization} = this.props;
-
+    let upgradeUrl = '';
+    let deprecationText = '';
+    if (plugin.deprecationDate !== null) {
+      deprecationText = `This integration is being deprecated on ${plugin.deprecationDate}. Please upgrade to avoid any disruption.`;
+    }
+    if (plugin.firstPartyAlternative !== null) {
+      upgradeUrl =
+        plugin.altIsSentryApp === false
+          ? `/settings/${organization.slug}/integrations/${plugin.firstPartyAlternative}/`
+          : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
+    }
     const isLegacy = plugin.isHidden;
     const displayName = `${plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
     // hide legacy integrations if we don't have any projects with them
-    if (isLegacy && !plugin.projectList.length) {
-      return null;
-    }
+    // if (isLegacy && !plugin.projectList.length) {
+    //   return null;
+    // }
     return (
       <IntegrationRow
         key={`row-plugin-${plugin.id}`}
@@ -399,6 +409,8 @@ export class IntegrationListDirectory extends AsyncComponent<
         publishStatus="published"
         configurations={plugin.projectList.length}
         categories={getCategoriesForIntegration(plugin)}
+        deprecationText={deprecationText}
+        upgradeUrl={upgradeUrl}
       />
     );
   };

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -380,17 +380,6 @@ export class IntegrationListDirectory extends AsyncComponent<
 
   renderPlugin = (plugin: PluginWithProjectList) => {
     const {organization} = this.props;
-    let upgradeUrl = '';
-    let deprecationText = '';
-    if (plugin.deprecationDate !== null) {
-      deprecationText = `This integration is being deprecated on ${plugin.deprecationDate}. Please upgrade to avoid any disruption.`;
-    }
-    if (plugin.firstPartyAlternative !== null) {
-      upgradeUrl =
-        plugin.altIsSentryApp === false
-          ? `/settings/${organization.slug}/integrations/${plugin.firstPartyAlternative}/`
-          : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
-    }
     const isLegacy = plugin.isHidden;
     const displayName = `${plugin.name} ${isLegacy ? '(Legacy)' : ''}`;
     // hide legacy integrations if we don't have any projects with them
@@ -409,8 +398,7 @@ export class IntegrationListDirectory extends AsyncComponent<
         publishStatus="published"
         configurations={plugin.projectList.length}
         categories={getCategoriesForIntegration(plugin)}
-        deprecationText={deprecationText}
-        upgradeUrl={upgradeUrl}
+        plugin={plugin}
       />
     );
   };

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -9,7 +9,7 @@ import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
-import {IntegrationInstallationStatus, Organization, Plugin, SentryApp} from 'app/types';
+import {IntegrationInstallationStatus, Organization, PluginWithProjectList, SentryApp} from 'app/types';
 import {
   convertIntegrationTypeToSnakeCase,
   trackIntegrationAnalytics,
@@ -28,7 +28,7 @@ type Props = {
   configurations: number;
   categories: string[];
   alertText?: string;
-  plugin?: Plugin;
+  plugin?: PluginWithProjectList;
 };
 
 const urlMap = {

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -27,6 +27,8 @@ type Props = {
   configurations: number;
   categories: string[];
   alertText?: string;
+  deprecationText?: string;
+  upgradeUrl?: string;
 };
 
 const urlMap = {
@@ -47,6 +49,8 @@ const IntegrationRow = (props: Props) => {
     configurations,
     categories,
     alertText,
+    deprecationText,
+    upgradeUrl,
   } = props;
 
   const baseUrl =
@@ -111,6 +115,26 @@ const IntegrationRow = (props: Props) => {
               }
             >
               {t('Resolve Now')}
+            </ResolveNowButton>
+          </Alert>
+        </AlertContainer>
+      )}
+      {deprecationText && (
+        <AlertContainer>
+          <Alert type="warning" icon={<IconWarning size="sm" />}>
+            <span>{deprecationText}</span>
+            <ResolveNowButton
+              href={`${upgradeUrl}?tab=configurations&referrer=directory_upgrade_now`}
+              size="xsmall"
+              onClick={() =>
+                trackIntegrationEvent('integrations.resolve_now_clicked', {
+                  integration_type: convertIntegrationTypeToSnakeCase(type),
+                  integration: slug,
+                  organization,
+                })
+              }
+            >
+              {t('Upgrade Now')}
             </ResolveNowButton>
           </Alert>
         </AlertContainer>

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -9,7 +9,12 @@ import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
-import {IntegrationInstallationStatus, Organization, PluginWithProjectList, SentryApp} from 'app/types';
+import {
+  IntegrationInstallationStatus,
+  Organization,
+  PluginWithProjectList,
+  SentryApp,
+} from 'app/types';
 import {
   convertIntegrationTypeToSnakeCase,
   trackIntegrationAnalytics,

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -9,13 +9,14 @@ import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
-import {IntegrationInstallationStatus, Organization, SentryApp} from 'app/types';
+import {IntegrationInstallationStatus, Organization, Plugin, SentryApp} from 'app/types';
 import {
   convertIntegrationTypeToSnakeCase,
   trackIntegrationAnalytics,
 } from 'app/utils/integrationUtil';
 
 import IntegrationStatus from './integrationStatus';
+import PluginDeprecationAlert from './pluginDeprecationAlert';
 
 type Props = {
   organization: Organization;
@@ -27,8 +28,7 @@ type Props = {
   configurations: number;
   categories: string[];
   alertText?: string;
-  deprecationText?: string;
-  upgradeUrl?: string;
+  plugin?: Plugin;
 };
 
 const urlMap = {
@@ -49,8 +49,7 @@ const IntegrationRow = (props: Props) => {
     configurations,
     categories,
     alertText,
-    deprecationText,
-    upgradeUrl,
+    plugin,
   } = props;
 
   const baseUrl =
@@ -119,29 +118,18 @@ const IntegrationRow = (props: Props) => {
           </Alert>
         </AlertContainer>
       )}
-      {deprecationText && (
-        <AlertContainer>
-          <Alert type="warning" icon={<IconWarning size="sm" />}>
-            <span>{deprecationText}</span>
-            <ResolveNowButton
-              href={`${upgradeUrl}?tab=configurations&referrer=directory_upgrade_now`}
-              size="xsmall"
-              onClick={() =>
-                trackIntegrationEvent('integrations.resolve_now_clicked', {
-                  integration_type: convertIntegrationTypeToSnakeCase(type),
-                  integration: slug,
-                  organization,
-                })
-              }
-            >
-              {t('Upgrade Now')}
-            </ResolveNowButton>
-          </Alert>
-        </AlertContainer>
+      {plugin?.deprecationDate && (
+        <PluginDeprecationAlertWrapper>
+          <PluginDeprecationAlert organization={organization} plugin={plugin} />
+        </PluginDeprecationAlertWrapper>
       )}
     </PanelRow>
   );
 };
+
+const PluginDeprecationAlertWrapper = styled('div')`
+  padding: 0px ${space(3)} 0px 68px;
+`;
 
 const PanelRow = styled(PanelItem)`
   flex-direction: column;

--- a/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
+++ b/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
@@ -24,12 +24,8 @@ class PluginDeprecationAlert extends Component<Props, State> {
       return <React.Fragment />;
     }
     let upgradeUrl = '';
-    if (plugin.firstPartyAlternative !== null) {
-      upgradeUrl =
-        plugin.altIsSentryApp === false
-          ? `/settings/${organization.slug}/integrations/${plugin.firstPartyAlternative}/`
-          : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
-    }
+    const resource = plugin.altIsSentryApp ? 'sentry-apps' : 'integrations';
+    upgradeUrl = `/settings/${organization.slug}/${resource}/${plugin.firstPartyAlternative}/`;
 
     return (
       <div>

--- a/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
+++ b/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
@@ -1,0 +1,62 @@
+import React, {Component} from 'react';
+import styled from '@emotion/styled';
+
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
+import {IconWarning} from 'app/icons';
+import {t} from 'app/locale';
+import {Organization, PluginWithProjectList} from 'app/types';
+import {trackIntegrationAnalytics} from 'app/utils/integrationUtil';
+
+type Props = {
+  organization: Organization;
+  plugin: PluginWithProjectList;
+};
+
+type State = {};
+
+class PluginDeprecationAlert extends Component<Props, State> {
+  render() {
+    const {organization, plugin} = this.props;
+
+    // Short-circuit if not deprecated.
+    if (!plugin.deprecationDate) {
+      return <React.Fragment />;
+    }
+    let upgradeUrl = '';
+    if (plugin.firstPartyAlternative !== null) {
+      upgradeUrl =
+        plugin.altIsSentryApp === false
+          ? `/settings/${organization.slug}/integrations/${plugin.firstPartyAlternative}/`
+          : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
+    }
+
+    return (
+      <div>
+        <Alert type="warning" icon={<IconWarning size="sm" />}>
+          <span>{`This integration is being deprecated on ${plugin.deprecationDate}. Please upgrade to avoid any disruption.`}</span>
+          <UpgradeNowButton
+            href={`${upgradeUrl}?tab=configurations&referrer=directory_upgrade_now`}
+            size="xsmall"
+            onClick={() =>
+              trackIntegrationAnalytics('integrations.resolve_now_clicked', {
+                integration_type: 'plugin',
+                integration: plugin.slug,
+                organization,
+              })
+            }
+          >
+            {t('Upgrade Now')}
+          </UpgradeNowButton>
+        </Alert>
+      </div>
+    );
+  }
+}
+
+const UpgradeNowButton = styled(Button)`
+  color: ${p => p.theme.subText};
+  float: right;
+`;
+
+export default PluginDeprecationAlert;

--- a/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
+++ b/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
@@ -23,9 +23,8 @@ class PluginDeprecationAlert extends Component<Props, State> {
     if (!plugin.deprecationDate) {
       return <React.Fragment />;
     }
-    let upgradeUrl = '';
     const resource = plugin.altIsSentryApp ? 'sentry-apps' : 'integrations';
-    upgradeUrl = `/settings/${organization.slug}/${resource}/${plugin.firstPartyAlternative}/`;
+    const upgradeUrl = `/settings/${organization.slug}/${resource}/${plugin.firstPartyAlternative}/`;
 
     return (
       <div>

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -152,7 +152,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     const plugin = this.plugin;
     const {organization} = this.props;
 
-    if (plugin.projectList.length && plugin.deprecationDate !== '') {
+    if (plugin.projectList.length) {
       return (
         <Fragment>
           <PluginDeprecationAlert organization={organization} plugin={plugin} />

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -1,11 +1,15 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import * as modal from 'app/actionCreators/modal';
+import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import ContextPickerModal from 'app/components/contextPickerModal';
+import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {PluginProjectItem, PluginWithProjectList} from 'app/types';
+import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
@@ -149,21 +153,56 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   renderConfigurations() {
     const plugin = this.plugin;
     const {organization} = this.props;
-    if (plugin.projectList.length) {
+
+    let upgradeUrl = '';
+    let deprecationText = '';
+    if (plugin.deprecationDate !== null) {
+      deprecationText = `This integration is being deprecated on ${plugin.deprecationDate}. Please upgrade to avoid any disruption.`;
+    }
+    if (plugin.firstPartyAlternative !== null) {
+      upgradeUrl =
+        plugin.altIsSentryApp === false
+          ? `/settings/${organization.slug}/integrations/${plugin.firstPartyAlternative}/`
+          : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
+    }
+
+    if (plugin.projectList.length && plugin.deprecationText !== '') {
       return (
-        <div>
-          {plugin.projectList.map((projectItem: PluginProjectItem) => (
-            <InstalledPlugin
-              key={projectItem.projectId}
-              organization={organization}
-              plugin={plugin}
-              projectItem={projectItem}
-              onResetConfiguration={this.handleResetConfiguration}
-              onPluginEnableStatusChange={this.handlePluginEnableStatus}
-              trackIntegrationAnalytics={this.trackIntegrationAnalytics}
-            />
-          ))}
-        </div>
+        <Fragment>
+          {plugin.deprecationDate && (
+            <AlertContainer>
+              <Alert type="warning" icon={<IconWarning size="sm" />}>
+                <span>{deprecationText}</span>
+                <ResolveNowButton
+                  href={`${upgradeUrl}?tab=configurations&referrer=directory_upgrade_now`}
+                  size="xsmall"
+                  onClick={() =>
+                    trackIntegrationEvent('integrations.resolve_now_clicked', {
+                      integration_type: 'plugin',
+                      integration: plugin.slug,
+                      organization,
+                    })
+                  }
+                >
+                  {t('Upgrade Now')}
+                </ResolveNowButton>
+              </Alert>
+            </AlertContainer>
+          )}
+          <div>
+            {plugin.projectList.map((projectItem: PluginProjectItem) => (
+              <InstalledPlugin
+                key={projectItem.projectId}
+                organization={organization}
+                plugin={plugin}
+                projectItem={projectItem}
+                onResetConfiguration={this.handleResetConfiguration}
+                onPluginEnableStatusChange={this.handlePluginEnableStatus}
+                trackIntegrationAnalytics={this.trackIntegrationAnalytics}
+              />
+            ))}
+          </div>
+        </Fragment>
       );
     }
     return this.renderEmptyConfigurations();
@@ -172,6 +211,15 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
 
 const AddButton = styled(Button)`
   margin-bottom: ${space(1)};
+`;
+
+const ResolveNowButton = styled(Button)`
+  color: ${p => p.theme.subText};
+  float: right;
+`;
+
+const AlertContainer = styled('div')`
+  padding: 0px ${space(3)} 0px 68px;
 `;
 
 export default withOrganization(PluginDetailedView);

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -166,14 +166,14 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
           : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
     }
 
-    if (plugin.projectList.length && plugin.deprecationText !== '') {
+    if (plugin.projectList.length && deprecationText !== '') {
       return (
         <Fragment>
           {plugin.deprecationDate && (
-            <AlertContainer>
+            <div>
               <Alert type="warning" icon={<IconWarning size="sm" />}>
                 <span>{deprecationText}</span>
-                <ResolveNowButton
+                <UpgradeNowButton
                   href={`${upgradeUrl}?tab=configurations&referrer=directory_upgrade_now`}
                   size="xsmall"
                   onClick={() =>
@@ -185,9 +185,9 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
                   }
                 >
                   {t('Upgrade Now')}
-                </ResolveNowButton>
+                </UpgradeNowButton>
               </Alert>
-            </AlertContainer>
+            </div>
           )}
           <div>
             {plugin.projectList.map((projectItem: PluginProjectItem) => (
@@ -213,13 +213,9 @@ const AddButton = styled(Button)`
   margin-bottom: ${space(1)};
 `;
 
-const ResolveNowButton = styled(Button)`
+const UpgradeNowButton = styled(Button)`
   color: ${p => p.theme.subText};
   float: right;
-`;
-
-const AlertContainer = styled('div')`
-  padding: 0px ${space(3)} 0px 68px;
 `;
 
 export default withOrganization(PluginDetailedView);

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -2,18 +2,16 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import * as modal from 'app/actionCreators/modal';
-import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import ContextPickerModal from 'app/components/contextPickerModal';
-import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {PluginProjectItem, PluginWithProjectList} from 'app/types';
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
 
 import AbstractIntegrationDetailedView from './abstractIntegrationDetailedView';
 import InstalledPlugin from './installedPlugin';
+import PluginDeprecationAlert from './pluginDeprecationAlert';
 
 type State = {
   plugins: PluginWithProjectList[];
@@ -154,41 +152,10 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     const plugin = this.plugin;
     const {organization} = this.props;
 
-    let upgradeUrl = '';
-    let deprecationText = '';
-    if (plugin.deprecationDate !== null) {
-      deprecationText = `This integration is being deprecated on ${plugin.deprecationDate}. Please upgrade to avoid any disruption.`;
-    }
-    if (plugin.firstPartyAlternative !== null) {
-      upgradeUrl =
-        plugin.altIsSentryApp === false
-          ? `/settings/${organization.slug}/integrations/${plugin.firstPartyAlternative}/`
-          : `/settings/${organization.slug}/sentry-apps/${plugin.firstPartyAlternative}/`;
-    }
-
-    if (plugin.projectList.length && deprecationText !== '') {
+    if (plugin.projectList.length && plugin.deprecationDate !== '') {
       return (
         <Fragment>
-          {plugin.deprecationDate && (
-            <div>
-              <Alert type="warning" icon={<IconWarning size="sm" />}>
-                <span>{deprecationText}</span>
-                <UpgradeNowButton
-                  href={`${upgradeUrl}?tab=configurations&referrer=directory_upgrade_now`}
-                  size="xsmall"
-                  onClick={() =>
-                    trackIntegrationEvent('integrations.resolve_now_clicked', {
-                      integration_type: 'plugin',
-                      integration: plugin.slug,
-                      organization,
-                    })
-                  }
-                >
-                  {t('Upgrade Now')}
-                </UpgradeNowButton>
-              </Alert>
-            </div>
-          )}
+          <PluginDeprecationAlert organization={organization} plugin={plugin} />
           <div>
             {plugin.projectList.map((projectItem: PluginProjectItem) => (
               <InstalledPlugin
@@ -211,11 +178,6 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
 
 const AddButton = styled(Button)`
   margin-bottom: ${space(1)};
-`;
-
-const UpgradeNowButton = styled(Button)`
-  color: ${p => p.theme.subText};
-  float: right;
 `;
 
 export default withOrganization(PluginDetailedView);


### PR DESCRIPTION
Have mercy on my backend soul. This is the front end piece to https://github.com/getsentry/sentry/pull/28137 which is a temporary banner to display plugin deprecation dates. The "upgrade now" button takes the user to the first party or sentry app version of the plugin so they can install that instead.

![Screen Shot 2021-08-24 at 11 35 12 AM](https://user-images.githubusercontent.com/29959063/130671163-61b11916-4419-4c44-9d9d-222c5815d18c.png)

<img width="961" alt="Screen Shot 2021-08-23 at 5 37 46 PM" src="https://user-images.githubusercontent.com/29959063/130537475-a4a073b1-02e5-464f-ab8a-303f74a38d6d.png">
