### PR TITLE
feat(alert-rules): Create UI Component schema for Alert Rules

### DIFF
--- a/src/sentry/api/validators/sentry_apps/schema.py
+++ b/src/sentry/api/validators/sentry_apps/schema.py
@@ -130,14 +130,24 @@ SCHEMA = {
             },
             "required": ["type", "link", "create"],
         },
+        "alert-rule-settings": {
+            "type": "object",
+            "properties": {
+                "type": {"type": "string", "enum": ["alert-rule-settings"]},
+                "uri": {"$ref": "#/definitions/uri"},
+                "required_fields": {"$ref": "#/definitions/fieldset"},
+                "optional_fields": {"$ref": "#/definitions/fieldset"},
+            },
+            "required": ["type", "uri", "required_fields"],
+        },
         "alert-rule-action": {
             "type": "object",
             "properties": {
                 "type": {"type": "string", "enum": ["alert-rule-action"]},
-                "required_fields": {"$ref": "#/definitions/fieldset"},
-                "optional_fields": {"$ref": "#/definitions/fieldset"},
+                "title": {"type": "string"},
+                "settings": {"$ref": "#/definitions/alert-rule-settings"},
             },
-            "required": ["type", "required_fields"],
+            "required": ["type", "title", "settings"],
         },
         "issue-media": {
             "type": "object",

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -482,18 +482,23 @@ class PostSentryAppsTest(SentryAppsTest):
                 "elements": [
                     {
                         "type": "alert-rule-action",
-                        "required_fields": [
-                            {
-                                "type": "select",
-                                "label": "Channel",
-                                "name": "channel",
-                                "options": [
-                                    # option items should have 2 elements
-                                    # i.e. ['channel_id', '#general']
-                                    ["#general"]
-                                ],
-                            }
-                        ],
+                        "title": "Create task",
+                        "settings": {
+                            "type": "alert-rule-settings",
+                            "uri": "/sentry/alert-rule",
+                            "required_fields": [
+                                {
+                                    "type": "select",
+                                    "label": "Channel",
+                                    "name": "channel",
+                                    "options": [
+                                        # option items should have 2 elements
+                                        # i.e. ['channel_id', '#general']
+                                        ["#general"]
+                                    ],
+                                }
+                            ],
+                        },
                     }
                 ]
             }

--- a/tests/sentry/api/validators/sentry_apps/test_alert_rule_action.py
+++ b/tests/sentry/api/validators/sentry_apps/test_alert_rule_action.py
@@ -8,8 +8,13 @@ class TestAlertRuleActionSchemaValidation(TestCase):
     def setUp(self):
         self.schema = {
             "type": "alert-rule-action",
-            "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
-            "optional_fields": [{"type": "text", "name": "prefix", "label": "Prefix"}],
+            "title": "Create Task",
+            "settings": {
+                "type": "alert-rule-settings",
+                "uri": "/sentry/alert-rule",
+                "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
+                "optional_fields": [{"type": "text", "name": "prefix", "label": "Prefix"}],
+            },
         }
 
     def test_valid_schema(self):
@@ -17,5 +22,5 @@ class TestAlertRuleActionSchemaValidation(TestCase):
 
     @invalid_schema
     def test_missing_required_fields_fails(self):
-        del self.schema["required_fields"]
+        del self.schema["settings"]["required_fields"]
         validate_component(self.schema)

--- a/tests/sentry/api/validators/sentry_apps/test_schema.py
+++ b/tests/sentry/api/validators/sentry_apps/test_schema.py
@@ -51,15 +51,20 @@ class TestSchemaValidation(TestCase):
                 },
                 {
                     "type": "alert-rule-action",
-                    "required_fields": [
-                        {"type": "text", "name": "channel", "label": "Channel"},
-                        {
-                            "type": "select",
-                            "name": "send_email",
-                            "label": "Send Email?",
-                            "options": [["Yes", "yes"], ["No", "no"]],
-                        },
-                    ],
+                    "title": "Create task",
+                    "settings": {
+                        "type": "alert-rule-settings",
+                        "uri": "/sentry/alert-rule",
+                        "required_fields": [
+                            {"type": "text", "name": "channel", "label": "Channel"},
+                            {
+                                "type": "select",
+                                "name": "send_email",
+                                "label": "Send Email?",
+                                "options": [["Yes", "yes"], ["No", "no"]],
+                            },
+                        ],
+                    },
                 },
                 {
                     "type": "issue-media",


### PR DESCRIPTION
## Objective:

We will use this schema of the Alert Rule UI Component to validate the integration's schema against.