### PR TITLE
fix(perf): Fix tag page buckets being cut off

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -494,22 +494,20 @@ def query_facet_performance_key_histogram(
 
     tag_values = [x["tags_value"] for x in top_tags]
 
-    num_buckets = num_buckets_per_key * limit
-
     results = discover.histogram_query(
         fields=[
             aggregate_column,
         ],
         user_query=filter_query,
         params=params,
-        num_buckets=num_buckets,
+        num_buckets=num_buckets_per_key,
         precision=precision,
         group_by=["tags_value", "tags_key"],
-        limit_by=[num_buckets_per_key, "tags_value"],
         extra_conditions=[
             ["tags_key", "IN", [tag_key]],
             ["tags_value", "IN", tag_values],
         ],
+        histogram_rows=limit,
         referrer="api.organization-events-facets-performance-histogram",
         normalize_results=False,
     )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -887,6 +887,7 @@ def histogram_query(
     group_by=None,
     order_by=None,
     limit_by=None,
+    histogram_rows=1,
     extra_conditions=None,
     normalize_results=True,
 ):
@@ -908,9 +909,10 @@ def histogram_query(
     :param float max_value: The maximum value allowed to be in the histogram.
         If left unspecified, it is queried using `user_query` and `params`.
     :param str data_filter: Indicate the filter strategy to be applied to the data.
-    :param [str] group_by: Experimental. Allows additional grouping to serve multifacet histograms.
-    :param [str] order_by: Experimental. Allows additional ordering within each alias to serve multifacet histograms.
-    :param [str] limit_by: Experimental. Allows limiting within a group when serving multifacet histograms.
+    :param [str] group_by: Allows additional grouping to serve multifacet histograms.
+    :param [str] order_by: Allows additional ordering within each alias to serve multifacet histograms.
+    :param [str] limit_by: Allows limiting within a group when serving multifacet histograms.
+    :param int histogram_rows: Used to modify the limit when fetching multiple rows of buckets (performance facets).
     :param [str] extra_conditions: Adds any additional conditions to the histogram query that aren't received from params.
     :param bool normalize_results: Indicate whether to normalize the results by column into bins.
     """
@@ -965,7 +967,7 @@ def histogram_query(
         conditions.append([histogram_alias, "<=", max_bin])
 
     columns = [] if key_column is None else [key_column]
-    limit = len(fields) * num_buckets
+    limit = len(fields) * num_buckets * histogram_rows
 
     histogram_query = prepare_discover_query(
         selected_columns=columns + [histogram_column, "count()"],

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -887,7 +887,7 @@ def histogram_query(
     group_by=None,
     order_by=None,
     limit_by=None,
-    histogram_rows=1,
+    histogram_rows=None,
     extra_conditions=None,
     normalize_results=True,
 ):
@@ -967,7 +967,8 @@ def histogram_query(
         conditions.append([histogram_alias, "<=", max_bin])
 
     columns = [] if key_column is None else [key_column]
-    limit = len(fields) * num_buckets * histogram_rows
+    groups = len(fields) if histogram_rows is None else histogram_rows
+    limit = groups * num_buckets
 
     histogram_query = prepare_discover_query(
         selected_columns=columns + [histogram_column, "count()"],

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
@@ -28,7 +28,7 @@ type Props = {
 };
 
 const HISTOGRAM_TAG_KEY_LIMIT = 8;
-const HISTOGRAM_BUCKET_LIMIT = 20;
+const HISTOGRAM_BUCKET_LIMIT = 40;
 const TAG_PAGE_TABLE_CURSOR = 'tableCursor';
 
 export type TagsTableColumnKeys =

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
@@ -27,6 +27,13 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
 
         self._transaction_count = 0
 
+        self.url = reverse(
+            "sentry-api-0-organization-events-facets-performance-histogram",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+
+    # Function to set up some transactions for most tests
+    def setup_transactions(self):
         for i in range(5):
             self.store_transaction(
                 tags=[["color", "blue"], ["many", "yes"]], duration=4000, lcp=4000
@@ -43,11 +50,6 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
             self.store_transaction(
                 tags=[["color", "green"], ["many", "no"]], duration=5000, lcp=5000
             )
-
-        self.url = reverse(
-            "sentry-api-0-organization-events-facets-performance-histogram",
-            kwargs={"organization_slug": self.project.organization.slug},
-        )
 
     def store_transaction(
         self,
@@ -129,6 +131,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert error_response.status_code == 404
 
     def test_num_buckets_error(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "sort": "-frequency",
@@ -147,6 +150,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         }
 
     def test_tag_key_histograms(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "sort": "-frequency",
@@ -172,11 +176,12 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 2
         assert histogram_data[0]["count"] == 14
-        assert histogram_data[0]["histogram_transaction_duration_50000_1000000_1"] == 1000000.0
+
+        assert histogram_data[0]["histogram_transaction_duration_500000_1000000_1"] == 1000000.0
         assert histogram_data[0]["tags_value"] == "red"
         assert histogram_data[0]["tags_key"] == "color"
         assert histogram_data[1]["count"] == 5
-        assert histogram_data[1]["histogram_transaction_duration_50000_1000000_1"] == 4000000.0
+        assert histogram_data[1]["histogram_transaction_duration_500000_1000000_1"] == 4000000.0
         assert histogram_data[1]["tags_value"] == "blue"
         assert histogram_data[1]["tags_key"] == "color"
 
@@ -186,6 +191,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert tag_data[1]["tags_value"] == "blue"
 
     def test_no_top_tags(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "sort": "-frequency",
@@ -207,6 +213,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert tag_data == []
 
     def test_tag_key_histogram_buckets(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "sort": "-frequency",
@@ -235,22 +242,24 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 3
+
         assert histogram_data[0]["count"] == 14
-        assert histogram_data[0]["histogram_transaction_duration_750000_750000_1"] == 750000.0
+        assert histogram_data[0]["histogram_transaction_duration_2500000_0_1"] == 0.0
         assert histogram_data[0]["tags_value"] == "red"
         assert histogram_data[0]["tags_key"] == "color"
 
         assert histogram_data[1]["count"] == 5
-        assert histogram_data[1]["histogram_transaction_duration_750000_750000_1"] == 3750000.0
+        assert histogram_data[1]["histogram_transaction_duration_2500000_0_1"] == 2500000.0
         assert histogram_data[1]["tags_value"] == "blue"
         assert histogram_data[1]["tags_key"] == "color"
 
         assert histogram_data[2]["count"] == 1
-        assert histogram_data[2]["histogram_transaction_duration_750000_750000_1"] == 4500000.0
+        assert histogram_data[2]["histogram_transaction_duration_2500000_0_1"] == 5000000.0
         assert histogram_data[2]["tags_value"] == "green"
         assert histogram_data[2]["tags_key"] == "color"
 
     def test_histograms_omit_empty_measurements(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "sort": "-frequency",
@@ -273,26 +282,29 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
             request, feature_list=self.feature_list + ("organizations:performance-tag-page",)
         )
 
-        assert data_response.data["tags"]["data"][2]["tags_value"] == "green"
+        tags_data = data_response.data["tags"]["data"]
+        assert len(tags_data) == 3
+        assert tags_data[2]["tags_value"] == "green"
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 3
         assert histogram_data[0]["count"] == 14
-        assert histogram_data[0]["histogram_measurements_lcp_750_750_1"] == 750.0
+        assert histogram_data[0]["histogram_measurements_lcp_2500_0_1"] == 0.0
         assert histogram_data[0]["tags_value"] == "red"
         assert histogram_data[0]["tags_key"] == "color"
 
         assert histogram_data[1]["count"] == 5
-        assert histogram_data[1]["histogram_measurements_lcp_750_750_1"] == 3750.0
+        assert histogram_data[1]["histogram_measurements_lcp_2500_0_1"] == 2500.0
         assert histogram_data[1]["tags_value"] == "blue"
         assert histogram_data[1]["tags_key"] == "color"
 
         assert histogram_data[2]["count"] == 1
-        assert histogram_data[2]["histogram_measurements_lcp_750_750_1"] == 4500.0
+        assert histogram_data[2]["histogram_measurements_lcp_2500_0_1"] == 5000.0
         assert histogram_data[2]["tags_value"] == "green"
         assert histogram_data[2]["tags_key"] == "color"
 
     def test_histogram_user_field(self):
+        self.setup_transactions()
         self.store_transaction(
             tags=[["color", "blue"], ["many", "yes"]], duration=4000, user_id=555
         )
@@ -319,6 +331,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert tag_data[0]["tags_value"] == "id:555"
 
     def test_histogram_pagination(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "per_page": 3,
@@ -343,6 +356,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert len(tag_data) == 1
 
     def test_histogram_sorting(self):
+        self.setup_transactions()
         request = {
             "aggregateColumn": "transaction.duration",
             "per_page": 1,
@@ -370,3 +384,41 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(SnubaTestCase, AP
         assert len(tag_data) == 1
         assert tag_data[0]["tags_value"] == "green"
         assert tag_data[0]["count"] == 1
+
+    def test_histogram_high_buckets(self):
+        for i in range(10):
+            self.store_transaction(tags=[["fruit", "apple"]], duration=i * 100 + 50)
+            self.store_transaction(tags=[["fruit", "orange"]], duration=i * 100 + 1000 + 50)
+
+        request = {
+            "aggregateColumn": "transaction.duration",
+            "per_page": 2,
+            "sort": "-frequency",
+            "numBucketsPerKey": 20,
+            "tagKey": "fruit",
+        }
+
+        data_response = self.do_request(
+            request, feature_list=self.feature_list + ("organizations:performance-tag-page",)
+        )
+
+        histogram_data = data_response.data["histogram"]["data"]
+        assert len(histogram_data) == 20
+
+        for i, d in enumerate(histogram_data):
+            assert d["count"] == 1
+            assert d["histogram_transaction_duration_100000_0_1"] == i * 100000.0
+            if i < 10:
+                assert d["tags_value"] == "apple"
+            else:
+                assert d["tags_value"] == "orange"
+
+        tag_data = data_response.data["tags"]["data"]
+        assert len(tag_data) == 2
+        assert tag_data[0]["tags_value"] == "apple"
+        assert tag_data[0]["count"] == 10
+        assert tag_data[0]["aggregate"] == 500000.0
+
+        assert tag_data[1]["tags_value"] == "orange"
+        assert tag_data[1]["count"] == 10
+        assert tag_data[1]["aggregate"] == 1500000.0


### PR DESCRIPTION
### Summary
For larger ranges of data, the tag page histogram was cutting off any buckets after 'num_buckets' per row. This removes the num_buckets modification so the bucket width should be appropriately calculated, it modifies the limit for the histogram query through a passed in param instead.

Bumped num buckets since this likely means the resolution will be a lot smaller, since before the multiplied num_buckets was affecting the modifications the histogram params would make.