### PR TITLE
ref(codeowners): Change beta badge to new badge

### DIFF
--- a/static/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/static/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -57,7 +57,7 @@ const OwnershipRules = ({
     <Container dashedBorder>
       <HeaderContainer>
         <Header>{t('Codeowners sync')}</Header>{' '}
-        <FeatureBadge style={{top: -3}} type="beta" noTooltip />
+        <FeatureBadge style={{top: -3}} type="new" noTooltip />
         <DismissButton
           icon={<IconClose size="xs" />}
           priority="link"

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -50,7 +50,7 @@ export default function getConfiguration({
           path: `${pathPrefix}/ownership/`,
           title: t('Issue Owners'),
           description: t('Manage issue ownership rules for a project'),
-          badge: () => 'beta',
+          badge: () => 'new',
         },
         {
           path: `${pathPrefix}/data-forwarding/`,

--- a/static/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -72,7 +72,6 @@ class CodeOwnersPanel extends Component<Props> {
             dateUpdated={dateUpdated}
             provider={provider}
             repoName={codeMapping?.repoName}
-            beta
             controls={[
               <Button
                 key="sync"

--- a/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -63,7 +63,7 @@ class RulesPanel extends React.Component<Props, State> {
               {this.renderIcon(provider ?? '')}
               <Title>{this.renderTitle()}</Title>
               {repoName && <Repository>{`- ${repoName}`}</Repository>}
-              {<FeatureBadge type="new" />}
+              <FeatureBadge type="new" />
             </Container>,
             <Container key="control">
               <SyncDate>

--- a/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -15,7 +15,6 @@ type Props = {
   dateUpdated: string | null;
   provider?: string;
   repoName?: string;
-  beta?: boolean;
   type: 'codeowners' | 'issueowners';
   placeholder?: string;
   controls?: React.ReactNode[];
@@ -54,7 +53,6 @@ class RulesPanel extends React.Component<Props, State> {
       repoName,
       placeholder,
       controls,
-      beta,
       ['data-test-id']: dataTestId,
     } = this.props;
     return (
@@ -65,7 +63,7 @@ class RulesPanel extends React.Component<Props, State> {
               {this.renderIcon(provider ?? '')}
               <Title>{this.renderTitle()}</Title>
               {repoName && <Repository>{`- ${repoName}`}</Repository>}
-              {beta && <FeatureBadge type="beta" />}
+              {<FeatureBadge type="new" />}
             </Container>,
             <Container key="control">
               <SyncDate>


### PR DESCRIPTION
Update the "beta" badge (the little pill thing) for codeowners features to say "new" instead. 