### PR TITLE
feat: Make tracing configurable for post_process_group

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1146,6 +1146,9 @@ SENTRY_APPCONNECT_APM_SAMPLING = 1
 # sample rate for suspect commits task
 SENTRY_SUSPECT_COMMITS_APM_SAMPLING = 0
 
+# sample rate for post_process_group task
+SENTRY_POST_PROCESS_GROUP_APM_SAMPLING = 0
+
 # ----
 # end APM config
 # ----

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -75,6 +75,7 @@ SAMPLED_TASKS = {
     "sentry.tasks.app_store_connect.dsym_download": settings.SENTRY_APPCONNECT_APM_SAMPLING,
     "sentry.tasks.app_store_connect.refresh_all_builds": settings.SENTRY_APPCONNECT_APM_SAMPLING,
     "sentry.tasks.process_suspect_commits": settings.SENTRY_SUSPECT_COMMITS_APM_SAMPLING,
+    "sentry.tasks.post_process.post_process_group": settings.SENTRY_POST_PROCESS_GROUP_APM_SAMPLING,
 }
 
 


### PR DESCRIPTION
Sampling rate is set to 0 by default.