### PR TITLE
fix(codeowners): Prevent interaction from on users without permissions

### DIFF
--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -35,16 +35,28 @@ class IntegrationExternalMappings extends Component<Props, State> {
             <HeaderLayout>
               <ExternalNameColumn>{tct('External [type]', {type})}</ExternalNameColumn>
               <SentryNameColumn>{tct('Sentry [type]', {type})}</SentryNameColumn>
-              <ButtonColumn>
-                <AddButton
-                  data-test-id="add-mapping-button"
-                  onClick={() => onCreateOrEdit()}
-                  size="xsmall"
-                  icon={<IconAdd size="xs" isCircled />}
-                >
-                  {tct('Add [type] Mapping', {type})}
-                </AddButton>
-              </ButtonColumn>
+              <Access access={['org:integrations']}>
+                {({hasAccess}) => (
+                  <ButtonColumn>
+                    <Tooltip
+                      title={t(
+                        'You must be an organization owner, manager or admin to edit or remove a code mapping.'
+                      )}
+                      disabled={hasAccess}
+                    >
+                      <AddButton
+                        data-test-id="add-mapping-button"
+                        onClick={() => onCreateOrEdit()}
+                        size="xsmall"
+                        icon={<IconAdd size="xs" isCircled />}
+                        disabled={!hasAccess}
+                      >
+                        {tct('Add [type] Mapping', {type})}
+                      </AddButton>
+                    </Tooltip>
+                  </ButtonColumn>
+                )}
+              </Access>
             </HeaderLayout>
           </PanelHeader>
           <PanelBody>

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -39,8 +39,9 @@ class IntegrationExternalMappings extends Component<Props, State> {
                 {({hasAccess}) => (
                   <ButtonColumn>
                     <Tooltip
-                      title={t(
-                        'You must be an organization owner, manager or admin to edit or remove a code mapping.'
+                      title={tct(
+                        'You must be an organization owner, manager or admin to edit or remove a [type] mapping.',
+                        {type}
                       )}
                       disabled={hasAccess}
                     >

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -5,6 +5,7 @@ import * as qs from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
+import Access from 'app/components/acl/access';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
@@ -16,6 +17,7 @@ import RepositoryProjectPathConfigRow, {
   NameRepoColumn,
   OutputPathColumn,
 } from 'app/components/repositoryProjectPathConfigRow';
+import Tooltip from 'app/components/tooltip';
 import {IconAdd} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
@@ -194,15 +196,29 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
               <NameRepoColumn>{t('Code Mappings')}</NameRepoColumn>
               <InputPathColumn>{t('Stack Trace Root')}</InputPathColumn>
               <OutputPathColumn>{t('Source Code Root')}</OutputPathColumn>
-              <ButtonColumn>
-                <AddButton
-                  onClick={() => this.openModal()}
-                  size="xsmall"
-                  icon={<IconAdd size="xs" isCircled />}
-                >
-                  {t('Add Mapping')}
-                </AddButton>
-              </ButtonColumn>
+
+              <Access access={['org:integrations']}>
+                {({hasAccess}) => (
+                  <ButtonColumn>
+                    <Tooltip
+                      title={t(
+                        'You must be an organization owner, manager or admin to edit or remove a code mapping.'
+                      )}
+                      disabled={hasAccess}
+                    >
+                      <AddButton
+                        data-test-id="add-mapping-button"
+                        onClick={() => this.openModal()}
+                        size="xsmall"
+                        icon={<IconAdd size="xs" isCircled />}
+                        disabled={!hasAccess}
+                      >
+                        {t('Add Code Mapping')}
+                      </AddButton>
+                    </Tooltip>
+                  </ButtonColumn>
+                )}
+              </Access>
             </HeaderLayout>
           </PanelHeader>
           <PanelBody>

--- a/static/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -85,13 +85,9 @@ class CodeOwnersPanel extends Component<Props> {
                 onConfirm={() => this.handleDelete(codeowner)}
                 message={t('Are you sure you want to remove this CODEOWNERS file?')}
                 key="confirm-delete"
+                disabled={disabled}
               >
-                <Button
-                  key="delete"
-                  icon={<IconDelete size="xs" />}
-                  size="xsmall"
-                  disabled={disabled}
-                />
+                <Button key="delete" icon={<IconDelete size="xs" />} size="xsmall" />
               </Confirm>,
             ]}
           />

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -3,6 +3,7 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {openEditOwnershipRules, openModal} from 'app/actionCreators/modal';
+import Access from 'app/components/acl/access';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
@@ -263,14 +264,20 @@ tags.sku_class:enterprise #enterprise`;
                 {t('View Issues')}
               </Button>
               <Feature features={['integrations-codeowners']}>
-                <CodeOwnerButton
-                  onClick={this.handleAddCodeOwner}
-                  size="small"
-                  priority="primary"
-                  data-test-id="add-codeowner-button"
-                >
-                  {t('Add CODEOWNERS File')}
-                </CodeOwnerButton>
+                <Access access={['project:write']}>
+                  {({hasAccess}) =>
+                    hasAccess && (
+                      <CodeOwnerButton
+                        onClick={this.handleAddCodeOwner}
+                        size="small"
+                        priority="primary"
+                        data-test-id="add-codeowner-button"
+                      >
+                        {t('Add CODEOWNERS File')}
+                      </CodeOwnerButton>
+                    )
+                  }
+                </Access>
               </Feature>
             </Fragment>
           }

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -85,7 +85,7 @@ describe('IntegrationCodeMappings', function () {
     const modal = await mountGlobalModal();
 
     expect(modal.find('input[name="stackRoot"]')).toHaveLength(0);
-    wrapper.find('button[aria-label="Add Mapping"]').first().simulate('click');
+    wrapper.find('button[data-test-id="add-mapping-button"]').first().simulate('click');
 
     await tick();
     modal.update();
@@ -107,7 +107,7 @@ describe('IntegrationCodeMappings', function () {
         defaultBranch,
       }),
     });
-    wrapper.find('button[aria-label="Add Mapping"]').first().simulate('click');
+    wrapper.find('button[data-test-id="add-mapping-button"]').first().simulate('click');
 
     const modal = await mountGlobalModal();
 

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -26,6 +26,10 @@ describe('IntegrationCodeMappings', function () {
   const org = TestStubs.Organization({
     projects,
   });
+  const invalidOrg = TestStubs.Organization({
+    projects,
+    access: [],
+  });
   const integration = TestStubs.GitHubIntegration();
   const repos = [
     TestStubs.Repository({
@@ -79,6 +83,26 @@ describe('IntegrationCodeMappings', function () {
     expect(wrapper.find('RepoName').length).toEqual(2);
     expect(wrapper.find('RepoName').at(0).text()).toEqual(repos[0].name);
     expect(wrapper.find('RepoName').at(1).text()).toEqual(repos[1].name);
+  });
+
+  it('requires permissions to click', async () => {
+    wrapper = mountWithTheme(
+      <IntegrationCodeMappings organization={invalidOrg} integration={integration} />,
+      TestStubs.routerContext([{organization: invalidOrg}])
+    );
+    const modal = await mountGlobalModal();
+    expect(modal.find('input[name="stackRoot"]')).toHaveLength(0);
+
+    const addMappingButton = wrapper
+      .find('Button[data-test-id="add-mapping-button"]')
+      .first();
+    expect(addMappingButton.prop('disabled')).toBe(true);
+    addMappingButton.simulate('click');
+
+    await tick();
+    modal.update();
+
+    expect(modal.find('input[name="stackRoot"]')).toHaveLength(0);
   });
 
   it('opens modal', async () => {

--- a/tests/js/spec/views/projectOwnership.spec.jsx
+++ b/tests/js/spec/views/projectOwnership.spec.jsx
@@ -58,7 +58,10 @@ describe('Project Ownership', function () {
 
   describe('codeowner action button', function () {
     it('renders button', function () {
-      org = TestStubs.Organization({features: ['integrations-codeowners']});
+      org = TestStubs.Organization({
+        features: ['integrations-codeowners'],
+        access: ['project:write'],
+      });
 
       const wrapper = mountWithTheme(
         <ProjectOwnership
@@ -71,6 +74,7 @@ describe('Project Ownership', function () {
 
       expect(wrapper.find('CodeOwnerButton').exists()).toBe(true);
     });
+
     it('clicking button opens modal', async function () {
       const wrapper = mountWithTheme(
         <ProjectOwnership
@@ -82,6 +86,21 @@ describe('Project Ownership', function () {
       );
       wrapper.find('[data-test-id="add-codeowner-button"] button').simulate('click');
       expect(openModal).toHaveBeenCalled();
+    });
+
+    it('does not render without permissions', function () {
+      org = TestStubs.Organization({features: ['integrations-codeowners'], access: []});
+
+      const wrapper = mountWithTheme(
+        <ProjectOwnership
+          params={{orgId: org.slug, projectId: project.slug}}
+          organization={org}
+          project={project}
+        />,
+        TestStubs.routerContext([{organization: org}])
+      );
+
+      expect(wrapper.find('CodeOwnerButton').exists()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
See: [API-2066](https://getsentry.atlassian.net/browse/API-2066)

This PR will prevent user interaction from any of the buttons on the Codeowners, Code Mappings, Team Mappings and User Mappings pages from users without the correct permissions. The API routes on the backend were already protected, but now there won't be a misleading UI telling users they can change something they actually can't.

**Before**

_Code Owners_
![Screen Shot 2021-08-26 at 11 22 56 AM](https://user-images.githubusercontent.com/35509934/130990731-db1eb490-cf47-4b07-820b-98a170959bf5.png)

---
_Code Mappings_
![Screen Shot 2021-08-26 at 11 18 00 AM](https://user-images.githubusercontent.com/35509934/130989906-54f8c458-cb0d-49c5-8911-800f73f3bf28.png)

---

_External Mappings_
![Screen Shot 2021-08-26 at 11 19 47 AM](https://user-images.githubusercontent.com/35509934/130990157-9414b4ca-cdf6-4781-a5b9-8298da37274e.png)



**After**

_Code Owners_
![after_codeowners](https://user-images.githubusercontent.com/35509934/130988938-f1798698-6309-41b7-8325-b3776ed3fd1b.png)
 - hidden Add CODEOWNERS button
 - disable delete codeowners file button

---

_Code Mappings_
![after_cm](https://user-images.githubusercontent.com/35509934/130988936-6c5f250c-9e85-4f57-a7c5-03293a6be2a6.png)
 - convert Add Mappings to Add Code Mappings (as is on the other pages)
 - disable Add Code Mappings button with tooltip

---


_External Mappings_
![Screen Shot 2021-08-26 at 11 16 52 AM](https://user-images.githubusercontent.com/35509934/130989696-62276a48-a7bb-4573-80aa-7ffb2a1762a2.png)
 - disable Add External Mappings button with tooltip

