### PR TITLE
ref(slack) Bulk lookup users.list instead of users.lookupByEmail

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -276,7 +276,7 @@ def parse_link(url):
     return parsed_path
 
 
-def get_slack_data_by_user(integration, organization, emails_by_user):
+def get_slack_info_by_email(integration, organization):
     access_token = (
         integration.metadata.get("user_access_token") or integration.metadata["access_token"]
     )
@@ -315,6 +315,12 @@ def get_slack_data_by_user(integration, organization, emails_by_user):
         next_cursor = user_list["response_metadata"]["next_cursor"]
         if not next_cursor:
             break
+
+    return slack_info_by_email
+
+
+def get_slack_data_by_user(integration, organization, emails_by_user):
+    slack_info_by_email = get_slack_info_by_email(integration, organization)
     slack_data_by_user = {}
     for user, emails in emails_by_user.items():
         for email in emails:

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -332,12 +332,8 @@ def get_slack_data_by_user(integration, organization, emails_by_user):
     slack_data_by_user = {}
     for user, emails in emails_by_user.items():
         for email in emails:
-            if email in slack_info_by_email.keys():
-                slack_data_by_user[user] = {
-                    "email": email,
-                    "team_id": slack_info_by_email[email]["team_id"],
-                    "slack_id": slack_info_by_email[email]["slack_id"],
-                }
+            if email in slack_info_by_email:
+                slack_data_by_user[user] = slack_info_by_email[email]
                 break
     return slack_data_by_user
 

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -3,6 +3,7 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import responses
 
 from sentry.integrations.slack import SlackIntegration, SlackIntegrationProvider
+from sentry.integrations.slack.utils import SLACK_GET_USERS_PAGE_SIZE
 from sentry.models import (
     AuditLogEntry,
     AuditLogEntryEvent,
@@ -56,18 +57,18 @@ class SlackIntegrationTest(IntegrationTestCase):
 
         responses.add(
             method=responses.GET,
-            url="https://slack.com/api/users.list/?limit=200",
+            url=f"https://slack.com/api/users.list?limit={SLACK_GET_USERS_PAGE_SIZE}",
             match_querystring=True,
             json={
                 "ok": True,
                 "members": [
                     {
-                        "id": "UXXXXXXX1",
-                        "team_id": "TXXXXXXX1",
+                        "id": authorizing_user_id,
+                        "team_id": team_id,
                         "deleted": False,
                         "profile": {
                             "email": self.user.email,
-                            "team": "TXXXXXXX1",
+                            "team": team_id,
                         },
                     },
                 ],
@@ -222,7 +223,7 @@ class SlackIntegrationPostInstallTest(APITestCase):
 
         responses.add(
             method=responses.GET,
-            url="https://slack.com/api/users.list/?limit=200",
+            url=f"https://slack.com/api/users.list?limit={SLACK_GET_USERS_PAGE_SIZE}",
             match_querystring=True,
             json={
                 "ok": True,

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -55,17 +55,23 @@ class SlackIntegrationTest(IntegrationTestCase):
         responses.add(responses.POST, "https://slack.com/api/oauth.v2.access", json=access_json)
 
         responses.add(
-            responses.GET,
-            "https://slack.com/api/users.lookupByEmail/",
+            method=responses.GET,
+            url="https://slack.com/api/users.list/?limit=200",
+            match_querystring=True,
             json={
                 "ok": True,
-                "user": {
-                    "id": authorizing_user_id,
-                    "team_id": team_id,
-                    "profile": {
-                        "email": self.user.email,
+                "members": [
+                    {
+                        "id": "UXXXXXXX1",
+                        "team_id": "TXXXXXXX1",
+                        "deleted": False,
+                        "profile": {
+                            "email": self.user.email,
+                            "team": "TXXXXXXX1",
+                        },
                     },
-                },
+                ],
+                "response_metadata": {"next_cursor": ""},
             },
         )
         responses.add(
@@ -179,6 +185,22 @@ class SlackIntegrationPostInstallTest(APITestCase):
             role="manager",
             teams=[self.team],
         )
+        self.user3 = self.create_user("hellboy@example.com")
+        self.member = self.create_member(
+            user=self.user3,
+            email="hellboy@example.com",
+            organization=self.organization,
+            role="manager",
+            teams=[self.team],
+        )
+        self.user4 = self.create_user("ialreadyexist@example.com")
+        self.member = self.create_member(
+            user=self.user4,
+            email="ialreadyexist@example.com",
+            organization=self.organization,
+            role="manager",
+            teams=[self.team],
+        )
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",
@@ -190,35 +212,59 @@ class SlackIntegrationPostInstallTest(APITestCase):
         )
         self.integration.add_organization(self.organization, self.user)
         self.idp = IdentityProvider.objects.create(type="slack", external_id="TXXXXXXX1", config={})
+        Identity.objects.create(
+            external_id="UXXXXXXX4",
+            idp=self.idp,
+            user=self.user4,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
 
         responses.add(
             method=responses.GET,
-            url=f"https://slack.com/api/users.lookupByEmail/?email={self.user2.email}",
+            url="https://slack.com/api/users.list/?limit=200",
             match_querystring=True,
             json={
                 "ok": True,
-                "user": {
-                    "id": "UXXXXXXX2",
-                    "team_id": "TXXXXXXX1",
-                    "profile": {
-                        "email": self.user2.email,
+                "members": [
+                    {
+                        "id": "UXXXXXXX1",
+                        "team_id": "TXXXXXXX1",
+                        "deleted": False,
+                        "profile": {
+                            "email": self.user.email,
+                            "team": "TXXXXXXX1",
+                        },
                     },
-                },
-            },
-        )
-        responses.add(
-            method=responses.GET,
-            url=f"https://slack.com/api/users.lookupByEmail/?email={self.user.email}",
-            match_querystring=True,
-            json={
-                "ok": True,
-                "user": {
-                    "id": "UXXXXXXX1",
-                    "team_id": "TXXXXXXX1",
-                    "profile": {
-                        "email": self.user.email,
+                    {
+                        "id": "UXXXXXXX2",
+                        "team_id": "TXXXXXXX1",
+                        "deleted": False,
+                        "profile": {
+                            "email": self.user2.email,
+                            "team": "TXXXXXXX1",
+                        },
                     },
-                },
+                    {
+                        "id": "UXXXXXXX3",
+                        "team_id": "TXXXXXXX1",
+                        "deleted": False,
+                        "profile": {
+                            "email": "wrongemail@example.com",
+                            "team": "TXXXXXXX1",
+                        },
+                    },
+                    {
+                        "id": "UXXXXXXX4",
+                        "team_id": "TXXXXXXX1",
+                        "deleted": False,
+                        "profile": {
+                            "email": "ialreadyexist@example.com",
+                            "team": "TXXXXXXX1",
+                        },
+                    },
+                ],
+                "response_metadata": {"next_cursor": ""},
             },
         )
 
@@ -247,35 +293,12 @@ class SlackIntegrationPostInstallTest(APITestCase):
         """
         Test that a user whose email does not match does not have an Identity created
         """
-        user3 = self.create_user("hellboy@example.com")
-        self.member = self.create_member(
-            user=user3,
-            email="hellboy@example.com",
-            organization=self.organization,
-            role="manager",
-            teams=[self.team],
-        )
-        responses.add(
-            method=responses.GET,
-            url=f"https://slack.com/api/users.lookupByEmail/email={user3.email}",
-            match_querystring=True,
-            json={
-                "ok": True,
-                "user": {
-                    "id": "UXXXXXXX1",
-                    "team_id": "TXXXXXXX1",
-                    "profile": {
-                        "email": "wrongemail@example.com",
-                    },
-                },
-            },
-        )
         with self.tasks():
             with self.feature("organizations:notification-platform"):
                 SlackIntegrationProvider().post_install(self.integration, self.organization)
 
         identities = Identity.objects.all()
-        assert identities.count() == 2
+        assert identities.count() == 3
 
     @responses.activate
     def test_update_identity(self):
@@ -283,42 +306,13 @@ class SlackIntegrationPostInstallTest(APITestCase):
         Test that when an additional user who already has an Identity's Slack external ID
         changes, that we update the Identity's external ID to match
         """
-        user3 = self.create_user("ialreadyexist@example.com")
-        self.member = self.create_member(
-            user=user3,
-            email="ialreadyexist@example.com",
-            organization=self.organization,
-            role="manager",
-            teams=[self.team],
-        )
-        user3_identity = Identity.objects.create(
-            external_id="UXXXXXXX1",
-            idp=self.idp,
-            user=user3,
-            status=IdentityStatus.VALID,
-            scopes=[],
-        )
-        responses.add(
-            responses.GET,
-            "https://slack.com/api/users.lookupByEmail/",
-            json={
-                "ok": True,
-                "user": {
-                    "id": "UXXXXXXX3",
-                    "team_id": "TXXXXXXX1",
-                    "profile": {
-                        "email": "ialreadyexist@example.com",
-                    },
-                },
-            },
-        )
         with self.tasks():
             with self.feature("organizations:notification-platform"):
                 SlackIntegrationProvider().post_install(self.integration, self.organization)
 
-        user3_identity = Identity.objects.get(user=user3)
+        user3_identity = Identity.objects.get(user=self.user4)
         assert user3_identity
-        assert user3_identity.external_id == "UXXXXXXX3"
+        assert user3_identity.external_id == "UXXXXXXX4"
         assert user3_identity.user.email == "ialreadyexist@example.com"
 
 


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/26377 wherein [users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail) is replaced with [users.list](https://api.slack.com/methods/users.list). The former would make an API call for each user and we had concerns that with a very large Sentry organization we'd trigger rate limiting and just generally be slow. The latter can return multiple results per page (I set it to 200 as recommended in the [pagination documentation](https://api.slack.com/docs/pagination)) which will speed up the process.