### PR TITLE
feat(alert): Add ability to create sessions crash alerts

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -570,8 +570,3 @@ ALERTS_MEMBER_WRITE_DEFAULT = True
 
 # Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
 DataCategory = sentry_relay.DataCategory
-
-# Crash Rate Alerts
-CRASH_RATE_ALERTS_RAW_CUTOFF_SEC = 3600
-CRASH_RATE_ALERTS_RAW_CUTOFF_MIN = 60
-CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS = [30, 60, 120, 240, 720, 1440]

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -570,3 +570,8 @@ ALERTS_MEMBER_WRITE_DEFAULT = True
 
 # Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
 DataCategory = sentry_relay.DataCategory
+
+# Crash Rate Alerts
+CRASH_RATE_ALERTS_RAW_CUTOFF_SEC = 3600
+CRASH_RATE_ALERTS_RAW_CUTOFF_MIN = 60
+CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS = [30, 60, 120, 240, 720, 1440]

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -74,7 +74,6 @@ dataset_valid_event_types = {
     QueryDatasets.TRANSACTIONS: {SnubaQueryEventType.EventType.TRANSACTION},
     QueryDatasets.SESSIONS: {
         SnubaQueryEventType.EventType.SESSION,
-        SnubaQueryEventType.EventType.USER,
     },
 }
 

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -10,10 +10,6 @@ from rest_framework import serializers
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.serializers.rest_framework.environment import EnvironmentField
 from sentry.api.serializers.rest_framework.project import ProjectField
-from sentry.constants import (
-    CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS,
-    CRASH_RATE_ALERTS_RAW_CUTOFF_MIN,
-)
 from sentry.exceptions import InvalidSearchQuery
 from sentry.incidents.logic import (
     CRITICAL_TRIGGER_LABEL,
@@ -79,6 +75,12 @@ dataset_valid_event_types = {
 
 # TODO(davidenwang): eventually we should pass some form of these to the event_search parser to raise an error
 unsupported_queries = {"release:latest"}
+
+# Represents the time window (in minutes) after which we cut off from sessions dataset query
+# granularity of 1 min to 1 hour
+CRASH_RATE_ALERTS_RAW_CUTOFF_MIN = 60
+# Allowed time windows (in minutes) for crash rate alerts
+CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS = [30, 60, 120, 240, 720, 1440]
 
 
 class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2147,6 +2147,11 @@ FUNCTIONS = {
                 ],
             ],
         ),
+        DiscoverFunction(
+            "crash_free_percentage",
+            aggregate=["multiply(minus(1, divide(sessions_crashed, sessions)), 100)", None, None],
+            default_result_type="number",
+        ),
     ]
 }
 

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -23,6 +23,7 @@ query_aggregation_to_snuba = {
 class QueryDatasets(Enum):
     EVENTS = "events"
     TRANSACTIONS = "transactions"
+    SESSIONS = "sessions"
 
 
 class SnubaQuery(Model):
@@ -52,6 +53,7 @@ class SnubaQueryEventType(Model):
         ERROR = 0
         DEFAULT = 1
         TRANSACTION = 2
+        SESSION = 3
 
     snuba_query = FlexibleForeignKey("sentry.SnubaQuery")
     type = models.SmallIntegerField()

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -5,8 +5,6 @@ import sentry_sdk
 from django.utils import timezone
 from snuba_sdk.legacy import json_to_snql
 
-from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.models import Project
 from sentry.search.events.fields import resolve_field_list
 from sentry.search.events.filter import get_filter
 from sentry.snuba.models import QueryDatasets, QuerySubscription
@@ -224,15 +222,10 @@ def _create_in_snuba(subscription):
     }
 
     if Dataset(snuba_query.dataset) == Dataset.Sessions:
-        try:
-            org_id = Project.objects.get(id=subscription.project_id).organization_id
-        except Project.DoesNotExist:
-            raise ResourceDoesNotExist
-
         body.update(
             {
                 "granularity": snuba_filter.rollup,
-                "organization": org_id,
+                "organization": subscription.project.organization_id,
             }
         )
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -986,6 +986,8 @@ def resolve_column(dataset):
         if dataset == Dataset.Discover:
             if isinstance(col, (list, tuple)) or col == "project_id":
                 return col
+        elif dataset == Dataset.Sessions:
+            return col
         else:
             if (
                 col in DATASET_FIELDS[dataset]

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -541,3 +541,134 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
 
         self.assert_alert_rule_serialized(self.two_alert_rule, result[0], skip_dates=True)
         self.assert_alert_rule_serialized(self.yet_another_alert_rule, result[1], skip_dates=True)
+
+
+@freeze_time()
+class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
+    endpoint = "sentry-api-0-project-alert-rules"
+    method = "post"
+
+    def setUp(self):
+        super().setUp()
+        self.valid_alert_rule = {
+            "aggregate": "crash_free_percentage()",
+            "query": "",
+            "timeWindow": "60",
+            "resolveThreshold": 90,
+            "thresholdType": 0,
+            "triggers": [
+                {
+                    "label": "critical",
+                    "alertThreshold": 70,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id}
+                    ],
+                },
+                {
+                    "label": "warning",
+                    "alertThreshold": 80,
+                    "actions": [
+                        {"type": "email", "targetType": "team", "targetIdentifier": self.team.id},
+                        {"type": "email", "targetType": "user", "targetIdentifier": self.user.id},
+                    ],
+                },
+            ],
+            "projects": [self.project.slug],
+            "owner": self.user.id,
+            "name": "JustAValidTestRule",
+            "dataset": "sessions",
+            "eventTypes": ["session"],
+        }
+
+    @fixture
+    def organization(self):
+        return self.create_organization()
+
+    @fixture
+    def project(self):
+        return self.create_project(organization=self.organization)
+
+    @fixture
+    def user(self):
+        return self.create_user()
+
+    def test_simple_crash_rate_alerts_for_sessions(self):
+        # Login
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
+            )
+        assert "id" in resp.data
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+        assert resp.data == serialize(alert_rule, self.user)
+
+    def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
+        # Login
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        self.valid_alert_rule["time_window"] = "90"
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
+            )
+        assert (
+            resp.data["nonFieldErrors"][0]
+            == "Invalid Time Window: Allowed time windows for crash rate alerts are: "
+            "30min, 1h, 2h, 4h, 12h and 24h"
+        )
+
+    @patch(
+        "sentry.integrations.slack.utils.get_channel_id_with_timeout",
+        return_value=("#", None, True),
+    )
+    @patch("sentry.integrations.slack.tasks.find_channel_id_for_alert_rule.apply_async")
+    @patch("sentry.integrations.slack.tasks.uuid4")
+    def test_crash_rate_alerts_kicks_off_slack_async_job(
+        self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
+    ):
+        mock_uuid4.return_value = self.get_mock_uuid()
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
+        self.integration = Integration.objects.create(
+            provider="slack",
+            name="Team A",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        self.integration.add_organization(self.organization, self.user)
+        self.valid_alert_rule["triggers"] = [
+            {
+                "label": "critical",
+                "alertThreshold": 200,
+                "actions": [
+                    {
+                        "type": "slack",
+                        "targetIdentifier": "my-channel",
+                        "targetType": "specific",
+                        "integration": self.integration.id,
+                    }
+                ],
+            },
+        ]
+        with self.feature(["organizations:incidents"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=202, **self.valid_alert_rule
+            )
+        resp.data["uuid"] = "abc123"
+        assert not AlertRule.objects.filter(name="JustAValidTestRule").exists()
+        kwargs = {
+            "organization_id": self.organization.id,
+            "uuid": "abc123",
+            "data": self.valid_alert_rule,
+            "user_id": self.user.id,
+        }
+        mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -555,7 +555,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             "query": "",
             "timeWindow": "60",
             "resolveThreshold": 90,
-            "thresholdType": 0,
+            "thresholdType": 1,
             "triggers": [
                 {
                     "label": "critical",
@@ -613,7 +613,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
         )
         self.login_as(self.user)
-        self.valid_alert_rule["time_window"] = "90"
+        self.valid_alert_rule["timeWindow"] = "90"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
@@ -648,7 +648,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         self.valid_alert_rule["triggers"] = [
             {
                 "label": "critical",
-                "alertThreshold": 200,
+                "alertThreshold": 50,
                 "actions": [
                     {
                         "type": "slack",

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -579,6 +579,11 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             "dataset": "sessions",
             "eventTypes": ["session"],
         }
+        # Login
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        self.login_as(self.user)
 
     @fixture
     def organization(self):
@@ -593,12 +598,6 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         return self.create_user()
 
     def test_simple_crash_rate_alerts_for_sessions(self):
-        # Login
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
-
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
@@ -608,11 +607,6 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
 
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
-        # Login
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.valid_alert_rule["timeWindow"] = "90"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_valid_response(
@@ -634,10 +628,6 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
         mock_uuid4.return_value = self.get_mock_uuid()
-        self.create_member(
-            user=self.user, organization=self.organization, role="owner", teams=[self.team]
-        )
-        self.login_as(self.user)
         self.integration = Integration.objects.create(
             provider="slack",
             name="Team A",

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -169,6 +169,7 @@ def test_get_json_meta_type(field_alias, snuba_type, function, expected):
             r'to_other(release,"asdf @ \"qwer: (3,2)")',
             ("to_other", ["release", r'"asdf @ \"qwer: (3,2)"'], None),
         ),
+        ("crash_free_percentage()", ("crash_free_percentage", [], None)),
     ],
 )
 def test_parse_function(function, expected):
@@ -1066,6 +1067,20 @@ class ResolveFieldListTest(unittest.TestCase):
             ],
             ["minus", ["percentile_range_2", "percentile_range_1"], "trend_difference"],
         ]
+
+    def test_crash_free_percentage(self):
+        fields = ["crash_free_percentage()"]
+        result = resolve_field_list(fields, eventstore.Filter())
+
+        assert result["selected_columns"] == []
+        assert result["aggregations"] == [
+            [
+                "multiply(minus(1, divide(sessions_crashed, sessions)), 100)",
+                None,
+                "crash_free_percentage",
+            ],
+        ]
+        assert result["groupby"] == []
 
     def test_invalid_alias(self):
         bad_function_aliases = [


### PR DESCRIPTION
This PR:
- Adds ability to create crash rate alerts for sessions crash free percentage over time windows of 30min, 1h, 2h, 4h, 12h, 24h
- Adds validation on `time_window` intervals when the requested dataset is the sessions dataset
- Adds granularity/rollup to the snuba query when querying the sessions dataset. Granularity is `60s` when the time_window is `<=1h` and granularity is `3600s` or `1h` for `time_window` greater than 1 hour
- Adds a discover function that contains an aggregation for calculating `crash_free_percentage` of sessions

Open Question:
- `allow_minute_resolution` is usually hidden behind a feature flag, and this flag is used to decide if we query the raw sessions table or the hourly sessions table. 
In Crash Rate Alerts,  for `time_window` intervals <= 1h, we use the raw sessions table, so in this case I see two solutions 
1. Bypass the `allow_minute_resolution` flag for this particular use case
2. Disable `time_window` less than 1h if the feature flag is not enabled

P.S. Some changes are required on snuba side for this to actually work and these are a wip