### PR TITLE
fix(api): Handle overflowing stats period

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -24,7 +24,10 @@ def get_datetime_from_stats_period(stats_period, now=None):
     stats_period = parse_stats_period(stats_period)
     if stats_period is None:
         raise InvalidParams("Invalid statsPeriod")
-    return now - stats_period
+    try:
+        return now - stats_period
+    except OverflowError:
+        raise InvalidParams("Invalid statsPeriod")
 
 
 def default_start_end_dates(now=None):

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -24,6 +24,9 @@ class GetDateRangeFromParamsTest(TestCase):
         start, end = get_date_range_from_params({"statsPeriod": "91d"})
         assert end - datetime.timedelta(days=91) == start
 
+        with self.assertRaises(InvalidParams):
+            get_date_range_from_params({"statsPeriod": "9000000d"})
+
     def test_date_range(self):
         start, end = get_date_range_from_params({"start": "2018-11-01", "end": "2018-11-07"})
 


### PR DESCRIPTION
It is possible to specify a large stats period like 9000000d to cause an
overflow error. This makes sure to handle this case an provide the user with a
meaningful error message.

Fixes SENTRY-S4M