### PR TITLE
ref(deletion) Move Team deletion to ScheduledDeletion

### DIFF
--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -97,15 +97,13 @@ class TeamDetailsEndpoint(TeamEndpoint):
         Schedules a team for deletion.
 
         **Note:** Deletion happens asynchronously and therefore is not
-        immediate.  However once deletion has begun the state of a team
-        changes and will be hidden from most public views.
+        immediate. Teams will have their slug released while waiting for deletion.
         """
+        transaction_id = uuid4().hex
         updated = Team.objects.filter(id=team.id, status=TeamStatus.VISIBLE).update(
-            status=TeamStatus.PENDING_DELETION
+            slug=f"{team.slug}-{transaction_id}", status=TeamStatus.PENDING_DELETION
         )
         if updated:
-            transaction_id = uuid4().hex
-
             self.create_audit_entry(
                 request=request,
                 organization=team.organization,

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -1,4 +1,3 @@
-import logging
 from uuid import uuid4
 
 from rest_framework import serializers, status
@@ -8,10 +7,7 @@ from sentry.api.bases.team import TeamEndpoint
 from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSerializer as ModelTeamSerializer
-from sentry.models import AuditLogEntryEvent, Team, TeamStatus
-from sentry.tasks.deletion import delete_team
-
-delete_logger = logging.getLogger("sentry.deletions.api")
+from sentry.models import AuditLogEntryEvent, ScheduledDeletion, Team, TeamStatus
 
 
 class TeamSerializer(serializers.ModelSerializer):
@@ -101,7 +97,7 @@ class TeamDetailsEndpoint(TeamEndpoint):
         Schedules a team for deletion.
 
         **Note:** Deletion happens asynchronously and therefore is not
-        immediate.  However once deletion has begun the state of a project
+        immediate.  However once deletion has begun the state of a team
         changes and will be hidden from most public views.
         """
         updated = Team.objects.filter(id=team.id, status=TeamStatus.VISIBLE).update(
@@ -119,15 +115,6 @@ class TeamDetailsEndpoint(TeamEndpoint):
                 transaction_id=transaction_id,
             )
 
-            delete_team.apply_async(kwargs={"object_id": team.id, "transaction_id": transaction_id})
-
-            delete_logger.info(
-                "object.delete.queued",
-                extra={
-                    "object_id": team.id,
-                    "transaction_id": transaction_id,
-                    "model": type(team).__name__,
-                },
-            )
+            ScheduledDeletion.schedule(team, days=0, actor=request.user)
 
         return Response(status=204)

--- a/src/sentry/deletions/defaults/team.py
+++ b/src/sentry/deletions/defaults/team.py
@@ -13,3 +13,12 @@ class TeamDeletionTask(ModelDeletionTask):
         for instance in instance_list:
             if instance.status != TeamStatus.DELETION_IN_PROGRESS:
                 instance.update(status=TeamStatus.DELETION_IN_PROGRESS)
+
+    def delete_instance(self, instance):
+        from sentry.incidents.models import AlertRule
+        from sentry.models import Rule
+
+        AlertRule.objects.filter(owner_id=instance.actor_id).update(owner=None)
+        Rule.objects.filter(owner_id=instance.actor_id).update(owner=None)
+
+        super().delete_instance(instance)

--- a/src/sentry/models/scheduledeletion.py
+++ b/src/sentry/models/scheduledeletion.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import timedelta
 from uuid import uuid4
 
@@ -6,6 +7,8 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import BoundedBigIntegerField, JSONField, Model
+
+delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 def default_guid():
@@ -37,7 +40,7 @@ class ScheduledDeletion(Model):
 
     @classmethod
     def schedule(cls, instance, days=30, data=None, actor=None):
-        return cls.objects.create(
+        record = cls.objects.create(
             app_label=instance._meta.app_label,
             model_name=type(instance).__name__,
             object_id=instance.pk,
@@ -45,6 +48,15 @@ class ScheduledDeletion(Model):
             data=data or {},
             actor_id=actor.id if actor else None,
         )
+        delete_logger.info(
+            "object.delete.queued",
+            extra={
+                "object_id": instance.id,
+                "transaction_id": record.guid,
+                "model": type(instance).__name__,
+            },
+        )
+        return record
 
     def get_model(self):
         return apps.get_model(self.app_label, self.model_name)

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -156,6 +156,7 @@ def delete_organization(object_id, transaction_id=None, actor_id=None, **kwargs)
 )
 @retry(exclude=(DeleteAborted,))
 def delete_team(object_id, transaction_id=None, **kwargs):
+    # TODO this method is deleted and should be removed/nerfed when it is no longer enqueuing jobs.
     from sentry import deletions
     from sentry.incidents.models import AlertRule
     from sentry.models import Rule, Team, TeamStatus

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -1,8 +1,12 @@
-from typing import Optional
-
-from sentry.models import AuditLogEntry, AuditLogEntryEvent, DeletedTeam, Team, TeamStatus
+from sentry.models import (
+    AuditLogEntry,
+    AuditLogEntryEvent,
+    DeletedTeam,
+    ScheduledDeletion,
+    Team,
+    TeamStatus,
+)
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class TeamDetailsTestBase(APITestCase):
@@ -15,9 +19,7 @@ class TeamDetailsTestBase(APITestCase):
     def assert_team_status(
         self,
         team_id: int,
-        mock_delete_team,
         status: TeamStatus,
-        transaction_id: Optional[int] = None,
     ) -> None:
         team = Team.objects.get(id=team_id)
 
@@ -31,32 +33,31 @@ class TeamDetailsTestBase(APITestCase):
         if status == TeamStatus.VISIBLE:
             assert not deleted_team
             assert not audit_log_entry
-            mock_delete_team.assert_not_called()  # NOQA
+            assert not ScheduledDeletion.objects.filter(
+                model_name="Team", object_id=team.id
+            ).exists()
             return
 
-        # On spite of the name, this checks the DeletedTeam object, not the audit log
+        # In spite of the name, this checks the DeletedTeam object, not the audit log
         self.assert_valid_deleted_log(deleted_team.get(), team)
         # *this* actually checks the audit log
         assert audit_log_entry.get()
-        mock_delete_team.apply_async.assert_called_once_with(
-            kwargs={"object_id": team.id, "transaction_id": transaction_id}
-        )
+        # Ensure a scheduled deletion was made.
+        assert ScheduledDeletion.objects.filter(model_name="Team", object_id=team.id).exists()
 
-    def assert_team_deleted(self, team_id, mock_delete_team, transaction_id):
+    def assert_team_deleted(self, team_id):
         """
         Checks team status, membership in DeletedTeams table, org
         audit log, and to see that delete function has been called.
         """
-        self.assert_team_status(
-            team_id, mock_delete_team, TeamStatus.PENDING_DELETION, transaction_id
-        )
+        self.assert_team_status(team_id, TeamStatus.PENDING_DELETION)
 
-    def assert_team_not_deleted(self, team_id, mock_delete_team):
+    def assert_team_not_deleted(self, team_id):
         """
         Checks team status, membership in DeletedTeams table, org
         audit log, and to see that delete function has not been called.
         """
-        self.assert_team_status(team_id, mock_delete_team, TeamStatus.VISIBLE)
+        self.assert_team_status(team_id, TeamStatus.VISIBLE)
 
 
 class TeamDetailsTest(TeamDetailsTestBase):
@@ -85,12 +86,8 @@ class TeamUpdateTest(TeamDetailsTestBase):
 class TeamDeleteTest(TeamDetailsTestBase):
     method = "delete"
 
-    @patch("sentry.api.endpoints.team_details.uuid4")
-    @patch("sentry.api.endpoints.team_details.delete_team")
-    def test_can_remove_as_admin_in_team(self, mock_delete_team, mock_uuid4):
+    def test_can_remove_as_admin_in_team(self):
         """Admins can remove teams of which they're a part"""
-        mock_uuid4.return_value = self.get_mock_uuid()
-
         org = self.create_organization()
         team = self.create_team(organization=org)
         admin_user = self.create_user(email="foo@example.com", is_superuser=False)
@@ -102,14 +99,11 @@ class TeamDeleteTest(TeamDetailsTestBase):
         self.get_valid_response(team.organization.slug, team.slug, status_code=204)
 
         team = Team.objects.get(id=team.id)
-        self.assert_team_deleted(team.id, mock_delete_team, "abc123")
+        self.assert_team_deleted(team.id)
 
-    @patch("sentry.api.endpoints.team_details.uuid4")
-    @patch("sentry.api.endpoints.team_details.delete_team")
-    def test_remove_as_admin_not_in_team(self, mock_delete_team, mock_uuid4):
+    def test_remove_as_admin_not_in_team(self):
         """Admins can't remove teams of which they're not a part, unless
         open membership is on."""
-        mock_uuid4.return_value = self.get_mock_uuid()
 
         # an org with closed membership (byproduct of flags=0)
         org = self.create_organization(owner=self.user, flags=0)
@@ -127,17 +121,16 @@ class TeamDeleteTest(TeamDetailsTestBase):
 
         # first, try deleting the team with open membership off
         self.get_valid_response(team.organization.slug, team.slug, status_code=403)
-        self.assert_team_not_deleted(team.id, mock_delete_team)
+        self.assert_team_not_deleted(team.id)
 
         # now, with open membership on
         org.flags.allow_joinleave = True
         org.save()
 
         self.get_valid_response(team.organization.slug, team.slug, status_code=204)
-        self.assert_team_deleted(team.id, mock_delete_team, "abc123")
+        self.assert_team_deleted(team.id)
 
-    @patch("sentry.api.endpoints.team_details.delete_team")
-    def test_cannot_remove_as_member(self, mock_delete_team):
+    def test_cannot_remove_as_member(self):
         """Members can't remove teams, even if they belong to them"""
 
         org = self.create_organization(owner=self.user)
@@ -154,4 +147,4 @@ class TeamDeleteTest(TeamDetailsTestBase):
         self.login_as(member_user)
 
         self.get_valid_response(team.organization.slug, team.slug, status_code=403)
-        self.assert_team_not_deleted(team.id, mock_delete_team)
+        self.assert_team_not_deleted(team.id)

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -98,8 +98,10 @@ class TeamDeleteTest(TeamDetailsTestBase):
 
         self.get_valid_response(team.organization.slug, team.slug, status_code=204)
 
-        team = Team.objects.get(id=team.id)
+        original_slug = team.slug
+        team.refresh_from_db()
         self.assert_team_deleted(team.id)
+        assert original_slug != team.slug, "Slug should be released on delete."
 
     def test_remove_as_admin_not_in_team(self):
         """Admins can't remove teams of which they're not a part, unless

--- a/tests/sentry/deletions/test_team.py
+++ b/tests/sentry/deletions/test_team.py
@@ -1,4 +1,4 @@
-from sentry.models import Project, ProjectTeam, ScheduledDeletion, Team
+from sentry.models import Project, ProjectTeam, Rule, ScheduledDeletion, Team
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TestCase
 
@@ -21,3 +21,24 @@ class DeleteTeamTest(TestCase):
         assert Project.objects.filter(id=project1.id).exists()
         assert Project.objects.filter(id=project2.id).exists()
         assert not ProjectTeam.objects.filter(team_id=team.id).exists()
+
+    def test_alert_blanking(self):
+        team = self.create_team(name="test")
+        project = self.create_project(teams=[team], name="test1")
+        rule = Rule.objects.create(label="test rule", project=project, owner=team.actor)
+        alert_rule = self.create_alert_rule(
+            name="test alert rule", owner=team.actor.get_actor_tuple(), projects=[project]
+        )
+        deletion = ScheduledDeletion.schedule(team, days=0)
+        deletion.update(in_progress=True)
+
+        with self.tasks():
+            run_deletion(deletion.id)
+
+        assert not Team.objects.filter(id=team.id).exists()
+        assert Project.objects.filter(id=project.id).exists()
+
+        alert_rule.refresh_from_db()
+        rule.refresh_from_db()
+        assert rule.owner_id is None, "Should be blank when team is deleted."
+        assert alert_rule.owner_id is None, "Should be blank when team is deleted."


### PR DESCRIPTION
We currently have more than 0 teams that have escaped deletion. To prevent this from happening in the future, I'll be moving background deletions to the `ScheduledDeletion` system that was built in 2017 and has laid dormant since.

This new subsystem tracks work to be completed in postgres allowing us to retry failures and be more resilient to deploy based restarts.

The celery job that reads from this table has been running for many years but doing no work. Tagging workflow on this as I replicated the alert owner blanking that is present in `delete_team`.