### PR TITLE
fix(workflow): Format release session duration axis, use avg

### DIFF
--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -120,7 +120,7 @@ export function getDuration(
 }
 
 export function getExactDuration(seconds: number, abbreviation: boolean = false) {
-  const convertDuration = (secs: number, abbr: boolean) => {
+  const convertDuration = (secs: number, abbr: boolean): string => {
     // value in milliseconds
     const msValue = round(secs * 1000);
     const value = round(Math.abs(secs * 1000));

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -25,6 +25,21 @@ export function getCrashFreeRate(
   return defined(crashedRate) ? getCrashFreePercent(100 - crashedRate) : null;
 }
 
+export function getSeriesAverage(
+  groups: SessionApiResponse['groups'] = [],
+  field: SessionField,
+  status: SessionStatus
+) {
+  const totalCount = getCount(groups, field);
+
+  const dataPoints =
+    groups.find(({by}) => by['session.status'] === status)?.series[field].length ?? null;
+
+  return !defined(totalCount) || dataPoints === null || totalCount === 0
+    ? null
+    : totalCount / dataPoints;
+}
+
 export function getSessionStatusRate(
   groups: SessionApiResponse['groups'] = [],
   field: SessionField,

--- a/static/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/static/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -125,7 +125,7 @@ class HealthChart extends React.Component<Props> {
       case YAxis.SESSIONS:
       case YAxis.USERS:
       default:
-        return typeof value === 'number' ? value.toLocaleString() : value;
+        return typeof value === 'number' ? value.toLocaleString() : value ?? '';
     }
   };
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -34,7 +34,12 @@ import {
 import {defined} from 'app/utils';
 import {formatPercentage} from 'app/utils/formatters';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
-import {getCount, getCrashFreeRate, getSessionStatusRate} from 'app/utils/sessions';
+import {
+  getCount,
+  getCrashFreeRate,
+  getSeriesAverage,
+  getSessionStatusRate,
+} from 'app/utils/sessions';
 import {Color} from 'app/utils/theme';
 import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {
@@ -389,10 +394,18 @@ function ReleaseComparisonChart({
   const allUsersCount = getCount(allSessions?.groups, SessionField.USERS);
 
   const sessionDurationTotal = roundDuration(
-    getCount(releaseSessions?.groups, SessionField.DURATION) / 1000
+    (getSeriesAverage(
+      releaseSessions?.groups,
+      SessionField.DURATION,
+      SessionStatus.HEALTHY
+    ) ?? 0) / 1000
   );
   const allSessionDurationTotal = roundDuration(
-    getCount(allSessions?.groups, SessionField.DURATION) / 1000
+    (getSeriesAverage(
+      allSessions?.groups,
+      SessionField.DURATION,
+      SessionStatus.HEALTHY
+    ) ?? 0) / 1000
   );
 
   const diffFailure =

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -21,6 +21,7 @@ import {
   SessionStatus,
 } from 'app/types';
 import {defined} from 'app/utils';
+import {getDuration, getExactDuration} from 'app/utils/formatters';
 import {getCrashFreeRateSeries, getSessionStatusRateSeries} from 'app/utils/sessions';
 import {Theme} from 'app/utils/theme';
 import {displayCrashFreePercent, roundDuration} from 'app/views/releases/utils';
@@ -77,8 +78,11 @@ class ReleaseSessionsChart extends React.Component<Props> {
       case ReleaseComparisonChartType.ERRORED_USERS:
       case ReleaseComparisonChartType.CRASHED_USERS:
         return defined(value) ? `${value}%` : '\u2015';
-      case ReleaseComparisonChartType.SESSION_COUNT:
       case ReleaseComparisonChartType.SESSION_DURATION:
+        return defined(value) && typeof value === 'number'
+          ? getExactDuration(value, true)
+          : '\u2015';
+      case ReleaseComparisonChartType.SESSION_COUNT:
       case ReleaseComparisonChartType.USER_COUNT:
       default:
         return typeof value === 'number' ? value.toLocaleString() : value;
@@ -113,8 +117,15 @@ class ReleaseSessionsChart extends React.Component<Props> {
             color: theme.chartLabel,
           },
         };
-      case ReleaseComparisonChartType.SESSION_COUNT:
       case ReleaseComparisonChartType.SESSION_DURATION:
+        return {
+          scale: true,
+          axisLabel: {
+            formatter: (value: number) => getDuration(value, undefined, true),
+            color: theme.chartLabel,
+          },
+        };
+      case ReleaseComparisonChartType.SESSION_COUNT:
       case ReleaseComparisonChartType.USER_COUNT:
       default:
         return undefined;

--- a/tests/js/spec/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/tests/js/spec/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -47,7 +47,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
       screen.getByTestId('release-comparison-table').textContent
     ).toMatchInlineSnapshot(
       // eslint-disable-next-line no-irregular-whitespace
-      `"DescriptionAll ReleasesThis ReleaseChangeCrash Free Session Rate 99.516%95.006%4.51% Healthy 98.564%94.001%4.563% Abnormal 0%0%0% —Errored 0.953%1.005%0.052% Crashed Session Rate 0.484%4.994%4.511% Crash Free User Rate 99.908%75%24.908% Healthy 98.994%72.022%26.972% Abnormal 0%0%0% —Errored 0.914%2.493%1.579% Crashed User Rate 0.092%25.485%25.393% Session Count 205k9.8k—Session Duration p50 110s585ms—User Count 100k361—"`
+      `"DescriptionAll ReleasesThis ReleaseChangeCrash Free Session Rate 99.516%95.006%4.51% Healthy 98.564%94.001%4.563% Abnormal 0%0%0% —Errored 0.953%1.005%0.052% Crashed Session Rate 0.484%4.994%4.511% Crash Free User Rate 99.908%75%24.908% Healthy 98.994%72.022%26.972% Abnormal 0%0%0% —Errored 0.914%2.493%1.579% Crashed User Rate 0.092%25.485%25.393% Session Count 205k9.8k—Session Duration p50 8s42ms—User Count 100k361—"`
     );
   });
 


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/1400464/131417362-9d4d98e7-94b9-42b3-b031-28bccbfd83e3.png)


after
axis is formatted, tooltip has seconds, and average makes more sense.
![image](https://user-images.githubusercontent.com/1400464/131417342-0a3bbf37-3228-431a-80a7-f01f6cf72188.png)

