### PR TITLE
fix(devenv): Fix py3 bootstrapping for getsentry

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -170,7 +170,7 @@ venv_name=".venv"
 if [ ! -f "${venv_name}/bin/activate" ]; then
     prompt_python_venv_creation
     # This is time consuming but it has to be done
-    source ./scripts/bootstrap-py3-venv
+    source "${SENTRY_ROOT}/scripts/bootstrap-py3-venv"
 fi
 
 # The user might be cd'ing into sentry with another non-direnv managed

--- a/scripts/bootstrap-py3-venv
+++ b/scripts/bootstrap-py3-venv
@@ -31,7 +31,7 @@ gitroot="$(git rev-parse --show-toplevel)"
 cd "$gitroot"
 # This executes very quickly if the Python versions are already installed
 make setup-pyenv
-export PYENV_VERSION=$(SENTRY_NO_VENV_CHECK=1 ./scripts/do.sh get-pyenv-version)
+export PYENV_VERSION=$(SENTRY_NO_VENV_CHECK=1 ${SCRIPTS_DIR}/do.sh get-pyenv-version)
 venv_name="${PWD}/.venv"
 
 if [[ -f "${venv_name}/bin/activate" ]]; then


### PR DESCRIPTION
This fixes bootstrapping py3 for getsentry, as we need to ensure the proper paths when these scripts are used outside of the current repo.