### PR TITLE
refs(sessions): Refactor session creation for some test code

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -161,12 +161,12 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         release_1 = self.create_release(version="1")
-        self.store_session(self.session_dict(release=release_1))
+        self.store_session(self.build_session(release=release_1))
         release_2 = self.create_release(version="2")
         release_3 = self.create_release(version="3")
         release_4 = self.create_release(version="4")
         release_5 = self.create_release(version="5")
-        self.bulk_store_sessions([self.session_dict(release=release_5) for _ in range(2)])
+        self.bulk_store_sessions([self.build_session(release=release_5) for _ in range(2)])
 
         response = self.get_valid_response(self.organization.slug, sort="sessions", flatten="1")
         self.assert_expected_versions(

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1799,21 +1799,13 @@ class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
         other_project_release_1 = self.create_release(other_project)
         self.bulk_store_sessions(
             [
-                generate_session_default_args(
-                    {
-                        "org_id": self.organization.id,
-                        "environment": "prod",
-                        "project_id": self.project.id,
-                        "release": project_release_1.version,
-                    }
+                self.build_session(
+                    environment=self.environment.name, release=project_release_1.version
                 ),
-                generate_session_default_args(
-                    {
-                        "org_id": self.organization.id,
-                        "environment": "staging",
-                        "project_id": other_project.id,
-                        "release": other_project_release_1.version,
-                    }
+                self.build_session(
+                    environment="staging",
+                    project_id=other_project.id,
+                    release=other_project_release_1.version,
                 ),
             ]
         )
@@ -1836,7 +1828,7 @@ class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
                 self.organization.id,
                 [self.project.id, other_project.id],
                 "sessions",
-                environments=["prod"],
+                environments=[self.environment.name],
             )
             == 1
         )
@@ -1872,27 +1864,9 @@ class CheckReleasesHaveHealthDataTest(TestCase, SnubaTestCase):
         release_2 = self.create_release(other_project, version="2")
         self.bulk_store_sessions(
             [
-                generate_session_default_args(
-                    {
-                        "org_id": self.organization.id,
-                        "project_id": self.project.id,
-                        "release": release_1.version,
-                    }
-                ),
-                generate_session_default_args(
-                    {
-                        "org_id": self.organization.id,
-                        "project_id": other_project.id,
-                        "release": release_1.version,
-                    }
-                ),
-                generate_session_default_args(
-                    {
-                        "org_id": self.organization.id,
-                        "project_id": other_project.id,
-                        "release": release_2.version,
-                    }
-                ),
+                self.build_session(release=release_1),
+                self.build_session(project_id=other_project, release=release_1),
+                self.build_session(project_id=other_project, release=release_2),
             ]
         )
         self.run_test([release_1], [self.project], [release_1])


### PR DESCRIPTION
This consolidates our session building into `SnubaTestCase.build_session`. The session here will
default to using the objects created in the base test class, so release, environment, project and
organization will use those by default.

I haven't translated all the tests in `test_sessions.py` to use this new format, not sure if there's
a lot of value there. This should work well going forward though.