### PR TITLE
test(ui): Convert breadcrumbs tests to RTL

### DIFF
--- a/docs-ui/stories/views/breadcrumbs.stories.js
+++ b/docs-ui/stories/views/breadcrumbs.stories.js
@@ -1,3 +1,5 @@
+import {action} from '@storybook/addon-actions';
+
 import Breadcrumbs from 'app/components/breadcrumbs';
 
 export default {
@@ -12,6 +14,26 @@ export const _Breadcrumbs = () => (
       {label: 'Test 2', to: '#'},
       {label: 'Test 3', to: '#'},
       {label: 'Test 4', to: null},
+    ]}
+  />
+);
+
+export const _BreadcrumbWithDropdown = () => (
+  <Breadcrumbs
+    crumbs={[
+      {
+        label: 'dropdown crumb',
+        onSelect: action('onSelect'),
+        items: [{label: 'item1'}, {label: 'item2'}, {label: 'item3'}],
+      },
+      {
+        label: 'Test 2',
+        to: '/test2',
+      },
+      {
+        label: 'Test 3',
+        to: null,
+      },
     ]}
   />
 );

--- a/tests/js/spec/components/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/breadcrumbs.spec.jsx
@@ -1,91 +1,93 @@
-import {shallow} from 'sentry-test/enzyme';
+import {fireEvent, mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import Breadcrumbs from 'app/components/breadcrumbs';
 
 describe('Breadcrumbs', () => {
-  const wrapper = shallow(
-    <Breadcrumbs
-      crumbs={[
-        {
-          label: 'Test 1',
-          to: '/test1',
-        },
-        {
-          label: 'Test 2',
-          to: '/test2',
-        },
-        {
-          label: 'Test 3',
-          to: null,
-        },
-      ]}
-    />
-  );
+  const routerContext = TestStubs.routerContext();
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
-  const wrapperWithDropdown = shallow(
-    <Breadcrumbs
-      crumbs={[
-        {
-          label: 'dropdown crumb',
-          onSelect: () => {},
-          items: ['item1', 'item2', 'item3'],
-        },
-        {
-          label: 'Test 2',
-          to: '/test2',
-        },
-        {
-          label: 'Test 3',
-          to: null,
-        },
-      ]}
-    />
-  );
+  function createWrapper() {
+    return mountWithTheme(
+      <Breadcrumbs
+        crumbs={[
+          {
+            label: 'Test 1',
+            to: '/test1',
+          },
+          {
+            label: 'Test 2',
+            to: '/test2',
+          },
+          {
+            label: 'Test 3',
+            to: null,
+          },
+        ]}
+      />,
+      {context: routerContext}
+    );
+  }
 
   it('returns null when 0 crumbs', () => {
-    const empty = shallow(<Breadcrumbs crumbs={[]} />);
+    const empty = mountWithTheme(<Breadcrumbs crumbs={[]} />);
 
-    expect(empty.html()).toBeNull();
+    expect(empty.container.firstChild).toBeNull();
+  });
+
+  it('renders crumbs with icon', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.container).toSnapshot();
   });
 
   it('generates correct links', () => {
-    const allElements = wrapper.find('BreadcrumbList').children();
-    const links = wrapper.find('BreadcrumbLink');
-
-    expect(links.length).toBe(2);
-    expect(allElements.at(0).props().to).toBe('/test1');
-    expect(allElements.at(0).props().children).toBe('Test 1');
-    expect(allElements.at(2).props().to).toBe('/test2');
-    expect(allElements.at(2).props().children).toBe('Test 2');
+    const wrapper = createWrapper();
+    fireEvent.click(wrapper.getByText('Test 1'));
+    expect(routerContext.context.router.push).toHaveBeenCalledWith('/test1');
+    fireEvent.click(wrapper.getByText('Test 2'));
+    expect(routerContext.context.router.push).toHaveBeenCalledWith('/test2');
   });
 
   it('does not make links where no `to` is provided', () => {
-    const allElements = wrapper.find('BreadcrumbList').children();
-    const notLink = wrapper.find('BreadcrumbItem');
-
-    expect(notLink.length).toBe(1);
-
-    expect(allElements.at(4).props().to).toBeUndefined();
-    expect(allElements.at(4).props().children).toBe('Test 3');
+    const wrapper = createWrapper();
+    fireEvent.click(wrapper.getByText('Test 3'));
+    expect(routerContext.context.router.push).not.toHaveBeenCalled();
   });
 
-  it('separates crumbs with icon', () => {
-    const allElements = wrapper.find('BreadcrumbList').children();
-    const dividers = wrapper.find('BreadcrumbDividerIcon');
+  it('renders a crumb dropdown', async () => {
+    const onSelect = jest.fn();
+    const wrapper = mountWithTheme(
+      <Breadcrumbs
+        crumbs={[
+          {
+            label: 'dropdown crumb',
+            onSelect,
+            items: [{label: 'item1'}, {label: 'item2'}, {label: 'item3'}],
+          },
+          {
+            label: 'Test 2',
+            to: '/test2',
+          },
+          {
+            label: 'Test 3',
+            to: null,
+          },
+        ]}
+      />,
+      {context: routerContext}
+    );
+    fireEvent.mouseOver(wrapper.getByText('dropdown crumb'));
 
-    expect(dividers.length).toBe(2);
+    await waitFor(() => {
+      expect(wrapper.getByText('item3')).toBeInTheDocument();
+    });
 
-    expect(allElements.at(1).is('BreadcrumbDividerIcon')).toBeTruthy();
-    expect(allElements.at(3).is('BreadcrumbDividerIcon')).toBeTruthy();
-    expect(allElements.at(5).exists()).toBeFalsy();
-  });
-
-  it('renders a crumb dropdown', () => {
-    const allElements = wrapperWithDropdown.find('BreadcrumbList').children();
-    const dropdown = wrapperWithDropdown.find('BreadcrumbDropdown');
-    expect(allElements.at(0).is('BreadcrumbDropdown')).toBeTruthy();
-    expect(allElements.at(1).is('BreadcrumbLink')).toBeTruthy();
-    expect(allElements.at(3).is('BreadcrumbItem')).toBeTruthy();
-    expect(dropdown.exists()).toBeTruthy();
+    fireEvent.click(wrapper.getByText('item3'));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({label: 'item3'}),
+      expect.anything(),
+      expect.anything()
+    );
   });
 });


### PR DESCRIPTION
Replaces the crumb counting test with a snapshot test. RTL doesn't have a good way to count the number of SVGs rendered between links

Adds a story for breadcrumb with dropdown