### PR TITLE
feat(codeowners): Manage external users without access to project

### DIFF
--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2186,6 +2186,7 @@ export type CodeOwner = {
     missing_external_users: string[];
     missing_user_emails: string[];
     teams_without_access: string[];
+    users_without_access: string[];
   };
 };
 

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -219,7 +219,7 @@ tags.sku_class:enterprise #enterprise`;
               return errMessageListComponent(
                 `The following users are not on a team that has access to the project: ${project.slug}`,
                 values,
-                _ => `/settings/${organization.slug}/members/`,
+                email => `/settings/${organization.slug}/members/?query=${email}`,
                 _ => `Configure Member Settings`
               );
             default:

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -210,8 +210,17 @@ tags.sku_class:enterprise #enterprise`;
               return errMessageListComponent(
                 `The following team do not have access to the project: ${project.slug}`,
                 values,
-                value => `/settings/${organization.slug}/teams/${value}/projects/`,
+                value =>
+                  `/settings/${organization.slug}/teams/${value.slice(1)}/projects/`,
                 value => `Configure ${value} Permissions`
+              );
+
+            case 'users_without_access':
+              return errMessageListComponent(
+                `The following users are not on a team that has access to the project: ${project.slug}`,
+                values,
+                _ => `/settings/${organization.slug}/members/`,
+                _ => `Configure Member Settings`
               );
             default:
               return null;
@@ -362,7 +371,7 @@ const CodeOwnerButton = styled(Button)`
 `;
 
 const AlertContentContainer = styled('div')`
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: 350px;
 `;
 

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -126,6 +126,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert errors["missing_external_users"] == []
         assert errors["missing_user_emails"] == []
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_empty_codeowners_text(self):
         self.data["raw"] = ""
@@ -149,6 +150,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert errors["missing_external_users"] == []
         assert errors["missing_user_emails"] == []
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_cannot_find_external_user_name_association(self):
         self.data["raw"] = "docs/*  @MeredithAnya"
@@ -165,6 +167,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert set(errors["missing_external_users"]) == {"@MeredithAnya"}
         assert errors["missing_user_emails"] == []
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_cannot_find_sentry_user_with_email(self):
         self.data["raw"] = "docs/*  someuser@sentry.io"
@@ -181,6 +184,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert errors["missing_external_users"] == []
         assert set(errors["missing_user_emails"]) == {"someuser@sentry.io"}
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_cannot_find_external_team_name_association(self):
         self.data["raw"] = "docs/*  @getsentry/frontend\nstatic/* @getsentry/frontend"
@@ -197,6 +201,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert errors["missing_external_users"] == []
         assert errors["missing_user_emails"] == []
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_cannot_find__multiple_external_name_association(self):
         self.data["raw"] = "docs/*  @AnotherUser @getsentry/frontend @getsentry/docs"
@@ -213,6 +218,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert set(errors["missing_external_users"]) == {"@AnotherUser"}
         assert errors["missing_user_emails"] == []
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_missing_code_mapping_id(self):
         self.data.pop("codeMappingId")
@@ -315,6 +321,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert errors["missing_external_users"] == []
         assert set(errors["missing_user_emails"]) == {self.user2.email}
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_multiple_codeowners_for_project(self):
         code_mapping_2 = self.create_code_mapping(stack_root="src/")
@@ -322,3 +329,27 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         with self.feature({"organizations:integrations-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201
+
+    def test_users_without_access(self):
+        user_2 = self.create_user("bar@example.com")
+        self.create_member(organization=self.organization, user=user_2, role="member")
+        team_2 = self.create_team(name="foo", organization=self.organization, members=[user_2])
+        self.create_project(organization=self.organization, teams=[team_2], slug="bass")
+        self.create_external_user(
+            user=user_2, external_name="@foobarSentry", integration=self.integration
+        )
+        self.data["raw"] = "docs/*  @foobarSentry\nstatic/* @foobarSentry"
+        with self.feature({"organizations:integrations-codeowners": True}):
+            response = self.client.post(self.url, self.data)
+        assert response.status_code == 201
+        assert response.data["raw"] == "docs/*  @foobarSentry\nstatic/* @foobarSentry"
+        assert response.data["codeMappingId"] == str(self.code_mapping.id)
+        assert response.data["provider"] == "github"
+        assert response.data["ownershipSyntax"] == ""
+
+        errors = response.data["errors"]
+        assert errors["missing_external_teams"] == []
+        assert errors["missing_external_users"] == []
+        assert errors["missing_user_emails"] == []
+        assert errors["teams_without_access"] == []
+        assert set(errors["users_without_access"]) == {user_2.email}

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -89,6 +89,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert set(errors["missing_external_users"]) == {"@AnotherUser"}
         assert errors["missing_user_emails"] == []
         assert errors["teams_without_access"] == []
+        assert errors["users_without_access"] == []
 
     def test_invalid_code_mapping_id_update(self):
         with self.feature({"organizations:integrations-codeowners": True}):


### PR DESCRIPTION
## Objective:
External Users that are not apart of teams that are a part of the project will fail CODEOWNERS sync and upload. We should handle similar to External Teams and show in the warning. This should not fail the upload/sync.

## UI:
![codeowners-alert-users-without-access](https://user-images.githubusercontent.com/10491193/131171875-42c50d9a-d232-468c-8e41-3c4d9fc39a7d.png)


## Tests:
Added integration test.