### PR TITLE
fix(django 2.2): use ContentFile instead of SimpleUploadedFile to be able to pass empty filename to tests

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_release_files.py
+++ b/tests/sentry/api/endpoints/test_organization_release_files.py
@@ -1,3 +1,4 @@
+from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -109,8 +110,11 @@ class ReleaseFileCreateTest(APITestCase):
             url,
             {
                 "header": "X-SourceMap: http://example.com",
-                "file": SimpleUploadedFile(
-                    "", b"function() { }", content_type="application/javascript"
+                # We can't use SimpleUploadedFile here, because it validates file names
+                # and doesn't allow for empty strings.
+                "file": ContentFile(
+                    content=b"function() { }",
+                    name="",
                 ),
             },
             format="multipart",

--- a/tests/sentry/api/endpoints/test_project_release_files.py
+++ b/tests/sentry/api/endpoints/test_project_release_files.py
@@ -1,3 +1,4 @@
+from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
@@ -266,8 +267,11 @@ class ReleaseFileCreateTest(APITestCase):
             url,
             {
                 "header": "X-SourceMap: http://example.com",
-                "file": SimpleUploadedFile(
-                    "", b"function() { }", content_type="application/javascript"
+                # We can't use SimpleUploadedFile here, because it validates file names
+                # and doesn't allow for empty strings.
+                "file": ContentFile(
+                    content=b"function() { }",
+                    name="",
                 ),
             },
             format="multipart",


### PR DESCRIPTION
In Django 2.2, SimpleUploadedFile (and other stuff) does some filename validation to protect against some bad filenames.

We can switch to using the simpler ContentFile instead. The content type isn't relevant here to what we're testing.