### PR TITLE
ref(py): Make `unversioned` frontend assets name more generic

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -373,7 +373,7 @@ STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned
 # as we configure webpack to include file content based hash in the filename
-STATIC_UNVERSIONED_URL = "/_static/dist/"
+STATIC_WEBPACK_URL = "/_static/dist/"
 
 # The webpack output directory
 STATICFILES_DIRS = [

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -373,7 +373,7 @@ STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
 STATIC_URL = "/_static/{version}/"
 # webpack assets live at a different URL that is unversioned
 # as we configure webpack to include file content based hash in the filename
-STATIC_WEBPACK_URL = "/_static/dist/"
+STATIC_FRONTEND_APP_URL = "/_static/dist/"
 
 # The webpack output directory
 STATICFILES_DIRS = [

--- a/src/sentry/middleware/user.py
+++ b/src/sentry/middleware/user.py
@@ -7,7 +7,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 class UserActiveMiddleware(MiddlewareMixin):
     disallowed_paths = (
-        "sentry.web.frontend.generic.unversioned_static_media",
+        "sentry.web.frontend.generic.webpack_static_media",
         "sentry.web.frontend.generic.static_media",
         "sentry.web.frontend.organization_avatar",
         "sentry.web.frontend.project_avatar",

--- a/src/sentry/middleware/user.py
+++ b/src/sentry/middleware/user.py
@@ -7,7 +7,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 class UserActiveMiddleware(MiddlewareMixin):
     disallowed_paths = (
-        "sentry.web.frontend.generic.webpack_static_media",
+        "sentry.web.frontend.generic.frontend_app_static_media",
         "sentry.web.frontend.generic.static_media",
         "sentry.web.frontend.organization_avatar",
         "sentry.web.frontend.project_avatar",

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% unversioned_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
+    {% webpack_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% webpack_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
+    {% frontend_app_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% unversioned_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
+  <link href="{% webpack_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -54,7 +54,7 @@
 
   {% block scripts %}
   {% block scripts_main_entrypoint %}
-    {% unversioned_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
+    {% webpack_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% webpack_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
+  <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -54,7 +54,7 @@
 
   {% block scripts %}
   {% block scripts_main_entrypoint %}
-    {% webpack_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
+    {% frontend_app_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -5,13 +5,13 @@ from django.conf import settings
 from django.template.base import token_kwargs
 
 from sentry import options
-from sentry.utils.assets import get_asset_url, get_unversioned_asset_url
+from sentry.utils.assets import get_asset_url, get_webpack_asset_url
 from sentry.utils.http import absolute_uri
 
 register = template.Library()
 
 register.simple_tag(get_asset_url, name="asset_url")
-register.simple_tag(get_unversioned_asset_url, name="unversioned_asset_url")
+register.simple_tag(get_webpack_asset_url, name="webpack_asset_url")
 
 
 @register.simple_tag

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -5,13 +5,13 @@ from django.conf import settings
 from django.template.base import token_kwargs
 
 from sentry import options
-from sentry.utils.assets import get_asset_url, get_webpack_asset_url
+from sentry.utils.assets import get_asset_url, get_frontend_app_asset_url
 from sentry.utils.http import absolute_uri
 
 register = template.Library()
 
 register.simple_tag(get_asset_url, name="asset_url")
-register.simple_tag(get_webpack_asset_url, name="webpack_asset_url")
+register.simple_tag(get_frontend_app_asset_url, name="frontend_app_asset_url")
 
 
 @register.simple_tag

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 
-def get_unversioned_asset_url(module, key, cache_bust=False):
+def get_webpack_asset_url(module, key, cache_bust=False):
     """
     Returns an asset URL that is unversioned. These assets should have a
     `Cache-Control: max-age=0, must-revalidate` so that clients must validate with the origin
@@ -13,13 +13,13 @@ def get_unversioned_asset_url(module, key, cache_bust=False):
     for frontend only deploys.
 
     Example:
-      {% unversioned_asset_url 'sentry' 'sentry.css' %}
+      {% webpack_asset_url 'sentry' 'sentry.css' %}
       =>  "/_static/dist/sentry/sentry.css"
 
-      {% unversioned_asset_url 'sentry' 'sentry.css' cache_bust=True %}
+      {% webpack_asset_url 'sentry' 'sentry.css' cache_bust=True %}
       =>  "/_static/dist/sentry/sentry.css?v=xxx"
     """
-    args = (settings.STATIC_UNVERSIONED_URL.rstrip("/"), module, key.lstrip("/"))
+    args = (settings.STATIC_WEBPACK_URL.rstrip("/"), module, key.lstrip("/"))
 
     if not cache_bust:
         return "{}/{}/{}".format(*args)

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 
-def get_webpack_asset_url(module, key, cache_bust=False):
+def get_frontend_app_asset_url(module, key, cache_bust=False):
     """
     Returns an asset URL that is unversioned. These assets should have a
     `Cache-Control: max-age=0, must-revalidate` so that clients must validate with the origin
@@ -13,13 +13,13 @@ def get_webpack_asset_url(module, key, cache_bust=False):
     for frontend only deploys.
 
     Example:
-      {% webpack_asset_url 'sentry' 'sentry.css' %}
+      {% frontend_app_asset_url 'sentry' 'sentry.css' %}
       =>  "/_static/dist/sentry/sentry.css"
 
-      {% webpack_asset_url 'sentry' 'sentry.css' cache_bust=True %}
+      {% frontend_app_asset_url 'sentry' 'sentry.css' cache_bust=True %}
       =>  "/_static/dist/sentry/sentry.css?v=xxx"
     """
-    args = (settings.STATIC_WEBPACK_URL.rstrip("/"), module, key.lstrip("/"))
+    args = (settings.STATIC_FRONTEND_APP_URL.rstrip("/"), module, key.lstrip("/"))
 
     if not cache_bust:
         return "{}/{}/{}".format(*args)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -12,7 +12,7 @@ from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
-from sentry.utils.assets import get_unversioned_asset_url
+from sentry.utils.assets import get_webpack_asset_url
 from sentry.utils.email import is_smtp_enabled
 from sentry.utils.support import get_support_mail
 
@@ -146,7 +146,7 @@ def get_client_config(request=None):
         "urlPrefix": options.get("system.url-prefix"),
         "version": version_info,
         "features": enabled_features,
-        "distPrefix": get_unversioned_asset_url("sentry", ""),
+        "distPrefix": get_webpack_asset_url("sentry", ""),
         "needsUpgrade": needs_upgrade,
         "dsn": public_dsn,
         "dsn_requests": _get_dsn_requests(),

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -12,7 +12,7 @@ from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
-from sentry.utils.assets import get_webpack_asset_url
+from sentry.utils.assets import get_frontend_app_asset_url
 from sentry.utils.email import is_smtp_enabled
 from sentry.utils.support import get_support_mail
 
@@ -146,7 +146,7 @@ def get_client_config(request=None):
         "urlPrefix": options.get("system.url-prefix"),
         "version": version_info,
         "features": enabled_features,
-        "distPrefix": get_webpack_asset_url("sentry", ""),
+        "distPrefix": get_frontend_app_asset_url("sentry", ""),
         "needsUpgrade": needs_upgrade,
         "dsn": public_dsn,
         "dsn_requests": _get_dsn_requests(),

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -45,7 +45,7 @@ def resolve(path):
     return os.path.split(absolute_path)
 
 
-def unversioned_static_media(request, **kwargs):
+def webpack_static_media(request, **kwargs):
     """
     Serve static files that should not have any versioned paths/filenames.
     These assets will have cache headers to say that it can be cached by a

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -45,7 +45,7 @@ def resolve(path):
     return os.path.split(absolute_path)
 
 
-def webpack_static_media(request, **kwargs):
+def frontend_app_static_media(request, **kwargs):
     """
     Serve static files that should not have any versioned paths/filenames.
     These assets will have cache headers to say that it can be cached by a

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -96,8 +96,8 @@ urlpatterns += [
     # a filecontent-based hash in its filenames so that it can be cached long term
     url(
         r"^_static/dist/(?P<module>[^/]+)/(?P<path>.*)$",
-        generic.unversioned_static_media,
-        name="sentry-unversioned-media",
+        generic.webpack_static_media,
+        name="sentry-webpack-media",
     ),
     # The static version is either a 10 digit timestamp, a sha1, or md5 hash
     url(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -96,8 +96,8 @@ urlpatterns += [
     # a filecontent-based hash in its filenames so that it can be cached long term
     url(
         r"^_static/dist/(?P<module>[^/]+)/(?P<path>.*)$",
-        generic.webpack_static_media,
-        name="sentry-webpack-media",
+        generic.frontend_app_static_media,
+        name="sentry-frontend-app-media",
     ),
     # The static version is either a 10 digit timestamp, a sha1, or md5 hash
     url(

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -3,7 +3,7 @@ import os
 from django.test.utils import override_settings
 
 from sentry.testutils import TestCase
-from sentry.utils.assets import get_unversioned_asset_url
+from sentry.utils.assets import get_webpack_asset_url
 from sentry.web.frontend.generic import FOREVER_CACHE, NEVER_CACHE, NO_CACHE
 
 
@@ -44,7 +44,7 @@ class StaticMediaTest(TestCase):
             assert response["Access-Control-Allow-Origin"] == "*"
 
     @override_settings(DEBUG=False)
-    def test_unversioned(self):
+    def test_webpack_assets(self):
         """
         static assets that do not have versioned filenames/paths
         """
@@ -58,7 +58,7 @@ class StaticMediaTest(TestCase):
 
         try:
             with open(os.path.join(dist_path, "test.js"), "a"):
-                url = get_unversioned_asset_url("sentry", "test.js", cache_bust=True)
+                url = get_webpack_asset_url("sentry", "test.js", cache_bust=True)
                 assert "?v=" in url
 
                 response = self.client.get(url)

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -3,7 +3,7 @@ import os
 from django.test.utils import override_settings
 
 from sentry.testutils import TestCase
-from sentry.utils.assets import get_webpack_asset_url
+from sentry.utils.assets import get_frontend_app_asset_url
 from sentry.web.frontend.generic import FOREVER_CACHE, NEVER_CACHE, NO_CACHE
 
 
@@ -44,7 +44,7 @@ class StaticMediaTest(TestCase):
             assert response["Access-Control-Allow-Origin"] == "*"
 
     @override_settings(DEBUG=False)
-    def test_webpack_assets(self):
+    def test_frontend_app_assets(self):
         """
         static assets that do not have versioned filenames/paths
         """
@@ -58,7 +58,7 @@ class StaticMediaTest(TestCase):
 
         try:
             with open(os.path.join(dist_path, "test.js"), "a"):
-                url = get_webpack_asset_url("sentry", "test.js", cache_bust=True)
+                url = get_frontend_app_asset_url("sentry", "test.js", cache_bust=True)
                 assert "?v=" in url
 
                 response = self.client.get(url)


### PR DESCRIPTION
Rename the use of `unversioned` throughout to be more generic and less implementation based. These assets are all bundled from `webpack`. 