### PR TITLE
fix: Bump symbolic version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ snuba-sdk>=0.0.23,<1.0.0
 simplejson==3.17.2
 statsd==3.3
 structlog==21.1.0
-symbolic==8.1.0
+symbolic==8.3.0
 toronado==0.1.0
 ua-parser==0.10.0
 unidiff==0.6.0


### PR DESCRIPTION
The new version correctly detects compact unwind information, and will thus avoid false negatives.