### PR TITLE
fix(trends): Header overlapping with graph

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -555,7 +555,7 @@ const ChartContainer = styled('div')`
 
 const StyledHeaderTitleLegend = styled(HeaderTitleLegend)`
   border-radius: ${p => p.theme.borderRadius};
-  padding: ${space(2)} ${space(3)};
+  margin: ${space(2)} ${space(3)};
 `;
 
 const StyledButton = styled(Button)`


### PR DESCRIPTION
### Summary
Fixes header overlapping graph due to padding.

### Screenshots
#### Before
![Screen Shot 2021-09-01 at 10 50 06 AM](https://user-images.githubusercontent.com/6111995/131693703-a30b85d3-1085-42a2-8355-d820c0cc34a8.png)

#### After
![Screen Shot 2021-09-01 at 10 51 20 AM](https://user-images.githubusercontent.com/6111995/131693731-7e148da7-e69f-4286-b124-247abefbbfed.png)
