### PR TITLE
fix(appstore): Redact iTunes session cookies as well

### DIFF
--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -18,7 +18,7 @@ import requests
 import sentry_sdk
 from django.db import transaction
 
-from sentry.lang.native.symbolicator import APP_STORE_CONNECT_SCHEMA
+from sentry.lang.native.symbolicator import APP_STORE_CONNECT_SCHEMA, secret_fields
 from sentry.models import Project
 from sentry.utils import json, sdk
 from sentry.utils.appleconnect import appstore_connect, itunes_connect
@@ -212,8 +212,8 @@ class AppStoreConnectConfig:
            should only occur if the class was created in a weird way.
         """
         data = self.to_json()
-        data["itunesPassword"] = {"hidden-secret": True}
-        data["appconnectPrivateKey"] = {"hidden-secret": True}
+        for to_redact in secret_fields("appStoreConnect"):
+            data[to_redact] = {"hidden-secret": True}
         return data
 
     def update_project_symbol_source(self, project: Project, allow_multiple: bool) -> json.JSONData:

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -307,7 +307,7 @@ def secret_fields(source_type):
     Returns a string list of all of the fields that contain a secret in a given source.
     """
     if source_type == "appStoreConnect":
-        yield from ["appconnectPrivateKey", "itunesPassword"]
+        yield from ["appconnectPrivateKey", "itunesPassword", "itunesSession"]
     elif source_type == "http":
         yield "password"
     elif source_type == "s3":

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -20,7 +20,9 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert data["appconnectPrivateKey"] is None
         assert data["itunesPassword"] is None
-        assert data["itunesSession"] is None
+        # This is in the list of secret fields, but it shouldn't be included
+        # after deserialization since it's not a member of AppStoreUpdateCredentials
+        assert "itunesSession" not in data
 
     def test_validate_secrets_magic_object_false(self):
         payload_json = """{
@@ -35,7 +37,9 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert serializer.errors["appconnectPrivateKey"][0].code == "invalid"
         assert serializer.errors["itunesPassword"][0].code == "invalid"
-        assert serializer.errors["itunesSession"][0].code == "invalid"
+        # This is in the list of secret fields, but it shouldn't be included
+        # after deserialization since it's not a member of AppStoreUpdateCredentials
+        assert "itunesSession" not in serializer.errors
 
     def test_validate_secrets_null(self):
         payload_json = """{
@@ -50,7 +54,9 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert serializer.errors["appconnectPrivateKey"][0].code == "null"
         assert serializer.errors["itunesPassword"][0].code == "null"
-        assert serializer.errors["itunesSession"][0].code == "null"
+        # This is in the list of secret fields, but it shouldn't be included
+        # after deserialization since it's not a member of AppStoreUpdateCredentials
+        assert "itunesSession" not in serializer.errors
 
     # also equivalent to
     # {
@@ -89,7 +95,7 @@ class TestAppStoreUpdateCredentialsSerializer:
         # credentials should be deleted instead of this
         assert serializer.errors["appconnectPrivateKey"][0].code == "blank"
         assert serializer.errors["itunesPassword"][0].code == "blank"
-        assert serializer.errors["itunesSession"][0].code == "blank"
+        assert "itunesSession" not in serializer.errors
 
     def test_validate_secrets_string(self):
         payload_json = """{
@@ -106,4 +112,6 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert data["appconnectPrivateKey"] == "honk"
         assert data["itunesPassword"] == "beep"
-        assert data["itunesSession"] == "beep"
+        # This is in the list of secret fields, but it shouldn't be included
+        # after deserialization since it's not a member of AppStoreUpdateCredentials
+        assert "itunesSession" not in serializer.errors

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -16,8 +16,7 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         payload = json.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
-        if not serializer.is_valid():
-            pytest.fail(serializer.errors)
+        assert serializer.is_valid(), serializer.errors
 
         data = serializer.validated_data
 
@@ -68,8 +67,7 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         payload = json.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
-        if not serializer.is_valid():
-            pytest.fail(serializer.errors)
+        assert serializer.is_valid(), serializer.errors
 
         data = serializer.validated_data
 
@@ -104,8 +102,7 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         payload = json.loads(payload_json)
         serializer = AppStoreUpdateCredentialsSerializer(data=payload)
-        if not serializer.is_valid():
-            pytest.fail(serializer.errors)
+        assert serializer.is_valid(), serializer.errors
 
         data = serializer.validated_data
 

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -11,6 +11,7 @@ class TestAppStoreUpdateCredentialsSerializer:
         payload_json = """{
             "appconnectPrivateKey": { "hidden-secret": true },
             "itunesPassword":  { "hidden-secret": true }
+            "itunesSession":  { "hidden-secret": true }
         }"""
 
         payload = json.loads(payload_json)
@@ -22,11 +23,13 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert data["appconnectPrivateKey"] is None
         assert data["itunesPassword"] is None
+        assert data["itunesSession"] is None
 
     def test_validate_secrets_magic_object_false(self):
         payload_json = """{
             "appconnectPrivateKey": { "hidden-secret": false },
             "itunesPassword":  { "hidden-secret": false }
+            "itunesSession":  { "hidden-secret": false }
         }"""
 
         payload = json.loads(payload_json)
@@ -35,11 +38,13 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert serializer.errors["appconnectPrivateKey"][0].code == "invalid"
         assert serializer.errors["itunesPassword"][0].code == "invalid"
+        assert serializer.errors["itunesSession"][0].code == "invalid"
 
     def test_validate_secrets_null(self):
         payload_json = """{
             "appconnectPrivateKey": null,
             "itunesPassword": null
+            "itunesSession": null
         }"""
 
         payload = json.loads(payload_json)
@@ -48,11 +53,13 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert serializer.errors["appconnectPrivateKey"][0].code == "null"
         assert serializer.errors["itunesPassword"][0].code == "null"
+        assert serializer.errors["itunesSession"][0].code == "null"
 
     # also equivalent to
     # {
     #    "appconnectPrivateKey": undefined,
     #    "itunesPassword": undefined
+    #    "itunesSession": undefined
     # }
     def test_validate_secrets_absent(self):
         payload_json = """{
@@ -69,11 +76,13 @@ class TestAppStoreUpdateCredentialsSerializer:
         assert data["appId"] == "honk"
         assert "appconnectPrivateKey" not in data
         assert "itunesPassword" not in data
+        assert "itunesSession" not in data
 
     def test_validate_secrets_empty_string(self):
         payload_json = """{
             "appconnectPrivateKey": "",
             "itunesPassword": ""
+            "itunesSession": ""
         }"""
 
         payload = json.loads(payload_json)
@@ -84,11 +93,13 @@ class TestAppStoreUpdateCredentialsSerializer:
         # credentials should be deleted instead of this
         assert serializer.errors["appconnectPrivateKey"][0].code == "blank"
         assert serializer.errors["itunesPassword"][0].code == "blank"
+        assert serializer.errors["itunesSession"][0].code == "blank"
 
     def test_validate_secrets_string(self):
         payload_json = """{
             "appconnectPrivateKey": "honk",
             "itunesPassword": "beep"
+            "itunesSession": "beep"
         }"""
 
         payload = json.loads(payload_json)
@@ -100,3 +111,4 @@ class TestAppStoreUpdateCredentialsSerializer:
 
         assert data["appconnectPrivateKey"] == "honk"
         assert data["itunesPassword"] == "beep"
+        assert data["itunesSession"] == "beep"

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -8,7 +8,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_magic_object_true(self):
         payload_json = """{
             "appconnectPrivateKey": { "hidden-secret": true },
-            "itunesPassword":  { "hidden-secret": true }
+            "itunesPassword":  { "hidden-secret": true },
             "itunesSession":  { "hidden-secret": true }
         }"""
 
@@ -25,7 +25,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_magic_object_false(self):
         payload_json = """{
             "appconnectPrivateKey": { "hidden-secret": false },
-            "itunesPassword":  { "hidden-secret": false }
+            "itunesPassword":  { "hidden-secret": false },
             "itunesSession":  { "hidden-secret": false }
         }"""
 
@@ -40,7 +40,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_null(self):
         payload_json = """{
             "appconnectPrivateKey": null,
-            "itunesPassword": null
+            "itunesPassword": null,
             "itunesSession": null
         }"""
 
@@ -55,7 +55,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     # also equivalent to
     # {
     #    "appconnectPrivateKey": undefined,
-    #    "itunesPassword": undefined
+    #    "itunesPassword": undefined,
     #    "itunesSession": undefined
     # }
     def test_validate_secrets_absent(self):
@@ -77,7 +77,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_empty_string(self):
         payload_json = """{
             "appconnectPrivateKey": "",
-            "itunesPassword": ""
+            "itunesPassword": "",
             "itunesSession": ""
         }"""
 
@@ -94,7 +94,7 @@ class TestAppStoreUpdateCredentialsSerializer:
     def test_validate_secrets_string(self):
         payload_json = """{
             "appconnectPrivateKey": "honk",
-            "itunesPassword": "beep"
+            "itunesPassword": "beep",
             "itunesSession": "beep"
         }"""
 

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -1,5 +1,3 @@
-import pytest
-
 from sentry.api.endpoints.project_app_store_connect_credentials import (
     AppStoreUpdateCredentialsSerializer,
 )

--- a/tests/sentry/lang/native/test_appconnect.py
+++ b/tests/sentry/lang/native/test_appconnect.py
@@ -76,8 +76,9 @@ class TestAppStoreConnectConfig:
         data["itunesCreated"] = now.isoformat()
 
         # Redacted secrets
-        data["itunesPassword"] = {"hidden-secret": True}
         data["appconnectPrivateKey"] = {"hidden-secret": True}
+        data["itunesPassword"] = {"hidden-secret": True}
+        data["itunesSession"] = {"hidden-secret": True}
 
         assert new_data == data
 


### PR DESCRIPTION
Missed a spot in #28334. This also redacts the contents of iTunes session cookies so they can't be retrieved from the API.