### PR TITLE
feat(ui): Display release marklines also on non-default timeframe

### DIFF
--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -3,6 +3,8 @@ import pick from 'lodash/pick';
 import moment from 'moment';
 
 import MarkLine from 'app/components/charts/components/markLine';
+import {parseStatsPeriod} from 'app/components/organizations/timeRangeSelector/utils';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
 import {
@@ -16,6 +18,7 @@ import {
   ReleaseWithHealth,
   Repository,
 } from 'app/types';
+import {Series} from 'app/types/echarts';
 import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
 import {decodeList} from 'app/utils/queryString';
@@ -23,6 +26,7 @@ import {Theme} from 'app/utils/theme';
 import {MutableSearch} from 'app/utils/tokenizeSearch';
 import {isProjectMobileForReleases} from 'app/views/releases/list';
 
+import {getReleaseBounds, getReleaseParams} from '../utils';
 import {commonTermsDescription, SessionTerm} from '../utils/sessionTerm';
 
 export type CommitsByRepository = {
@@ -242,49 +246,63 @@ export function generateReleaseMarkLines(
   location: Location,
   options?: GenerateReleaseMarklineOptions
 ) {
+  const markLines: Series[] = [];
   const adoptionStages = release.adoptionStages?.[project.slug];
+  const isSingleEnv = decodeList(location.query.environment).length === 1;
+  const {statsPeriod, ...releaseParamsRest} = getReleaseParams({
+    location,
+    releaseBounds: getReleaseBounds(release),
+    defaultStatsPeriod: DEFAULT_STATS_PERIOD, // this will be removed once we get rid off legacy release details
+    allowEmptyPeriod: true,
+  });
+  let {start, end} = releaseParamsRest;
   const isDefaultPeriod = !(
     location.query.pageStart ||
     location.query.pageEnd ||
     location.query.pageStatsPeriod
   );
-  const isSingleEnv = decodeList(location.query.environment).length === 1;
 
-  if (!isDefaultPeriod) {
-    // do not show marklines on non-default period
-    return [];
+  if (statsPeriod) {
+    const parsedStatsPeriod = parseStatsPeriod(statsPeriod, null);
+    start = parsedStatsPeriod.start;
+    end = parsedStatsPeriod.end;
   }
 
-  const markLines = [
-    generateReleaseMarkLine(
-      releaseMarkLinesLabels.created,
-      moment(release.dateCreated).startOf('minute').valueOf(),
-      theme,
-      options
-    ),
-  ];
-
-  if (!isSingleEnv || !isProjectMobileForReleases(project.platform)) {
-    // for now want to show marklines only on mobile platforms with single environment selected
-    return markLines;
-  }
-
-  if (adoptionStages?.adopted) {
+  const releaseCreated = moment(release.dateCreated).startOf('minute');
+  if (releaseCreated.isBetween(start, end) || isDefaultPeriod) {
     markLines.push(
       generateReleaseMarkLine(
-        releaseMarkLinesLabels.adopted,
-        moment(adoptionStages.adopted).valueOf(),
+        releaseMarkLinesLabels.created,
+        releaseCreated.valueOf(),
         theme,
         options
       )
     );
   }
 
-  if (adoptionStages?.unadopted) {
+  if (!isSingleEnv || !isProjectMobileForReleases(project.platform)) {
+    // for now want to show marklines only on mobile platforms with single environment selected
+    return markLines;
+  }
+
+  const releaseAdopted = adoptionStages?.adopted && moment(adoptionStages.adopted);
+  if (releaseAdopted && releaseAdopted.isBetween(start, end)) {
+    markLines.push(
+      generateReleaseMarkLine(
+        releaseMarkLinesLabels.adopted,
+        releaseAdopted.valueOf(),
+        theme,
+        options
+      )
+    );
+  }
+
+  const releaseReplaced = adoptionStages?.unadopted && moment(adoptionStages.unadopted);
+  if (releaseReplaced && releaseReplaced.isBetween(start, end)) {
     markLines.push(
       generateReleaseMarkLine(
         releaseMarkLinesLabels.unadopted,
-        moment(adoptionStages.unadopted).valueOf(),
+        releaseReplaced.valueOf(),
         theme,
         options
       )

--- a/tests/fixtures/js-stubs/release.js
+++ b/tests/fixtures/js-stubs/release.js
@@ -77,6 +77,7 @@ export function Release(params, healthParams) {
         id: 4383603,
         name: 'Sentry-Android-Shop',
         slug: 'sentry-android-shop',
+        platform: 'android',
       },
     ],
     currentProjectMeta: {
@@ -86,6 +87,13 @@ export function Release(params, healthParams) {
       lastReleaseVersion: '999',
       sessionsUpperBound: null,
       sessionsLowerBound: null,
+    },
+    adoptionStages: {
+      'sentry-android-shop': {
+        adopted: '2020-03-24T01:02:30Z',
+        stage: 'replaced',
+        unadopted: '2020-03-24T02:02:30Z',
+      },
     },
     ...params,
   };

--- a/tests/js/spec/views/releases/detail/utils.spec.tsx
+++ b/tests/js/spec/views/releases/detail/utils.spec.tsx
@@ -1,0 +1,92 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {lightTheme} from 'app/utils/theme';
+import {
+  generateReleaseMarkLines,
+  releaseMarkLinesLabels,
+} from 'app/views/releases/detail/utils';
+
+describe('releases/detail/utils', () => {
+  describe('generateReleaseMarkLines', () => {
+    const {created, adopted, unadopted} = releaseMarkLinesLabels;
+    const {router} = initializeOrg();
+    // @ts-expect-error
+    const release = TestStubs.Release();
+    const project = release.projects[0];
+
+    it('generates "Created" markline', () => {
+      const marklines = generateReleaseMarkLines(
+        release,
+        project,
+        lightTheme,
+        router.location
+      );
+
+      expect(marklines.map(markline => markline.seriesName)).toEqual([created]);
+    });
+
+    it('generates also Adoption marklines if exactly one env is selected', () => {
+      const marklines = generateReleaseMarkLines(release, project, lightTheme, {
+        ...router.location,
+        query: {environment: 'prod'},
+      });
+
+      expect(marklines).toEqual([
+        expect.objectContaining({
+          seriesName: created,
+          data: [
+            {
+              name: 1584925320000,
+              value: null,
+            },
+          ],
+        }),
+        expect.objectContaining({
+          seriesName: adopted,
+          data: [
+            {
+              name: 1585011750000,
+              value: null,
+            },
+          ],
+        }),
+        expect.objectContaining({
+          seriesName: unadopted,
+          data: [
+            {
+              name: 1585015350000,
+              value: null,
+            },
+          ],
+        }),
+      ]);
+    });
+
+    it('does not generate Adoption marklines for non-mobile projects', () => {
+      const marklines = generateReleaseMarkLines(
+        {...release, projects: [{...release.projects[0], platform: 'javascript'}]},
+        {...project, platform: 'javascript'},
+        lightTheme,
+        {
+          ...router.location,
+          query: {environment: 'prod'},
+        }
+      );
+
+      expect(marklines.map(markline => markline.seriesName)).toEqual([created]);
+    });
+
+    it('shows only marklines that are in current time window', () => {
+      const marklines = generateReleaseMarkLines(release, project, lightTheme, {
+        ...router.location,
+        query: {
+          environment: 'prod',
+          pageStart: '2020-03-24T01:00:30Z',
+          pageEnd: '2020-03-24T01:03:30Z',
+        },
+      });
+
+      expect(marklines.map(markline => markline.seriesName)).toEqual([adopted]);
+    });
+  });
+});

--- a/tests/js/spec/views/releases/utils/index.spec.tsx
+++ b/tests/js/spec/views/releases/utils/index.spec.tsx
@@ -2,7 +2,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {getReleaseBounds, getReleaseParams} from 'app/views/releases/utils';
 
-describe('releases/details/utils', () => {
+describe('releases/utils', () => {
   describe('getReleaseBounds', () => {
     it('returns start and end of a release', () => {
       // @ts-expect-error


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/132512133-3f308db8-2ea8-408f-b42f-aa46998e05fe.png)
![image](https://user-images.githubusercontent.com/9060071/132512169-67f96491-7d36-4795-9c86-9bce78f157da.png)

We used to show these release marklines only on the default timeframe. Now we are showing them all the time (if they are in the selected time window)