### PR TITLE
ref(appstore-connect): Remove deprecated project option

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -500,12 +500,6 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
             latestBuildVersion = latest_build.bundle_short_version
             latestBuildNumber = latest_build.bundle_version
 
-        # All existing usages of this option are internal, so it's fine if we don't carry these over
-        # to the table
-        # TODO: Clean this up by App Store Connect GA
-        if projectoptions.isset(project, appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION):
-            project.delete_option(appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION)
-
         try:
             check_entry = LatestAppConnectBuildsCheck.objects.get(
                 project=project, source_id=symbol_source_cfg.id

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -59,7 +59,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features, projectoptions
+from sentry import features
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission
 from sentry.api.exceptions import (
     AppConnectAuthenticationError,

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -32,11 +32,6 @@ SYMBOL_SOURCES_PROP_NAME = "sentry:symbol_sources"
 # The symbol source type for an App Store Connect symbol source.
 SYMBOL_SOURCE_TYPE_NAME = "appStoreConnect"
 
-# The key in the project options under which all of the dates corresponding to the last time sentry
-# checked for new builds in App Store Connect are stored.
-# TODO: Remove this before App Store Connect GA
-APPSTORECONNECT_BUILD_REFRESHES_OPTION = "sentry:asc_build_refresh_dates"
-
 
 class InvalidCredentialsError(Exception):
     """Invalid credentials for the App Store Connect API."""

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -156,12 +156,6 @@ def process_builds(
             if not build_state.fetched:
                 pending_builds.append((build, build_state))
 
-    # All existing usages of this option are internal, so it's fine if we don't carry these over
-    # to the table
-    # TODO: Clean this up by App Store Connect GA
-    if projectoptions.isset(project, appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION):
-        project.delete_option(appconnect.APPSTORECONNECT_BUILD_REFRESHES_OPTION)
-
     LatestAppConnectBuildsCheck.objects.create_or_update(
         project=project, source_id=config.id, values={"last_checked": timezone.now()}
     )

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -13,7 +13,6 @@ import requests
 import sentry_sdk
 from django.utils import timezone
 
-from sentry import projectoptions
 from sentry.lang.native import appconnect
 from sentry.models import (
     AppConnectBuild,


### PR DESCRIPTION
A project option was temporarily introduced prior to EA to track the last time sentry checked for new builds for custom repositories connected to AppStore Connect. Clean-up code was added in and kept to ensure that the project option was removed from most projects, and now this removes all logic related to that option as we approach GA for ASC.

NATIVE-202