### PR TITLE
ref(codeowners): Add feedback banner to codeowners page

### DIFF
--- a/static/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -7,12 +7,12 @@ import {Client} from 'app/api';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
-import {IconInfo} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Integration, Organization, Project} from 'app/types';
 import {getIntegrationIcon, trackIntegrationAnalytics} from 'app/utils/integrationUtil';
 import withApi from 'app/utils/withApi';
+import FeedbackAlert from 'app/views/settings/account/notifications/feedbackAlert';
 import InputField from 'app/views/settings/components/forms/inputField';
 
 type Props = ModalRenderProps & {
@@ -163,11 +163,7 @@ class StacktraceLinkModal extends Component<Props, State> {
                 </Button>
               ))}
             </ManualSetup>
-            <FeedbackAlert type="info" icon={<IconInfo />}>
-              {tct('Got feedback? Email [email:ecosystem-feedback@sentry.io].', {
-                email: <a href="mailto:ecosystem-feedback@sentry.io" />,
-              })}
-            </FeedbackAlert>
+            <StyledFeedbackAlert />
           </ModalContainer>
         </Body>
       </Fragment>
@@ -196,8 +192,8 @@ const ModalContainer = styled('div')`
   }
 `;
 
-const FeedbackAlert = styled(Alert)`
-  margin: 20px 0px 0px 0px;
+const StyledFeedbackAlert = styled(FeedbackAlert)`
+  margin-bottom: 0;
 `;
 
 const StyledInputField = styled(InputField)`

--- a/static/app/views/settings/account/notifications/feedbackAlert.tsx
+++ b/static/app/views/settings/account/notifications/feedbackAlert.tsx
@@ -4,8 +4,12 @@ import Alert from 'app/components/alert';
 import {IconInfo} from 'app/icons';
 import {tct} from 'app/locale';
 
-const FeedbackAlert = () => (
-  <StyledAlert type="info" icon={<IconInfo />}>
+type Props = {
+  className?: string;
+};
+
+const FeedbackAlert = ({className}: Props) => (
+  <StyledAlert type="info" icon={<IconInfo />} className={className}>
     {tct('Got feedback? Email [email:ecosystem-feedback@sentry.io].', {
       email: <a href="mailto:ecosystem-feedback@sentry.io" />,
     })}

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -19,6 +19,7 @@ import {
 } from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import AsyncView from 'app/views/asyncView';
+import FeedbackAlert from 'app/views/settings/account/notifications/feedbackAlert';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
@@ -276,6 +277,7 @@ tags.sku_class:enterprise #enterprise`;
         />
         <IssueOwnerDetails>{this.getDetail()}</IssueOwnerDetails>
         <PermissionAlert />
+        <FeedbackAlert />
         {this.renderCodeOwnerErrors()}
         <RulesPanel
           data-test-id="issueowners-panel"


### PR DESCRIPTION
See: [API-2065](https://getsentry.atlassian.net/browse/API-2065)

Add the feedback banner to the codeowners page. I also noticed some duplicate code, so I refactored that file because of how small this PR is.

**Before**:
No banner:
![before-banner](https://user-images.githubusercontent.com/35509934/131010067-edfce698-98a9-47ea-b864-4b0237242716.png)

Identical, duplicate component:
![before-extra](https://user-images.githubusercontent.com/35509934/131010132-5739b80b-fd09-49d9-8080-98e1ea3cacd9.png)


**After**:
Now, with banner:
![after-banner](https://user-images.githubusercontent.com/35509934/131010184-eb98a01e-af44-4671-af90-df4296cdbfc8.png)


Refactored banner, should look identical:
![after-extra](https://user-images.githubusercontent.com/35509934/131010262-2950d223-096a-455e-8dcf-90680827fdf3.png)

