### PR TITLE
fix(ui): Issues list dropdowns placement with multi-line query

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -85,16 +85,20 @@ class IssueListFilters extends React.Component<Props> {
 
         <DropdownsWrapper hasIssuePercentDisplay={hasIssuePercentDisplay}>
           {hasIssuePercentDisplay && (
-            <IssueListDisplayOptions
-              onDisplayChange={onDisplayChange}
-              display={display}
-              hasSessions={hasSessions}
-              hasMultipleProjectsSelected={
-                selectedProjects.length !== 1 || selectedProjects[0] === -1
-              }
-            />
+            <div>
+              <IssueListDisplayOptions
+                onDisplayChange={onDisplayChange}
+                display={display}
+                hasSessions={hasSessions}
+                hasMultipleProjectsSelected={
+                  selectedProjects.length !== 1 || selectedProjects[0] === -1
+                }
+              />
+            </div>
           )}
-          <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
+          <div>
+            <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
+          </div>
         </DropdownsWrapper>
       </SearchContainer>
     );

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -85,20 +85,16 @@ class IssueListFilters extends React.Component<Props> {
 
         <DropdownsWrapper hasIssuePercentDisplay={hasIssuePercentDisplay}>
           {hasIssuePercentDisplay && (
-            <div>
-              <IssueListDisplayOptions
-                onDisplayChange={onDisplayChange}
-                display={display}
-                hasSessions={hasSessions}
-                hasMultipleProjectsSelected={
-                  selectedProjects.length !== 1 || selectedProjects[0] === -1
-                }
-              />
-            </div>
+            <IssueListDisplayOptions
+              onDisplayChange={onDisplayChange}
+              display={display}
+              hasSessions={hasSessions}
+              hasMultipleProjectsSelected={
+                selectedProjects.length !== 1 || selectedProjects[0] === -1
+              }
+            />
           )}
-          <div>
-            <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
-          </div>
+          <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
         </DropdownsWrapper>
       </SearchContainer>
     );
@@ -124,6 +120,7 @@ const DropdownsWrapper = styled('div')<{hasIssuePercentDisplay?: boolean}>`
   display: grid;
   grid-gap: ${space(1)};
   grid-template-columns: 1fr ${p => (p.hasIssuePercentDisplay ? '1fr' : '')};
+  align-items: start;
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     grid-template-columns: 1fr;


### PR DESCRIPTION
fixes an issue when the query is more than one line

before:
![image](https://user-images.githubusercontent.com/1400464/130676266-551a1978-b05a-400a-a955-972cb0724ab4.png)

after:
<img width="891" alt="Screen Shot 2021-08-24 at 11 43 28 AM" src="https://user-images.githubusercontent.com/1400464/130676276-5a4364fd-0b49-437b-850f-0f307e222317.png">
