### PR TITLE
fix: CDC search filter expect an iterable

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -728,6 +728,8 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         max_hits=None,
     ) -> CursorResult:
 
+        search_filters = search_filters or []
+
         if not validate_cdc_search_filters(search_filters):
             raise InvalidQueryForExecutor("Search filters invalid for this query executor")
 


### PR DESCRIPTION
Search filters needs to be an iterable but it
seems like it sometimes can be None Type. As a
temporary fix, making it an iterable when it's
None.

Fixes: SENTRY-S5F