### PR TITLE
ref(reports): Handle bad data in weekly reports disabled orgs

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -668,9 +668,21 @@ DISABLED_ORGANIZATIONS_USER_OPTION_KEY = "reports:disabled-organizations"
 
 
 def user_subscribed_to_organization_reports(user, organization):
-    return organization.id not in UserOption.objects.get_value(
+    value = UserOption.objects.get_value(
         user=user, key=DISABLED_ORGANIZATIONS_USER_OPTION_KEY, default=[]
     )
+    if value == "":
+        # a small number of users have incorrect data stored
+        logger.info(
+            "reports.useroption.invalid",
+            extra={
+                "user": user.id,
+                "organization_id": organization.id,
+                "value": value,
+            },
+        )
+        return True
+    return organization.id not in value
 
 
 class Skipped:

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -668,21 +668,10 @@ DISABLED_ORGANIZATIONS_USER_OPTION_KEY = "reports:disabled-organizations"
 
 
 def user_subscribed_to_organization_reports(user, organization):
-    value = UserOption.objects.get_value(
-        user=user, key=DISABLED_ORGANIZATIONS_USER_OPTION_KEY, default=[]
+    return organization.id not in (
+        UserOption.objects.get_value(user, key=DISABLED_ORGANIZATIONS_USER_OPTION_KEY)
+        or []  # A small number of users have incorrect data stored
     )
-    if value == "":
-        # a small number of users have incorrect data stored
-        logger.info(
-            "reports.useroption.invalid",
-            extra={
-                "user": user.id,
-                "organization_id": organization.id,
-                "value": value,
-            },
-        )
-        return True
-    return organization.id not in value
 
 
 class Skipped:

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -278,6 +278,9 @@ class ReportTestCase(TestCase, SnubaTestCase):
         set_option_value([organization.id])
         assert user_subscribed_to_organization_reports(user, organization) is False
 
+        set_option_value([""])
+        assert user_subscribed_to_organization_reports(user, organization) is True
+
     @mock.patch("sentry.tasks.reports.BATCH_SIZE", 1)
     def test_paginates_project_issue_summaries_and_reassembles_result(self):
         self.login_as(user=self.user)

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -278,7 +278,7 @@ class ReportTestCase(TestCase, SnubaTestCase):
         set_option_value([organization.id])
         assert user_subscribed_to_organization_reports(user, organization) is False
 
-        set_option_value([""])
+        set_option_value("")
         assert user_subscribed_to_organization_reports(user, organization) is True
 
     @mock.patch("sentry.tasks.reports.BATCH_SIZE", 1)


### PR DESCRIPTION
Some users have unexpected data stored as the `UserOption` value for the key `'reports:disabled-organizations'` - it's supposed to be a dictionary of org IDs to 0 or 1 for off or on, but in some cases is an empty string (and also sometimes an array of 0s, but that doesn't matter here). A longer term solution would be a data migration to either update these erroneous rows or to migrate the data entirely to `NotificationSettings`, but this should do for now. 

Fixes [SENTRY-C8A](https://sentry.io/organizations/sentry/issues/1169645329/)