### PR TITLE
build(ui): Transpile only when running webpack

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -50,5 +50,8 @@
     "plugins": [{"name": "typescript-styled-plugin"}]
   },
   "include": ["../static", "../tests/js"],
-  "exclude": ["../node_modules"]
+  "exclude": ["../node_modules"],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -144,7 +144,7 @@ const localeCatalogPath = path.join(
 );
 
 type LocaleCatalog = {
-  supported_locales: string[];
+  supported_locales: string;
 };
 
 const localeCatalog: LocaleCatalog = JSON.parse(

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -144,7 +144,7 @@ const localeCatalogPath = path.join(
 );
 
 type LocaleCatalog = {
-  supported_locales: string;
+  supported_locales: string[];
 };
 
 const localeCatalog: LocaleCatalog = JSON.parse(


### PR DESCRIPTION
webpack uses ts-node to load `webpack.config.ts` because it is in typescript. It is doing type checking by default. This option will disable type checking when using ts-node, starting webpack faster.