### PR TITLE
ref(options) Register post process forwarder concurrency options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -353,8 +353,11 @@ register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=False)
 
-# Post process forwarder gets data from Kafka headers
+# Post process forwarder options
+# Gets data from Kafka headers
 register("post-process-forwarder:kafka-headers", default=False)
+# Number of threads to use for post processing
+register("post-process-forwarder:concurrency", default=1)
 
 # Subscription queries sampling rate
 register("subscriptions-query.sample-rate", default=0.01)


### PR DESCRIPTION
Registers the option which would be used to control the concurrency
of the post process forwarder.