### PR TITLE
feat(deletions) Add daily re-attempt for deletions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -729,6 +729,11 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=15),
         "options": {"expires": 60 * 25},
     },
+    "reattempt-deletions": {
+        "task": "sentry.tasks.deletion.reattempt_deletions",
+        "schedule": crontab(hour=10, minute=0),  # 03:00 PDT, 07:00 EDT, 10:00 UTC
+        "options": {"expires": 60 * 25},
+    },
     "schedule-weekly-organization-reports": {
         "task": "sentry.tasks.reports.prepare_reports",
         "schedule": crontab(

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from uuid import uuid4
 
 from django.apps import apps
@@ -14,6 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 MAX_RETRIES = 5
+
+
+@instrumented_task(
+    name="sentry.tasks.deletion.reattempt_deletions", queue="cleanup", acks_late=True
+)
+def reattempt_deletions():
+    from sentry.models import ScheduledDeletion
+
+    # If a deletion is in progress and was scheduled to run more than
+    # a day ago we can assume the previous job died/failed.
+    # Turning off the in_progress flag will result in the job being picked
+    # up in the next deletion run allowing us to start over.
+    queryset = ScheduledDeletion.objects.filter(
+        in_progress=True, aborted=False, date_scheduled__lte=timezone.now() - timedelta(days=1)
+    )
+    queryset.update(in_progress=False)
 
 
 @instrumented_task(
@@ -44,7 +61,7 @@ def run_scheduled_deletions():
     acks_late=True,
 )
 @retry(exclude=(DeleteAborted,))
-def run_deletion(deletion_id):
+def run_deletion(deletion_id, first_pass=True):
     from sentry import deletions
     from sentry.models import ScheduledDeletion
 
@@ -56,12 +73,10 @@ def run_deletion(deletion_id):
     if deletion.aborted:
         raise DeleteAborted
 
-    if not deletion.in_progress:
+    if first_pass:
         actor = deletion.get_actor()
         instance = deletion.get_instance()
-        with transaction.atomic():
-            deletion.update(in_progress=True)
-            pending_delete.send(sender=type(instance), instance=instance, actor=actor)
+        pending_delete.send(sender=type(instance), instance=instance, actor=actor)
 
     task = deletions.get(
         model=deletion.get_model(),
@@ -71,8 +86,11 @@ def run_deletion(deletion_id):
     )
     has_more = task.chunk()
     if has_more:
-        run_deletion.apply_async(kwargs={"deletion_id": deletion_id}, countdown=15)
-    deletion.delete()
+        run_deletion.apply_async(
+            kwargs={"deletion_id": deletion_id, "first_pass": False}, countdown=15
+        )
+    else:
+        deletion.delete()
 
 
 @instrumented_task(


### PR DESCRIPTION
With scheduled deletions we have a record of the work we wanted to do which is left behind when we can't do the intended work. Because starting a deletion moves a job into `in_progress` we need to revert that state on dropped jobs, so that they can be resumed.

I've also fixed the problem where a deletion job that had additional chunks would never finish because the first chunk would delete the deletion record which we need to finish the other chunks.