### PR TITLE
feat(symbol-sources): Redact symbol source secrets from audit logs

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -70,7 +70,7 @@ from sentry.api.exceptions import (
 )
 from sentry.api.fields.secret import SecretField, validate_secret
 from sentry.lang.native import appconnect
-from sentry.lang.native.symbolicator import secret_fields
+from sentry.lang.native.symbolicator import redact_source_secrets, secret_fields
 from sentry.models import AppConnectBuild, AuditLogEntryEvent, LatestAppConnectBuildsCheck, Project
 from sentry.tasks.app_store_connect import dsym_download
 from sentry.utils import json
@@ -287,12 +287,14 @@ class AppStoreConnectCreateCredentialsEndpoint(ProjectEndpoint):  # type: ignore
             new_sources = validated_config.update_project_symbol_source(project, allow_multiple)
         except ValueError:
             raise AppConnectMultipleSourcesError
+
+        redacted_sources = redact_source_secrets(new_sources)
         self.create_audit_entry(
             request=request,
             organization=project.organization,
             target_object=project.id,
             event=AuditLogEntryEvent.PROJECT_EDIT,
-            data={appconnect.SYMBOL_SOURCES_PROP_NAME: new_sources},
+            data={appconnect.SYMBOL_SOURCES_PROP_NAME: redacted_sources},
         )
 
         dsym_download.apply_async(
@@ -403,12 +405,13 @@ class AppStoreConnectUpdateCredentialsEndpoint(ProjectEndpoint):  # type: ignore
             project, allow_multiple=True
         )
 
+        redacted_sources = redact_source_secrets(new_sources)
         self.create_audit_entry(
             request=request,
             organization=project.organization,
             target_object=project.id,
             event=AuditLogEntryEvent.PROJECT_EDIT,
-            data={appconnect.SYMBOL_SOURCES_PROP_NAME: new_sources},
+            data={appconnect.SYMBOL_SOURCES_PROP_NAME: redacted_sources},
         )
 
         dsym_download.apply_async(

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -18,7 +18,7 @@ from sentry.digests import backend as digests
 from sentry.eventstore.models import DEFAULT_SUBJECT_TEMPLATE
 from sentry.features.base import ProjectFeature
 from sentry.ingest.inbound_filters import FilterTypes
-from sentry.lang.native.symbolicator import redact_source_secrets
+from sentry.lang.native.symbolicator import parse_sources, redact_source_secrets
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models import (
     EnvironmentProject,
@@ -41,6 +41,7 @@ from sentry.notifications.helpers import (
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.snuba import discover
 from sentry.snuba.sessions import check_has_health_data, get_current_and_previous_crash_free_rates
+from sentry.utils import json
 from sentry.utils.compat import zip
 
 STATUS_LABELS = {
@@ -797,16 +798,19 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         )
         custom_symbol_sources_json = attrs["options"].get("sentry:symbol_sources")
         try:
-            symbol_sources = redact_source_secrets(custom_symbol_sources_json)
+            sources = parse_sources(custom_symbol_sources_json, False)
         except Exception:
             # In theory sources stored on the project should be valid. If they are invalid, we don't
             # want to abort serialization just for sources, so just return an empty list instead of
             # returning sources with their secrets included.
-            symbol_sources = "[]"
+            serialized_sources = "[]"
+        else:
+            redacted_sources = redact_source_secrets(sources)
+            serialized_sources = json.dumps(redacted_sources)
 
         data.update(
             {
-                "symbolSources": symbol_sources,
+                "symbolSources": serialized_sources,
             }
         )
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -391,7 +391,12 @@ def parse_backfill_sources(sources_json, original_sources):
 
 
 def redact_source_secrets(config_sources: json.JSONData) -> json.JSONData:
-    """Returns a JSONData with all of the secrets redacted from every source."""
+    """
+    Returns a JSONData with all of the secrets redacted from every source.
+
+    The original value is not mutated in the process; A clone is created
+    and returned by this function.
+    """
 
     redacted_sources = deepcopy(config_sources)
     for source in redacted_sources:

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -4,6 +4,7 @@ import random
 import sys
 import time
 import uuid
+from copy import deepcopy
 from urllib.parse import urljoin
 
 import jsonschema
@@ -389,20 +390,16 @@ def parse_backfill_sources(sources_json, original_sources):
     return sources
 
 
-def redact_source_secrets(config_sources):
-    """
-    Returns a json string with all of the secrets redacted from every source.
+def redact_source_secrets(config_sources: json.JSONData) -> json.JSONData:
+    """Returns a JSONData with all of the secrets redacted from every source."""
 
-    May raise InvalidSourcesError if the provided sources are invalid.
-    """
-
-    sources = parse_sources(config_sources, False)
-    for source in sources:
+    redacted_sources = deepcopy(config_sources)
+    for source in redacted_sources:
         for secret in secret_fields(source["type"]):
             if secret in source:
                 source[secret] = {"hidden-secret": True}
 
-    return json.dumps(sources)
+    return redacted_sources
 
 
 def get_options_for_project(project):


### PR DESCRIPTION
Does what it says on the tin. Instead of storing the raw contents of a symbol source's secret into an audit log entry, this uses existing logic to store redacted values instead.

Things left to do:
- I can't figure out how to get the mock to hook up properly

NATIVE-178