### PR TITLE
fix(django 2.2): Release should inherit __hash__

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -468,6 +468,10 @@ class Release(Model):
         """
         return Model.__eq__(self, other) and self._for_project_id == other._for_project_id
 
+    def __hash__(self):
+        # https://code.djangoproject.com/ticket/30333
+        return super().__hash__()
+
     @staticmethod
     def is_valid_version(value):
         return not (


### PR DESCRIPTION
In Django 2.2, we get `unhashable type: 'Release'` a bunch in the test suite when it's used as a dict key here (actually it's `result[item]` few lines up):

```
  File "/Users/josh/dev/sentry/src/sentry/api/serializers/models/release.py", line 177, in _get_commit_metadata
    "last_commit": commits.get(item.last_commit_id),
TypeError: unhashable type: 'Release'
```

For Release we define `__eq__` and not `__hash__`. In that case, Django 2.2 now sets `__hash__` to None to comply with how Python says things should be. From https://docs.python.org/3.6/reference/datamodel.html#object.__hash__:

> A class that overrides __eq__() and does not define __hash__() will have its __hash__() implicitly set to None. When the __hash__() method of a class is None, ... , and will also be correctly identified as unhashable when checking isinstance(obj, collections.Hashable).

The previous behavior was that `__hash__` would be inherited from model.Model if only `__eq__` is defined:

```
(Pdb) item.__hash__
<bound method BaseModel.__hash__ of <Release at 0x116ce5908: id=1, organization_id=2, version='1.0'>>
```