### PR TITLE
feat(notifications): Automatically Opt Users into Slack Notifications

### DIFF
--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -2,21 +2,18 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.notification_setting import NotificationSettingsSerializer
 from sentry.api.validators.notifications import validate, validate_type_option
+from sentry.features.helpers import any_organization_has_feature
 from sentry.models import NotificationSetting, User
 
 
 def validate_has_feature(user: User) -> None:
-    if not any(
-        [
-            features.has("organizations:notification-platform", organization, actor=user)
-            for organization in user.get_orgs()
-        ]
+    if not any_organization_has_feature(
+        "organizations:notification-platform", user.get_orgs(), actor=user
     ):
         raise ResourceDoesNotExist
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1012,6 +1012,8 @@ SENTRY_FEATURES = {
     # Enable option to send alert, workflow, and deploy notifications
     # to 3rd parties (e.g. Slack) in addition to email
     "organizations:notification-platform": False,
+    # Automatically opt IN users to receiving Slack notifications.
+    "organizations:notification-slack-automatic": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable sorting+filtering by semantic version of a release

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -109,6 +109,7 @@ default_manager.add("organizations:minute-resolution-sessions", OrganizationFeat
 default_manager.add("organizations:mobile-screenshots", OrganizationFeature, True)
 default_manager.add("organizations:monitors", OrganizationFeature)
 default_manager.add("organizations:notification-platform", OrganizationFeature, True)
+default_manager.add("organizations:notification-slack-automatic", OrganizationFeature, True)
 default_manager.add("organizations:onboarding", OrganizationFeature)
 default_manager.add("organizations:org-subdomains", OrganizationFeature)
 default_manager.add("organizations:performance-landing-widgets", OrganizationFeature, True)

--- a/src/sentry/features/helpers.py
+++ b/src/sentry/features/helpers.py
@@ -1,17 +1,19 @@
-from typing import Any, Callable, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.models import Organization
+
+if TYPE_CHECKING:
+    from sentry.models import Organization
 
 # TODO(mgaeta): It's not currently possible to type a Callable's args with kwargs.
 EndpointFunc = Callable[..., Response]
 
 
 def any_organization_has_feature(
-    feature: str, organizations: Sequence[Organization], **kwargs: Any
+    feature: str, organizations: Sequence["Organization"], **kwargs: Any
 ) -> bool:
     return any([features.has(feature, organization, **kwargs) for organization in organizations])
 

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -1,0 +1,26 @@
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.types.integrations import ExternalProviders
+
+"""
+These mappings represents how to interpret the absence of a DB row for a given
+provider. For example, a user with no NotificationSettings should be opted
+into receiving emails but no Slack messages.
+"""
+
+# Each type has a different "sometimes" value.
+NOTIFICATION_SETTINGS_ALL_SOMETIMES = {
+    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.COMMITTED_ONLY,
+    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+}
+
+NOTIFICATION_SETTINGS_ALL_NEVER = {
+    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.NEVER,
+    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.NEVER,
+    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.NEVER,
+}
+
+NOTIFICATION_SETTING_DEFAULTS = {
+    ExternalProviders.EMAIL: NOTIFICATION_SETTINGS_ALL_SOMETIMES,
+    ExternalProviders.SLACK: NOTIFICATION_SETTINGS_ALL_NEVER,
+}

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -14,6 +14,10 @@ from typing import (
 )
 
 from sentry.features.helpers import any_organization_has_feature
+from sentry.notifications.defaults import (
+    NOTIFICATION_SETTING_DEFAULTS,
+    NOTIFICATION_SETTINGS_ALL_SOMETIMES,
+)
 from sentry.notifications.types import (
     NOTIFICATION_SCOPE_TYPE,
     NOTIFICATION_SETTING_OPTION_VALUES,
@@ -39,25 +43,6 @@ if TYPE_CHECKING:
     )
 
 
-# These mappings represents how to interpret the absence of a DB row for a given
-# provider. For example, a user with no NotificationSettings should be opted
-# into receiving emails but no Slack messages.
-NOTIFICATION_SETTING_DEFAULTS_DEFAULT = {
-    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.COMMITTED_ONLY,
-    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
-    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-}
-NOTIFICATION_SETTING_DEFAULTS_OFF = {
-    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.NEVER,
-    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.NEVER,
-}
-NOTIFICATION_SETTING_DEFAULTS = {
-    ExternalProviders.EMAIL: NOTIFICATION_SETTING_DEFAULTS_DEFAULT,
-    ExternalProviders.SLACK: NOTIFICATION_SETTING_DEFAULTS_OFF,
-}
-
-
 def _get_notification_setting_default(
     provider: ExternalProviders,
     type: NotificationSettingTypes,
@@ -78,7 +63,7 @@ def _get_notification_setting_default(
     if any_organization_has_feature(
         "organizations:notification-slack-automatic", organizations, actor=actor
     ):
-        return NOTIFICATION_SETTING_DEFAULTS_DEFAULT[type]
+        return NOTIFICATION_SETTINGS_ALL_SOMETIMES[type]
     return NOTIFICATION_SETTING_DEFAULTS[provider][type]
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -57,7 +57,10 @@ def _get_notification_setting_default(
     if organization:
         organizations = [organization]
     elif user:
-        organizations = user.get_orgs()
+        if user.is_anonymous:
+            organizations = []
+        else:
+            organizations = user.get_orgs()
         actor = user
 
     if any_organization_has_feature(

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -134,6 +134,7 @@ def get_participants_for_release(
             notification_settings_by_scope,
             notification_providers(),
             NotificationSettingTypes.DEPLOY,
+            organization=organization,
         )
         for provider, value in values_by_provider.items():
             reason_option = get_reason(user, value, user_ids)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -93,6 +93,9 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
         expected_queries += 1
 
+        # TODO(mgaeta): Extra queries while we're checking a feature flag in the ProjectSerializer.
+        expected_queries += 4
+
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)
 

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -90,7 +90,10 @@ class NotificationHelpersTest(TestCase):
 
     def test_get_deploy_values_by_provider_empty_settings(self):
         values_by_provider = get_values_by_provider_by_type(
-            {}, notification_providers(), NotificationSettingTypes.DEPLOY
+            {},
+            notification_providers(),
+            NotificationSettingTypes.DEPLOY,
+            organization=self.organization,
         )
         assert values_by_provider == {
             ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY,
@@ -110,6 +113,7 @@ class NotificationHelpersTest(TestCase):
             notification_settings_by_scope,
             notification_providers(),
             NotificationSettingTypes.DEPLOY,
+            organization=self.organization,
         )
         assert values_by_provider == {
             ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,

--- a/tests/sentry/notifications/utils/test_get_groups_for_query.py
+++ b/tests/sentry/notifications/utils/test_get_groups_for_query.py
@@ -1,16 +1,13 @@
-from unittest import TestCase
-
-from sentry.models import Group, Project, User
+from sentry.models import Group, Project
 from sentry.notifications.helpers import get_groups_for_query
 from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
+from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 
 
 class GetGroupsForQueryTestCase(TestCase):
     def setUp(self) -> None:
-        self.user = User(1)
-        self.project = Project(id=123)
-        self.group = Group(id=456, project=self.project)
+        super().setUp()
 
     def test_get_groups_for_query_empty(self):
         groups_by_project = {self.project: {self.group}}

--- a/tests/sentry/notifications/utils/test_get_most_specific.py
+++ b/tests/sentry/notifications/utils/test_get_most_specific.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-
 from sentry.models import User
 from sentry.notifications.helpers import (
     get_highest_notification_setting_value,
@@ -10,12 +8,13 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
+from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 
 
 class GetMostSpecificNotificationSettingValueTestCase(TestCase):
     def setUp(self) -> None:
-        self.user = User(id=1)
+        super().setUp()
 
     def test_get_most_specific_notification_setting_value_empty_workflow(self):
         value = get_most_specific_notification_setting_value(

--- a/tests/sentry/notifications/utils/test_get_user_subscriptions_for_groups.py
+++ b/tests/sentry/notifications/utils/test_get_user_subscriptions_for_groups.py
@@ -1,16 +1,12 @@
-from unittest import TestCase
-
-from sentry.models import Group, GroupSubscription, Project, User
+from sentry.models import GroupSubscription
 from sentry.notifications.helpers import get_user_subscriptions_for_groups
 from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
+from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 
 
 class GetUserSubscriptionsForGroupsTestCase(TestCase):
     def setUp(self) -> None:
-        self.user = User(1)
-        self.project = Project(id=123)
-        self.group = Group(id=456, project=self.project)
         self.group_subscription = GroupSubscription(is_active=True)
 
     def test_get_user_subscriptions_for_groups_empty(self):


### PR DESCRIPTION
Creating a new feature flag that when enabled changes the fallback notification settings for Slack.