### PR TITLE
feat(webpack): Revert of unversioned frontend assets

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -67,11 +67,15 @@ jobs:
           name: jest-html
           path: .artifacts/visual-snapshots/jest
 
+      - name: Get CSS filename
+        id: css-manifest
+        run: echo "::set-output name=sentrycss::$(jq -r '.["sentry.css"]' src/sentry/static/sentry/dist/manifest.json)"
+
       - name: Create Images from HTML
         uses: getsentry/action-html-to-image@main
         with:
           base-path: .artifacts/visual-snapshots/jest
-          css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
+          css-path: src/sentry/static/sentry/dist/${{ steps.css-manifest.outputs.sentrycss }}
 
       - name: Save snapshots
         if: always()

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,10 @@ from collections import OrderedDict
 
 import pytest
 
+dist_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "src", "sentry", "static", "sentry", "dist")
+)
+manifest_path = os.path.join(dist_path, "manifest.json")
 pytest_plugins = ["sentry.utils.pytest"]
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -15,6 +19,27 @@ def pytest_configure(config):
     # XXX(dcramer): Kombu throws a warning due to transaction.commit_manually
     # being used
     warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
+
+    # Create an empty webpack manifest file - otherwise tests will crash if it does not exist
+    os.makedirs(dist_path, exist_ok=True)
+
+    # Only create manifest if it doesn't exist
+    # (e.g. acceptance tests will have an actual manifest from webpack)
+    if os.path.exists(manifest_path):
+        return
+
+    with open(manifest_path, "w+") as fp:
+        fp.write("{}")
+
+
+def pytest_unconfigure():
+    if not os.path.exists(manifest_path):
+        return
+
+    # Clean up manifest file if contents are empty
+    with open(manifest_path) as f:
+        if f.read() == "{}":
+            os.remove(manifest_path)
 
 
 def pytest_addoption(parser):

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "u2f-api": "1.0.10",
     "webpack": "5.48.0",
     "webpack-cli": "4.7.2",
+    "webpack-manifest-plugin": "^3.1.1",
     "webpack-remove-empty-scripts": "^0.7.1",
     "wink-jaro-distance": "^2.0.0",
     "zxcvbn": "^4.4.2"

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -9,6 +9,7 @@ croniter==0.3.37
 dataclasses==0.8; python_version <= '3.6'
 datadog==0.29.3
 django-crispy-forms==1.8.1
+django-manifest-loader==1.0.0
 django-picklefield==2.1.0
 Django==2.2.23
 djangorestframework==3.11.2

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -327,6 +327,7 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "crispy_forms",
     "rest_framework",
+    "manifest_loader",
     "sentry",
     "sentry.analytics",
     "sentry.incidents.apps.Config",
@@ -375,10 +376,13 @@ STATIC_URL = "/_static/{version}/"
 # as we configure webpack to include file content based hash in the filename
 STATIC_FRONTEND_APP_URL = "/_static/dist/"
 
-# The webpack output directory
+# The webpack output directory, used by django-manifest-loader
 STATICFILES_DIRS = [
     os.path.join(STATIC_ROOT, "sentry", "dist"),
 ]
+
+# django-manifest-loader settings
+MANIFEST_LOADER = {"cache": True}
 
 # various middleware will use this to identify resources which should not access
 # cookies

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -1,2 +1,1 @@
 {% extends "sentry/base-react.html" %}
-{% load sentry_assets %}

--- a/src/sentry/templates/sentry/bases/react.html
+++ b/src/sentry/templates/sentry/bases/react.html
@@ -1,1 +1,2 @@
 {% extends "sentry/base-react.html" %}
+{% load sentry_assets %}

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,10 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-<<<<<<< HEAD
-    {% frontend_app_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
-=======
-    {% webpack_asset_url "sentry" "pipeline.js" as asset_url %}
->>>>>>> a5420cc4bd (oops wrong import)
+    {% frontend_app_asset_url "sentry" "pipeline.js" cache_bust=True as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,10 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
+<<<<<<< HEAD
     {% frontend_app_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
+=======
+    {% webpack_asset_url "sentry" "pipeline.js" as asset_url %}
+>>>>>>> a5420cc4bd (oops wrong import)
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -25,7 +25,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
+  <link href="{% frontend_app_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -54,7 +54,7 @@
 
   {% block scripts %}
   {% block scripts_main_entrypoint %}
-    {% frontend_app_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
+    {% frontend_app_asset_url "sentry" "app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -113,6 +113,36 @@ class BaseTestCase(Fixtures, Exam):
 
     @classmethod
     @contextmanager
+    def static_asset_manifest(cls, manifest_data):
+        dist_path = "src/sentry/static/sentry/dist"
+        manifest_path = f"{dist_path}/manifest.json"
+
+        with open(manifest_path, "w") as manifest_fp:
+            json.dump(manifest_data, manifest_fp)
+
+        files = []
+        for file_path in manifest_data.values():
+            full_path = f"{dist_path}/{file_path}"
+            # make directories in case they don't exist
+            # (e.g. dist path should exist, but subdirs won't)
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            open(full_path, "a").close()
+            files.append(full_path)
+
+        try:
+            yield {"manifest": manifest_data, "files": files}
+        finally:
+            with open(manifest_path, "w") as manifest_fp:
+                # Instead of unlinking, preserve an empty manifest file so that other tests that
+                # may or may not load static assets, do not fail
+                manifest_fp.write("{}")
+
+            # Remove any files created from the test manifest
+            for filepath in files:
+                os.unlink(filepath)
+
+    @classmethod
+    @contextmanager
     def capture_on_commit_callbacks(cls, using=DEFAULT_DB_ALIAS, execute=False):
         """
         Context manager to capture transaction.on_commit() callbacks.

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -30,7 +30,7 @@ def get_frontend_app_asset_url(module, key, cache_bust=False):
     """
     manifest_obj = get_manifest_obj()
     manifest_value = _load_from_manifest(manifest_obj, key=key)
-    args = (settings.STATIC_WEBPACK_URL.rstrip("/"), module, manifest_value)
+    args = (settings.STATIC_FRONTEND_APP_URL.rstrip("/"), module, manifest_value)
 
     if not cache_bust:
         return "{}/{}/{}".format(*args)

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,11 +1,20 @@
 from django.conf import settings
+from manifest_loader.utils import _get_manifest, _load_from_manifest
+
+
+def get_manifest_obj():
+    """
+    Returns the webpack asset manifest as a dict of <file key, hashed file name>
+
+    The `manifest_loader` library caches this (if `cache` settings is set)
+    """
+    return _get_manifest()
 
 
 def get_frontend_app_asset_url(module, key, cache_bust=False):
     """
-    Returns an asset URL that is unversioned. These assets should have a
-    `Cache-Control: max-age=0, must-revalidate` so that clients must validate with the origin
-    server before using their locally cached asset.
+    Returns an asset URL that is produced by webpack. Uses webpack's manifest to map
+    `key` to the asset produced by webpack. Required if using file contents based hashing for filenames.
 
     XXX(epurkhiser): As a temporary workaround for flakeyness with the CDN,
     we're busting caches when version_bust is True using a query parameter with
@@ -19,7 +28,9 @@ def get_frontend_app_asset_url(module, key, cache_bust=False):
       {% frontend_app_asset_url 'sentry' 'sentry.css' cache_bust=True %}
       =>  "/_static/dist/sentry/sentry.css?v=xxx"
     """
-    args = (settings.STATIC_FRONTEND_APP_URL.rstrip("/"), module, key.lstrip("/"))
+    manifest_obj = get_manifest_obj()
+    manifest_value = _load_from_manifest(manifest_obj, key=key)
+    args = (settings.STATIC_WEBPACK_URL.rstrip("/"), module, manifest_value)
 
     if not cache_bust:
         return "{}/{}/{}".format(*args)
@@ -31,7 +42,7 @@ def get_asset_url(module, path):
     Returns a versioned asset URL (located within Sentry's static files).
 
     Example:
-    {% asset_url 'sentry' 'images/sentry.png' %}
-    =>  "/_static/74d127b78dc7daf2c51f/sentry/sentry.png"
+      {% asset_url 'sentry' 'images/sentry.png' %}
+      =>  "/_static/74d127b78dc7daf2c51f/sentry/sentry.png"
     """
     return "{}/{}/{}".format(settings.STATIC_URL.rstrip("/"), module, path.lstrip("/"))

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -8,18 +8,6 @@ from django.http import Http404, HttpResponseNotFound
 from django.views import static
 
 FOREVER_CACHE = "max-age=315360000"
-
-# See
-# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#requiring_revalidation
-# This means that clients *CAN* cache the resource, but they must revalidate
-# before using it This means we will have a small HTTP request overhead to
-# verify that the local resource is not outdated
-#
-# Note that the above docs state that "no-cache" is the same as "max-age=0,
-# must-revalidate", but some CDNs will not treat them as the same
-NO_CACHE = "max-age=0, must-revalidate"
-
-# no-store means that the response should not be stored in *ANY* cache
 NEVER_CACHE = "max-age=0, no-cache, no-store, must-revalidate"
 
 
@@ -47,19 +35,17 @@ def resolve(path):
 
 def frontend_app_static_media(request, **kwargs):
     """
-    Serve static files that should not have any versioned paths/filenames.
-    These assets will have cache headers to say that it can be cached by a
-    client, but it *must* be validated against the origin server before the
-    cached asset can be used.
-    """
+    Serve static files that are generated with webpack.
 
+    Only these assets should have a long TTL as its filename has a hash based on file contents
+    """
     path = kwargs.get("path", "")
 
     kwargs["path"] = f"dist/{path}"
     response = static_media(request, **kwargs)
 
     if not settings.DEBUG:
-        response["Cache-Control"] = NO_CACHE
+        response["Cache-Control"] = FOREVER_CACHE
 
     return response
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -278,7 +278,16 @@ let appConfig: Configuration = {
       {
         test: /\.less$/,
         include: [staticPrefix],
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'less-loader'],
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {
+              publicPath: 'auto',
+            },
+          },
+          'css-loader',
+          'less-loader',
+        ],
       },
       {
         test: /\.(woff|woff2|ttf|eot|svg|png|gif|ico|jpg|mp4)($|\?)/,
@@ -314,7 +323,7 @@ let appConfig: Configuration = {
      * Extract CSS into separate files.
      */
     new MiniCssExtractPlugin({
-      filename: '[name].[contenthash:6].css',
+      filename: 'entrypoints/[name].[contenthash:6].css',
     }),
 
     /**
@@ -411,7 +420,7 @@ let appConfig: Configuration = {
     clean: true, // Clean the output directory before emit.
     path: distPath,
     publicPath: '',
-    filename: '[name].[contenthash].js',
+    filename: 'entrypoints/[name].[contenthash].js',
     chunkFilename: 'chunks/[name].[contenthash].js',
     sourceMapFilename: 'sourcemaps/[name].[contenthash].js.map',
     assetModuleFilename: 'assets/[name].[contenthash][ext]',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,7 +10,7 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import webpack from 'webpack';
 import {Configuration as DevServerConfig} from 'webpack-dev-server';
-import WebpackManifestPlugin from 'webpack-manifest-plugin';
+import {WebpackManifestPlugin} from 'webpack-manifest-plugin';
 import FixStyleOnlyEntriesPlugin from 'webpack-remove-empty-scripts';
 
 import IntegrationDocsFetchPlugin from './build-utils/integration-docs-fetch-plugin';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13882,7 +13882,7 @@ sockjs@^0.3.21:
     uuid "^3.4.0"
     websocket-driver "^0.7.4"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -15468,6 +15468,14 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-manifest-plugin@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.1.tgz#d4c57ef70e0641f754dd005cb5ba7ca5601ac9d3"
+  integrity sha512-r3vL8BBNVtyeNbaFwDQoOWqBd0Gp/Tbzo8Q3YGZDV+IG77gsB9VZry5XKKbfFNFHSmwW+f1z4/w2XPt6wBZJYg==
+  dependencies:
+    tapable "^2.0.0"
+    webpack-sources "^2.2.0"
+
 webpack-merge@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
@@ -15488,6 +15496,14 @@ webpack-sources@^1.1.0:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
+  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack-sources@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This reverts https://github.com/getsentry/sentry/pull/27091 and restores the usage of a webpack manifest file. We have encountered expected caching behaviors with our CDN and are reverting this change to prevent future unexpected behaviors. We would rather rely on the CDN to long term cache files and ensure that our files are hashed based on file contents.