### PR TITLE
fix(celery): Add time limit for post_process_group task

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -186,7 +186,11 @@ def update_existing_attachments(event):
     )
 
 
-@instrumented_task(name="sentry.tasks.post_process.post_process_group")
+@instrumented_task(
+    name="sentry.tasks.post_process.post_process_group",
+    time_limit=120,
+    soft_time_limit=110,
+)
 def post_process_group(
     is_new, is_regression, is_new_group_environment, cache_key, group_id=None, **kwargs
 ):


### PR DESCRIPTION
Both hard and soft limits are pretty relaxed at the moment (about 2 minutes),
to make sure that we don't unintentionally kill some long-running task,
in which case we'll need to investigate why they're taking so long.