### PR TITLE
ref(api) Use ScheduledDeletion for projects

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1,9 +1,7 @@
-import logging
 import math
 import time
 from datetime import timedelta
 from itertools import chain
-from uuid import uuid4
 
 from django.db import IntegrityError, transaction
 from django.utils import timezone
@@ -36,15 +34,13 @@ from sentry.models import (
     ProjectRedirect,
     ProjectStatus,
     ProjectTeam,
+    ScheduledDeletion,
 )
 from sentry.notifications.types import NotificationSettingTypes
 from sentry.notifications.utils.legacy_mappings import get_option_value_from_boolean
-from sentry.tasks.deletion import delete_project
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.compat import filter
-
-delete_logger = logging.getLogger("sentry.deletions.api")
 
 
 def clean_newline_inputs(value, case_insensitive=True):
@@ -731,11 +727,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             status=ProjectStatus.PENDING_DELETION
         )
         if updated:
-            transaction_id = uuid4().hex
-
-            delete_project.apply_async(
-                kwargs={"object_id": project.id, "transaction_id": transaction_id}, countdown=3600
-            )
+            scheduled = ScheduledDeletion.schedule(project, days=0, actor=request.user)
 
             self.create_audit_entry(
                 request=request,
@@ -743,18 +735,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 target_object=project.id,
                 event=AuditLogEntryEvent.PROJECT_REMOVE,
                 data=project.get_audit_log_data(),
-                transaction_id=transaction_id,
+                transaction_id=scheduled.id,
             )
-
-            delete_logger.info(
-                "object.delete.queued",
-                extra={
-                    "object_id": project.id,
-                    "transaction_id": transaction_id,
-                    "model": type(project).__name__,
-                },
-            )
-
             project.rename_on_pending_deletion()
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/team_details.py
+++ b/src/sentry/api/endpoints/team_details.py
@@ -104,15 +104,14 @@ class TeamDetailsEndpoint(TeamEndpoint):
             slug=f"{team.slug}-{transaction_id}", status=TeamStatus.PENDING_DELETION
         )
         if updated:
+            scheduled = ScheduledDeletion.schedule(team, days=0, actor=request.user)
             self.create_audit_entry(
                 request=request,
                 organization=team.organization,
                 target_object=team.id,
                 event=AuditLogEntryEvent.TEAM_REMOVE,
                 data=team.get_audit_log_data(),
-                transaction_id=transaction_id,
+                transaction_id=scheduled.id,
             )
-
-            ScheduledDeletion.schedule(team, days=0, actor=request.user)
 
         return Response(status=204)

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -191,6 +191,8 @@ def delete_team(object_id, transaction_id=None, **kwargs):
 )
 @retry(exclude=(DeleteAborted,))
 def delete_project(object_id, transaction_id=None, **kwargs):
+    # TODO this method is no longer in use and should be removed when jobs are
+    # no longer being enqueued for it.
     from sentry import deletions
     from sentry.models import Project, ProjectStatus
 

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -2,7 +2,6 @@ from django.core import mail
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 class ProjectTransferTest(APITestCase):
@@ -21,9 +20,7 @@ class ProjectTransferTest(APITestCase):
 
         assert response.status_code == 403
 
-    @mock.patch("sentry.api.endpoints.project_details.uuid4")
-    def test_transfer_project(self, mock_uuid4):
-        mock_uuid4.return_value = self.get_mock_uuid()
+    def test_transfer_project(self):
         project = self.create_project()
         new_user = self.create_user("b@example.com")
         self.create_organization(name="New Org", owner=new_user)
@@ -44,9 +41,7 @@ class ProjectTransferTest(APITestCase):
                 # assertion does not pass
                 assert mail.outbox
 
-    @mock.patch("sentry.api.endpoints.project_details.uuid4")
-    def test_transfer_project_to_invalid_user(self, mock_uuid4):
-        mock_uuid4.return_value = self.get_mock_uuid()
+    def test_transfer_project_to_invalid_user(self):
         project = self.create_project()
         # new user is not an owner of anything
         new_user = self.create_user("b@example.com")


### PR DESCRIPTION
Update project deletion to use ScheduledDeletion. This subsystem uses database records to track deletion jobs so that they are easier to retry on failure.