### PR TITLE
refs(tests): Tidy up how issue alert tests run.

### DIFF
--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -28,28 +28,28 @@ class FrequencyConditionMixin:
         rule = self.get_rule(data=data, rule=Rule(environment_id=None))
         environment_rule = self.get_rule(data=data, rule=Rule(environment_id=self.environment.id))
 
-        event = self.store_event(
-            data={
-                "fingerprint": ["something_random"],
-                "timestamp": iso_format(before_now(minutes=minutes)),
-                "user": {"id": uuid4().hex},
-            },
-            project_id=self.project.id,
-        )
-        if add_events:
-            self.increment(
-                event,
-                data["value"] + 1,
-                environment=self.environment.name,
-                timestamp=now() - timedelta(minutes=minutes),
+        with freeze_time(before_now(minutes=0)):
+            event = self.store_event(
+                data={
+                    "fingerprint": ["something_random"],
+                    "timestamp": iso_format(before_now(minutes=minutes)),
+                    "user": {"id": uuid4().hex},
+                },
+                project_id=self.project.id,
             )
-            self.increment(
-                event,
-                data["value"] + 1,
-                timestamp=now() - timedelta(minutes=minutes),
-            )
+            if add_events:
+                self.increment(
+                    event,
+                    data["value"] + 1,
+                    environment=self.environment.name,
+                    timestamp=now() - timedelta(minutes=minutes),
+                )
+                self.increment(
+                    event,
+                    data["value"] + 1,
+                    timestamp=now() - timedelta(minutes=minutes),
+                )
 
-        with freeze_time(before_now(minutes=minutes)):
             if passes:
                 self.assertPasses(rule, event)
                 self.assertPasses(environment_rule, event)


### PR DESCRIPTION
When printing out queries to snuba from issue alerts, I was getting strange values. This is because
if `group.first_seen > start` then `start = group.first_seen`. This is an efficiency optmization,
but is confusing if trying to understand production behaviour.

Freezing time at the beginning of the process makes this a little clearer. Doesn't effect how the
tests run at all.