### PR TITLE
chore(performance): Remove check for legacy key transactions count

### DIFF
--- a/static/app/actionCreators/performance.tsx
+++ b/static/app/actionCreators/performance.tsx
@@ -20,17 +20,6 @@ type TeamKeyTransaction = {
 
 export type TeamKeyTransactions = TeamKeyTransaction[];
 
-export async function fetchLegacyKeyTransactionsCount(orgSlug): Promise<number> {
-  const api = new Client();
-  const url = `/organizations/${orgSlug}/legacy-key-transactions-count/`;
-
-  const [data] = await api.requestPromise(url, {
-    method: 'GET',
-    includeAllArgs: true,
-  });
-  return data.keyed;
-}
-
 export async function fetchTeamKeyTransactions(
   api: Client,
   orgSlug: string,

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -4,7 +4,6 @@ import {Location, LocationDescriptorObject} from 'history';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
-import {fetchLegacyKeyTransactionsCount} from 'app/actionCreators/performance';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import GridEditable, {COL_WIDTH_UNDEFINED, GridColumn} from 'app/components/gridEditable';
 import SortLink from 'app/components/gridEditable/sortLink';
@@ -63,7 +62,6 @@ type Props = {
 
 type State = {
   widths: number[];
-  keyedTransactions: number | null;
   transaction: string | undefined;
   transactionThreshold: number | undefined;
   transactionThresholdMetric: TransactionThresholdMetric | undefined;
@@ -71,25 +69,10 @@ type State = {
 class Table extends React.Component<Props, State> {
   state: State = {
     widths: [],
-    keyedTransactions: null,
     transaction: undefined,
     transactionThreshold: undefined,
     transactionThresholdMetric: undefined,
   };
-
-  componentDidMount() {
-    this.fetchKeyTransactionCount();
-  }
-
-  async fetchKeyTransactionCount() {
-    const {organization} = this.props;
-    try {
-      const count = await fetchLegacyKeyTransactionsCount(organization.slug);
-      this.setState({keyedTransactions: count});
-    } catch (error) {
-      this.setState({keyedTransactions: null});
-    }
-  }
 
   handleCellAction = (column: TableColumn<keyof TableDataRow>, dataRow: TableDataRow) => {
     return (action: Actions, value: React.ReactText) => {
@@ -334,7 +317,6 @@ class Table extends React.Component<Props, State> {
 
   renderPrependCellWithData = (tableData: TableData | null) => {
     const {eventView} = this.props;
-    const {keyedTransactions} = this.state;
 
     const keyTransactionColumn = eventView
       .getColumns()
@@ -360,23 +342,13 @@ class Table extends React.Component<Props, State> {
       } else if (teamKeyTransactionColumn) {
         if (isHeader) {
           const star = (
-            <GuideAnchor
-              target="team_key_transaction_header"
-              position="top"
-              disabled={keyedTransactions === null} // wait for the legacy counts to load
-            >
-              <GuideAnchor
-                target="team_key_transaction_existing"
-                position="top"
-                disabled={!keyedTransactions}
-              >
-                <IconStar
-                  key="keyTransaction"
-                  color="yellow300"
-                  isSolid
-                  data-test-id="team-key-transaction-header"
-                />
-              </GuideAnchor>
+            <GuideAnchor target="team_key_transaction_header" position="top">
+              <IconStar
+                key="keyTransaction"
+                color="yellow300"
+                isSolid
+                data-test-id="team-key-transaction-header"
+              />
             </GuideAnchor>
           );
           return [this.renderHeadCell(tableData?.meta, teamKeyTransactionColumn, star)];

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -243,11 +243,6 @@ describe('Performance > Content', function () {
       url: `/organizations/org-slug/key-transactions-list/`,
       body: [],
     });
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: `/organizations/org-slug/legacy-key-transactions-count/`,
-      body: [],
-    });
   });
 
   afterEach(function () {

--- a/tests/js/spec/views/performance/table.spec.jsx
+++ b/tests/js/spec/views/performance/table.spec.jsx
@@ -146,11 +146,6 @@ describe('Performance > Table', function () {
       url: `/organizations/org-slug/key-transactions-list/`,
       body: [],
     });
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: `/organizations/org-slug/legacy-key-transactions-count/`,
-      body: [],
-    });
   });
 
   afterEach(function () {

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -87,12 +87,6 @@ describe('Performance Transaction Events Content', function () {
       url: '/organizations/org-slug/sdk-updates/',
       body: [],
     });
-    // @ts-expect-error
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: `/organizations/org-slug/legacy-key-transactions-count/`,
-      body: [],
-    });
     data = [
       {
         id: 'deadbeef',

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -91,12 +91,6 @@ describe('Performance GridEditable Table', function () {
       url: '/organizations/org-slug/sdk-updates/',
       body: [],
     });
-    // @ts-expect-error
-    MockApiClient.addMockResponse({
-      method: 'GET',
-      url: `/organizations/org-slug/legacy-key-transactions-count/`,
-      body: [],
-    });
     data = [
       {
         id: 'deadbeef',


### PR DESCRIPTION
Now that team key transactions have been in GA for a while, we can remove this
check for the legacy key transactions.