### PR TITLE
fix(ui): Change LogicBoolean color to Gray 300

### DIFF
--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -273,7 +273,7 @@ const Unit = styled('span')`
 
 const LogicBoolean = styled('span')`
   font-weight: bold;
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.gray300};
 `;
 
 const Boolean = styled('span')`


### PR DESCRIPTION
Currently the AND/OR search token is in Red 300. 

<img width="249" alt="Screen Shot 2021-09-07 at 9 18 20 AM" src="https://user-images.githubusercontent.com/44172267/132378770-c69be83a-b68a-473f-b2f1-24aa3e2d52a3.png">

However, red as a color is reserved for conveying error states only. We should be using a more neutral color -- Gray 300.

<img width="247" alt="Screen Shot 2021-09-07 at 9 18 00 AM" src="https://user-images.githubusercontent.com/44172267/132378822-426a2f0d-8914-494a-99f8-050a5df1decc.png">

<img width="247" alt="Screen Shot 2021-09-07 at 9 17 29 AM" src="https://user-images.githubusercontent.com/44172267/132378853-7b6803d7-c4c4-4f96-ae94-c84d88bc051c.png">

Why Gray 300? Because it is:
* Neutral (doesn't convey much meaning like red or green), which is what boolean operators are
* Less prominent than Gray 500/400, communicating the operators' place as connectors, not part of the main query. This also makes the operators are visually separated from the unfinished text query in Gray 500.