### PR TITLE
feat(reprocessing): Endpoint to determine reprocessability of an event INGEST-356

### DIFF
--- a/src/sentry/api/endpoints/event_reprocessable.py
+++ b/src/sentry/api/endpoints/event_reprocessable.py
@@ -1,0 +1,64 @@
+import sentry_sdk
+
+from sentry import features
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.reprocessing2 import CannotReprocess, pull_event_data
+
+
+class EventReprocessableEndpoint(ProjectEndpoint):
+    def get(self, request, project, event_id):
+        """
+        Retrieve information about whether an event can be reprocessed.
+        ```````````````````````````````````````````````````````````````
+
+        Returns `{"reprocessable": true}` if the event can be reprocessed, or
+        `{"reprocessable": false, "reason": "<code>"}` if it can't.
+
+        Returns 404 if the reprocessing feature is disabled.
+
+        Only entire issues can be reprocessed using
+        `GroupReprocessingEndpoint`, but we can tell you whether we will even
+        attempt to reprocess a particular event within that issue being
+        reprocessed based on what we know ahead of time.  reprocessable=true
+        means that the event may change in some way, reprocessable=false means
+        that there is no way it will change/improve.
+
+        Note this endpoint inherently suffers from time-of-check-time-of-use
+        problem (time of check=calling this endpoint, time of use=triggering
+        reprocessing) and the fact that event data + attachments is only
+        eventually consistent.
+
+        `<code>` can be:
+
+        * `unprocessed_event.not_found`: Can have many reasons. The event
+          is too old to be reprocessed (very unlikely!) or was not a native
+          event.
+        * `event.not_found`: The event does not exist.
+        * `attachment.not_found`: A required attachment, such as the original
+          minidump, is missing.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          issues belong to.
+        :pparam string project_slug: the slug of the project the event
+                                     belongs to.
+        :pparam string event_id: the id of the event.
+        :auth: required
+        """
+
+        if not features.has(
+            "organizations:reprocessing-v2", project.organization, actor=request.user
+        ):
+            return self.respond(
+                {"error": "This project does not have the reprocessing v2 feature"},
+                status=404,
+            )
+
+        try:
+            pull_event_data(project.id, event_id)
+        except CannotReprocess as e:
+            sentry_sdk.set_tag("reprocessable", "false")
+            sentry_sdk.set_tag("reprocessable.reason", str(e))
+            return self.respond({"reprocessable": False, "reason": str(e)})
+        else:
+            sentry_sdk.set_tag("reprocessable", "true")
+            return self.respond({"reprocessable": True})

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -88,6 +88,7 @@ from .endpoints.event_attachments import EventAttachmentsEndpoint
 from .endpoints.event_file_committers import EventFileCommittersEndpoint
 from .endpoints.event_grouping_info import EventGroupingInfoEndpoint
 from .endpoints.event_owners import EventOwnersEndpoint
+from .endpoints.event_reprocessable import EventReprocessableEndpoint
 from .endpoints.external_team import ExternalTeamEndpoint
 from .endpoints.external_team_details import ExternalTeamDetailsEndpoint
 from .endpoints.external_user import ExternalUserEndpoint
@@ -1599,6 +1600,11 @@ urlpatterns = [
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/events/(?P<event_id>[\w-]+)/attachments/$",
                     EventAttachmentsEndpoint.as_view(),
+                    name="sentry-api-0-event-attachments",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/events/(?P<event_id>[\w-]+)/reprocessable/$",
+                    EventReprocessableEndpoint.as_view(),
                     name="sentry-api-0-event-attachments",
                 ),
                 url(

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -79,6 +79,8 @@ instead of group deletion is:
 
 import hashlib
 import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 import sentry_sdk
 from django.conf import settings
@@ -154,11 +156,15 @@ def backup_unprocessed_event(project, data):
     event_processing_store.store(dict(data), unprocessed=True)
 
 
-def reprocess_event(project_id, event_id, start_time):
+@dataclass
+class ReprocessableEvent:
+    event: Event
+    data: Dict[str, Any]
+    attachments: List[models.EventAttachment]
 
-    from sentry.ingest.ingest_consumer import CACHE_TIMEOUT
+
+def pull_event_data(project_id, event_id) -> ReprocessableEvent:
     from sentry.lang.native.processing import get_required_attachment_types
-    from sentry.tasks.store import preprocess_event_from_reprocessing
 
     with sentry_sdk.start_span(op="reprocess_events.nodestore.get"):
         node_id = Event.generate_node_id(project_id, event_id)
@@ -167,14 +173,15 @@ def reprocess_event(project_id, event_id, start_time):
             node_id = _generate_unprocessed_event_node_id(project_id=project_id, event_id=event_id)
             data = nodestore.get(node_id)
 
-    if data is None:
-        raise CannotReprocess("reprocessing_nodestore.not_found")
-
     with sentry_sdk.start_span(op="reprocess_events.eventstore.get"):
         event = eventstore.get_event_by_id(project_id, event_id)
 
     if event is None:
         raise CannotReprocess("event.not_found")
+
+    # Check data after checking presence of event to avoid too many instances.
+    if data is None:
+        raise CannotReprocess("unprocessed_event.not_found")
 
     required_attachment_types = get_required_attachment_types(data)
     attachments = list(
@@ -185,9 +192,21 @@ def reprocess_event(project_id, event_id, start_time):
     missing_attachment_types = required_attachment_types - {ea.type for ea in attachments}
 
     if missing_attachment_types:
-        raise CannotReprocess(
-            f"attachment.not_found.{'_and_'.join(sorted(missing_attachment_types))}"
-        )
+        raise CannotReprocess("attachment.not_found")
+
+    return ReprocessableEvent(event=event, data=data, attachments=attachments)
+
+
+def reprocess_event(project_id, event_id, start_time):
+
+    from sentry.ingest.ingest_consumer import CACHE_TIMEOUT
+    from sentry.tasks.store import preprocess_event_from_reprocessing
+
+    reprocessable_event = pull_event_data(project_id, event_id)
+
+    data = reprocessable_event.data
+    event = reprocessable_event.event
+    attachments = reprocessable_event.attachments
 
     # Step 1: Fix up the event payload for reprocessing and put it in event
     # cache/event_processing_store

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/actions.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/actions.tsx
@@ -12,7 +12,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import Tooltip from 'app/components/tooltip';
 import {IconDelete, IconDownload, IconEllipsis} from 'app/icons';
 import {t} from 'app/locale';
-import {Organization} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {CandidateDownloadStatus, ImageCandidate} from 'app/types/debugImage';
 
 const noPermissionToDownloadDebugFilesInfo = t(
@@ -30,7 +30,7 @@ type Props = {
   organization: Organization;
   isInternalSource: boolean;
   baseUrl: string;
-  projectId: string;
+  projSlug: Project['slug'];
   onDelete: (debugFileId: string) => void;
 };
 
@@ -39,7 +39,7 @@ function Actions({
   organization,
   isInternalSource,
   baseUrl,
-  projectId,
+  projSlug,
   onDelete,
 }: Props) {
   const {download, location: debugFileId} = candidate;
@@ -50,7 +50,7 @@ function Actions({
   }
 
   const deleted = status === CandidateDownloadStatus.DELETED;
-  const downloadUrl = `${baseUrl}/projects/${organization.slug}/${projectId}/files/dsyms/?id=${debugFileId}`;
+  const downloadUrl = `${baseUrl}/projects/${organization.slug}/${projSlug}/files/dsyms/?id=${debugFileId}`;
 
   const actions = (
     <Role role={organization.debugFilesRole} organization={organization}>

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/index.tsx
@@ -13,7 +13,7 @@ import Information from './information';
 type Props = {
   candidate: ImageCandidate;
   organization: Organization;
-  projectId: Project['slug'];
+  projSlug: Project['slug'];
   baseUrl: string;
   haveCandidatesAtLeastOneAction: boolean;
   hasReprocessWarning: boolean;
@@ -24,7 +24,7 @@ type Props = {
 function Candidate({
   candidate,
   organization,
-  projectId,
+  projSlug,
   baseUrl,
   haveCandidatesAtLeastOneAction,
   hasReprocessWarning,
@@ -54,7 +54,7 @@ function Candidate({
           <Actions
             onDelete={onDelete}
             baseUrl={baseUrl}
-            projectId={projectId}
+            projSlug={projSlug}
             organization={organization}
             candidate={candidate}
             isInternalSource={isInternalSource}

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -33,7 +33,7 @@ type ImageCandidates = Image['candidates'];
 type Props = {
   candidates: ImageCandidates;
   organization: Organization;
-  projectId: Project['id'];
+  projSlug: Project['slug'];
   baseUrl: string;
   isLoading: boolean;
   hasReprocessWarning: boolean;
@@ -288,7 +288,7 @@ class Candidates extends React.Component<Props, State> {
   render() {
     const {
       organization,
-      projectId,
+      projSlug,
       baseUrl,
       onDelete,
       isLoading,
@@ -357,7 +357,7 @@ class Candidates extends React.Component<Props, State> {
               candidate={candidate}
               organization={organization}
               baseUrl={baseUrl}
-              projectId={projectId}
+              projSlug={projSlug}
               eventDateReceived={eventDateReceived}
               hasReprocessWarning={hasReprocessWarning}
               haveCandidatesAtLeastOneAction={haveCandidatesAtLeastOneAction}

--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/reprocessAlert.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/reprocessAlert.tsx
@@ -1,0 +1,96 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Client} from 'app/api';
+import Alert from 'app/components/alert';
+import AlertLink from 'app/components/alertLink';
+import {t} from 'app/locale';
+import {Organization, Project} from 'app/types';
+import {Event} from 'app/types/event';
+
+enum ReprocessableEventReason {
+  // It can have many reasons. The event is too old to be reprocessed (very unlikely!)
+  // or was not a native event.
+  UNPROCESSED_EVENT_NOT_FOUND = 'unprocessed_event.not_found',
+  // The event does not exist.
+  EVENT_NOT_FOUND = 'event.not_found',
+  // A required attachment, such as the original minidump, is missing.
+  ATTACHMENT_NOT_FOUND = 'attachment.not_found',
+}
+
+type ReprocessableEvent = {
+  reprocessable: boolean;
+  reason?: ReprocessableEventReason;
+};
+
+type Props = {
+  onReprocessEvent: () => void;
+  api: Client;
+  orgSlug: Organization['slug'];
+  projSlug: Project['slug'];
+  eventId: Event['id'];
+};
+
+function ReprocessAlert({onReprocessEvent, api, orgSlug, projSlug, eventId}: Props) {
+  const [reprocessableEvent, setReprocessableEvent] = useState<
+    undefined | ReprocessableEvent
+  >();
+
+  useEffect(() => {
+    checkEventReprocessable();
+  }, []);
+
+  async function checkEventReprocessable() {
+    try {
+      const response = await api.requestPromise(
+        `/projects/${orgSlug}/${projSlug}/events/${eventId}/reprocessable/`
+      );
+      setReprocessableEvent(response);
+    } catch {
+      // do nothing
+    }
+  }
+
+  if (!reprocessableEvent) {
+    return null;
+  }
+
+  const {reprocessable, reason} = reprocessableEvent;
+
+  if (reprocessable) {
+    return (
+      <AlertLink
+        priority="warning"
+        size="small"
+        onClick={onReprocessEvent}
+        withoutMarginBottom
+      >
+        {t(
+          'You’ve uploaded new debug files. Reprocess events in this issue to view a better stack trace'
+        )}
+      </AlertLink>
+    );
+  }
+
+  function getAlertInfoMessage() {
+    switch (reason) {
+      case ReprocessableEventReason.EVENT_NOT_FOUND:
+        return t('This event cannot be reprocessed because the event has not been found');
+      case ReprocessableEventReason.ATTACHMENT_NOT_FOUND:
+        return t(
+          'This event cannot be reprocessed because a required attachment is missing'
+        );
+      case ReprocessableEventReason.UNPROCESSED_EVENT_NOT_FOUND:
+      default:
+        return t('This event cannot be reprocessed');
+    }
+  }
+
+  return <StyledAlert type="info">{getAlertInfoMessage()}</StyledAlert>;
+}
+
+export default ReprocessAlert;
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: 0;
+`;

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -215,7 +215,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
       return;
     }
 
-    const {location, organization, projectId, groupId, event} = this.props;
+    const {location, organization, projectId: projSlug, groupId, event} = this.props;
     const {query} = location;
 
     const {imageCodeId, imageDebugId} = query;
@@ -243,7 +243,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
           {...deps}
           image={image}
           organization={organization}
-          projectId={projectId}
+          projSlug={projSlug}
           event={event}
           onReprocessEvent={
             defined(groupId) ? this.handleReprocessEvent(groupId) : undefined

--- a/tests/js/spec/components/events/interfaces/debugMeta-v2/imageDetailsCandidates.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/debugMeta-v2/imageDetailsCandidates.spec.tsx
@@ -9,7 +9,7 @@ import GlobalModal from 'app/components/globalModal';
 
 describe('Debug Meta - Image Details Candidates', function () {
   let wrapper: ReturnType<typeof mountWithTheme>;
-  const projectId = 'foo';
+  const projSlug = 'foo';
   // @ts-expect-error
   const organization = TestStubs.Organization();
   // @ts-expect-error
@@ -23,7 +23,7 @@ describe('Debug Meta - Image Details Candidates', function () {
   beforeAll(async function () {
     // @ts-expect-error
     MockApiClient.addMockResponse({
-      url: `/projects/${organization.slug}/${projectId}/files/dsyms/?debug_id=${debugImage.debug_id}`,
+      url: `/projects/${organization.slug}/${projSlug}/files/dsyms/?debug_id=${debugImage.debug_id}`,
       method: 'GET',
       body: [],
     });
@@ -43,7 +43,7 @@ describe('Debug Meta - Image Details Candidates', function () {
           {...modalProps}
           image={debugImage}
           organization={organization}
-          projectId={projectId}
+          projSlug={projSlug}
           event={event}
         />
       ),

--- a/tests/sentry/api/endpoints/test_event_reprocessable.py
+++ b/tests/sentry/api/endpoints/test_event_reprocessable.py
@@ -1,0 +1,30 @@
+import pytest
+
+from sentry.testutils.helpers import Feature
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+
+@pytest.fixture(autouse=True)
+def reprocessing_feature(monkeypatch):
+    with Feature({"organizations:reprocessing-v2": True}):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def auto_login(settings, client, default_user):
+    assert client.login(username=default_user.username, password="admin")
+
+
+@pytest.mark.django_db
+def test_simple(client, factories, default_project):
+    min_ago = iso_format(before_now(minutes=1))
+    event1 = factories.store_event(
+        data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=default_project.id
+    )
+
+    path = f"/api/0/projects/{event1.project.organization.slug}/{event1.project.slug}/events/{event1.event_id}/reprocessable/"
+
+    response = client.get(path, format="json")
+    assert response.status_code == 200
+    assert not response.data["reprocessable"]
+    assert response.data["reason"] == "unprocessed_event.not_found"

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -408,4 +408,4 @@ def test_nodestore_missing(
             GroupRedirect.objects.get(previous_group_id=old_group.id).group_id == new_event.group_id
         )
 
-    assert logs == ["reprocessing2.reprocessing_nodestore.not_found"]
+    assert logs == ["reprocessing2.unprocessed_event.not_found"]


### PR DESCRIPTION
From the JIRA ticket:

>reprocessing is currently suggested by our DIF view in case there is a new codefile that would match the event. However, what is not taken into account is whether the original minidump still exists that would be required to reprocess. So there's a suggestion to click a button that ends up doing nothing.

this endpoint will help with implementing the extra check in the UI