### PR TITLE
fix(itunes): Change required state for SMS slightly

### DIFF
--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -67,9 +67,6 @@ class AppStoreConnectConfig:
     type: str
 
     # The ID which identifies this symbol source for this project.
-    #
-    # Currently we only allow one appStoreConnect source per project, but we already
-    # identify them using an ID anyway for future safety.
     id: str
 
     # The name of the symbol source.

--- a/src/sentry/utils/appleconnect/itunes_connect.py
+++ b/src/sentry/utils/appleconnect/itunes_connect.py
@@ -190,10 +190,10 @@ class ITunesClient:
         if self.session_id is not None:
             context["session_id"] = self.session_id
         if self._scnt is not None:
-            context["scnt"] = self._scnt
         if self._trusted_phone is not None:
             context["phone_id"] = self._trusted_phone.id
             context["phone_push_mode"] = self._trusted_phone.push_mode
+            context["scnt"] = self.scnt
         if self.state is ClientState.AUTHENTICATED:
             context["session_cookie"] = self.session_cookie()
         return context


### PR DESCRIPTION
The itunes client has intricate state during authentication, while
ideally this would be split off in a ITunesAuthenticator and
ITunesClient during the authentication phase it still has a lot of
itunes state anyway.

This tries to keep track of this a little different by instead making
the state access itself enforce that the state is correct, instead of
keeping strict track of which state the entire state machine is in.
This is easlier for the helper methods to keep track of state.

Finally it removes the trusted phone info as state, this was only used
in one place anyway so caching it as state did not gain anything.

NATIVE-183

---

I have tested this once running through the normal and the sms flow, but I haven't tested any weird variations or abuse attempts.