### PR TITLE
fix(dashboards): added error capture for dashboard dereferencing issue

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -2,6 +2,7 @@ import {CSSProperties} from 'react';
 import * as React from 'react';
 import {components, OptionProps, SingleValueProps} from 'react-select';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import cloneDeep from 'lodash/cloneDeep';
 
 import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
@@ -101,18 +102,32 @@ type OptionType = {
 
 class QueryField extends React.Component<Props> {
   FieldSelectComponents = {
-    Option: ({label, data, ...props}: OptionProps<OptionType>) => (
-      <components.Option label={label} data={data} {...props}>
-        <span data-test-id="label">{label}</span>
-        {this.renderTag(data.value.kind)}
-      </components.Option>
-    ),
-    SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => (
-      <components.SingleValue data={data} {...props}>
-        <span data-test-id="label">{data.label}</span>
-        {this.renderTag(data.value.kind)}
-      </components.SingleValue>
-    ),
+    Option: ({label, data, ...props}: OptionProps<OptionType>) => {
+      if (data.value === undefined)
+        Sentry.withScope(scope => {
+          scope.setExtra('data', data);
+          Sentry.captureException(new Error('Value missing from field option data'));
+        });
+      return (
+        <components.Option label={label} data={data} {...props}>
+          <span data-test-id="label">{label}</span>
+          {this.renderTag(data.value.kind)}
+        </components.Option>
+      );
+    },
+    SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => {
+      if (data.value === undefined)
+        Sentry.withScope(scope => {
+          scope.setExtra('data', data);
+          Sentry.captureException(new Error('Value missing from field option data'));
+        });
+      return (
+        <components.SingleValue data={data} {...props}>
+          <span data-test-id="label">{data.label}</span>
+          {this.renderTag(data.value.kind)}
+        </components.SingleValue>
+      );
+    },
   };
 
   FieldSelectStyles = {

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -103,11 +103,12 @@ type OptionType = {
 class QueryField extends React.Component<Props> {
   FieldSelectComponents = {
     Option: ({label, data, ...props}: OptionProps<OptionType>) => {
-      if (data.value === undefined)
+      if (!data.value) {
         Sentry.withScope(scope => {
           scope.setExtra('data', data);
           Sentry.captureException(new Error('Value missing from field option data'));
         });
+      }
       return (
         <components.Option label={label} data={data} {...props}>
           <span data-test-id="label">{label}</span>
@@ -116,11 +117,12 @@ class QueryField extends React.Component<Props> {
       );
     },
     SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => {
-      if (data.value === undefined)
+      if (!data.value) {
         Sentry.withScope(scope => {
           scope.setExtra('data', data);
           Sentry.captureException(new Error('Value missing from field option data'));
         });
+      }
       return (
         <components.SingleValue data={data} {...props}>
           <span data-test-id="label">{data.label}</span>


### PR DESCRIPTION
Added error capturing on `data` when `value` is `undefined` to debug.