### PR TITLE
feat(workflow): Calculate adoption % by selected period

### DIFF
--- a/tests/js/spec/views/releases/utils/releaseHealthRequest.spec.tsx
+++ b/tests/js/spec/views/releases/utils/releaseHealthRequest.spec.tsx
@@ -65,6 +65,49 @@ describe('ReleaseHealthRequest', function () {
   );
 
   // @ts-expect-error
+  const requestForAutoTotalCountByProjectInPeriod = MockApiClient.addMockResponse(
+    {
+      url: `/organizations/org-slug/sessions/`,
+      // @ts-expect-error
+      body: TestStubs.SessionTotalCountByProjectIn24h(),
+    },
+    {
+      predicate(_url, {query}) {
+        return isEqual(query, {
+          query: undefined,
+          interval: '1d',
+          statsPeriod: '14d',
+          project: [123],
+          field: ['sum(session)'],
+          groupBy: ['project'],
+        });
+      },
+    }
+  );
+
+  // @ts-expect-error
+  const requestForAutoTotalCountByReleaseInPeriod = MockApiClient.addMockResponse(
+    {
+      url: `/organizations/org-slug/sessions/`,
+      // @ts-expect-error
+      body: TestStubs.SesssionTotalCountByReleaseIn24h(),
+    },
+    {
+      predicate(_url, {query}) {
+        return isEqual(query, {
+          query:
+            'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
+          interval: '1d',
+          statsPeriod: '14d',
+          project: [123],
+          field: ['sum(session)'],
+          groupBy: ['project', 'release'],
+        });
+      },
+    }
+  );
+
+  // @ts-expect-error
   MockApiClient.addMockResponse(
     {
       url: `/organizations/${organization.slug}/sessions/`,
@@ -709,7 +752,16 @@ describe('ReleaseHealthRequest', function () {
         z: 0,
       },
     ]);
+    expect(
+      healthData.getAdoption(
+        '7a82c130be9143361f20bc77252df783cf91e4fc',
+        projectId,
+        DisplayOption.SESSIONS
+      )
+    ).toBe(26.29607698886915);
 
     expect(requestForAutoHealthStatsPeriodSessionHistogram).toHaveBeenCalledTimes(1);
+    expect(requestForAutoTotalCountByProjectInPeriod).toHaveBeenCalledTimes(1);
+    expect(requestForAutoTotalCountByReleaseInPeriod).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Adds two additional requests when viewing the releases list by "auto" which is the currently selected graph period. 

Allows you to see the adoption rate in the current period eg adoption % of 14 days.

![image](https://user-images.githubusercontent.com/1400464/130707876-3c3a3b79-e572-41ac-a2b6-da85b30bf0e4.png)
