### PR TITLE
ref(ts): Target es6 for type checking

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -23,7 +23,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "strictBindCallApply": false,
     "experimentalDecorators": true,
     // Skip type checking of all declaration files


### PR DESCRIPTION
This doesn't affect compile output since babel handles that, but let's us use some features like private properties.