### PR TITLE
ref(growth): remove performance-create-sample-transaction feature

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -989,8 +989,6 @@ SENTRY_FEATURES = {
     "organizations:performance-events-page": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
-    # Allow the user to create a sample transaction while onboarding
-    "organizations:performance-create-sample-transaction": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -121,9 +121,6 @@ default_manager.add("organizations:performance-chart-interpolation", Organizatio
 default_manager.add("organizations:performance-suspect-spans-ingestion", OrganizationFeature)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
-default_manager.add(
-    "organizations:performance-create-sample-transaction", OrganizationFeature, True
-)
 default_manager.add("organizations:project-transaction-threshold", OrganizationFeature, True)
 default_manager.add(
     "organizations:project-transaction-threshold-override", OrganizationFeature, True

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -108,9 +108,6 @@ function Onboarding({organization, project, api}: Props) {
       organization,
     });
   }
-  const showSampleTransactionBtn = organization.features.includes(
-    'performance-create-sample-transaction'
-  );
   const featureTourBtn = (
     <FeatureTourModal
       steps={PERFORMANCE_TOUR_STEPS}
@@ -121,7 +118,7 @@ function Onboarding({organization, project, api}: Props) {
     >
       {({showModal}) => (
         <Button
-          priority={showSampleTransactionBtn ? 'link' : 'default'}
+          priority="link"
           onClick={() => {
             trackAdvancedAnalyticsEvent('performance_views.tour.start', {organization});
             showModal();
@@ -132,7 +129,7 @@ function Onboarding({organization, project, api}: Props) {
       )}
     </FeatureTourModal>
   );
-  const secondaryBtn = showSampleTransactionBtn ? (
+  const secondaryBtn = (
     <Button
       data-test-id="create-sample-transaction-btn"
       onClick={async () => {
@@ -163,8 +160,6 @@ function Onboarding({organization, project, api}: Props) {
     >
       {t('Create Sample Transaction')}
     </Button>
-  ) : (
-    featureTourBtn
   );
 
   return (
@@ -185,7 +180,7 @@ function Onboarding({organization, project, api}: Props) {
         </Button>
         {secondaryBtn}
       </ButtonList>
-      {showSampleTransactionBtn && featureTourBtn}
+      {featureTourBtn}
     </OnboardingPanel>
   );
 }

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -108,60 +108,6 @@ function Onboarding({organization, project, api}: Props) {
       organization,
     });
   }
-  const featureTourBtn = (
-    <FeatureTourModal
-      steps={PERFORMANCE_TOUR_STEPS}
-      onAdvance={handleAdvance}
-      onCloseModal={handleClose}
-      doneUrl={performanceSetupUrl}
-      doneText={t('Start Setup')}
-    >
-      {({showModal}) => (
-        <Button
-          priority="link"
-          onClick={() => {
-            trackAdvancedAnalyticsEvent('performance_views.tour.start', {organization});
-            showModal();
-          }}
-        >
-          {t('Take a Tour')}
-        </Button>
-      )}
-    </FeatureTourModal>
-  );
-  const secondaryBtn = (
-    <Button
-      data-test-id="create-sample-transaction-btn"
-      onClick={async () => {
-        trackAdvancedAnalyticsEvent('performance_views.create_sample_transaction', {
-          platform: project.platform,
-          organization,
-        });
-        addLoadingMessage(t('Processing sample event...'), {
-          duration: 15000,
-        });
-        const url = `/projects/${organization.slug}/${project.slug}/create-sample-transaction/`;
-        try {
-          const eventData = await api.requestPromise(url, {method: 'POST'});
-          browserHistory.push(
-            `/organizations/${organization.slug}/performance/${project.slug}:${eventData.eventID}/`
-          );
-          clearIndicators();
-        } catch (error) {
-          Sentry.withScope(scope => {
-            scope.setExtra('error', error);
-            Sentry.captureException(new Error('Failed to create sample event'));
-          });
-          clearIndicators();
-          addErrorMessage(t('Failed to create a new sample event'));
-          return;
-        }
-      }}
-    >
-      {t('Create Sample Transaction')}
-    </Button>
-  );
-
   return (
     <OnboardingPanel image={<PerfImage src={emptyStateImg} />}>
       <h3>{t('Pinpoint problems')}</h3>
@@ -178,9 +124,56 @@ function Onboarding({organization, project, api}: Props) {
         >
           {t('Start Setup')}
         </Button>
-        {secondaryBtn}
+        <Button
+          data-test-id="create-sample-transaction-btn"
+          onClick={async () => {
+            trackAdvancedAnalyticsEvent('performance_views.create_sample_transaction', {
+              platform: project.platform,
+              organization,
+            });
+            addLoadingMessage(t('Processing sample event...'), {
+              duration: 15000,
+            });
+            const url = `/projects/${organization.slug}/${project.slug}/create-sample-transaction/`;
+            try {
+              const eventData = await api.requestPromise(url, {method: 'POST'});
+              browserHistory.push(
+                `/organizations/${organization.slug}/performance/${project.slug}:${eventData.eventID}/`
+              );
+              clearIndicators();
+            } catch (error) {
+              Sentry.withScope(scope => {
+                scope.setExtra('error', error);
+                Sentry.captureException(new Error('Failed to create sample event'));
+              });
+              clearIndicators();
+              addErrorMessage(t('Failed to create a new sample event'));
+              return;
+            }
+          }}
+        >
+          {t('Create Sample Transaction')}
+        </Button>
       </ButtonList>
-      {featureTourBtn}
+      <FeatureTourModal
+        steps={PERFORMANCE_TOUR_STEPS}
+        onAdvance={handleAdvance}
+        onCloseModal={handleClose}
+        doneUrl={performanceSetupUrl}
+        doneText={t('Start Setup')}
+      >
+        {({showModal}) => (
+          <Button
+            priority="link"
+            onClick={() => {
+              trackAdvancedAnalyticsEvent('performance_views.tour.start', {organization});
+              showModal();
+            }}
+          >
+            {t('Take a Tour')}
+          </Button>
+        )}
+      </FeatureTourModal>
     </OnboardingPanel>
   );
 }

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -522,9 +522,7 @@ describe('Performance > Content', function () {
       TestStubs.Project({id: 1, firstTransactionEvent: false}),
       TestStubs.Project({id: 2, firstTransactionEvent: false}),
     ];
-    const data = initializeData(projects, {view: undefined}, [
-      'performance-create-sample-transaction',
-    ]);
+    const data = initializeData(projects, {view: undefined});
 
     const wrapper = mountWithTheme(
       <PerformanceContent
@@ -537,25 +535,5 @@ describe('Performance > Content', function () {
     expect(
       wrapper.find('Button[data-test-id="create-sample-transaction-btn"]').exists()
     ).toBe(true);
-  });
-
-  it('Do not display Create Sample Transaction Button with feature flag turned off', async function () {
-    const projects = [
-      TestStubs.Project({id: 1, firstTransactionEvent: false}),
-      TestStubs.Project({id: 2, firstTransactionEvent: false}),
-    ];
-    const data = initializeData(projects, {view: undefined}, []);
-
-    const wrapper = mountWithTheme(
-      <PerformanceContent
-        organization={data.organization}
-        location={data.router.location}
-      />,
-      data.routerContext
-    );
-
-    expect(
-      wrapper.find('Button[data-test-id="create-sample-transaction-btn"]').exists()
-    ).toBe(false);
   });
 });


### PR DESCRIPTION
We set the `performance-create-sample-transaction` feature to 100% so we can remove the feature flag.