### PR TITLE
fix(django 2.2): rename view method to avoid clashing

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -36,7 +36,10 @@ class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2Endpoi
     def has_tag_page_feature(self, organization, request):
         return features.has("organizations:performance-tag-page", organization, actor=request.user)
 
-    def setup(self, request, organization):
+    # NOTE: This used to be called setup, but since Django 2.2 it's a View method.
+    #       We don't fit its semantics, but I couldn't think of a better name, and
+    #       it's only used in child classes.
+    def _setup(self, request, organization):
         if not (
             self.has_feature(organization, request)
             or self.has_tag_page_feature(organization, request)
@@ -63,7 +66,7 @@ class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2Endpoi
 class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerformanceEndpointBase):
     def get(self, request, organization):
         try:
-            params, aggregate_column, filter_query = self.setup(request, organization)
+            params, aggregate_column, filter_query = self._setup(request, organization)
         except NoProjects:
             return Response([])
 
@@ -134,7 +137,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpoint(
 
     def get(self, request, organization):
         try:
-            params, aggregate_column, filter_query = self.setup(request, organization)
+            params, aggregate_column, filter_query = self._setup(request, organization)
         except NoProjects:
             return Response([])
 


### PR DESCRIPTION
Django 2.2 introduces a new `setup` method for Views. AFAICT this is the only View with an existing `setup` method, which needs to be renamed.