### PR TITLE
fix(discover): Validate trace id in search

### DIFF
--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -6,7 +6,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
-from sentry.utils.validators import INVALID_EVENT_DETAILS, is_event_id
+from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 
 class EventIdLookupEndpoint(OrganizationEndpoint):
@@ -25,7 +25,7 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
         :auth: required
         """
         if event_id and not is_event_id(event_id):
-            return Response({"detail": INVALID_EVENT_DETAILS.format("Event")}, status=400)
+            return Response({"detail": INVALID_ID_DETAILS.format("Event ID")}, status=400)
 
         project_slugs_by_id = dict(
             Project.objects.filter(organization=organization).values_list("id", "slug")

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -31,7 +31,7 @@ from sentry.models import Organization
 from sentry.snuba import discover
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.snuba import Dataset, SnubaQueryParams, bulk_raw_query
-from sentry.utils.validators import INVALID_EVENT_DETAILS, is_event_id
+from sentry.utils.validators import INVALID_ID_DETAILS, is_event_id
 
 logger: logging.Logger = logging.getLogger(__name__)
 MAX_TRACE_SIZE: int = 100
@@ -361,7 +361,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):  # 
 
         # Only need to validate event_id as trace_id is validated in the URL
         if event_id and not is_event_id(event_id):
-            return Response({"detail": INVALID_EVENT_DETAILS.format("Event")}, status=400)
+            return Response({"detail": INVALID_ID_DETAILS.format("Event ID")}, status=400)
 
         with self.handle_query_errors():
             transactions, errors = query_trace_data(trace_id, params)

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -1349,10 +1349,12 @@ class QueryFilter(QueryFields):
         }:
             value = int(to_timestamp(value)) * 1000
 
-        # Validate event ids are uuids
+        # Validate event ids and trace ids are uuids
         if name in {"id", "trace"}:
             if search_filter.value.is_wildcard():
-                raise InvalidSearchQuery("Wildcard conditions are not permitted on `id` field.")
+                raise InvalidSearchQuery(
+                    f"Wildcard conditions are not permitted on `{name}` field."
+                )
             elif not search_filter.value.is_event_id():
                 label = "Filter ID" if name == "id" else "Filter Trace ID"
                 raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -60,7 +60,7 @@ from sentry.utils.snuba import (
     Dataset,
     QueryOutsideRetentionError,
 )
-from sentry.utils.validators import INVALID_EVENT_DETAILS
+from sentry.utils.validators import INVALID_ID_DETAILS
 
 
 def is_condition(term):
@@ -638,12 +638,15 @@ def convert_search_filter_to_snuba_query(
         }:
             value = int(to_timestamp(value)) * 1000
 
-        # Validate event ids are uuids
-        if name == "id":
+        # Validate event ids and trace ids are uuids
+        if name in {"id", "trace"}:
             if search_filter.value.is_wildcard():
-                raise InvalidSearchQuery("Wildcard conditions are not permitted on `id` field.")
+                raise InvalidSearchQuery(
+                    f"Wildcard conditions are not permitted on `{name}` field."
+                )
             elif not search_filter.value.is_event_id():
-                raise InvalidSearchQuery(INVALID_EVENT_DETAILS.format("Filter"))
+                label = "Filter ID" if name == "id" else "Filter Trace ID"
+                raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
 
         # most field aliases are handled above but timestamp.to_{hour,day} are
         # handled here
@@ -1347,11 +1350,12 @@ class QueryFilter(QueryFields):
             value = int(to_timestamp(value)) * 1000
 
         # Validate event ids are uuids
-        if name == "id":
+        if name in {"id", "trace"}:
             if search_filter.value.is_wildcard():
                 raise InvalidSearchQuery("Wildcard conditions are not permitted on `id` field.")
             elif not search_filter.value.is_event_id():
-                raise InvalidSearchQuery(INVALID_EVENT_DETAILS.format("Filter"))
+                label = "Filter ID" if name == "id" else "Filter Trace ID"
+                raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
 
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.utils.encoding import force_text
 
-INVALID_EVENT_DETAILS = "{} ID must be a valid UUID hex (32-36 characters long, containing only digits, dashes, or a-f characters)"
+INVALID_ID_DETAILS = "{} must be a valid UUID hex (32-36 characters long, containing only digits, dashes, or a-f characters)"
 
 
 def validate_ip(value, required=True):

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -836,7 +836,7 @@ class GetSnubaQueryArgsTest(TestCase):
         with self.assertRaises(InvalidSearchQuery):
             get_filter("id:deadbeef*")
 
-    def test_event_id(self):
+    def test_event_id_validation(self):
         event_id = "a" * 32
         results = get_filter(f"id:{event_id}")
         assert results.conditions == [["id", "=", event_id]]
@@ -850,6 +850,21 @@ class GetSnubaQueryArgsTest(TestCase):
 
         with self.assertRaises(InvalidSearchQuery):
             get_filter(f"id:{'g' * 32}")
+
+    def test_trace_id_validation(self):
+        trace_id = "a" * 32
+        results = get_filter(f"trace:{trace_id}")
+        assert results.conditions == [["trace", "=", trace_id]]
+
+        trace_id = "a" * 16 + "-" * 16 + "b" * 16
+        results = get_filter(f"trace:{trace_id}")
+        assert results.conditions == [["trace", "=", trace_id]]
+
+        with self.assertRaises(InvalidSearchQuery):
+            get_filter("trace:deadbeef")
+
+        with self.assertRaises(InvalidSearchQuery):
+            get_filter(f"trace:{'g' * 32}")
 
     def test_negated_wildcard(self):
         _filter = get_filter("!release:3.1.* user.email:*@example.com")


### PR DESCRIPTION
Snuba validates that trace ids are valid UUIDs. This needs to be properly
handled in Sentry and provide a meaningful error message.

Fixes JAVASCRIPT-25J2
Fixes JAVASCRIPT-25J3