### PR TITLE
feat(cdc_search): Add more flexible way to add supported queries for the cdc search backend

### DIFF
--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2078,6 +2078,8 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
         self.group2.save()
         self.store_group(self.group2)
         self.run_test("is:unresolved", [self.group1], None)
+        self.run_test("is:resolved", [self.group2], None)
+        self.run_test("is:unresolved is:resolved", [], None)
 
     def test_environment(self):
         self.run_test("is:unresolved", [self.group1], None, environments=[self.env1])


### PR DESCRIPTION
Prior to this pr we just had a single query hardcoded in the backend. This pr introduces
`supported_cdc_conditions` to allow us to list which conditions we want to support, based on the
condition name and optionally, the condition operators.

It also provides `validate_cdc_search_filters`, which is used for validation in the backend, and can
also be used in our selector to determine where to send incoming queries.