### PR TITLE
chore(sdk): add login endpoints to sampled list

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -61,6 +61,14 @@ SAMPLED_URL_NAMES = {
     "sentry-api-0-organization-scim-member-details": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-organization-scim-team-index": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-organization-scim-team-details": settings.SAMPLED_DEFAULT_RATE,
+    # login
+    "sentry-login": 0.1,
+    "sentry-auth-organization": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-auth-link-identity": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-auth-sso": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-logout": 0.1,
+    "sentry-register": 0.1,
+    "sentry-2fa-dialog": 0.1,
 }
 if settings.ADDITIONAL_SAMPLED_URLS:
     SAMPLED_URL_NAMES.update(settings.ADDITIONAL_SAMPLED_URLS)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -67,8 +67,8 @@ SAMPLED_URL_NAMES = {
     "sentry-auth-link-identity": settings.SAMPLED_DEFAULT_RATE,
     "sentry-auth-sso": settings.SAMPLED_DEFAULT_RATE,
     "sentry-logout": 0.1,
-    "sentry-register": 0.1,
-    "sentry-2fa-dialog": 0.1,
+    "sentry-register": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-2fa-dialog": settings.SAMPLED_DEFAULT_RATE,
 }
 if settings.ADDITIONAL_SAMPLED_URLS:
     SAMPLED_URL_NAMES.update(settings.ADDITIONAL_SAMPLED_URLS)


### PR DESCRIPTION
we'd like to capture transactions for debugging / measuring response times for the login endpoints, and they are not currently sampled on the backend. some are set at `.1` as i couldn't get concrete RPS numbers from datadog easily and don't want to send too many txs.