### PR TITLE
fix(semver): Don't filter out non-semver releases when sorting by semver on the release endpoint (WOR-1178)

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -291,15 +291,13 @@ class OrganizationReleasesEndpoint(
             queryset = queryset.filter(build_number__isnull=False).order_by("-build_number")
             paginator_kwargs["order_by"] = "-build_number"
         elif sort == "semver":
-            order_by = [f"-{col}" for col in Release.SEMVER_COLS]
+            queryset = queryset.annotate_prerelease_column()
+
+            order_by = [F(col).desc(nulls_last=True) for col in Release.SEMVER_COLS]
             # TODO: Adding this extra sort order breaks index usage. Index usage is already broken
             # when we filter by status, so when we fix that we should also consider the best way to
             # make this work as expected.
-            queryset = (
-                queryset.annotate_prerelease_column()
-                .filter_to_semver()
-                .order_by(*order_by, "-date_added")
-            )
+            order_by.append(F("date_added").desc())
             paginator_kwargs["order_by"] = order_by
         elif sort == "adoption":
             # sort by adoption date (most recently adopted first)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -169,18 +169,20 @@ class OrganizationReleaseListTest(APITestCase):
         release_5 = self.create_release(version="test@2.20.3")
         release_6 = self.create_release(version="test@2.20.3.3")
         release_7 = self.create_release(version="test@10.0+123")
-        self.create_release(version="test@some_thing")
-        self.create_release(version="random_junk")
+        release_8 = self.create_release(version="test@some_thing")
+        release_9 = self.create_release(version="random_junk")
 
         response = self.get_valid_response(self.organization.slug, sort="semver")
         assert [r["version"] for r in response.data] == [
-            release_2.version,
             release_7.version,
+            release_2.version,
             release_6.version,
             release_5.version,
             release_4.version,
             release_1.version,
             release_3.version,
+            release_9.version,
+            release_8.version,
         ]
 
     def test_query_filter(self):


### PR DESCRIPTION
This changes the sort on the org release endpoint to not filter out non-semver releases. We were
already attempting to fall back to sorting on `date_added` here, but it was getting overriden by the
order_by on the paginator.

Since we're filtering by status we're already pretty slow here and not using the index for sorting.
If we get complaints we can mess with the indexes some more to get things a little faster.