### PR TITLE
fix(appconnect): Ensure a bool is returned for promptItunesSession

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -524,7 +524,7 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
                 "latestBuildVersion": latestBuildVersion,
                 "latestBuildNumber": latestBuildNumber,
                 "lastCheckedBuilds": last_checked_builds,
-                "promptItunesSession": pending_downloads and itunes_session_info is None,
+                "promptItunesSession": bool(pending_downloads and itunes_session_info is None),
             },
             status=200,
         )


### PR DESCRIPTION
This is supposed to return a boolean JSON type, but that is not what
it was doing, if there were no pending downloads it would return `0`
if there was no valid itunes session.