### PR TITLE
feat(growth): new members added through SSO arrive disabled if org lacks invite-members feature

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -187,10 +187,7 @@ class AuthIdentityHandler:
         flags = OrganizationMember.flags["sso:linked"]
         # if the org doesn't have the ability to add members then anyone who get added
         # this way should be disabled until the org upgrades
-        if (
-            not features.has("organizations:invite-members", self.organization)
-            and self.organization.default_role != "owner"
-        ):
+        if not features.has("organizations:invite-members", self.organization):
             flags = flags | OrganizationMember.flags["member-limit:restricted"]
 
         # Otherwise create a new membership

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -185,7 +185,7 @@ class AuthIdentityHandler:
             invite_helper.handle_invite_not_approved()
 
         flags = OrganizationMember.flags["sso:linked"]
-        # if the org doesn't have the ability to add members then anyone who get added
+        # if the org doesn't have the ability to add members then anyone who got added
         # this way should be disabled until the org upgrades
         if not features.has("organizations:invite-members", self.organization):
             flags = flags | OrganizationMember.flags["member-limit:restricted"]

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -184,12 +184,21 @@ class AuthIdentityHandler:
             # In that case, delete the invite request and create a new membership.
             invite_helper.handle_invite_not_approved()
 
+        flags = OrganizationMember.flags["sso:linked"]
+        # if the org doesn't have the ability to add members then anyone who get added
+        # this way should be disabled until the org upgrades
+        if (
+            not features.has("organizations:invite-members", self.organization)
+            and self.organization.default_role != "owner"
+        ):
+            flags = flags | OrganizationMember.flags["member-limit:restricted"]
+
         # Otherwise create a new membership
         om = OrganizationMember.objects.create(
             organization=self.organization,
             role=self.organization.default_role,
             user=user,
-            flags=OrganizationMember.flags["sso:linked"],
+            flags=flags,
         )
 
         default_teams = self.auth_provider.default_teams.all()

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -162,11 +162,33 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest):
 
         persisted_om = OrganizationMember.objects.get(user=user, organization=self.organization)
         assert getattr(persisted_om.flags, "sso:linked")
+        assert not getattr(persisted_om.flags, "member-limit:restricted")
         assert not getattr(persisted_om.flags, "sso:invalid")
 
         login_request, login_user = mock_auth.login.call_args.args
         assert login_request == self.request
         assert login_user == user
+
+    @mock.patch("sentry.auth.helper.auth")
+    def test_no_invite_members_flag(self, mock_auth):
+        with self.feature({"organizations:sso-basic": False}):
+            mock_auth.get_login_redirect.return_value = "test_login_url"
+            user, auth_identity = self.set_up_user_identity()
+
+            redirect = self.handler.handle_existing_identity(
+                self.state, auth_identity, self.identity
+            )
+
+            assert redirect.url == mock_auth.get_login_redirect.return_value
+            assert mock_auth.get_login_redirect.called_with(self.request)
+
+            persisted_identity = AuthIdentity.objects.get(ident=auth_identity.ident)
+            assert persisted_identity.data == self.identity["data"]
+
+            persisted_om = OrganizationMember.objects.get(user=user, organization=self.organization)
+            assert getattr(persisted_om.flags, "sso:linked")
+            assert getattr(persisted_om.flags, "member-limit:restricted")
+            assert not getattr(persisted_om.flags, "sso:invalid")
 
 
 class HandleAttachIdentityTest(AuthIdentityHandlerTest):

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -171,7 +171,7 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest):
 
     @mock.patch("sentry.auth.helper.auth")
     def test_no_invite_members_flag(self, mock_auth):
-        with self.feature({"organizations:sso-basic": False}):
+        with mock.patch("sentry.features.has", return_value=False) as features_has:
             mock_auth.get_login_redirect.return_value = "test_login_url"
             user, auth_identity = self.set_up_user_identity()
 
@@ -189,6 +189,7 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest):
             assert getattr(persisted_om.flags, "sso:linked")
             assert getattr(persisted_om.flags, "member-limit:restricted")
             assert not getattr(persisted_om.flags, "sso:invalid")
+            features_has.assert_called_once_with("organizations:invite-members", self.organization)
 
 
 class HandleAttachIdentityTest(AuthIdentityHandlerTest):


### PR DESCRIPTION
In preparation for enabling SSO during trials, we need to plug another potential exploit: bypassing the member limit restrictions when adding members through SSO (only paid plans get more than one member). In this exploit, an organization could set up SSO, downgrade, then add members past their limit through the special SSO code pathway.

In this PR, we check the `organizations:invite-members` feature flag when adding new members through SSO. If that feature flag is not set, we set the `member-limit:restricted` flag on the member so when they try to log in:

<img width="1382" alt="Screen Shot 2021-08-25 at 5 46 22 PM" src="https://user-images.githubusercontent.com/8533851/130826137-689f2d17-e778-44b3-a0b4-303020b41bba.png">

Once the organization upgrades to get unlimited members, the disabled members will be enabled.