### PR TITLE
fix(email): Fix bug that sent emails to deleted emails

### DIFF
--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -21,8 +21,10 @@ from sentry.models import (
     InviteStatus,
     OrganizationMember,
     OrganizationMemberTeam,
+    Project,
     Team,
     TeamStatus,
+    UserOption,
 )
 from sentry.utils import metrics, ratelimits
 
@@ -277,6 +279,15 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
             AuthIdentity.objects.filter(
                 user=om.user, auth_provider__organization=organization
             ).delete()
+
+            # Delete instances of `UserOption` that are scoped to the projects within the
+            # organization when corresponding member is removed from org
+            proj_list = Project.objects.filter(organization=organization).values_list(
+                "id", flat=True
+            )
+            uo_list = UserOption.objects.filter(project_id__in=proj_list, key="mail:email")
+            for uo in uo_list:
+                uo.delete()
 
             om.delete()
 

--- a/src/sentry/api/endpoints/organization_member_details.py
+++ b/src/sentry/api/endpoints/organization_member_details.py
@@ -285,7 +285,9 @@ class OrganizationMemberDetailsEndpoint(OrganizationEndpoint):
             proj_list = Project.objects.filter(organization=organization).values_list(
                 "id", flat=True
             )
-            uo_list = UserOption.objects.filter(project_id__in=proj_list, key="mail:email")
+            uo_list = UserOption.objects.filter(
+                user=om.user, project_id__in=proj_list, key="mail:email"
+            )
             for uo in uo_list:
                 uo.delete()
 

--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -213,6 +213,9 @@ class UserEmailsEndpoint(UserEndpoint):
         email = validator.validated_data["email"]
         primary_email = UserEmail.get_primary_email(user)
         del_email = UserEmail.objects.filter(user=user, email__iexact=email).first()
+        del_useroption_email_list = UserOption.objects.filter(
+            user=user, key="mail:email", value=email
+        )
 
         # Don't allow deleting primary email?
         if primary_email == del_email:
@@ -220,6 +223,9 @@ class UserEmailsEndpoint(UserEndpoint):
 
         if del_email:
             del_email.delete()
+
+        for useroption in del_useroption_email_list:
+            useroption.delete()
 
         logger.info(
             "user.email.remove",

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -21,7 +21,7 @@ from django.utils.encoding import force_bytes, force_str, force_text
 
 from sentry import options
 from sentry.logging import LoggingFormat
-from sentry.models import Activity, Group, GroupEmailThread, Project, User, UserOption
+from sentry.models import Activity, Group, GroupEmailThread, Project, User, UserEmail, UserOption
 from sentry.utils import metrics
 from sentry.utils.compat import map
 from sentry.utils.safe import safe_execute
@@ -168,8 +168,12 @@ def get_email_addresses(user_ids: Iterable[int], project: Project = None) -> Map
     if project:
         queryset = UserOption.objects.filter(project=project, user__in=pending, key="mail:email")
         for option in (o for o in queryset if o.value and not is_fake_email(o.value)):
-            results[option.user_id] = option.value
-            pending.discard(option.user_id)
+            if len(UserEmail.objects.filter(user=option.user, email=option.value)) > 0:
+                results[option.user_id] = option.value
+                pending.discard(option.user_id)
+            else:
+                pending.discard(option.user_id)
+                option.delete()
 
     if pending:
         queryset = User.objects.filter(pk__in=pending, is_active=True)

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -168,7 +168,7 @@ def get_email_addresses(user_ids: Iterable[int], project: Project = None) -> Map
     if project:
         queryset = UserOption.objects.filter(project=project, user__in=pending, key="mail:email")
         for option in (o for o in queryset if o.value and not is_fake_email(o.value)):
-            if len(UserEmail.objects.filter(user=option.user, email=option.value)) > 0:
+            if UserEmail.objects.filter(user=option.user, email=option.value).exists():
                 results[option.user_id] = option.value
                 pending.discard(option.user_id)
             else:

--- a/tests/sentry/api/endpoints/test_user_emails.py
+++ b/tests/sentry/api/endpoints/test_user_emails.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from sentry.models import User, UserEmail
+from sentry.models import User, UserEmail, UserOption
 from sentry.testutils import APITestCase
 
 
@@ -73,6 +73,20 @@ class UserEmailsTest(APITestCase):
         response = self.client.delete(self.url, data={"email": "altemail1@example.com"})
         assert response.status_code == 204, response.data
         assert not len(UserEmail.objects.filter(user=self.user, email="altemail1@example.com"))
+
+    def test_remove_email_also_deletes_user_option_with_same_email(self):
+        mail_to_del = "altemail1@example.com"
+        UserEmail.objects.create(user=self.user, email=mail_to_del)
+        UserOption.objects.create(
+            user=self.user, project=self.project, key="mail:email", value=mail_to_del
+        )
+
+        response = self.client.delete(self.url, data={"email": mail_to_del})
+        assert response.status_code == 204, response.data
+        assert not len(UserEmail.objects.filter(user=self.user, email=mail_to_del))
+        assert not len(
+            UserOption.objects.filter(user=self.user, key="mail:email", value=mail_to_del)
+        )
 
     def test_cant_remove_primary_email(self):
         response = self.client.delete(self.url, data={"email": "foo@example.com"})

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -24,7 +24,7 @@ from sentry.incidents.models import (
     IncidentStatusMethod,
     TriggerStatus,
 )
-from sentry.models import Integration, NotificationSetting, PagerDutyService, UserOption
+from sentry.models import Integration, NotificationSetting, PagerDutyService, UserEmail, UserOption
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
@@ -113,9 +113,14 @@ class EmailActionHandlerGetTargetsTest(TestCase):
         assert handler.get_targets() == [(self.user.id, new_email)]
 
     def test_team_email_routing(self):
-        new_user = self.create_user()
-
         new_email = "marcos@sentry.io"
+
+        new_user = self.create_user(new_email)
+
+        useremail = UserEmail.objects.get(email=self.user.email)
+        useremail.email = new_email
+        useremail.save()
+
         UserOption.objects.create(
             user=self.user, project=self.project, key="mail:email", value=new_email
         )

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -104,6 +104,10 @@ class EmailActionHandlerGetTargetsTest(TestCase):
             user=self.user, project=self.project, key="mail:email", value=new_email
         )
 
+        useremail = UserEmail.objects.get(email=self.user.email)
+        useremail.email = new_email
+        useremail.save()
+
         action = self.create_alert_rule_trigger_action(
             target_type=AlertRuleTriggerAction.TargetType.USER,
             target_identifier=str(self.user.id),

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -26,6 +26,7 @@ from sentry.models import (
     Repository,
     Rule,
     User,
+    UserEmail,
     UserOption,
     UserReport,
 )
@@ -50,7 +51,7 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import mock
-from sentry.utils.email import MessageBuilder
+from sentry.utils.email import MessageBuilder, get_email_addresses
 from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 
 
@@ -297,6 +298,56 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
         self.assertEquals(notification.project, self.project)
         self.assertEquals(notification.get_reference(), group)
         assert notification.get_subject() == "BAR-1 - hello world"
+
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_email_notification_is_not_sent_to_deleted_email(self, mock_func):
+        """
+        Test that ensures if we still have some stale emails in UserOption, then upon attempting
+        to send an email notification to those emails, these stale `UserOption` instances are
+        deleted
+        """
+        # Initial Creation
+        user = self.create_user(email="foo@bar.dodo", is_active=True)
+        self.create_member(user=user, organization=self.organization, teams=[self.team])
+
+        UserOption.objects.create(
+            user=user, key="mail:email", value="foo@bar.dodo", project=self.project
+        )
+
+        # New secondary email is created
+        useremail = UserEmail.objects.create(user=user, email="ahmed@ahmed.io", is_verified=True)
+
+        # Set secondary email to be primary
+        user.email = useremail.email
+        user.save()
+
+        # Delete first email
+        old_useremail = UserEmail.objects.get(email="foo@bar.dodo")
+        old_useremail.delete()
+
+        event_manager = EventManager({"message": "hello world", "level": "error"})
+        event_manager.normalize()
+        event_data = event_manager.get_data()
+        event_type = get_event_type(event_data)
+        event_data["type"] = event_type.key
+        event_data["metadata"] = event_type.get_metadata(event_data)
+
+        event = event_manager.save(self.project.id)
+
+        with self.tasks():
+            AlertRuleNotification(Notification(event=event), ActionTargetType.ISSUE_OWNERS).send()
+
+        assert mock_func.call_count == 1
+
+        args, kwargs = mock_func.call_args
+        notification = args[1]
+
+        user_ids = []
+        for user in list(notification.get_participants().values())[0]:
+            user_ids.append(user.id)
+
+        assert get_email_addresses(user_ids, self.project)[1] == "ahmed@ahmed.io"
+        assert not len(UserOption.objects.filter(key="mail:email", value="foo@bar.dodo"))
 
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_multiline_error(self, mock_func):

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -345,8 +345,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
         user_ids = []
         for user in list(notification.get_participants().values())[0]:
             user_ids.append(user.id)
-
-        assert get_email_addresses(user_ids, self.project)[1] == "ahmed@ahmed.io"
+        assert list(get_email_addresses(user_ids, self.project).values())[1] == "ahmed@ahmed.io"
         assert not len(UserOption.objects.filter(key="mail:email", value="foo@bar.dodo"))
 
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)


### PR DESCRIPTION
This PR:
- Adds functionality that deletes `UserOption` instances of key `mail:email` when the related email is deleted through `UserEmailsEndpoint`. 
- Adds functionality that checks when sending an email in `get_email_addresses` if the `UserOption` key `mail:email` email was deleted, ignores it and deletes the `UserOption` instance
- Adds functionality that deletes `UserOption` instances of key key `mail:email` for all projects within an org when that user is removed from the org 

Ref: https://getsentry.atlassian.net/browse/ISSUE-1267?atlOrigin=eyJpIjoiNzE2NGYwNjY3MTA5NDIyOGFhYTM2ZTlkMjM4OWIwZDUiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

<img width="709" alt="Screenshot 2021-08-27 at 14 30 20" src="https://user-images.githubusercontent.com/10855986/131127605-0abedb4e-aaf0-484c-b784-e2789003c88c.png">
