### PR TITLE
chore(chart-unfurl): Explicitly capture sentry exceptions

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -91,6 +91,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
         except Exception as exc:
             sentry_sdk.capture_exception(exc)
+            raise exc
 
     def get_orderby(self, request):
         sort = request.GET.getlist("sort")

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -2,6 +2,7 @@ import re
 from typing import Any, List, Mapping
 from urllib.parse import urlparse
 
+import sentry_sdk
 from django.http.request import HttpRequest, QueryDict
 
 from sentry import features
@@ -109,6 +110,7 @@ def unfurl_discover(
                 params=params,
             )
         except Exception as exc:
+            sentry_sdk.capture_exception(exc)
             logger.error(
                 "Failed to load events-stats for unfurl: %s",
                 str(exc),


### PR DESCRIPTION
We see status tagged as internal_error in the filter_params
span. Since we're unable to reproduce this locally, trying
to log the exception to Sentry to see what the issue is.

![Screen Shot 2021-09-08 at 10 21 52 AM](https://user-images.githubusercontent.com/63818634/132700796-43ba0ae2-549b-45ef-a8bd-470b796cf85d.png)
