### PR TITLE
revert: CDC search filter expect an iterable

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -728,8 +728,6 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         max_hits=None,
     ) -> CursorResult:
 
-        search_filters = search_filters or []
-
         if not validate_cdc_search_filters(search_filters):
             raise InvalidQueryForExecutor("Search filters invalid for this query executor")
 


### PR DESCRIPTION
The fix had to be made on [getsentry](https://github.com/getsentry/getsentry/pull/6243/files), not here.