### PR TITLE
ref(issue-link): Move UISchema-to-Form logic to separate component

### DIFF
--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
 
-import {Client} from 'app/api';
 import {t} from 'app/locale';
 import ExternalIssueStore from 'app/stores/externalIssueStore';
 import {Group, PlatformExternalIssue, SentryAppInstallation} from 'app/types';
@@ -13,7 +12,6 @@ import SentryAppExternalForm, {
 } from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type Props = {
-  api: Client;
   group: Group;
   sentryAppInstallation: SentryAppInstallation;
   appName: string;

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -1,8 +1,5 @@
 import {Component} from 'react';
-import {createFilter} from 'react-select';
-import debounce from 'lodash/debounce';
 
-import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
 import ExternalIssueStore from 'app/stores/externalIssueStore';
@@ -10,35 +7,10 @@ import {Group, PlatformExternalIssue, SentryAppInstallation} from 'app/types';
 import {Event} from 'app/types/event';
 import getStacktraceBody from 'app/utils/getStacktraceBody';
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
-import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
-import withApi from 'app/utils/withApi';
-import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
-import Form from 'app/views/settings/components/forms/form';
-import FormModel from 'app/views/settings/components/forms/model';
-import {Field, FieldValue} from 'app/views/settings/components/forms/type';
-
-// 0 is a valid choice but empty string, undefined, and null are not
-const hasValue = value => !!value || value === 0;
-
-type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
-  type: 'select' | 'textarea' | 'text';
-  default?: string;
-  uri?: string;
-  depends_on?: string[];
-  choices?: Array<[any, string]>;
-  async?: boolean;
-};
-
-type Config = {
-  uri: string;
-  required_fields?: FieldFromSchema[];
-  optional_fields?: FieldFromSchema[];
-};
-
-// only need required_fields and optional_fields
-type State = Omit<Config, 'uri'> & {
-  optionsByField: Map<string, Array<{label: string; value: any}>>;
-};
+import SentryAppExternalForm, {
+  Config,
+  FieldFromSchema,
+} from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type Props = {
   api: Client;
@@ -51,94 +23,10 @@ type Props = {
   onSubmitSuccess: (externalIssue: PlatformExternalIssue) => void;
 };
 
-export class SentryAppExternalIssueForm extends Component<Props, State> {
-  state: State = {optionsByField: new Map()};
-
-  componentDidMount() {
-    this.resetStateFromProps();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (prevProps.action !== this.props.action) {
-      this.model.reset();
-      this.resetStateFromProps();
-    }
-  }
-
-  model = new FormModel();
-
-  // reset the state when we mount or the action changes
-  resetStateFromProps() {
-    const {config, action, group} = this.props;
-    this.setState({
-      required_fields: config.required_fields,
-      optional_fields: config.optional_fields,
-    });
-    // we need to pass these fields in the API so just set them as values so we don't need hidden form fields
-    this.model.setInitialData({
-      action,
-      groupId: group.id,
-      uri: config.uri,
-    });
-  }
-
+export class SentryAppExternalIssueForm extends Component<Props> {
   onSubmitSuccess = (issue: PlatformExternalIssue) => {
     ExternalIssueStore.add(issue);
     this.props.onSubmitSuccess(issue);
-  };
-
-  onSubmitError = () => {
-    const {action, appName} = this.props;
-    addErrorMessage(t('Unable to %s %s issue.', action, appName));
-  };
-
-  getOptions = (field: FieldFromSchema, input: string) =>
-    new Promise(resolve => {
-      this.debouncedOptionLoad(field, input, resolve);
-    });
-
-  debouncedOptionLoad = debounce(
-    // debounce is used to prevent making a request for every input change and
-    // instead makes the requests every 200ms
-    async (field: FieldFromSchema, input, resolve) => {
-      const choices = await this.makeExternalRequest(field, input);
-      const options = choices.map(([value, label]) => ({value, label}));
-      const optionsByField = new Map(this.state.optionsByField);
-      optionsByField.set(field.name, options);
-      this.setState({
-        optionsByField,
-      });
-      return resolve(options);
-    },
-    200,
-    {trailing: true}
-  );
-
-  makeExternalRequest = async (field: FieldFromSchema, input: FieldValue) => {
-    const install = this.props.sentryAppInstallation;
-    const projectId = this.props.group.project.id;
-    const query: {[key: string]: any} = {
-      projectId,
-      uri: field.uri,
-      query: input,
-    };
-
-    if (field.depends_on) {
-      const dependentData = field.depends_on.reduce((accum, dependentField: string) => {
-        accum[dependentField] = this.model.getValue(dependentField);
-        return accum;
-      }, {});
-      // stringify the data
-      query.dependentData = JSON.stringify(dependentData);
-    }
-
-    const {choices} = await this.props.api.requestPromise(
-      `/sentry-app-installations/${install.uuid}/external-requests/`,
-      {
-        query,
-      }
-    );
-    return choices || [];
   };
 
   getStacktrace() {
@@ -172,174 +60,22 @@ export class SentryAppExternalIssueForm extends Component<Props, State> {
     }
   }
 
-  /**
-   * This function determines which fields need to be reset and new options fetched
-   * based on the dependencies defined with the depends_on attribute.
-   * This is done because the autoload flag causes fields to load at different times
-   * if you have multiple dependent fields while this solution updates state at once.
-   */
-  handleFieldChange = async (id: string) => {
-    const config = this.state;
-
-    let requiredFields = config.required_fields || [];
-    let optionalFields = config.optional_fields || [];
-
-    const fieldList: FieldFromSchema[] = requiredFields.concat(optionalFields);
-
-    // could have multiple impacted fields
-    const impactedFields = fieldList.filter(({depends_on}) => {
-      if (!depends_on) {
-        return false;
-      }
-      // must be dependent on the field we just set
-      return depends_on.includes(id);
-    });
-
-    // load all options in parallel
-    const choiceArray = await Promise.all(
-      impactedFields.map(field => {
-        // reset all impacted fields first
-        this.model.setValue(field.name || '', '', {quiet: true});
-        return this.makeExternalRequest(field, '');
-      })
-    );
-
-    this.setState(state => {
-      // pull the field lists from latest state
-      requiredFields = state.required_fields || [];
-      optionalFields = state.optional_fields || [];
-      // iterate through all the impacted fields and get new values
-      impactedFields.forEach((impactedField, i) => {
-        const choices = choiceArray[i];
-        const requiredIndex = requiredFields.indexOf(impactedField);
-        const optionalIndex = optionalFields.indexOf(impactedField);
-
-        const updatedField = {...impactedField, choices};
-
-        // immutably update the lists with the updated field depending where we got it from
-        if (requiredIndex > -1) {
-          requiredFields = replaceAtArrayIndex(
-            requiredFields,
-            requiredIndex,
-            updatedField
-          );
-        } else if (optionalIndex > -1) {
-          optionalFields = replaceAtArrayIndex(
-            optionalFields,
-            optionalIndex,
-            updatedField
-          );
-        }
-      });
-      return {
-        required_fields: requiredFields,
-        optional_fields: optionalFields,
-      };
-    });
-  };
-
-  renderField = (field: FieldFromSchema, required: boolean) => {
-    // This function converts the field we get from the backend into
-    // the field we need to pass down
-    let fieldToPass: Field = {
-      ...field,
-      inline: false,
-      stacked: true,
-      flexibleControlStateSize: true,
-      required,
-    };
-
-    // async only used for select components
-    const isAsync = typeof field.async === 'undefined' ? true : !!field.async; // default to true
-
-    if (fieldToPass.type === 'select') {
-      // find the options from state to pass down
-      const defaultOptions = (field.choices || []).map(([value, label]) => ({
-        value,
-        label,
-      }));
-      const options = this.state.optionsByField.get(field.name) || defaultOptions;
-      const allowClear = !required;
-      // filter by what the user is typing
-      const filterOption = createFilter({});
-      fieldToPass = {
-        ...fieldToPass,
-        options,
-        defaultOptions,
-        filterOption,
-        allowClear,
-      };
-      // default message for async select fields
-      if (isAsync) {
-        fieldToPass.noOptionsMessage = () => 'Type to search';
-      }
-    } else if (['text', 'textarea'].includes(fieldToPass.type || '') && field.default) {
-      fieldToPass = {...fieldToPass, defaultValue: this.getFieldDefault(field)};
-    }
-
-    if (field.depends_on) {
-      // check if this is dependent on other fields which haven't been set yet
-      const shouldDisable = field.depends_on.some(
-        dependentField => !hasValue(this.model.getValue(dependentField))
-      );
-      if (shouldDisable) {
-        fieldToPass = {...fieldToPass, disabled: true};
-      }
-    }
-
-    // if we have a uri, we need to set extra parameters
-    const extraProps = field.uri
-      ? {
-          loadOptions: (input: string) => this.getOptions(field, input),
-          async: isAsync,
-          cache: false,
-          onSelectResetsInput: false,
-          onCloseResetsInput: false,
-          onBlurResetsInput: false,
-          autoload: false,
-        }
-      : {};
-
-    return (
-      <FieldFromConfig
-        key={field.name}
-        field={fieldToPass}
-        data-test-id={field.name}
-        {...extraProps}
-      />
-    );
-  };
-
   render() {
-    const {sentryAppInstallation, action} = this.props;
-
-    const requiredFields = this.state.required_fields || [];
-    const optionalFields = this.state.optional_fields || [];
-
-    if (!sentryAppInstallation) {
-      return '';
-    }
-
     return (
-      <Form
-        key={action}
-        apiEndpoint={`/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`}
-        apiMethod="POST"
+      <SentryAppExternalForm
+        sentryAppInstallation={this.props.sentryAppInstallation}
+        appName={this.props.appName}
+        config={this.props.config}
+        action={this.props.action}
+        element="issue-link"
+        extraFields={{groupId: this.props.group.id}}
+        extraRequestBody={{projectId: this.props.group.project.id}}
         onSubmitSuccess={this.onSubmitSuccess}
-        onSubmitError={this.onSubmitError}
-        onFieldChange={this.handleFieldChange}
-        model={this.model}
-      >
-        {requiredFields.map((field: FieldFromSchema) => {
-          return this.renderField(field, true);
-        })}
-
-        {optionalFields.map((field: FieldFromSchema) => {
-          return this.renderField(field, false);
-        })}
-      </Form>
+        // Needs to bind to access this.props
+        getFieldDefault={field => this.getFieldDefault(field)}
+      />
     );
   }
 }
 
-export default withApi(SentryAppExternalIssueForm);
+export default SentryAppExternalIssueForm;

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -1,0 +1,323 @@
+import {Component} from 'react';
+import {createFilter} from 'react-select';
+import debounce from 'lodash/debounce';
+
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {Client} from 'app/api';
+import {t} from 'app/locale';
+import {SentryAppInstallation} from 'app/types';
+import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
+import withApi from 'app/utils/withApi';
+import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
+import Form from 'app/views/settings/components/forms/form';
+import FormModel from 'app/views/settings/components/forms/model';
+import {Field, FieldValue} from 'app/views/settings/components/forms/type';
+
+// 0 is a valid choice but empty string, undefined, and null are not
+const hasValue = value => !!value || value === 0;
+
+export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
+  type: 'select' | 'textarea' | 'text';
+  default?: 'issue.title' | 'issue.description';
+  uri?: string;
+  depends_on?: string[];
+  choices?: Array<[any, string]>;
+  async?: boolean;
+};
+
+export type Config = {
+  uri: string;
+  required_fields?: FieldFromSchema[];
+  optional_fields?: FieldFromSchema[];
+};
+
+// only need required_fields and optional_fields
+type State = Omit<Config, 'uri'> & {
+  optionsByField: Map<string, Array<{label: string; value: any}>>;
+};
+
+type Props = {
+  api: Client;
+  sentryAppInstallation: SentryAppInstallation;
+  appName: string;
+  config: Config;
+  action: 'create' | 'link';
+  element: 'issue-link' | 'alert-rule-action';
+  extraFields?: {[key: string]: any};
+  extraRequestBody?: {[key: string]: any};
+  onSubmitSuccess: (...params: any[]) => void;
+  getFieldDefault?: (field: FieldFromSchema) => string;
+};
+
+export class SentryAppExternalForm extends Component<Props, State> {
+  state: State = {optionsByField: new Map()};
+
+  componentDidMount() {
+    this.resetStateFromProps();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.action !== this.props.action) {
+      this.model.reset();
+      this.resetStateFromProps();
+    }
+  }
+
+  model = new FormModel();
+
+  // reset the state when we mount or the action changes
+  resetStateFromProps() {
+    const {config, action, extraFields} = this.props;
+    this.setState({
+      required_fields: config.required_fields,
+      optional_fields: config.optional_fields,
+    });
+    // we need to pass these fields in the API so just set them as values so we don't need hidden form fields
+    this.model.setInitialData({
+      ...extraFields,
+      action,
+      uri: config.uri,
+    });
+  }
+
+  onSubmitError = () => {
+    const {action, appName} = this.props;
+    addErrorMessage(t('Unable to %s %s %s.', action, appName, this.getElementText()));
+  };
+
+  getOptions = (field: FieldFromSchema, input: string) =>
+    new Promise(resolve => {
+      this.debouncedOptionLoad(field, input, resolve);
+    });
+
+  getElementText = () => {
+    const {element} = this.props;
+    switch (element) {
+      case 'issue-link':
+        return 'issue';
+      case 'alert-rule-action':
+        return 'alert';
+      default:
+        return 'connection';
+    }
+  };
+
+  debouncedOptionLoad = debounce(
+    // debounce is used to prevent making a request for every input change and
+    // instead makes the requests every 200ms
+    async (field: FieldFromSchema, input, resolve) => {
+      const choices = await this.makeExternalRequest(field, input);
+      const options = choices.map(([value, label]) => ({value, label}));
+      const optionsByField = new Map(this.state.optionsByField);
+      optionsByField.set(field.name, options);
+      this.setState({
+        optionsByField,
+      });
+      return resolve(options);
+    },
+    200,
+    {trailing: true}
+  );
+
+  makeExternalRequest = async (field: FieldFromSchema, input: FieldValue) => {
+    const install = this.props.sentryAppInstallation;
+    const {extraRequestBody = {}} = this.props;
+    const query: {[key: string]: any} = {
+      ...extraRequestBody,
+      uri: field.uri,
+      query: input,
+    };
+
+    if (field.depends_on) {
+      const dependentData = field.depends_on.reduce((accum, dependentField: string) => {
+        accum[dependentField] = this.model.getValue(dependentField);
+        return accum;
+      }, {});
+      // stringify the data
+      query.dependentData = JSON.stringify(dependentData);
+    }
+
+    const {choices} = await this.props.api.requestPromise(
+      `/sentry-app-installations/${install.uuid}/external-requests/`,
+      {
+        query,
+      }
+    );
+    return choices || [];
+  };
+
+  /**
+   * This function determines which fields need to be reset and new options fetched
+   * based on the dependencies defined with the depends_on attribute.
+   * This is done because the autoload flag causes fields to load at different times
+   * if you have multiple dependent fields while this solution updates state at once.
+   */
+  handleFieldChange = async (id: string) => {
+    const config = this.state;
+
+    let requiredFields = config.required_fields || [];
+    let optionalFields = config.optional_fields || [];
+
+    const fieldList: FieldFromSchema[] = requiredFields.concat(optionalFields);
+
+    // could have multiple impacted fields
+    const impactedFields = fieldList.filter(({depends_on}) => {
+      if (!depends_on) {
+        return false;
+      }
+      // must be dependent on the field we just set
+      return depends_on.includes(id);
+    });
+
+    // load all options in parallel
+    const choiceArray = await Promise.all(
+      impactedFields.map(field => {
+        // reset all impacted fields first
+        this.model.setValue(field.name || '', '', {quiet: true});
+        return this.makeExternalRequest(field, '');
+      })
+    );
+
+    this.setState(state => {
+      // pull the field lists from latest state
+      requiredFields = state.required_fields || [];
+      optionalFields = state.optional_fields || [];
+      // iterate through all the impacted fields and get new values
+      impactedFields.forEach((impactedField, i) => {
+        const choices = choiceArray[i];
+        const requiredIndex = requiredFields.indexOf(impactedField);
+        const optionalIndex = optionalFields.indexOf(impactedField);
+
+        const updatedField = {...impactedField, choices};
+
+        // immutably update the lists with the updated field depending where we got it from
+        if (requiredIndex > -1) {
+          requiredFields = replaceAtArrayIndex(
+            requiredFields,
+            requiredIndex,
+            updatedField
+          );
+        } else if (optionalIndex > -1) {
+          optionalFields = replaceAtArrayIndex(
+            optionalFields,
+            optionalIndex,
+            updatedField
+          );
+        }
+      });
+      return {
+        required_fields: requiredFields,
+        optional_fields: optionalFields,
+      };
+    });
+  };
+
+  renderField = (field: FieldFromSchema, required: boolean) => {
+    // This function converts the field we get from the backend into
+    // the field we need to pass down
+    let fieldToPass: Field = {
+      ...field,
+      inline: false,
+      stacked: true,
+      flexibleControlStateSize: true,
+      required,
+    };
+
+    // async only used for select components
+    const isAsync = typeof field.async === 'undefined' ? true : !!field.async; // default to true
+
+    if (fieldToPass.type === 'select') {
+      // find the options from state to pass down
+      const defaultOptions = (field.choices || []).map(([value, label]) => ({
+        value,
+        label,
+      }));
+      const options = this.state.optionsByField.get(field.name) || defaultOptions;
+      const allowClear = !required;
+      // filter by what the user is typing
+      const filterOption = createFilter({});
+      fieldToPass = {
+        ...fieldToPass,
+        options,
+        defaultOptions,
+        filterOption,
+        allowClear,
+      };
+      // default message for async select fields
+      if (isAsync) {
+        fieldToPass.noOptionsMessage = () => 'Type to search';
+      }
+    } else if (
+      ['text', 'textarea'].includes(fieldToPass.type || '') &&
+      field.default &&
+      this.props.getFieldDefault
+    ) {
+      fieldToPass = {...fieldToPass, defaultValue: this.props.getFieldDefault(field)};
+    }
+
+    if (field.depends_on) {
+      // check if this is dependent on other fields which haven't been set yet
+      const shouldDisable = field.depends_on.some(
+        dependentField => !hasValue(this.model.getValue(dependentField))
+      );
+      if (shouldDisable) {
+        fieldToPass = {...fieldToPass, disabled: true};
+      }
+    }
+
+    // if we have a uri, we need to set extra parameters
+    const extraProps = field.uri
+      ? {
+          loadOptions: (input: string) => this.getOptions(field, input),
+          async: isAsync,
+          cache: false,
+          onSelectResetsInput: false,
+          onCloseResetsInput: false,
+          onBlurResetsInput: false,
+          autoload: false,
+        }
+      : {};
+
+    return (
+      <FieldFromConfig
+        key={field.name}
+        field={fieldToPass}
+        data-test-id={field.name}
+        {...extraProps}
+      />
+    );
+  };
+
+  render() {
+    const {sentryAppInstallation, action} = this.props;
+
+    const requiredFields = this.state.required_fields || [];
+    const optionalFields = this.state.optional_fields || [];
+
+    if (!sentryAppInstallation) {
+      return '';
+    }
+
+    return (
+      <Form
+        key={action}
+        apiEndpoint={`/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`}
+        apiMethod="POST"
+        onSubmitSuccess={this.props.onSubmitSuccess}
+        onSubmitError={this.onSubmitError}
+        onFieldChange={this.handleFieldChange}
+        model={this.model}
+      >
+        {requiredFields.map((field: FieldFromSchema) => {
+          return this.renderField(field, true);
+        })}
+
+        {optionalFields.map((field: FieldFromSchema) => {
+          return this.renderField(field, false);
+        })}
+      </Form>
+    );
+  }
+}
+
+export default withApi(SentryAppExternalForm);

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -49,6 +49,14 @@ type Props = {
   getFieldDefault?: (field: FieldFromSchema) => string;
 };
 
+/**
+ *  This component is the result of a refactor of sentryAppExternalIssueForm.tsx.
+ *  Most of it contains a direct copy of the code from that original file (comments included)
+ *  to allow for an abstract way of turning Sentry App Schema -> Form UI, rather than being
+ *  specific to Issue Linking.
+ *
+ *  See (#28465) for more details.
+ */
 export class SentryAppExternalForm extends Component<Props, State> {
   state: State = {optionsByField: new Map()};
 


### PR DESCRIPTION
See [API-2080](https://getsentry.atlassian.net/browse/API-2080).

Since were working on the Alert Rule Schema upgrade, the logic that translates that schema into a form should be moved to a separate component rather than being tied in to _only_ work for Issue Linking. This avoids duplicate code and inconsistency if we ever add more UI components for both Issue Link forms and Alert Rule.

Still works just as before, passing the same tests and making the same API calls.
![still works](https://user-images.githubusercontent.com/35509934/132729571-0cb7c8da-ca2b-4f81-a948-5153732d7dd8.gif)
