### PR TITLE
chore(integrations): Add organization slug to internal sentry app metrics

### DIFF
--- a/src/sentry/mediators/external_requests/util.py
+++ b/src/sentry/mediators/external_requests/util.py
@@ -4,7 +4,7 @@ from jsonschema import Draft7Validator
 from requests.exceptions import ConnectionError, Timeout
 
 from sentry.http import safe_urlopen
-from sentry.models.sentryapp import track_response_code
+from sentry.models.sentryapp import track_response_code, track_response_code_internal
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,8 @@ def send_and_save_sentry_app_request(url, sentry_app, org_id, event, **kwargs):
             },
         )
         track_response_code(error_type, slug, event)
+        if sentry_app.is_internal:
+            track_response_code_internal(error_type, sentry_app.slug, event)
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
         # Re-raise the exception because some of these tasks might retry on the exception

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -78,6 +78,14 @@ def track_response_code(status, integration_slug, webhook_event):
     )
 
 
+def track_response_code_internal(status, integration_slug, webhook_event):
+    metrics.incr(
+        "integration-platform.http_response.internal",
+        sample_rate=1.0,
+        tags={"status": status, "integration": integration_slug, "webhook_event": webhook_event},
+    )
+
+
 class SentryAppManager(ParanoidManager):
     def get_alertable_sentry_apps(self, organization_id: int) -> QuerySet:
         return self.filter(

--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -78,6 +78,7 @@ def track_response_code(status, integration_slug, webhook_event):
     )
 
 
+# TODO(leander): Remove this temporary log after debugging inconsitent internal webhook response
 def track_response_code_internal(status, integration_slug, webhook_event):
     metrics.incr(
         "integration-platform.http_response.internal",

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -18,7 +18,7 @@ from sentry.models import (
     ServiceHookProject,
     User,
 )
-from sentry.models.sentryapp import VALID_EVENTS, track_response_code
+from sentry.models.sentryapp import VALID_EVENTS, track_response_code, track_response_code_internal
 from sentry.shared_integrations.exceptions import (
     ApiHostError,
     ApiTimeoutError,
@@ -372,6 +372,8 @@ def send_and_save_webhook_request(sentry_app, app_platform_event, url=None):
             },
         )
         track_response_code(error_type, slug, event)
+        if sentry_app.is_internal:
+            track_response_code_internal(error_type, sentry_app.slug, event)
         # Response code of 0 represents timeout
         buffer.add_request(response_code=0, org_id=org_id, event=event, url=url)
         # Re-raise the exception because some of these tasks might retry on the exception


### PR DESCRIPTION
This PR adds a new metric which logs the unique slug for Sentry Apps if they're internal instead of just using `"internal"`. Specifically being added to help diagnose a customer issue.