### PR TITLE
fix(emailverification): allow users with caps to verify email

### DIFF
--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -36,6 +36,9 @@ def add_email(email, user):
     if email is None:
         raise InvalidEmailError
 
+    if UserEmail.objects.filter(user=user, email__iexact=email).exists():
+        raise DuplicateEmailError
+
     try:
         with transaction.atomic():
             new_email = UserEmail.objects.create(user=user, email=email)

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -61,7 +61,7 @@ class UserEmailsConfirmEndpoint(UserEndpoint):
         # If email is specified then try to only send one confirmation email
         try:
             email_to_send = UserEmail.objects.get(
-                user=user, email=serializer.validated_data["email"].lower().strip()
+                user=user, email__iexact=serializer.validated_data["email"].strip()
             )
         except UserEmail.DoesNotExist:
             return InvalidEmailResponse()

--- a/tests/sentry/api/endpoints/test_user_emails.py
+++ b/tests/sentry/api/endpoints/test_user_emails.py
@@ -42,6 +42,13 @@ class UserEmailsTest(APITestCase):
         response = self.client.post(self.url, data={"email": "altemail1@example.com"})
         assert response.status_code == 200, response.data
 
+    def test_cant_have_same_email_with_different_casing(self):
+        user = self.create_user(email="FOOBAR@example.com")
+        self.login_as(user=user)
+        url = reverse("sentry-api-0-user-emails", kwargs={"user_id": user.id})
+        response = self.client.post(url, data={"email": "foobar@example.com"})
+        assert response.status_code == 200, response.data
+
     def test_change_verified_secondary_to_primary(self):
         UserEmail.objects.create(user=self.user, email="altemail1@example.com", is_verified=True)
         response = self.client.put(self.url, data={"email": "altemail1@example.com"})

--- a/tests/sentry/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/api/endpoints/test_user_emails_confirm.py
@@ -20,6 +20,14 @@ class UserEmailsConfirmTest(APITestCase):
         send_confirm_email.assert_called_once_with(UserEmail.objects.get(email="bar@example.com"))
 
     @mock.patch("sentry.models.User.send_confirm_email_singular")
+    def test_can_confirm_with_uppercase(self, send_confirm_email):
+        email = UserEmail.objects.create(email="Bar@example.com", is_verified=False, user=self.user)
+        email.save()
+
+        self.get_valid_response(self.user.id, email="Bar@example.com", status_code=204)
+        send_confirm_email.assert_called_once_with(UserEmail.objects.get(email="Bar@example.com"))
+
+    @mock.patch("sentry.models.User.send_confirm_email_singular")
     def test_cant_confirm_verified_email(self, send_confirm_email):
         email = UserEmail.objects.create(email="bar@example.com", is_verified=True, user=self.user)
         email.save()


### PR DESCRIPTION
Email lowercasing isn't enforced at the DB level and users created via SAML may have an uppercase email. In email verification we were lowercasing the email which causes verification to break for these users. (They would see an `Invalid Email` error message).

- This PR switches the lowercasing to a case insensitive match (we already were using elsewhere for email matching as well). 
- We also enforces insensitivate case uniqueness while creating a secondary email

We probably want to lowercase SAML emails when they're created, but I'm unsure at this time if this would cause issues.