### PR TITLE
ref(events): Don't query snuba unnecessarily

### DIFF
--- a/src/sentry/web/frontend/group_event_json.py
+++ b/src/sentry/web/frontend/group_event_json.py
@@ -20,7 +20,9 @@ class GroupEventJsonView(OrganizationView):
         if event_id_or_latest == "latest":
             event = group.get_latest_event()
         else:
-            event = eventstore.get_event_by_id(group.project.id, event_id_or_latest)
+            event = eventstore.get_event_by_id(
+                group.project.id, event_id_or_latest, group_id=group.id
+            )
 
         if event is None:
             raise Http404


### PR DESCRIPTION
The group ID parameter can be populated from the group we just got from postgres.

Note: This endpoint doesn't validate the group ID against the event at all. You can swap out the issue ID of a working link with another totally unrelated issue ID and it will work. This PR doesn't change that.