### PR TITLE
ref(trends): Remove jsx from ./utils

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -8,6 +8,7 @@ import Button from 'app/components/button';
 import {HeaderTitleLegend} from 'app/components/charts/styles';
 import Count from 'app/components/count';
 import DropdownLink from 'app/components/dropdownLink';
+import Duration from 'app/components/duration';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
@@ -18,7 +19,7 @@ import {Panel} from 'app/components/panels';
 import QuestionTooltip from 'app/components/questionTooltip';
 import Radio from 'app/components/radio';
 import Tooltip from 'app/components/tooltip';
-import {IconEllipsis} from 'app/icons';
+import {IconArrow, IconEllipsis} from 'app/icons';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -51,7 +52,6 @@ import {
   getTrendProjectId,
   modifyTrendView,
   normalizeTrends,
-  StyledIconArrow,
   transformDeltaSpread,
   transformValueDelta,
   trendCursorNames,
@@ -479,23 +479,37 @@ function TrendsListItem(props: TrendsListItemProps) {
         <CompareDurations {...props} />
       </ItemTransactionDurationChange>
       <ItemTransactionStatus color={color}>
-        <Fragment>
-          {transformValueDelta(transaction.trend_difference, trendChangeType)}
-        </Fragment>
+        <ValueDelta {...props} />
       </ItemTransactionStatus>
     </ListItemContainer>
   );
 }
 
-type CompareLinkProps = TrendsListItemProps & {};
-
-const CompareDurations = (props: CompareLinkProps) => {
-  const {transaction} = props;
+const CompareDurations = ({transaction}: TrendsListItemProps) => {
+  const {fromSeconds, toSeconds, showDigits} = transformDeltaSpread(
+    transaction.aggregate_range_1,
+    transaction.aggregate_range_2
+  );
 
   return (
     <DurationChange>
-      {transformDeltaSpread(transaction.aggregate_range_1, transaction.aggregate_range_2)}
+      <Duration seconds={fromSeconds} fixedDigits={showDigits ? 1 : 0} abbreviation />
+      <StyledIconArrow direction="right" size="xs" />
+      <Duration seconds={toSeconds} fixedDigits={showDigits ? 1 : 0} abbreviation />
     </DurationChange>
+  );
+};
+
+const ValueDelta = ({transaction, trendChangeType}: TrendsListItemProps) => {
+  const {seconds, fixedDigits, changeLabel} = transformValueDelta(
+    transaction.trend_difference,
+    trendChangeType
+  );
+
+  return (
+    <span>
+      <Duration seconds={seconds} fixedDigits={fixedDigits} abbreviation /> {changeLabel}
+    </span>
   );
 };
 
@@ -609,6 +623,10 @@ const TooltipContent = styled('div')`
   display: flex;
   flex-direction: column;
   align-items: center;
+`;
+
+const StyledIconArrow = styled(IconArrow)`
+  margin: 0 ${space(1)};
 `;
 
 export default withApi(withProjects(withOrganization(ChangedTransactions)));

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -1,13 +1,9 @@
-import styled from '@emotion/styled';
 import {ASAP} from 'downsample/methods/ASAP';
 import {Location} from 'history';
 import moment from 'moment';
 
 import {getInterval} from 'app/components/charts/utils';
-import Duration from 'app/components/duration';
-import {IconArrow} from 'app/icons';
 import {t} from 'app/locale';
-import space from 'app/styles/space';
 import {Project} from 'app/types';
 import {Series, SeriesDataUnit} from 'app/types/echarts';
 import EventView from 'app/utils/discover/eventView';
@@ -179,13 +175,7 @@ export function transformDeltaSpread(from: number, to: number) {
 
   const showDigits = from > 1000 || to > 1000 || from < 10 || to < 10; // Show digits consistently if either has them
 
-  return (
-    <span>
-      <Duration seconds={fromSeconds} fixedDigits={showDigits ? 1 : 0} abbreviation />
-      <StyledIconArrow direction="right" size="xs" />
-      <Duration seconds={toSeconds} fixedDigits={showDigits ? 1 : 0} abbreviation />
-    </span>
-  );
+  return {fromSeconds, toSeconds, showDigits};
 }
 
 export function getTrendProjectId(
@@ -272,11 +262,8 @@ export function transformValueDelta(value: number, trendType: TrendChangeType) {
   const seconds = absoluteValue / 1000;
 
   const fixedDigits = absoluteValue > 1000 || absoluteValue < 10 ? 1 : 0;
-  return (
-    <span>
-      <Duration seconds={seconds} fixedDigits={fixedDigits} abbreviation /> {changeLabel}
-    </span>
-  );
+
+  return {seconds, fixedDigits, changeLabel};
 }
 
 /**
@@ -390,7 +377,3 @@ export function transformEventStatsSmoothed(data?: Series[], seriesName?: string
     smoothedResults,
   };
 }
-
-export const StyledIconArrow = styled(IconArrow)`
-  margin: 0 ${space(1)};
-`;


### PR DESCRIPTION
It's a bit unconventional to have a `utils` module export functions that return React Nodes.

This moves the rendering into the only place these functions are used, but keeps the business calculations in there