### PR TITLE
ref(deletion) Move organization deletion to scheduled deletions

### DIFF
--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -1,7 +1,18 @@
+from sentry.models import OrganizationStatus
+
 from ..base import ModelDeletionTask, ModelRelation
 
 
 class OrganizationDeletionTask(ModelDeletionTask):
+    def should_proceed(self, instance):
+        """
+        Only delete organizations that haven't been undeleted.
+        """
+        return instance.status in {
+            OrganizationStatus.PENDING_DELETION,
+            OrganizationStatus.DELETION_IN_PROGRESS,
+        }
+
     def get_child_relations(self, instance):
         from sentry.discover.models import DiscoverSavedQuery, KeyTransaction, TeamKeyTransaction
         from sentry.incidents.models import AlertRule, Incident

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -146,6 +146,7 @@ def revoke_api_tokens(object_id, transaction_id=None, timestamp=None, **kwargs):
 )
 @retry(exclude=(DeleteAborted,))
 def delete_organization(object_id, transaction_id=None, actor_id=None, **kwargs):
+    # TODO(mark) remove this task once all in flight jobs have been processed.
     from sentry import deletions
     from sentry.models import Organization, OrganizationStatus
 


### PR DESCRIPTION
Move organization deletion to scheduled deletions. This will allow us to retry organization deletions that fail in the future, and eventually delete everything.

There are likely problems in organization deletion that will need to be fixed as there is a non-zero number of organizations stuck in pending deletion in production.