### PR TITLE
chore(issue_alerts): Bump `MIN_SESSIONS_TO_FIRE` to 50

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -146,7 +146,7 @@ percent_intervals_to_display = {
     "30m": ("30 minutes", timedelta(minutes=30)),
     "1h": ("1 hour", timedelta(minutes=60)),
 }
-MIN_SESSIONS_TO_FIRE = 1
+MIN_SESSIONS_TO_FIRE = 50
 
 
 class EventFrequencyPercentForm(EventFrequencyForm):


### PR DESCRIPTION
We're going to release % based issue alerts today, we want this min amount of sessions in the last
hour to be 50 so that things aren't too noisy.