### PR TITLE
feat(cdc_search): Recheck group level conditions when querying postgres. (WOR-1304)

### DIFF
--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2231,3 +2231,11 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
         self.run_test(
             "is:unresolved", [group3, self.group1], 4, limit=2, cursor=results.next, count_hits=True
         )
+
+    def test_rechecking(self):
+        self.group2.status = GroupStatus.RESOLVED
+        self.group2.save()
+        # Explicitly avoid calling `store_group` here. This means that Clickhouse will still see
+        # this group as `UNRESOLVED` and it will be returned in the snuba results. This group
+        # should still be filtered out by our recheck.
+        self.run_test("is:unresolved", [self.group1], None)


### PR DESCRIPTION
Due to replag, it's possible that when filtering on group level conditions in Clickhouse that we
might return results that don't match all the conditions.

To prevent this, we filter the passed `group_queryset` by the received group_ids. This queryset
already has all the Postgres conditions in it, and so it acts as a way to recheck the conditions.

Note that this doesn't account for rows that Snuba should have returned but doesn't.
If we filter out rows in Postgres, we could make a second query to Snuba to fetch missing rows. I'm
not going to handle that in this pr since I think that in practice most users won't notice a couple
of groups missing.