### PR TITLE
types(python): Azure DevOps Integration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -30,6 +30,7 @@ files = src/sentry/api/bases/external_actor.py,
         src/sentry/integrations/slack/unfurl/*.py,
         src/sentry/integrations/slack/util/*.py,
         src/sentry/integrations/slack/views/*.py,
+        src/sentry/integrations/vsts/**/*.py,
         src/sentry/killswitches.py,
         src/sentry/lang/native/appconnect.py,
         src/sentry/models/debugfile.py,
@@ -83,6 +84,8 @@ ignore_missing_imports = True
 [mypy-google.*]
 ignore_missing_imports = True
 [mypy-jsonschema]
+ignore_missing_imports = True
+[mypy-mistune.*]
 ignore_missing_imports = True
 [mypy-rb.*]
 ignore_missing_imports = True

--- a/src/sentry/integrations/vsts/__init__.py
+++ b/src/sentry/integrations/vsts/__init__.py
@@ -3,6 +3,7 @@ from sentry.utils.imports import import_submodules
 
 from .notify_action import AzureDevopsCreateTicketAction
 
-import_submodules(globals(), __name__, __path__)
+path = __path__  # type: ignore
+import_submodules(globals(), __name__, path)
 
 rules.add(AzureDevopsCreateTicketAction)

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -260,7 +260,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
             params={"continuationToken": continuation_token},
         )
 
-    def create_subscription(self, instance: str, shared_secret: str) -> Response:
+    def create_subscription(self, instance: Optional[str], shared_secret: str) -> Response:
         return self.post(
             VstsApiPath.subscriptions.format(instance=instance),
             data={

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -88,7 +88,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
     def create_work_item(
         self,
         instance: str,
-        project: Project,
+        project: "Project",
         item_type: Optional[str] = None,
         title: Optional[str] = None,
         description: Optional[str] = None,

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -52,7 +52,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
     integration_name = "vsts"
 
     def __init__(
-        self, identity: Identity, oauth_redirect_url: str, *args: Any, **kwargs: Any
+        self, identity: "Identity", oauth_redirect_url: str, *args: Any, **kwargs: Any
     ) -> None:
         super().__init__(*args, **kwargs)
         self.identity = identity
@@ -240,8 +240,8 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
             offset = self.page_size * page_number
             return {"stateFilter": "WellFormed", "$skip": offset, "$top": page_size}
 
-        def get_results(resp):
-            return resp["value"]
+        def get_results(resp: Response) -> Sequence[Any]:
+            return resp["value"]  # type: ignore
 
         return self.get_with_pagination(
             VstsApiPath.projects.format(instance=instance),

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -241,7 +241,9 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
             return {"stateFilter": "WellFormed", "$skip": offset, "$top": page_size}
 
         def get_results(resp: Response) -> Sequence[Any]:
-            return resp["value"]  # type: ignore
+            # Explicitly typing to satisfy mypy.
+            results: Sequence[Any] = resp["value"]
+            return results
 
         return self.get_with_pagination(
             VstsApiPath.projects.format(instance=instance),

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -44,7 +44,7 @@ class VstsApiPath:
     work_item_categories = "{instance}{project}/_apis/wit/workitemtypecategories"
 
 
-class VstsApiClient(ApiClient, OAuth2RefreshMixin):
+class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
     api_version = "4.1"  # TODO: update api version
     api_version_preview = "-preview.1"
     integration_name = "vsts"

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -1,5 +1,12 @@
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Sequence, Union
+
+from rest_framework.response import Response
+
 from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
 from sentry.utils.http import absolute_uri
+
+if TYPE_CHECKING:
+    from sentry.models import Identity, Project
 
 UNSET = object()
 
@@ -42,14 +49,24 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
     api_version_preview = "-preview.1"
     integration_name = "vsts"
 
-    def __init__(self, identity, oauth_redirect_url, *args, **kwargs):
+    def __init__(
+        self, identity: Identity, oauth_redirect_url: str, *args: Any, **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.identity = identity
         self.oauth_redirect_url = oauth_redirect_url
         if "access_token" not in self.identity.data:
             raise ValueError("Vsts Identity missing access token")
 
-    def request(self, method, path, data=None, params=None, api_preview=False, timeout=None):
+    def request(
+        self,
+        method: str,
+        path: str,
+        data: Optional[Mapping[str, Any]] = None,
+        params: Optional[Sequence[Any]] = None,
+        api_preview: bool = False,
+        timeout: Optional[int] = None,
+    ) -> Response:
         self.check_auth(redirect_url=self.oauth_redirect_url)
         headers = {
             "Accept": "application/json; api-version={}{}".format(
@@ -68,14 +85,14 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
 
     def create_work_item(
         self,
-        instance,
-        project,
-        item_type=None,
-        title=None,
-        description=None,
-        comment=None,
-        link=None,
-    ):
+        instance: str,
+        project: Project,
+        item_type: Optional[str] = None,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        comment: Optional[str] = None,
+        link: Optional[str] = None,
+    ) -> Response:
         data = []
         if title:
             data.append({"op": "add", "path": FIELD_MAP["title"], "value": title})
@@ -143,10 +160,10 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
 
         return self.patch(VstsApiPath.work_items.format(instance=instance, id=id), data=data)
 
-    def get_work_item(self, instance, id):
+    def get_work_item(self, instance: str, id: str) -> Response:
         return self.get(VstsApiPath.work_items.format(instance=instance, id=id))
 
-    def get_work_item_states(self, instance, project):
+    def get_work_item_states(self, instance: str, project: str) -> Response:
         return self.get(
             VstsApiPath.work_item_states.format(
                 instance=instance,
@@ -157,10 +174,10 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             api_preview=True,
         )
 
-    def get_work_item_categories(self, instance, project):
+    def get_work_item_categories(self, instance: str, project: str) -> Response:
         return self.get(VstsApiPath.work_item_categories.format(instance=instance, project=project))
 
-    def get_repo(self, instance, name_or_id, project=None):
+    def get_repo(self, instance: str, name_or_id: str, project: Optional[str] = None) -> Response:
         return self.get(
             VstsApiPath.repository.format(
                 instance=instance,
@@ -169,7 +186,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             )
         )
 
-    def get_repos(self, instance, project=None):
+    def get_repos(self, instance: str, project: Optional[str] = None) -> Response:
         return self.get(
             VstsApiPath.repositories.format(
                 instance=instance, project=f"{project}/" if project else ""
@@ -177,25 +194,27 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             timeout=5,
         )
 
-    def get_commits(self, instance, repo_id, commit, limit=100):
+    def get_commits(self, instance: str, repo_id: str, commit: str, limit: int = 100) -> Response:
         return self.get(
             VstsApiPath.commits.format(instance=instance, repo_id=repo_id),
             params={"commit": commit, "$top": limit},
         )
 
-    def get_commit(self, instance, repo_id, commit):
+    def get_commit(self, instance: str, repo_id: str, commit: str) -> Response:
         return self.get(
             VstsApiPath.commit.format(instance=instance, repo_id=repo_id, commit_id=commit)
         )
 
-    def get_commit_filechanges(self, instance, repo_id, commit):
+    def get_commit_filechanges(self, instance: str, repo_id: str, commit: str) -> Response:
         resp = self.get(
             VstsApiPath.commits_changes.format(instance=instance, repo_id=repo_id, commit_id=commit)
         )
         changes = resp["changes"]
         return changes
 
-    def get_commit_range(self, instance, repo_id, start_sha, end_sha):
+    def get_commit_range(
+        self, instance: str, repo_id: str, start_sha: str, end_sha: str
+    ) -> Response:
         return self.post(
             VstsApiPath.commits_batch.format(instance=instance, repo_id=repo_id),
             data={
@@ -204,17 +223,18 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             },
         )
 
-    def get_project(self, instance, project_id):
+    def get_project(self, instance: str, project_id: str) -> Response:
         return self.get(
             VstsApiPath.project.format(instance=instance, project_id=project_id),
             params={"stateFilter": "WellFormed"},
         )
 
-    def get_projects(self, instance):
-        def gen_params(page_number, page_size):
-            # ADO supports a continuation token in the response but only in the newer API version (https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-6.1)
-            # the token comes as a response header instead of the body and our API clients currently only return the body
-            # we can use count, $skip, and $top to get the same result
+    def get_projects(self, instance: str) -> Response:
+        def gen_params(page_number: int, page_size: int) -> Mapping[str, Union[str, int]]:
+            # ADO supports a continuation token in the response but only in the newer API version (
+            # https://docs.microsoft.com/en-us/rest/api/azure/devops/core/projects/list?view=azure-devops-rest-6.1
+            # ). The token comes as a response header instead of the body and our API clients
+            # currently only return the body we can use count, $skip, and $top to get the same result.
             offset = self.page_size * page_number
             return {"stateFilter": "WellFormed", "$skip": offset, "$top": page_size}
 
@@ -227,7 +247,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             get_results=get_results,
         )
 
-    def get_users(self, account_name, continuation_token=None):
+    def get_users(self, account_name: str, continuation_token: Optional[str] = None) -> Response:
         """
         Gets Users with access to a given account/organization
         https://docs.microsoft.com/en-us/rest/api/azure/devops/graph/users/list?view=azure-devops-rest-4.1
@@ -238,7 +258,7 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             params={"continuationToken": continuation_token},
         )
 
-    def create_subscription(self, instance, shared_secret):
+    def create_subscription(self, instance: str, shared_secret: str) -> Response:
         return self.post(
             VstsApiPath.subscriptions.format(instance=instance),
             data={
@@ -255,22 +275,22 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):
             },
         )
 
-    def get_subscription(self, instance, subscription_id):
+    def get_subscription(self, instance: str, subscription_id: str) -> Response:
         return self.get(
             VstsApiPath.subscription.format(instance=instance, subscription_id=subscription_id)
         )
 
-    def delete_subscription(self, instance, subscription_id):
+    def delete_subscription(self, instance: str, subscription_id: str) -> Response:
         return self.delete(
             VstsApiPath.subscription.format(instance=instance, subscription_id=subscription_id)
         )
 
-    def update_subscription(self, instance, subscription_id):
+    def update_subscription(self, instance: str, subscription_id: str) -> Response:
         return self.put(
             VstsApiPath.subscription.format(instance=instance, subscription_id=subscription_id)
         )
 
-    def search_issues(self, account_name, query=None):
+    def search_issues(self, account_name: str, query: Optional[str] = None) -> Response:
         return self.post(
             VstsApiPath.work_item_search.format(account_name=account_name),
             data={"searchText": query, "$top": 1000},

--- a/src/sentry/integrations/vsts/client.py
+++ b/src/sentry/integrations/vsts/client.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 UNSET = object()
 
+UnsettableString = Union[str, object, None]
+
 FIELD_MAP = {
     "title": "/fields/System.Title",
     "description": "/fields/System.Description",
@@ -120,16 +122,16 @@ class VstsApiClient(ApiClient, OAuth2RefreshMixin):  # type: ignore
 
     def update_work_item(
         self,
-        instance,
-        id,
-        title=UNSET,
-        description=UNSET,
-        link=UNSET,
-        comment=UNSET,
-        assigned_to=UNSET,
-        state=UNSET,
-    ):
-        data = []
+        instance: str,
+        id: str,
+        title: UnsettableString = UNSET,
+        description: UnsettableString = UNSET,
+        link: UnsettableString = UNSET,
+        comment: UnsettableString = UNSET,
+        assigned_to: UnsettableString = UNSET,
+        state: UnsettableString = UNSET,
+    ) -> Response:
+        data: List[Mapping[str, Any]] = []
 
         for f_name, f_value in (
             ("title", title),

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -390,7 +390,8 @@ class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
         account = state["account"]
         user = get_user_info(data["access_token"])
         scopes = sorted(self.get_scopes())
-        base_url = self.get_base_url(data["access_token"], account["accountId"])
+        # TODO(mgaeta): get_base_url() can return None.
+        base_url: str = self.get_base_url(data["access_token"], account["accountId"])  # type: ignore
 
         integration: MutableMapping[str, Any] = {
             "name": account["accountName"],

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -175,7 +175,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
         instance = self.model.metadata["domain_name"]
 
         project_selector = []
-        all_states = set()
+        all_states_set = set()
         try:
             projects = client.get_projects(instance)
             for idx, project in enumerate(projects):
@@ -185,12 +185,12 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
                 if idx <= 5:
                     project_states = client.get_work_item_states(instance, project["id"])["value"]
                     for state in project_states:
-                        all_states.add(state["name"])
+                        all_states_set.add(state["name"])
 
-            all_states = {(state, state) for state in all_states}
+            all_states = [(state, state) for state in all_states_set]
             disabled = False
         except (ApiError, IdentityNotValid):
-            all_states = set()
+            all_states = []
             disabled = True
 
         fields = [

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -157,14 +157,15 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
         if self.default_identity is None:
             self.default_identity = self.get_default_identity()
 
-        self.check_domain_name()
+        self.check_domain_name(self.default_identity)
         return VstsApiClient(self.default_identity, VstsIntegrationProvider.oauth_redirect_url)
 
-    def check_domain_name(self):
+    def check_domain_name(self, default_identity: Identity) -> None:
         if re.match("^https://.+/$", self.model.metadata["domain_name"]):
             return
+
         base_url = VstsIntegrationProvider.get_base_url(
-            self.default_identity.data["access_token"], self.model.external_id
+            default_identity.data["access_token"], self.model.external_id
         )
         self.model.metadata["domain_name"] = base_url
         self.model.save()

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -105,7 +105,7 @@ metadata = IntegrationMetadata(
 logger = logging.getLogger("sentry.integrations")
 
 
-class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
+class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):  # type: ignore
     logger = logger
     comment_key = "sync_comments"
     outbound_status_key = "sync_status_forward"
@@ -317,7 +317,7 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync):
             return None
 
 
-class VstsIntegrationProvider(IntegrationProvider):
+class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
     key = "vsts"
     name = "Azure DevOps"
     metadata = metadata
@@ -478,8 +478,8 @@ class VstsIntegrationProvider(IntegrationProvider):
         )
 
 
-class AccountConfigView(PipelineView):
-    def dispatch(self, request, pipeline):
+class AccountConfigView(PipelineView):  # type: ignore
+    def dispatch(self, request: Request, pipeline: Pipeline) -> Response:
         if "account" in request.POST:
             account_id = request.POST.get("account")
             accounts = pipeline.fetch_state(key="accounts")

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -174,11 +174,9 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
         instance = self.model.metadata["domain_name"]
 
         project_selector = []
-
+        all_states = set()
         try:
             projects = client.get_projects(instance)
-            all_states = set()
-
             for idx, project in enumerate(projects):
                 project_selector.append({"value": project["id"], "label": project["name"]})
                 # only request states for the first 5 projects to limit number
@@ -188,10 +186,10 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
                     for state in project_states:
                         all_states.add(state["name"])
 
-            all_states = [(state, state) for state in all_states]
+            all_states = {(state, state) for state in all_states}
             disabled = False
         except (ApiError, IdentityNotValid):
-            all_states = []
+            all_states = set()
             disabled = True
 
         fields = [

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -291,8 +291,8 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
         config.update(data)
         self.org_integration.update(config=config)
 
-    def get_config_data(self):
-        config = self.org_integration.config
+    def get_config_data(self) -> Mapping[str, Any]:
+        config: MutableMapping[str, Any] = self.org_integration.config
         project_mappings = IntegrationExternalProject.objects.filter(
             organization_integration_id=self.org_integration.id
         )
@@ -306,15 +306,19 @@ class VstsIntegration(IntegrationInstallation, RepositoryMixin, VstsIssueSync): 
         return config
 
     @property
-    def instance(self):
-        return self.model.metadata["domain_name"]
+    def instance(self) -> str:
+        # Explicitly typing to satisfy mypy.
+        instance_: str = self.model.metadata["domain_name"]
+        return instance_
 
     @property
     def default_project(self) -> Optional[str]:
         try:
-            return self.model.metadata["default_project"]
+            # Explicitly typing to satisfy mypy.
+            default_project_: str = self.model.metadata["default_project"]
         except KeyError:
             return None
+        return default_project_
 
 
 class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
@@ -389,7 +393,7 @@ class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
         scopes = sorted(self.get_scopes())
         base_url = self.get_base_url(data["access_token"], account["accountId"])
 
-        integration = {
+        integration: MutableMapping[str, Any] = {
             "name": account["accountName"],
             "external_id": account["accountId"],
             "metadata": {"domain_name": base_url, "scopes": scopes},
@@ -467,7 +471,9 @@ class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
                 },
             )
         if response.status_code == 200:
-            return response.json()["locationUrl"]
+            # Explicitly typing to satisfy mypy.
+            location_url: Optional[str] = response.json()["locationUrl"]
+            return location_url
         return None
 
     def setup(self) -> None:

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -31,7 +31,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         return (project["id"], project["name"])
 
     def get_project_choices(
-        self, group: Optional[Group] = None, **kwargs: Any
+        self, group: Optional["Group"] = None, **kwargs: Any
     ) -> Tuple[Optional[str], Sequence[Tuple[str, str]]]:
         client = self.get_client()
         try:
@@ -71,7 +71,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         return default_project, project_choices
 
     def get_work_item_choices(
-        self, project: str, group: Optional[Group] = None
+        self, project: str, group: Optional["Group"] = None
     ) -> Tuple[Optional[str], Sequence[Tuple[str, str]]]:
         client = self.get_client()
         try:
@@ -106,7 +106,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         return self.get_create_issue_config(None, None, project=project)
 
     def get_create_issue_config(
-        self, group: Optional[Group], user: Optional[User], **kwargs: Any
+        self, group: Optional["Group"], user: Optional[User], **kwargs: Any
     ) -> Sequence[Mapping[str, Any]]:
         kwargs["link_referrer"] = "vsts_integration"
         fields = []
@@ -145,7 +145,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
             },
         ] + fields
 
-    def get_link_issue_config(self, group: Group, **kwargs: Any) -> Sequence[Mapping[str, str]]:
+    def get_link_issue_config(self, group: "Group", **kwargs: Any) -> Sequence[Mapping[str, str]]:
         fields: Sequence[MutableMapping[str, str]] = super().get_link_issue_config(group, **kwargs)
         org = group.organization
         autocomplete_url = reverse("sentry-extensions-vsts-search", args=[org.slug, self.model.id])
@@ -208,7 +208,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         }
 
     def sync_assignee_outbound(
-        self, external_issue: ExternalIssue, user: User, assign: bool = True, **kwargs: Any
+        self, external_issue: "ExternalIssue", user: User, assign: bool = True, **kwargs: Any
     ) -> None:
         client = self.get_client()
         assignee = None
@@ -253,7 +253,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
             )
 
     def sync_status_outbound(
-        self, external_issue: ExternalIssue, is_resolved: bool, project_id: int, **kwargs: Any
+        self, external_issue: "ExternalIssue", is_resolved: bool, project_id: int, **kwargs: Any
     ) -> None:
         client = self.get_client()
         work_item = client.get_work_item(self.instance, external_issue.key)
@@ -329,7 +329,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         ]
         return done_states
 
-    def get_issue_display_name(self, external_issue: ExternalIssue) -> str:
+    def get_issue_display_name(self, external_issue: "ExternalIssue") -> str:
         return (external_issue.metadata or {}).get("display_name", "")
 
     def create_comment(self, issue_id: str, user_id: int, group_note: Activity) -> Response:

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -42,10 +42,10 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         project_choices = [(project["id"], project["name"]) for project in projects]
 
         params = kwargs.get("params", {})
+        project = kwargs.get("project")
         if group:
             default_project_id = group.project_id
-        elif kwargs.get("project"):
-            project = kwargs.get("project")
+        elif project:
             default_project_id = project.id
         else:
             default_project_id = projects[0]["id"]

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -329,10 +329,8 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         ]
         return done_states
 
-    def get_issue_display_name(self, external_issue):
-        if external_issue.metadata is None:
-            return ""
-        return external_issue.metadata["display_name"]
+    def get_issue_display_name(self, external_issue: ExternalIssue) -> str:
+        return (external_issue.metadata or {}).get("display_name", "")
 
     def create_comment(self, issue_id: str, user_id: int, group_note: Activity) -> Response:
         comment = group_note.data["text"]

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -13,7 +13,8 @@ from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 if TYPE_CHECKING:
     from sentry.models import ExternalIssue, Group
 
-class VstsIssueSync(IssueSyncMixin):
+
+class VstsIssueSync(IssueSyncMixin):  # type: ignore
     description = "Integrate Azure DevOps work items by linking a project."
     slug = "vsts"
     conf_key = slug

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -116,8 +116,8 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
             # Workitems (issues) are associated with the project not the repository.
         default_project, project_choices = self.get_project_choices(group, **kwargs)
 
-        work_item_choices = []
-        default_work_item = None
+        work_item_choices: Sequence[Tuple[str, str]] = []
+        default_work_item: Optional[str] = None
         if default_project:
             default_work_item, work_item_choices = self.get_work_item_choices(
                 default_project, group

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -1,13 +1,17 @@
 from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from mistune import markdown
+from rest_framework.response import Response
 
 from sentry.integrations.issues import IssueSyncMixin
-from sentry.models import IntegrationExternalProject, OrganizationIntegration, User
+from sentry.models import Activity, IntegrationExternalProject, OrganizationIntegration, User
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 
+if TYPE_CHECKING:
+    from sentry.models import ExternalIssue, Group
 
 class VstsIssueSync(IssueSyncMixin):
     description = "Integrate Azure DevOps work items by linking a project."
@@ -17,15 +21,17 @@ class VstsIssueSync(IssueSyncMixin):
     issue_fields = frozenset(["id", "title", "url"])
     done_categories = frozenset(["Resolved", "Completed", "Closed"])
 
-    def get_persisted_default_config_fields(self):
+    def get_persisted_default_config_fields(self) -> Sequence[str]:
         return ["project", "work_item_type"]
 
-    def create_default_repo_choice(self, default_repo):
+    def create_default_repo_choice(self, default_repo: str) -> Tuple[str, str]:
         # default_repo should be the project_id
         project = self.get_client().get_project(self.instance, default_repo)
         return (project["id"], project["name"])
 
-    def get_project_choices(self, group=None, **kwargs):
+    def get_project_choices(
+        self, group: Optional[Group] = None, **kwargs: Any
+    ) -> Tuple[Optional[str], Sequence[Tuple[str, str]]]:
         client = self.get_client()
         try:
             projects = client.get_projects(self.instance)
@@ -63,7 +69,9 @@ class VstsIssueSync(IssueSyncMixin):
 
         return default_project, project_choices
 
-    def get_work_item_choices(self, project, group=None):
+    def get_work_item_choices(
+        self, project: str, group: Optional[Group] = None
+    ) -> Tuple[Optional[str], Sequence[Tuple[str, str]]]:
         client = self.get_client()
         try:
             item_categories = client.get_work_item_categories(self.instance, project)["value"]
@@ -93,10 +101,12 @@ class VstsIssueSync(IssueSyncMixin):
 
         return default_item_type, item_tuples
 
-    def get_create_issue_config_no_group(self, project):
+    def get_create_issue_config_no_group(self, project: str) -> Sequence[Mapping[str, Any]]:
         return self.get_create_issue_config(None, None, project=project)
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(
+        self, group: Optional[Group], user: Optional[User], **kwargs: Any
+    ) -> Sequence[Mapping[str, Any]]:
         kwargs["link_referrer"] = "vsts_integration"
         fields = []
         if group:
@@ -134,8 +144,8 @@ class VstsIssueSync(IssueSyncMixin):
             },
         ] + fields
 
-    def get_link_issue_config(self, group, **kwargs):
-        fields = super().get_link_issue_config(group, **kwargs)
+    def get_link_issue_config(self, group: Group, **kwargs: Any) -> Sequence[Mapping[str, str]]:
+        fields: Sequence[MutableMapping[str, str]] = super().get_link_issue_config(group, **kwargs)
         org = group.organization
         autocomplete_url = reverse("sentry-extensions-vsts-search", args=[org.slug, self.model.id])
         for field in fields:
@@ -144,10 +154,10 @@ class VstsIssueSync(IssueSyncMixin):
                 field["type"] = "select"
         return fields
 
-    def get_issue_url(self, key, **kwargs):
+    def get_issue_url(self, key: str, **kwargs: Any) -> str:
         return f"{self.instance}_workitems/edit/{key}"
 
-    def create_issue(self, data, **kwargs):
+    def create_issue(self, data: Mapping[str, str], **kwargs: Any) -> Mapping[str, Any]:
         """
         Creates the issue on the remote service and returns an issue ID.
         """
@@ -182,7 +192,7 @@ class VstsIssueSync(IssueSyncMixin):
             "metadata": {"display_name": "{}#{}".format(project_name, created_item["id"])},
         }
 
-    def get_issue(self, issue_id, **kwargs):
+    def get_issue(self, issue_id: str, **kwargs: Any) -> Mapping[str, Any]:
         client = self.get_client()
         work_item = client.get_work_item(self.instance, issue_id)
         return {
@@ -196,7 +206,9 @@ class VstsIssueSync(IssueSyncMixin):
             },
         }
 
-    def sync_assignee_outbound(self, external_issue, user, assign=True, **kwargs):
+    def sync_assignee_outbound(
+        self, external_issue: ExternalIssue, user: User, assign: bool = True, **kwargs: Any
+    ) -> None:
         client = self.get_client()
         assignee = None
 
@@ -239,7 +251,9 @@ class VstsIssueSync(IssueSyncMixin):
                 },
             )
 
-    def sync_status_outbound(self, external_issue, is_resolved, project_id, **kwargs):
+    def sync_status_outbound(
+        self, external_issue: ExternalIssue, is_resolved: bool, project_id: int, **kwargs: Any
+    ) -> None:
         client = self.get_client()
         work_item = client.get_work_item(self.instance, external_issue.key)
         # For some reason, vsts doesn't include the project id
@@ -291,15 +305,15 @@ class VstsIssueSync(IssueSyncMixin):
                 },
             )
 
-    def should_unresolve(self, data):
+    def should_unresolve(self, data: Mapping[str, str]) -> bool:
         done_states = self.get_done_states(data["project"])
         return not data["new_state"] in done_states or data["old_state"] is None
 
-    def should_resolve(self, data):
+    def should_resolve(self, data: Mapping[str, str]) -> bool:
         done_states = self.get_done_states(data["project"])
         return not data["old_state"] in done_states and data["new_state"] in done_states
 
-    def get_done_states(self, project):
+    def get_done_states(self, project: str) -> Sequence[str]:
         client = self.get_client()
         try:
             all_states = client.get_work_item_states(self.instance, project)["value"]
@@ -319,12 +333,12 @@ class VstsIssueSync(IssueSyncMixin):
             return ""
         return external_issue.metadata["display_name"]
 
-    def create_comment(self, issue_id, user_id, group_note):
+    def create_comment(self, issue_id: str, user_id: int, group_note: Activity) -> Response:
         comment = group_note.data["text"]
         quoted_comment = self.create_comment_attribution(user_id, comment)
         return self.get_client().update_work_item(self.instance, issue_id, comment=quoted_comment)
 
-    def create_comment_attribution(self, user_id, comment_text):
+    def create_comment_attribution(self, user_id: int, comment_text: str) -> str:
         # VSTS uses markdown or xml
         # https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-text-formats
         user = User.objects.get(id=user_id)
@@ -332,6 +346,6 @@ class VstsIssueSync(IssueSyncMixin):
         quoted_comment = f"{attribution}<blockquote>{comment_text}</blockquote>"
         return quoted_comment
 
-    def update_comment(self, issue_id, user_id, group_note):
+    def update_comment(self, issue_id: int, user_id: int, group_note: str) -> None:
         # Azure does not support updating comments.
         pass

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -1,5 +1,7 @@
 import logging
+from typing import Any
 
+from sentry.eventstore.models import Event
 from sentry.rules.actions.base import TicketEventAction
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
@@ -14,12 +16,12 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     provider = "vsts"
     integration_key = "integration"
 
-    def generate_footer(self, rule_url):
+    def generate_footer(self, rule_url: str) -> str:
         return "\nThis work item was automatically created by Sentry via [{}]({})".format(
             self.rule.label,
             absolute_uri(rule_url),
         )
 
     @transaction_start("AzureDevopsCreateTicketAction.after")
-    def after(self, event, state):
+    def after(self, event: Event, state: str) -> Any:
         yield super().after(event, state)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -9,7 +9,7 @@ from sentry.web.decorators import transaction_start
 logger = logging.getLogger("sentry.rules")
 
 
-class AzureDevopsCreateTicketAction(TicketEventAction):
+class AzureDevopsCreateTicketAction(TicketEventAction):  # type: ignore
     label = "Create an Azure DevOps work item in {integration} with these "
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/source-code-mgmt/azure-devops/#issue-sync"

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
-from sentry.models import Integration
+from sentry.integrations import IntegrationInstallation
+from sentry.models import Commit, Integration, Organization, Repository
 from sentry.plugins import providers
 from sentry.shared_integrations.exceptions import IntegrationError
 
@@ -11,7 +13,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
     name = "Azure DevOps"
     logger = logging.getLogger("sentry.integrations.vsts")
 
-    def get_installation(self, integration_id, organization_id):
+    def get_installation(
+        self, integration_id: Optional[int], organization_id: int
+    ) -> IntegrationInstallation:
         if integration_id is None:
             raise IntegrationError("%s requires an integration id." % self.name)
 
@@ -21,7 +25,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
 
         return integration_model.get_installation(organization_id)
 
-    def get_repository_data(self, organization, config):
+    def get_repository_data(
+        self, organization: Organization, config: MutableMapping[str, Any]
+    ) -> Mapping[str, str]:
         installation = self.get_installation(config.get("installation"), organization.id)
         client = installation.get_client()
         instance = installation.instance
@@ -43,7 +49,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
         )
         return config
 
-    def build_repository_config(self, organization, data):
+    def build_repository_config(
+        self, organization: Organization, data: Mapping[str, str]
+    ) -> Mapping[str, Any]:
         return {
             "name": data["name"],
             "external_id": data["external_id"],
@@ -56,7 +64,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
             "integration_id": data["installation"],
         }
 
-    def transform_changes(self, patch_set):
+    def transform_changes(
+        self, patch_set: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, str]]:
         type_mapping = {"add": "A", "delete": "D", "edit": "M"}
         file_changes = []
         # https://docs.microsoft.com/en-us/rest/api/vsts/git/commits/get%20changes#versioncontrolchangetype
@@ -68,7 +78,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
 
         return file_changes
 
-    def zip_commit_data(self, repo, commit_list, organization_id):
+    def zip_commit_data(
+        self, repo: Repository, commit_list: Sequence[Commit], organization_id: int
+    ) -> Sequence[Commit]:
         installation = self.get_installation(repo.integration_id, organization_id)
         client = installation.get_client()
         n = 0
@@ -95,7 +107,10 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
 
         return commit_list
 
-    def compare_commits(self, repo, start_sha, end_sha):
+    def compare_commits(
+        self, repo: Repository, start_sha: Optional[str], end_sha: str
+    ) -> Sequence[Mapping[str, str]]:
+        """TODO(mgaeta): This function is kinda a mess."""
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
         instance = repo.config["instance"]
@@ -111,7 +126,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
         commits = self.zip_commit_data(repo, res["value"], repo.organization_id)
         return self._format_commits(repo, commits)
 
-    def _format_commits(self, repo, commit_list):
+    def _format_commits(
+        self, repo: Repository, commit_list: Sequence[Mapping[str, Any]]
+    ) -> Sequence[Mapping[str, Any]]:
         return [
             {
                 "id": c["commitId"],
@@ -125,5 +142,7 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
             for c in commit_list
         ]
 
-    def repository_external_slug(self, repo):
-        return repo.external_id
+    def repository_external_slug(self, repo: Repository) -> str:
+        # Explicitly typing to satisfy mypy.
+        external_id: str = repo.external_id
+        return external_id

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -23,7 +23,9 @@ class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):  # type: 
             id=integration_id, organizations=organization_id, provider="vsts"
         )
 
-        return integration_model.get_installation(organization_id)
+        # Explicitly typing to satisfy mypy.
+        installation: IntegrationInstallation = integration_model.get_installation(organization_id)
+        return installation
 
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -9,7 +9,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 MAX_COMMIT_DATA_REQUESTS = 90
 
 
-class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):
+class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):  # type: ignore
     name = "Azure DevOps"
     logger = logging.getLogger("sentry.integrations.vsts")
 

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -1,7 +1,8 @@
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.integration import IntegrationEndpoint
-from sentry.models import Integration
+from sentry.models import Integration, Organization
 
 
 class VstsSearchEndpoint(IntegrationEndpoint):

--- a/src/sentry/integrations/vsts/search.py
+++ b/src/sentry/integrations/vsts/search.py
@@ -5,8 +5,8 @@ from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.models import Integration, Organization
 
 
-class VstsSearchEndpoint(IntegrationEndpoint):
-    def get(self, request, organization, integration_id):
+class VstsSearchEndpoint(IntegrationEndpoint):  # type: ignore
+    def get(self, request: Request, organization: Organization, integration_id: int) -> Response:
         try:
             integration = Integration.objects.get(
                 organizations=organization, id=integration_id, provider="vsts"

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -190,9 +190,9 @@ class WorkItemWebhook(Endpoint):  # type: ignore
 
             installation.sync_status_inbound(external_issue_key, data)
 
-    def parse_email(self, email):
-        # TODO(lb): hmm... this looks brittle to me
-        return EMAIL_PARSER.search(email).group(1)
+    def parse_email(self, email: str) -> str:
+        # TODO(mgaeta): This is too brittle and doesn't pass types.
+        return EMAIL_PARSER.search(email).group(1)  # type: ignore
 
     def create_subscription(
         self, instance: str, identity_data: Mapping[str, Any], oauth_redirect_url: str

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -195,7 +195,7 @@ class WorkItemWebhook(Endpoint):  # type: ignore
         return EMAIL_PARSER.search(email).group(1)  # type: ignore
 
     def create_subscription(
-        self, instance: str, identity_data: Mapping[str, Any], oauth_redirect_url: str
+        self, instance: Optional[str], identity_data: Mapping[str, Any], oauth_redirect_url: str
     ) -> Response:
         client = self.get_client(Identity(data=identity_data), oauth_redirect_url)
         shared_secret = generate_token()

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -25,15 +25,15 @@ logger = logging.getLogger("sentry.integrations")
 PROVIDER_KEY = "vsts"
 
 
-class WorkItemWebhook(Endpoint):
+class WorkItemWebhook(Endpoint):  # type: ignore
     authentication_classes = ()
     permission_classes = ()
 
     def get_client(self, identity: Identity, oauth_redirect_url: str) -> VstsApiClient:
         return VstsApiClient(identity, oauth_redirect_url)
 
-    @csrf_exempt
-    def dispatch(self, request, *args, **kwargs):
+    @csrf_exempt  # type: ignore
+    def dispatch(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -1,8 +1,11 @@
 import logging
 import re
+from typing import Any, Mapping, Optional
 
 from django.utils.crypto import constant_time_compare
 from django.views.decorators.csrf import csrf_exempt
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.models import (
@@ -26,14 +29,14 @@ class WorkItemWebhook(Endpoint):
     authentication_classes = ()
     permission_classes = ()
 
-    def get_client(self, identity, oauth_redirect_url):
+    def get_client(self, identity: Identity, oauth_redirect_url: str) -> VstsApiClient:
         return VstsApiClient(identity, oauth_redirect_url)
 
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
-    def post(self, request, *args, **kwargs):
+    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         data = request.data
         try:
             event_type = data["eventType"]
@@ -69,7 +72,7 @@ class WorkItemWebhook(Endpoint):
             self.handle_updated_workitem(data, integration)
         return self.respond()
 
-    def check_webhook_secret(self, request, integration):
+    def check_webhook_secret(self, request: Request, integration: Integration) -> None:
         try:
             integration_secret = integration.metadata["subscription"]["secret"]
             webhook_payload_secret = request.META["HTTP_SHARED_SECRET"]
@@ -126,7 +129,12 @@ class WorkItemWebhook(Endpoint):
         self.handle_assign_to(integration, external_issue_key, assigned_to)
         self.handle_status_change(integration, external_issue_key, status_change, project)
 
-    def handle_assign_to(self, integration, external_issue_key, assigned_to):
+    def handle_assign_to(
+        self,
+        integration: Integration,
+        external_issue_key: str,
+        assigned_to: Optional[Mapping[str, str]],
+    ) -> None:
         if not assigned_to:
             return
         new_value = assigned_to.get("newValue")
@@ -156,7 +164,13 @@ class WorkItemWebhook(Endpoint):
             assign=assign,
         )
 
-    def handle_status_change(self, integration, external_issue_key, status_change, project):
+    def handle_status_change(
+        self,
+        integration: Integration,
+        external_issue_key: str,
+        status_change: Optional[Mapping[str, str]],
+        project: Optional[str],
+    ) -> None:
         if status_change is None:
             return
 
@@ -179,7 +193,9 @@ class WorkItemWebhook(Endpoint):
         # TODO(lb): hmm... this looks brittle to me
         return EMAIL_PARSER.search(email).group(1)
 
-    def create_subscription(self, instance, identity_data, oauth_redirect_url):
+    def create_subscription(
+        self, instance: str, identity_data: Mapping[str, Any], oauth_redirect_url: str
+    ) -> Response:
         client = self.get_client(Identity(data=identity_data), oauth_redirect_url)
         shared_secret = generate_token()
         return client.create_subscription(instance, shared_secret), shared_secret

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -93,8 +93,8 @@ class WorkItemWebhook(Endpoint):  # type: ignore
 
         assert constant_time_compare(integration_secret, webhook_payload_secret)
 
-    def handle_updated_workitem(self, data, integration):
-        project = None
+    def handle_updated_workitem(self, data: Mapping[str, Any], integration: Integration) -> None:
+        project: Optional[str] = None
         try:
             external_issue_key = data["resource"]["workItemId"]
             project = data["resourceContainers"]["project"]["id"]
@@ -137,6 +137,10 @@ class WorkItemWebhook(Endpoint):  # type: ignore
     ) -> None:
         if not assigned_to:
             return
+
+        email: Optional[str] = None
+        assign = False
+
         new_value = assigned_to.get("newValue")
         if new_value is not None:
             try:
@@ -153,9 +157,6 @@ class WorkItemWebhook(Endpoint):  # type: ignore
                 )
                 return  # TODO(lb): return if cannot parse email?
             assign = True
-        else:
-            email = None
-            assign = False
 
         sync_group_assignee_inbound(
             integration=integration,


### PR DESCRIPTION
This PR adds types to `src/sentry/integrations/vsts/`. The code in this directory was pretty straightforward to type but I've pulled out some of the trickier bits into their own commits. For example:
- We use `UNSET = object()` as a placeholder for unset values so that we can still explicitly pass `None` as a parameter.
- We use the variable names `instance`, `base_url`, and `domain_name` interchangeably for an optional string which can be confusing
