### PR TITLE
feat(notifications): Remove NotificationSettings when Slack is uninstalled

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1084,6 +1084,7 @@ urlpatterns = [
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/$",
                     OrganizationIntegrationDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-integration-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/repos/$",

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -14,9 +14,10 @@ from sentry.integrations import (
     IntegrationProvider,
 )
 from sentry.integrations.slack import tasks
-from sentry.models import Integration, Organization
+from sentry.models import Integration, NotificationSetting, Organization, User
 from sentry.pipeline import NestedPipelineView
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 from sentry.utils.json import JSONData
 
@@ -68,6 +69,20 @@ metadata = IntegrationMetadata(
 class SlackIntegration(IntegrationInstallation):  # type: ignore
     def get_config_data(self) -> Mapping[str, str]:
         return {"installationType": get_integration_type(self.model)}
+
+    def uninstall(self) -> None:
+        """
+        Delete all parent-specific notification settings. For each user and team,
+        if this is their ONLY Slack integration, set their parent-independent
+        Slack notification setting to NEVER.
+        """
+        provider = ExternalProviders.SLACK
+        organization = Organization.objects.get(id=self.organization_id)
+        users = User.objects.get_users_with_only_one_integration_for_provider(
+            provider, organization
+        )
+        NotificationSetting.objects.remove_parent_settings_for_organization(organization, provider)
+        NotificationSetting.objects.disable_settings_for_users(provider, users)
 
 
 class SlackIntegrationProvider(IntegrationProvider):  # type: ignore

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -83,7 +83,7 @@ from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
 from sentry.snuba.models import QueryDatasets
-from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, loremipsum
 
 
@@ -1017,11 +1017,11 @@ class Factories:
         )
 
     @staticmethod
-    def create_integration(
-        organization: Organization, provider: ExternalProviders, external_id: str, **kwargs: Any
-    ) -> Identity:
+    def create_slack_integration(
+        organization: Organization, external_id: str, **kwargs: Any
+    ) -> Integration:
         integration = Integration.objects.create(
-            provider=EXTERNAL_PROVIDERS[provider],
+            provider="slack",
             name="Team A",
             external_id=external_id,
             metadata={

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -54,6 +54,10 @@ from sentry.models import (
     File,
     Group,
     GroupLink,
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
     Organization,
     OrganizationMember,
     OrganizationMemberTeam,
@@ -79,7 +83,7 @@ from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
 from sentry.snuba.models import QueryDatasets
-from sentry.types.integrations import ExternalProviders
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json, loremipsum
 
 
@@ -1010,4 +1014,40 @@ class Factories:
 
         return ProjectCodeOwners.objects.create(
             project=project, repository_project_path_config=code_mapping, **kwargs
+        )
+
+    @staticmethod
+    def create_integration(
+        organization: Organization, provider: ExternalProviders, external_id: str, **kwargs: Any
+    ) -> Identity:
+        integration = Integration.objects.create(
+            provider=EXTERNAL_PROVIDERS[provider],
+            name="Team A",
+            external_id=external_id,
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+        integration.add_organization(organization)
+        return integration
+
+    @staticmethod
+    def create_identity_provider(integration: Integration, **kwargs: Any) -> IdentityProvider:
+        return IdentityProvider.objects.create(
+            type=integration.provider,
+            external_id=integration.external_id,
+            config={},
+        )
+
+    @staticmethod
+    def create_identity(
+        user: User, identity_provider: IdentityProvider, external_id: str, **kwargs: Any
+    ) -> Identity:
+        return Identity.objects.create(
+            external_id=external_id,
+            idp=identity_provider,
+            user=user,
+            status=IdentityStatus.VALID,
+            scopes=[],
         )

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -13,7 +13,6 @@ from sentry.models import (
 )
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.types.integrations import ExternalProviders
 
 
 # XXX(dcramer): this is a compatibility layer to transition to pytest-based fixtures
@@ -344,15 +343,14 @@ class Fixtures:
 
         return Factories.create_codeowners(project=project, code_mapping=code_mapping, **kwargs)
 
-    def create_integration(
+    def create_slack_integration(
         self,
         organization: "Organization",
-        provider: ExternalProviders = ExternalProviders.SLACK,
         external_id: str = "TXXXXXXX1",
         **kwargs: Any,
     ):
-        integration = Factories.create_integration(
-            organization=organization, provider=provider, external_id=external_id, **kwargs
+        integration = Factories.create_slack_integration(
+            organization=organization, external_id=external_id, **kwargs
         )
         idp = Factories.create_identity_provider(integration=integration)
         Factories.create_identity(organization.get_default_owner(), idp, "UXXXXXXX1")

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -10,11 +10,12 @@ from sentry.testutils.helpers import with_feature
 
 
 class OrganizationIntegrationDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-integration-details"
+
     def setUp(self):
         super().setUp()
 
         self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user, name="baz")
         self.integration = Integration.objects.create(
             provider="gitlab", name="Gitlab", external_id="gitlab:1"
         )
@@ -24,83 +25,88 @@ class OrganizationIntegrationDetailsTest(APITestCase):
             external_id="base_id",
             data={},
         )
-        self.integration.add_organization(self.org, self.user, default_auth_id=self.identity.id)
+        self.integration.add_organization(
+            self.organization, self.user, default_auth_id=self.identity.id
+        )
 
         self.repo = Repository.objects.create(
             provider="gitlab",
             name="getsentry/sentry",
-            organization_id=self.org.id,
+            organization_id=self.organization.id,
             integration_id=self.integration.id,
         )
 
-        self.path = f"/api/0/organizations/{self.org.slug}/integrations/{self.integration.id}/"
 
+class OrganizationIntegrationDetailsGetTest(OrganizationIntegrationDetailsTest):
     def test_simple(self):
-        response = self.client.get(self.path, format="json")
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(self.organization.slug, self.integration.id)
         assert response.data["id"] == str(self.integration.id)
+
+
+class OrganizationIntegrationDetailsPostTest(OrganizationIntegrationDetailsTest):
+    method = "post"
+
+    def test_update_config(self):
+        config = {"setting": "new_value", "setting2": "baz"}
+        self.get_success_response(self.organization.slug, self.integration.id, **config)
+
+        org_integration = OrganizationIntegration.objects.get(
+            integration=self.integration, organization=self.organization
+        )
+
+        assert org_integration.config == config
+
+
+class OrganizationIntegrationDetailsDeleteTest(OrganizationIntegrationDetailsTest):
+    method = "delete"
 
     def test_removal(self):
         with self.tasks():
-            response = self.client.delete(self.path, format="json")
-
-            assert response.status_code == 204, response.content
+            self.get_success_response(self.organization.slug, self.integration.id)
             assert Integration.objects.filter(id=self.integration.id).exists()
 
             # Ensure Organization integrations are removed
             assert not OrganizationIntegration.objects.filter(
-                integration=self.integration, organization=self.org
+                integration=self.integration, organization=self.organization
             ).exists()
             assert not Identity.objects.filter(user=self.user).exists()
 
             # make sure repo is dissociated from integration
             assert Repository.objects.get(id=self.repo.id).integration_id is None
 
-    def test_update_config(self):
-        config = {"setting": "new_value", "setting2": "baz"}
-
-        response = self.client.post(self.path, format="json", data=config)
-
-        assert response.status_code == 200, response.content
-
-        org_integration = OrganizationIntegration.objects.get(
-            integration=self.integration, organization=self.org
-        )
-
-        assert org_integration.config == config
-
     def test_removal_default_identity_already_removed(self):
         with self.tasks():
             self.identity.delete()
-            response = self.client.delete(self.path, format="json")
+            self.get_success_response(self.organization.slug, self.integration.id)
 
-            assert response.status_code == 204, response.content
             assert Integration.objects.filter(id=self.integration.id).exists()
 
             # Ensure Organization integrations are removed
             assert not OrganizationIntegration.objects.filter(
-                integration=self.integration, organization=self.org
+                integration=self.integration, organization=self.organization
             ).exists()
 
-    def test_no_access_put_request(self):
-        data = {"name": "Example Name"}
 
-        response = self.client.put(self.path, format="json", data=data)
-        assert response.status_code == 404
+class OrganizationIntegrationDetailsPutTest(OrganizationIntegrationDetailsTest):
+    method = "put"
+
+    def test_no_access_put_request(self):
+        self.get_error_response(
+            self.organization.slug, self.integration.id, **{"name": "Example Name"}, status_code=404
+        )
 
     @with_feature("organizations:integrations-custom-scm")
     def test_valid_put_request(self):
         integration = Integration.objects.create(
             provider="custom_scm", name="A Name", external_id="1232948573948579127"
         )
-        integration.add_organization(self.org, self.user)
-        path = f"/api/0/organizations/{self.org.slug}/integrations/{integration.id}/"
+        integration.add_organization(self.organization, self.user)
 
-        data = {"name": "New Name", "domain": "https://example.com/"}
-
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(
+            self.organization.slug,
+            integration.id,
+            **{"name": "New Name", "domain": "https://example.com/"},
+        )
 
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "New Name"
@@ -111,27 +117,22 @@ class OrganizationIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(
             provider="custom_scm", name="A Name", external_id="1232948573948579127"
         )
-        integration.add_organization(self.org, self.user)
-        path = f"/api/0/organizations/{self.org.slug}/integrations/{integration.id}/"
+        integration.add_organization(self.organization, self.user)
 
-        data = {"domain": "https://example.com/"}
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(
+            self.organization.slug, integration.id, **{"domain": "https://example.com/"}
+        )
 
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "A Name"
         assert updated.metadata["domain_name"] == "https://example.com/"
 
-        data = {"name": "Newness"}
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(self.organization.slug, integration.id, **{"name": "Newness"})
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "Newness"
         assert updated.metadata["domain_name"] == "https://example.com/"
 
-        data = {"domain": ""}
-        response = self.client.put(path, format="json", data=data)
-        assert response.status_code == 200
+        self.get_success_response(self.organization.slug, integration.id, **{"domain": ""})
         updated = Integration.objects.get(id=integration.id)
         assert updated.name == "Newness"
         assert updated.metadata["domain_name"] == ""

--- a/tests/sentry/integrations/slack/test_uninstall.py
+++ b/tests/sentry/integrations/slack/test_uninstall.py
@@ -1,0 +1,137 @@
+from typing import Optional
+
+from sentry.models import (
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    NotificationSetting,
+    Organization,
+    OrganizationIntegration,
+    Project,
+    User,
+)
+from sentry.notifications.helpers import NOTIFICATION_SETTING_DEFAULTS
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders
+
+
+class SlackUninstallTest(APITestCase):
+    """TODO(mgaeta): Extract the endpoint's DELETE logic to a helper and use it instead of API."""
+
+    endpoint = "sentry-api-0-organization-integration-details"
+    method = "delete"
+
+    def setUp(self) -> None:
+        self.integration = self.create_integration(self.organization, "TXXXXXXX1")
+        self.login_as(self.user)
+
+    def create_integration(self, organization: Organization, external_id: str):
+        integration = Integration.objects.create(
+            provider="slack",
+            name="Team A",
+            external_id=external_id,
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
+        )
+        integration.add_organization(organization)
+
+        idp = IdentityProvider.objects.create(type="slack", external_id=external_id, config={})
+        Identity.objects.create(
+            external_id="UXXXXXXX1",
+            idp=idp,
+            user=self.user,
+            status=IdentityStatus.VALID,
+            scopes=[],
+        )
+        return integration
+
+    def uninstall(self) -> None:
+        assert OrganizationIntegration.objects.filter(
+            integration=self.integration, organization=self.organization
+        ).exists()
+
+        with self.tasks():
+            self.get_success_response(self.organization.slug, self.integration.id)
+
+        assert Integration.objects.filter(id=self.integration.id).exists()
+
+        assert not OrganizationIntegration.objects.filter(
+            integration=self.integration, organization=self.organization
+        ).exists()
+
+    def get_setting(
+        self, user: User, provider: ExternalProviders, parent: Optional[Project] = None
+    ) -> NotificationSettingOptionValues:
+        type = NotificationSettingTypes.ISSUE_ALERTS
+        parent_specific_setting = NotificationSetting.objects.get_settings(
+            provider=provider, type=type, user=user, project=parent
+        )
+        if parent_specific_setting != NotificationSettingOptionValues.DEFAULT:
+            return parent_specific_setting
+        parent_independent_setting = NotificationSetting.objects.get_settings(
+            provider=provider, type=type, user=user
+        )
+        if parent_independent_setting != NotificationSettingOptionValues.DEFAULT:
+            return parent_independent_setting
+
+        return NOTIFICATION_SETTING_DEFAULTS[provider][type]
+
+    def assert_settings(
+        self, provider: ExternalProviders, value: NotificationSettingOptionValues
+    ) -> None:
+        assert self.get_setting(self.user, provider) == value
+        assert self.get_setting(self.user, provider, parent=self.project) == value
+
+    def set_setting(
+        self, provider: ExternalProviders, value: NotificationSettingOptionValues
+    ) -> None:
+        type = NotificationSettingTypes.ISSUE_ALERTS
+        NotificationSetting.objects.update_settings(provider, type, value, user=self.user)
+        NotificationSetting.objects.update_settings(
+            provider, type, value, user=self.user, project=self.project
+        )
+
+    def test_uninstall_email_only(self):
+        self.uninstall()
+
+        self.assert_settings(ExternalProviders.EMAIL, NotificationSettingOptionValues.ALWAYS)
+        self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.NEVER)
+
+    def test_uninstall_slack_and_email(self):
+        self.set_setting(ExternalProviders.SLACK, NotificationSettingOptionValues.ALWAYS)
+
+        self.uninstall()
+
+        self.assert_settings(ExternalProviders.EMAIL, NotificationSettingOptionValues.ALWAYS)
+        self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.NEVER)
+
+    def test_uninstall_slack_only(self):
+        self.set_setting(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
+        self.set_setting(ExternalProviders.SLACK, NotificationSettingOptionValues.ALWAYS)
+
+        self.uninstall()
+
+        self.assert_settings(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
+        self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.NEVER)
+
+    def test_uninstall_with_multiple_organizations(self):
+        organization = self.create_organization(owner=self.user)
+        integration = self.create_integration(organization, "TXXXXXXX2")
+
+        self.set_setting(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
+        self.set_setting(ExternalProviders.SLACK, NotificationSettingOptionValues.ALWAYS)
+
+        self.uninstall()
+
+        # No changes to second organization.
+        assert Integration.objects.filter(id=integration.id).exists()
+        assert OrganizationIntegration.objects.filter(
+            integration=integration, organization=organization
+        ).exists()
+
+        self.assert_settings(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
+        self.assert_settings(ExternalProviders.SLACK, NotificationSettingOptionValues.ALWAYS)

--- a/tests/sentry/integrations/slack/test_uninstall.py
+++ b/tests/sentry/integrations/slack/test_uninstall.py
@@ -1,16 +1,6 @@
 from typing import Optional
 
-from sentry.models import (
-    Identity,
-    IdentityProvider,
-    IdentityStatus,
-    Integration,
-    NotificationSetting,
-    Organization,
-    OrganizationIntegration,
-    Project,
-    User,
-)
+from sentry.models import Integration, NotificationSetting, OrganizationIntegration, Project, User
 from sentry.notifications.helpers import NOTIFICATION_SETTING_DEFAULTS
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import APITestCase
@@ -24,30 +14,8 @@ class SlackUninstallTest(APITestCase):
     method = "delete"
 
     def setUp(self) -> None:
-        self.integration = self.create_integration(self.organization, "TXXXXXXX1")
+        self.integration = self.create_integration(self.organization, ExternalProviders.SLACK)
         self.login_as(self.user)
-
-    def create_integration(self, organization: Organization, external_id: str):
-        integration = Integration.objects.create(
-            provider="slack",
-            name="Team A",
-            external_id=external_id,
-            metadata={
-                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-                "installation_type": "born_as_bot",
-            },
-        )
-        integration.add_organization(organization)
-
-        idp = IdentityProvider.objects.create(type="slack", external_id=external_id, config={})
-        Identity.objects.create(
-            external_id="UXXXXXXX1",
-            idp=idp,
-            user=self.user,
-            status=IdentityStatus.VALID,
-            scopes=[],
-        )
-        return integration
 
     def uninstall(self) -> None:
         assert OrganizationIntegration.objects.filter(
@@ -120,7 +88,7 @@ class SlackUninstallTest(APITestCase):
 
     def test_uninstall_with_multiple_organizations(self):
         organization = self.create_organization(owner=self.user)
-        integration = self.create_integration(organization, "TXXXXXXX2")
+        integration = self.create_integration(organization, ExternalProviders.SLACK, "TXXXXXXX2")
 
         self.set_setting(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
         self.set_setting(ExternalProviders.SLACK, NotificationSettingOptionValues.ALWAYS)

--- a/tests/sentry/integrations/slack/test_uninstall.py
+++ b/tests/sentry/integrations/slack/test_uninstall.py
@@ -14,7 +14,7 @@ class SlackUninstallTest(APITestCase):
     method = "delete"
 
     def setUp(self) -> None:
-        self.integration = self.create_integration(self.organization, ExternalProviders.SLACK)
+        self.integration = self.create_slack_integration(self.organization)
         self.login_as(self.user)
 
     def uninstall(self) -> None:
@@ -88,7 +88,7 @@ class SlackUninstallTest(APITestCase):
 
     def test_uninstall_with_multiple_organizations(self):
         organization = self.create_organization(owner=self.user)
-        integration = self.create_integration(organization, ExternalProviders.SLACK, "TXXXXXXX2")
+        integration = self.create_slack_integration(organization, "TXXXXXXX2")
 
         self.set_setting(ExternalProviders.EMAIL, NotificationSettingOptionValues.NEVER)
         self.set_setting(ExternalProviders.SLACK, NotificationSettingOptionValues.ALWAYS)


### PR DESCRIPTION
When a user uninstalls Slack for their organization, we should turn _off_ all of the parent-specific Slack notification settings for all users in the organization. If an affected user had only one organization with Slack installed, also delete their parent-independent Slack notification settings.