### PR TITLE
feat(perf): Add UI barebones for landing v3

### DIFF
--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
@@ -29,6 +30,7 @@ import withProjects from 'app/utils/withProjects';
 import LandingContent from './landing/content';
 import {DEFAULT_MAX_DURATION} from './trends/utils';
 import {DEFAULT_STATS_PERIOD, generatePerformanceEventView} from './data';
+import {PerformanceLanding} from './landing';
 import Onboarding from './onboarding';
 import {addRoutePerformanceContext, getPerformanceTrendsUrl} from './utils';
 
@@ -250,6 +252,19 @@ class PerformanceContent extends Component<Props, State> {
     );
   }
 
+  renderLandingV3() {
+    return (
+      <PerformanceLanding
+        eventView={this.state.eventView}
+        setError={this.setError}
+        handleSearch={this.handleSearch}
+        handleTrendsClick={() => this.handleTrendsClick()}
+        shouldShowOnboarding={this.shouldShowOnboarding()}
+        {...this.props}
+      />
+    );
+  }
+
   render() {
     const {organization} = this.props;
 
@@ -265,7 +280,9 @@ class PerformanceContent extends Component<Props, State> {
             },
           }}
         >
-          {this.renderBody()}
+          <Feature features={['organizations:performance-landing-widgets']}>
+            {({hasFeature}) => (hasFeature ? this.renderLandingV3() : this.renderBody())}
+          </Feature>
         </GlobalSelectionHeader>
       </SentryDocumentTitle>
     );

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -130,7 +130,7 @@ class PerformanceContent extends Component<Props, State> {
     });
   };
 
-  handleTrendsClick() {
+  handleTrendsClick = () => {
     const {location, organization} = this.props;
 
     const newQuery = {
@@ -171,7 +171,7 @@ class PerformanceContent extends Component<Props, State> {
       pathname: getPerformanceTrendsUrl(organization),
       query: {...newQuery},
     });
-  }
+  };
 
   shouldShowOnboarding() {
     const {projects, demoMode} = this.props;
@@ -217,7 +217,7 @@ class PerformanceContent extends Component<Props, State> {
               <Button
                 priority="primary"
                 data-test-id="landing-header-trends"
-                onClick={() => this.handleTrendsClick()}
+                onClick={this.handleTrendsClick}
               >
                 {t('View Trends')}
               </Button>
@@ -258,7 +258,7 @@ class PerformanceContent extends Component<Props, State> {
         eventView={this.state.eventView}
         setError={this.setError}
         handleSearch={this.handleSearch}
-        handleTrendsClick={() => this.handleTrendsClick()}
+        handleTrendsClick={this.handleTrendsClick}
         shouldShowOnboarding={this.shouldShowOnboarding()}
         {...this.props}
       />

--- a/static/app/views/performance/landing/contexts/operationBreakdownFilter.tsx
+++ b/static/app/views/performance/landing/contexts/operationBreakdownFilter.tsx
@@ -1,0 +1,33 @@
+import {createContext, useContext, useState} from 'react';
+
+import {SpanOperationBreakdownFilter} from '../../transactionSummary/filter';
+
+const OpBreakdownFilterContext = createContext<{
+  opBreakdownFilter: SpanOperationBreakdownFilter;
+  setOpBreakdownFilter: (filter: SpanOperationBreakdownFilter) => void;
+}>({
+  opBreakdownFilter: SpanOperationBreakdownFilter.None,
+  setOpBreakdownFilter: (_: SpanOperationBreakdownFilter) => {},
+});
+
+export const OpBreakdownFilterProvider = ({
+  filter,
+  children,
+}: {
+  filter?: SpanOperationBreakdownFilter;
+  children: React.ReactNode;
+}) => {
+  const [opBreakdownFilter, setOpBreakdownFilter] = useState(filter);
+  return (
+    <OpBreakdownFilterContext.Provider
+      value={{
+        opBreakdownFilter: opBreakdownFilter ?? SpanOperationBreakdownFilter.None,
+        setOpBreakdownFilter,
+      }}
+    >
+      {children}
+    </OpBreakdownFilterContext.Provider>
+  );
+};
+
+export const useOpBreakdownFilter = () => useContext(OpBreakdownFilterContext);

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -1,0 +1,176 @@
+import {FC, useState} from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import Button from 'app/components/button';
+import SearchBar from 'app/components/events/searchBar';
+import FeatureBadge from 'app/components/featureBadge';
+import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
+import * as Layout from 'app/components/layouts/thirds';
+import NavTabs from 'app/components/navTabs';
+import PageHeading from 'app/components/pageHeading';
+import * as TeamKeyTransactionManager from 'app/components/performance/teamKeyTransactionsManager';
+import {MAX_QUERY_LENGTH} from 'app/constants';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization, Project, Team} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {generateAggregateFields} from 'app/utils/discover/fields';
+import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
+import withTeams from 'app/utils/withTeams';
+
+import Filter, {SpanOperationBreakdownFilter} from '../transactionSummary/filter';
+import {getTransactionSearchQuery} from '../utils';
+
+import {OpBreakdownFilterProvider} from './contexts/operationBreakdownFilter';
+import {AllTransactionsView} from './views/allTransactionsView';
+import {BackendView} from './views/backendView';
+import {FrontendOtherView} from './views/frontendOtherView';
+import {FrontendPageloadView} from './views/frontendPageloadView';
+import {MobileView} from './views/mobileView';
+import {
+  getCurrentLandingDisplay,
+  handleLandingDisplayChange,
+  LANDING_DISPLAYS,
+  LandingDisplayField,
+} from './utils';
+
+type Props = {
+  organization: Organization;
+  eventView: EventView;
+  location: Location;
+  projects: Project[];
+  teams: Team[];
+  shouldShowOnboarding: boolean;
+  setError: (msg: string | undefined) => void;
+  handleSearch: (searchQuery: string) => void;
+  handleTrendsClick: () => void;
+};
+
+const fieldToViewMap: Record<LandingDisplayField, FC<Props>> = {
+  [LandingDisplayField.ALL]: AllTransactionsView,
+  [LandingDisplayField.BACKEND]: BackendView,
+  [LandingDisplayField.FRONTEND_OTHER]: FrontendOtherView,
+  [LandingDisplayField.FRONTEND_PAGELOAD]: FrontendPageloadView,
+  [LandingDisplayField.MOBILE]: MobileView,
+};
+
+function _PerformanceLanding(props: Props) {
+  const {
+    organization,
+    location,
+    eventView,
+    projects,
+    teams,
+    handleSearch,
+    handleTrendsClick,
+    shouldShowOnboarding,
+  } = props;
+
+  const currentLandingDisplay = getCurrentLandingDisplay(location, projects, eventView);
+  const filterString = getTransactionSearchQuery(location, eventView.query);
+
+  const isSuperuser = isActiveSuperuser();
+  const userTeams = teams.filter(({isMember}) => isMember || isSuperuser);
+
+  const [spanFilter, setSpanFilter] = useState(SpanOperationBreakdownFilter.None);
+  const showOnboarding = shouldShowOnboarding;
+
+  const shownLandingDisplays = LANDING_DISPLAYS.filter(
+    ({isShown}) => !isShown || isShown(organization)
+  );
+
+  const ViewComponent = fieldToViewMap[currentLandingDisplay.field];
+
+  return (
+    <div data-test-id="performance-landing-v3">
+      <Layout.Header>
+        <Layout.HeaderContent>
+          <StyledHeading>{t('Performance')}</StyledHeading>
+        </Layout.HeaderContent>
+        <Layout.HeaderActions>
+          {!showOnboarding && (
+            <Button
+              priority="primary"
+              data-test-id="landing-header-trends"
+              onClick={() => handleTrendsClick()}
+            >
+              {t('View Trends')}
+            </Button>
+          )}
+        </Layout.HeaderActions>
+
+        <StyledNavTabs>
+          {shownLandingDisplays.map(({badge, label, field}) => (
+            <li
+              key={label}
+              className={currentLandingDisplay.field === field ? 'active' : ''}
+            >
+              <a href="#" onClick={() => handleLandingDisplayChange(field, location)}>
+                {t(label)}
+                {badge && <FeatureBadge type={badge} />}
+              </a>
+            </li>
+          ))}
+        </StyledNavTabs>
+      </Layout.Header>
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <GlobalSdkUpdateAlert />
+          <OpBreakdownFilterProvider>
+            <SearchContainerWithFilter>
+              <Filter
+                organization={organization}
+                currentFilter={spanFilter}
+                onChangeFilter={setSpanFilter}
+              />
+              <SearchBar
+                searchSource="performance_landing"
+                organization={organization}
+                projectIds={eventView.project}
+                query={filterString}
+                fields={generateAggregateFields(
+                  organization,
+                  [...eventView.fields, {field: 'tps()'}],
+                  ['epm()', 'eps()']
+                )}
+                onSearch={handleSearch}
+                maxQueryLength={MAX_QUERY_LENGTH}
+              />
+            </SearchContainerWithFilter>
+            <TeamKeyTransactionManager.Provider
+              organization={organization}
+              teams={userTeams}
+              selectedTeams={['myteams']}
+              selectedProjects={eventView.project.map(String)}
+            >
+              <ViewComponent {...props} />
+            </TeamKeyTransactionManager.Provider>
+          </OpBreakdownFilterProvider>
+        </Layout.Main>
+      </Layout.Body>
+    </div>
+  );
+}
+
+export const PerformanceLanding = withTeams(_PerformanceLanding);
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+`;
+
+const StyledNavTabs = styled(NavTabs)`
+  margin-bottom: 0;
+  /* Makes sure the tabs are pushed into another row */
+  width: 100%;
+`;
+
+const SearchContainerWithFilter = styled('div')`
+  display: grid;
+  grid-gap: ${space(0)};
+  margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: min-content 1fr;
+  }
+`;

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -1,3 +1,4 @@
+import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
 import {t} from 'app/locale';
@@ -11,6 +12,7 @@ import {
 } from 'app/utils/formatters';
 import {HistogramData} from 'app/utils/performance/histogram/types';
 import {decodeScalar} from 'app/utils/queryString';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
 
 import {AxisOption, getTermHelp, PERFORMANCE_TERM} from '../data';
 import {Rectangle} from '../transactionSummary/transactionVitals/types';
@@ -74,6 +76,27 @@ export function getCurrentLandingDisplay(
     ({field}) => field === defaultDisplayField
   );
   return defaultDisplay || LANDING_DISPLAYS[0];
+}
+
+export function handleLandingDisplayChange(field: string, location: Location) {
+  const newQuery = {...location.query};
+
+  delete newQuery[LEFT_AXIS_QUERY_KEY];
+  delete newQuery[RIGHT_AXIS_QUERY_KEY];
+
+  // Transaction op can affect the display and show no results if it is explicitly set.
+  const query = decodeScalar(location.query.query, '');
+  const searchConditions = new MutableSearch(query);
+  searchConditions.removeFilter('transaction.op');
+
+  browserHistory.push({
+    pathname: location.pathname,
+    query: {
+      ...newQuery,
+      query: searchConditions.formatString(),
+      landingDisplay: field,
+    },
+  });
 }
 
 export function getChartWidth(chartData: HistogramData, refPixelRect: Rectangle | null) {

--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -1,0 +1,5 @@
+import {BasePerformanceViewProps} from './types';
+
+export function AllTransactionsView(_: BasePerformanceViewProps) {
+  return <div />;
+}

--- a/static/app/views/performance/landing/views/backendView.tsx
+++ b/static/app/views/performance/landing/views/backendView.tsx
@@ -1,0 +1,5 @@
+import {BasePerformanceViewProps} from './types';
+
+export function BackendView(_: BasePerformanceViewProps) {
+  return <div />;
+}

--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -1,0 +1,5 @@
+import {BasePerformanceViewProps} from './types';
+
+export function FrontendOtherView(_: BasePerformanceViewProps) {
+  return <div />;
+}

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -1,0 +1,5 @@
+import {BasePerformanceViewProps} from './types';
+
+export function FrontendPageloadView(_: BasePerformanceViewProps) {
+  return <div data-test-id="frontend-pageload-view" />;
+}

--- a/static/app/views/performance/landing/views/mobileView.tsx
+++ b/static/app/views/performance/landing/views/mobileView.tsx
@@ -1,0 +1,5 @@
+import {BasePerformanceViewProps} from './types';
+
+export function MobileView(_: BasePerformanceViewProps) {
+  return <div />;
+}

--- a/static/app/views/performance/landing/views/types.tsx
+++ b/static/app/views/performance/landing/views/types.tsx
@@ -1,0 +1,1 @@
+export type BasePerformanceViewProps = {};

--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -42,95 +42,93 @@ type Props = {
   onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
 };
 
-class Filter extends React.Component<Props> {
-  render() {
-    const {currentFilter, onChangeFilter, organization} = this.props;
+function Filter(props: Props) {
+  const {currentFilter, onChangeFilter, organization} = props;
 
-    if (!organization.features.includes('performance-ops-breakdown')) {
-      return null;
-    }
+  if (!organization.features.includes('performance-ops-breakdown')) {
+    return null;
+  }
 
-    const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
-      hasDarkBorderBottomColor: boolean;
-    } = {
-      children: (
-        <React.Fragment>
-          <IconFilter size="xs" />
-          <FilterLabel>
-            {currentFilter === SpanOperationBreakdownFilter.None
-              ? t('Filter')
-              : tct('Filter - [operationName]', {
-                  operationName: currentFilter,
-                })}
-          </FilterLabel>
-        </React.Fragment>
-      ),
-      priority: 'default',
-      hasDarkBorderBottomColor: false,
-    };
+  const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
+    hasDarkBorderBottomColor: boolean;
+  } = {
+    children: (
+      <React.Fragment>
+        <IconFilter size="xs" />
+        <FilterLabel>
+          {currentFilter === SpanOperationBreakdownFilter.None
+            ? t('Filter')
+            : tct('Filter - [operationName]', {
+                operationName: currentFilter,
+              })}
+        </FilterLabel>
+      </React.Fragment>
+    ),
+    priority: 'default',
+    hasDarkBorderBottomColor: false,
+  };
 
-    return (
-      <GuideAnchor target="span_op_breakdowns_filter" position="top">
-        <Wrapper>
-          <DropdownControl
-            menuWidth="240px"
-            blendWithActor
-            button={({isOpen, getActorProps}) => (
-              <StyledDropdownButton
-                {...getActorProps()}
-                showChevron={false}
-                isOpen={isOpen}
-                hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
-                priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
-                data-test-id="filter-button"
-              >
-                {dropDownButtonProps.children}
-              </StyledDropdownButton>
-            )}
+  return (
+    <GuideAnchor target="span_op_breakdowns_filter" position="top">
+      <Wrapper>
+        <DropdownControl
+          menuWidth="240px"
+          blendWithActor
+          button={({isOpen, getActorProps}) => (
+            <StyledDropdownButton
+              {...getActorProps()}
+              showChevron={false}
+              isOpen={isOpen}
+              hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
+              priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
+              data-test-id="filter-button"
+            >
+              {dropDownButtonProps.children}
+            </StyledDropdownButton>
+          )}
+        >
+          <MenuContent
+            onClick={event => {
+              // propagated clicks will dismiss the menu; we stop this here
+              event.stopPropagation();
+            }}
           >
-            <MenuContent
+            <Header
               onClick={event => {
-                // propagated clicks will dismiss the menu; we stop this here
                 event.stopPropagation();
+                onChangeFilter(SpanOperationBreakdownFilter.None);
               }}
             >
-              <Header
-                onClick={event => {
-                  event.stopPropagation();
-                  onChangeFilter(SpanOperationBreakdownFilter.None);
-                }}
-              >
-                <HeaderTitle>{t('Operation')}</HeaderTitle>
-                <Radio
-                  radioSize="small"
-                  checked={SpanOperationBreakdownFilter.None === currentFilter}
-                />
-              </Header>
-              <List>
-                {Array.from([...OPTIONS], (filterOption, index) => {
-                  const operationName = filterOption;
-                  return (
-                    <ListItem
-                      key={String(index)}
-                      isChecked={false}
-                      onClick={event => {
-                        event.stopPropagation();
-                        onChangeFilter(filterOption);
-                      }}
-                    >
-                      <OperationDot backgroundColor={pickBarColor(operationName)} />
-                      <OperationName>{operationName}</OperationName>
-                      <Radio radioSize="small" checked={filterOption === currentFilter} />
-                    </ListItem>
-                  );
-                })}
-              </List>
-            </MenuContent>
-          </DropdownControl>
-        </Wrapper>
-      </GuideAnchor>
-    );
-  }
+              <HeaderTitle>{t('Operation')}</HeaderTitle>
+              <Radio
+                radioSize="small"
+                checked={SpanOperationBreakdownFilter.None === currentFilter}
+              />
+            </Header>
+            <List>
+              {Array.from([...OPTIONS], (filterOption, index) => {
+                const operationName = filterOption;
+                return (
+                  <ListItem
+                    key={String(index)}
+                    isChecked={false}
+                    onClick={event => {
+                      event.stopPropagation();
+                      onChangeFilter(filterOption);
+                    }}
+                  >
+                    <OperationDot backgroundColor={pickBarColor(operationName)} />
+                    <OperationName>{operationName}</OperationName>
+                    <Radio radioSize="small" checked={filterOption === currentFilter} />
+                  </ListItem>
+                );
+              })}
+            </List>
+          </MenuContent>
+        </DropdownControl>
+      </Wrapper>
+    </GuideAnchor>
+  );
 }
 
 const FilterLabel = styled('span')`

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -536,4 +536,23 @@ describe('Performance > Content', function () {
       wrapper.find('Button[data-test-id="create-sample-transaction-btn"]').exists()
     ).toBe(true);
   });
+
+  it('Displays new landing component with feature flag on', async function () {
+    const projects = [TestStubs.Project({id: 1, firstTransactionEvent: false})];
+    const data = initializeData(projects, {view: undefined}, [
+      'performance-landing-widgets',
+    ]);
+
+    const wrapper = mountWithTheme(
+      <PerformanceContent
+        organization={data.organization}
+        location={data.router.location}
+      />,
+      data.routerContext
+    );
+
+    expect(wrapper.find('div[data-test-id="performance-landing-v3"]').exists()).toBe(
+      true
+    );
+  });
 });

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -1,0 +1,111 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {PerformanceLanding} from 'app/views/performance/landing';
+import {LandingDisplayField} from 'app/views/performance/landing/utils';
+
+declare global {
+  let TestStubs: any;
+  let tick: any;
+  let MockApiClient: any;
+}
+
+function initializeData(settings?: {
+  query?: {};
+  features?: string[];
+  projects?: Project[];
+  project?: Project;
+}) {
+  const _defaultProject = TestStubs.Project();
+  const _settings = {
+    query: {},
+    features: [],
+    projects: [_defaultProject],
+    project: _defaultProject,
+    ...settings,
+  };
+  const {query, features} = _settings;
+
+  const projects = [TestStubs.Project()];
+  const [project] = projects;
+
+  const organization = TestStubs.Organization({
+    features,
+    projects,
+  });
+  const router = {
+    location: {
+      query: {
+        ...query,
+      },
+    },
+  };
+  const initialData = initializeOrg({organization, projects, project, router});
+  return initialData;
+}
+
+const WrappedComponent = ({data}) => {
+  const eventView = EventView.fromLocation(data.router.location);
+  return (
+    <PerformanceLanding
+      organization={data.organization}
+      location={data.router.location}
+      eventView={eventView}
+      projects={data.projects}
+      shouldShowOnboarding={false}
+      handleSearch={() => {}}
+      handleTrendsClick={() => {}}
+      setError={() => {}}
+    />
+  );
+};
+
+describe('Performance > Landing > Index', function () {
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sdk-updates/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/key-transactions-list/`,
+      body: [],
+    });
+  });
+
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders basic UI elements', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-landing-v3"]').exists()).toBe(
+      true
+    );
+  });
+
+  it('renders frontend pageload view', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.FRONTEND_PAGELOAD},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="frontend-pageload-view"]').exists()).toBe(
+      true
+    );
+  });
+});

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -6,18 +6,13 @@ import EventView from 'app/utils/discover/eventView';
 import {PerformanceLanding} from 'app/views/performance/landing';
 import {LandingDisplayField} from 'app/views/performance/landing/utils';
 
-declare global {
-  let TestStubs: any;
-  let tick: any;
-  let MockApiClient: any;
-}
-
 function initializeData(settings?: {
   query?: {};
   features?: string[];
   projects?: Project[];
   project?: Project;
 }) {
+  // @ts-expect-error
   const _defaultProject = TestStubs.Project();
   const _settings = {
     query: {},
@@ -28,9 +23,11 @@ function initializeData(settings?: {
   };
   const {query, features} = _settings;
 
+  // @ts-expect-error
   const projects = [TestStubs.Project()];
   const [project] = projects;
 
+  // @ts-expect-error
   const organization = TestStubs.Organization({
     features,
     projects,
@@ -64,14 +61,17 @@ const WrappedComponent = ({data}) => {
 
 describe('Performance > Landing > Index', function () {
   beforeEach(function () {
+    // @ts-expect-error
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',
       body: [],
     });
+    // @ts-expect-error
     MockApiClient.addMockResponse({
       url: '/prompts-activity/',
       body: {},
     });
+    // @ts-expect-error
     MockApiClient.addMockResponse({
       method: 'GET',
       url: `/organizations/org-slug/key-transactions-list/`,
@@ -80,6 +80,7 @@ describe('Performance > Landing > Index', function () {
   });
 
   afterEach(function () {
+    // @ts-expect-error
     MockApiClient.clearMockResponses();
   });
 
@@ -87,6 +88,7 @@ describe('Performance > Landing > Index', function () {
     const data = initializeData();
 
     const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    // @ts-expect-error
     await tick();
     wrapper.update();
 
@@ -101,6 +103,7 @@ describe('Performance > Landing > Index', function () {
     });
 
     const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    // @ts-expect-error
     await tick();
     wrapper.update();
 


### PR DESCRIPTION
### Summary
This is setup work for the upcoming performance landing changes (widgets). It redirects to a dedicated landing index page if the `performance-landing-widgets` feature flag is enabled. This also makes a couple changes to other components to help make the new performance landing almost entirely use functional components, where reasonable.

#### Screenshots
![Screen Shot 2021-08-30 at 12 46 40 PM](https://user-images.githubusercontent.com/6111995/131395328-ca3d4253-cb91-403f-a906-a8046875e663.png)


#### Other
- Just stubbed out view files for now, might change implementation later.
- Trying out a provider / state / hooks approach with `opBreakdownFilter`, it can easily be expanded to use location later. 
- I'm probably going to be simplifying landing more, which is why I made it use a dedicated component for landing so I can hard swap them out when the feature is done.
- fieldToViewMap offers full coverage because it's enforced with `Record` now.