### PR TITLE
ref(post-process-forwarder): Track message types

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from sentry.tasks.post_process import post_process_group
+from sentry.utils import metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.services import Service
 
@@ -48,6 +49,11 @@ class EventStream(Service):
             logger.info("post_process.skip.raw_event", extra={"event_id": event_id})
         else:
             cache_key = cache_key_for_event({"project": project_id, "event_id": event_id})
+            if group_id:
+                metrics.incr("eventstream.messages", tags={"type": "errors"})
+            else:
+                metrics.incr("eventstream.messages", tags={"type": "transactions"})
+
             post_process_group.delay(
                 is_new=is_new,
                 is_regression=is_regression,


### PR DESCRIPTION
There is no mechanism to get a breakdown of the number of messages
being processed by the post process forwarder since the events topic
has both errors and transactions. This PR adds metrics to track how
many messages of type errors and transactions are being processed.