### PR TITLE
feat(ui): Session Duration all releases comparison

### DIFF
--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -1,4 +1,5 @@
 import compact from 'lodash/compact';
+import mean from 'lodash/mean';
 import moment from 'moment';
 
 import {
@@ -119,6 +120,31 @@ export function getSessionStatusRateSeries(
       return {
         name: interval,
         value: getSessionStatusPercent(statusSessionsPercent),
+      };
+    })
+  );
+}
+
+export function getSessionP50Series(
+  groups: SessionApiResponse['groups'] = [],
+  intervals: SessionApiResponse['intervals'] = [],
+  field: SessionField,
+  valueFormatter?: (value: number) => number
+): SeriesDataUnit[] {
+  return compact(
+    intervals.map((interval, i) => {
+      const meanValue = mean(
+        groups.map(group => group.series[field][i]).filter(v => !!v)
+      );
+
+      if (!meanValue) {
+        return null;
+      }
+
+      return {
+        name: interval,
+        value:
+          typeof valueFormatter === 'function' ? valueFormatter(meanValue) : meanValue,
       };
     })
   );

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -22,7 +22,11 @@ import {
 } from 'app/types';
 import {defined} from 'app/utils';
 import {getDuration, getExactDuration} from 'app/utils/formatters';
-import {getCrashFreeRateSeries, getSessionStatusRateSeries} from 'app/utils/sessions';
+import {
+  getCrashFreeRateSeries,
+  getSessionP50Series,
+  getSessionStatusRateSeries,
+} from 'app/utils/sessions';
 import {Theme} from 'app/utils/theme';
 import {displayCrashFreePercent, roundDuration} from 'app/views/releases/utils';
 
@@ -478,15 +482,29 @@ class ReleaseSessionsChart extends React.Component<Props> {
         };
       case ReleaseComparisonChartType.SESSION_DURATION:
         return {
-          series: Object.values(
-            fillChartDataFromSessionsResponse({
-              response: releaseSessions,
-              field: SessionField.DURATION,
-              groupBy: 'session.status',
-              chartData: initSessionsBreakdownChartData(theme),
-              valueFormatter: duration => roundDuration(duration ? duration / 1000 : 0),
-            })
-          ),
+          series: [
+            {
+              seriesName: t('This Release'),
+              connectNulls: true,
+              data: getSessionP50Series(
+                releaseSessions?.groups,
+                releaseSessions?.intervals,
+                SessionField.DURATION,
+                duration => roundDuration(duration / 1000)
+              ),
+            },
+          ],
+          previousSeries: [
+            {
+              seriesName: t('All Releases'),
+              data: getSessionP50Series(
+                allSessions?.groups,
+                allSessions?.intervals,
+                SessionField.DURATION,
+                duration => roundDuration(duration / 1000)
+              ),
+            },
+          ],
           markLines,
         };
       case ReleaseComparisonChartType.USER_COUNT:


### PR DESCRIPTION
Compare session duration p50 on the release details page against all releases instead of breaking it down by healthy/crashed.