### PR TITLE
feat(codeowners): Add strict naming to user/team mappings for GH/GL

### DIFF
--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -49,7 +49,8 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
 
     def validate_external_name(self, external_name: str) -> str:
         try:
-            # Only validate the External Name if the provider is strict\
+            # Only validate the External Name if the provider is strict
+            # (i.e. Users/Teams from Github or Gitlab)
             validate_provider(
                 self.initial_data["provider"], available_providers=STRICT_NAME_PROVIDERS
             )

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -55,7 +55,8 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
                 self.initial_data["provider"], available_providers=STRICT_NAME_PROVIDERS
             )
             return validate_external_name(external_name)
-        except ParameterValidationError:
+        except (ParameterValidationError, KeyError):
+            # Requests with invalid/absent providers will get handled by `validate_provider`
             return external_name
 
     def validate_provider(self, provider_name_option: str) -> int:

--- a/src/sentry/api/validators/external_actor.py
+++ b/src/sentry/api/validators/external_actor.py
@@ -1,9 +1,12 @@
 import re
-from typing import Optional
+from typing import Optional, Set
 
 from rest_framework import serializers
 
+from sentry.api.exceptions import ParameterValidationError
+from sentry.api.validators.integrations import validate_provider
 from sentry.models import Organization, OrganizationIntegration
+from sentry.types.integrations import ExternalProviders
 
 EXTERNAL_ID_LENGTH_MIN = 1
 EXTERNAL_ID_LENGTH_MAX = 64
@@ -15,6 +18,16 @@ EXTERNAL_NAME_REGEX = re.compile(r"^@[\w/\.-]+$")
 
 def _out_of_range_string(param: str, minimum: int, maximum: int, actual: int) -> str:
     return f"{param} has invalid length: {actual}. Length must be between {minimum} and {maximum}"
+
+
+def is_valid_provider(
+    provider: str, available_providers: Optional[Set[ExternalProviders]] = None
+) -> bool:
+    try:
+        validate_provider(provider, available_providers)
+    except ParameterValidationError:
+        return False
+    return True
 
 
 def validate_external_id_option(external_id: Optional[str]) -> Optional[str]:

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -1,4 +1,5 @@
 import {Component} from 'react';
+import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
 import pick from 'lodash/pick';
 
@@ -107,24 +108,32 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
     const apiMethod = !baseEndpoint ? undefined : mapping ? 'PUT' : 'POST';
 
     return (
-      <Form
-        onSubmitSuccess={onSubmitSuccess}
-        initialData={this.initialData}
-        apiEndpoint={endpoint}
-        apiMethod={apiMethod}
-        onCancel={onCancel}
-        onSubmit={onSubmit}
-      >
-        {this.formFields.map(field => (
-          <FieldFromConfig
-            key={field.name}
-            field={field}
-            inline={false}
-            stacked
-            flexibleControlStateSize
-          />
-        ))}
-      </Form>
+      <FormWrapper>
+        <Form
+          requireChanges
+          onSubmitSuccess={onSubmitSuccess}
+          initialData={this.initialData}
+          apiEndpoint={endpoint}
+          apiMethod={apiMethod}
+          onCancel={onCancel}
+          onSubmit={onSubmit}
+        >
+          {this.formFields.map(field => (
+            <FieldFromConfig
+              key={field.name}
+              field={field}
+              inline={false}
+              stacked
+              flexibleControlStateSize
+            />
+          ))}
+        </Form>
+      </FormWrapper>
     );
   }
 }
+
+// Prevents errors from appearing off the modal
+const FormWrapper = styled('div')`
+  position: relative;
+`;

--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -78,7 +78,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
 
             # Add Mapping Modal
             externalName = self.browser.find_element_by_name("externalName")
-            externalName.send_keys("user2")
+            externalName.send_keys("@user2")
             self.browser.click("#userId:first-child div")
             self.browser.click('[id="react-select-2-option-1"]')
             self.browser.snapshot("integrations - save new external user mapping")

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -1,7 +1,12 @@
+from sentry.api.bases.external_actor import (
+    STRICT_NAME_PROVIDERS,
+    ExternalTeamSerializer,
+    ExternalUserSerializer,
+)
 from sentry.api.serializers import serialize
 from sentry.models import ExternalActor, Integration
 from sentry.testutils import TestCase
-from sentry.types.integrations import ExternalProviders
+from sentry.types.integrations import ExternalProviders, get_provider_name
 
 
 class ExternalActorSerializerTest(TestCase):
@@ -17,6 +22,7 @@ class ExternalActorSerializerTest(TestCase):
                 "installation_type": "born_as_bot",
             },
         )
+        self.org_integration = self.integration.add_organization(self.organization, self.user)
 
     def test_user(self):
         external_actor, _ = ExternalActor.objects.get_or_create(
@@ -55,3 +61,85 @@ class ExternalActorSerializerTest(TestCase):
         assert result["externalName"] == "Marcos"
         assert result["externalId"] == "Gaeta"
         assert result["teamId"] == str(team.id)
+
+    def test_strict_external_user_name(self):
+        # Ensure user names must start with @
+        external_actor_user_data = {
+            "provider": get_provider_name(ExternalProviders.GITHUB.value),
+            "externalName": "raz",
+            "integrationId": self.integration.id,
+            "userId": self.user.id,
+        }
+        serializer = ExternalUserSerializer(
+            data=external_actor_user_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is False
+        assert "externalName" in serializer.errors
+
+        # Ensure longer user names are limited in length
+        external_actor_user_data["externalName"] = "@" + ("razputin_aquato" * 20)
+        serializer = ExternalUserSerializer(
+            data=external_actor_user_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is False
+        assert "externalName" in serializer.errors
+
+        # Ensure proper user names are valid
+        external_actor_user_data["externalName"] = "@raz"
+        serializer = ExternalUserSerializer(
+            data=external_actor_user_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True
+
+    def test_strict_external_team_name(self):
+        team = self.create_team(organization=self.organization, members=[self.user])
+
+        # Ensure team names must start with @
+        external_actor_team_data = {
+            "provider": get_provider_name(ExternalProviders.GITHUB.value),
+            "externalName": "the-psychic-six",
+            "integrationId": self.integration.id,
+            "team_id": team.id,
+        }
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is False
+        assert "externalName" in serializer.errors
+
+        # Ensure longer team names are limited in length
+        external_actor_team_data["externalName"] = "@" + ("the-psychic-six" * 20)
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is False
+        assert "externalName" in serializer.errors
+
+        # Ensure proper team names are valid
+        external_actor_team_data["externalName"] = "@the-psychic-six"
+        serializer = ExternalTeamSerializer(
+            data=external_actor_team_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True
+
+    def test_avoid_strict_external_name(self):
+        # Strict rules should only run for strict providers
+        provider = get_provider_name(ExternalProviders.SLACK.value)
+        assert provider not in STRICT_NAME_PROVIDERS
+        external_actor_user_data = {
+            "provider": get_provider_name(ExternalProviders.SLACK.value),
+            "externalName": "ford-cruller",
+            "integrationId": self.integration.id,
+            "userId": self.user.id,
+        }
+        serializer = ExternalUserSerializer(
+            data=external_actor_user_data,
+            context={"organization": self.organization},
+        )
+        assert serializer.is_valid() is True


### PR DESCRIPTION
See: [API-2064](https://getsentry.atlassian.net/browse/API-2064)

This PR adds a validator to the ExternalActor object which will ensure that specific providers (Github and Gitlab), are only added if their `external_name` field follows some restrictions. This will apply for both ExternalTeam and ExternalUsers.
The restrictions are as follows:
- begins with an '@'
- does not contain special characters (aside from '/', '-', '_', '.')
- is between 1 and 255 characters

**Before:**

UI bug in displaying errors (this error was never surfaced in the first place):
![form-errors-before](https://user-images.githubusercontent.com/35509934/131358591-56486426-f5b1-4b96-a7ae-3968cd3cc606.png)

**After:** 

Examples of the regex matching:
![regex-matching](https://user-images.githubusercontent.com/35509934/131358085-951ea631-48f2-4a51-aeb1-db8ec63d468b.png)

---

(team mapping) Must start with '@' and not contain special chars error:
![spec-chars-after](https://user-images.githubusercontent.com/35509934/131358134-1db40907-abe3-48fd-9240-22269e245c14.png)
![no-emoji-after](https://user-images.githubusercontent.com/35509934/131358306-08d43a20-6563-4082-bcaa-d049d1aee5f2.png)

---

(user mapping) Must start with '@' and not contain special chars error:
![spec-chars-user-after](https://user-images.githubusercontent.com/35509934/131358367-eb9f03d0-16c1-4514-bd21-e27ede039d7b.png)

---

Must fall between required length
![length-after](https://user-images.githubusercontent.com/35509934/131358462-28d2a18d-2e62-49b2-82dd-2cf801900d8e.png)


