### PR TITLE
ref(appstore): warnings related to credentials are consistently shown in the UI

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -432,7 +432,6 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
     ```json
     {
         "appstoreCredentialsValid": true,
-        "itunesSessionValid": true,
         "promptItunesSession": false,
         "pendingDownloads": 123,
         "latestBuildVersion: "9.8.7" | null,
@@ -513,7 +512,6 @@ class AppStoreConnectCredentialsValidateEndpoint(ProjectEndpoint):  # type: igno
         return Response(
             {
                 "appstoreCredentialsValid": apps is not None,
-                "itunesSessionValid": itunes_session_info is not None,
                 "pendingDownloads": pending_downloads,
                 "latestBuildVersion": latestBuildVersion,
                 "latestBuildNumber": latestBuildNumber,

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -44,7 +44,6 @@ export enum CustomRepoType {
 export type AppStoreConnectValidationData = {
   id: string;
   appstoreCredentialsValid: boolean;
-  itunesSessionValid: boolean;
   /** Indicates if the itunesSession is actually *needed* to complete any downloads that are pending. */
   pendingDownloads: number;
   /**

--- a/static/app/views/settings/project/projectSettingsNavigation.tsx
+++ b/static/app/views/settings/project/projectSettingsNavigation.tsx
@@ -12,9 +12,15 @@ type Props = {
 };
 
 const ProjectSettingsNavigation = ({organization, project}: Props) => {
-  const appStoreConnectContext = useContext(AppStoreConnectContext);
+  const {promptItunesSession, appstoreCredentialsValid} = useContext(
+    AppStoreConnectContext
+  ) || {
+    promptItunesSession: false,
+    // Default to not showing any alerts if we have no info
+    appstoreCredentialsValid: true,
+  };
 
-  const debugFilesNeedsReview = !!appStoreConnectContext?.updateAlertMessage;
+  const debugFilesNeedsReview = promptItunesSession || !appstoreCredentialsValid;
 
   return (
     <SettingsNavigation

--- a/static/app/views/settings/project/projectSettingsNavigation.tsx
+++ b/static/app/views/settings/project/projectSettingsNavigation.tsx
@@ -12,15 +12,9 @@ type Props = {
 };
 
 const ProjectSettingsNavigation = ({organization, project}: Props) => {
-  const {promptItunesSession, appstoreCredentialsValid} = useContext(
-    AppStoreConnectContext
-  ) || {
-    promptItunesSession: false,
-    // Default to not showing any alerts if we have no info
-    appstoreCredentialsValid: true,
-  };
+  const appStoreConnectContext = useContext(AppStoreConnectContext);
 
-  const debugFilesNeedsReview = promptItunesSession || !appstoreCredentialsValid;
+  const debugFilesNeedsReview = !!appStoreConnectContext?.updateAlertMessage;
 
   return (
     <SettingsNavigation

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -26,12 +26,12 @@ function Status({theme, details, onEditRepository, onRevalidateItunesSession}: P
 
   const {
     pendingDownloads,
-    itunesSessionValid,
+    promptItunesSession,
     appstoreCredentialsValid,
     lastCheckedBuilds,
   } = details ?? {};
 
-  if (itunesSessionValid === false) {
+  if (promptItunesSession) {
     return (
       <Wrapper color={theme.red300} onClick={onRevalidateItunesSession}>
         <StyledTooltip


### PR DESCRIPTION
There are three places where the UI warns the user about expired credentials, but some of them use different sets of logic or don't receive updates as expected, leading to this kind of behaviour where not all of the warnings show up: 

<img width="1098" alt="Screenshot 2021-09-07 at 11 09 46 AM" src="https://user-images.githubusercontent.com/5597345/132562545-df679d29-cdfe-4d08-9d0d-72737d8ff5cc.png">

In this case, I'm pretty sure the Debug Files entry in the sidebar should show a warning. A bit of logging showed that the `AppStoreConnectContext` was missing the `updateAlertMessage` property when `ProjectSettingsNavigation` is rendering, which suggests that it's either not receiving all updates to the context, or something's going wrong. I'm not too sure.

This diff tries to unify the logic a little by ensuring that the values returned by the back end are what's being checked, and that the same ones are always being checked to determine whether credentials need to be updated or not. 

This is being opened as a draft because I'm unsure if the correct property is being checked in this diff: should `promptItunesSession` or `itunesSessionValid` determine whether the UI warns the user about their credentials? Should one only be used in some places in the UI and the other in the rest?

**Edit**: The answer is to only rely on `promptItunesSession` to determine when to tell the user to update their iTunes session. Under the hood this is determined by two things: When the session is invalid, and when the project has pending downloads from App Store Connect. It is fine if events are sent while the session is invalid: When examining an issue's details, the UI also prompts the user to re-process if it may have not been symbolicated due to missing dSYMS (which is a possible result of an expired iTunes session).

`itunesSessionValid` is now removed from the response payload since it's not being used. It'll get added back in later if/when we find another use for it.