### PR TITLE
fix(discover): Handle percentage searches on non percentage fields

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -703,8 +703,14 @@ class SearchVisitor(NodeVisitor):
             # Even if the search value matches percentage format, only act as
             # percentage for certain columns
             function = resolve_field(search_key.name, self.params, functions_acl=FUNCTIONS.keys())
-            if function.aggregate is not None and self.is_percentage_key(function.aggregate[0]):
-                aggregate_value = parse_percentage(search_value)
+            if function.aggregate is not None:
+                aggregate_key = function.aggregate[0]
+                if self.is_percentage_key(aggregate_key):
+                    aggregate_value = parse_percentage(search_value)
+                else:
+                    raise InvalidSearchQuery(
+                        f'Invalid aggregate condition: "{aggregate_key}" is not a percentage value.'
+                    )
         except ValueError:
             raise InvalidSearchQuery(f"Invalid aggregate query condition: {search_key}")
         except InvalidQuery as exc:

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -54,6 +54,7 @@ filter
   / aggregate_percentage_filter
   / aggregate_date_filter
   / aggregate_rel_date_filter
+  / aggregate_filter
   / has_filter
   / is_filter
   / text_in_filter
@@ -169,6 +170,17 @@ is_filter
       return tc.predicateFilter(FilterType.Is, key)
     } {
       return tc.tokenFilter(FilterType.Is, key, value, opDefault, !!negation);
+    }
+
+aggregate_filter
+  = negation:negation?
+    key:aggregate_key
+    sep
+    op:(operator &{ return tc.predicateTextOperator(key); })?
+    value:search_value &{
+      return tc.predicateFilter(FilterType.Text, key)
+    } {
+      return tc.tokenFilter(FilterType.Aggregate, key, value, op ? op[0] : opDefault, !!negation);
     }
 
 // in filter key:[val1, val2]

--- a/tests/fixtures/search-syntax/invalid_aggregate_column_with_duration_filter.json
+++ b/tests/fixtures/search-syntax/invalid_aggregate_column_with_duration_filter.json
@@ -3,7 +3,36 @@
     "query": "avg(stack.colno):>500s",
     "result": [
       {"type": "spaces", "value": ""},
-      {"type": "freeText", "quoted": false, "value": "avg(stack.colno):>500s"},
+      {
+        "type": "filter",
+        "filter": "aggregate",
+        "negated": false,
+        "invalid": {
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)",
+          "expectedType": ["aggregateNumeric"]
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "stack.colno",
+                  "quoted": false
+                }
+              }
+            ]
+          }
+        },
+        "operator": "",
+        "value": {"type": "valueText", "value": ">500s", "quoted": false}
+      },
       {"type": "spaces", "value": ""}
     ]
   }

--- a/tests/fixtures/search-syntax/invalid_aggregate_duration_filter.json
+++ b/tests/fixtures/search-syntax/invalid_aggregate_duration_filter.json
@@ -3,7 +3,36 @@
     "query": "avg(transaction.duration):>..500s",
     "result": [
       {"type": "spaces", "value": ""},
-      {"type": "freeText", "value": "avg(transaction.duration):>..500s", "quoted": false},
+      {
+        "type": "filter",
+        "filter": "aggregate",
+        "negated": false,
+        "invalid": {
+          "reason": "Invalid duration. Expected number followed by duration unit suffix",
+          "expectedType": ["aggregateDuration"]
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "transaction.duration",
+                  "quoted": false
+                }
+              }
+            ]
+          }
+        },
+        "operator": "",
+        "value": {"type": "valueText", "value": ">..500s", "quoted": false}
+      },
       {"type": "spaces", "value": ""}
     ]
   }

--- a/tests/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
+++ b/tests/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
@@ -12,8 +12,65 @@
     ]
   },
   {
-    "query": "p75(transaction.duration):>5%",
-    "raisesError": true,
-    "result": []
+    "query": "avg(transaction.duration):>5%",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregate",
+        "negated": false,
+        "invalid": {
+          "reason": "Invalid duration. Expected number followed by duration unit suffix",
+          "expectedType": ["aggregateDuration"]
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "avg", "quoted": false},
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "transaction.duration",
+                  "quoted": false
+                }
+              }
+            ]
+          }
+        },
+        "operator": "",
+        "value": {"type": "valueText", "value": ">5%", "quoted": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
+  },
+  {
+    "query": "apdex():>5%",
+    "result": [
+      {"type": "spaces", "value": ""},
+      {
+        "type": "filter",
+        "filter": "aggregate",
+        "negated": false,
+        "invalid": {
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)",
+          "expectedType": ["aggregateNumeric"]
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "apdex", "quoted": false},
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""},
+          "args": null
+        },
+        "operator": "",
+        "value": {"type": "valueText", "value": ">5%", "quoted": false}
+      },
+      {"type": "spaces", "value": ""}
+    ]
   }
 ]

--- a/tests/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
+++ b/tests/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
@@ -10,5 +10,10 @@
       },
       {"type": "spaces", "value": ""}
     ]
+  },
+  {
+    "query": "p75(transaction.duration):>5%",
+    "raisesError": true,
+    "result": []
   }
 ]

--- a/tests/fixtures/search-syntax/invalid_numeric_aggregate_filter.json
+++ b/tests/fixtures/search-syntax/invalid_numeric_aggregate_filter.json
@@ -3,7 +3,36 @@
     "query": "min(measurements.size):3s",
     "result": [
       {"type": "spaces", "value": ""},
-      {"type": "freeText", "quoted": false, "value": "min(measurements.size):3s"},
+      {
+        "type": "filter",
+        "filter": "aggregate",
+        "negated": false,
+        "invalid": {
+          "reason": "Invalid number. Expected number then optional k, m, or b suffix (e.g. 500k)",
+          "expectedType": ["aggregateNumeric"]
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {"type": "keySimple", "value": "min", "quoted": false},
+          "argsSpaceBefore": {"type": "spaces", "value": ""},
+          "argsSpaceAfter": {"type": "spaces", "value": ""},
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "measurements.size",
+                  "quoted": false
+                }
+              }
+            ]
+          }
+        },
+        "operator": "",
+        "value": {"type": "valueText", "value": "3s", "quoted": false}
+      },
       {"type": "spaces", "value": ""}
     ]
   }


### PR DESCRIPTION
Currently, when searching for a percentage value on a non percentage field, the
query becomes a string search. For example, `p75(transaction.duration):>5%`.
This errors out on the snuba side. This change validates that if a percentage is
used as the value, it must be on a valid percentage field.