### PR TITLE
fix(workflow): Fixing bugs with existing 1m rules and 0 session counts

### DIFF
--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -232,7 +232,7 @@ class EventFrequencyPercentConditionTestCase(
                 project_id=self.project.id,
             )
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_five_minutes_with_events(self):
         self._make_sessions(60, 5)
         data = {"interval": "5m", "value": 39}
@@ -240,7 +240,7 @@ class EventFrequencyPercentConditionTestCase(
         data = {"interval": "5m", "value": 41}
         self._run_test(data=data, minutes=5, passes=False)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_ten_minutes_with_events(self):
         self._make_sessions(60, 10)
         data = {"interval": "10m", "value": 49}
@@ -248,7 +248,7 @@ class EventFrequencyPercentConditionTestCase(
         data = {"interval": "10m", "value": 51}
         self._run_test(data=data, minutes=10, passes=False)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_thirty_minutes_with_events(self):
         self._make_sessions(60, 30)
         data = {"interval": "30m", "value": 49}
@@ -256,7 +256,7 @@ class EventFrequencyPercentConditionTestCase(
         data = {"interval": "30m", "value": 51}
         self._run_test(data=data, minutes=30, passes=False)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_one_hour_with_events(self):
         self._make_sessions(60, 60)
         data = {"interval": "1h", "value": 49}
@@ -264,25 +264,25 @@ class EventFrequencyPercentConditionTestCase(
         data = {"interval": "1h", "value": 51}
         self._run_test(data=data, minutes=60, passes=False)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_five_minutes_no_events(self):
         self._make_sessions(60, 5)
         data = {"interval": "5m", "value": 39}
         self._run_test(data=data, minutes=5, passes=True, add_events=True)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_ten_minutes_no_events(self):
         self._make_sessions(60, 10)
         data = {"interval": "10m", "value": 49}
         self._run_test(data=data, minutes=10, passes=True, add_events=True)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_thirty_minutes_no_events(self):
         self._make_sessions(60, 30)
         data = {"interval": "30m", "value": 49}
         self._run_test(data=data, minutes=30, passes=True, add_events=True)
 
-    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 0)
+    @patch("sentry.rules.conditions.event_frequency.MIN_SESSIONS_TO_FIRE", 1)
     def test_one_hour_no_events(self):
         self._make_sessions(60, 60)
         data = {"interval": "1h", "value": 49}


### PR DESCRIPTION
Removing the 1m option from this rule bork'd rules that had already selected it. Making it so that new rules cannot be created with the 1 min interval but the old rules will still work.

Will have to figure out what to do with the existing 1m rules (they should fall off gradually as editing them will not allow you to save with 1m again)

Fixes SENTRY-S16 and SENTRY-S17