### PR TITLE
fix(integrations): Catch empty request body and return 400

### DIFF
--- a/src/sentry/integrations/jira/urls.py
+++ b/src/sentry/integrations/jira/urls.py
@@ -12,7 +12,7 @@ from .webhooks import JiraIssueUpdatedWebhook
 urlpatterns = [
     url(r"^ui-hook/$", JiraUiHookView.as_view()),
     url(r"^descriptor/$", JiraDescriptorEndpoint.as_view()),
-    url(r"^installed/$", JiraInstalledEndpoint.as_view()),
+    url(r"^installed/$", JiraInstalledEndpoint.as_view(), name="sentry-extensions-jira-installed"),
     url(r"^uninstalled/$", JiraUninstalledEndpoint.as_view()),
     url(
         r"^issue-updated/$",

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -173,3 +173,17 @@ class JiraWebhooksTest(APITestCase):
             data = StubService.get_stub_data("jira", "changelog_missing.json")
             resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
+
+    def test_missing_body(self):
+        org = self.organization
+
+        integration = Integration.objects.create(provider="jira", name="Example Jira")
+        integration.add_organization(org, self.user)
+
+        path = reverse("sentry-extensions-jira-installed")
+
+        with patch(
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+        ):
+            resp = self.client.post(path, data={}, HTTP_AUTHORIZATION="JWT anexampletoken")
+            assert resp.status_code == 400


### PR DESCRIPTION
This code block 500s when `state` is empty.
```python
if state.get("jira"):
	...
else:
    external_id = state["clientKey"]
```
Detect empty state in the endpoint and return a 400.

Fixes [SENTRY-Q2S](https://sentry.io/organizations/sentry/issues/2378735045/activity/).