### PR TITLE
build(ci): Fix specifying python-version in `setup-sentry`

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -15,6 +15,9 @@ inputs:
   pip-cache-version:
     description: 'pip cache version in order to bust cache'
     required: false
+  python-version:
+    description: "python version to install"
+    required: false
 
 outputs:
   python-version:
@@ -34,7 +37,11 @@ runs:
       id: python-version
       shell: bash
       run: |
-        echo "::set-output name=python-version::$(cat .python-version)"
+        if [ ${{ inputs.python-version }} == "" ]; then
+          echo "::set-output name=python-version::$(cat .python-version)"
+        else
+          echo "::set-output name=python-version::${{ inputs.python-version }}"
+        fi
 
     - name: Setup default environment variables
       shell: bash

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -37,7 +37,7 @@ runs:
       id: python-version
       shell: bash
       run: |
-        if [ ${{ inputs.python-version }} == "" ]; then
+        if [ "${{ inputs.python-version }}" == "" ]; then
           echo "::set-output name=python-version::$(cat .python-version)"
         else
           echo "::set-output name=python-version::${{ inputs.python-version }}"

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -23,6 +23,13 @@ inputs:
     description: 'Is chartcuterie required?'
     required: false
     default: 'false'
+  cache-files-hash:
+    description: 'A single hash for a set of files. Used for caching.'
+    required: false
+    default: ${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
+  python-version:
+    description: "python version to install"
+    required: false
   pip-cache-version:
     description: 'pip cache version in order to bust cache'
     required: false
@@ -96,6 +103,8 @@ runs:
       id: setup-python
       uses: ./.github/actions/setup-python
       with:
+        python-version: ${{ inputs.python-version }}
+        cache-files-hash: ${{ inputs.cache-files-hash }}
         pip-cache-version: ${{ inputs.pip-cache-version }}
         workdir: ${{ inputs.workdir }}
 


### PR DESCRIPTION
`python-version` input needs to be piped from `setup-sentry` to `setup-python` to support custom defined python version