### PR TITLE
ref(analytics): convert performance views analytics in table

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -14,6 +14,12 @@ export type PerformanceEventParameters = {
   'performance_views.tour.start': {};
   'performance_views.tour.advance': PerformanceTourParams;
   'performance_views.tour.close': PerformanceTourParams;
+  'performance_views.landingv2.transactions.sort': {
+    field?: string;
+    direction?: string;
+  };
+  'performance_views.overview.navigate.summary': {};
+  'performance_views.overview.cellaction': {action?: string};
 };
 
 export type PerformanceEventKey = keyof PerformanceEventParameters;
@@ -23,4 +29,9 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.tour.start': 'Performance Views: Tour Start',
   'performance_views.tour.advance': 'Performance Views: Tour Advance',
   'performance_views.tour.close': 'Performance Views: Tour Close',
+  'performance_views.landingv2.transactions.sort':
+    'Performance Views: Landing Transactions Sorted',
+  'performance_views.overview.navigate.summary':
+    'Performance Views: Overview view summary',
+  'performance_views.overview.cellaction': 'Performance Views: Cell Action Clicked',
 };

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -15,7 +15,7 @@ import {IconStar} from 'app/icons';
 import {tct} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'app/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery, {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView, {EventData, isFieldSortable} from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
@@ -95,10 +95,8 @@ class Table extends React.Component<Props, State> {
     return (action: Actions, value: React.ReactText) => {
       const {eventView, location, organization, projects} = this.props;
 
-      trackAnalyticsEvent({
-        eventKey: 'performance_views.overview.cellaction',
-        eventName: 'Performance Views: Cell Action Clicked',
-        organization_id: parseInt(organization.id, 10),
+      trackAdvancedAnalyticsEvent('performance_views.overview.cellaction', {
+        organization,
         action,
       });
 
@@ -268,10 +266,8 @@ class Table extends React.Component<Props, State> {
 
   onSortClick(currentSortKind?: string, currentSortField?: string) {
     const {organization} = this.props;
-    trackAnalyticsEvent({
-      eventKey: 'performance_views.landingv2.transactions.sort',
-      eventName: 'Performance Views: Landing Transactions Sorted',
-      organization_id: parseInt(organization.id, 10),
+    trackAdvancedAnalyticsEvent('performance_views.landingv2.transactions.sort', {
+      organization,
       field: currentSortField,
       direction: currentSortKind,
     });
@@ -394,10 +390,8 @@ class Table extends React.Component<Props, State> {
 
   handleSummaryClick = () => {
     const {organization} = this.props;
-    trackAnalyticsEvent({
-      eventKey: 'performance_views.overview.navigate.summary',
-      eventName: 'Performance Views: Overview view summary',
-      organization_id: parseInt(organization.id, 10),
+    trackAdvancedAnalyticsEvent('performance_views.overview.navigate.summary', {
+      organization,
     });
   };
 


### PR DESCRIPTION
This PR converts some analytics for `performance_views` to use the new `trackAdvancedAnalyticsEvent` function