### PR TITLE
build(ci): Remove `make` usage in GH Actions

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,7 +1,13 @@
+# NOTE: Do not rely on `make` commands here as this action is used across different repos
+# where the Makefile will not be available
 name: 'python setup'
 description: 'Configures python, pip, and configures pip cache dir as output.'
 
 inputs:
+  workdir:
+    description: 'Directory where the sentry source is located'
+    required: false
+    default: '.'
   cache-files-hash:
     description: 'A single hash for a set of files. Used for caching.'
     required: false

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -49,6 +49,8 @@ runs:
 
     - name: Install pip
       shell: bash
+      env:
+        WORKDIR: ${{ inputs.workdir }}
       run: |
         source "$WORKDIR/scripts/lib.sh" && upgrade-pip
 

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Install pip
       shell: bash
       run: |
-        make upgrade-pip
+        source "$WORKDIR/scripts/lib.sh" && upgrade-pip
 
     - name: Get pip cache dir & version
       id: pip-info

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -1,3 +1,5 @@
+# NOTE: Do not rely on `make` commands here as this action is used across different repos
+# where the Makefile will not be available
 name: 'Sentry Setup'
 description: 'Sets up a Sentry test environment'
 inputs:

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -97,6 +97,7 @@ runs:
       uses: ./.github/actions/setup-python
       with:
         pip-cache-version: ${{ inputs.pip-cache-version }}
+        workdir: ${{ inputs.workdir }}
 
     - name: Install system dependencies
       shell: bash

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -2,6 +2,9 @@
 # Module containing code shared across various shell scripts
 # Execute functions from this module via the script do.sh
 
+# NOTE: This file is sourced in CI across different repos (e.g. snuba),
+# so renaming this file or any functions can break CI!
+
 # Check if a command is available
 require() {
     command -v "$1" >/dev/null 2>&1


### PR DESCRIPTION
The `setup-sentry` action is used in other repos (e.g. snuba). Makefile will not be available in those repos. Instead, have the action source `scripts/lib` and call `upgrade_pip` directly.