### PR TITLE
fix(ui): Don't show 100% crash free rate when crashes > 0

### DIFF
--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -24,10 +24,11 @@ export const getCrashFreePercent = (
   decimalThreshold = CRASH_FREE_DECIMAL_THRESHOLD,
   decimalPlaces = 3
 ): number => {
-
   const roundedValue = round(percent, percent > decimalThreshold ? decimalPlaces : 0);
   if (roundedValue === 100 && percent < 100) {
-    return Math.floor(percent * Math.pow(10, decimalPlaces)) / Math.pow(10, decimalPlaces);
+    return (
+      Math.floor(percent * Math.pow(10, decimalPlaces)) / Math.pow(10, decimalPlaces)
+    );
   }
 
   return roundedValue;

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -24,7 +24,13 @@ export const getCrashFreePercent = (
   decimalThreshold = CRASH_FREE_DECIMAL_THRESHOLD,
   decimalPlaces = 3
 ): number => {
-  return round(percent, percent > decimalThreshold ? decimalPlaces : 0);
+
+  const roundedValue = round(percent, percent > decimalThreshold ? decimalPlaces : 0);
+  if (roundedValue === 100 && percent < 100) {
+    return Math.floor(percent * Math.pow(10, decimalPlaces)) / Math.pow(10, decimalPlaces);
+  }
+
+  return roundedValue;
 };
 
 export const displayCrashFreePercent = (


### PR DESCRIPTION
This slightly alters the releases crash free rate, the % displayed. When there are non-zero crashes but the rate is >99.9995% it gets rounded to 100%, this causes confusion for some users, added a small check in the percentage calculation to truncate the rate in that case.

Jira: [WOR-1180](https://getsentry.atlassian.net/browse/WOR-1180)

before:
![Screen Shot 2021-09-08 at 11 55 47 PM](https://user-images.githubusercontent.com/15015880/132637626-5c8f2646-940a-402c-80fa-ce4bbf4cb9ee.png)

after:
![Screen Shot 2021-09-08 at 11 54 50 PM](https://user-images.githubusercontent.com/15015880/132637635-a60918ca-52e6-47c2-9367-e8288587a923.png)
