### PR TITLE
feat(perf): Initial pass of generic performance widget

### DIFF
--- a/static/app/utils/discover/genericDiscoverQuery.tsx
+++ b/static/app/utils/discover/genericDiscoverQuery.tsx
@@ -16,7 +16,7 @@ export type GenericChildrenProps<T> = {
   pageLinks: null | string;
 };
 
-export type DiscoverQueryProps = {
+type BaseDiscoverQueryProps = {
   api: Client;
   /**
    * Used as the default source for cursor values.
@@ -49,14 +49,18 @@ export type DiscoverQueryProps = {
   referrer?: string;
 };
 
+export type DiscoverQueryProps = BaseDiscoverQueryProps & {
+  orgSlug: string;
+};
+
 type RequestProps<P> = DiscoverQueryProps & P;
 
-type ReactProps<T> = {
+export type ReactChildrenProps<T> = {
   children?: (props: GenericChildrenProps<T>) => React.ReactNode;
 };
 
 type Props<T, P> = RequestProps<P> &
-  ReactProps<T> & {
+  ReactChildrenProps<T> & {
     /**
      * Route to the endpoint
      */
@@ -223,7 +227,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
       tableData,
       pageLinks,
     };
-    const children: ReactProps<T>['children'] = this.props.children; // Explicitly setting type due to issues with generics and React's children
+    const children: ReactChildrenProps<T>['children'] = this.props.children; // Explicitly setting type due to issues with generics and React's children
     return children?.(childrenProps);
   }
 }

--- a/static/app/utils/performance/histogram/histogramQuery.tsx
+++ b/static/app/utils/performance/histogram/histogramQuery.tsx
@@ -11,7 +11,7 @@ import withApi from 'app/utils/withApi';
 
 type Histograms = Record<string, HistogramData>;
 
-type HistogramProps = {
+export type HistogramProps = {
   fields: string[];
   numBuckets: number;
   min?: number;
@@ -23,13 +23,18 @@ type HistogramProps = {
 
 type RequestProps = DiscoverQueryProps & HistogramProps;
 
-type ChildrenProps = Omit<GenericChildrenProps<HistogramProps>, 'tableData'> & {
+export type HistogramChildrenProps = Omit<
+  GenericChildrenProps<HistogramProps>,
+  'tableData'
+> & {
   histograms: Histograms | null;
 };
 
-type Props = RequestProps & {
-  children: (props: ChildrenProps) => React.ReactNode;
+export type HistogramChildren = {
+  children: (props: HistogramChildrenProps) => React.ReactNode;
 };
+
+type Props = RequestProps & HistogramChildren;
 
 function getHistogramRequestPayload(props: RequestProps) {
   const {fields, numBuckets, min, max, precision, dataFilter, eventView, location} =

--- a/static/app/views/performance/contexts/operationBreakdownFilter.tsx
+++ b/static/app/views/performance/contexts/operationBreakdownFilter.tsx
@@ -1,6 +1,13 @@
 import {createContext, useContext, useState} from 'react';
 
-import {SpanOperationBreakdownFilter} from '../../transactionSummary/filter';
+// Make sure to update other instances like trends column fields, discover field types.
+export enum SpanOperationBreakdownFilter {
+  None = 'none',
+  Http = 'http',
+  Db = 'db',
+  Browser = 'browser',
+  Resource = 'resource',
+}
 
 const OpBreakdownFilterContext = createContext<{
   opBreakdownFilter: SpanOperationBreakdownFilter;
@@ -11,13 +18,16 @@ const OpBreakdownFilterContext = createContext<{
 });
 
 export const OpBreakdownFilterProvider = ({
-  filter,
+  initialFilter,
   children,
 }: {
-  filter?: SpanOperationBreakdownFilter;
+  initialFilter?: SpanOperationBreakdownFilter;
   children: React.ReactNode;
 }) => {
-  const [opBreakdownFilter, setOpBreakdownFilter] = useState(filter);
+  const [opBreakdownFilter, setOpBreakdownFilter] = useState(
+    initialFilter ?? SpanOperationBreakdownFilter.None
+  );
+
   return (
     <OpBreakdownFilterContext.Provider
       value={{

--- a/static/app/views/performance/contexts/pageError.tsx
+++ b/static/app/views/performance/contexts/pageError.tsx
@@ -1,0 +1,41 @@
+import {createContext, useContext, useState} from 'react';
+
+import Alert from 'app/components/alert';
+import {IconFlag} from 'app/icons';
+
+const pageErrorContext = createContext<{
+  pageError?: string;
+  setPageError: (error: string | undefined) => void;
+}>({
+  pageError: undefined,
+  setPageError: (_: string | undefined) => {},
+});
+
+export const PageErrorProvider = ({children}: {children: React.ReactNode}) => {
+  const [pageError, setPageError] = useState<string | undefined>();
+  return (
+    <pageErrorContext.Provider
+      value={{
+        pageError,
+        setPageError,
+      }}
+    >
+      {children}
+    </pageErrorContext.Provider>
+  );
+};
+
+export const ErrorAlert = () => {
+  const {pageError} = useContext(pageErrorContext);
+  if (!pageError) {
+    return null;
+  }
+
+  return (
+    <Alert type="error" icon={<IconFlag size="md" />}>
+      {pageError}
+    </Alert>
+  );
+};
+
+export const usePageError = () => useContext(pageErrorContext);

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -339,7 +339,7 @@ export function getMobileAxisOptions(
 
 type TermFormatter = (organization: LightWeightOrganization) => string;
 
-const PERFORMANCE_TERMS: Record<PERFORMANCE_TERM, TermFormatter> = {
+export const PERFORMANCE_TERMS: Record<PERFORMANCE_TERM, TermFormatter> = {
   apdex: () =>
     t(
       'Apdex is the ratio of both satisfactory and tolerable response times to all response times. To adjust the tolerable threshold, go to performance settings.'

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -1,5 +1,21 @@
+import {usePageError} from '../../contexts/pageError';
+import Table from '../../table';
+import {FRONTEND_PAGELOAD_COLUMN_TITLES} from '../data';
+import MiniChartRow from '../widgets/miniChartRow';
+
 import {BasePerformanceViewProps} from './types';
 
-export function FrontendPageloadView(_: BasePerformanceViewProps) {
-  return <div data-test-id="frontend-pageload-view" />;
+export function FrontendPageloadView(props: BasePerformanceViewProps) {
+  return (
+    <div data-test-id="frontend-pageload-view">
+      <MiniChartRow {...props} />
+
+      <Table
+        {...props}
+        columnTitles={FRONTEND_PAGELOAD_COLUMN_TITLES}
+        setError={usePageError().setPageError}
+        summaryConditions={props.eventView.getQueryWithAdditionalConditions()}
+      />
+    </div>
+  );
 }

--- a/static/app/views/performance/landing/views/types.tsx
+++ b/static/app/views/performance/landing/views/types.tsx
@@ -1,1 +1,11 @@
-export type BasePerformanceViewProps = {};
+import {Location} from 'history';
+
+import {Organization, Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+
+export type BasePerformanceViewProps = {
+  eventView: EventView;
+  location: Location;
+  projects: Project[];
+  organization: Organization;
+};

--- a/static/app/views/performance/landing/widgets/components/performanceWidgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidgetContainer.tsx
@@ -1,0 +1,28 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Panel} from 'app/components/panels';
+import space from 'app/styles/space';
+
+export type PerformanceWidgetContainerTypes = 'panel' | 'inline';
+
+const StyledPanel = styled(Panel)`
+  padding: ${space(2)};
+  margin-bottom: 0;
+`;
+
+const getPerformanceWidgetContainer = ({
+  containerType,
+}: {
+  containerType: PerformanceWidgetContainerTypes;
+}) => {
+  if (containerType === 'panel') {
+    return StyledPanel;
+  } else if (containerType === 'inline') {
+    return Fragment;
+  } else {
+    return Fragment;
+  }
+};
+
+export default getPerformanceWidgetContainer;

--- a/static/app/views/performance/landing/widgets/genericPerformanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/genericPerformanceWidget.tsx
@@ -1,0 +1,153 @@
+import {FunctionComponent, ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import ErrorPanel from 'app/components/charts/errorPanel';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
+import Placeholder from 'app/components/placeholder';
+import QuestionTooltip from 'app/components/questionTooltip';
+import {IconWarning} from 'app/icons/iconWarning';
+import space from 'app/styles/space';
+import {HistogramChildren} from 'app/utils/performance/histogram/histogramQuery';
+import {DataFilter} from 'app/utils/performance/histogram/types';
+import getPerformanceWidgetContainer, {
+  PerformanceWidgetContainerTypes,
+} from 'app/views/performance/landing/widgets/components/performanceWidgetContainer';
+
+import {ChartDataProps} from '../chart/histogramChart';
+
+export enum GenericPerformanceWidgetDataType {
+  histogram,
+}
+
+type HeaderProps = {
+  title: string;
+  titleTooltip: string;
+};
+
+type BaseProps = {
+  chartField: string;
+  chartHeight: number;
+  dataType: GenericPerformanceWidgetDataType;
+  containerType: PerformanceWidgetContainerTypes;
+} & HeaderProps;
+
+type HistogramWidgetProps = BaseProps & {
+  dataType: GenericPerformanceWidgetDataType.histogram;
+  Query: FunctionComponent<
+    HistogramChildren & {fields: string[]; dataFilter?: DataFilter}
+  >;
+  HeaderActions?: FunctionComponent<ChartDataProps>;
+  Chart: FunctionComponent<ChartDataProps & {chartHeight: number}>;
+};
+
+function DataStateSwitch(props: {
+  loading: boolean;
+  errored: boolean;
+  hasData: boolean;
+
+  loadingComponent?: JSX.Element;
+  errorComponent: JSX.Element;
+  chartComponent: JSX.Element;
+  emptyComponent: JSX.Element;
+}): JSX.Element {
+  if (props.loading && props.loadingComponent) {
+    return props.loadingComponent;
+  }
+  if (props.errored) {
+    return props.errorComponent;
+  }
+  if (!props.hasData) {
+    return props.emptyComponent;
+  }
+  return props.chartComponent;
+}
+
+// TODO(k-fish): Remove hardcoding the grid once all the charts are in
+const grid = {
+  left: space(3),
+  right: space(3),
+  top: '25px',
+  bottom: '0px',
+};
+
+function WidgetHeader(props: HeaderProps & {renderedActions: ReactNode}) {
+  const {title, titleTooltip, renderedActions} = props;
+  return (
+    <WidgetHeaderContainer>
+      <div>
+        <HeaderTitleLegend>
+          {title}
+          <QuestionTooltip position="top" size="sm" title={titleTooltip} />
+        </HeaderTitleLegend>
+      </div>
+
+      {renderedActions && (
+        <HeaderActionsContainer>{renderedActions}</HeaderActionsContainer>
+      )}
+    </WidgetHeaderContainer>
+  );
+}
+
+const WidgetHeaderContainer = styled('div')``;
+const HeaderActionsContainer = styled('div')``;
+
+function GenericPerformanceWidget(props: HistogramWidgetProps): React.ReactElement;
+function GenericPerformanceWidget(props: HistogramWidgetProps) {
+  const {chartField, Query, Chart, HeaderActions, chartHeight, containerType} = props;
+
+  return (
+    <Query fields={[chartField]} dataFilter="exclude_outliers">
+      {results => {
+        const loading = results.isLoading;
+        const errored = results.error !== null;
+        const chartData = results.histograms?.[chartField];
+
+        const Container = getPerformanceWidgetContainer({
+          containerType,
+        });
+
+        const childData = {
+          loading,
+          errored,
+          chartData,
+          field: chartField,
+        };
+
+        return (
+          <Container>
+            <WidgetHeader
+              {...props}
+              renderedActions={
+                HeaderActions && <HeaderActions grid={grid} {...childData} />
+              }
+            />
+            <DataStateSwitch
+              {...childData}
+              hasData={!!(chartData && chartData.length)}
+              errorComponent={<DefaultErrorComponent chartHeight={chartHeight} />}
+              chartComponent={
+                <Chart {...childData} grid={grid} chartHeight={chartHeight} />
+              }
+              emptyComponent={<Placeholder height={`${chartHeight}px`} />}
+            />
+          </Container>
+        );
+      }}
+    </Query>
+  );
+}
+
+const DefaultErrorComponent = (props: {chartHeight: number}) => {
+  return (
+    <ErrorPanel height={`${props.chartHeight}px`}>
+      <IconWarning color="gray300" size="lg" />
+    </ErrorPanel>
+  );
+};
+
+GenericPerformanceWidget.defaultProps = {
+  containerType: 'panel',
+  chartHeight: 200,
+};
+
+export default GenericPerformanceWidget;

--- a/static/app/views/performance/landing/widgets/miniChartContainer.tsx
+++ b/static/app/views/performance/landing/widgets/miniChartContainer.tsx
@@ -1,0 +1,158 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import MenuItem from 'app/components/menuItem';
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import localStorage from 'app/utils/localStorage';
+import HistogramQuery from 'app/utils/performance/histogram/histogramQuery';
+import withOrganization from 'app/utils/withOrganization';
+import ContextMenu from 'app/views/dashboardsV2/contextMenu';
+
+import {getTermHelp, PERFORMANCE_TERM} from '../../data';
+import {Chart as _HistogramChart} from '../chart/histogramChart';
+
+import GenericPerformanceWidget, {
+  GenericPerformanceWidgetDataType,
+} from './genericPerformanceWidget';
+import {ChartRowProps} from './miniChartRow';
+
+type Props = {
+  index: number;
+  organization: Organization;
+  defaultChartSetting: ChartSettingType;
+} & ChartRowProps;
+
+type ForwardedProps = Omit<Props, 'organization' | 'chartSetting' | 'index'> & {
+  orgSlug: string;
+};
+
+export enum ChartSettingType {
+  LCP_HISTOGRAM = 'lcp_histogram',
+  FCP_HISTOGRAM = 'fcp_histogram',
+}
+
+interface ChartSetting {
+  title: string;
+  titleTooltip: string;
+  chartField: string;
+  dataType: GenericPerformanceWidgetDataType;
+}
+
+const getContainerLocalStorageKey = (index: number) => `mini-chart-container#${index}`;
+const getChartSetting = (
+  index: number,
+  defaultType: ChartSettingType
+): ChartSettingType => {
+  const key = getContainerLocalStorageKey(index);
+  const value = localStorage.getItem(key);
+  if (value && Object.values(ChartSettingType).includes(value as ChartSettingType)) {
+    const _value: ChartSettingType = value as ChartSettingType;
+    return _value;
+  }
+  return defaultType;
+};
+const _setChartSetting = (index: number, setting: ChartSettingType) => {
+  const key = getContainerLocalStorageKey(index);
+  localStorage.setItem(key, setting);
+};
+
+const CHART_SETTING_OPTIONS: ({
+  organization: Organization,
+}) => Record<ChartSettingType, ChartSetting> = ({
+  organization,
+}: {
+  organization: Organization;
+}) => ({
+  [ChartSettingType.LCP_HISTOGRAM]: {
+    title: t('LCP Distribution'),
+    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+    chartField: 'measurements.lcp',
+    dataType: GenericPerformanceWidgetDataType.histogram,
+  },
+  [ChartSettingType.FCP_HISTOGRAM]: {
+    title: t('FCP Distribution'),
+    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
+    chartField: 'measurements.fcp',
+    dataType: GenericPerformanceWidgetDataType.histogram,
+  },
+});
+
+const _MiniChartContainer = ({organization, index, ...rest}: Props) => {
+  const _chartSetting = getChartSetting(index, rest.defaultChartSetting);
+  const [chartSetting, setChartSettingState] = useState(_chartSetting);
+
+  const setChartSetting = (setting: ChartSettingType) => {
+    _setChartSetting(index, setting);
+    setChartSettingState(setting);
+  };
+  const onFilterChange = () => {};
+
+  const chartSettingOptions = CHART_SETTING_OPTIONS({organization})[chartSetting];
+
+  const queryProps: ForwardedProps = {
+    ...rest,
+    orgSlug: organization.slug,
+  };
+
+  return (
+    <GenericPerformanceWidget
+      chartHeight={160}
+      {...chartSettingOptions}
+      HeaderActions={provided => (
+        <ChartContainerActions
+          {...provided}
+          {...rest}
+          organization={organization}
+          setChartSetting={setChartSetting}
+        />
+      )}
+      Query={provided => <HistogramQuery {...provided} {...queryProps} numBuckets={20} />}
+      Chart={provided => <HistogramChart {...provided} onFilterChange={onFilterChange} />}
+    />
+  );
+};
+
+const ChartContainerActions = ({
+  organization,
+  setChartSetting,
+}: {
+  loading: boolean;
+  organization: Organization;
+  setChartSetting: (setting: ChartSettingType) => void;
+}) => {
+  const menuOptions: React.ReactNode[] = [];
+
+  const settingsMap = CHART_SETTING_OPTIONS({organization});
+  for (const _setting in ChartSettingType) {
+    const setting: ChartSettingType = ChartSettingType[_setting] as ChartSettingType;
+
+    const options = settingsMap[setting];
+    menuOptions.push(
+      <MenuItem key={_setting} onClick={() => setChartSetting(setting)}>
+        {t(options.title)}
+      </MenuItem>
+    );
+  }
+
+  return (
+    <ChartActionContainer>
+      <ContextMenu>{menuOptions}</ContextMenu>
+    </ChartActionContainer>
+  );
+};
+
+const ChartActionContainer = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const HistogramChart = styled(_HistogramChart)`
+  & .Container {
+    padding-bottom: 0px;
+  }
+`;
+
+const MiniChartContainer = withOrganization(_MiniChartContainer);
+
+export default MiniChartContainer;

--- a/static/app/views/performance/landing/widgets/miniChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/miniChartRow.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import space from 'app/styles/space';
+import EventView from 'app/utils/discover/eventView';
+
+import {PerformanceLayoutBodyRow} from '../../layouts';
+
+import MiniChartContainer, {ChartSettingType} from './miniChartContainer';
+
+export type ChartRowProps = {
+  eventView: EventView;
+  location: Location;
+};
+
+const MiniChartRow = (props: ChartRowProps) => {
+  return (
+    <StyledRow minSize={200}>
+      {new Array(3).fill(0).map((_, index) => (
+        <MiniChartContainer
+          {...props}
+          key={index}
+          index={index}
+          defaultChartSetting={ChartSettingType.LCP_HISTOGRAM}
+        />
+      ))}
+    </StyledRow>
+  );
+};
+
+const StyledRow = styled(PerformanceLayoutBodyRow)`
+  margin-bottom: ${space(2)};
+`;
+
+export default MiniChartRow;

--- a/static/app/views/performance/layouts/index.tsx
+++ b/static/app/views/performance/layouts/index.tsx
@@ -1,0 +1,31 @@
+import styled from '@emotion/styled';
+
+import space from 'app/styles/space';
+
+/**
+ * Common performance layouts
+ */
+
+export const PerformanceLayoutBodyRow = styled('div')<{
+  columns?: number;
+  minSize: number;
+}>`
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-column-gap: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    ${p =>
+      p.columns
+        ? `
+    grid-template-columns: repeat(${p.columns}, 1fr);
+    `
+        : `
+    grid-template-columns: repeat(auto-fit, minmax(${p.minSize}px, 1fr));
+    `}
+  }
+`;

--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -26,7 +26,6 @@ type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 // TODO(k-fish): Re-export until other files use context
 export {SpanOperationBreakdownFilter} from '../contexts/operationBreakdownFilter';
 
-// Make sure to update other instances like trends column fields, discover field types.
 const OPTIONS: SpanOperationBreakdownFilter[] = [
   SpanOperationBreakdownFilter.Http,
   SpanOperationBreakdownFilter.Db,

--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -14,19 +14,19 @@ import space from 'app/styles/space';
 import {OrganizationSummary} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
 
+import {
+  SpanOperationBreakdownFilter,
+  useOpBreakdownFilter,
+} from '../contexts/operationBreakdownFilter';
+
 import {decodeHistogramZoom} from './latencyChart';
 
 type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
-// Make sure to update other instances like trends column fields, discover field types.
-export enum SpanOperationBreakdownFilter {
-  None = 'none',
-  Http = 'http',
-  Db = 'db',
-  Browser = 'browser',
-  Resource = 'resource',
-}
+// TODO(k-fish): Re-export until other files use context
+export {SpanOperationBreakdownFilter} from '../contexts/operationBreakdownFilter';
 
+// Make sure to update other instances like trends column fields, discover field types.
 const OPTIONS: SpanOperationBreakdownFilter[] = [
   SpanOperationBreakdownFilter.Http,
   SpanOperationBreakdownFilter.Db,
@@ -38,12 +38,19 @@ export const spanOperationBreakdownSingleColumns = OPTIONS.map(o => `spans.${o}`
 
 type Props = {
   organization: OrganizationSummary;
-  currentFilter: SpanOperationBreakdownFilter;
-  onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
+  currentFilter?: SpanOperationBreakdownFilter;
+  onChangeFilter?: (newFilter: SpanOperationBreakdownFilter) => void;
 };
 
 function Filter(props: Props) {
-  const {currentFilter, onChangeFilter, organization} = props;
+  const {opBreakdownFilter, setOpBreakdownFilter} = useOpBreakdownFilter();
+  const {
+    currentFilter: _currentFilter,
+    onChangeFilter: _onChangeFilter,
+    organization,
+  } = props;
+  const currentFilter = _currentFilter ?? opBreakdownFilter;
+  const onChangeFilter = _onChangeFilter ?? setOpBreakdownFilter;
 
   if (!organization.features.includes('performance-ops-breakdown')) {
     return null;

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -77,6 +77,12 @@ describe('Performance > Landing > Index', function () {
       url: `/organizations/org-slug/key-transactions-list/`,
       body: [],
     });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/legacy-key-transactions-count/`,
+      body: [],
+    });
   });
 
   afterEach(function () {
@@ -110,5 +116,11 @@ describe('Performance > Landing > Index', function () {
     expect(wrapper.find('div[data-test-id="frontend-pageload-view"]').exists()).toBe(
       true
     );
+
+    expect(wrapper.find('_MiniChartContainer')).toHaveLength(3);
+    expect(
+      wrapper.find('_MiniChartContainer GenericPerformanceWidget').at(0).text()
+    ).toEqual('LCP Distribution');
+    expect(wrapper.find('Table')).toHaveLength(1);
   });
 });


### PR DESCRIPTION
### Summary
This adds a generic performance widget which takes in a chart and a query and displays something akin to our existing landing panels. This supports just basic histograms at the moment, and the ability to switch between them, with your preference being stored in local storage.

#### Other
- Had to modify histogramChart so it was compatible with both use cases.
- Also includes a small change that was dropped to actually start using the ops breakdown filter context, as well as adding a page-wide error context so setError does not need to be drilled.
- Might switch mini chart container to just be 'chartContainer', but it depends on changes needed for the larger performance widgets planned (inline tables etc.)
- Delaying unit tests for genericPerformanceWidget since it's quite likely it will change.

#### Screenshots
![Screen Shot 2021-08-31 at 7 06 10 PM](https://user-images.githubusercontent.com/6111995/131588153-9ea23845-f555-4b56-b21f-78f3eebe1834.png)

#### Why though?
Now that we have far more visualizations and different queries returning different data shapes, it'll likely be helpful to put guardrails onto how we make these on page widgets (or inline as this code supports it). This will involved fixing up a few of our genericDiscoverQuery specializations as well as our charts, but it should allow use to mix any genericDiscoverQuery with a chart that supports it by using something like the following code:

```jsx
    <GenericPerformanceWidget
      {...chartSettingOptions}
      Query={provided => <HistogramQuery {...provided} {...queryProps} numBuckets={20} />}
      Chart={provided => <HistogramChart {...provided} onFilterChange={onFilterChange} />}
    />
```

The output of which should roughly build a widget either inlined or panelled that follows roughly this format:
![Screen Shot 2021-05-26 at 6 05 49 PM](https://user-images.githubusercontent.com/6111995/131589344-1f818622-a1ec-4a9f-8671-919fcc0302ab.png)

Using this format we can internally handle various common features like loading, error and placeholder states, legends, actions, pagination for charts that come with lists etc.
 

This should hopefully simplify our use cases by compositionally building our widgets instead of doing bespoke code for each instance across the landing, trends, vital details etc. etc. in the future. That being said, this specific pass is a WIP so aside from general direction the implementation could change substantially before EA. 

