### PR TITLE
fix(metric-alerts): Fix bug that swallows Warning alert

### DIFF
--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -235,23 +235,23 @@ class SubscriptionProcessor:
                     metrics.incr("incidents.alert_rules.threshold", tags={"type": "resolve"})
                     incident_trigger = self.trigger_resolve_threshold(trigger, aggregation_value)
 
-                    # Check that ensures that we are resolving a Critical trigger and that after
-                    # resolving it, we still have active triggers i.e. self.incident_triggers was
-                    # not cleared out, which means that we are probably still above the warning
-                    # threshold, and so we will check if we are above the warning threshold and
-                    # if so fire a warning alert
-                    # This is mainly for handling transition from Critical -> Warning
-                    if (
-                        incident_trigger.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL
-                        and self.incident_triggers
-                    ):
-                        active_warning_it = self.find_and_fire_active_warning_trigger(
-                            alert_operator=alert_operator, aggregation_value=aggregation_value
-                        )
-                        if active_warning_it is not None:
-                            fired_incident_triggers.append(active_warning_it)
-
                     if incident_trigger is not None:
+                        # Check that ensures that we are resolving a Critical trigger and that after
+                        # resolving it, we still have active triggers i.e. self.incident_triggers
+                        # was not cleared out, which means that we are probably still above the
+                        # warning threshold, and so we will check if we are above the warning
+                        # threshold and if so fire a warning alert
+                        # This is mainly for handling transition from Critical -> Warning
+                        if (
+                            incident_trigger.alert_rule_trigger.label == CRITICAL_TRIGGER_LABEL
+                            and self.incident_triggers
+                        ):
+                            active_warning_it = self.find_and_fire_active_warning_trigger(
+                                alert_operator=alert_operator, aggregation_value=aggregation_value
+                            )
+                            if active_warning_it is not None:
+                                fired_incident_triggers.append(active_warning_it)
+
                         fired_incident_triggers.append(incident_trigger)
                 else:
                     self.trigger_resolve_counts[trigger.id] = 0

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime, timedelta
 
 import pytest
@@ -1834,7 +1833,21 @@ class TriggerActionTest(TestCase):
         assert out.subject == f"[Resolved] {incident.title} - {self.project.slug}"
 
 
-class TestDeduplicateTriggerActions(unittest.TestCase):
+class TestDeduplicateTriggerActions(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.alert_rule = self.create_alert_rule()
+        self.incident = self.create_incident(alert_rule=self.alert_rule)
+        self.integration = Integration.objects.create(
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+
     @fixture
     def critical(self):
         return AlertRuleTrigger(label=CRITICAL_TRIGGER_LABEL)
@@ -1847,7 +1860,38 @@ class TestDeduplicateTriggerActions(unittest.TestCase):
         key = lambda action: action.id
         assert sorted(deduplicate_trigger_actions(input), key=key) == sorted(output, key=key)
 
-    def test_critical_only(self):
+    def create_it_and_action(
+        self,
+        id,
+        target_identifier,
+        trigger_type=AlertRuleTriggerAction.Type.EMAIL.value,
+        target_type=AlertRuleTriggerAction.TargetType.USER.value,
+        warning=False,
+        status=TriggerStatus.ACTIVE.value,
+    ):
+        rule = self.create_alert_rule()
+        rule_trigger = self.create_alert_rule_trigger(
+            alert_rule=rule,
+            label=WARNING_TRIGGER_LABEL if warning else CRITICAL_TRIGGER_LABEL,
+            alert_threshold=100,
+        )
+        action = AlertRuleTriggerAction.objects.create(
+            id=id,
+            alert_rule_trigger=rule_trigger,
+            type=trigger_type,
+            integration_id=self.integration.id,
+            target_type=target_type,
+            target_identifier=target_identifier,
+        )
+        it = IncidentTrigger.objects.create(
+            incident=self.incident, alert_rule_trigger=rule_trigger, status=status
+        )
+        return it, action
+
+    @patch("sentry.incidents.logic.prioritize_actions")
+    def test_critical_only(self, prioritize_actions_patched):
+        patched_incident_triggers_input = []
+
         action = AlertRuleTriggerAction(
             id=1,
             alert_rule_trigger=self.critical,
@@ -1855,8 +1899,12 @@ class TestDeduplicateTriggerActions(unittest.TestCase):
             target_type=AlertRuleTriggerAction.TargetType.USER,
             target_identifier="1",
         )
-        self.run_test([action], [action])
-        self.run_test([action, action], [action])
+
+        prioritize_actions_patched.return_value = [action]
+        self.run_test(patched_incident_triggers_input, [action])
+
+        prioritize_actions_patched.return_value = [action, action]
+        self.run_test(patched_incident_triggers_input, [action])
 
         other_action = AlertRuleTriggerAction(
             id=2,
@@ -1865,7 +1913,10 @@ class TestDeduplicateTriggerActions(unittest.TestCase):
             target_type=AlertRuleTriggerAction.TargetType.USER,
             target_identifier="2",
         )
-        self.run_test([action, action, other_action], [action, other_action])
+
+        prioritize_actions_patched.return_value = [action, action, other_action]
+        self.run_test(patched_incident_triggers_input, [action, other_action])
+
         integration_action = AlertRuleTriggerAction(
             id=3,
             alert_rule_trigger=self.critical,
@@ -1882,94 +1933,121 @@ class TestDeduplicateTriggerActions(unittest.TestCase):
             target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
             target_identifier="D12345",
         )
+
+        input_action_arr = [action, action, other_action, integration_action, app_action]
+        prioritize_actions_patched.return_value = input_action_arr
         self.run_test(
-            [action, action, other_action, integration_action, app_action],
+            patched_incident_triggers_input,
             [action, other_action, integration_action, app_action],
         )
+
+        input_action_arr = [
+            action,
+            action,
+            other_action,
+            other_action,
+            integration_action,
+            integration_action,
+            app_action,
+            app_action,
+        ]
+        prioritize_actions_patched.return_value = input_action_arr
         self.run_test(
-            [
-                action,
-                action,
-                other_action,
-                other_action,
-                integration_action,
-                integration_action,
-                app_action,
-                app_action,
-            ],
+            patched_incident_triggers_input,
             [action, other_action, integration_action, app_action],
         )
 
     def test_critical_warning(self):
-        action_c = AlertRuleTriggerAction(
-            id=1,
-            alert_rule_trigger=self.critical,
-            type=AlertRuleTriggerAction.Type.EMAIL.value,
-            target_type=AlertRuleTriggerAction.TargetType.USER,
-            target_identifier="1",
+        it_w, _ = self.create_it_and_action(id=2, target_identifier="1", warning=True)
+        it_c, action_c = self.create_it_and_action(id=1, target_identifier="1", warning=False)
+        self.run_test([it_w, it_c, it_c], [action_c])
+
+        other_it_w, other_action_w = self.create_it_and_action(
+            id=3, target_identifier="2", warning=True
         )
-        action_w = AlertRuleTriggerAction(
-            id=2,
-            alert_rule_trigger=self.warning,
-            type=AlertRuleTriggerAction.Type.EMAIL.value,
-            target_type=AlertRuleTriggerAction.TargetType.USER,
-            target_identifier="1",
-        )
-        self.run_test([action_w, action_c, action_c], [action_c])
-        other_action_w = AlertRuleTriggerAction(
-            id=3,
-            alert_rule_trigger=self.warning,
-            type=AlertRuleTriggerAction.Type.EMAIL.value,
-            target_type=AlertRuleTriggerAction.TargetType.USER,
-            target_identifier="2",
-        )
-        self.run_test([action_w, action_c, action_c, other_action_w], [action_c, other_action_w])
-        integration_action_w = AlertRuleTriggerAction(
+        self.run_test([it_w, it_c, it_c, other_it_w], [action_c, other_action_w])
+
+        integration_it_w, integration_action_w = self.create_it_and_action(
             id=4,
-            alert_rule_trigger=self.warning,
-            type=AlertRuleTriggerAction.Type.SLACK.value,
-            integration_id=1,
-            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            trigger_type=AlertRuleTriggerAction.Type.SLACK.value,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC.value,
             target_identifier="D12345",
+            warning=True,
         )
-        app_action_w = AlertRuleTriggerAction(
+        app_it_w, app_action_w = self.create_it_and_action(
             id=5,
-            alert_rule_trigger=self.warning,
-            type=AlertRuleTriggerAction.Type.MSTEAMS.value,
-            integration_id=1,
-            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            trigger_type=AlertRuleTriggerAction.Type.MSTEAMS.value,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC.value,
             target_identifier="D12345",
+            warning=True,
         )
         self.run_test(
-            [action_w, action_c, action_c, other_action_w, integration_action_w, app_action_w],
+            [it_w, it_c, it_c, other_it_w, integration_it_w, app_it_w],
             [action_c, other_action_w, integration_action_w, app_action_w],
         )
-        integration_action_c = AlertRuleTriggerAction(
+
+        integration_it_c, integration_action_c = self.create_it_and_action(
             id=6,
-            alert_rule_trigger=self.critical,
-            type=AlertRuleTriggerAction.Type.SLACK.value,
-            integration_id=1,
-            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            trigger_type=AlertRuleTriggerAction.Type.SLACK.value,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC.value,
             target_identifier="D12345",
+            warning=False,
         )
-        app_action_c = AlertRuleTriggerAction(
+        app_it_c, app_action_c = self.create_it_and_action(
             id=7,
-            alert_rule_trigger=self.critical,
-            type=AlertRuleTriggerAction.Type.MSTEAMS.value,
-            integration_id=1,
-            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            trigger_type=AlertRuleTriggerAction.Type.MSTEAMS.value,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC.value,
             target_identifier="D12345",
+            warning=False,
         )
         self.run_test(
             [
-                action_w,
-                action_c,
-                action_c,
-                other_action_w,
-                integration_action_w,
-                app_action_w,
-                integration_action_c,
-                app_action_c,
+                it_w,
+                it_c,
+                it_c,
+                other_it_w,
+                integration_it_w,
+                app_it_w,
+                integration_it_c,
+                app_it_c,
             ],
             [action_c, other_action_w, integration_action_c, app_action_c],
+        )
+
+    def test_critical_and_warning_prioritization(self):
+        """
+        Test that ensures that the array of actions returned matches the following
+        priority ordering regardless of the ordering of the incident triggers
+        1- Critical & Active
+        2- Warning & Active
+        3- Critical & Resolved
+        4- Warning & Resolved
+        """
+        it_w, action_w = self.create_it_and_action(id=2, target_identifier="1", warning=True)
+        it_c, action_c = self.create_it_and_action(
+            id=1, target_identifier="1", warning=False, status=TriggerStatus.RESOLVED.value
+        )
+        self.run_test([it_w, it_c, it_c], [action_w])
+
+        other_it_c, other_action_c = self.create_it_and_action(
+            id=3, target_identifier="2", warning=False
+        )
+        other_it_w, other_action_w = self.create_it_and_action(
+            id=4, target_identifier="3", warning=True, status=TriggerStatus.RESOLVED.value
+        )
+        other_it_c_resolved, other_action_c_resolved = self.create_it_and_action(
+            id=5, target_identifier="4", warning=False, status=TriggerStatus.RESOLVED.value
+        )
+
+        self.run_test(
+            [it_w, it_c, other_it_c, other_it_c_resolved, other_it_w],
+            [other_action_c, action_w, other_action_c_resolved, other_action_w],
+        )
+        self.run_test(
+            [it_c, it_w, other_it_c_resolved, other_it_c, other_it_w],
+            [other_action_c, action_w, other_action_c_resolved, other_action_w],
+        )
+        self.run_test(
+            [other_it_c, it_w, other_it_c_resolved, other_it_w, it_c],
+            [other_action_c, action_w, other_action_c_resolved, other_action_w],
         )

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -302,8 +302,7 @@ class ProcessUpdateTest(TestCase):
         # alert threshold triggers correctly
         rule = self.rule
         c_trigger = self.trigger
-        c_action = self.action
-        create_alert_rule_trigger_action(
+        c_action_2 = create_alert_rule_trigger_action(
             self.trigger,
             AlertRuleTriggerAction.Type.EMAIL,
             AlertRuleTriggerAction.TargetType.USER,
@@ -326,7 +325,7 @@ class ProcessUpdateTest(TestCase):
             timezone.now().replace(microsecond=0) - timedelta(seconds=rule.snuba_query.time_window)
         )
         self.assert_trigger_exists_with_status(incident, self.trigger, TriggerStatus.ACTIVE)
-        self.assert_actions_fired_for_incident(incident, [c_action])
+        self.assert_actions_fired_for_incident(incident, [c_action_2])
 
     def test_alert_nullable(self):
         # Verify that an alert rule that only expects a single update to be over the

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -8,7 +8,12 @@ from django.utils import timezone
 from exam import fixture, patcher
 from freezegun import freeze_time
 
-from sentry.incidents.logic import create_alert_rule_trigger, create_alert_rule_trigger_action
+from sentry.incidents.logic import (
+    CRITICAL_TRIGGER_LABEL,
+    WARNING_TRIGGER_LABEL,
+    create_alert_rule_trigger,
+    create_alert_rule_trigger_action,
+)
 from sentry.incidents.models import (
     AlertRule,
     AlertRuleThresholdType,
@@ -30,10 +35,12 @@ from sentry.incidents.subscription_processor import (
     partition,
     update_alert_rule_stats,
 )
+from sentry.models import Integration
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils import TestCase
+from sentry.utils import json
 from sentry.utils.compat import map
-from sentry.utils.compat.mock import Mock, call
+from sentry.utils.compat.mock import Mock, call, patch
 from sentry.utils.dates import to_timestamp
 
 EMPTY = object()
@@ -84,7 +91,7 @@ class ProcessUpdateTest(TestCase):
             threshold_period=1,
         )
         # Make sure the trigger exists
-        trigger = create_alert_rule_trigger(rule, "hi", 100)
+        trigger = create_alert_rule_trigger(rule, CRITICAL_TRIGGER_LABEL, 100)
         create_alert_rule_trigger_action(
             trigger,
             AlertRuleTriggerAction.Type.EMAIL,
@@ -292,7 +299,9 @@ class ProcessUpdateTest(TestCase):
             AlertRuleTriggerAction.TargetType.USER,
             str(self.user.id),
         )
-        w_trigger = create_alert_rule_trigger(self.rule, "hello", c_trigger.alert_threshold - 10)
+        w_trigger = create_alert_rule_trigger(
+            self.rule, WARNING_TRIGGER_LABEL, c_trigger.alert_threshold - 10
+        )
         create_alert_rule_trigger_action(
             w_trigger,
             AlertRuleTriggerAction.Type.EMAIL,
@@ -746,6 +755,84 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.RESOLVED)
         self.assert_trigger_exists_with_status(incident, other_trigger, TriggerStatus.RESOLVED)
         self.assert_actions_resolved_for_incident(incident, [self.action, other_action])
+
+    @patch("sentry.integrations.slack.utils.SlackClient.post")
+    def test_slack_multiple_triggers(self, client):
+        """
+        Test that ensures that when we get a critical update is sent followed by a warning update,
+        the warning update is not swallowed and an alert is triggered as a warning alert granted
+        the count is above the warning trigger threshold
+        """
+        from sentry.incidents.action_handlers import SlackActionHandler
+
+        slack_handler = SlackActionHandler
+
+        # Create Slack Integration
+        integration = Integration.objects.create(
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+        integration.add_organization(self.project.organization, self.user)
+
+        # Register Slack Handler
+        AlertRuleTriggerAction.register_type(
+            "slack",
+            AlertRuleTriggerAction.Type.SLACK,
+            [AlertRuleTriggerAction.TargetType.SPECIFIC],
+            integration_provider="slack",
+        )(slack_handler)
+
+        rule = self.create_alert_rule(
+            projects=[self.project, self.other_project],
+            name="some rule 2",
+            query="",
+            aggregate="count()",
+            time_window=1,
+            threshold_type=AlertRuleThresholdType.ABOVE,
+            resolve_threshold=10,
+            threshold_period=1,
+        )
+
+        trigger = create_alert_rule_trigger(rule, "critical", 100)
+        trigger_warning = create_alert_rule_trigger(rule, "warning", 10)
+
+        for t in [trigger, trigger_warning]:
+            create_alert_rule_trigger_action(
+                t,
+                AlertRuleTriggerAction.Type.SLACK,
+                AlertRuleTriggerAction.TargetType.SPECIFIC,
+                integration=integration,
+                input_channel_id="#workflow",
+            )
+
+        # Send Critical Update
+        self.send_update(
+            rule,
+            trigger.alert_threshold + 5,
+            timedelta(minutes=-10),
+            subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
+        )
+
+        # Send Warning Update
+        self.send_update(
+            rule,
+            trigger_warning.alert_threshold + 5,
+            timedelta(minutes=0),
+            subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
+        )
+        self.assert_active_incident(rule)
+
+        for idx, label in enumerate(["Critical", "Warning"]):
+            _, call_kwargs = client.call_args_list[idx]
+            assert (
+                json.loads(call_kwargs["data"]["attachments"])[0]["title"]
+                == f"{label}: some rule 2"
+            )
 
     def test_multiple_triggers_at_same_time(self):
         # Check that both triggers fire if an update comes through that exceeds both of


### PR DESCRIPTION
This PR:-
- Adds a bug fix that fixes the behaviour where a warning alert is swallowed if it comes right after a critical trigger alert
- Added prioritisation ordering to prioritise Warning Label Alerts with Active Status over Critical Label and Resolved Status
Ordering now goes as follows: (Critical, Active) -> (Warning, Active) -> (Critical, Resolved) -> (Warning, Resolved)

The reason why this happens is that, when a critical alert is triggered, a warning alert is marked as active and incident trigger is created for it as well but the user only receives a notification of the critical alert as they should(expected behaviour). 
However in the next update, if metric has a value that is above the Warning threshold but below the Critical threshold, a warning trigger is not fired because it was already set to active in the first update (like the Critical alert), which means no `fire` type incident is added here for the warning alert -> https://github.com/getsentry/sentry/blob/a741e8c1fd8fe80b348b3fcaad5ec4d70bebe123/src/sentry/incidents/subscription_processor.py#L204
but we rather go into the resolve branch here -> https://github.com/getsentry/sentry/blob/a741e8c1fd8fe80b348b3fcaad5ec4d70bebe123/src/sentry/incidents/subscription_processor.py#L212
There by only sending a resolve notification, which is incorrect behaviour.

~~To fix this behaviour, I added logic that only creates a critical incident trigger, not both~~

To fix this behaviour, I added logic that checks when we are resolving a Critical `IncidentTrigger` if there are any active warning triggers. 
If there is and the the conditions for a warning trigger are still met, we re-fire the warning trigger,
but this posed another problem, now if a metric goes from Critical to Warning, we end up having two entries/ alerts to fire -> https://github.com/getsentry/sentry/blob/a741e8c1fd8fe80b348b3fcaad5ec4d70bebe123/src/sentry/incidents/subscription_processor.py#L225

So we end up with (Critical + Resolve) and (Warning + Active), and since we were prioritising Critical over warning regardless of the status of the `IncidentTrigger` here -> https://github.com/getsentry/sentry/blob/3dfe0fcd9d000c771b60793fde40c07d7b1e5cbb/src/sentry/incidents/logic.py#L1099
(Critical + Resolve) was being prioritised and was fired. I fixed that behavior by adding a prioritisation dictionary that also prioritises Active Status over Resolved Status


