### PR TITLE
ref(demo) Move deletions spawned by sandbox to new deletions

### DIFF
--- a/src/sentry/demo/demo_org_manager.py
+++ b/src/sentry/demo/demo_org_manager.py
@@ -15,10 +15,10 @@ from sentry.models import (
     OrganizationStatus,
     Project,
     ProjectKey,
+    ScheduledDeletion,
     Team,
     User,
 )
-from sentry.tasks.deletion import delete_organization
 from sentry.utils.email import create_fake_email
 
 from .data_population import DataPopulation, populate_org_members
@@ -92,7 +92,7 @@ def create_demo_org(quick=False) -> Organization:
                 # delete the organization if data population fails
                 org.status = OrganizationStatus.PENDING_DELETION
                 org.save()
-                delete_organization.apply_async(kwargs={"object_id": org.id})
+                ScheduledDeletion.schedule(org, days=0)
                 raise
 
         # update the org status now that it's populated

--- a/src/sentry/demo/tasks.py
+++ b/src/sentry/demo/tasks.py
@@ -4,9 +4,8 @@ from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
 
-from sentry.models import Organization, OrganizationStatus, User
+from sentry.models import Organization, OrganizationStatus, ScheduledDeletion, User
 from sentry.tasks.base import instrumented_task
-from sentry.tasks.deletion import delete_organization
 
 from .demo_org_manager import create_demo_org
 from .models import DemoOrganization, DemoOrgStatus
@@ -45,7 +44,7 @@ def delete_users_orgs(**kwargs):
     for org in org_list:
         # apply async so if so we continue if one org aborts
         logger.info("delete_initializing_orgs.delete", extra={"organization_slug": org.slug})
-        delete_organization.apply_async(kwargs={"object_id": org.id})
+        ScheduledDeletion.schedule(org, days=0)
 
 
 @instrumented_task(
@@ -77,7 +76,7 @@ def delete_initializing_orgs(**kwargs):
     for org in org_list:
         # apply async so if so we continue if one org aborts
         logger.info("delete_initializing_orgs.delete", extra={"organization_slug": org.slug})
-        delete_organization.apply_async(kwargs={"object_id": org.id})
+        ScheduledDeletion.schedule(org, days=0)
 
     # build up the org buffer at the end to replace the orgs being removed
     build_up_org_buffer()

--- a/tests/sentry/demo/test_tasks.py
+++ b/tests/sentry/demo/test_tasks.py
@@ -3,7 +3,7 @@ from django.test import override_settings
 
 from sentry.demo.models import DemoOrganization, DemoOrgStatus, DemoUser
 from sentry.demo.tasks import build_up_org_buffer, delete_initializing_orgs, delete_users_orgs
-from sentry.models import Organization, User
+from sentry.models import Organization, OrganizationStatus, User
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.compat import mock
@@ -39,7 +39,7 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
         with self.tasks():
             delete_users_orgs()
 
-        assert not Organization.objects.filter(id=org.id).exists()
+        assert not Organization.objects.filter(id=org.id, status=OrganizationStatus.ACTIVE).exists()
         assert not User.objects.filter(id=user.id).exists()
 
     @override_settings(DEMO_MODE=False)
@@ -147,7 +147,9 @@ class DeleteInitializingOrgTest(DemoTaskBaseClass):
         with self.tasks():
             delete_initializing_orgs()
 
-        assert not Organization.objects.filter(id=org1.id).exists()
+        assert not Organization.objects.filter(
+            id=org1.id, status=OrganizationStatus.ACTIVE
+        ).exists()
         assert Organization.objects.filter(id=org2.id).exists()
         assert Organization.objects.filter(id=org3.id).exists()
 


### PR DESCRIPTION
Make deletions done by sandbox creation use scheduled deletions. This should help ensure demo accounts are removed more consistently.