### PR TITLE
ref(custom-repos): Hide custom repos secrets

### DIFF
--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
@@ -115,11 +115,7 @@ function AppStoreConnect({
   const [stepOneData, setStepOneData] = useState<StepOneData>({
     issuer: initialData?.appconnectIssuer,
     keyId: initialData?.appconnectKey,
-    privateKey:
-      typeof initialData?.appconnectPrivateKey === 'object'
-        ? undefined
-        : initialData?.appconnectPrivateKey,
-    unchanged: typeof initialData?.appconnectPrivateKey === 'object',
+    privateKey: typeof initialData?.appconnectPrivateKey === 'object' ? undefined : '',
   });
 
   const [stepTwoData, setStepTwoData] = useState<StepTwoData>({
@@ -135,11 +131,7 @@ function AppStoreConnect({
 
   const [stepThreeData, setStepThreeData] = useState<StepThreeData>({
     username: initialData?.itunesUser,
-    password:
-      typeof initialData?.itunesPassword === 'object'
-        ? undefined
-        : initialData?.itunesPassword,
-    unchanged: typeof initialData?.itunesPassword === 'object',
+    password: typeof initialData?.itunesPassword === 'object' ? undefined : '',
   });
 
   const [stepFourData, setStepFourData] = useState<StepFourData>({
@@ -180,7 +172,7 @@ function AppStoreConnect({
         {
           method: 'POST',
           data: {
-            id: initialData?.id,
+            id: stepOneData.privateKey !== undefined ? undefined : initialData?.id,
             appconnectIssuer: stepOneData.issuer,
             appconnectKey: stepOneData.keyId,
             appconnectPrivateKey: stepOneData.privateKey,
@@ -285,7 +277,7 @@ function AppStoreConnect({
     switch (activeStep) {
       case 0:
         return Object.keys(stepOneData).some(key => {
-          if ((key === 'privateKey' && stepOneData.unchanged) || key === 'unchanged') {
+          if (key === 'privateKey' && stepOneData[key] === undefined) {
             return false;
           }
           return !stepOneData[key];
@@ -294,7 +286,7 @@ function AppStoreConnect({
         return Object.keys(stepTwoData).some(key => !stepTwoData[key]);
       case 2: {
         return Object.keys(stepThreeData).some(key => {
-          if ((key === 'password' && stepThreeData.unchanged) || key === 'unchanged') {
+          if (key === 'password' && stepThreeData[key] === undefined) {
             return false;
           }
           return !stepThreeData[key];
@@ -330,7 +322,7 @@ function AppStoreConnect({
         {
           method: 'POST',
           data: {
-            id: initialData?.id,
+            id: stepThreeData.password !== undefined ? undefined : initialData?.id,
             itunesUser: stepThreeData.username,
             itunesPassword: stepThreeData.password,
           },

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepOne.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepOne.tsx
@@ -56,9 +56,7 @@ function StepOne({stepOneData, onSetStepOneData}: Props) {
           rows={5}
           autosize
           placeholder={
-            stepOneData.unchanged
-              ? `${'('}${t('Private Key unchanged')}${')'}`
-              : t('Private Key')
+            stepOneData.unchanged ? t('(Private Key unchanged)') : t('Private Key')
           }
           onChange={e =>
             onSetStepOneData({

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepOne.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepOne.tsx
@@ -56,13 +56,14 @@ function StepOne({stepOneData, onSetStepOneData}: Props) {
           rows={5}
           autosize
           placeholder={
-            stepOneData.unchanged ? t('(Private Key unchanged)') : t('Private Key')
+            stepOneData.privateKey === undefined
+              ? t('(Private Key unchanged)')
+              : t('Private Key')
           }
           onChange={e =>
             onSetStepOneData({
               ...stepOneData,
               privateKey: e.target.value,
-              unchanged: false,
             })
           }
         />

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepOne.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepOne.tsx
@@ -52,14 +52,19 @@ function StepOne({stepOneData, onSetStepOneData}: Props) {
       >
         <Textarea
           name="privateKey"
-          placeholder={t('Private Key')}
           value={stepOneData.privateKey}
           rows={5}
           autosize
+          placeholder={
+            stepOneData.unchanged
+              ? `${'('}${t('Private Key unchanged')}${')'}`
+              : t('Private Key')
+          }
           onChange={e =>
             onSetStepOneData({
               ...stepOneData,
               privateKey: e.target.value,
+              unchanged: false,
             })
           }
         />

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepThree.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepThree.tsx
@@ -41,9 +41,7 @@ function StepThree({stepThreeData, onSetStepOneData}: Props) {
           type={stepThreeData.unchanged ? 'text' : 'password'}
           value={stepThreeData.password}
           placeholder={
-            stepThreeData.unchanged
-              ? `${'('}${t('Password unchanged')}${')'}`
-              : t('Password')
+            stepThreeData.unchanged ? t('(Password unchanged)') : t('Password')
           }
           onChange={e =>
             onSetStepOneData({

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepThree.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepThree.tsx
@@ -38,16 +38,17 @@ function StepThree({stepThreeData, onSetStepOneData}: Props) {
       >
         <Input
           name="password"
-          type={stepThreeData.unchanged ? 'text' : 'password'}
+          type={stepThreeData.password === undefined ? 'text' : 'password'}
           value={stepThreeData.password}
           placeholder={
-            stepThreeData.unchanged ? t('(Password unchanged)') : t('Password')
+            stepThreeData.password === undefined
+              ? t('(Password unchanged)')
+              : t('Password')
           }
           onChange={e =>
             onSetStepOneData({
               ...stepThreeData,
               password: e.target.value,
-              unchanged: false,
             })
           }
         />

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepThree.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepThree.tsx
@@ -25,6 +25,7 @@ function StepThree({stepThreeData, onSetStepOneData}: Props) {
           type="text"
           name="username"
           placeholder={t('Username')}
+          value={stepThreeData.username}
           onChange={e => onSetStepOneData({...stepThreeData, username: e.target.value})}
         />
       </Field>
@@ -36,10 +37,21 @@ function StepThree({stepThreeData, onSetStepOneData}: Props) {
         required
       >
         <Input
-          type="password"
           name="password"
-          placeholder={t('Password')}
-          onChange={e => onSetStepOneData({...stepThreeData, password: e.target.value})}
+          type={stepThreeData.unchanged ? 'text' : 'password'}
+          value={stepThreeData.password}
+          placeholder={
+            stepThreeData.unchanged
+              ? `${'('}${t('Password unchanged')}${')'}`
+              : t('Password')
+          }
+          onChange={e =>
+            onSetStepOneData({
+              ...stepThreeData,
+              password: e.target.value,
+              unchanged: false,
+            })
+          }
         />
       </Field>
     </Fragment>

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/types.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/types.tsx
@@ -10,7 +10,6 @@ export type AppleStoreOrg = {
 };
 
 export type StepOneData = {
-  unchanged: boolean;
   issuer?: string;
   keyId?: string;
   privateKey?: string;
@@ -21,7 +20,6 @@ export type StepTwoData = {
 };
 
 export type StepThreeData = {
-  unchanged: boolean;
   username?: string;
   password?: string;
 };

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/types.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/types.tsx
@@ -10,6 +10,7 @@ export type AppleStoreOrg = {
 };
 
 export type StepOneData = {
+  unchanged: boolean;
   issuer?: string;
   keyId?: string;
   privateKey?: string;
@@ -20,6 +21,7 @@ export type StepTwoData = {
 };
 
 export type StepThreeData = {
+  unchanged: boolean;
   username?: string;
   password?: string;
 };

--- a/static/app/components/modals/debugFileCustomRepository/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/index.tsx
@@ -12,7 +12,7 @@ import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig
 import Form from 'app/views/settings/components/forms/form';
 
 import AppStoreConnect from './appStoreConnect';
-import {getFormFields, getInitialData} from './utils';
+import {getFinalData, getFormFieldsAndInitialData} from './utils';
 
 type AppStoreConnectInitialData = React.ComponentProps<
   typeof AppStoreConnect
@@ -52,13 +52,15 @@ function DebugFileCustomRepository({
   appStoreConnectContext,
   closeModal,
 }: Props) {
-  function handleSave(data: Record<string, any>) {
-    onSave({...data, type: sourceType}).then(() => {
+  function handleSave(data?: Record<string, any>) {
+    if (!data) {
       closeModal();
+      window.location.reload();
+      return;
+    }
 
-      if (sourceType === CustomRepoType.APP_STORE_CONNECT) {
-        window.location.reload();
-      }
+    onSave({...getFinalData(sourceType, data), type: sourceType}).then(() => {
+      closeModal();
     });
   }
 
@@ -78,8 +80,7 @@ function DebugFileCustomRepository({
     );
   }
 
-  const fields = getFormFields(sourceType);
-  const initialData = getInitialData(sourceConfig);
+  const {initialData, fields} = getFormFieldsAndInitialData(sourceType, sourceConfig);
 
   return (
     <Fragment>

--- a/static/app/components/modals/debugFileCustomRepository/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/utils.tsx
@@ -98,9 +98,7 @@ export function getFormFieldsAndInitialData(
             required: false,
             label: t('Password'),
             placeholder:
-              typeof password === 'object'
-                ? `${'('}${t('Password unchanged')}${')'}`
-                : 'open-sesame',
+              typeof password === 'object' ? t('(Password unchanged)') : 'open-sesame',
             help: t('Password for HTTP basic auth'),
           },
           commonFields.separator,
@@ -167,7 +165,7 @@ export function getFormFieldsAndInitialData(
             label: t('Secret Access Key'),
             placeholder:
               typeof secret_key === 'object'
-                ? `${'('}${t('Secret Access Key unchanged')}${')'}`
+                ? t('(Secret Access Key unchanged)')
                 : 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
           },
           commonFields.separator,
@@ -217,7 +215,7 @@ export function getFormFieldsAndInitialData(
             label: t('Private Key'),
             placeholder:
               typeof private_key === 'object'
-                ? `${'('}${t('Private Key unchanged')}${')'}`
+                ? t('(Private Key unchanged)')
                 : '-----BEGIN PRIVATE KEY-----\n[PRIVATE-KEY]\n-----END PRIVATE KEY-----',
             help: tct(
               'The service account key. Credentials can be managed on the [link].',

--- a/static/app/components/modals/debugFileCustomRepository/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/utils.tsx
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/react';
+
 import ExternalLink from 'app/components/links/externalLink';
 import {
   AWS_REGIONS,
@@ -58,174 +60,221 @@ const commonFields: FieldMap = {
   },
 };
 
-const httpFields: FieldMap = {
-  url: {
-    name: 'url',
-    type: 'url',
-    required: true,
-    label: t('Download Url'),
-    placeholder: 'https://msdl.microsoft.com/download/symbols/',
-    help: t('Full URL to the symbol server'),
-  },
-  username: {
-    name: 'username',
-    type: 'string',
-    required: false,
-    label: t('User'),
-    placeholder: 'admin',
-    help: t('User for HTTP basic auth'),
-  },
-  password: {
-    name: 'password',
-    type: 'string',
-    required: false,
-    label: t('Password'),
-    placeholder: 'open-sesame',
-    help: t('Password for HTTP basic auth'),
-  },
-};
+export function getFormFieldsAndInitialData(
+  type: CustomRepoType,
+  sourceConfig?: Record<string, any>
+) {
+  const {password, secret_key, layout, private_key, ...config} = sourceConfig ?? {};
+  const initialData = layout
+    ? {...config, 'layout.casing': layout.casing, 'layout.type': layout.type}
+    : config;
 
-const s3Fields: FieldMap = {
-  bucket: {
-    name: 'bucket',
-    type: 'string',
-    required: true,
-    label: t('Bucket'),
-    placeholder: 's3-bucket-name',
-    help: t('Name of the S3 bucket. Read permissions are required to download symbols.'),
-  },
-  region: {
-    name: 'region',
-    type: 'select',
-    required: true,
-    label: t('Region'),
-    help: t('The AWS region and availability zone of the bucket.'),
-    choices: AWS_REGIONS.map(([k, v]) => [
-      k,
-      <span key={k}>
-        <code>{k}</code> {v}
-      </span>,
-    ]),
-  },
-  accessKey: {
-    name: 'access_key',
-    type: 'string',
-    required: true,
-    label: t('Access Key ID'),
-    placeholder: 'AKIAIOSFODNN7EXAMPLE',
-    help: tct(
-      'Access key to the AWS account. Credentials can be managed in the [link].',
-      {
-        link: (
-          <ExternalLink href="https://console.aws.amazon.com/iam/">
-            IAM console
-          </ExternalLink>
-        ),
-      }
-    ),
-  },
-  secretKey: {
-    name: 'secret_key',
-    type: 'string',
-    required: true,
-    label: t('Secret Access Key'),
-    placeholder: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-  },
-};
-
-const gcsFields: FieldMap = {
-  bucket: {
-    name: 'bucket',
-    type: 'string',
-    required: true,
-    label: t('Bucket'),
-    placeholder: 'gcs-bucket-name',
-    help: t('Name of the GCS bucket. Read permissions are required to download symbols.'),
-  },
-  clientEmail: {
-    name: 'client_email',
-    type: 'email',
-    required: true,
-    label: t('Client Email'),
-    placeholder: 'user@project.iam.gserviceaccount.com',
-    help: t('Email address of the GCS service account.'),
-  },
-  privateKey: {
-    name: 'private_key',
-    type: 'string',
-    required: true,
-    multiline: true,
-    autosize: true,
-    maxRows: 5,
-    rows: 3,
-    label: t('Private Key'),
-    placeholder: '-----BEGIN PRIVATE KEY-----\n[PRIVATE-KEY]\n-----END PRIVATE KEY-----',
-    help: tct('The service account key. Credentials can be managed on the [link].', {
-      link: (
-        <ExternalLink href="https://console.cloud.google.com/project/_/iam-admin">
-          IAM &amp; Admin Page
-        </ExternalLink>
-      ),
-    }),
-  },
-};
-
-export function getFormFields(type: CustomRepoType) {
   switch (type) {
     case 'http':
-      return [
-        commonFields.id,
-        commonFields.name,
-        commonFields.separator,
-        httpFields.url,
-        httpFields.username,
-        httpFields.password,
-        commonFields.separator,
-        commonFields.layoutType,
-        commonFields.layoutCasing,
-      ];
+      return {
+        fields: [
+          commonFields.id,
+          commonFields.name,
+          commonFields.separator,
+          {
+            name: 'url',
+            type: 'url',
+            required: true,
+            label: t('Download Url'),
+            placeholder: 'https://msdl.microsoft.com/download/symbols/',
+            help: t('Full URL to the symbol server'),
+          },
+          {
+            name: 'username',
+            type: 'string',
+            required: false,
+            label: t('User'),
+            placeholder: 'admin',
+            help: t('User for HTTP basic auth'),
+          },
+          {
+            name: 'password',
+            type: 'string',
+            required: false,
+            label: t('Password'),
+            placeholder:
+              typeof password === 'object'
+                ? `${'('}${t('Password unchanged')}${')'}`
+                : 'open-sesame',
+            help: t('Password for HTTP basic auth'),
+          },
+          commonFields.separator,
+          commonFields.layoutType,
+          commonFields.layoutCasing,
+        ],
+        initialData: !initialData
+          ? undefined
+          : {
+              ...initialData,
+              password: typeof password === 'object' ? undefined : password,
+            },
+      };
     case 's3':
-      return [
-        commonFields.id,
-        commonFields.name,
-        commonFields.separator,
-        s3Fields.bucket,
-        s3Fields.region,
-        s3Fields.accessKey,
-        s3Fields.secretKey,
-        commonFields.separator,
-        commonFields.prefix,
-        commonFields.layoutType,
-        commonFields.layoutCasing,
-      ];
+      return {
+        fields: [
+          commonFields.id,
+          commonFields.name,
+          commonFields.separator,
+          {
+            name: 'bucket',
+            type: 'string',
+            required: true,
+            label: t('Bucket'),
+            placeholder: 's3-bucket-name',
+            help: t(
+              'Name of the S3 bucket. Read permissions are required to download symbols.'
+            ),
+          },
+          {
+            name: 'region',
+            type: 'select',
+            required: true,
+            label: t('Region'),
+            help: t('The AWS region and availability zone of the bucket.'),
+            choices: AWS_REGIONS.map(([k, v]) => [
+              k,
+              <span key={k}>
+                <code>{k}</code> {v}
+              </span>,
+            ]),
+          },
+          {
+            name: 'access_key',
+            type: 'string',
+            required: true,
+            label: t('Access Key ID'),
+            placeholder: 'AKIAIOSFODNN7EXAMPLE',
+            help: tct(
+              'Access key to the AWS account. Credentials can be managed in the [link].',
+              {
+                link: (
+                  <ExternalLink href="https://console.aws.amazon.com/iam/">
+                    IAM console
+                  </ExternalLink>
+                ),
+              }
+            ),
+          },
+          {
+            name: 'secret_key',
+            type: 'string',
+            required: true,
+            label: t('Secret Access Key'),
+            placeholder:
+              typeof secret_key === 'object'
+                ? `${'('}${t('Secret Access Key unchanged')}${')'}`
+                : 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+          },
+          commonFields.separator,
+          commonFields.prefix,
+          commonFields.layoutType,
+          commonFields.layoutCasing,
+        ],
+        initialData: !initialData
+          ? undefined
+          : {
+              ...initialData,
+              secret_key: typeof secret_key === 'object' ? undefined : secret_key,
+            },
+      };
     case 'gcs':
-      return [
-        commonFields.id,
-        commonFields.name,
-        commonFields.separator,
-        gcsFields.bucket,
-        gcsFields.clientEmail,
-        gcsFields.privateKey,
-        commonFields.separator,
-        commonFields.prefix,
-        commonFields.layoutType,
-        commonFields.layoutCasing,
-      ];
-    default:
-      return undefined;
+      return {
+        fields: [
+          commonFields.id,
+          commonFields.name,
+          commonFields.separator,
+          {
+            name: 'bucket',
+            type: 'string',
+            required: true,
+            label: t('Bucket'),
+            placeholder: 'gcs-bucket-name',
+            help: t(
+              'Name of the GCS bucket. Read permissions are required to download symbols.'
+            ),
+          },
+          {
+            name: 'client_email',
+            type: 'email',
+            required: true,
+            label: t('Client Email'),
+            placeholder: 'user@project.iam.gserviceaccount.com',
+            help: t('Email address of the GCS service account.'),
+          },
+          {
+            name: 'private_key',
+            type: 'string',
+            required: true,
+            multiline: true,
+            autosize: true,
+            maxRows: 5,
+            rows: 3,
+            label: t('Private Key'),
+            placeholder:
+              typeof private_key === 'object'
+                ? `${'('}${t('Private Key unchanged')}${')'}`
+                : '-----BEGIN PRIVATE KEY-----\n[PRIVATE-KEY]\n-----END PRIVATE KEY-----',
+            help: tct(
+              'The service account key. Credentials can be managed on the [link].',
+              {
+                link: (
+                  <ExternalLink href="https://console.cloud.google.com/project/_/iam-admin">
+                    IAM &amp; Admin Page
+                  </ExternalLink>
+                ),
+              }
+            ),
+          },
+          commonFields.separator,
+          commonFields.prefix,
+          commonFields.layoutType,
+          commonFields.layoutCasing,
+        ],
+        initialData: !initialData
+          ? undefined
+          : {
+              ...initialData,
+              private_key: typeof private_key === 'object' ? undefined : private_key,
+            },
+      };
+    default: {
+      Sentry.captureException(new Error('Unknown custom repository type'));
+      return {}; // this shall never happen
+    }
   }
 }
 
-export function getInitialData(sourceConfig?: Record<string, any>) {
-  if (!sourceConfig) {
-    return undefined;
+export function getFinalData(type: CustomRepoType, data: Record<string, any>) {
+  switch (type) {
+    case 'http':
+      return {
+        ...data,
+        password: data.password ?? {
+          'hidden-secret': true,
+        },
+      };
+    case 's3':
+      return {
+        ...data,
+        secret_key: data.secret_key ?? {
+          'hidden-secret': true,
+        },
+      };
+    case 'gcs':
+      return {
+        ...data,
+        private_key: data.private_key ?? {
+          'hidden-secret': true,
+        },
+      };
+    default: {
+      Sentry.captureException(new Error('Unknown custom repository type'));
+      return {}; // this shall never happen
+    }
   }
-
-  if (sourceConfig.layout) {
-    const {layout, ...initialData} = sourceConfig;
-    const {casing, type} = layout;
-    return {...initialData, ['layout.casing']: casing, ['layout.type']: type};
-  }
-
-  return sourceConfig;
 }

--- a/static/app/views/settings/components/forms/field/fieldControl.tsx
+++ b/static/app/views/settings/components/forms/field/fieldControl.tsx
@@ -88,6 +88,7 @@ export default FieldControl;
 // * can NOT have overflow hidden because "control error message" overflows
 const FieldControlErrorWrapper = styled('div')<{inline?: boolean}>`
   ${p => (p.inline ? 'width: 50%; padding-left: 10px;' : '')};
+  position: relative;
 `;
 
 const FieldControlStyled = styled('div')<{alignRight?: boolean}>`

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/actions.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/actions.tsx
@@ -64,7 +64,7 @@ function Actions({
         <StyledDropdownButton
           isOpen={isDetailsExpanded}
           size="small"
-          onClick={onToggleDetails}
+          onClick={isDetailsDisabled ? undefined : onToggleDetails}
           hideBottomBorder={false}
           disabled={isDetailsDisabled}
         >

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -21,6 +21,10 @@ type Props = {
 };
 
 function Status({theme, details, onEditRepository, onRevalidateItunesSession}: Props) {
+  if (!details) {
+    return <Placeholder height="14px" />;
+  }
+
   const {
     pendingDownloads,
     updateAlertMessage,
@@ -97,7 +101,7 @@ function Status({theme, details, onEditRepository, onRevalidateItunesSession}: P
     );
   }
 
-  return <Placeholder height="14px" />;
+  return null;
 }
 
 export default withTheme(Status);


### PR DESCRIPTION
Custom repositories no longer display secrets, exposing sensitive information.

closes: NATIVE-177

Previews:

![image](https://user-images.githubusercontent.com/29228205/130986811-b538b456-2136-4cec-a7ca-5d911b1335a6.png)

![image](https://user-images.githubusercontent.com/29228205/131100537-634e6558-2303-4807-aa8b-33b47cb37df5.png)

![image](https://user-images.githubusercontent.com/29228205/131144249-6d80bc37-b4a0-489e-b147-f1776c512349.png)


this PR also fixes the small issue below:

Before:

![image](https://user-images.githubusercontent.com/29228205/131145900-da51f5ae-e0b2-4653-9cc2-3a20bf7e60c3.png)

After:

![image](https://user-images.githubusercontent.com/29228205/131145823-29c7ed8e-3352-4d39-a868-975b2555e8fb.png)
