### PR TITLE
fix(test): Fix flakey tooltip on trends

### DIFF
--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -414,6 +414,7 @@ function TrendsListItem(props: TrendsListItemProps) {
               </span>
             </TooltipContent>
           }
+          disableForVisualTest // Disabled tooltip in snapshots because of overlap order issues.
         >
           <RadioLineItem index={index} role="radio">
             <Radio


### PR DESCRIPTION
### Summary
We can fix these by just manually disabling that specific tooltip if it's a low-priority area. Left a comment for future reference.