### PR TITLE
ref(post-process-forwarder) Add partition to type metrics

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 
 from sentry.tasks.post_process import post_process_group
-from sentry.utils import metrics
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.services import Service
 
@@ -49,10 +48,6 @@ class EventStream(Service):
             logger.info("post_process.skip.raw_event", extra={"event_id": event_id})
         else:
             cache_key = cache_key_for_event({"project": project_id, "event_id": event_id})
-            if group_id:
-                metrics.incr("eventstream.messages", tags={"type": "errors"})
-            else:
-                metrics.incr("eventstream.messages", tags={"type": "transactions"})
 
             post_process_group.delay(
                 is_new=is_new,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -289,6 +289,16 @@ class KafkaEventStream(SnubaProtocolEventStream):
                         with self.sampled_eventstream_timer(
                             instance="dispatch_post_process_group_task"
                         ):
+                            if task_kwargs["group_id"] is None:
+                                metrics.incr(
+                                    "eventstream.messages",
+                                    tags={"partition": message.partition(), "type": "transactions"},
+                                )
+                            else:
+                                metrics.incr(
+                                    "eventstream.messages",
+                                    tags={"partition": message.partition(), "type": "errors"},
+                                )
                             self._dispatch_post_process_group_task(**task_kwargs)
 
                 except Exception as error:
@@ -311,6 +321,16 @@ class KafkaEventStream(SnubaProtocolEventStream):
             task_kwargs = get_task_kwargs_for_message(message.value())
 
         if task_kwargs is not None:
+            if task_kwargs["group_id"] is None:
+                metrics.incr(
+                    "eventstream.messages",
+                    tags={"partition": message.partition(), "type": "transactions"},
+                )
+            else:
+                metrics.incr(
+                    "eventstream.messages",
+                    tags={"partition": message.partition(), "type": "errors"},
+                )
             with metrics.timer("eventstream.duration", instance="dispatch_post_process_group_task"):
                 self._dispatch_post_process_group_task(**task_kwargs)
 


### PR DESCRIPTION
We want to be able to see how many messages are being processed
by each partition. Added the partition tag to the type of message.