### PR TITLE
ref(performance): Wrap the tab pages into a shared parent component

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -64,32 +64,16 @@ class TransactionHeader extends React.Component<Props> {
     });
   }
 
-  trackVitalsTabClick = () => {
-    const {organization} = this.props;
-    trackAnalyticsEvent({
-      eventKey: 'performance_views.vitals.vitals_tab_clicked',
-      eventName: 'Performance Views: Vitals tab clicked',
-      organization_id: organization.id,
-    });
-  };
-
-  trackTagsTabClick = () => {
-    const {organization} = this.props;
-    trackAnalyticsEvent({
-      eventKey: 'performance_views.tags.tags_tab_clicked',
-      eventName: 'Performance Views: Tags tab clicked',
-      organization_id: organization.id,
-    });
-  };
-
-  trackEventsTabClick = () => {
-    const {organization} = this.props;
-    trackAnalyticsEvent({
-      eventKey: 'performance_views.events.events_tab_clicked',
-      eventName: 'Performance Views: Events tab clicked',
-      organization_id: organization.id,
-    });
-  };
+  trackTabClick =
+    ({eventKey, eventName}: {eventKey: string; eventName: string}) =>
+    () => {
+      const {organization} = this.props;
+      trackAnalyticsEvent({
+        eventKey,
+        eventName,
+        organization_id: organization.id,
+      });
+    };
 
   handleIncompatibleQuery: React.ComponentProps<
     typeof CreateAlertFromViewButton
@@ -185,7 +169,10 @@ class TransactionHeader extends React.Component<Props> {
         data-test-id="web-vitals-tab"
         to={vitalsTarget}
         isActive={() => currentTab === Tab.RealUserMonitoring}
-        onClick={this.trackVitalsTabClick}
+        onClick={this.trackTabClick({
+          eventKey: 'performance_views.vitals.vitals_tab_clicked',
+          eventName: 'Performance Views: Vitals tab clicked',
+        })}
       >
         {t('Web Vitals')}
       </ListLink>
@@ -283,7 +270,10 @@ class TransactionHeader extends React.Component<Props> {
               <ListLink
                 to={tagsTarget}
                 isActive={() => currentTab === Tab.Tags}
-                onClick={this.trackTagsTabClick}
+                onClick={this.trackTabClick({
+                  eventKey: 'performance_views.tags.tags_tab_clicked',
+                  eventName: 'Performance Views: Tags tab clicked',
+                })}
               >
                 {t('Tags')}
                 <FeatureBadge type="new" noTooltip />
@@ -293,7 +283,10 @@ class TransactionHeader extends React.Component<Props> {
               <ListLink
                 to={eventsTarget}
                 isActive={() => currentTab === Tab.Events}
-                onClick={this.trackEventsTabClick}
+                onClick={this.trackTabClick({
+                  eventKey: 'performance_views.events.events_tab_clicked',
+                  eventName: 'Performance Views: Events tab clicked',
+                })}
               >
                 {t('All Events')}
               </ListLink>

--- a/static/app/views/performance/transactionSummary/page.tsx
+++ b/static/app/views/performance/transactionSummary/page.tsx
@@ -1,0 +1,114 @@
+import {ReactNode} from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {t} from 'app/locale';
+import {PageContent} from 'app/styles/organization';
+import {GlobalSelection, Organization, Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import withOrganization from 'app/utils/withOrganization';
+import withProjects from 'app/utils/withProjects';
+
+import {getTransactionName} from '../utils';
+
+type ChildProps = {
+  location: Location;
+  organization: Organization;
+  projects: Project[];
+  transactionName: string;
+  eventView: EventView;
+};
+
+type Props = {
+  title: string;
+  location: Location;
+  organization: Organization;
+  projects: Project[];
+  selection: GlobalSelection;
+  eventView: EventView | undefined;
+  children: (props: ChildProps) => ReactNode;
+  featureFlags?: string[];
+};
+
+function Page({
+  title,
+  organization,
+  projects,
+  location,
+  eventView,
+  featureFlags,
+  children,
+}: Props) {
+  const transactionName = getTransactionName(location);
+  if (!eventView || transactionName === undefined) {
+    // If there is no transaction name, redirect to the Performance landing page
+    browserHistory.replace({
+      pathname: `/organizations/${organization.slug}/performance/`,
+      query: {
+        ...location.query,
+      },
+    });
+    return null;
+  }
+
+  const shouldForceProject = eventView.project.length === 1;
+  const forceProject = shouldForceProject
+    ? projects.find(p => parseInt(p.id, 10) === eventView.project[0])
+    : undefined;
+  const projectSlugs = eventView.project
+    .map(projectId => projects.find(p => parseInt(p.id, 10) === projectId))
+    .filter((p: Project | undefined): p is Project => p !== undefined)
+    .map(p => p.slug);
+
+  return (
+    <SentryDocumentTitle
+      title={title}
+      orgSlug={organization.slug}
+      projectSlug={forceProject?.slug}
+    >
+      <Feature
+        features={['performance-view', ...(featureFlags ?? [])]}
+        organization={organization}
+        renderDisabled={NoAccessPage}
+      >
+        <GlobalSelectionHeader
+          lockedMessageSubject={t('transaction')}
+          shouldForceProject={shouldForceProject}
+          forceProject={forceProject}
+          specificProjectSlugs={projectSlugs}
+          disableMultipleProjectSelection
+          showProjectSettingsLink
+        >
+          <StyledPageContent>
+            <LightWeightNoProjectMessage organization={organization}>
+              {children({
+                location,
+                organization,
+                projects,
+                transactionName,
+                eventView,
+              })}
+            </LightWeightNoProjectMessage>
+          </StyledPageContent>
+        </GlobalSelectionHeader>
+      </Feature>
+    </SentryDocumentTitle>
+  );
+}
+
+function NoAccessPage() {
+  return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
+}
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
+
+export default withGlobalSelection(withProjects(withOrganization(Page)));


### PR DESCRIPTION
The performance tabs share a lot of the same layouts, this refactor brings them
into a shared component.