### PR TITLE
fix(spans): Remove regroup feature whenever the first descendant is not span_group_chain type

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -274,6 +274,11 @@ class SpanTreeModel {
           : undefined,
     };
 
+    if (wrappedSpan.type === 'root_span') {
+      // @ts-expect-error
+      delete wrappedSpan.toggleSpanGroup;
+    }
+
     const treeDepthEntry = isOrphanSpan(this.span)
       ? ({type: 'orphan', depth: treeDepth} as OrphanTreeDepth)
       : treeDepth;

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -412,11 +412,8 @@ class SpanTreeModel {
       wrappedSpan.toggleSpanGroup = undefined;
     }
 
+    // Do not autogroup groups that will only have two spans
     if (isLastSpanOfGroup && Array.isArray(spanGrouping) && spanGrouping.length === 1) {
-      if (toggleSpanGroup !== undefined && !showSpanGroup) {
-        toggleSpanGroup();
-      }
-
       if (!showSpanGroup) {
         return [spanGrouping[0], wrappedSpan, ...descendants];
       }

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -420,7 +420,15 @@ class SpanTreeModel {
     // Do not autogroup groups that will only have two spans
     if (isLastSpanOfGroup && Array.isArray(spanGrouping) && spanGrouping.length === 1) {
       if (!showSpanGroup) {
-        return [spanGrouping[0], wrappedSpan, ...descendants];
+        const parentSpan = spanGrouping[0].span;
+        const parentSpanBounds = generateBounds({
+          startTimestamp: parentSpan.start_timestamp,
+          endTimestamp: parentSpan.timestamp,
+        });
+        const isParentSpanOutOfView = !parentSpanBounds.isSpanVisibleInView;
+        if (!isParentSpanOutOfView) {
+          return [spanGrouping[0], wrappedSpan, ...descendants];
+        }
       }
 
       return [wrappedSpan, ...descendants];

--- a/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -77,10 +77,94 @@ describe('WaterfallModel', () => {
           {
             timestamp: 1622079938.32451,
             start_timestamp: 1622079938.31431,
-            description: '/_static/dist/sentry/sentry.541f5b.min.css',
+            description: 'fonts_bundle.css',
+            op: 'fonts',
+            span_id: 'a0e89ce4e0900ad5',
+            parent_span_id: 'a23f26b939d1a735',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'google-fonts.css',
+            op: 'fonts',
+            span_id: 'aa764a4e9d70c907',
+            parent_span_id: 'a0e89ce4e0900ad5',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'icon-fonts.css',
+            op: 'fonts',
+            span_id: '883837a47bc0d836',
+            parent_span_id: 'a0e89ce4e0900ad5',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: '/_static/dist/sentry/sentry.fonts.min.css',
             op: 'css',
             span_id: 'b5795cf4ba68bbb4',
             parent_span_id: 'a934857184bdf5a6',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'fonts1.css',
+            op: 'fonts',
+            span_id: 'b5795cf4ba68bbb5',
+            parent_span_id: 'b5795cf4ba68bbb4',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'fonts2.css',
+            op: 'fonts',
+            span_id: 'b5795cf4ba68bbb6',
+            parent_span_id: 'b5795cf4ba68bbb5',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'fonts3.css',
+            op: 'fonts',
+            span_id: 'b5795cf4ba68bbb7',
+            parent_span_id: 'b5795cf4ba68bbb6',
             trace_id: '8cbbc19c0f54447ab702f00263262726',
             data: {
               'Decoded Body Size': 159248,
@@ -195,8 +279,83 @@ describe('WaterfallModel', () => {
           'Transfer Size': 275,
         },
       },
-      numOfSpanChildren: 0,
+      numOfSpanChildren: 1,
       treeDepth: 2,
+      isLastSibling: true,
+      continuingTreeDepths: [1],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
+      toggleSpanGroup: undefined,
+    },
+    {
+      type: 'span',
+      span: {
+        timestamp: 1622079938.32451,
+        start_timestamp: 1622079938.31431,
+        description: 'fonts_bundle.css',
+        op: 'fonts',
+        span_id: 'a0e89ce4e0900ad5',
+        parent_span_id: 'a23f26b939d1a735',
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        data: {
+          'Decoded Body Size': 159248,
+          'Encoded Body Size': 159248,
+          'Transfer Size': 275,
+        },
+      },
+      numOfSpanChildren: 2,
+      treeDepth: 3,
+      isLastSibling: true,
+      continuingTreeDepths: [1],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
+      toggleSpanGroup: undefined,
+    },
+    {
+      type: 'span',
+      span: {
+        timestamp: 1622079938.32451,
+        start_timestamp: 1622079938.31431,
+        description: 'google-fonts.css',
+        op: 'fonts',
+        span_id: 'aa764a4e9d70c907',
+        parent_span_id: 'a0e89ce4e0900ad5',
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        data: {
+          'Decoded Body Size': 159248,
+          'Encoded Body Size': 159248,
+          'Transfer Size': 275,
+        },
+      },
+      numOfSpanChildren: 0,
+      treeDepth: 4,
+      isLastSibling: false,
+      continuingTreeDepths: [1],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
+      toggleSpanGroup: undefined,
+    },
+    {
+      type: 'span',
+      span: {
+        timestamp: 1622079938.32451,
+        start_timestamp: 1622079938.31431,
+        description: 'icon-fonts.css',
+        op: 'fonts',
+        span_id: '883837a47bc0d836',
+        parent_span_id: 'a0e89ce4e0900ad5',
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        data: {
+          'Decoded Body Size': 159248,
+          'Encoded Body Size': 159248,
+          'Transfer Size': 275,
+        },
+      },
+      numOfSpanChildren: 0,
+      treeDepth: 4,
       isLastSibling: true,
       continuingTreeDepths: [1],
       showEmbeddedChildren: false,
@@ -226,7 +385,7 @@ describe('WaterfallModel', () => {
       span: {
         timestamp: 1622079938.32451,
         start_timestamp: 1622079938.31431,
-        description: '/_static/dist/sentry/sentry.541f5b.min.css',
+        description: '/_static/dist/sentry/sentry.fonts.min.css',
         op: 'css',
         span_id: 'b5795cf4ba68bbb4',
         parent_span_id: 'a934857184bdf5a6',
@@ -237,8 +396,106 @@ describe('WaterfallModel', () => {
           'Transfer Size': 275,
         },
       },
-      numOfSpanChildren: 0,
+      numOfSpanChildren: 1,
       treeDepth: 1,
+      isLastSibling: true,
+      continuingTreeDepths: [],
+      showEmbeddedChildren: false,
+      toggleEmbeddedChildren: expect.any(Function),
+      fetchEmbeddedChildrenState: 'idle',
+      toggleSpanGroup: undefined,
+    },
+    {
+      type: 'span_group_chain',
+      span: {
+        timestamp: 1622079938.32451,
+        start_timestamp: 1622079938.31431,
+        description: 'fonts3.css',
+        op: 'fonts',
+        span_id: 'b5795cf4ba68bbb7',
+        parent_span_id: 'b5795cf4ba68bbb6',
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        data: {
+          'Decoded Body Size': 159248,
+          'Encoded Body Size': 159248,
+          'Transfer Size': 275,
+        },
+      },
+      treeDepth: 2,
+      continuingTreeDepths: [],
+      spanGrouping: [
+        {
+          type: 'span',
+          span: {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'fonts1.css',
+            op: 'fonts',
+            span_id: 'b5795cf4ba68bbb5',
+            parent_span_id: 'b5795cf4ba68bbb4',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          numOfSpanChildren: 1,
+          treeDepth: 2,
+          isLastSibling: true,
+          continuingTreeDepths: [],
+          showEmbeddedChildren: false,
+          toggleEmbeddedChildren: expect.any(Function),
+          fetchEmbeddedChildrenState: 'idle',
+          toggleSpanGroup: undefined,
+        },
+        {
+          type: 'span',
+          span: {
+            timestamp: 1622079938.32451,
+            start_timestamp: 1622079938.31431,
+            description: 'fonts2.css',
+            op: 'fonts',
+            span_id: 'b5795cf4ba68bbb6',
+            parent_span_id: 'b5795cf4ba68bbb5',
+            trace_id: '8cbbc19c0f54447ab702f00263262726',
+            data: {
+              'Decoded Body Size': 159248,
+              'Encoded Body Size': 159248,
+              'Transfer Size': 275,
+            },
+          },
+          numOfSpanChildren: 1,
+          treeDepth: 2,
+          isLastSibling: true,
+          continuingTreeDepths: [],
+          showEmbeddedChildren: false,
+          toggleEmbeddedChildren: expect.any(Function),
+          fetchEmbeddedChildrenState: 'idle',
+          toggleSpanGroup: undefined,
+        },
+      ],
+      showSpanGroup: false,
+      toggleSpanGroup: expect.any(Function),
+    },
+    {
+      type: 'span',
+      span: {
+        timestamp: 1622079938.32451,
+        start_timestamp: 1622079938.31431,
+        description: 'fonts3.css',
+        op: 'fonts',
+        span_id: 'b5795cf4ba68bbb7',
+        parent_span_id: 'b5795cf4ba68bbb6',
+        trace_id: '8cbbc19c0f54447ab702f00263262726',
+        data: {
+          'Decoded Body Size': 159248,
+          'Encoded Body Size': 159248,
+          'Transfer Size': 275,
+        },
+      },
+      numOfSpanChildren: 0,
+      treeDepth: 3,
       isLastSibling: true,
       continuingTreeDepths: [],
       showEmbeddedChildren: false,
@@ -301,6 +558,7 @@ describe('WaterfallModel', () => {
     expect(operationNameFilters.type).toBe('active_filter');
     expect(Array.from(operationNameFilters.operationNames)).toEqual([
       'css',
+      'fonts',
       'http',
       'pageload',
       'resource.link',
@@ -313,6 +571,7 @@ describe('WaterfallModel', () => {
     expect(operationNameFilters.type).toBe('active_filter');
     expect(Array.from(operationNameFilters.operationNames)).toEqual([
       'css',
+      'fonts',
       'pageload',
       'resource.link',
     ]);
@@ -324,6 +583,7 @@ describe('WaterfallModel', () => {
     expect(operationNameFilters.type).toBe('active_filter');
     expect(Array.from(operationNameFilters.operationNames)).toEqual([
       'css',
+      'fonts',
       'http',
       'pageload',
       'resource.link',
@@ -377,7 +637,7 @@ describe('WaterfallModel', () => {
       viewEnd: 0.65,
     });
 
-    const expected = [...fullWaterfall];
+    let expected = [...fullWaterfall];
 
     expected[1] = {
       type: 'out_of_view',
@@ -398,7 +658,10 @@ describe('WaterfallModel', () => {
       viewEnd: 0.65,
     });
 
-    expect(spans).toEqual([
+    assert(
+      fullWaterfall[10].type === 'span_group_chain' && fullWaterfall[10].spanGrouping
+    );
+    expected = [
       {
         type: 'filtered_out',
         span: fullWaterfall[0].span,
@@ -415,9 +678,35 @@ describe('WaterfallModel', () => {
       },
       {
         type: 'filtered_out',
+        span: fullWaterfall[5].span,
+      },
+      {
+        type: 'filtered_out',
         span: fullWaterfall[6].span,
       },
-    ]);
+      {
+        type: 'filtered_out',
+        span: fullWaterfall[7].span,
+      },
+      {
+        type: 'filtered_out',
+        span: fullWaterfall[9].span,
+      },
+      {
+        type: 'filtered_out',
+        span: fullWaterfall[10].spanGrouping[0].span,
+      },
+      {
+        type: 'filtered_out',
+        span: fullWaterfall[10].spanGrouping[1].span,
+      },
+      {
+        type: 'filtered_out',
+        span: fullWaterfall[11].span,
+      },
+    ] as EnhancedProcessedSpanType[];
+
+    expect(spans).toEqual(expected);
 
     // toggle ops filters with a window selection and search query
     // NOTE: http was toggled on in the previous case
@@ -429,26 +718,9 @@ describe('WaterfallModel', () => {
       viewEnd: 0.65,
     });
 
-    expect(spans).toEqual([
-      {
-        type: 'filtered_out',
-        span: fullWaterfall[0].span,
-      },
-      {
-        type: 'filtered_out',
-        span: fullWaterfall[1].span,
-      },
-      fullWaterfall[2],
-      fullWaterfall[3],
-      {
-        type: 'filtered_out',
-        span: fullWaterfall[4].span,
-      },
-      {
-        type: 'filtered_out',
-        span: fullWaterfall[6].span,
-      },
-    ]);
+    expected[1].type = 'filtered_out';
+
+    expect(spans).toEqual(expected);
   });
 
   it('toggleSpanGroup()', () => {
@@ -471,8 +743,8 @@ describe('WaterfallModel', () => {
 
     expect(spans).toEqual(
       fullWaterfall.filter((_span, index) => {
-        // 5th span should be hidden
-        return index !== 4;
+        // 5th through 8th spans should be hidden
+        return !(index >= 4 && index <= 7);
       })
     );
 


### PR DESCRIPTION
Shoutout to @Zylphrex for finding this edge case.

**Before:**

<img width="360" alt="Screen Shot 2021-08-25 at 7 14 07 PM" src="https://user-images.githubusercontent.com/139499/130876469-f6c53425-5f7c-4a55-a69c-755ce9ff17b6.png">

**After:**

<img width="240" alt="Screen Shot 2021-08-25 at 7 16 32 PM" src="https://user-images.githubusercontent.com/139499/130876575-b1e64293-4c2c-4fc3-bd39-ad047541b18d.png">
