### PR TITLE
feat(issue-alerts): Add Sentry Apps Alert Rule Action as an Action

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -15,3 +15,16 @@ class SentryAppComponentSerializer(Serializer):
                 "name": obj.sentry_app.name,
             },
         }
+
+
+class SentryAppAlertRuleActionSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs):
+        return {
+            "id": f"sentry.sentryapp.{obj.sentry_app.slug}",
+            "uuid": str(obj.uuid),
+            "actionType": "sentryapp",
+            "prompt": f"{obj.sentry_app.name}",
+            "enabled": True,
+            "label": obj.schema.get("title", ""),
+            "formfields": obj.schema.get("settings", {}),
+        }

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -157,9 +157,11 @@ class NotifyEventServiceAction(EventAction):
             yield self.future(plugin.rule_notify)
 
     def get_sentry_app_services(self):
+        # excludes Sentry Apps that have Alert Rule UI Component in their schema
         return [
             SentryAppService(app)
             for app in SentryApp.objects.get_alertable_sentry_apps(self.project.organization_id)
+            if not SentryAppService(app).has_alert_rule_action()
         ]
 
     def get_plugins(self):

--- a/src/sentry/rules/actions/services.py
+++ b/src/sentry/rules/actions/services.py
@@ -37,3 +37,10 @@ class SentryAppService(PluginService):
     @property
     def service_type(self):
         return "sentry_app"
+
+    def has_alert_rule_action(self):
+        from sentry.models import SentryAppComponent
+
+        return SentryAppComponent.objects.filter(
+            sentry_app_id=self.service.id, type="alert-rule-action"
+        ).exists()

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -779,7 +779,12 @@ class Factories:
     def create_alert_rule_action_schema():
         return {
             "type": "alert-rule-action",
-            "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
+            "title": "Create Task with App",
+            "settings": {
+                "type": "alert-rule-settings",
+                "uri": "/sentry/alert-rule",
+                "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
+            },
         }
 
     @staticmethod

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -120,3 +120,68 @@ class ProjectRuleConfigurationTest(APITestCase):
                 ):
                     found = True
             assert found is True
+
+    def test_sentry_app_alertable_webhook(self):
+        team = self.create_team()
+        project1 = self.create_project(teams=[team], name="foo")
+        self.create_project(teams=[team], name="baz")
+
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            is_alertable=True,
+        )
+        self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+
+        response = self.get_valid_response(self.organization.slug, project1.slug)
+
+        assert len(response.data["actions"]) == 8
+        assert {
+            "id": "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+            "label": "Send a notification via {service}",
+            "enabled": True,
+            "prompt": "Send a notification via an integration",
+            "formFields": {
+                "service": {"type": "choice", "choices": [[sentry_app.slug, sentry_app.name]]}
+            },
+        } in response.data["actions"]
+        assert len(response.data["conditions"]) == 6
+        assert len(response.data["filters"]) == 7
+
+    def test_sentry_app_alert_rules(self):
+        from sentry.models import SentryAppComponent
+
+        team = self.create_team()
+        project1 = self.create_project(teams=[team], name="foo")
+        self.create_project(teams=[team], name="baz")
+
+        sentry_app = self.create_sentry_app(
+            organization=self.organization,
+            schema={"elements": [self.create_alert_rule_action_schema()]},
+            is_alertable=True,
+        )
+        self.create_sentry_app_installation(
+            slug=sentry_app.slug, organization=self.organization, user=self.user
+        )
+        component = SentryAppComponent.objects.get(
+            sentry_app_id=sentry_app.id, type="alert-rule-action"
+        )
+        response = self.get_valid_response(self.organization.slug, project1.slug)
+
+        assert len(response.data["actions"]) == 8
+        assert {
+            "id": f"sentry.sentryapp.{sentry_app.slug}",
+            "uuid": str(component.uuid),
+            "actionType": "sentryapp",
+            "prompt": sentry_app.name,
+            "enabled": True,
+            "label": "Create Task with App",
+            "formfields": {
+                "type": "alert-rule-settings",
+                "uri": "/sentry/alert-rule",
+                "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
+            },
+        } in response.data["actions"]
+        assert len(response.data["conditions"]) == 6
+        assert len(response.data["filters"]) == 7


### PR DESCRIPTION
## Objective:

Issue Alert configurations should return the Sentry App alert rule action as one of the actions. If the Sentry App does not have and Alert Rule UI Component defined but isAlertable, then we should return our current response.

## Tests
Added tests for Sentry Apps with only `isAlertable` webhooks and for Sentry Apps that have Alert Rule UI Components.