### PR TITLE
feat(discover): Add new sort options

### DIFF
--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -30,6 +30,8 @@ const SORT_OPTIONS: SelectValue<string>[] = [
   {label: t('Dashboard Name (A-Z)'), value: 'title'},
   {label: t('Date Created (Newest)'), value: '-dateCreated'},
   {label: t('Date Created (Oldest)'), value: 'dateCreated'},
+  {label: t('Most Popular'), value: 'mostPopular'},
+  {label: t('Recently Viewed'), value: 'recentlyViewed'},
 ];
 
 type Props = {

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -36,6 +36,8 @@ const SORT_OPTIONS: SelectValue<string>[] = [
   {label: t('Date Created (Newest)'), value: '-dateCreated'},
   {label: t('Date Created (Oldest)'), value: 'dateCreated'},
   {label: t('Most Outdated'), value: 'dateUpdated'},
+  {label: t('Most Popular'), value: 'mostPopular'},
+  {label: t('Recently Viewed'), value: 'recentlyViewed'},
 ];
 
 type Props = {

--- a/tests/js/spec/views/dashboardsV2/manage/index.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/manage/index.spec.jsx
@@ -95,7 +95,21 @@ describe('Dashboards > Detail', function () {
 
     const dropdownItems = wrapper.find('DropdownItem span');
 
-    expect(dropdownItems).toHaveLength(4);
+    expect(dropdownItems).toHaveLength(6);
+
+    const expectedSorts = [
+      'My Dashboards',
+      'Dashboard Name (A-Z)',
+      'Date Created (Newest)',
+      'Date Created (Oldest)',
+      'Most Popular',
+      'Recently Viewed',
+    ];
+
+    expect(dropdownItems.children().map(element => element.text())).toEqual(
+      expectedSorts
+    );
+
     dropdownItems.at(1).simulate('click');
 
     await tick();

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -53,6 +53,11 @@ describe('EventsV2 > Landing', function () {
       },
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/discover/saved/',
       method: 'GET',
       body: [],
@@ -85,5 +90,36 @@ describe('EventsV2 > Landing', function () {
 
     const content = wrapper.find('PageContent');
     expect(content.text()).toContain("You don't have access to this feature");
+  });
+
+  it('has the right sorts', async function () {
+    const org = TestStubs.Organization({
+      features,
+      projects: [TestStubs.Project()],
+    });
+    const wrapper = mountWithTheme(
+      <DiscoverLanding organization={org} location={{query: {}}} router={{}} />,
+      TestStubs.routerContext()
+    );
+
+    await tick();
+
+    const dropdownItems = wrapper.find('DropdownItem span');
+    expect(dropdownItems).toHaveLength(8);
+
+    const expectedSorts = [
+      'My Queries',
+      'Recently Edited',
+      'Query Name (A-Z)',
+      'Date Created (Newest)',
+      'Date Created (Oldest)',
+      'Most Outdated',
+      'Most Popular',
+      'Recently Viewed',
+    ];
+
+    expect(dropdownItems.children().map(element => element.text())).toEqual(
+      expectedSorts
+    );
   });
 });


### PR DESCRIPTION
Added 'Most Popular' and 'Recently Viewed' sort
options to Discover and Dashboards Manager.

Reopening this as a new PR since I did a bad merge [here](https://github.com/getsentry/sentry/pull/28239)