### PR TITLE
chore(cdc_search): Remove unused `query` and `active_at` fields.

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -31,7 +31,7 @@ issue_search_config = SearchConfig.create_from(
     allow_boolean=False,
     is_filter_translation=is_filter_translation,
     numeric_keys=default_config.numeric_keys | {"times_seen"},
-    date_keys=default_config.date_keys | {"active_at", "date"},
+    date_keys=default_config.date_keys | {"date"},
     key_mappings={
         "assigned_to": ["assigned"],
         "bookmarked_by": ["bookmarks"],
@@ -40,7 +40,6 @@ issue_search_config = SearchConfig.create_from(
         "first_release": ["first-release", "firstRelease"],
         "first_seen": ["age", "firstSeen"],
         "last_seen": ["lastSeen"],
-        "active_at": ["activeSince"],
         # TODO: Special case this in the backends, since they currently rely
         # on date_from and date_to explicitly
         "date": ["event.timestamp"],

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -721,7 +721,6 @@ class SharedGroupSerializer(GroupSerializer):
 
 class GroupSerializerSnuba(GroupSerializerBase):
     skip_snuba_fields = {
-        "query",
         "status",
         "bookmarked_by",
         "assigned_to",
@@ -730,7 +729,6 @@ class GroupSerializerSnuba(GroupSerializerBase):
         "unassigned",
         "linked",
         "subscribed_by",
-        "active_at",
         "first_release",
         "first_seen",
         "last_seen",

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -462,7 +462,6 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
                     ).values_list("group")
                 )
             ),
-            "active_at": ScalarCondition("active_at"),
             "for_review": QCallbackCondition(functools.partial(inbox_filter, projects=projects)),
             "assigned_or_suggested": QCallbackCondition(
                 functools.partial(assigned_or_suggested_filter, projects=projects)

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -257,7 +257,6 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
     logger = logging.getLogger("sentry.search.postgressnuba")
     dependency_aggregations = {"priority": ["last_seen", "times_seen"]}
     postgres_only_fields = {
-        "query",
         "status",
         "for_review",
         "assigned_or_suggested",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -265,7 +265,6 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "unassigned",
         "linked",
         "subscribed_by",
-        "active_at",
         "first_release",
         "first_seen",
     }
@@ -387,7 +386,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             # If the pre-filter query didn't include anything to significantly
             # filter down the number of results (from 'first_release', 'query',
             # 'status', 'bookmarked_by', 'assigned_to', 'unassigned',
-            # 'subscribed_by', 'active_at_from', or 'active_at_to') then it
+            # or 'subscribed_by') then it
             # might have surpassed the `max_candidates`. In this case,
             # we *don't* want to pass candidates down to Snuba, and instead we
             # want Snuba to do all the filtering/sorting it can and *then* apply

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -384,10 +384,9 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
             return self.empty_result
         elif len(group_ids) > max_candidates:
             # If the pre-filter query didn't include anything to significantly
-            # filter down the number of results (from 'first_release', 'query',
-            # 'status', 'bookmarked_by', 'assigned_to', 'unassigned',
-            # or 'subscribed_by') then it
-            # might have surpassed the `max_candidates`. In this case,
+            # filter down the number of results (from 'first_release', 'status',
+            # 'bookmarked_by', 'assigned_to', 'unassigned', or 'subscribed_by')
+            # then it might have surpassed the `max_candidates`. In this case,
             # we *don't* want to pass candidates down to Snuba, and instead we
             # want Snuba to do all the filtering/sorting it can and *then* apply
             # this queryset to the results from Snuba, which we call

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -536,13 +536,6 @@ class ParseQueryTest(TestCase):
         assert result["date_to"] == date_value + timedelta(minutes=6)
         assert not result["date_to_inclusive"]
 
-    def test_active_range(self):
-        result = self.parse_query("activeSince:-24h activeSince:+12h")
-        assert result["active_at_from"] > timezone.now() - timedelta(hours=25)
-        assert result["active_at_from"] < timezone.now() - timedelta(hours=23)
-        assert result["active_at_to"] > timezone.now() - timedelta(hours=13)
-        assert result["active_at_to"] < timezone.now() - timedelta(hours=11)
-
     def test_last_seen_range(self):
         result = self.parse_query("lastSeen:-24h lastSeen:+12h")
         assert result["last_seen_from"] > timezone.now() - timedelta(hours=25)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1514,7 +1514,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         query = "server:example.com"
         query += " status:unresolved"
-        query += " active_at:" + iso_format(before_now(seconds=350))
         query += " first_seen:" + iso_format(before_now(seconds=500))
 
         self.login_as(user=self.user)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -646,27 +646,6 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         assert list(results) == []
         assert results.hits == 2
 
-    def test_active_at_filter(self):
-        results = self.make_query(
-            search_filter_query="activeSince:>=%s" % date_to_query_format(self.group2.active_at)
-        )
-        assert set(results) == {self.group2}
-
-        results = self.make_query(
-            search_filter_query="activeSince:<=%s"
-            % date_to_query_format(self.group1.active_at + timedelta(minutes=1))
-        )
-        assert set(results) == {self.group1}
-
-        results = self.make_query(
-            search_filter_query="activeSince:>=%s activeSince:<=%s"
-            % (
-                date_to_query_format(self.group1.active_at),
-                date_to_query_format(self.group1.active_at + timedelta(minutes=1)),
-            )
-        )
-        assert set(results) == {self.group1}
-
     def test_age_filter(self):
         results = self.make_query(
             search_filter_query="firstSeen:>=%s" % date_to_query_format(self.group2.first_seen)


### PR DESCRIPTION
Since this is marked as a `postgres_only_field` we never search for a query tag in snuba. But
there's no corresponding `query` filter in postgres, so we're essentially just ignoring this component
of  any search queries that contain `query:<something>`. I don't remember why we added `query`
here originally, just removing now since it doesn't make sense.

I also investigated `active_at` and there is no public documentation on it, no autocomplete, and 
nothing in the `RecentSearch` table, so I think we can safely remove it as well.