### PR TITLE
feat(deletions) Add metric to validate unused signal

### DIFF
--- a/src/sentry/models/repository.py
+++ b/src/sentry/models/repository.py
@@ -6,6 +6,7 @@ from sentry.constants import ObjectStatus
 from sentry.db.mixin import PendingDeletionMixin, delete_pending_deletion_option
 from sentry.db.models import BoundedPositiveIntegerField, JSONField, Model, sane_repr
 from sentry.signals import pending_delete
+from sentry.utils import metrics
 
 
 class Repository(Model, PendingDeletionMixin):
@@ -77,6 +78,9 @@ class Repository(Model, PendingDeletionMixin):
 
 
 def on_delete(instance, actor=None, **kwargs):
+    # TODO(mark) Remove this metric and code path once it is proven to have no callers.
+    metrics.incr("repository.on_delete", sample_rate=1.0)
+
     # If there is no provider, we don't have any webhooks, etc to delete
     if not instance.provider:
         return


### PR DESCRIPTION
I'm pretty sure the pending_delete signal is never called for repositories, and if that is true we can delete a bunch of code in repository integrations as it is also unused.