### PR TITLE
ref(performance): Separate header from content in transaction overview

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -5,7 +5,6 @@ import {Location} from 'history';
 import omit from 'lodash/omit';
 
 import Feature from 'app/components/acl/feature';
-import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
 import TransactionsList, {DropdownOption} from 'app/components/discover/transactionsList';
 import SearchBar from 'app/components/events/searchBar';
 import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
@@ -42,9 +41,6 @@ import Filter, {
   filterToSearchConditions,
   SpanOperationBreakdownFilter,
 } from '../filter';
-import TransactionHeader from '../header';
-import Tab from '../tabs';
-import {TransactionThresholdMetric} from '../transactionThresholdModal';
 import {
   generateTraceLink,
   generateTransactionLink,
@@ -69,19 +65,10 @@ type Props = {
   totalValues: Record<string, number> | null;
   projects: Project[];
   onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
-  onChangeThreshold?: (threshold: number, metric: TransactionThresholdMetric) => void;
   spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
 };
 
-type State = {
-  incompatibleAlertNotice: React.ReactNode;
-};
-
-class SummaryContent extends React.Component<Props, State> {
-  state: State = {
-    incompatibleAlertNotice: null,
-  };
-
+class SummaryContent extends React.Component<Props> {
   handleSearch = (query: string) => {
     const {location} = this.props;
 
@@ -107,15 +94,6 @@ class SummaryContent extends React.Component<Props, State> {
       ...location,
       query,
     };
-  };
-
-  handleIncompatibleQuery: React.ComponentProps<
-    typeof CreateAlertFromViewButton
-  >['onIncompatibleQuery'] = (incompatibleAlertNoticeFn, _errors) => {
-    const incompatibleAlertNotice = incompatibleAlertNoticeFn(() =>
-      this.setState({incompatibleAlertNotice: null})
-    );
-    this.setState({incompatibleAlertNotice});
   };
 
   handleCellAction = (column: TableColumn<React.ReactText>) => {
@@ -215,7 +193,6 @@ class SummaryContent extends React.Component<Props, State> {
       error,
       totalValues,
       onChangeFilter,
-      onChangeThreshold,
       spanOperationBreakdownFilter,
     } = this.props;
     const hasPerformanceEventsPage = organization.features.includes(
@@ -225,7 +202,6 @@ class SummaryContent extends React.Component<Props, State> {
       'performance-chart-interpolation'
     );
 
-    const {incompatibleAlertNotice} = this.state;
     const query = decodeScalar(location.query.query, '');
     const totalCount = totalValues === null ? null : totalValues.count;
 
@@ -321,132 +297,115 @@ class SummaryContent extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <TransactionHeader
-          eventView={eventView}
-          location={location}
-          organization={organization}
-          projects={projects}
-          transactionName={transactionName}
-          currentTab={Tab.TransactionSummary}
-          hasWebVitals="maybe"
-          handleIncompatibleQuery={this.handleIncompatibleQuery}
-          onChangeThreshold={onChangeThreshold}
-        />
-        <Layout.Body>
-          <StyledSdkUpdatesAlert />
-          {incompatibleAlertNotice && (
-            <Layout.Main fullWidth>{incompatibleAlertNotice}</Layout.Main>
-          )}
-          <Layout.Main>
-            <Search>
-              <Filter
-                organization={organization}
-                currentFilter={spanOperationBreakdownFilter}
-                onChangeFilter={onChangeFilter}
-              />
-              <StyledSearchBar
-                searchSource="transaction_summary"
-                organization={organization}
-                projectIds={eventView.project}
-                query={query}
-                fields={eventView.fields}
-                onSearch={this.handleSearch}
-                maxQueryLength={MAX_QUERY_LENGTH}
-              />
-            </Search>
-            <TransactionSummaryCharts
+        <Layout.Main>
+          <Search>
+            <Filter
               organization={organization}
-              location={location}
-              eventView={eventView}
-              totalValues={totalCount}
               currentFilter={spanOperationBreakdownFilter}
-              withoutZerofill={hasPerformanceChartInterpolation}
+              onChangeFilter={onChangeFilter}
             />
-            <TransactionsList
-              location={location}
+            <StyledSearchBar
+              searchSource="transaction_summary"
               organization={organization}
-              eventView={transactionsListEventView}
-              {...(hasPerformanceEventsPage ? openAllEventsProps : openInDiscoverProps)}
-              showTransactions={
-                decodeScalar(
-                  location.query.showTransactions,
-                  TransactionFilterOptions.SLOW
-                ) as TransactionFilterOptions
-              }
-              breakdown={decodeFilterFromLocation(location)}
-              titles={transactionsListTitles}
-              handleDropdownChange={this.handleTransactionsListSortChange}
-              generateLink={{
-                id: generateTransactionLink(transactionName),
-                trace: generateTraceLink(eventView.normalizeDateSelection(location)),
-              }}
-              baseline={transactionName}
-              handleBaselineClick={this.handleViewDetailsClick}
-              handleCellAction={this.handleCellAction}
-              {...getTransactionsListSort(location, {
-                p95: totalValues?.p95 ?? 0,
-                spanOperationBreakdownFilter,
-              })}
-              forceLoading={isLoading}
+              projectIds={eventView.project}
+              query={query}
+              fields={eventView.fields}
+              onSearch={this.handleSearch}
+              maxQueryLength={MAX_QUERY_LENGTH}
             />
-            <Feature
-              requireAll={false}
-              features={['performance-tag-explorer', 'performance-tag-page']}
-            >
-              <TagExplorer
-                eventView={eventView}
-                organization={organization}
-                location={location}
-                projects={projects}
-                transactionName={transactionName}
-                currentFilter={spanOperationBreakdownFilter}
-              />
-            </Feature>
-            <RelatedIssues
+          </Search>
+          <TransactionSummaryCharts
+            organization={organization}
+            location={location}
+            eventView={eventView}
+            totalValues={totalCount}
+            currentFilter={spanOperationBreakdownFilter}
+            withoutZerofill={hasPerformanceChartInterpolation}
+          />
+          <TransactionsList
+            location={location}
+            organization={organization}
+            eventView={transactionsListEventView}
+            {...(hasPerformanceEventsPage ? openAllEventsProps : openInDiscoverProps)}
+            showTransactions={
+              decodeScalar(
+                location.query.showTransactions,
+                TransactionFilterOptions.SLOW
+              ) as TransactionFilterOptions
+            }
+            breakdown={decodeFilterFromLocation(location)}
+            titles={transactionsListTitles}
+            handleDropdownChange={this.handleTransactionsListSortChange}
+            generateLink={{
+              id: generateTransactionLink(transactionName),
+              trace: generateTraceLink(eventView.normalizeDateSelection(location)),
+            }}
+            baseline={transactionName}
+            handleBaselineClick={this.handleViewDetailsClick}
+            handleCellAction={this.handleCellAction}
+            {...getTransactionsListSort(location, {
+              p95: totalValues?.p95 ?? 0,
+              spanOperationBreakdownFilter,
+            })}
+            forceLoading={isLoading}
+          />
+          <Feature
+            requireAll={false}
+            features={['performance-tag-explorer', 'performance-tag-page']}
+          >
+            <TagExplorer
+              eventView={eventView}
               organization={organization}
               location={location}
-              transaction={transactionName}
-              start={eventView.start}
-              end={eventView.end}
-              statsPeriod={eventView.statsPeriod}
-            />
-          </Layout.Main>
-          <Layout.Side>
-            <UserStats
-              organization={organization}
-              location={location}
-              isLoading={isLoading}
-              hasWebVitals={hasWebVitals}
-              error={error}
-              totals={totalValues}
+              projects={projects}
               transactionName={transactionName}
-              eventView={eventView}
+              currentFilter={spanOperationBreakdownFilter}
             />
-            {!isFrontendView && (
-              <StatusBreakdown
-                eventView={eventView}
-                organization={organization}
-                location={location}
-              />
-            )}
-            <SidebarSpacer />
-            <SidebarCharts
-              organization={organization}
-              isLoading={isLoading}
-              error={error}
-              totals={totalValues}
-              eventView={eventView}
-            />
-            <SidebarSpacer />
-            <Tags
-              generateUrl={this.generateTagUrl}
-              totalValues={totalCount}
+          </Feature>
+          <RelatedIssues
+            organization={organization}
+            location={location}
+            transaction={transactionName}
+            start={eventView.start}
+            end={eventView.end}
+            statsPeriod={eventView.statsPeriod}
+          />
+        </Layout.Main>
+        <Layout.Side>
+          <UserStats
+            organization={organization}
+            location={location}
+            isLoading={isLoading}
+            hasWebVitals={hasWebVitals}
+            error={error}
+            totals={totalValues}
+            transactionName={transactionName}
+            eventView={eventView}
+          />
+          {!isFrontendView && (
+            <StatusBreakdown
               eventView={eventView}
               organization={organization}
               location={location}
             />
-          </Layout.Side>
-        </Layout.Body>
+          )}
+          <SidebarSpacer />
+          <SidebarCharts
+            organization={organization}
+            isLoading={isLoading}
+            error={error}
+            totals={totalValues}
+            eventView={eventView}
+          />
+          <SidebarSpacer />
+          <Tags
+            generateUrl={this.generateTagUrl}
+            totalValues={totalCount}
+            eventView={eventView}
+            organization={organization}
+            location={location}
+          />
+        </Layout.Side>
       </React.Fragment>
     );
   }

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -95,8 +95,7 @@ function TransactionOverview(props: Props) {
 
   const spanOperationBreakdownFilter = decodeFilterFromLocation(location);
 
-  // TODO: make not undefined
-  const eventView = generateEventView(location, transactionName)!;
+  const eventView = generateEventView(location, transactionName);
   const totalsView = getTotalsEventView(organization, eventView);
 
   const onChangeFilter = (newFilter: SpanOperationBreakdownFilter) => {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -1,17 +1,19 @@
-import {Component} from 'react';
+import {ReactNode, useEffect, useState} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import isEqual from 'lodash/isEqual';
 
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import {Client} from 'app/api';
+import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
+import * as Layout from 'app/components/layouts/thirds';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import {GlobalSelection, Organization, Project} from 'app/types';
+import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
@@ -35,6 +37,8 @@ import {
   filterToLocationQuery,
   SpanOperationBreakdownFilter,
 } from '../filter';
+import TransactionHeader from '../header';
+import Tab from '../tabs';
 import {TransactionThresholdMetric} from '../transactionThresholdModal';
 import {
   PERCENTILE as VITAL_PERCENTILE,
@@ -44,68 +48,58 @@ import {
 import SummaryContent from './content';
 import {ZOOM_END, ZOOM_START} from './latencyChart';
 
-type Props = RouteComponentProps<{}, {}> & {
-  api: Client;
-  organization: Organization;
-  projects: Project[];
-  selection: GlobalSelection;
-  loadingProjects: boolean;
-};
-
-type State = {
-  spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
-  eventView: EventView | undefined;
-  transactionThreshold: number | undefined;
-  transactionThresholdMetric: TransactionThresholdMetric | undefined;
-};
-
 // Used to cast the totals request to numbers
 // as React.ReactText
 type TotalValues = Record<string, number>;
 
-class TransactionSummary extends Component<Props, State> {
-  state: State = {
-    transactionThreshold: undefined,
-    transactionThresholdMetric: undefined,
-    spanOperationBreakdownFilter: decodeFilterFromLocation(this.props.location),
-    eventView: generateSummaryEventView(
-      this.props.location,
-      getTransactionName(this.props.location)
-    ),
-  };
+type Props = RouteComponentProps<{}, {}> & {
+  api: Client;
+  selection: GlobalSelection;
+  organization: Organization;
+  projects: Project[];
+};
 
-  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
-    return {
-      ...prevState,
-      spanOperationBreakdownFilter: decodeFilterFromLocation(nextProps.location),
-      eventView: generateSummaryEventView(
-        nextProps.location,
-        getTransactionName(nextProps.location)
-      ),
-    };
+function TransactionOverview(props: Props) {
+  const {api, location, selection, organization, projects} = props;
+  const projectId = decodeScalar(location.query.project);
+  const transactionName = getTransactionName(location);
+
+  if (!defined(projectId) || !defined(transactionName)) {
+    // If there is no transaction name, redirect to the Performance landing page
+    browserHistory.replace({
+      pathname: `/organizations/${organization.slug}/performance/`,
+      query: {
+        ...location.query,
+      },
+    });
+    return null;
   }
 
-  componentDidMount() {
-    const {api, organization, selection} = this.props;
+  const project = projects.find(p => p.id === projectId);
+
+  useEffect(() => {
     loadOrganizationTags(api, organization.slug, selection);
     addRoutePerformanceContext(selection);
-  }
+  }, [selection]);
 
-  componentDidUpdate(prevProps: Props) {
-    const {api, organization, selection} = this.props;
+  const [incompatibleAlertNotice, setIncompatibleAlertNotice] = useState<ReactNode>(null);
+  const handleIncompatibleQuery = (incompatibleAlertNoticeFn, _errors) => {
+    const notice = incompatibleAlertNoticeFn(() => setIncompatibleAlertNotice(null));
+    setIncompatibleAlertNotice(notice);
+  };
 
-    if (
-      !isEqual(prevProps.selection.projects, selection.projects) ||
-      !isEqual(prevProps.selection.datetime, selection.datetime)
-    ) {
-      loadOrganizationTags(api, organization.slug, selection);
-      addRoutePerformanceContext(selection);
-    }
-  }
+  const [transactionThreshold, setTransactionThreshold] = useState<number | undefined>();
+  const [transactionThresholdMetric, setTransactionThresholdMetric] = useState<
+    TransactionThresholdMetric | undefined
+  >();
 
-  onChangeFilter = (newFilter: SpanOperationBreakdownFilter) => {
-    const {location, organization} = this.props;
+  const spanOperationBreakdownFilter = decodeFilterFromLocation(location);
 
+  // TODO: make not undefined
+  const eventView = generateEventView(location, transactionName)!;
+  const totalsView = getTotalsEventView(organization, eventView);
+
+  const onChangeFilter = (newFilter: SpanOperationBreakdownFilter) => {
     trackAnalyticsEvent({
       eventName: 'Performance Views: Filter Dropdown',
       eventKey: 'performance_views.filter_dropdown.selection',
@@ -127,140 +121,41 @@ class TransactionSummary extends Component<Props, State> {
     });
   };
 
-  getDocumentTitle(): string {
-    const name = getTransactionName(this.props.location);
-
-    const hasTransactionName = typeof name === 'string' && String(name).trim().length > 0;
-
-    if (hasTransactionName) {
-      return [String(name).trim(), t('Performance')].join(' - ');
-    }
-
-    return [t('Summary'), t('Performance')].join(' - ');
-  }
-
-  getTotalsEventView(organization: Organization, eventView: EventView): EventView {
-    const threshold = organization.apdexThreshold.toString();
-
-    const vitals = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce(
-      (keys: WebVital[], vs) => {
-        vs.forEach(vital => keys.push(vital));
-        return keys;
-      },
-      []
-    );
-
-    const totalsColumns: QueryFieldValue[] = [
-      {
-        kind: 'function',
-        function: ['p95', '', undefined, undefined],
-      },
-      {
-        kind: 'function',
-        function: ['count', '', undefined, undefined],
-      },
-      {
-        kind: 'function',
-        function: ['count_unique', 'user', undefined, undefined],
-      },
-      {
-        kind: 'function',
-        function: ['failure_rate', '', undefined, undefined],
-      },
-      {
-        kind: 'function',
-        function: ['tpm', '', undefined, undefined],
-      },
-    ];
-
-    const featureColumns: QueryFieldValue[] = organization.features.includes(
-      'project-transaction-threshold'
-    )
-      ? [
-          {
-            kind: 'function',
-            function: ['count_miserable', 'user', undefined, undefined],
-          },
-          {
-            kind: 'function',
-            function: ['user_misery', '', undefined, undefined],
-          },
-          {
-            kind: 'function',
-            function: ['apdex', '', undefined, undefined],
-          },
-        ]
-      : [
-          {
-            kind: 'function',
-            function: ['count_miserable', 'user', threshold, undefined],
-          },
-          {
-            kind: 'function',
-            function: ['user_misery', threshold, undefined, undefined],
-          },
-          {
-            kind: 'function',
-            function: ['apdex', threshold, undefined, undefined],
-          },
-        ];
-
-    return eventView.withColumns([
-      ...totalsColumns,
-      ...featureColumns,
-      ...vitals.map(
-        vital =>
-          ({
-            kind: 'function',
-            function: ['percentile', vital, VITAL_PERCENTILE.toString(), undefined],
-          } as Column)
-      ),
-    ]);
-  }
-
-  render() {
-    const {organization, projects, location} = this.props;
-    const {eventView, transactionThreshold, transactionThresholdMetric} = this.state;
-    const transactionName = getTransactionName(location);
-    if (!eventView || transactionName === undefined) {
-      // If there is no transaction name, redirect to the Performance landing page
-
-      browserHistory.replace({
-        pathname: `/organizations/${organization.slug}/performance/`,
-        query: {
-          ...location.query,
-        },
-      });
-      return null;
-    }
-    const totalsView = this.getTotalsEventView(organization, eventView);
-
-    const shouldForceProject = eventView.project.length === 1;
-    const forceProject = shouldForceProject
-      ? projects.find(p => parseInt(p.id, 10) === eventView.project[0])
-      : undefined;
-
-    const projectSlugs = eventView.project
-      .map(projectId => projects.find(p => parseInt(p.id, 10) === projectId))
-      .filter((p: Project | undefined): p is Project => p !== undefined)
-      .map(p => p.slug);
-
-    return (
-      <SentryDocumentTitle
-        title={this.getDocumentTitle()}
-        orgSlug={organization.slug}
-        projectSlug={forceProject?.slug}
+  return (
+    <SentryDocumentTitle
+      title={getDocumentTitle(transactionName)}
+      orgSlug={organization.slug}
+      projectSlug={project?.slug}
+    >
+      <GlobalSelectionHeader
+        lockedMessageSubject={t('transaction')}
+        shouldForceProject={defined(project)}
+        forceProject={project}
+        specificProjectSlugs={defined(project) ? [project.slug] : []}
+        disableMultipleProjectSelection
+        showProjectSettingsLink
       >
-        <GlobalSelectionHeader
-          lockedMessageSubject={t('transaction')}
-          shouldForceProject={shouldForceProject}
-          forceProject={forceProject}
-          specificProjectSlugs={projectSlugs}
-          disableMultipleProjectSelection
-          showProjectSettingsLink
-        >
-          <StyledPageContent>
-            <LightWeightNoProjectMessage organization={organization}>
+        <StyledPageContent>
+          <LightWeightNoProjectMessage organization={organization}>
+            <TransactionHeader
+              eventView={eventView}
+              location={location}
+              organization={organization}
+              projects={projects}
+              transactionName={transactionName}
+              currentTab={Tab.TransactionSummary}
+              hasWebVitals="maybe"
+              handleIncompatibleQuery={handleIncompatibleQuery}
+              onChangeThreshold={(threshold, metric) => {
+                setTransactionThreshold(threshold);
+                setTransactionThresholdMetric(metric);
+              }}
+            />
+            <Layout.Body>
+              <StyledSdkUpdatesAlert />
+              {incompatibleAlertNotice && (
+                <Layout.Main fullWidth>{incompatibleAlertNotice}</Layout.Main>
+              )}
               <DiscoverQuery
                 eventView={totalsView}
                 orgSlug={organization.slug}
@@ -280,39 +175,36 @@ class TransactionSummary extends Component<Props, State> {
                       isLoading={isLoading}
                       error={error}
                       totalValues={totals}
-                      onChangeFilter={this.onChangeFilter}
-                      spanOperationBreakdownFilter={
-                        this.state.spanOperationBreakdownFilter
-                      }
-                      onChangeThreshold={(threshold, metric) =>
-                        this.setState({
-                          transactionThreshold: threshold,
-                          transactionThresholdMetric: metric,
-                        })
-                      }
+                      onChangeFilter={onChangeFilter}
+                      spanOperationBreakdownFilter={spanOperationBreakdownFilter}
                     />
                   );
                 }}
               </DiscoverQuery>
-            </LightWeightNoProjectMessage>
-          </StyledPageContent>
-        </GlobalSelectionHeader>
-      </SentryDocumentTitle>
-    );
+            </Layout.Body>
+          </LightWeightNoProjectMessage>
+        </StyledPageContent>
+      </GlobalSelectionHeader>
+    </SentryDocumentTitle>
+  );
+}
+
+function getDocumentTitle(transactionName: string): string {
+  const hasTransactionName =
+    typeof transactionName === 'string' && String(transactionName).trim().length > 0;
+
+  if (hasTransactionName) {
+    return [String(transactionName).trim(), t('Performance')].join(' - ');
   }
+
+  return [t('Summary'), t('Performance')].join(' - ');
 }
 
 const StyledPageContent = styled(PageContent)`
   padding: 0;
 `;
 
-function generateSummaryEventView(
-  location: Location,
-  transactionName: string | undefined
-): EventView | undefined {
-  if (transactionName === undefined) {
-    return undefined;
-  }
+function generateEventView(location: Location, transactionName: string): EventView {
   // Use the user supplied query but overwrite any transaction or event type
   // conditions they applied.
   const query = decodeScalar(location.query.query, '');
@@ -340,6 +232,92 @@ function generateSummaryEventView(
   );
 }
 
+function getTotalsEventView(organization: Organization, eventView: EventView): EventView {
+  const threshold = organization.apdexThreshold.toString();
+
+  const vitals = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce((keys: WebVital[], vs) => {
+    vs.forEach(vital => keys.push(vital));
+    return keys;
+  }, []);
+
+  const totalsColumns: QueryFieldValue[] = [
+    {
+      kind: 'function',
+      function: ['p95', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['count', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['count_unique', 'user', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['failure_rate', '', undefined, undefined],
+    },
+    {
+      kind: 'function',
+      function: ['tpm', '', undefined, undefined],
+    },
+  ];
+
+  const featureColumns: QueryFieldValue[] = organization.features.includes(
+    'project-transaction-threshold'
+  )
+    ? [
+        {
+          kind: 'function',
+          function: ['count_miserable', 'user', undefined, undefined],
+        },
+        {
+          kind: 'function',
+          function: ['user_misery', '', undefined, undefined],
+        },
+        {
+          kind: 'function',
+          function: ['apdex', '', undefined, undefined],
+        },
+      ]
+    : [
+        {
+          kind: 'function',
+          function: ['count_miserable', 'user', threshold, undefined],
+        },
+        {
+          kind: 'function',
+          function: ['user_misery', threshold, undefined, undefined],
+        },
+        {
+          kind: 'function',
+          function: ['apdex', threshold, undefined, undefined],
+        },
+      ];
+
+  return eventView.withColumns([
+    ...totalsColumns,
+    ...featureColumns,
+    ...vitals.map(
+      vital =>
+        ({
+          kind: 'function',
+          function: ['percentile', vital, VITAL_PERCENTILE.toString(), undefined],
+        } as Column)
+    ),
+  ]);
+}
+
+const StyledSdkUpdatesAlert = styled(GlobalSdkUpdateAlert)`
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    margin-bottom: 0;
+  }
+`;
+
+StyledSdkUpdatesAlert.defaultProps = {
+  Wrapper: p => <Layout.Main fullWidth {...p} />,
+};
+
 export default withApi(
-  withGlobalSelection(withProjects(withOrganization(TransactionSummary)))
+  withGlobalSelection(withProjects(withOrganization(TransactionOverview)))
 );

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -26,7 +26,7 @@ function initializeData({features: additionalFeatures = [], query = {}} = {}) {
       location: {
         query: {
           transaction: '/performance',
-          project: 2,
+          project: '2',
           transactionCursor: '1:0:0',
           ...query,
         },
@@ -267,6 +267,9 @@ describe('Performance > TransactionSummary', function () {
     await tick();
     wrapper.update();
 
+    // It shows the header
+    expect(wrapper.find('TransactionHeader')).toHaveLength(1);
+
     // It shows a chart
     expect(wrapper.find('TransactionSummaryCharts')).toHaveLength(1);
 
@@ -405,7 +408,7 @@ describe('Performance > TransactionSummary', function () {
       pathname: undefined,
       query: {
         transaction: '/performance',
-        project: 2,
+        project: '2',
         statsPeriod: '14d',
         query: 'user.email:uhoh*',
         transactionCursor: '1:0:0',
@@ -469,7 +472,7 @@ describe('Performance > TransactionSummary', function () {
       pathname: undefined,
       query: {
         transaction: '/performance',
-        project: 2,
+        project: '2',
         showTransactions: 'slow',
         transactionCursor: undefined,
       },
@@ -499,7 +502,7 @@ describe('Performance > TransactionSummary', function () {
       pathname: undefined,
       query: {
         transaction: '/performance',
-        project: 2,
+        project: '2',
         transactionCursor: '2:0:0',
       },
     });

--- a/tests/js/spec/views/performance/transactionSummary/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/content.spec.tsx
@@ -133,7 +133,6 @@ describe('Transaction Summary Content', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('TransactionHeader')).toHaveLength(1);
     expect(wrapper.find('Filter')).toHaveLength(1);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
     expect(wrapper.find('TransactionSummaryCharts')).toHaveLength(1);
@@ -182,7 +181,6 @@ describe('Transaction Summary Content', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('TransactionHeader')).toHaveLength(1);
     expect(wrapper.find('Filter')).toHaveLength(1);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
     expect(wrapper.find('TransactionSummaryCharts')).toHaveLength(1);


### PR DESCRIPTION
Continuing from #28343, this separates the header from the content on the
transaction overview tab.