### PR TITLE
fix(django 2.2): new SILENCED_SYSTEM_CHECKS 

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -360,6 +360,11 @@ SILENCED_SYSTEM_CHECKS = (
     # the trailing slash. This confuses the warning as the regex is `/$` which
     # looks like it starts with a slash but it doesn't.
     "urls.W002",
+    # Our own AuthenticationMiddleware suffices.
+    "admin.E408",
+    # This is fixed in Django@7c08f26bf0439c1ed593b51b51ad847f7e262bc1.
+    # It's not our problem.
+    "urls.E007",
 )
 
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -360,10 +360,12 @@ SILENCED_SYSTEM_CHECKS = (
     # the trailing slash. This confuses the warning as the regex is `/$` which
     # looks like it starts with a slash but it doesn't.
     "urls.W002",
-    # Our own AuthenticationMiddleware suffices.
+    # Our own AuthenticationMiddleware suffices as a replacement for
+    # django.contrib.auth.middleware.AuthenticationMiddleware; both add the
+    # authenticated user to the HttpRequest which is what's needed here.
     "admin.E408",
     # This is fixed in Django@7c08f26bf0439c1ed593b51b51ad847f7e262bc1.
-    # It's not our problem.
+    # It's not our problem; refer to Django issue 32260.
     "urls.E007",
 )
 


### PR DESCRIPTION
`sentry django makemigrations -n test` results in the following in Django 2.2 which can be silenced:

```
ERRORS:
?: (admin.E408) 'django.contrib.auth.middleware.AuthenticationMiddleware'
must be in MIDDLEWARE in order to use the admin application.
?: (urls.E007) The custom handler500 view 'sentry.web.frontend.error_500.Error500View'
does not take the correct number of arguments (request).
```

Also, verified still works on Django 2.1.