### PR TITLE
fix(scim): add SCIM GET query param serializer

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
-from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from sentry import roles
@@ -23,18 +22,12 @@ from sentry.signals import member_invited
 from sentry.utils.cursors import SCIMCursor
 
 from .constants import (
-    SCIM_400_INVALID_FILTER,
     SCIM_400_INVALID_PATCH,
     SCIM_400_TOO_MANY_PATCH_OPS_ERROR,
     SCIM_409_USER_EXISTS,
     MemberPatchOps,
 )
-from .utils import (
-    OrganizationSCIMMemberPermission,
-    SCIMEndpoint,
-    SCIMFilterError,
-    parse_filter_conditions,
-)
+from .utils import OrganizationSCIMMemberPermission, SCIMEndpoint
 
 ERR_ONLY_OWNER = "You cannot remove the only remaining owner of the organization."
 from rest_framework.exceptions import PermissionDenied
@@ -123,11 +116,8 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
 
     def get(self, request, organization):
         # note that SCIM doesn't care about changing results as they're queried
-        # TODO: sanitize get parameter inputs?
-        try:
-            filter_val = parse_filter_conditions(request.GET.get("filter"))
-        except SCIMFilterError:
-            raise ParseError(detail=SCIM_400_INVALID_FILTER)
+
+        query_params = self.get_query_parameters(request)
 
         queryset = (
             OrganizationMember.objects.filter(
@@ -138,9 +128,10 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
             .select_related("user")
             .order_by("email", "user__email")
         )
-        if filter_val:
+        if query_params["filter"]:
             queryset = queryset.filter(
-                Q(email__iexact=filter_val) | Q(user__email__iexact=filter_val)
+                Q(email__iexact=query_params["filter"])
+                | Q(user__email__iexact=query_params["filter"])
             )  # not including secondary email vals (dups, etc.)
 
         def data_fn(offset, limit):
@@ -152,13 +143,13 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
                 None,
                 _scim_member_serializer_with_expansion(organization),
             )
-            return self.list_api_format(request, queryset.count(), results)
+            return self.list_api_format(results, queryset.count(), query_params["start_index"])
 
         return self.paginate(
             request=request,
             on_results=on_results,
             paginator=GenericOffsetPaginator(data_fn=data_fn),
-            default_per_page=int(request.GET.get("count", 100)),
+            default_per_page=query_params["count"],
             queryset=queryset,
             cursor_cls=SCIMCursor,
         )

--- a/src/sentry/scim/endpoints/schemas.py
+++ b/src/sentry/scim/endpoints/schemas.py
@@ -183,10 +183,10 @@ SCIM_SCHEMA_LIST = [SCIM_USER_ATTRIBUTES_SCHEMA, SCIM_GROUP_ATTRIBUTES_SCHEMA]
 
 class OrganizationSCIMSchemaIndex(SCIMEndpoint):
     def get(self, request, organization):
+        query_params = self.get_query_parameters(request)
+
         return Response(
             self.list_api_format(
-                request,
-                len(SCIM_SCHEMA_LIST),
-                SCIM_SCHEMA_LIST,
+                SCIM_SCHEMA_LIST, len(SCIM_SCHEMA_LIST), query_params["start_index"]
             )
         )

--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -41,8 +41,8 @@ from .utils import (
 delete_logger = logging.getLogger("sentry.deletions.api")
 
 
-def _team_expand(query):
-    return None if "members" in query.get("excludedAttributes", []) else ["members"]
+def _team_expand(excluded_attributes):
+    return None if "members" in excluded_attributes else ["members"]
 
 
 class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
@@ -55,29 +55,31 @@ class OrganizationSCIMTeamIndex(SCIMEndpoint, OrganizationTeamsEndpoint):
         return False
 
     def get(self, request, organization):
-        try:
-            filter_val = parse_filter_conditions(request.GET.get("filter"))
-        except SCIMFilterError:
-            raise ParseError(detail=SCIM_400_INVALID_FILTER)
+
+        query_params = self.get_query_parameters(request)
 
         queryset = Team.objects.filter(
             organization=organization, status=TeamStatus.VISIBLE
         ).order_by("slug")
-        if filter_val:
-            queryset = queryset.filter(name__iexact=filter_val)
+        if query_params["filter"]:
+            queryset = queryset.filter(name__iexact=query_params["filter"])
 
         def data_fn(offset, limit):
             return list(queryset[offset : offset + limit])
 
         def on_results(results):
-            results = serialize(results, None, TeamSCIMSerializer(expand=_team_expand(request.GET)))
-            return self.list_api_format(request, queryset.count(), results)
+            results = serialize(
+                results,
+                None,
+                TeamSCIMSerializer(expand=_team_expand(query_params["excluded_attributes"])),
+            )
+            return self.list_api_format(results, queryset.count(), query_params["start_index"])
 
         return self.paginate(
             request=request,
             on_results=on_results,
             paginator=GenericOffsetPaginator(data_fn=data_fn),
-            default_per_page=int(request.GET.get("count", 100)),
+            default_per_page=query_params["count"],
             queryset=queryset,
             cursor_cls=SCIMCursor,
         )
@@ -113,7 +115,12 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         return team
 
     def get(self, request, organization, team):
-        context = serialize(team, serializer=TeamSCIMSerializer(expand=_team_expand(request.GET)))
+        query_params = self.get_query_parameters(request)
+
+        context = serialize(
+            team,
+            serializer=TeamSCIMSerializer(expand=_team_expand(query_params["excluded_attributes"])),
+        )
         return Response(context)
 
     def _add_members_operation(self, request, operation, team):

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -195,7 +195,7 @@ class SCIMGroupIndexTests(SCIMTestCase):
             ],
         }
 
-    def test_invalid_filter(self):
+    def test_scim_invalid_filter(self):
         url = reverse("sentry-api-0-organization-scim-team-index", args=[self.organization.slug])
         response = self.client.get(f"{url}?startIndex=1&count=1&filter=bad filter eq 23")
         assert response.status_code == 400, response.data
@@ -203,6 +203,11 @@ class SCIMGroupIndexTests(SCIMTestCase):
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
             "scimType": "invalidFilter",
         }
+
+    def test_scim_invalid_startIndex(self):
+        url = reverse("sentry-api-0-organization-scim-team-index", args=[self.organization.slug])
+        response = self.client.get(f"{url}?startIndex=0")
+        assert response.status_code == 400, response.data
 
     def test_scim_team_no_duplicate_names(self):
         self.create_team(organization=self.organization, name=CREATE_TEAM_POST_DATA["displayName"])
@@ -212,3 +217,6 @@ class SCIMGroupIndexTests(SCIMTestCase):
         )
         response = self.client.post(url, CREATE_TEAM_POST_DATA)
         assert response.status_code == 409, response.content
+
+
+# TODO: test serializer, some E2E validation errors

--- a/tests/sentry/api/endpoints/test_scim_team_index.py
+++ b/tests/sentry/api/endpoints/test_scim_team_index.py
@@ -217,6 +217,3 @@ class SCIMGroupIndexTests(SCIMTestCase):
         )
         response = self.client.post(url, CREATE_TEAM_POST_DATA)
         assert response.status_code == 409, response.content
-
-
-# TODO: test serializer, some E2E validation errors

--- a/tests/sentry/api/endpoints/test_scim_user_index.py
+++ b/tests/sentry/api/endpoints/test_scim_user_index.py
@@ -2,7 +2,8 @@ from django.urls import reverse
 
 from sentry.models import OrganizationMember
 from sentry.models.auditlogentry import AuditLogEntry, AuditLogEntryEvent
-from sentry.testutils import SCIMAzureTestCase, SCIMTestCase
+from sentry.scim.endpoints.utils import SCIMQueryParamSerializer
+from sentry.testutils import SCIMAzureTestCase, SCIMTestCase, TestCase
 
 CREATE_USER_POST_DATA = {
     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
@@ -172,3 +173,35 @@ class SCIMMemberIndexAzureTests(SCIMAzureTestCase):
                 }
             ],
         }
+
+
+class SCIMQueryParameterSerializerTest(TestCase):
+    def test_defaults(self):
+        serializer = SCIMQueryParamSerializer(data={})
+        assert serializer.is_valid()
+        assert serializer.validated_data["start_index"] == 1
+        assert serializer.validated_data["count"] == 100
+        assert serializer.validated_data["excluded_attributes"] == []
+        assert serializer.validated_data["filter"] is None
+
+    def test_start_index(self):
+        serializer = SCIMQueryParamSerializer(data={"startIndex": 0})
+        assert not serializer.is_valid()
+
+        serializer = SCIMQueryParamSerializer(data={"startIndex": 1})
+        assert serializer.is_valid()
+
+    def test_count(self):
+        serializer = SCIMQueryParamSerializer(data={"count": -1})
+        assert not serializer.is_valid()
+
+        serializer = SCIMQueryParamSerializer(data={"count": 0})
+        assert serializer.is_valid()
+
+    def test_filter(self):
+        serializer = SCIMQueryParamSerializer(data={"filter": "aoiwefjoi3j9f"})
+        assert not serializer.is_valid()
+
+    def test_excluded_attributes(self):
+        serializer = SCIMQueryParamSerializer(data={"excludedAttributes": ["members"]})
+        assert serializer.is_valid()


### PR DESCRIPTION
Motivation: Seeing a few users in production who try to hit our SCIM endpoints with a startIndex of 0 -- this is considered an invalid request by the SCIM spec, and we were previously 500ing. 

In order to fix this and clean up the code, I've added a new serializer for SCIM GET parameters. All behaviour should remain the same except for 400ing on invalid parameters instead of 500ing.