### PR TITLE
ref: Narrow down ingestion delay

### DIFF
--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -216,6 +216,7 @@ class SnubaEventStorage(EventStorage):
                         "group_id": group_id,
                         "event_datetime": event.datetime,
                         "event_timestamp": event.timestamp,
+                        "received": event.data.get("received"),
                         "len_data": len(result["data"]),
                     },
                 )


### PR DESCRIPTION
We have seen cases where data is in Nodestore but not Snuba. I am trying to
figure out if there is a delay in writing to Snuba, or a delay in writing to
Snuba and Nodestore.