### PR TITLE
fix(releases): Fix bug when sorting by combination of session and release values.

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -332,7 +332,7 @@ class MergingOffsetPaginator(OffsetPaginator):
             extra_limit = limit - len(results) + 1
             total_data_count = self.data_count_func()
             total_offset = offset + len(results)
-            qs_offset = total_offset - total_data_count
+            qs_offset = max(0, total_offset - total_data_count)
             qs_results = self.queryset_load_func(
                 self.queryset, total_offset, qs_offset, extra_limit
             )

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -269,7 +269,7 @@ def get_project_releases_count(
     query = Query(
         dataset="sessions",
         match=Entity("sessions"),
-        select=[Function("uniq", [Column("release"), Column("project_id")], alias="count")],
+        select=[Function("uniqExact", [Column("release"), Column("project_id")], alias="count")],
         where=where,
         having=having,
     )


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/getsentry/sentry/pull/28234.

It's hard to reproduce, but I believe this is caused by not using `uniqExact`. As per the Clickhouse
docs:
https://clickhouse.tech/docs/en/sql-reference/aggregate-functions/reference/uniq/#agg_function-uniq
> Calculates the approximate number of different values of the argument.

This matches up with what I'm seeing, with the counts of unique sessions not matching up to the
number of sessions. It should be cheap to use it here, since we're not hitting many rows in the
rollup table.

I'm also adding a failsafe so that the offset never goes below 0.

Fixes SENTRY-S2H