### PR TITLE
fix(ci): Python deps requires libxmlsec1 to be installed

### DIFF
--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -31,7 +31,7 @@ jobs:
         # brew can be finicky but it does not always means that the rest of the job will fail
         run: |
           # Needed for xmlsec
-          brew install libxml2 libxmlsec1 pkg-config
+          brew install libxmlsec1 pkg-config
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -2,9 +2,9 @@ name: python deps
 on:
   pull_request:
     paths:
-      - '.github/actions/*'
+      - '.github/actions/setup-python/action.yml'
       - '.github/workflows/python-deps.yml'
-      - 'requirements*'
+      - 'requirements-*.txt'
 
 jobs:
   # This workflow makes sure that Python dependencies install correctly for
@@ -27,11 +27,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install Python dependencies
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install libxmlsec1 || brew update; brew install libxmlsec1
+
       - name: Setup Python
         uses: ./.github/actions/setup-python
+        with:
+          # Non-default value since install-py-dev installs all requirements files
+          # We also want to bust the cache if the action and workflow change
+          cache-files-hash: ${{ hashFiles('requirements-*.txt', '.github/actions/setup-python/action.yml', '.github/workflows/python-deps.yml') }}
 
       - name: Install dependencies
         run: |
           python -m venv .venv
           source .venv/bin/activate
           make install-py-dev
+          pip install -r requirements-pre-commit.txt

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          brew info libxmlsec1 > /dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install libxmlsec1 || brew install libxmlsec1
+          brew info libxmlsec1 || HOMEBREW_NO_AUTO_UPDATE=1 brew install libxmlsec1 || brew install libxmlsec1
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -28,9 +28,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install prerequisites
+        # brew can be finicky but it does not always means that the rest of the job will fail
         run: |
           # Needed for xmlsec
-          brew install libxml2 libxmlsec1 pkg-config
+          brew update -q && brew install libxml2 libxmlsec1 pkg-config || exit 0
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -31,7 +31,7 @@ jobs:
         # brew can be finicky but it does not always means that the rest of the job will fail
         run: |
           # Needed for xmlsec
-          brew update -q && brew install libxml2 libxmlsec1 pkg-config || exit 0
+          brew install libxml2 libxmlsec1 pkg-config
 
       - name: Setup Python
         uses: ./.github/actions/setup-python
@@ -45,4 +45,5 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           make install-py-dev
-          pip install -r requirements-pre-commit.txt
+          # This exercises the requirements-pre-commit.txt file
+          make setup-git

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -27,9 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Python dependencies
+      - name: Install prerequisites
         run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install libxmlsec1 || brew update; brew install libxmlsec1
+          brew info libxmlsec1 > /dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install libxmlsec1 || brew install libxmlsec1
 
       - name: Setup Python
         uses: ./.github/actions/setup-python

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -29,7 +29,8 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          brew info libxmlsec1 || HOMEBREW_NO_AUTO_UPDATE=1 brew install libxmlsec1 || brew install libxmlsec1
+          # Needed for xmlsec
+          brew install libxml2 libxmlsec1 pkg-config
 
       - name: Setup Python
         uses: ./.github/actions/setup-python


### PR DESCRIPTION
This is a regression from PR #28352 since the cache for Python deps did not bust,
thus, it used the wheel from the cache (`xmlsec-1.3.11-cp36-cp36m-macosx_10_14_x86_64.whl`).

`xmlsec` does not produce wheels for Mac.