### PR TITLE
chore(performance): removed new tag from all events tab

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -296,7 +296,6 @@ class TransactionHeader extends React.Component<Props> {
                 onClick={this.trackEventsTabClick}
               >
                 {t('All Events')}
-                <FeatureBadge type="new" noTooltip />
               </ListLink>
             </Feature>
           </StyledNavTabs>

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -169,10 +169,7 @@ describe('Performance > TransactionSummary', function () {
     wrapper.update();
 
     expect(
-      wrapper
-        .find('NavTabs')
-        .find({children: ['All Events']})
-        .find('Link')
+      wrapper.find('NavTabs').find({children: 'All Events'}).find('Link')
     ).toHaveLength(1);
     expect(wrapper.find('SentryDocumentTitle')).toHaveLength(1);
     expect(wrapper.find('SearchBar')).toHaveLength(1);


### PR DESCRIPTION
It's been slightly over a month since the All Events tab released. Removes the following `new` tag from the All Events tab menu:
![image](https://user-images.githubusercontent.com/83961295/130623568-745d7b03-473a-424a-8b60-cce37460c62e.png)
