### PR TITLE
ref(js): Invert Styled exports with Base* wrapped components

### DIFF
--- a/static/app/components/events/eventMessage.tsx
+++ b/static/app/components/events/eventMessage.tsx
@@ -15,7 +15,7 @@ type Props = {
   hasGuideAnchor?: boolean;
 };
 
-const EventMessage = ({
+const BaseEventMessage = ({
   className,
   level,
   levelIndicatorSize,
@@ -35,7 +35,7 @@ const EventMessage = ({
   </div>
 );
 
-const StyledEventMessage = styled(EventMessage)`
+const EventMessage = styled(BaseEventMessage)`
   display: flex;
   align-items: center;
   position: relative;
@@ -53,4 +53,4 @@ const Message = styled('span')`
   max-height: 38px;
 `;
 
-export default StyledEventMessage;
+export default EventMessage;

--- a/static/app/components/events/rrwebReplayer/index.tsx
+++ b/static/app/components/events/rrwebReplayer/index.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 
-import RRWebReplayer from './rrWebReplayer';
+import BaseRRWebReplayer from './rrWebReplayer';
 
-const StyledRRWebReplayer = styled(RRWebReplayer)`
+const RRWebReplayer = styled(BaseRRWebReplayer)`
   .rr-player {
     width: auto !important;
   }
@@ -192,4 +192,4 @@ const StyledRRWebReplayer = styled(RRWebReplayer)`
   }
 `;
 
-export default StyledRRWebReplayer;
+export default RRWebReplayer;

--- a/static/app/components/events/rrwebReplayer/rrWebReplayer.tsx
+++ b/static/app/components/events/rrwebReplayer/rrWebReplayer.tsx
@@ -9,7 +9,7 @@ type Props = {
   className?: string;
 };
 
-class RRWebReplayer extends Component<Props> {
+class BaseRRWebReplayer extends Component<Props> {
   componentDidMount() {
     this.rrwebPlayer();
   }
@@ -54,4 +54,4 @@ class RRWebReplayer extends Component<Props> {
   }
 }
 
-export default RRWebReplayer;
+export default BaseRRWebReplayer;

--- a/static/app/components/featureBadge.tsx
+++ b/static/app/components/featureBadge.tsx
@@ -31,7 +31,7 @@ const labels = {
   new: t('new'),
 };
 
-const FeatureBadge = ({
+const BaseFeatureBadge = ({
   type,
   variant = 'badge',
   title,
@@ -55,7 +55,7 @@ const StyledTag = styled(Tag)`
   padding: 3px ${space(0.75)};
 `;
 
-const StyledFeatureBadge = styled(withTheme(FeatureBadge))`
+const FeatureBadge = styled(withTheme(BaseFeatureBadge))`
   display: inline-flex;
   align-items: center;
   margin-left: ${space(0.75)};
@@ -63,4 +63,4 @@ const StyledFeatureBadge = styled(withTheme(FeatureBadge))`
   top: -1px;
 `;
 
-export default StyledFeatureBadge;
+export default FeatureBadge;

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -13,7 +13,7 @@ type Props = {
   className?: string;
 };
 
-function Footer({className}: Props) {
+function BaseFooter({className}: Props) {
   const config = ConfigStore.getConfig();
   return (
     <footer className={className}>
@@ -101,7 +101,7 @@ const Build = styled('span')`
   margin-left: ${space(1)};
 `;
 
-const StyledFooter = styled(Footer)`
+const Footer = styled(BaseFooter)`
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   color: ${p => p.theme.subText};
@@ -114,4 +114,4 @@ const StyledFooter = styled(Footer)`
   }
 `;
 
-export default StyledFooter;
+export default Footer;

--- a/static/app/components/scoreBar.tsx
+++ b/static/app/components/scoreBar.tsx
@@ -13,7 +13,7 @@ type Props = {
   vertical?: boolean;
 };
 
-const ScoreBar = ({
+const BaseScoreBar = ({
   score,
   className,
   vertical,
@@ -49,7 +49,7 @@ const ScoreBar = ({
   );
 };
 
-const StyledScoreBar = styled(ScoreBar)`
+const ScoreBar = styled(BaseScoreBar)`
   display: flex;
 
   ${p =>
@@ -78,4 +78,4 @@ const Bar = styled('div')<BarProps>`
   height: ${p => (!p.vertical ? p.size : p.thickness)}px;
 `;
 
-export default StyledScoreBar;
+export default ScoreBar;

--- a/static/app/components/similarSpectrum.tsx
+++ b/static/app/components/similarSpectrum.tsx
@@ -6,21 +6,19 @@ type Props = {
   className?: string;
 };
 
-function SimilarSpectrum({className}: Props) {
-  return (
-    <div className={className}>
-      <span>{t('Similar')}</span>
-      <SpectrumItem colorIndex={4} />
-      <SpectrumItem colorIndex={3} />
-      <SpectrumItem colorIndex={2} />
-      <SpectrumItem colorIndex={1} />
-      <SpectrumItem colorIndex={0} />
-      <span>{t('Not Similar')}</span>
-    </div>
-  );
-}
+const BaseSimilarSpectrum = ({className}: Props) => (
+  <div className={className}>
+    <span>{t('Similar')}</span>
+    <SpectrumItem colorIndex={4} />
+    <SpectrumItem colorIndex={3} />
+    <SpectrumItem colorIndex={2} />
+    <SpectrumItem colorIndex={1} />
+    <SpectrumItem colorIndex={0} />
+    <span>{t('Not Similar')}</span>
+  </div>
+);
 
-const StyledSimilarSpectrum = styled(SimilarSpectrum)`
+const SimilarSpectrum = styled(BaseSimilarSpectrum)`
   display: flex;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
@@ -36,4 +34,4 @@ const SpectrumItem = styled('span')<ItemProps>`
   ${p => `background-color: ${p.theme.similarity.colors[p.colorIndex]};`};
 `;
 
-export default StyledSimilarSpectrum;
+export default SimilarSpectrum;


### PR DESCRIPTION
Exports the component without a `Styled` prefix, and wraps Base* components instead.