### PR TITLE
ref(ui): Fix duplicate TS types and JS variable declarations

### DIFF
--- a/static/app/components/similarScoreCard.tsx
+++ b/static/app/components/similarScoreCard.tsx
@@ -17,11 +17,13 @@ const scoreComponents = {
   'similarity:*:message:character-5-shingle': t('Log Message'),
 };
 
+type ScoreValue = number | null;
+
 type Props = {
   // we treat the score list keys as opaque as we wish to be able to extend the
   // backend without having to fix UI. Keys not in scoreComponents are grouped
   // into Other anyway
-  scoreList?: [string, number | null][];
+  scoreList?: [string, ScoreValue][];
 };
 
 const SimilarScoreCard = ({scoreList = []}: Props) => {
@@ -70,7 +72,7 @@ const Wrapper = styled('div')`
   margin: ${space(0.25)} 0;
 `;
 
-const Score = styled('div')<{score: Score}>`
+const Score = styled('div')<{score: ScoreValue}>`
   height: 16px;
   width: 48px;
   border-radius: 2px;

--- a/static/app/components/similarScoreCard.tsx
+++ b/static/app/components/similarScoreCard.tsx
@@ -17,13 +17,11 @@ const scoreComponents = {
   'similarity:*:message:character-5-shingle': t('Log Message'),
 };
 
-type Score = number | null;
-
 type Props = {
   // we treat the score list keys as opaque as we wish to be able to extend the
   // backend without having to fix UI. Keys not in scoreComponents are grouped
   // into Other anyway
-  scoreList?: [string, Score][];
+  scoreList?: [string, number | null][];
 };
 
 const SimilarScoreCard = ({scoreList = []}: Props) => {

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -105,8 +105,6 @@ const storeConfig: AlertStoreInterface & Internals = {
   },
 };
 
-type AlertStore = Reflux.Store & AlertStoreInterface;
-
-const AlertStore = Reflux.createStore(storeConfig) as AlertStore;
+const AlertStore = Reflux.createStore(storeConfig) as Reflux.Store & AlertStoreInterface;
 
 export default AlertStore;

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -102,8 +102,7 @@ export function getCommitterStoreKey(
   return `${orgSlug} ${projectSlug} ${eventId}`;
 }
 
-type CommitterStore = Reflux.Store & CommitterStoreInterface;
-
-const CommitterStore = Reflux.createStore(CommitterStoreConfig) as CommitterStore;
+const CommitterStore = Reflux.createStore(CommitterStoreConfig) as Reflux.Store &
+  CommitterStoreInterface;
 
 export default CommitterStore;

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -69,8 +69,7 @@ const configStoreConfig: Reflux.StoreDefinition & ConfigStoreInterface = {
   },
 };
 
-type ConfigStore = Reflux.Store & ConfigStoreInterface;
-
-const ConfigStore = Reflux.createStore(configStoreConfig) as ConfigStore;
+const ConfigStore = Reflux.createStore(configStoreConfig) as Reflux.Store &
+  ConfigStoreInterface;
 
 export default ConfigStore;

--- a/static/app/stores/eventStore.tsx
+++ b/static/app/stores/eventStore.tsx
@@ -98,8 +98,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & EventStoreInterface = {
   },
 };
 
-type EventStore = Reflux.Store & EventStoreInterface;
-
-const EventStore = Reflux.createStore(storeConfig) as EventStore;
+const EventStore = Reflux.createStore(storeConfig) as Reflux.Store & EventStoreInterface;
 
 export default EventStore;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -57,8 +57,7 @@ const formSearchStoreConfig: Reflux.StoreDefinition & Internals & StoreInterface
   },
 };
 
-type FormSearchStore = Reflux.Store & StoreInterface;
-
-const FormSearchStore = Reflux.createStore(formSearchStoreConfig) as FormSearchStore;
+const FormSearchStore = Reflux.createStore(formSearchStoreConfig) as Reflux.Store &
+  StoreInterface;
 
 export default FormSearchStore;

--- a/static/app/stores/globalSelectionStore.tsx
+++ b/static/app/stores/globalSelectionStore.tsx
@@ -37,8 +37,6 @@ type GlobalSelectionStoreInterface = {
   onSave: (data: UpdateData) => void;
 };
 
-type GlobalSelectionStore = Reflux.Store & GlobalSelectionStoreInterface;
-
 const storeConfig: Reflux.StoreDefinition & GlobalSelectionStoreInterface = {
   state: getDefaultSelection(),
 
@@ -162,6 +160,7 @@ const storeConfig: Reflux.StoreDefinition & GlobalSelectionStoreInterface = {
   },
 };
 
-const GlobalSelectionStore = Reflux.createStore(storeConfig) as GlobalSelectionStore;
+const GlobalSelectionStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  GlobalSelectionStoreInterface;
 
 export default GlobalSelectionStore;

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -96,8 +96,6 @@ type GroupStoreInterface = Reflux.StoreDefinition & {
   onPopulateReleases: (itemId: string, releaseData: GroupRelease) => void;
 };
 
-type GroupStore = Reflux.Store & GroupStoreInterface;
-
 const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
   listenables: [GroupActions],
   pendingChanges: new PendingChangeQueue(),
@@ -513,6 +511,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
   },
 };
 
-const GroupStore = Reflux.createStore(storeConfig) as GroupStore;
+const GroupStore = Reflux.createStore(storeConfig) as Reflux.Store & GroupStoreInterface;
 
 export default GroupStore;

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -171,8 +171,6 @@ type Internals = {
   api: Client;
 };
 
-type GroupingStore = Reflux.Store & GroupingStoreInterface;
-
 const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface = {
   listenables: [GroupingActions],
   api: new Client(),
@@ -618,6 +616,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
   },
 };
 
-const GroupingStore = Reflux.createStore(storeConfig) as GroupingStore;
+const GroupingStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  GroupingStoreInterface;
 
 export default GroupingStore;

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -249,8 +249,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
   },
 };
 
-type GuideStore = Reflux.Store & GuideStoreInterface;
-
-const GuideStore = Reflux.createStore(guideStoreConfig) as GuideStore;
+const GuideStore = Reflux.createStore(guideStoreConfig) as Reflux.Store &
+  GuideStoreInterface;
 
 export default GuideStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -131,14 +131,13 @@ const hookStoreConfig: Reflux.StoreDefinition & HookStoreInterface = {
   },
 };
 
-type HookStore = Reflux.Store & HookStoreInterface;
-
 /**
  * HookStore is used to allow extensibility into Sentry's frontend via
  * registration of 'hook functions'.
  *
  * This functionality is primarily used by the SASS sentry.io product.
  */
-const HookStore = Reflux.createStore(hookStoreConfig) as HookStore;
+const HookStore = Reflux.createStore(hookStoreConfig) as Reflux.Store &
+  HookStoreInterface;
 
 export default HookStore;

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -138,8 +138,7 @@ const storeConfig: Reflux.StoreDefinition & IndicatorStoreInterface & Internals 
   },
 };
 
-type IndicatorStore = Reflux.Store & IndicatorStoreInterface;
-
-const IndicatorStore = Reflux.createStore(storeConfig) as IndicatorStore;
+const IndicatorStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  IndicatorStoreInterface;
 
 export default IndicatorStore;

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -143,8 +143,7 @@ const storeConfig: Reflux.StoreDefinition & LatestContextStoreInterface = {
   },
 };
 
-type LatestContextStore = Reflux.Store & LatestContextStoreInterface;
-
-const LatestContextStore = Reflux.createStore(storeConfig) as LatestContextStore;
+const LatestContextStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  LatestContextStoreInterface;
 
 export default LatestContextStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -67,8 +67,7 @@ const memberListStoreConfig: Reflux.StoreDefinition & MemberListStoreInterface =
   },
 };
 
-type MemberListStore = Reflux.Store & MemberListStoreInterface;
-
-const MemberListStore = Reflux.createStore(memberListStoreConfig) as MemberListStore;
+const MemberListStore = Reflux.createStore(memberListStoreConfig) as Reflux.Store &
+  MemberListStoreInterface;
 
 export default MemberListStore;

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -47,8 +47,6 @@ const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {
   },
 };
 
-type ModalStore = Reflux.Store & ModalStoreInterface;
-
-const ModalStore = Reflux.createStore(storeConfig) as ModalStore;
+const ModalStore = Reflux.createStore(storeConfig) as Reflux.Store & ModalStoreInterface;
 
 export default ModalStore;

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -76,11 +76,7 @@ const storeConfig: Reflux.StoreDefinition & OrganizationEnvironmentsStoreInterfa
   },
 };
 
-type OrganizationEnvironmentsStore = Reflux.Store &
+const OrganizationEnvironmentsStore = Reflux.createStore(storeConfig) as Reflux.Store &
   OrganizationEnvironmentsStoreInterface;
-
-const OrganizationEnvironmentsStore = Reflux.createStore(
-  storeConfig
-) as OrganizationEnvironmentsStore;
 
 export default OrganizationEnvironmentsStore;

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -124,8 +124,7 @@ const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {
   },
 };
 
-type OrganizationStore = Reflux.Store & OrganizationStoreInterface;
-
-const OrganizationStore = Reflux.createStore(storeConfig) as OrganizationStore;
+const OrganizationStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  OrganizationStoreInterface;
 
 export default OrganizationStore;

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -17,8 +17,6 @@ type OrganizationsStoreInterface = {
   load: (items: Organization[]) => void;
 };
 
-type OrganizationsStore = Reflux.Store & OrganizationsStoreInterface;
-
 const organizationsStoreConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {
   listenables: [OrganizationsActions],
 
@@ -87,8 +85,7 @@ const organizationsStoreConfig: Reflux.StoreDefinition & OrganizationsStoreInter
   },
 };
 
-const OrganizationsStore = Reflux.createStore(
-  organizationsStoreConfig
-) as OrganizationsStore;
+const OrganizationsStore = Reflux.createStore(organizationsStoreConfig) as Reflux.Store &
+  OrganizationsStoreInterface;
 
 export default OrganizationsStore;

--- a/static/app/stores/pluginsStore.tsx
+++ b/static/app/stores/pluginsStore.tsx
@@ -121,8 +121,7 @@ const PluginStoreConfig: Reflux.StoreDefinition & PluginStoreInterface = {
   },
 };
 
-type PluginStore = Reflux.Store & PluginStoreInterface;
+const PluginStore = Reflux.createStore(PluginStoreConfig) as Reflux.Store &
+  PluginStoreInterface;
 
-const PluginStore = Reflux.createStore(PluginStoreConfig);
-
-export default PluginStore as PluginStore;
+export default PluginStore;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -54,12 +54,11 @@ const preferenceStoreConfig: Reflux.StoreDefinition & PreferenceStoreInterface =
   },
 };
 
-type PreferenceStore = Reflux.Store & PreferenceStoreInterface;
-
 /**
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const PreferenceStore = Reflux.createStore(preferenceStoreConfig) as PreferenceStore;
+const PreferenceStore = Reflux.createStore(preferenceStoreConfig) as Reflux.Store &
+  PreferenceStoreInterface;
 
 export default PreferenceStore;

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -101,8 +101,7 @@ const projectsStatsStore: Reflux.StoreDefinition & ProjectsStatsStoreInterface =
   },
 };
 
-type ProjectsStatsStore = Reflux.Store & ProjectsStatsStoreInterface;
-
-const ProjectsStatsStore = Reflux.createStore(projectsStatsStore) as ProjectsStatsStore;
+const ProjectsStatsStore = Reflux.createStore(projectsStatsStore) as Reflux.Store &
+  ProjectsStatsStoreInterface;
 
 export default ProjectsStatsStore;

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -225,8 +225,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & ProjectsStoreInterface =
   },
 };
 
-type ProjectsStore = Reflux.Store & ProjectsStoreInterface;
-
-const ProjectsStore = Reflux.createStore(storeConfig) as ProjectsStore;
+const ProjectsStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  ProjectsStoreInterface;
 
 export default ProjectsStore;

--- a/static/app/stores/releaseStore.tsx
+++ b/static/app/stores/releaseStore.tsx
@@ -222,8 +222,7 @@ const ReleaseStoreConfig: Reflux.StoreDefinition & ReleaseStoreInterface = {
   },
 };
 
-type ReleaseStore = Reflux.Store & ReleaseStoreInterface;
-
-const ReleaseStore = Reflux.createStore(ReleaseStoreConfig) as ReleaseStore;
+const ReleaseStore = Reflux.createStore(ReleaseStoreConfig) as Reflux.Store &
+  ReleaseStoreInterface;
 
 export default ReleaseStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -81,8 +81,7 @@ export const RepositoryStoreConfig: Reflux.StoreDefinition & RepositoryStoreInte
   },
 };
 
-type RepositoryStore = Reflux.Store & RepositoryStoreInterface;
-
-const RepositoryStore = Reflux.createStore(RepositoryStoreConfig) as RepositoryStore;
+const RepositoryStore = Reflux.createStore(RepositoryStoreConfig) as Reflux.Store &
+  RepositoryStoreInterface;
 
 export default RepositoryStore;

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -230,10 +230,7 @@ const savedSearchesStoreConfig: Reflux.StoreDefinition & SavedSearchesStoreInter
   },
 };
 
-type SavedSearchesStore = Reflux.Store & SavedSearchesStoreInterface;
-
-const SavedSearchesStore = Reflux.createStore(
-  savedSearchesStoreConfig
-) as SavedSearchesStore;
+const SavedSearchesStore = Reflux.createStore(savedSearchesStoreConfig) as Reflux.Store &
+  SavedSearchesStoreInterface;
 
 export default SavedSearchesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -37,8 +37,7 @@ const storeConfig: Reflux.StoreDefinition & SdkUpdatesStoreInterface & Internal 
   },
 };
 
-type SdkUpdatesStore = Reflux.Store & SdkUpdatesStoreInterface;
-
-const SdkUpdatesStore = Reflux.createStore(storeConfig) as SdkUpdatesStore;
+const SdkUpdatesStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  SdkUpdatesStoreInterface;
 
 export default SdkUpdatesStore;

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -118,8 +118,7 @@ const storeConfig: Reflux.StoreDefinition & SelectedGroupStoreInterface & Intern
   },
 };
 
-type SelectedGroupStore = Reflux.Store & SelectedGroupStoreInterface;
-
-const SelectedGroupStore = Reflux.createStore(storeConfig) as SelectedGroupStore;
+const SelectedGroupStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  SelectedGroupStoreInterface;
 
 export default SelectedGroupStore;

--- a/static/app/stores/settingsBreadcrumbStore.tsx
+++ b/static/app/stores/settingsBreadcrumbStore.tsx
@@ -54,10 +54,7 @@ const storeConfig: Reflux.StoreDefinition & SettingsBreadcrumbStoreInterface & I
     },
   };
 
-type SettingsBreadcrumbStore = Reflux.Store & SettingsBreadcrumbStoreInterface;
-
-const SettingsBreadcrumbStore = Reflux.createStore(
-  storeConfig
-) as SettingsBreadcrumbStore;
+const SettingsBreadcrumbStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  SettingsBreadcrumbStoreInterface;
 
 export default SettingsBreadcrumbStore;

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -40,14 +40,11 @@ const sidebarPanelStoreConfig: Reflux.StoreDefinition & SidebarPanelStoreInterfa
   },
 };
 
-type SidebarPanelStore = Reflux.Store & SidebarPanelStoreInterface;
-
 /**
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const SidebarPanelStore = Reflux.createStore(
-  sidebarPanelStoreConfig
-) as SidebarPanelStore;
+const SidebarPanelStore = Reflux.createStore(sidebarPanelStoreConfig) as Reflux.Store &
+  SidebarPanelStoreInterface;
 
 export default SidebarPanelStore;

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -173,8 +173,6 @@ const tagStoreConfig: Reflux.StoreDefinition & TagStoreInterface = {
   },
 };
 
-type TagStore = Reflux.Store & TagStoreInterface;
-
-const TagStore = Reflux.createStore(tagStoreConfig) as TagStore;
+const TagStore = Reflux.createStore(tagStoreConfig) as Reflux.Store & TagStoreInterface;
 
 export default TagStore;

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -120,8 +120,7 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
   },
 };
 
-type TeamStore = Reflux.Store & TeamStoreInterface;
-
-const TeamStore = Reflux.createStore(teamStoreConfig) as TeamStore;
+const TeamStore = Reflux.createStore(teamStoreConfig) as Reflux.Store &
+  TeamStoreInterface;
 
 export default TeamStore;

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -140,7 +140,7 @@ class ProjectContext extends Component<Props, State> {
   );
 
   unsubscribeMembers = MemberListStore.listen(
-    (memberList: MemberListStore['state']) => this.setState({memberList}),
+    (memberList: typeof MemberListStore['state']) => this.setState({memberList}),
     undefined
   );
 

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -42,7 +42,7 @@ import ReleaseHeader from './releaseHeader';
 
 const DEFAULT_FRESH_RELEASE_STATS_PERIOD = '24h';
 
-type ReleaseContext = {
+type ReleaseContextType = {
   release: ReleaseWithHealth;
   project: Required<ReleaseProject>;
   deploys: Deploy[];
@@ -54,7 +54,7 @@ type ReleaseContext = {
   hasHealthData: boolean;
   releaseBounds: ReleaseBounds;
 };
-const ReleaseContext = createContext<ReleaseContext>({} as ReleaseContext);
+const ReleaseContext = createContext<ReleaseContextType>({} as ReleaseContextType);
 
 type RouteParams = {
   orgId: string;

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -74,7 +74,7 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
       <FilterHeader>{t('Filter By')}</FilterHeader>
 
       <FilterLists>
-        <Filters>
+        <FilterList>
           <h3>{t('User Role')}</h3>
           {roles.map(({id, name}) => (
             <label key={id}>
@@ -86,9 +86,9 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
               {name}
             </label>
           ))}
-        </Filters>
+        </FilterList>
 
-        <Filters>
+        <FilterList>
           <h3>{t('Status')}</h3>
           <BooleanFilter
             data-test-id="filter-isInvited"
@@ -111,7 +111,7 @@ const MembersFilter = ({className, roles, query, onChange}: Props) => {
           >
             {t('SSO Linked')}
           </BooleanFilter>
-        </Filters>
+        </FilterList>
       </FilterLists>
     </FilterContainer>
   );
@@ -159,7 +159,7 @@ const FilterLists = styled('div')`
   margin-top: ${space(0.75)};
 `;
 
-const Filters = styled('div')`
+const FilterList = styled('div')`
   display: grid;
   grid-template-rows: repeat(auto-fit, minmax(0, max-content));
   grid-gap: ${space(1)};

--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -43,7 +43,7 @@ function Conditions({conditions, onDelete, onChange}: Props) {
           displayLegacyBrowsers;
 
         return (
-          <Condition key={index}>
+          <ConditionWrapper key={index}>
             <LeftCell>{getInnerNameLabel(category)}</LeftCell>
             <CenterCell>
               {!isABooleanField && (
@@ -77,7 +77,7 @@ function Conditions({conditions, onDelete, onChange}: Props) {
                 }}
               />
             )}
-          </Condition>
+          </ConditionWrapper>
         );
       })}
     </Fragment>
@@ -86,7 +86,7 @@ function Conditions({conditions, onDelete, onChange}: Props) {
 
 export default Conditions;
 
-const Condition = styled('div')`
+const ConditionWrapper = styled('div')`
   display: grid;
   grid-template-columns: 1fr max-content;
   align-items: flex-start;


### PR DESCRIPTION
This fixes the issue where we have a TS type alias with the same identifier as a JS variable. This needs to be fixed so we can upgrade `@typescript/eslint` (see https://github.com/getsentry/eslint-config-sentry/pull/105)