### PR TITLE
ref(ui): Team selector component to handle all team selection in app

### DIFF
--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -56,11 +56,17 @@ type Props = {
   organization: Organization;
   teams: Team[];
   onChange: (value: any) => any;
-  // Function to control whether a team should be shown in the dropdown
+  /**
+   * Function to control whether a team should be shown in the dropdown
+   */
   teamFilter?: (team: Team) => boolean;
-  // Include only the provided Project's teams and allow user to add teams to projects on the fly
+  /**
+   * Can be used to restrict teams to a certain project and allow for new teams to be add to that project
+   */
   project?: Project;
-  // Controls whether the value in the dropdown is an id instead of slug
+  /**
+   * Controls whether the value in the dropdown is a team id or team slug
+   */
   useId?: boolean;
   includeUnassigned?: boolean;
 } & ControlProps;
@@ -79,11 +85,7 @@ type SelectableTeam = {
   disabled?: boolean;
 };
 
-type UnselectableTeam = SelectableTeam & {
-  disabled: true;
-};
-
-type TeamOption = SelectableTeam | UnselectableTeam | typeof unassignedOption;
+type TeamOption = SelectableTeam | typeof unassignedOption;
 
 type State = {
   options: TeamOption[];
@@ -185,7 +187,7 @@ class TeamSelector extends React.Component<Props, State> {
     this.closeSelectMenu();
   };
 
-  createTeamOutsideProjectOption = (team: Team): UnselectableTeam => {
+  createTeamOutsideProjectOption = (team: Team): TeamOption => {
     const {organization} = this.props;
     const canAddTeam = organization.access.includes('project:write');
 

--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -228,7 +228,6 @@ class TeamSelector extends React.Component<Props, State> {
   render() {
     const {includeUnassigned, styles, ...props} = this.props;
     const {options} = this.state;
-    console.log(options);
     return (
       <SelectControl
         ref={this.selectRef}

--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -144,8 +144,6 @@ class TeamSelector extends React.Component<Props, State> {
       return;
     }
 
-    // @ts-ignore The types for react-select don't cover this property
-    // or the type of selectRef is incorrect.
     const select = this.selectRef.current.select;
     const input: HTMLInputElement = select.inputRef;
     if (input) {

--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -104,6 +104,7 @@ class TeamSelector extends React.Component<Props, State> {
   get teamOptions() {
     const {teams, teamFilter, includeUnassigned, project} = this.props;
     const filteredTeams = teamFilter ? teams.filter(teamFilter) : teams;
+
     if (project) {
       const teamsInProjectIdSet = new Set(project.teams.map(team => team.id));
       const teamsInProject = filteredTeams.filter(team =>
@@ -119,6 +120,7 @@ class TeamSelector extends React.Component<Props, State> {
         ...(includeUnassigned ? [unassignedOption] : []),
       ];
     }
+
     return [
       ...filteredTeams.map(this.createTeamOption),
       ...(includeUnassigned ? [unassignedOption] : []),
@@ -147,6 +149,7 @@ class TeamSelector extends React.Component<Props, State> {
 
     const select = this.selectRef.current.select;
     const input: HTMLInputElement = select.inputRef;
+
     if (input) {
       // I don't think there's another way to close `react-select`
       input.blur();
@@ -154,7 +157,7 @@ class TeamSelector extends React.Component<Props, State> {
   }
 
   handleAddTeamToProject = async (team: Team) => {
-    const {api, organization, project, value} = this.props;
+    const {api, organization, project, value, multiple} = this.props;
     const {options} = this.state;
 
     if (!project) {
@@ -163,8 +166,7 @@ class TeamSelector extends React.Component<Props, State> {
     }
 
     // Copy old value
-    const oldValue = value ? [...value] : {value};
-
+    const oldValue = multiple ? [...(value ?? [])] : {value};
     // Optimistic update
     this.props.onChange?.(this.createTeamOption(team));
 
@@ -180,11 +182,13 @@ class TeamSelector extends React.Component<Props, State> {
 
         return option;
       });
+
       this.setState({options: newOptions});
     } catch (err) {
       // Unable to add team to project, revert select menu value
       this.props.onChange?.(oldValue);
     }
+
     this.closeSelectMenu();
   };
 
@@ -229,6 +233,7 @@ class TeamSelector extends React.Component<Props, State> {
   render() {
     const {includeUnassigned, styles, ...props} = this.props;
     const {options} = this.state;
+
     return (
       <SelectControl
         ref={this.selectRef}

--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -1,0 +1,265 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+
+import {addTeamToProject} from 'app/actionCreators/projects';
+import {Client} from 'app/api';
+import Button from 'app/components/button';
+import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
+import {IconAdd, IconUser} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization, Project, Team} from 'app/types';
+import withApi from 'app/utils/withApi';
+import withOrganization from 'app/utils/withOrganization';
+import withTeams from 'app/utils/withTeams';
+
+import IdBadge from '../idBadge';
+import Tooltip from '../tooltip';
+
+const UnassignedWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledIconUser = styled(IconUser)`
+  margin-left: ${space(0.25)};
+  margin-right: ${space(1)};
+  color: ${p => p.theme.gray400};
+`;
+
+// An option to be unassigned on the team dropdown
+const unassignedOption = {
+  value: null,
+  label: (
+    <UnassignedWrapper>
+      <StyledIconUser size="20px" />
+      {t('Unassigned')}
+    </UnassignedWrapper>
+  ),
+  searchKey: 'unassigned',
+  actor: null,
+  disabled: false,
+};
+
+// Ensures that the svg icon is white when selected
+const unassignedSelectStyles = {
+  option: (provided, state: any) => ({
+    ...provided,
+    svg: {
+      color: state.isSelected && state.theme.white,
+    },
+  }),
+};
+
+type Props = {
+  api: Client;
+  organization: Organization;
+  teams: Team[];
+  onChange: (value: any) => any;
+  // Function to control whether a team should be shown in the dropdown
+  teamFilter?: (team: Team) => boolean;
+  // Include only the provided Project's teams and allow user to add teams to projects on the fly
+  project?: Project;
+  // Controls whether the value in the dropdown is an id instead of slug
+  useId?: boolean;
+  includeUnassigned?: boolean;
+} & ControlProps;
+
+type TeamActor = {
+  type: 'team';
+  id: string;
+  name: string;
+};
+
+type SelectableTeam = {
+  value: string;
+  label: React.ReactElement;
+  searchKey: string;
+  actor: TeamActor;
+  disabled?: boolean;
+};
+
+type UnselectableTeam = SelectableTeam & {
+  disabled: true;
+};
+
+type TeamOption = SelectableTeam | UnselectableTeam | typeof unassignedOption;
+
+type State = {
+  options: TeamOption[];
+};
+
+class TeamSelector extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      options: this.teamOptions,
+    };
+  }
+
+  // TODO(ts) This type could be improved when react-select types are better.
+  selectRef = React.createRef<any>();
+
+  get teamOptions() {
+    const {teams, teamFilter, includeUnassigned, project} = this.props;
+    const filteredTeams = teamFilter ? teams.filter(teamFilter) : teams;
+    if (project) {
+      const teamsInProjectIdSet = new Set(project.teams.map(({id}) => id));
+      const teamsInProject = filteredTeams.filter(({id}) => teamsInProjectIdSet.has(id));
+      const teamsNotInProject = filteredTeams.filter(
+        ({id}) => !teamsInProjectIdSet.has(id)
+      );
+
+      return [
+        ...teamsInProject.map(this.createTeamOption),
+        ...teamsNotInProject.map(this.createTeamOutsideProjectOption),
+        ...(includeUnassigned ? [unassignedOption] : []),
+      ];
+    }
+    const teamOptions: TeamOption[] = filteredTeams.map(this.createTeamOption);
+    if (includeUnassigned) {
+      teamOptions.push(unassignedOption);
+    }
+    return teamOptions;
+  }
+
+  createTeamOption = (team: Team): SelectableTeam => ({
+    value: this.props.useId ? team.id : team.slug,
+    label: <IdBadge team={team} />,
+    searchKey: `#${team.slug}`,
+    actor: {
+      type: 'team',
+      id: team.id,
+      name: team.slug,
+    },
+  });
+
+  /**
+   * Closes the select menu by blurring input if possible since that seems to be the only
+   * way to close it.
+   */
+  closeSelectMenu() {
+    if (!this.selectRef.current) {
+      return;
+    }
+
+    // @ts-ignore The types for react-select don't cover this property
+    // or the type of selectRef is incorrect.
+    const select = this.selectRef.current.select;
+    const input: HTMLInputElement = select.inputRef;
+    if (input) {
+      // I don't think there's another way to close `react-select`
+      input.blur();
+    }
+  }
+
+  handleAddTeamToProject = async (team: Team) => {
+    const {api, organization, project, value} = this.props;
+    const {options} = this.state;
+
+    // Copy old value
+    const oldValue = value ? [...value] : {value};
+
+    // Optimistic update
+    this.props.onChange?.(this.createTeamOption(team));
+
+    try {
+      // Try to add team to project
+      if (project) {
+        await addTeamToProject(api, organization.slug, project.slug, team);
+
+        // Remove add to project button without changing order
+        const newOptions = options!.map(option => {
+          if (option.actor?.id === team.id) {
+            option.disabled = false;
+            option.label = <IdBadge team={team} />;
+          }
+
+          return option;
+        });
+        this.setState({options: newOptions});
+      }
+    } catch (err) {
+      // Unable to add team to project, revert select menu value
+      this.props.onChange?.(oldValue);
+    }
+    this.closeSelectMenu();
+  };
+
+  createTeamOutsideProjectOption = (team: Team): UnselectableTeam => {
+    const {organization} = this.props;
+    const canAddTeam = organization.access.includes('project:write');
+
+    return {
+      ...this.createTeamOption(team),
+      disabled: true,
+      label: (
+        <TeamOutsideProject>
+          <DisabledLabel>
+            <Tooltip
+              position="left"
+              title={t('%s is not a member of project', `#${team.slug}`)}
+            >
+              <IdBadge team={team} />
+            </Tooltip>
+          </DisabledLabel>
+          <Tooltip
+            title={
+              canAddTeam
+                ? t('Add %s to project', `#${team.slug}`)
+                : t('You do not have permission to add team to project.')
+            }
+          >
+            <AddToProjectButton
+              type="button"
+              size="zero"
+              borderless
+              disabled={!canAddTeam}
+              onClick={() => this.handleAddTeamToProject(team)}
+              icon={<IconAdd isCircled />}
+            />
+          </Tooltip>
+        </TeamOutsideProject>
+      ),
+    };
+  };
+
+  render() {
+    const {includeUnassigned, styles, ...props} = this.props;
+    const {options} = this.state;
+    console.log(options);
+    return (
+      <SelectControl
+        ref={this.selectRef}
+        options={options}
+        isOptionDisabled={option => option.disabled}
+        styles={{
+          styles,
+          ...(includeUnassigned ? unassignedSelectStyles : {}),
+        }}
+        {...props}
+      />
+    );
+  }
+}
+
+const TeamOutsideProject = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+`;
+
+const DisabledLabel = styled('div')`
+  display: flex;
+  opacity: 0.5;
+  overflow: hidden; /* Needed so that "Add to team" button can fit */
+`;
+
+const AddToProjectButton = styled(Button)`
+  flex-shrink: 0;
+`;
+
+export {TeamSelector};
+
+export default withApi(withTeams(withOrganization(TeamSelector)));

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -12,11 +12,10 @@ import {MEMBER_ROLES} from 'app/constants';
 import {IconAdd, IconCheckmark, IconWarning} from 'app/icons';
 import {t, tct, tn} from 'app/locale';
 import space from 'app/styles/space';
-import {Organization, Team} from 'app/types';
+import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {uniqueId} from 'app/utils/guid';
 import withLatestContext from 'app/utils/withLatestContext';
-import withTeams from 'app/utils/withTeams';
 
 import InviteRowControl from './inviteRowControl';
 import {InviteRow, InviteStatus, NormalizedInvite} from './types';
@@ -24,7 +23,6 @@ import {InviteRow, InviteStatus, NormalizedInvite} from './types';
 type Props = AsyncComponent['props'] &
   ModalRenderProps & {
     organization: Organization;
-    teams: Team[];
     source?: string;
     initialData?: Partial<InviteRow>[];
   };
@@ -327,7 +325,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
   }
 
   render() {
-    const {Footer, closeModal, organization, teams: allTeams} = this.props;
+    const {Footer, closeModal, organization} = this.props;
     const {pendingInvites, sendingInvites, complete, inviteStatus, member} = this.state;
 
     const disableInputs = sendingInvites || complete;
@@ -375,7 +373,6 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
             teams={[...teams]}
             roleOptions={member ? member.roles : MEMBER_ROLES}
             roleDisabledUnallowed={this.willInvite}
-            teamOptions={allTeams}
             inviteStatus={inviteStatus}
             onRemove={() => this.removeInviteRow(i)}
             onChangeEmails={opts => this.setEmails(opts?.map(v => v.value) ?? [], i)}
@@ -524,4 +521,4 @@ export const modalCss = css`
   margin: 50px auto;
 `;
 
-export default withLatestContext(withTeams(InviteMembersModal));
+export default withLatestContext(InviteMembersModal);

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -4,10 +4,11 @@ import {withTheme} from '@emotion/react';
 
 import Button from 'app/components/button';
 import SelectControl from 'app/components/forms/selectControl';
+import TeamSelector from 'app/components/forms/teamSelector';
 import RoleSelectControl from 'app/components/roleSelectControl';
 import {IconClose} from 'app/icons/iconClose';
 import {t} from 'app/locale';
-import {MemberRole, SelectValue, Team} from 'app/types';
+import {MemberRole, SelectValue} from 'app/types';
 import {Theme} from 'app/utils/theme';
 
 import renderEmailValue from './renderEmailValue';
@@ -24,7 +25,6 @@ type Props = {
   teams: string[];
   roleOptions: MemberRole[];
   roleDisabledUnallowed: boolean;
-  teamOptions: Team[];
   inviteStatus: InviteStatus;
   onRemove: () => void;
   theme: Theme;
@@ -81,7 +81,6 @@ class InviteRowControl extends React.Component<Props, State> {
       teams,
       roleOptions,
       roleDisabledUnallowed,
-      teamOptions,
       inviteStatus,
       onRemove,
       onChangeEmails,
@@ -131,15 +130,11 @@ class InviteRowControl extends React.Component<Props, State> {
           disableUnallowed={roleDisabledUnallowed}
           onChange={onChangeRole}
         />
-        <SelectControl
+        <TeamSelector
           data-test-id="select-teams"
           disabled={disabled}
           placeholder={t('Add to teams\u2026')}
           value={teams}
-          options={teamOptions.map(({slug}) => ({
-            value: slug,
-            label: `#${slug}`,
-          }))}
           onChange={onChangeTeams}
           multiple
           clearable

--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -24,16 +24,8 @@ type MentionableUser = {
     id: string;
     name: string;
   };
+  disabled?: boolean;
 };
-
-type Unmentionable = {
-  disabled: boolean;
-  label: React.ReactElement;
-};
-
-type UnmentionableUser = MentionableUser & Unmentionable;
-
-type AllMentionable = MentionableUser & Partial<Unmentionable>;
 
 type Props = {
   api: Client;
@@ -52,7 +44,7 @@ type State = {
   loading: boolean;
   memberListLoading: boolean;
   inputValue: string;
-  options: AllMentionable[] | null;
+  options: MentionableUser[] | null;
 };
 
 type FilterOption<T> = {
@@ -149,7 +141,7 @@ class SelectMembers extends React.Component<Props, State> {
       );
   }, 250);
 
-  handleLoadOptions = (): Promise<AllMentionable[]> => {
+  handleLoadOptions = (): Promise<MentionableUser[]> => {
     const usersInProject = this.getMentionableUsers();
     const usersInProjectById = usersInProject.map(({actor}) => actor.id);
 
@@ -171,9 +163,9 @@ class SelectMembers extends React.Component<Props, State> {
             ? (members as Member[])
                 .filter(({user}) => user && usersInProjectById.indexOf(user.id) === -1)
                 .map(this.createUnmentionableUser)
-            : []) as UnmentionableUser[]
+            : []) as MentionableUser[]
       )
-      .then((members: UnmentionableUser[]) => {
+      .then((members: MentionableUser[]) => {
         const options = [...usersInProject, ...members];
         this.setState({options});
         return options;
@@ -192,7 +184,7 @@ class SelectMembers extends React.Component<Props, State> {
 
     return (
       <StyledSelectControl
-        filterOption={(option: FilterOption<AllMentionable>, filterText: string) =>
+        filterOption={(option: FilterOption<MentionableUser>, filterText: string) =>
           option?.data?.searchKey?.indexOf(filterText) > -1
         }
         loadOptions={this.handleLoadOptions}

--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -2,74 +2,38 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
-import {addTeamToProject} from 'app/actionCreators/projects';
 import {Client} from 'app/api';
-import Button from 'app/components/button';
 import SelectControl from 'app/components/forms/selectControl';
 import IdBadge from 'app/components/idBadge';
 import Tooltip from 'app/components/tooltip';
-import {IconAdd, IconUser} from 'app/icons';
 import {t} from 'app/locale';
 import MemberListStore from 'app/stores/memberListStore';
-import ProjectsStore from 'app/stores/projectsStore';
-import TeamStore from 'app/stores/teamStore';
-import space from 'app/styles/space';
-import {Member, Organization, Project, Team, User} from 'app/types';
+import {Member, Organization, Project, User} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import withApi from 'app/utils/withApi';
 
 const getSearchKeyForUser = (user: User) =>
   `${user.email && user.email.toLowerCase()} ${user.name && user.name.toLowerCase()}`;
 
-type Actor<T> = {
-  type: T;
-  id: string;
-  name: string;
-};
-
-type Mentionable<T> = {
+type MentionableUser = {
   value: string;
   label: React.ReactElement;
   searchKey: string;
-  actor: Actor<T>;
+  actor: {
+    type: 'user';
+    id: string;
+    name: string;
+  };
 };
-
-const UnassignedWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const StyledIconUser = styled(IconUser)`
-  margin-left: ${space(0.25)};
-  margin-right: ${space(1)};
-  color: ${p => p.theme.gray400};
-`;
-
-const unassignedOption = {
-  value: null,
-  label: (
-    <UnassignedWrapper>
-      <StyledIconUser size="20px" />
-      {t('Unassigned')}
-    </UnassignedWrapper>
-  ),
-  searchKey: 'unassigned',
-  actor: null,
-};
-type MentionableUnassigned = typeof unassignedOption;
 
 type Unmentionable = {
   disabled: boolean;
   label: React.ReactElement;
 };
 
-type MentionableTeam = Mentionable<'team'>;
-type UnmentionableTeam = MentionableTeam & Unmentionable;
-type MentionableUser = Mentionable<'user'>;
 type UnmentionableUser = MentionableUser & Unmentionable;
 
-type AllMentionable = (MentionableUser | MentionableTeam | MentionableUnassigned) &
-  Partial<Unmentionable>;
+type AllMentionable = MentionableUser & Partial<Unmentionable>;
 
 type Props = {
   api: Client;
@@ -82,9 +46,6 @@ type Props = {
   disabled?: boolean;
   placeholder?: string;
   styles?: {control?: (provided: any) => any};
-  filteredTeamIds?: Set<string>;
-  // Used to display an additional unassigned option
-  includeUnassigned?: boolean;
 };
 
 type State = {
@@ -114,9 +75,6 @@ class SelectMembers extends React.Component<Props, State> {
   componentWillUnmount() {
     this.unlisteners.forEach(callIfFunction);
   }
-
-  // TODO(ts) This type could be improved when react-select types are better.
-  selectRef = React.createRef<any>();
 
   unlisteners = [
     MemberListStore.listen(() => {
@@ -156,134 +114,8 @@ class SelectMembers extends React.Component<Props, State> {
     ),
   });
 
-  createMentionableTeam = (team: Team): MentionableTeam => ({
-    value: team.id,
-    label: <IdBadge team={team} />,
-    searchKey: `#${team.slug}`,
-    actor: {
-      type: 'team',
-      id: team.id,
-      name: team.slug,
-    },
-  });
-
-  createUnmentionableTeam = (team: Team): UnmentionableTeam => {
-    const {organization} = this.props;
-    const canAddTeam = organization.access.includes('project:write');
-
-    return {
-      ...this.createMentionableTeam(team),
-      disabled: true,
-      label: (
-        <UnmentionableTeam>
-          <DisabledLabel>
-            <Tooltip
-              position="left"
-              title={t('%s is not a member of project', `#${team.slug}`)}
-            >
-              <IdBadge team={team} />
-            </Tooltip>
-          </DisabledLabel>
-          <Tooltip
-            title={
-              canAddTeam
-                ? t('Add %s to project', `#${team.slug}`)
-                : t('You do not have permission to add team to project.')
-            }
-          >
-            <AddToProjectButton
-              type="button"
-              size="zero"
-              borderless
-              disabled={!canAddTeam}
-              onClick={this.handleAddTeamToProject.bind(this, team)}
-              icon={<IconAdd isCircled />}
-            />
-          </Tooltip>
-        </UnmentionableTeam>
-      ),
-    };
-  };
-
   getMentionableUsers() {
     return MemberListStore.getAll().map(this.createMentionableUser);
-  }
-
-  getMentionableTeams(): MentionableTeam[] {
-    const {project} = this.props;
-    const projectData = project && ProjectsStore.getBySlug(project.slug);
-
-    if (!projectData) {
-      return [];
-    }
-
-    return projectData.teams.map(this.createMentionableTeam);
-  }
-
-  /**
-   * Get list of teams that are not in the current project, for use in `MultiSelectMenu`
-   *
-   * @param {Team[]} teamsInProject A list of teams that are in the current project
-   */
-  getTeamsNotInProject(teamsInProject: MentionableTeam[] = []): UnmentionableTeam[] {
-    const teams: Team[] = TeamStore.getAll() || [];
-    const excludedTeamIds = teamsInProject.map(({actor}) => actor.id);
-
-    return teams
-      .filter(team => excludedTeamIds.indexOf(team.id) === -1)
-      .map(this.createUnmentionableTeam);
-  }
-
-  /**
-   * Closes the select menu by blurring input if possible since that seems to be the only
-   * way to close it.
-   */
-  closeSelectMenu() {
-    if (!this.selectRef.current) {
-      return;
-    }
-
-    // @ts-ignore The types for react-select don't cover this property
-    // or the type of selectRef is incorrect.
-    const select = this.selectRef.current.select.select;
-    const input: HTMLInputElement = select.inputRef;
-    if (input) {
-      // I don't think there's another way to close `react-select`
-      input.blur();
-    }
-  }
-
-  async handleAddTeamToProject(team: Team) {
-    const {api, organization, project, value} = this.props;
-    const {options} = this.state;
-
-    // Copy old value
-    const oldValue = value ? [...value] : {value};
-
-    // Optimistic update
-    this.props.onChange(this.createMentionableTeam(team));
-
-    try {
-      // Try to add team to project
-      if (project) {
-        await addTeamToProject(api, organization.slug, project.slug, team);
-
-        // Remove add to project button without changing order
-        const newOptions = options!.map(option => {
-          if (option.actor?.id === team.id) {
-            option.disabled = false;
-            option.label = <IdBadge team={team} />;
-          }
-
-          return option;
-        });
-        this.setState({options: newOptions});
-      }
-    } catch (err) {
-      // Unable to add team to project, revert select menu value
-      this.props.onChange(oldValue);
-    }
-    this.closeSelectMenu();
   }
 
   handleChange = newValue => {
@@ -318,21 +150,6 @@ class SelectMembers extends React.Component<Props, State> {
   }, 250);
 
   handleLoadOptions = (): Promise<AllMentionable[]> => {
-    const {showTeam, filteredTeamIds, includeUnassigned} = this.props;
-    if (showTeam) {
-      const teamsInProject = this.getMentionableTeams();
-      const teamsNotInProject = this.getTeamsNotInProject(teamsInProject);
-      const unfilteredOptions = [...teamsInProject, ...teamsNotInProject];
-      const options: AllMentionable[] = filteredTeamIds
-        ? unfilteredOptions.filter(({value}) => !value || filteredTeamIds.has(value))
-        : unfilteredOptions;
-      if (includeUnassigned) {
-        options.push(unassignedOption);
-      }
-      this.setState({options});
-      return Promise.resolve(options);
-    }
-
     const usersInProject = this.getMentionableUsers();
     const usersInProjectById = usersInProject.map(({actor}) => actor.id);
 
@@ -375,7 +192,6 @@ class SelectMembers extends React.Component<Props, State> {
 
     return (
       <StyledSelectControl
-        ref={this.selectRef}
         filterOption={(option: FilterOption<AllMentionable>, filterText: string) =>
           option?.data?.searchKey?.indexOf(filterText) > -1
         }
@@ -407,16 +223,6 @@ const DisabledLabel = styled('div')`
   display: flex;
   opacity: 0.5;
   overflow: hidden; /* Needed so that "Add to team" button can fit */
-`;
-
-const AddToProjectButton = styled(Button)`
-  flex-shrink: 0;
-`;
-
-const UnmentionableTeam = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
 `;
 
 const StyledSelectControl = styled(SelectControl)`

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -654,12 +654,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     );
 
     const ruleNameOwnerForm = (hasAccess: boolean) => (
-      <RuleNameOwnerForm
-        disabled={!hasAccess || !canEdit}
-        organization={organization}
-        project={project}
-        userTeamIds={userTeamIds}
-      />
+      <RuleNameOwnerForm disabled={!hasAccess || !canEdit} project={project} />
     );
 
     return (

--- a/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleNameOwnerForm.tsx
@@ -1,22 +1,20 @@
 import {PureComponent} from 'react';
 
+import TeamSelector from 'app/components/forms/teamSelector';
 import {Panel, PanelBody} from 'app/components/panels';
-import SelectMembers from 'app/components/selectMembers';
 import {t} from 'app/locale';
-import {Organization, Project} from 'app/types';
+import {Project, Team} from 'app/types';
 import FormField from 'app/views/settings/components/forms/formField';
 import TextField from 'app/views/settings/components/forms/textField';
 
 type Props = {
   disabled: boolean;
   project: Project;
-  organization: Organization;
-  userTeamIds: string[];
 };
 
 class RuleNameOwnerForm extends PureComponent<Props> {
   render() {
-    const {disabled, project, organization, userTeamIds} = this.props;
+    const {disabled, project} = this.props;
     return (
       <Panel>
         <PanelBody>
@@ -38,22 +36,16 @@ class RuleNameOwnerForm extends PureComponent<Props> {
             {({model}) => {
               const owner = model.getValue('owner');
               const ownerId = owner && owner.split(':')[1];
-              const filteredTeamIds = new Set(userTeamIds);
-              // Add the current team that owns the alert
-              if (ownerId) {
-                filteredTeamIds.add(ownerId);
-              }
               return (
-                <SelectMembers
-                  showTeam
-                  project={project}
-                  organization={organization}
+                <TeamSelector
                   value={ownerId}
+                  project={project}
                   onChange={({value}) => {
                     const ownerValue = value && `team:${value}`;
                     model.setValue('owner', ownerValue);
                   }}
-                  filteredTeamIds={filteredTeamIds}
+                  teamFilter={(team: Team) => team.isMember || team.id === ownerId}
+                  useId
                   includeUnassigned
                   disabled={disabled}
                 />

--- a/static/app/views/alerts/issueRuleEditor/index.tsx
+++ b/static/app/views/alerts/issueRuleEditor/index.tsx
@@ -17,11 +17,11 @@ import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
+import TeamSelector from 'app/components/forms/teamSelector';
 import List from 'app/components/list';
 import ListItem from 'app/components/list/listItem';
 import LoadingMask from 'app/components/loadingMask';
 import {Panel, PanelBody} from 'app/components/panels';
-import SelectMembers from 'app/components/selectMembers';
 import {ALL_ENVIRONMENTS_KEY} from 'app/constants';
 import {IconChevron, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
@@ -532,11 +532,6 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     // check if superuser or if user is on the alert's team
     const canEdit = isActiveSuperuser() || (ownerId ? userTeams.includes(ownerId) : true);
 
-    const filteredTeamIds = new Set(userTeams);
-    if (ownerId) {
-      filteredTeamIds.add(ownerId);
-    }
-
     // Note `key` on `<Form>` below is so that on initial load, we show
     // the form with a loading mask on top of it, but force a re-render by using
     // a different key when we have fetched the rule so that form inputs are filled in
@@ -595,13 +590,12 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     help={t('The team that can edit this alert.')}
                     disabled={!hasAccess || !canEdit}
                   >
-                    <SelectMembers
-                      showTeam
-                      project={project}
-                      organization={organization}
+                    <TeamSelector
                       value={this.getTeamId()}
+                      project={project}
                       onChange={this.handleOwnerChange}
-                      filteredTeamIds={filteredTeamIds}
+                      teamFilter={(team: Team) => team.isMember || team.id === ownerId}
+                      useId
                       includeUnassigned
                       disabled={!hasAccess || !canEdit}
                     />

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -8,8 +8,7 @@ import {openCreateTeamModal} from 'app/actionCreators/modal';
 import ProjectActions from 'app/actions/projectActions';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
-import SelectControl from 'app/components/forms/selectControl';
-import IdBadge from 'app/components/idBadge';
+import TeamSelector from 'app/components/forms/teamSelector';
 import PageHeading from 'app/components/pageHeading';
 import PlatformPicker from 'app/components/platformPicker';
 import Tooltip from 'app/components/tooltip';
@@ -89,8 +88,6 @@ class CreateProject extends React.Component<Props, State> {
     const {organization} = this.props;
     const {projectName, platform, team} = this.state;
 
-    const teams = this.props.teams.filter(filterTeam => filterTeam.hasAccess);
-
     const createProjectForm = (
       <CreateProjectForm onSubmit={this.createProject}>
         <div>
@@ -110,16 +107,13 @@ class CreateProject extends React.Component<Props, State> {
         <div>
           <FormLabel>{t('Team')}</FormLabel>
           <TeamSelectInput>
-            <SelectControl
+            <TeamSelector
               name="select-team"
               clearable={false}
               value={team}
               placeholder={t('Select a Team')}
               onChange={choice => this.setState({team: choice.value})}
-              options={teams.map(teamItem => ({
-                label: <IdBadge team={teamItem} />,
-                value: teamItem.slug,
-              }))}
+              teamFilter={(filterTeam: Team) => filterTeam.hasAccess}
             />
             <Tooltip title={t('Create a team')}>
               <Button

--- a/tests/js/spec/components/forms/teamSelector.spec.jsx
+++ b/tests/js/spec/components/forms/teamSelector.spec.jsx
@@ -28,7 +28,6 @@ const teams = teamData.map(data => TestStubs.Team(data));
 const project = TestStubs.Project({teams: [teams[0]]});
 
 function createWrapper(props = {}) {
-  // const {organization} = initializeOrg({organization: });
   const organization = TestStubs.Organization({access: ['project:write']});
   return mountWithTheme(
     <TeamSelector

--- a/tests/js/spec/components/forms/teamSelector.spec.jsx
+++ b/tests/js/spec/components/forms/teamSelector.spec.jsx
@@ -55,12 +55,9 @@ describe('Team Selector', function () {
     const wrapper = createWrapper();
     openSelectMenu(wrapper);
 
-    let option = wrapper.getByText('#team1');
-    expect(option).toBeTruthy();
-    option = wrapper.getByText('#team2');
-    expect(option).toBeTruthy();
-    option = wrapper.getByText('#team3');
-    expect(option).toBeTruthy();
+    expect(wrapper.getByText('#team1')).toBeTruthy();
+    expect(wrapper.getByText('#team2')).toBeTruthy();
+    expect(wrapper.getByText('#team3')).toBeTruthy();
   });
 
   it('selects an option', function () {
@@ -78,26 +75,21 @@ describe('Team Selector', function () {
     const wrapper = createWrapper({teamFilter});
     openSelectMenu(wrapper);
 
-    let option = wrapper.getByText('#team1');
-    expect(option).toBeTruthy();
+    expect(wrapper.getByText('#team1')).toBeTruthy();
 
     // These options should be filtered out
-    option = wrapper.queryByText('#team2');
-    expect(option).toBeFalsy();
-    option = wrapper.queryByText('#team3');
-    expect(option).toBeFalsy();
+    expect(wrapper.queryByText('#team2')).toBeFalsy();
+    expect(wrapper.queryByText('#team3')).toBeFalsy();
   });
 
   it('respects the project filter', async function () {
     const wrapper = createWrapper({project});
     openSelectMenu(wrapper);
 
-    const option = wrapper.getByText('#team1');
-    expect(option).toBeTruthy();
+    expect(wrapper.getByText('#team1')).toBeTruthy();
 
     // team2 and team3 should have add to project buttons
-    const addToProjectButtons = wrapper.getAllByRole('button');
-    expect(addToProjectButtons.length).toBe(2);
+    expect(wrapper.getAllByRole('button').length).toBe(2);
   });
 
   it('respects the team and project filter', async function () {
@@ -105,24 +97,20 @@ describe('Team Selector', function () {
     const wrapper = createWrapper({teamFilter, project});
     openSelectMenu(wrapper);
 
-    let option = wrapper.getByText('#team1');
-    expect(option).toBeTruthy();
+    expect(wrapper.getByText('#team1')).toBeTruthy();
 
     // team3 should be filtered out
-    option = wrapper.queryByText('#team3');
-    expect(option).toBeFalsy();
+    expect(wrapper.queryByText('#team3')).toBeFalsy();
 
     // team2 should have add to project buttons
-    const addToProjectButtons = wrapper.getAllByRole('button');
-    expect(addToProjectButtons.length).toBe(1);
+    expect(wrapper.getAllByRole('button').length).toBe(1);
   });
 
   it('allows you to add teams outside of project', async function () {
     const wrapper = createWrapper({project});
     openSelectMenu(wrapper);
 
-    const option = wrapper.getByText('#team1');
-    expect(option).toBeTruthy();
+    expect(wrapper.getByText('#team1')).toBeTruthy();
 
     // team2 and team3 should have add to project buttons
     const addToProjectButtons = wrapper.getAllByRole('button');

--- a/tests/js/spec/components/forms/teamSelector.spec.jsx
+++ b/tests/js/spec/components/forms/teamSelector.spec.jsx
@@ -1,0 +1,135 @@
+import {fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
+
+import {addTeamToProject} from 'app/actionCreators/projects';
+import {TeamSelector} from 'app/components/forms/teamSelector';
+
+jest.mock('app/actionCreators/projects', () => ({
+  addTeamToProject: jest.fn(),
+}));
+
+const teamData = [
+  {
+    id: '1',
+    slug: 'team1',
+    name: 'Team 1',
+  },
+  {
+    id: '2',
+    slug: 'team2',
+    name: 'Team 2',
+  },
+  {
+    id: '3',
+    slug: 'team3',
+    name: 'Team 3',
+  },
+];
+const teams = teamData.map(data => TestStubs.Team(data));
+const project = TestStubs.Project({teams: [teams[0]]});
+
+function createWrapper(props = {}) {
+  // const {organization} = initializeOrg({organization: });
+  const organization = TestStubs.Organization({access: ['project:write']});
+  return mountWithTheme(
+    <TeamSelector
+      teams={teams}
+      organization={organization}
+      name="teamSelector"
+      {...props}
+    />
+  );
+}
+
+function openSelectMenu(wrapper) {
+  const keyDownEvent = {
+    key: 'ArrowDown',
+  };
+
+  const placeholder = wrapper.getByText('Select...');
+  fireEvent.keyDown(placeholder, keyDownEvent);
+}
+
+describe('Team Selector', function () {
+  beforeAll(function () {});
+
+  it('renders options', function () {
+    const wrapper = createWrapper();
+    openSelectMenu(wrapper);
+
+    let option = wrapper.getByText('#team1');
+    expect(option).toBeTruthy();
+    option = wrapper.getByText('#team2');
+    expect(option).toBeTruthy();
+    option = wrapper.getByText('#team3');
+    expect(option).toBeTruthy();
+  });
+
+  it('selects an option', function () {
+    const onChangeMock = jest.fn();
+    const wrapper = createWrapper({onChange: onChangeMock});
+    openSelectMenu(wrapper);
+
+    const option = wrapper.getByText('#team1');
+    fireEvent.click(option);
+    expect(onChangeMock).toHaveBeenCalled();
+  });
+
+  it('respects the team filter', async function () {
+    const teamFilter = team => team.slug === 'team1';
+    const wrapper = createWrapper({teamFilter});
+    openSelectMenu(wrapper);
+
+    let option = wrapper.getByText('#team1');
+    expect(option).toBeTruthy();
+
+    // These options should be filtered out
+    option = wrapper.queryByText('#team2');
+    expect(option).toBeFalsy();
+    option = wrapper.queryByText('#team3');
+    expect(option).toBeFalsy();
+  });
+
+  it('respects the project filter', async function () {
+    const wrapper = createWrapper({project});
+    openSelectMenu(wrapper);
+
+    const option = wrapper.getByText('#team1');
+    expect(option).toBeTruthy();
+
+    // team2 and team3 should have add to project buttons
+    const addToProjectButtons = wrapper.getAllByRole('button');
+    expect(addToProjectButtons.length).toBe(2);
+  });
+
+  it('respects the team and project filter', async function () {
+    const teamFilter = team => team.slug === 'team1' || team.slug === 'team2';
+    const wrapper = createWrapper({teamFilter, project});
+    openSelectMenu(wrapper);
+
+    let option = wrapper.getByText('#team1');
+    expect(option).toBeTruthy();
+
+    // team3 should be filtered out
+    option = wrapper.queryByText('#team3');
+    expect(option).toBeFalsy();
+
+    // team2 should have add to project buttons
+    const addToProjectButtons = wrapper.getAllByRole('button');
+    expect(addToProjectButtons.length).toBe(1);
+  });
+
+  it('allows you to add teams outside of project', async function () {
+    const wrapper = createWrapper({project});
+    openSelectMenu(wrapper);
+
+    const option = wrapper.getByText('#team1');
+    expect(option).toBeTruthy();
+
+    // team2 and team3 should have add to project buttons
+    const addToProjectButtons = wrapper.getAllByRole('button');
+
+    // add team2 to project
+    fireEvent.click(addToProjectButtons[0]);
+    expect(addTeamToProject).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Removes the need to do a manual team selector component by retrieving teams and feeding them to react-select

gets rid of instances on
- create project page
- invite members modal
- issue alert editing/creation
- metric alert editing/creation

Allows for filtering down teams by a filter function or by supplying a project. If a project is supplied we allow users to add a team outside of the project. 