### PR TITLE
chore(chart-unfurls): Add a warning in Slack integration

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -52,7 +52,7 @@ setup_alert = {
 
 discover_unfurl_alert = {
     "type": "warning",
-    "text": "Project permissions will not apply when unfurling Sentry Discover charts your Slack workspace.",
+    "text": "Project permissions will not apply when unfurling Sentry Discover charts from within your Slack workspace.",
     "icon": "icon-warning-sm",
     "feature": "chart-unfurls",
 }

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -50,6 +50,13 @@ setup_alert = {
     "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
 }
 
+discover_unfurl_alert = {
+    "type": "warning",
+    "text": "Project permissions will not apply when unfurling Sentry Discover charts your Slack workspace.",
+    "icon": "icon-warning-sm",
+    "feature": "chart-unfurls",
+}
+
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
     features=FEATURES,
@@ -57,7 +64,7 @@ metadata = IntegrationMetadata(
     noun=_("Workspace"),
     issue_url="https://github.com/getsentry/sentry/issues/new?assignees=&labels=Component:%20Integrations&template=bug.yml&title=Slack%20Integration%20Problem",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/slack",
-    aspects={"alerts": [setup_alert]},
+    aspects={"alerts": [setup_alert, discover_unfurl_alert]},
 )
 
 

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -20,6 +20,7 @@ import {
   IntegrationType,
   Organization,
 } from 'app/types';
+import {defined} from 'app/utils';
 import {
   IntegrationAnalyticsKey,
   IntegrationEventParameters,
@@ -39,6 +40,7 @@ type Tab = 'overview' | 'configurations';
 
 type AlertType = React.ComponentProps<typeof Alert> & {
   text: string;
+  feature?: string;
 };
 
 type State = {
@@ -329,13 +331,19 @@ class AbstractIntegrationDetailedView<
               provider={{key: this.props.params.integrationSlug}}
             />
             {this.renderPermissions()}
-            {this.alerts.map((alert, i) => (
-              <Alert key={i} type={alert.type} icon={alert.icon}>
-                <span
-                  dangerouslySetInnerHTML={{__html: singleLineRenderer(alert.text)}}
-                />
-              </Alert>
-            ))}
+            {this.alerts.map((alert, i) => {
+              return (
+                (defined(alert.feature)
+                  ? this.props.organization.features.includes(alert.feature)
+                  : true) && (
+                  <Alert key={i} type={alert.type} icon={alert.icon}>
+                    <span
+                      dangerouslySetInnerHTML={{__html: singleLineRenderer(alert.text)}}
+                    />
+                  </Alert>
+                )
+              );
+            })}
           </FlexContainer>
           <Metadata>
             {!!this.author && (


### PR DESCRIPTION
With discover charts unfurl in slack being EA'ed add a note
in the Slack integration for those who have the feature
letting them know that project permissions will not be
honoured with chart unfurls.

Screenshots without and with the feature flag:
![Screen Shot 2021-09-02 at 7 21 46 AM](https://user-images.githubusercontent.com/63818634/131835201-39b532f3-3367-4508-982f-6ce213a37a7e.png)
![Screen Shot 2021-09-02 at 7 21 55 AM](https://user-images.githubusercontent.com/63818634/131835206-b6cefee9-1dce-4c2f-9b9d-9c397a641883.png)
