### PR TITLE
feat(growth): Add open in discover hooks

### DIFF
--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -39,6 +39,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:events-sidebar-item',
   'feature-disabled:grid-editable-actions',
   'feature-disabled:open-discover',
+  'feature-disabled:open-in-discover',
   'feature-disabled:dashboards-edit',
   'feature-disabled:dashboards-page',
   'feature-disabled:dashboards-sidebar-item',
@@ -76,7 +77,6 @@ const validHookNames = new Set<HookName>([
   'sidebar:item-override',
   'sidebar:organization-dropdown-menu',
   'sidebar:organization-dropdown-menu-bottom',
-  'button:open-in-discover',
 ]);
 
 type HookStoreInterface = {

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -76,6 +76,7 @@ const validHookNames = new Set<HookName>([
   'sidebar:item-override',
   'sidebar:organization-dropdown-menu',
   'sidebar:organization-dropdown-menu-bottom',
+  'button:open-in-discover',
 ]);
 
 type HookStoreInterface = {

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -162,6 +162,7 @@ export type InterfaceChromeHooks = {
   'sidebar:item-label': SidebarItemLabelHook;
   'sidebar:item-override': SidebarItemOverrideHook;
   'help-modal:footer': HelpModalFooterHook;
+  'button:open-in-discover': GenericOrganizationComponentHook;
 };
 
 /**

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -127,6 +127,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:discover-sidebar-item': FeatureDisabledHook;
   'feature-disabled:discover2-page': FeatureDisabledHook;
   'feature-disabled:discover2-sidebar-item': FeatureDisabledHook;
+  'feature-disabled:open-in-discover': FeatureDisabledHook;
   'feature-disabled:events-page': FeatureDisabledHook;
   'feature-disabled:events-sidebar-item': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
@@ -162,7 +163,6 @@ export type InterfaceChromeHooks = {
   'sidebar:item-label': SidebarItemLabelHook;
   'sidebar:item-override': SidebarItemOverrideHook;
   'help-modal:footer': HelpModalFooterHook;
-  'button:open-in-discover': GenericButtonComponentHook;
 };
 
 /**
@@ -197,14 +197,6 @@ type RoutesHook = () => Route[];
  */
 type GenericOrganizationComponentHook = (opts: {
   organization: Organization;
-}) => React.ReactNode;
-
-/**
- * A hook for a generic button component
- */
-type GenericButtonComponentHook = (opts: {
-  organization: Organization;
-  disabled: boolean;
 }) => React.ReactNode;
 
 // TODO(ts): We should correct the organization header hook to conform to the

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -162,7 +162,7 @@ export type InterfaceChromeHooks = {
   'sidebar:item-label': SidebarItemLabelHook;
   'sidebar:item-override': SidebarItemOverrideHook;
   'help-modal:footer': HelpModalFooterHook;
-  'button:open-in-discover': GenericOrganizationComponentHook;
+  'button:open-in-discover': GenericButtonComponentHook;
 };
 
 /**
@@ -197,6 +197,14 @@ type RoutesHook = () => Route[];
  */
 type GenericOrganizationComponentHook = (opts: {
   organization: Organization;
+}) => React.ReactNode;
+
+/**
+ * A hook for a generic button component
+ */
+type GenericButtonComponentHook = (opts: {
+  organization: Organization;
+  disabled: boolean;
 }) => React.ReactNode;
 
 // TODO(ts): We should correct the organization header hook to conform to the

--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -66,6 +66,7 @@ export type GrowthEventParameters = {
   'growth.sample_transaction_docs_link_clicked': {
     project_id: string;
   };
+  'growth.issue_open_in_discover_btn_clicked': {};
 };
 
 type GrowthAnalyticsKey = keyof GrowthEventParameters;
@@ -100,4 +101,6 @@ export const growthEventMap: Record<GrowthAnalyticsKey, string> = {
   'growth.demo_modal_clicked_continue': 'Growth: Demo Modal Clicked Continue',
   'growth.sample_transaction_docs_link_clicked':
     'Growth: Sample Transacton Docs Link Clicked',
+  'growth.issue_open_in_discover_btn_clicked':
+    'Growth: Open in Discover Button in Issue Details clicked',
 };

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -282,7 +282,11 @@ class Actions extends React.Component<Props, State> {
             <GuideAnchor target="open_in_discover">{t('Open in Discover')}</GuideAnchor>
           </ActionButton>
         ) : (
-          <Hook name="button:open-in-discover" organization={organization} />
+          <Hook
+            name="button:open-in-discover"
+            organization={organization}
+            disabled={disabled}
+          />
         )}
 
         <BookmarkButton

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -11,11 +11,11 @@ import {
 import {openReprocessEventModal} from 'app/actionCreators/modal';
 import GroupActions from 'app/actions/groupActions';
 import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
 import ActionButton from 'app/components/actions/button';
 import IgnoreActions from 'app/components/actions/ignore';
 import ResolveActions from 'app/components/actions/resolve';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
-import Hook from 'app/components/hook';
 import Tooltip from 'app/components/tooltip';
 import {IconStar} from 'app/icons';
 import {IconRefresh} from 'app/icons/iconRefresh';
@@ -277,17 +277,15 @@ class Actions extends React.Component<Props, State> {
           />
         )}
 
-        {orgFeatures.has('discover-basic') ? (
+        <Feature
+          hookName="feature-disabled:open-in-discover"
+          features={['discover-basic']}
+          organization={organization}
+        >
           <ActionButton disabled={disabled} to={disabled ? '' : this.getDiscoverUrl()}>
             <GuideAnchor target="open_in_discover">{t('Open in Discover')}</GuideAnchor>
           </ActionButton>
-        ) : (
-          <Hook
-            name="button:open-in-discover"
-            organization={organization}
-            disabled={disabled}
-          />
-        )}
+        </Feature>
 
         <BookmarkButton
           disabled={disabled}

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -15,6 +15,7 @@ import ActionButton from 'app/components/actions/button';
 import IgnoreActions from 'app/components/actions/ignore';
 import ResolveActions from 'app/components/actions/resolve';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
+import Hook from 'app/components/hook';
 import Tooltip from 'app/components/tooltip';
 import {IconStar} from 'app/icons';
 import {IconRefresh} from 'app/icons/iconRefresh';
@@ -276,10 +277,12 @@ class Actions extends React.Component<Props, State> {
           />
         )}
 
-        {orgFeatures.has('discover-basic') && (
+        {orgFeatures.has('discover-basic') ? (
           <ActionButton disabled={disabled} to={disabled ? '' : this.getDiscoverUrl()}>
             <GuideAnchor target="open_in_discover">{t('Open in Discover')}</GuideAnchor>
           </ActionButton>
+        ) : (
+          <Hook name="button:open-in-discover" organization={organization} />
         )}
 
         <BookmarkButton

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -29,6 +29,7 @@ import {
   UpdateResolutionStatus,
 } from 'app/types';
 import {Event} from 'app/types/event';
+import trackAdvancedAnalyticsEvent from 'app/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'app/utils/discover/eventView';
 import {displayReprocessEventAction} from 'app/utils/displayReprocessEventAction';
 import {uniqueId} from 'app/utils/guid';
@@ -282,7 +283,15 @@ class Actions extends React.Component<Props, State> {
           features={['discover-basic']}
           organization={organization}
         >
-          <ActionButton disabled={disabled} to={disabled ? '' : this.getDiscoverUrl()}>
+          <ActionButton
+            disabled={disabled}
+            to={disabled ? '' : this.getDiscoverUrl()}
+            onClick={() => {
+              trackAdvancedAnalyticsEvent('growth.issue_open_in_discover_btn_clicked', {
+                organization,
+              });
+            }}
+          >
             <GuideAnchor target="open_in_discover">{t('Open in Discover')}</GuideAnchor>
           </ActionButton>
         </Feature>


### PR DESCRIPTION
This PR adds hooks for when `discover-basic` feature flag was not enabled.