### PR TITLE
feat(outcomes): Added new client discard outcome type

### DIFF
--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -18,6 +18,7 @@ class Outcome(IntEnum):
     RATE_LIMITED = 2
     INVALID = 3
     ABUSE = 4
+    CLIENT_DISCARD = 5
 
     def api_name(self) -> str:
         return self.name.lower()

--- a/static/app/views/organizationStats/types.tsx
+++ b/static/app/views/organizationStats/types.tsx
@@ -6,6 +6,7 @@ export enum Outcome {
   INVALID = 'invalid',
   DROPPED = 'dropped',
   RATE_LIMITED = 'rate_limited',
+  CLIENT_DISCARD = 'client_discard',
 }
 
 /**

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -245,6 +245,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         [Outcome.DROPPED]: 0,
         [Outcome.INVALID]: 0, // Combined with dropped later
         [Outcome.RATE_LIMITED]: 0, // Combined with dropped later
+        [Outcome.CLIENT_DISCARD]: 0, // Not exposed yet
       };
 
       orgStats.groups.forEach(group => {


### PR DESCRIPTION
This adds a new outcome type `5` which is reserved for recording events discarded on the client side.

Refs getsentry/relay#1074