### PR TITLE
fix(ui): handle localStorage null

### DIFF
--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -2,7 +2,7 @@ import {LightWeightOrganization} from 'app/types';
 import {Hooks} from 'app/types/hooks';
 import {trackAnalyticsEventV2} from 'app/utils/analytics';
 
-const hasAnalyticsDebug = () => window.localStorage.getItem('DEBUG_ANALYTICS') === '1';
+const hasAnalyticsDebug = () => window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
 
 type OptionalOrg = {organization: LightWeightOrganization | null};
 type Options = Parameters<Hooks['analytics:track-event-v2']>[1];


### PR DESCRIPTION
Certain browsers may not allow the usage of localStorage so we need to check if it's null

Fixes JAVASCRIPT-25D6