### PR TITLE
fix(chart-unfurls): Fix blank unfurls caused by django update

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -143,6 +143,8 @@ def map_discover_query_args(url: str, args: Mapping[str, str]) -> Mapping[str, A
     """
     Extracts discover arguments from the discover link's query string
     """
+    # Slack uses HTML escaped ampersands in its Event Links, when need
+    # to be unescaped for QueryDict to split properly.
     url = html.unescape(url)
     parsed_url = urlparse(url)
     query = QueryDict(parsed_url.query).copy()

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -1,3 +1,4 @@
+import html
 import re
 from typing import Any, List, Mapping
 from urllib.parse import urlparse
@@ -142,6 +143,7 @@ def map_discover_query_args(url: str, args: Mapping[str, str]) -> Mapping[str, A
     """
     Extracts discover arguments from the discover link's query string
     """
+    url = html.unescape(url)
     parsed_url = urlparse(url)
     query = QueryDict(parsed_url.query).copy()
 


### PR DESCRIPTION
Slack links have html escaped ampersands like this:
`https://dev.getsentry.net/organizations/sentry/discover/results/?id=3&amp;statsPeriod=1h&amp;user=1&amp;project=1`
We used django's QueryDict to parse these urls into a dict. In the old version of django, the QueryDict class split the url on re.compile('[&;]') but 2.2 uses re.compile('&').
```
So the qs params were being parsed differently:
In [1]: import re

In [2]: FIELDS_MATCH = re.compile('[&;]')

In [3]: FIELDS_MATCH.split("id=3&amp;statsPeriod=1h&amp;user=1&amp;project=1")
Out[3]: ['id=3', 'amp', 'statsPeriod=1h', 'amp', 'user=1', 'amp', 'project=1']

In [4]: FIELDS_MATCH = re.compile('&')

In [5]: FIELDS_MATCH.split("id=3&amp;statsPeriod=1h&amp;user=1&amp;project=1")
Out[5]: ['id=3', 'amp;statsPeriod=1h', 'amp;user=1', 'amp;project=1']
```

And resulted in poorly parsed payloads being sent to the `events-stats` endpoint,
resulting in an empty unfurl.