### PR TITLE
refs(service_delegator): Add a generic function for reporting metrics on backend results

### DIFF
--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -3,6 +3,7 @@ import inspect
 import itertools
 import logging
 import threading
+from concurrent import futures
 from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Type, TypeVar
 
 from django.utils.functional import LazyObject, empty
@@ -13,6 +14,8 @@ from sentry.utils.concurrent import Executor, FutureSet, ThreadedExecutor, Timed
 from .imports import import_string
 
 logger = logging.getLogger(__name__)
+
+STATUS_SUCCESS = "success"
 
 
 def raises(exceptions):
@@ -444,3 +447,129 @@ class ServiceDelegator(Delegator, Service):
     def setup(self):
         for backend, executor in self.backends.values():
             backend.setup()
+
+
+def get_invalid_timing_reason(timing: Tuple[Optional[float], Optional[float]]) -> str:
+    start, stop = timing
+    if start is None and stop is None:
+        return "no_data"
+    elif start is None:
+        return "no_start"
+    elif stop is None:
+        return "no_stop"
+    else:
+        raise Exception("unexpected value for timing")
+
+
+def get_future_status(future: TimedFuture) -> str:
+    try:
+        future.result(timeout=0)
+        return STATUS_SUCCESS
+    except futures.CancelledError:
+        return "cancelled"  # neither succeeded nor failed
+    except futures.TimeoutError:
+        raise  # tried to check before ready
+    except Exception:
+        return "failure"
+
+
+def callback_timing(
+    context: Context,
+    method_name: str,
+    callargs: Mapping[str, Any],
+    backend_names: Sequence[str],
+    results: Sequence[TimedFuture],
+    metric_name: str,
+    result_comparator: Optional[Callable[[str, str, str, Any, Any], Mapping[str, str]]] = None,
+) -> None:
+    """
+    Collects timing stats on results returned to the callback method of a `ServiceDelegator`. Either
+    partial this and pass it directly as the `callback_func` or
+    :param metric_name: Prefix to use when writing these timing metrics to Datadog
+    :param method_name: method_name passed to callback
+    :param backend_names: backend_names passed to callback
+    :param results: results passed to callback
+    :param result_comparator: An optional comparator to compare the primary result to each secondary
+    result. Should return a string that represents the result of the comparison. This will be stored
+    as the `match` tag on the metrics.
+    :return:
+    """
+    if not len(backend_names) > 1:
+        return
+    primary_backend_name = backend_names[0]
+    primary_future = results[0]
+    primary_status = get_future_status(primary_future)
+    primary_timing = primary_future.get_timing()
+
+    # If either endpoint of the timing data is not set, just ignore this call.
+    # This really shouldn't happen on the primary backend, but playing it safe
+    # here out of an abundance of caution.
+    if not all(primary_timing):
+        logger.warning("Recieved timing with unexpected endpoint: %r", primary_timing)
+        return
+
+    primary_duration_ms = (primary_timing[1] - primary_timing[0]) * 1000
+
+    metrics.timing(
+        f"{metric_name}.timing_ms",
+        primary_duration_ms,
+        tags={
+            "method": method_name,
+            "backend": primary_backend_name,
+            "status": primary_status,
+            "primary": "true",
+        },
+    )
+
+    for i, secondary_backend_name in enumerate(backend_names[1:], 1):
+        secondary_future = results[i]
+        secondary_timing = secondary_future.get_timing()
+        secondary_status = get_future_status(secondary_future)
+
+        tags = {
+            "method": method_name,
+            "primary_backend": primary_backend_name,
+            "primary_status": primary_status,
+            "secondary_backend": secondary_backend_name,
+            "secondary_status": secondary_status,
+        }
+
+        if result_comparator:
+            comparator_result = result_comparator(
+                method_name,
+                primary_status,
+                secondary_status,
+                primary_future.result(),
+                secondary_future.result(),
+            )
+            tags.update(comparator_result)
+
+        # If either endpoint of the timing data is not set, this means
+        # something weird happened (more than likely a cancellation.)
+        if not all(secondary_timing):
+            metrics.incr(
+                f"{metric_name}.timing_invalid",
+                tags={**tags, "reason": get_invalid_timing_reason(secondary_timing)},
+            )
+        else:
+            secondary_duration_ms = (secondary_timing[1] - secondary_timing[0]) * 1000
+            metrics.timing(
+                f"{metric_name}.timing_ms",
+                secondary_duration_ms,
+                tags={
+                    "method": method_name,
+                    "backend": secondary_backend_name,
+                    "status": secondary_status,
+                    "primary": "false",
+                },
+            )
+            metrics.timing(
+                f"{metric_name}.timing_delta_ms",
+                secondary_duration_ms - primary_duration_ms,
+                tags=tags,
+            )
+            metrics.timing(
+                f"{metric_name}.timing_relative_delta",
+                secondary_duration_ms / primary_duration_ms,
+                tags=tags,
+            )

--- a/src/sentry/utils/services.py
+++ b/src/sentry/utils/services.py
@@ -490,8 +490,8 @@ def callback_timing(
     :param backend_names: backend_names passed to callback
     :param results: results passed to callback
     :param result_comparator: An optional comparator to compare the primary result to each secondary
-    result. Should return a string that represents the result of the comparison. This will be stored
-    as the `match` tag on the metrics.
+    result. Should return a dict represents the result of the comparison. This will be merged into
+    tags to be stored in the metrics backend.
     :return:
     """
     if not len(backend_names) > 1:


### PR DESCRIPTION
This takes the timing code from https://github.com/getsentry/getsentry/blob/0a0dc08b627635deae8be383a7a45df3211f9226/getsentry/processingstore.py#L123
 and makes it more abstract. It's mostly unchanged, we just allow the metric we write to to be
specified by a parameter, and also provide an optional comparator for results, which is only 
used in the processingstore callback function.

We also flipped the order of operations for comparison as discussed here: https://github.com/getsentry/getsentry/pull/6218#discussion_r706373307

The original code for this doesn't have tests, I'm probably not going to add them here since I'm
short on time for cdc issue search.