### PR TITLE
fix(performance): Use project id from event for transaction details

### DIFF
--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -17,7 +17,10 @@ import {getPerformanceLandingUrl} from './utils';
 type Props = {
   organization: Organization;
   location: Location;
-  transactionName?: string;
+  transaction?: {
+    project: string;
+    name: string;
+  };
   vitalName?: string;
   eventSlug?: string;
   traceSlug?: string;
@@ -31,7 +34,7 @@ class Breadcrumb extends Component<Props> {
     const {
       organization,
       location,
-      transactionName,
+      transaction,
       vitalName,
       eventSlug,
       traceSlug,
@@ -66,16 +69,17 @@ class Breadcrumb extends Component<Props> {
         label: t('Vital Detail'),
         preserveGlobalSelection: true,
       });
-    } else if (transactionName) {
+    } else if (transaction) {
+      const routeQuery = {
+        orgSlug: organization.slug,
+        transaction: transaction.name,
+        projectID: transaction.project,
+        query: location.query,
+      };
+
       switch (tab) {
         case Tab.Tags: {
-          const tagsTarget = tagsRouteWithQuery({
-            orgSlug: organization.slug,
-            transaction: transactionName,
-            projectID: decodeScalar(location.query.project),
-            query: location.query,
-          });
-
+          const tagsTarget = tagsRouteWithQuery(routeQuery);
           crumbs.push({
             to: tagsTarget,
             label: t('Tags'),
@@ -84,13 +88,7 @@ class Breadcrumb extends Component<Props> {
           break;
         }
         case Tab.Events: {
-          const eventsTarget = eventsRouteWithQuery({
-            orgSlug: organization.slug,
-            transaction: transactionName,
-            projectID: decodeScalar(location.query.project),
-            query: location.query,
-          });
-
+          const eventsTarget = eventsRouteWithQuery(routeQuery);
           crumbs.push({
             to: eventsTarget,
             label: t('All Events'),
@@ -99,13 +97,7 @@ class Breadcrumb extends Component<Props> {
           break;
         }
         case Tab.WebVitals: {
-          const webVitalsTarget = vitalsRouteWithQuery({
-            orgSlug: organization.slug,
-            transaction: transactionName,
-            projectID: decodeScalar(location.query.project),
-            query: location.query,
-          });
-
+          const webVitalsTarget = vitalsRouteWithQuery(routeQuery);
           crumbs.push({
             to: webVitalsTarget,
             label: t('Web Vitals'),
@@ -115,13 +107,7 @@ class Breadcrumb extends Component<Props> {
         }
         case Tab.TransactionSummary:
         default: {
-          const summaryTarget = transactionSummaryRouteWithQuery({
-            orgSlug: organization.slug,
-            transaction: transactionName,
-            projectID: decodeScalar(location.query.project),
-            query: location.query,
-          });
-
+          const summaryTarget = transactionSummaryRouteWithQuery(routeQuery);
           crumbs.push({
             to: summaryTarget,
             label: t('Transaction Summary'),
@@ -131,7 +117,7 @@ class Breadcrumb extends Component<Props> {
       }
     }
 
-    if (transactionName && eventSlug) {
+    if (transaction && eventSlug) {
       crumbs.push({
         to: '',
         label: t('Event Details'),

--- a/static/app/views/performance/compare/content.tsx
+++ b/static/app/views/performance/compare/content.tsx
@@ -48,8 +48,8 @@ class TransactionComparisonContent extends Component<Props> {
   render() {
     const {baselineEvent, regressionEvent, organization, location, params} = this.props;
 
-    const transactionName =
-      baselineEvent.title === regressionEvent.title ? baselineEvent.title : undefined;
+    // const transactionName =
+    //   baselineEvent.title === regressionEvent.title ? baselineEvent.title : undefined;
 
     return (
       <Fragment>
@@ -58,7 +58,11 @@ class TransactionComparisonContent extends Component<Props> {
             <Breadcrumb
               organization={organization}
               location={location}
-              transactionName={transactionName}
+              // TODO: add this back in if transaction comparison is used
+              // transaction={{
+              //   project: <insert project id>,
+              //   name: transactionName,
+              // }}
               transactionComparison
             />
             <Layout.Title>{this.getTransactionName()}</Layout.Title>

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -87,7 +87,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return transactionSummaryRouteWithQuery({
       orgSlug: organization.slug,
       transaction: event.title,
-      projectID: decodeScalar(location.query.project),
+      projectID: event.projectID,
       query: newQuery,
     });
   };
@@ -138,7 +138,10 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     <Breadcrumb
                       organization={organization}
                       location={location}
-                      transactionName={transactionName}
+                      transaction={{
+                        project: event.projectID,
+                        name: transactionName,
+                      }}
                       eventSlug={eventSlug}
                     />
                     <Layout.Title data-test-id="event-header">{event.title}</Layout.Title>

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -56,6 +56,7 @@ type Props = {
   location: Location;
   organization: Organization;
   projects: Project[];
+  projectId: string;
   transactionName: string;
   currentTab: Tab;
   hasWebVitals: 'maybe' | 'yes' | 'no';
@@ -226,28 +227,18 @@ class TransactionHeader extends React.Component<Props> {
   }
 
   render() {
-    const {organization, location, transactionName, currentTab} = this.props;
+    const {organization, location, projectId, transactionName, currentTab} = this.props;
 
-    const summaryTarget = transactionSummaryRouteWithQuery({
+    const routeQuery = {
       orgSlug: organization.slug,
       transaction: transactionName,
-      projectID: decodeScalar(location.query.project),
+      projectID: projectId,
       query: location.query,
-    });
+    };
 
-    const tagsTarget = tagsRouteWithQuery({
-      orgSlug: organization.slug,
-      transaction: transactionName,
-      projectID: decodeScalar(location.query.project),
-      query: location.query,
-    });
-
-    const eventsTarget = eventsRouteWithQuery({
-      orgSlug: organization.slug,
-      transaction: transactionName,
-      projectID: decodeScalar(location.query.project),
-      query: location.query,
-    });
+    const summaryTarget = transactionSummaryRouteWithQuery(routeQuery);
+    const tagsTarget = tagsRouteWithQuery(routeQuery);
+    const eventsTarget = eventsRouteWithQuery(routeQuery);
 
     return (
       <Layout.Header>
@@ -255,7 +246,10 @@ class TransactionHeader extends React.Component<Props> {
           <Breadcrumb
             organization={organization}
             location={location}
-            transactionName={transactionName}
+            transaction={{
+              project: projectId,
+              name: transactionName,
+            }}
             tab={currentTab}
           />
           <Layout.Title>{transactionName}</Layout.Title>

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -191,6 +191,7 @@ function TransactionEvents(props: Props) {
               location={location}
               organization={organization}
               projects={projects}
+              projectId={projectId}
               transactionName={transactionName}
               currentTab={Tab.Events}
               hasWebVitals="maybe"

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -141,6 +141,7 @@ function TransactionOverview(props: Props) {
               location={location}
               organization={organization}
               projects={projects}
+              projectId={projectId}
               transactionName={transactionName}
               currentTab={Tab.TransactionSummary}
               hasWebVitals="maybe"

--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -83,6 +83,7 @@ function TransactionTags(props: Props) {
                 location={location}
                 organization={organization}
                 projects={projects}
+                projectId={projectId}
                 transactionName={transactionName}
                 currentTab={Tab.Tags}
                 hasWebVitals="maybe"

--- a/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/index.tsx
@@ -86,6 +86,7 @@ function TransactionVitals(props: Props) {
                 location={location}
                 organization={organization}
                 projects={projects}
+                projectId={projectId}
                 transactionName={transactionName}
                 currentTab={Tab.WebVitals}
                 hasWebVitals="yes"

--- a/tests/js/spec/views/performance/transactionSummary/header.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/header.spec.tsx
@@ -58,6 +58,7 @@ describe('Performance > Transaction Summary Header', function () {
         location={router.location}
         organization={organization}
         projects={[project]}
+        projectId={project.id}
         transactionName="transaction_name"
         currentTab={Tab.TransactionSummary}
         hasWebVitals="yes"
@@ -81,6 +82,7 @@ describe('Performance > Transaction Summary Header', function () {
         location={router.location}
         organization={organization}
         projects={[project]}
+        projectId={project.id}
         transactionName="transaction_name"
         currentTab={Tab.TransactionSummary}
         hasWebVitals="no"
@@ -106,6 +108,7 @@ describe('Performance > Transaction Summary Header', function () {
         location={router.location}
         organization={organization}
         projects={[project]}
+        projectId={project.id}
         transactionName="transaction_name"
         currentTab={Tab.TransactionSummary}
         hasWebVitals="maybe"
@@ -135,6 +138,7 @@ describe('Performance > Transaction Summary Header', function () {
         location={router.location}
         organization={organization}
         projects={[project]}
+        projectId={project.id}
         transactionName="transaction_name"
         currentTab={Tab.TransactionSummary}
         hasWebVitals="maybe"
@@ -164,6 +168,7 @@ describe('Performance > Transaction Summary Header', function () {
         location={router.location}
         organization={organization}
         projects={[project]}
+        projectId={project.id}
         transactionName="transaction_name"
         currentTab={Tab.TransactionSummary}
         hasWebVitals="maybe"


### PR DESCRIPTION
When on the transaction details page, the url parameters may not have the
project id as it's not a requirement. This means that the breadcrumbs will link
to the transaction summary page without the project set but it's required. This
change uses the project id from the event to avoid this issue.