### PR TITLE
feat(issue-alert): Render Sentry App Alert Rule once selected

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -25,6 +25,6 @@ class SentryAppAlertRuleActionSerializer(Serializer):
             "actionType": "sentryapp",
             "prompt": f"{obj.sentry_app.name}",
             "enabled": True,
-            "label": obj.schema.get("title", ""),
+            "label": f"{obj.schema.get('title', obj.sentry_app.name)} with these ",
             "formfields": obj.schema.get("settings", {}),
         }

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -27,7 +27,7 @@ export type IssueAlertRuleActionTemplate = {
   label: string;
   prompt: string;
   enabled: boolean;
-  actionType?: 'ticket';
+  actionType?: 'ticket' | 'sentryapp';
   formFields?: {
     [key: string]: IssueAlertRuleFormField;
   };

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -354,7 +354,9 @@ class RuleNode extends React.Component<Props> {
 
   render() {
     const {data, disabled, index, node, organization} = this.props;
-    const ticketRule = node?.hasOwnProperty('actionType');
+    const ticketRule = node?.hasOwnProperty('actionType') && node.actionType === 'ticket';
+    const sentryAppRule =
+      node?.hasOwnProperty('actionType') && node.actionType === 'sentryapp';
     const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
     return (
       <RuleRowContainer>
@@ -384,6 +386,18 @@ class RuleNode extends React.Component<Props> {
                 }
               >
                 {t('Issue Link Settings')}
+              </Button>
+            )}
+            {sentryAppRule && node && (
+              <Button
+                size="small"
+                icon={<IconSettings size="xs" />}
+                type="button"
+                onClick={() => {
+                  // TODO(nisanthan): Placeholder. Modal will be implemented in next PR.
+                }}
+              >
+                {t('Settings')}
               </Button>
             )}
           </Rule>

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -354,9 +354,8 @@ class RuleNode extends React.Component<Props> {
 
   render() {
     const {data, disabled, index, node, organization} = this.props;
-    const ticketRule = node?.hasOwnProperty('actionType') && node.actionType === 'ticket';
-    const sentryAppRule =
-      node?.hasOwnProperty('actionType') && node.actionType === 'sentryapp';
+    const ticketRule = node?.actionType === 'ticket';
+    const sentryAppRule = node?.actionType === 'sentryapp';
     const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
     return (
       <RuleRowContainer>

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -176,7 +176,7 @@ class ProjectRuleConfigurationTest(APITestCase):
             "actionType": "sentryapp",
             "prompt": sentry_app.name,
             "enabled": True,
-            "label": "Create Task with App",
+            "label": "Create Task with App with these ",
             "formfields": {
                 "type": "alert-rule-settings",
                 "uri": "/sentry/alert-rule",


### PR DESCRIPTION
## Objective:
If the option is a Sentry App with a defined Alert Rule Action UI Component, then it should render as below.

https://user-images.githubusercontent.com/10491193/131745644-a40d9df3-824d-4b91-9cf9-241e75c6c24f.mov

