### PR TITLE
fix(trace-view): Center project icon in each row

### DIFF
--- a/static/app/views/performance/traceDetails/styles.tsx
+++ b/static/app/views/performance/traceDetails/styles.tsx
@@ -3,7 +3,6 @@ import {Location} from 'history';
 
 import EventTagsPill from 'app/components/events/eventTags/eventTagsPill';
 import {SecondaryHeader} from 'app/components/events/interfaces/spans/header';
-import ProjectBadge from 'app/components/idBadge/projectBadge';
 import {Panel} from 'app/components/panels';
 import Pills from 'app/components/pills';
 import SearchBar from 'app/components/searchBar';
@@ -62,8 +61,11 @@ export const StyledPanel = styled(Panel)`
   overflow: hidden;
 `;
 
-export const StyledProjectBadge = styled(ProjectBadge)`
+export const ProjectBadgeContainer = styled('span')`
   margin-right: ${space(0.75)};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `;
 
 const StyledPills = styled(Pills)`

--- a/static/app/views/performance/traceDetails/transactionBar.tsx
+++ b/static/app/views/performance/traceDetails/transactionBar.tsx
@@ -6,6 +6,7 @@ import Count from 'app/components/count';
 import * as AnchorLinkManager from 'app/components/events/interfaces/spans/anchorLinkManager';
 import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
 import * as ScrollbarManager from 'app/components/events/interfaces/spans/scrollbarManager';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
 import {ROW_HEIGHT} from 'app/components/performance/waterfall/constants';
 import {Row, RowCell, RowCellContainer} from 'app/components/performance/waterfall/row';
 import {DurationPill, RowRectangle} from 'app/components/performance/waterfall/rowBar';
@@ -39,7 +40,7 @@ import {TraceFullDetailed} from 'app/utils/performance/quickTrace/types';
 import {isTraceFullDetailed} from 'app/utils/performance/quickTrace/utils';
 import Projects from 'app/utils/projects';
 
-import {StyledProjectBadge} from './styles';
+import {ProjectBadgeContainer} from './styles';
 import TransactionDetail from './transactionDetail';
 import {TraceInfo, TraceRoot, TreeDepth} from './types';
 
@@ -210,13 +211,15 @@ class TransactionBar extends React.Component<Props, State> {
           {({projects}) => {
             const project = projects.find(p => p.slug === transaction.project_slug);
             return (
-              <Tooltip title={transaction.project_slug}>
-                <StyledProjectBadge
-                  project={project ? project : {slug: transaction.project_slug}}
-                  avatarSize={16}
-                  hideName
-                />
-              </Tooltip>
+              <ProjectBadgeContainer>
+                <Tooltip title={transaction.project_slug}>
+                  <ProjectBadge
+                    project={project ? project : {slug: transaction.project_slug}}
+                    avatarSize={16}
+                    hideName
+                  />
+                </Tooltip>
+              </ProjectBadgeContainer>
             );
           }}
         </Projects>


### PR DESCRIPTION
Unsure when this regressed but the project icons were no longer centered.

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/10239353/130846784-a35eecd8-0523-46eb-a5d6-00195f341cc6.png)

## After
![image](https://user-images.githubusercontent.com/10239353/130846775-6acde060-2da1-411a-8fb1-e8ab37075bea.png)
