### PR TITLE
ref(subscription consumer) Use dynamic sampling rate

### DIFF
--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -10,6 +10,7 @@ from confluent_kafka.admin import AdminClient
 from dateutil.parser import parse as parse_date
 from django.conf import settings
 
+from sentry import options
 from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTION_WRAPPER_SCHEMA
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.tasks import _delete_from_snuba
@@ -21,8 +22,6 @@ logger = logging.getLogger(__name__)
 TQuerySubscriptionCallable = Callable[[Dict[str, Any], QuerySubscription], None]
 
 subscriber_registry: Dict[str, TQuerySubscriptionCallable] = {}
-
-CONSUMER_TRANSACTION_SAMPLE_RATE = 0.01
 
 
 def register_subscriber(
@@ -176,7 +175,7 @@ class QuerySubscriptionConsumer:
             with sentry_sdk.start_transaction(
                 op="handle_message",
                 name="query_subscription_consumer_process_message",
-                sampled=random() <= CONSUMER_TRANSACTION_SAMPLE_RATE,
+                sampled=random() <= options.get("subscriptions-query.sample-rate"),
             ), metrics.timer("snuba_query_subscriber.handle_message"):
                 self.handle_message(message)
 


### PR DESCRIPTION
Use the sentry option "subscriptions-query.sample-rate" which was
added as part of https://github.com/getsentry/sentry/pull/28453 to
control how much transaction data gets sampled