### PR TITLE
feat(dev): Remove VSCode extension "Babel ES6/7"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,12 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": [
-        "dzannotti.vscode-babel-coloring",
-        "esbenp.prettier-vscode",
-        "ms-python.python",
-        "dbaeumer.vscode-eslint",
-        "lextudio.restructuredtext",
-        "ziyasal.vscode-open-in-github",
-        "timonwong.shellcheck"
-    ]
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "ms-python.python",
+    "dbaeumer.vscode-eslint",
+    "lextudio.restructuredtext",
+    "ziyasal.vscode-open-in-github",
+    "timonwong.shellcheck"
+  ]
 }


### PR DESCRIPTION
Removing this outdated VSCode extension for Babel es6/7 syntax highlighting. Not needed as we are now 100% TS which is well supported in VSCode