### PR TITLE
ref(subscription query) Make sample rate configurable

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -355,3 +355,6 @@ register("eventstream:kafka-headers", default=False)
 
 # Post process forwarder gets data from Kafka headers
 register("post-process-forwarder:kafka-headers", default=False)
+
+# Subscription queries sampling rate
+register("subscriptions-query.sample-rate", default=0.01)


### PR DESCRIPTION
In order to stress test the post process forwarder, we would be
increasing the transaction sampling rate in the subscription
consumer. That requires us to configure the rate dynamically
using sentry option manager. This change introduces the new option
which would be subsequently used in another PR.

The current value is taken from https://github.com/getsentry/sentry/blob/248a203a83a66dc1f945b82b45b373a2b27c45ca/src/sentry/snuba/query_subscription_consumer.py#L25