### PR TITLE
fix: Use event.dateReceived as fallback for relative times

### DIFF
--- a/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/app/getAppKnownDataDetails.tsx
@@ -27,7 +27,7 @@ function getAppKnownDataDetails(
       return {
         subject: t('Start Time'),
         value: getRelativeTimeFromEventDateCreated(
-          event.dateCreated,
+          event.dateCreated ? event.dateCreated : event.dateReceived,
           data.app_start_time
         ),
       };

--- a/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
+++ b/static/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
@@ -137,7 +137,10 @@ function getDeviceKnownDataDetails(
     case DeviceKnownDataType.BOOT_TIME:
       return {
         subject: t('Boot Time'),
-        value: getRelativeTimeFromEventDateCreated(event.dateCreated, data.boot_time),
+        value: getRelativeTimeFromEventDateCreated(
+          event.dateCreated ? event.dateCreated : event.dateReceived,
+          data.boot_time
+        ),
       };
     case DeviceKnownDataType.TIMEZONE:
       return {

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -55,7 +55,7 @@ function Modal({
                   })}
                 />
                 {getRelativeTimeFromEventDateCreated(
-                  event.dateCreated,
+                  event.dateCreated ? event.dateCreated : event.dateReceived,
                   dateCreated,
                   false
                 )}

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -176,7 +176,7 @@ type EventBase = {
   eventID: string;
   title: string;
   culprit: string;
-  dateCreated: string;
+  dateCreated?: string;
   dist: string | null;
   metadata: EventMetadata;
   contexts: EventContexts;
@@ -203,7 +203,7 @@ type EventBase = {
   device?: Record<string, any>;
   packages?: Record<string, string>;
   platform?: PlatformType;
-  dateReceived?: string;
+  dateReceived: string;
   endTimestamp?: number;
   userReport?: any;
   sdk?: {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -176,7 +176,6 @@ type EventBase = {
   eventID: string;
   title: string;
   culprit: string;
-  dateCreated?: string;
   dist: string | null;
   metadata: EventMetadata;
   contexts: EventContexts;
@@ -200,6 +199,7 @@ type EventBase = {
   nextEventID?: string;
   groupID?: string;
   context?: Record<string, any>;
+  dateCreated?: string;
   device?: Record<string, any>;
   packages?: Record<string, string>;
   platform?: PlatformType;

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -28,7 +28,14 @@ function NewIssue({sampleEvent, eventCount, organization}: Props) {
         <ExtraInfo>
           <TimeWrapper>
             <StyledIconClock size="11px" />
-            <TimeSince date={sampleEvent.dateCreated} suffix={t('old')} />
+            <TimeSince
+              date={
+                sampleEvent.dateCreated
+                  ? sampleEvent.dateCreated
+                  : sampleEvent.dateReceived
+              }
+              suffix={t('old')}
+            />
           </TimeWrapper>
         </ExtraInfo>
       </EventDetails>


### PR DESCRIPTION
Bruno (@bruno-garcia) has reported that relative times are incorrect for transaction events since these events do not have a `dateCreated` attribute. See https://github.com/getsentry/sentry/blob/d7be6f804df37d6359475fd3723adc10305e3e48/src/sentry/api/serializers/models/event.py#L280-L301

`dateReceived` is used as a fallback.



**Before:**

<img width="726" alt="Screen Shot 2021-09-11 at 12 30 12 PM" src="https://user-images.githubusercontent.com/139499/133098940-77bfb14e-193b-4d94-a40b-ab1da6f3f2c3.png">

**After:**

<img width="693" alt="Screen Shot 2021-09-13 at 10 09 46 AM" src="https://user-images.githubusercontent.com/139499/133098936-de2d276f-7d15-4b24-aecd-8d886b179060.png">