### PR TITLE
ref(appstore): Remove unused warning

### DIFF
--- a/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
+++ b/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
@@ -93,12 +93,7 @@ function UpdateAlert({api, Wrapper, isCompact, project, organization, className}
                   : `${projectSettingsLink}&revalidateItunesSession=true`
               }
             >
-              {updateAlertMessage ===
-              appStoreConnectAlertMessage.isTodayAfterItunesSessionRefreshAt
-                ? t(
-                    'We recommend that you revalidate the session in the project settings'
-                  )
-                : t('Update it in the project settings to reconnect')}
+              {t('Update it in the project settings to reconnect')}
             </Link>
           </Fragment>
         )}

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
@@ -495,29 +495,6 @@ function AppStoreConnect({
       );
     }
 
-    if (
-      updateAlertMessage ===
-      appStoreConnectAlertMessage.isTodayAfterItunesSessionRefreshAt
-    ) {
-      alerts.push(
-        <AlertLink
-          withoutMarginBottom
-          icon={<IconWarning />}
-          to={{
-            pathname: location.pathname,
-            query: {
-              ...location.query,
-              revalidateItunesSession: true,
-            },
-          }}
-        >
-          {t(
-            'Your iTunes session will likely expire soon. We recommend that you revalidate the session.'
-          )}
-        </AlertLink>
-      );
-    }
-
     return alerts;
   }
 

--- a/static/app/components/projects/appStoreConnectContext/utils.tsx
+++ b/static/app/components/projects/appStoreConnectContext/utils.tsx
@@ -8,9 +8,6 @@ export const appStoreConnectAlertMessage = {
   appStoreCredentialsInvalid: t(
     'The credentials of your configured App Store Connect are invalid.'
   ),
-  isTodayAfterItunesSessionRefreshAt: t(
-    'The iTunes session of your configured App Store Connect will likely expire soon.'
-  ),
 };
 
 export function getAppConnectStoreUpdateAlertMessage(

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -31,7 +31,6 @@ function Status({theme, details, onEditRepository, onRevalidateItunesSession}: P
     lastCheckedBuilds,
   } = details ?? {};
 
-
   if (itunesSessionValid === false) {
     return (
       <Wrapper color={theme.red300} onClick={onRevalidateItunesSession}>

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -2,7 +2,6 @@ import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Placeholder from 'app/components/placeholder';
-import {appStoreConnectAlertMessage} from 'app/components/projects/appStoreConnectContext/utils';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import {IconDownload} from 'app/icons/iconDownload';
@@ -27,29 +26,11 @@ function Status({theme, details, onEditRepository, onRevalidateItunesSession}: P
 
   const {
     pendingDownloads,
-    updateAlertMessage,
     itunesSessionValid,
     appstoreCredentialsValid,
     lastCheckedBuilds,
   } = details ?? {};
 
-  if (
-    itunesSessionValid &&
-    appstoreCredentialsValid &&
-    updateAlertMessage === appStoreConnectAlertMessage.isTodayAfterItunesSessionRefreshAt
-  ) {
-    return (
-      <Wrapper color={theme.red300} onClick={onRevalidateItunesSession}>
-        <StyledTooltip
-          title={t('We recommend that you revalidate the iTunes session')}
-          containerDisplayMode="inline-flex"
-        >
-          <IconWarning size="sm" />
-        </StyledTooltip>
-        {t('iTunes session will likely expire soon')}
-      </Wrapper>
-    );
-  }
 
   if (itunesSessionValid === false) {
     return (


### PR DESCRIPTION
There was dead code related to an alert which relied on a value that was removed in #27676.

A caveat to this is that we no longer pre-emptively warn the user that their iTunes session may be expiring soon. I don't think the front end has the right information to figure this out, though. Is it important that we do this? Currently the back end returns two values related to the iTunes session's validity: `itunesSessionValid` and `promptItunesSession`. The latter is only set to `true` when there are pending dsyms _and_ the session is invalid. We could instead have two warnings: 
- Your iTunes session is expired but you don't have any pending downloads, refresh it to avoid any disruptions
- Your iTunes session is expired and is needed to download new dsyms that are currently pending