### PR TITLE
fix(api): Fix bug in `rate_limit_endpoint` that causes rate limiting to be per process.

### DIFF
--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -2,6 +2,7 @@ from django.http import QueryDict
 
 from sentry.api.helpers.group_index import (
     ValidationError,
+    build_rate_limit_key,
     update_groups,
     validate_search_filter_permissions,
 )
@@ -9,6 +10,7 @@ from sentry.api.issue_search import parse_search_query
 from sentry.models import GroupInbox, GroupInboxReason, GroupStatus, add_group_to_inbox
 from sentry.testutils import TestCase
 from sentry.utils.compat.mock import Mock, patch
+from sentry.utils.hashlib import md5_text
 
 
 class ValidateSearchFilterPermissionsTest(TestCase):
@@ -168,3 +170,13 @@ class UpdateGroupsTest(TestCase):
 
         assert not GroupInbox.objects.filter(group=group).exists()
         assert send_robust.called
+
+
+class BuildRateLimitKeyTest(TestCase):
+    def some_function(self):
+        pass
+
+    def test(self):
+        request = self.make_request()
+        expected = f"rate_limit_endpoint:{md5_text('BuildRateLimitKeyTest.some_function').hexdigest()}:{request.META['REMOTE_ADDR']}"
+        assert build_rate_limit_key(self.some_function, request) == expected


### PR DESCRIPTION
This decorator was producing an md5 via `md5_text(function)`. This converts a function to a string,
which looks like `'<function ProjectGroupIndexEndpoint.get at 0x10a54cd90>'`. This means that every
process has a unique value for this, and so we're only rate limiting per process at best.

This fixes the rate limiter to use `__qualname__` to get the expected name. Also fixes the same bug
in `track_slo_response`, although in that case we were just writing a bad tag value.