### PR TITLE
feat(aws-lambda): Add permissions to allow retrieval of layer versions

### DIFF
--- a/src/sentry/integrations/aws_lambda/client.py
+++ b/src/sentry/integrations/aws_lambda/client.py
@@ -51,6 +51,7 @@ def gen_aws_client(account_number, region, aws_external_id, service_name="lambda
                         "Effect": "Allow",
                         "Action": [
                             "lambda:ListFunctions",
+                            "lambda:ListLayerVersions",
                             "lambda:GetLayerVersion",
                             "organizations:DescribeAccount",
                         ],

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -57,6 +57,7 @@ class AwsLambdaClientTest(TestCase):
                             "Effect": "Allow",
                             "Action": [
                                 "lambda:ListFunctions",
+                                "lambda:ListLayerVersions",
                                 "lambda:GetLayerVersion",
                                 "organizations:DescribeAccount",
                             ],


### PR DESCRIPTION
Adds `ListLayerVersions` permission to support serverless plugin `serverless-latest-layer-version` auto-fetching latest layer version rather than specifying specific versions

Ref: https://github.com/getsentry/sentry-javascript/issues/3834