### PR TITLE
fix(tests): Make `TestMigrations` a `TransactionTestCase`

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1170,7 +1170,7 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
         self.login_as(self.user)
 
 
-class TestMigrations(TestCase):
+class TestMigrations(TransactionTestCase):
     """
     From https://www.caktusgroup.com/blog/2016/02/02/writing-unit-tests-django-migrations/
     """


### PR DESCRIPTION
When we wind back migrations these ended up being run inside of a transaction, which causes problems
for any migrations using `CREATE INDEX CONCURRENTLY` and other transaction unfriendly operations.
Just making this a `TransactionTestCase` solves the problem.