### PR TITLE
feat(notifications): Collapsible Panel

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -47,12 +47,12 @@ const GroupingComponentList = styled('ul')<{isInline: boolean}>`
   }
 `;
 
-export const GroupingComponentListItem = styled('li')<{isCollapsable?: boolean}>`
+export const GroupingComponentListItem = styled('li')<{isCollapsible?: boolean}>`
   padding: 0;
   margin: ${space(0.25)} 0 ${space(0.25)} ${space(1.5)};
 
   ${p =>
-    p.isCollapsable &&
+    p.isCollapsible &&
     `
     border-left: 1px solid ${p.theme.innerBorder};
     margin: 0 0 -${space(0.25)} ${space(1)};

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -32,14 +32,14 @@ class GroupingComponentFrames extends React.Component<Props, State> {
   render() {
     const {items, maxVisibleItems} = this.props;
     const {collapsed} = this.state;
-    const isCollapsable = items.length > maxVisibleItems;
+    const isCollapsible = items.length > maxVisibleItems;
 
     return (
       <React.Fragment>
         {items.map((item, index) => {
           if (!collapsed || index < maxVisibleItems) {
             return (
-              <GroupingComponentListItem isCollapsable={isCollapsable} key={index}>
+              <GroupingComponentListItem isCollapsible={isCollapsible} key={index}>
                 {item}
               </GroupingComponentListItem>
             );

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -161,7 +161,7 @@ export class Line extends React.Component<Props, State> {
   }
 
   scrollToImage = event => {
-    event.stopPropagation(); // to prevent collapsing if collapsable
+    event.stopPropagation(); // to prevent collapsing if collapsible
 
     const {instructionAddr, addrMode} = this.props.data;
     if (instructionAddr) {

--- a/static/app/components/events/interfaces/frame/lineV2/native.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/native.tsx
@@ -87,7 +87,7 @@ function Native({
   }
 
   function scrollToImage(event: MouseEvent<HTMLAnchorElement>) {
-    event.stopPropagation(); // to prevent collapsing if collapsable
+    event.stopPropagation(); // to prevent collapsing if collapsible
 
     if (instructionAddr) {
       DebugMetaActions.updateFilter(makeFilter(instructionAddr));

--- a/static/app/components/events/interfaces/stacktraceContent.tsx
+++ b/static/app/components/events/interfaces/stacktraceContent.tsx
@@ -104,7 +104,7 @@ class StacktraceContent extends React.Component<Props, State> {
   }
 
   handleToggleAddresses = (event: React.MouseEvent<SVGElement>) => {
-    event.stopPropagation(); // to prevent collapsing if collapsable
+    event.stopPropagation(); // to prevent collapsing if collapsible
 
     this.setState(prevState => ({
       showingAbsoluteAddresses: !prevState.showingAbsoluteAddresses,
@@ -112,7 +112,7 @@ class StacktraceContent extends React.Component<Props, State> {
   };
 
   handleToggleFunctionName = (event: React.MouseEvent<SVGElement>) => {
-    event.stopPropagation(); // to prevent collapsing if collapsable
+    event.stopPropagation(); // to prevent collapsing if collapsible
 
     this.setState(prevState => ({
       showCompleteFunctionName: !prevState.showCompleteFunctionName,

--- a/static/app/components/events/interfaces/stacktraceContentV2.tsx
+++ b/static/app/components/events/interfaces/stacktraceContentV2.tsx
@@ -78,12 +78,12 @@ function StackTraceContent({
   }
 
   function handleToggleAddresses(mouseEvent: MouseEvent<SVGElement>) {
-    mouseEvent.stopPropagation(); // to prevent collapsing if collapsable
+    mouseEvent.stopPropagation(); // to prevent collapsing if collapsible
     setShowingAbsoluteAddresses(!showingAbsoluteAddresses);
   }
 
   function handleToggleFunctionName(mouseEvent: MouseEvent<SVGElement>) {
-    mouseEvent.stopPropagation(); // to prevent collapsing if collapsable
+    mouseEvent.stopPropagation(); // to prevent collapsing if collapsible
     setShowCompleteFunctionName(!showCompleteFunctionName);
   }
 

--- a/static/app/components/repositoryFileSummary.tsx
+++ b/static/app/components/repositoryFileSummary.tsx
@@ -25,7 +25,7 @@ function Collapsed(props: CollapsedProps) {
 type Props = {
   fileChangeSummary: FilesByRepository[string];
   repository: string;
-  collapsable: boolean;
+  collapsible: boolean;
   maxWhenCollapsed: number;
 };
 
@@ -36,7 +36,7 @@ type State = {
 
 class RepositoryFileSummary extends React.Component<Props, State> {
   static defaultProps = {
-    collapsable: true,
+    collapsible: true,
     maxWhenCollapsed: 5,
   };
 
@@ -52,15 +52,15 @@ class RepositoryFileSummary extends React.Component<Props, State> {
   };
 
   render() {
-    const {repository, fileChangeSummary, collapsable, maxWhenCollapsed} = this.props;
+    const {repository, fileChangeSummary, collapsible, maxWhenCollapsed} = this.props;
     let files = Object.keys(fileChangeSummary);
     const fileCount = files.length;
     files.sort();
-    if (this.state.collapsed && collapsable && fileCount > maxWhenCollapsed) {
+    if (this.state.collapsed && collapsible && fileCount > maxWhenCollapsed) {
       files = files.slice(0, maxWhenCollapsed);
     }
     const numCollapsed = fileCount - files.length;
-    const canCollapse = collapsable && fileCount > maxWhenCollapsed;
+    const canCollapse = collapsible && fileCount > maxWhenCollapsed;
     return (
       <Container>
         <h5>

--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
@@ -102,7 +102,7 @@ class NotificationSettingsByProjects extends AsyncComponent<Props, State> {
           ) : (
             Object.entries(this.getGroupedProjects()).map(([groupTitle, parents]) => (
               <JsonForm
-                collapsable
+                collapsible
                 key={groupTitle}
                 title={groupTitle}
                 fields={parents.map(parent =>

--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
@@ -102,6 +102,7 @@ class NotificationSettingsByProjects extends AsyncComponent<Props, State> {
           ) : (
             Object.entries(this.getGroupedProjects()).map(([groupTitle, parents]) => (
               <JsonForm
+                collapsable
                 key={groupTitle}
                 title={groupTitle}
                 fields={parents.map(parent =>

--- a/static/app/views/settings/components/forms/formPanel.tsx
+++ b/static/app/views/settings/components/forms/formPanel.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import styled from '@emotion/styled';
 
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {IconChevron} from 'app/icons';
 import {Scope} from 'app/types';
 import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
@@ -44,11 +46,28 @@ type Props = DefaultProps & {
    * Disables the entire form
    */
   disabled?: boolean;
+
+  /** Can the PanelBody be hidden with a click? */
+  collapsable?: boolean;
 };
 
-export default class FormPanel extends React.Component<Props> {
+type State = {
+  collapsed: boolean;
+};
+
+export default class FormPanel extends React.Component<Props, State> {
   static defaultProps: DefaultProps = {
     additionalFieldProps: {},
+  };
+
+  state: State = {
+    collapsed: false,
+  };
+
+  handleToggleEvents = () => {
+    const {collapsed} = this.state;
+
+    this.setState({collapsed: !collapsed});
   };
 
   render() {
@@ -60,44 +79,61 @@ export default class FormPanel extends React.Component<Props> {
       additionalFieldProps,
       renderFooter,
       renderHeader,
+      collapsable,
       ...otherProps
     } = this.props;
+    const {collapsed} = this.state;
 
     return (
       <Panel id={typeof title === 'string' ? sanitizeQuerySelector(title) : undefined}>
-        {title && <PanelHeader>{title}</PanelHeader>}
-        <PanelBody>
-          {typeof renderHeader === 'function' && renderHeader({title, fields})}
+        {title && (
+          <PanelHeader>
+            {title}
+            {collapsable && (
+              <Collapse onClick={this.handleToggleEvents}>
+                <IconChevron direction={collapsed ? 'down' : 'up'} size="xs" />
+              </Collapse>
+            )}
+          </PanelHeader>
+        )}
+        {!collapsed && (
+          <PanelBody>
+            {typeof renderHeader === 'function' && renderHeader({title, fields})}
 
-          {fields.map(field => {
-            if (typeof field === 'function') {
-              return field();
-            }
+            {fields.map(field => {
+              if (typeof field === 'function') {
+                return field();
+              }
 
-            const {defaultValue: _, ...fieldWithoutDefaultValue} = field;
+              const {defaultValue: _, ...fieldWithoutDefaultValue} = field;
 
-            // Allow the form panel disabled prop to override the fields
-            // disabled prop, with fallback to the fields disabled state.
-            if (disabled === true) {
-              fieldWithoutDefaultValue.disabled = true;
-              fieldWithoutDefaultValue.disabledReason = undefined;
-            }
+              // Allow the form panel disabled prop to override the fields
+              // disabled prop, with fallback to the fields disabled state.
+              if (disabled === true) {
+                fieldWithoutDefaultValue.disabled = true;
+                fieldWithoutDefaultValue.disabledReason = undefined;
+              }
 
-            return (
-              <FieldFromConfig
-                access={access}
-                disabled={disabled}
-                key={field.name}
-                {...otherProps}
-                {...additionalFieldProps}
-                field={fieldWithoutDefaultValue}
-                highlighted={this.props.highlighted === `#${field.name}`}
-              />
-            );
-          })}
-          {typeof renderFooter === 'function' && renderFooter({title, fields})}
-        </PanelBody>
+              return (
+                <FieldFromConfig
+                  access={access}
+                  disabled={disabled}
+                  key={field.name}
+                  {...otherProps}
+                  {...additionalFieldProps}
+                  field={fieldWithoutDefaultValue}
+                  highlighted={this.props.highlighted === `#${field.name}`}
+                />
+              );
+            })}
+            {typeof renderFooter === 'function' && renderFooter({title, fields})}
+          </PanelBody>
+        )}
       </Panel>
     );
   }
 }
+
+const Collapse = styled('span')`
+  cursor: pointer;
+`;

--- a/static/app/views/settings/components/forms/formPanel.tsx
+++ b/static/app/views/settings/components/forms/formPanel.tsx
@@ -48,7 +48,7 @@ type Props = DefaultProps & {
   disabled?: boolean;
 
   /** Can the PanelBody be hidden with a click? */
-  collapsable?: boolean;
+  collapsible?: boolean;
 };
 
 type State = {
@@ -79,7 +79,7 @@ export default class FormPanel extends React.Component<Props, State> {
       additionalFieldProps,
       renderFooter,
       renderHeader,
-      collapsable,
+      collapsible,
       ...otherProps
     } = this.props;
     const {collapsed} = this.state;
@@ -89,7 +89,7 @@ export default class FormPanel extends React.Component<Props, State> {
         {title && (
           <PanelHeader>
             {title}
-            {collapsable && (
+            {collapsible && (
               <Collapse onClick={this.handleToggleEvents}>
                 <IconChevron direction={collapsed ? 'down' : 'up'} size="xs" />
               </Collapse>

--- a/static/app/views/settings/components/forms/jsonForm.tsx
+++ b/static/app/views/settings/components/forms/jsonForm.tsx
@@ -127,6 +127,7 @@ class JsonForm extends React.Component<Props, State> {
   render() {
     const {
       access,
+      collapsable,
       fields,
       title,
       forms,
@@ -147,6 +148,7 @@ class JsonForm extends React.Component<Props, State> {
       renderFooter,
       renderHeader,
       highlighted: this.state.highlighted,
+      collapsable,
     };
 
     return (

--- a/static/app/views/settings/components/forms/jsonForm.tsx
+++ b/static/app/views/settings/components/forms/jsonForm.tsx
@@ -127,7 +127,7 @@ class JsonForm extends React.Component<Props, State> {
   render() {
     const {
       access,
-      collapsable,
+      collapsible,
       fields,
       title,
       forms,
@@ -148,7 +148,7 @@ class JsonForm extends React.Component<Props, State> {
       renderFooter,
       renderHeader,
       highlighted: this.state.highlighted,
-      collapsable,
+      collapsible,
     };
 
     return (


### PR DESCRIPTION
We got feedback that the project fine-tuning page is difficult to navigate when there are a lot of organizations. To remedy this, we should make the headers collapsable.
<img width="771" alt="Screen Shot 2021-09-02 at 3 20 26 PM" src="https://user-images.githubusercontent.com/31750075/131923706-03d75182-c12b-4d7a-977a-00a7bc67cc62.png">
<img width="730" alt="Screen Shot 2021-09-02 at 3 20 31 PM" src="https://user-images.githubusercontent.com/31750075/131923689-8df28c61-6d9a-4e16-b9d9-3bd5958438f5.png">

