### PR TITLE
ref(api): Adding a tag to track backend api hits

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -234,12 +234,11 @@ class Endpoint(APIView):
                     # setup default access
                     request.access = access.from_request(request)
 
-            if hasattr(self.request.successful_authenticator, "token_name"):
-                if (
-                    self.request.successful_authenticator.token_name
-                    == TokenAuthentication.token_name
-                ):
-                    request._metric_tags["backend_request"] = True
+            if (
+                getattr(self.request.successful_authenticator, "token_name", None)
+                == TokenAuthentication.token_name
+            ):
+                request._metric_tags["backend_request"] = True
 
             with sentry_sdk.start_span(
                 op="base.dispatch.execute",

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -197,10 +197,6 @@ class Endpoint(APIView):
         # the request (happens via middleware/stats.py).
         request._metric_tags = {}
 
-        if hasattr(self.request.successful_authenticator, "token_name"):
-            if self.request.successful_authenticator.token_name == "bearer":
-                request._metric_tags["backend_request"] = True
-
         if settings.SENTRY_API_RESPONSE_DELAY:
             start_time = time.time()
 
@@ -237,6 +233,10 @@ class Endpoint(APIView):
                 if getattr(request, "access", None) is None:
                     # setup default access
                     request.access = access.from_request(request)
+
+            if hasattr(self.request.successful_authenticator, "token_name"):
+                if self.request.successful_authenticator.token_name == "bearer":
+                    request._metric_tags["backend_request"] = True
 
             with sentry_sdk.start_span(
                 op="base.dispatch.execute",

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -197,6 +197,10 @@ class Endpoint(APIView):
         # the request (happens via middleware/stats.py).
         request._metric_tags = {}
 
+        if hasattr(self.request.successful_authenticator, "token_name"):
+            if self.request.successful_authenticator.token_name == "bearer":
+                request._metric_tags["backend_request"] = True
+
         if settings.SENTRY_API_RESPONSE_DELAY:
             start_time = time.time()
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -235,7 +235,10 @@ class Endpoint(APIView):
                     request.access = access.from_request(request)
 
             if hasattr(self.request.successful_authenticator, "token_name"):
-                if self.request.successful_authenticator.token_name == "bearer":
+                if (
+                    self.request.successful_authenticator.token_name
+                    == TokenAuthentication.token_name
+                ):
                     request._metric_tags["backend_request"] = True
 
             with sentry_sdk.start_span(


### PR DESCRIPTION
Trying to differentiate frontend and backend API hits to gather some data. This change checks if a request has a bearer token and records a bool tag if it does.