### PR TITLE
fix(grouping): Actually fix missing tree labels in JS

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -140,7 +140,7 @@ class GroupingComponent:
             self.contributes = contributes
         if contributes_to_similarity is not None:
             self.contributes_to_similarity = contributes_to_similarity
-        if self.contributes and tree_label is not None:
+        if tree_label is not None:
             self.tree_label = tree_label
         if is_prefix_frame is not None:
             self.is_prefix_frame = is_prefix_frame

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -264,7 +264,7 @@ def get_function_component(
                 hint="ignored because sourcemap used and context line available",
             )
 
-    if context["hierarchical_grouping"]:
+    if function_component.values and context["hierarchical_grouping"]:
         function_component.update(tree_label={"function": function_component.values[0]})
 
     return function_component
@@ -321,7 +321,6 @@ def frame(frame, event, context, **meta):
         # cannot show. In that case we want to show something else instead
         # of hiding the frame from the title as if it didn't contribute.
         context_line_component.update(tree_label=function_component.tree_label)
-
         values.append(context_line_component)
 
     if (

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -264,7 +264,7 @@ def get_function_component(
                 hint="ignored because sourcemap used and context line available",
             )
 
-    if function_component.values and context["hierarchical_grouping"]:
+    if context["hierarchical_grouping"]:
         function_component.update(tree_label={"function": function_component.values[0]})
 
     return function_component
@@ -303,13 +303,15 @@ def frame(frame, event, context, **meta):
             context=context,
         )
 
+    context_line_available = context_line_component and context_line_component.contributes
+
     function_component = get_function_component(
         context=context,
         function=frame.function,
         raw_function=frame.raw_function,
         platform=platform,
         sourcemap_used=frame.data and frame.data.get("sourcemap") is not None,
-        context_line_available=context_line_component and context_line_component.contributes,
+        context_line_available=context_line_available,
     )
 
     values = [module_component, filename_component, function_component]
@@ -319,6 +321,7 @@ def frame(frame, event, context, **meta):
         # cannot show. In that case we want to show something else instead
         # of hiding the frame from the title as if it didn't contribute.
         context_line_component.update(tree_label=function_component.tree_label)
+
         values.append(context_line_component)
 
     if (

--- a/tests/sentry/grouping/grouping_inputs/javascript_regression_tree_labels.json
+++ b/tests/sentry/grouping/grouping_inputs/javascript_regression_tree_labels.json
@@ -1,4 +1,5 @@
 {
+  "platform": "javascript",
   "exception": {
     "values": [
       {

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/javascript_regression_tree_labels.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2021-08-30T07:01:14.796853Z'
+created: '2021-09-01T16:43:50.626906Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","handlexhrerrorresponse.tsx"],["module","app/utils/handleXhrErrorResponse"]],[["filename","index.js"],["function","Sentry"],["module","@sentry/minimal/esm/index"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","hub.js"],["function","apply"],["module","@sentry/hub/esm/hub"]],[["filename","handlexhrerrorresponse.tsx"],["function","callback"],["module","app/utils/handleXhrErrorResponse"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","index.js"],["function","Sentry"],["module","@sentry/minimal/esm/index"]],[["filename","index.js"],["function","callOnHub"],["module","@sentry/minimal/esm/index"]]]
-similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","index.js"],["function","callOnHub"],["module","@sentry/minimal/esm/index"]],[["filename","hub.js"],["function","apply"],["module","@sentry/hub/esm/hub"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","Sentry.withScope(scope => {"],["filename","handlexhrerrorresponse.tsx"],["module","app/utils/handleXhrErrorResponse"]],[["context-line","callOnHub('withScope', callback);"],["filename","index.js"],["function","Sentry"],["module","@sentry/minimal/esm/index"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","callOnHub('withScope', callback);"],["filename","index.js"],["function","Sentry"],["module","@sentry/minimal/esm/index"]],[["context-line","return hub[method].apply(hub, __spread(args));"],["filename","index.js"],["function","callOnHub"],["module","@sentry/minimal/esm/index"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","callback(scope);"],["filename","hub.js"],["function","apply"],["module","@sentry/hub/esm/hub"]],[["context-line","Sentry.captureException(new Error(message));"],["filename","handlexhrerrorresponse.tsx"],["function","callback"],["module","app/utils/handleXhrErrorResponse"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["context-line","return hub[method].apply(hub, __spread(args));"],["filename","index.js"],["function","callOnHub"],["module","@sentry/minimal/esm/index"]],[["context-line","callback(scope);"],["filename","hub.js"],["function","apply"],["module","@sentry/hub/esm/hub"]]]
 similarity:2020-07-23:type:ident-shingle: "Error"
 similarity:2020-07-23:value:character-5-shingle: " a re"
 similarity:2020-07-23:value:character-5-shingle: " rece"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_javascript_no_in_app.pysnap
@@ -1,10 +1,11 @@
 ---
-created: '2021-06-30T16:44:00.436983Z'
+created: '2021-09-01T10:07:53.921178Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
   hash: "2f2dc85b9b0cd1e3be91984802c7b1b7"
+  tree_label: "onError"
   component:
     app-depth-1*
       exception*
@@ -25,6 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "26552f86ca2368e708afa1df6effc1c5"
+  tree_label: "onError"
   component:
     app-depth-2*
       exception*
@@ -52,6 +54,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "26552f86ca2368e708afa1df6effc1c5"
+  tree_label: "onError"
   component:
     app-depth-max*
       exception*
@@ -79,6 +82,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "26552f86ca2368e708afa1df6effc1c5"
+  tree_label: "onError"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_regression_tree_labels.pysnap
@@ -1,10 +1,10 @@
 ---
-created: '2021-08-27T14:37:16.077166Z'
+created: '2021-09-01T10:05:52.756531Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
-  hash: "dbfdfa9b4ca52c948eaa7ada4bff306a"
+  hash: "568f39f50e20dc57f30bf2a9767460bc"
   tree_label: "callback"
   component:
     app-depth-1*
@@ -15,15 +15,17 @@ app-depth-1:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 app-depth-2:
-  hash: "e61ad0fd02c88e22581b7f4b5849c2d1"
+  hash: "6c5d8ee9b543cfc85b2e3c11c79ffdf2"
   tree_label: "callback | apply"
   component:
     app-depth-2*
@@ -34,22 +36,26 @@ app-depth-2:
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 app-depth-3:
-  hash: "b1fa3c0a9289db9c8b7471d50ff2e4e0"
+  hash: "139ce9f6566a1d464f45e04389ceddd2"
   tree_label: "callback | apply | callOnHub"
   component:
     app-depth-3*
@@ -60,29 +66,35 @@ app-depth-3:
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 app-depth-4:
-  hash: "2f0afd41cbd4f4a3954d0afda56b47ed"
+  hash: "9699ab131909e91ad03317bac01bd8ed"
   tree_label: "callback | apply | callOnHub | Sentry"
   component:
     app-depth-4*
@@ -93,36 +105,44 @@ app-depth-4:
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 app-depth-5:
-  hash: "2a8970581cc3478959e826ee278af1d5"
+  hash: "8fb2eda9663c3c026c23475d6da30363"
   tree_label: "callback | apply | callOnHub | Sentry"
   component:
     app-depth-5*
@@ -133,41 +153,51 @@ app-depth-5:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 app-depth-max:
-  hash: "2a8970581cc3478959e826ee278af1d5"
+  hash: "8fb2eda9663c3c026c23475d6da30363"
   tree_label: "callback | apply | callOnHub | Sentry"
   component:
     app-depth-max*
@@ -178,41 +208,51 @@ app-depth-max:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 system:
-  hash: "2a8970581cc3478959e826ee278af1d5"
+  hash: "8fb2eda9663c3c026c23475d6da30363"
   tree_label: "callback | apply | callOnHub | Sentry"
   component:
     system*
@@ -223,34 +263,44 @@ system:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,10 +1,11 @@
 ---
-created: '2021-08-04T15:53:48.057531Z'
+created: '2021-09-01T10:07:53.623239Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
   hash: "37431f5f13e61c1a604e54d097c98cc5"
+  tree_label: "fetchGroupEventAndMarkSeen"
   component:
     app-depth-1*
       exception*
@@ -25,6 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "caa5df29a33af87ed50ebc242e35178d"
+  tree_label: "fetchGroupEventAndMarkSeen | this"
   component:
     app-depth-2*
       exception*
@@ -54,6 +56,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "0d2903c79166b4f45dce1a21dd5bca2a"
+  tree_label: "fetchGroupEventAndMarkSeen | this | X"
   component:
     app-depth-3*
       exception*
@@ -92,6 +95,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4a3cf3893b6485428dd02da116c8370e"
+  tree_label: "fetchGroupEventAndMarkSeen | this | X | fn"
   component:
     app-depth-4*
       exception*
@@ -139,6 +143,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "4a3cf3893b6485428dd02da116c8370e"
+  tree_label: "fetchGroupEventAndMarkSeen | this | X | fn"
   component:
     app-depth-max*
       exception*
@@ -186,7 +191,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "d5456487ea8dccfe96c1968b19870978"
-  tree_label: "rh | Xg | Yg | If | this | this"
+  tree_label: "fetchGroupEventAndMarkSeen | this | X | rh | Xg | Yg | If | this | this | fn | tryCatch | this | key | asyncGeneratorStep | _next | run | fn | M"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,10 +1,11 @@
 ---
-created: '2021-08-04T15:53:48.543344Z'
+created: '2021-09-01T10:07:53.232413Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
   hash: "37431f5f13e61c1a604e54d097c98cc5"
+  tree_label: "fetchGroupEventAndMarkSeen"
   component:
     app-depth-1*
       exception*
@@ -25,6 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "caa5df29a33af87ed50ebc242e35178d"
+  tree_label: "fetchGroupEventAndMarkSeen | fetchData"
   component:
     app-depth-2*
       exception*
@@ -54,6 +56,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-3:
   hash: "0d2903c79166b4f45dce1a21dd5bca2a"
+  tree_label: "fetchGroupEventAndMarkSeen | fetchData | q"
   component:
     app-depth-3*
       exception*
@@ -92,6 +95,7 @@ app-depth-3:
 --------------------------------------------------------------------------
 app-depth-4:
   hash: "4a3cf3893b6485428dd02da116c8370e"
+  tree_label: "fetchGroupEventAndMarkSeen | fetchData | q | call"
   component:
     app-depth-4*
       exception*
@@ -139,6 +143,7 @@ app-depth-4:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "4a3cf3893b6485428dd02da116c8370e"
+  tree_label: "fetchGroupEventAndMarkSeen | fetchData | q | call"
   component:
     app-depth-max*
       exception*
@@ -186,7 +191,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "0b81da6ea3d7cc82b1d4825b7aac0b8d"
-  tree_label: "ih | Xg | Yg | tag | enqueueSetState | setState"
+  tree_label: "fetchGroupEventAndMarkSeen | fetchData | q | ih | Xg | Yg | tag | enqueueSetState | setState | call | tryCatch | key | asyncGeneratorStep | _next"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/react_native.pysnap
@@ -1,10 +1,11 @@
 ---
-created: '2021-08-04T15:53:47.789973Z'
+created: '2021-09-01T10:07:54.631051Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app-depth-1:
   hash: "f3c55d92b61d1734b37445f461758449"
+  tree_label: "Button"
   component:
     app-depth-1*
       exception*
@@ -25,6 +26,7 @@ app-depth-1:
 --------------------------------------------------------------------------
 app-depth-2:
   hash: "73470e545e51eea9cff8a6c006f68f57"
+  tree_label: "Button | onPress"
   component:
     app-depth-2*
       exception*
@@ -54,6 +56,7 @@ app-depth-2:
 --------------------------------------------------------------------------
 app-depth-max:
   hash: "73470e545e51eea9cff8a6c006f68f57"
+  tree_label: "Button | onPress"
   component:
     app-depth-max*
       exception*
@@ -83,7 +86,7 @@ app-depth-max:
 --------------------------------------------------------------------------
 system:
   hash: "ecd413627f0d90a5a25cb28d1ba9c39f"
-  tree_label: "[native code] forEach"
+  tree_label: "Button | onPress | this | _performSideEffectsForTransition | _receiveSignal | arguments | apply | apply | invokeGuardedCallbackAndCatchFirstError | executeDispatch | D | [native code] forEach | forEachAccumulated | fn | _batchedUpdates | batchedUpdates | _receiveRootNodeIDEvent | _lastFlush | flushedQueue | _inCall | flushedQueue | value"
   component:
     system*
       exception*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/javascript_regression_tree_labels.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-08-27T14:37:12.782079Z'
+created: '2021-09-01T09:11:06.764404Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,41 +14,51 @@ app:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame (non app frame)
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame (non app frame)
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame (non app frame)
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame (non app frame)
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value*
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 system:
-  hash: "2a8970581cc3478959e826ee278af1d5"
+  hash: "8fb2eda9663c3c026c23475d6da30363"
   component:
     system*
       exception*
@@ -58,34 +68,44 @@ system:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/javascript_regression_tree_labels.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-08-27T14:37:14.312382Z'
+created: '2021-09-01T09:11:07.313744Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,41 +14,51 @@ app:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame (non app frame)
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame (non app frame)
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame (non app frame)
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame (non app frame)
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value*
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 system:
-  hash: "2a8970581cc3478959e826ee278af1d5"
+  hash: "8fb2eda9663c3c026c23475d6da30363"
   component:
     system*
       exception*
@@ -58,34 +68,44 @@ system:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/javascript_regression_tree_labels.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/javascript_regression_tree_labels.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-08-27T14:37:19.459376Z'
+created: '2021-09-01T09:11:11.279049Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -14,41 +14,51 @@ app:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame (non app frame)
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame (non app frame)
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame (non app frame)
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame (non app frame)
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value*
           "Unable to save a recent search"
 --------------------------------------------------------------------------
 system:
-  hash: "2a8970581cc3478959e826ee278af1d5"
+  hash: "8fb2eda9663c3c026c23475d6da30363"
   component:
     system*
       exception*
@@ -58,34 +68,44 @@ system:
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
+            context-line*
+              "Sentry.withScope(scope => {"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "Sentry"
+            context-line*
+              "callOnHub('withScope', callback);"
           frame*
             module*
               "@sentry/minimal/esm/index"
             filename (module takes precedence)
               "index.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callOnHub"
+            context-line*
+              "return hub[method].apply(hub, __spread(args));"
           frame*
             module*
               "@sentry/hub/esm/hub"
             filename (module takes precedence)
               "hub.js"
-            function*
+            function (ignored because sourcemap used and context line available)
               "apply"
+            context-line*
+              "callback(scope);"
           frame*
             module*
               "app/utils/handleXhrErrorResponse"
             filename (module takes precedence)
               "handlexhrerrorresponse.tsx"
-            function*
+            function (ignored because sourcemap used and context line available)
               "callback"
+            context-line*
+              "Sentry.captureException(new Error(message));"
         type*
           "Error"
         value (ignored because stacktrace takes precedence)


### PR DESCRIPTION
The snapshot file did not contain the correct platform, so function was
never discarded for grouping in the first place. That uncovered
unexpected behavior in GroupingComponent.update.