### PR TITLE
fix(scim): move auditlog out of transaction to get member_id

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -193,19 +193,21 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                 role=result["role"],
                 inviter=request.user,
             )
-            self.create_audit_entry(
-                request=request,
-                organization_id=organization.id,
-                target_object=member.id,
-                data=member.get_audit_log_data(),
-                event=AuditLogEntryEvent.MEMBER_INVITE
-                if settings.SENTRY_ENABLE_INVITES
-                else AuditLogEntryEvent.MEMBER_ADD,
-            )
+
             # TODO: are invite tokens needed for SAML orgs?
             if settings.SENTRY_ENABLE_INVITES:
                 member.token = member.generate_token()
             member.save()
+
+        self.create_audit_entry(
+            request=request,
+            organization_id=organization.id,
+            target_object=member.id,
+            data=member.get_audit_log_data(),
+            event=AuditLogEntryEvent.MEMBER_INVITE
+            if settings.SENTRY_ENABLE_INVITES
+            else AuditLogEntryEvent.MEMBER_ADD,
+        )
 
         if settings.SENTRY_ENABLE_INVITES and result.get("sendInvite"):
             member.send_invite_email()

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from sentry.models import OrganizationMember
+from sentry.models.auditlogentry import AuditLogEntry, AuditLogEntryEvent
 from sentry.testutils import SCIMAzureTestCase, SCIMTestCase
 
 CREATE_USER_POST_DATA = {
@@ -44,6 +45,10 @@ class SCIMMemberIndexTests(SCIMTestCase):
             "name": {"familyName": "N/A", "givenName": "N/A"},
             "meta": {"resourceType": "User"},
         }
+
+        assert AuditLogEntry.objects.filter(
+            target_object=member.id, event=AuditLogEntryEvent.MEMBER_INVITE
+        ).exists()
         assert correct_post_data == response.data
         assert member.email == "test.user@okta.local"
 


### PR DESCRIPTION
We had the auditlog creation in the SCIM member creation transaction -- this caused the `target_object` id to be null.

This PR moves the audit log creation out of the transaction so we can put the id in the auditlog. This will be particularly useful for monitoring % of members invited via SCIM who accept their invite.