### PR TITLE
Fix(metrics): Make metrics endpoint work with actual data

### DIFF
--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -591,7 +591,12 @@ class SnubaResultConverter:
     def _transform_series(self, groups):
         for data in groups:
             series = data["series"]
-            data["series"] = [series[ts] for ts in sorted(series.keys())]
+            new_series = {}
+            for timestamp in sorted(series.keys()):
+                for key, value in series[timestamp].items():
+                    new_series.setdefault(key, []).append(value)
+
+            data["series"] = new_series
 
     def translate_results(self):
         groups = {}

--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -648,7 +648,11 @@ class SnubaDataSource(IndexMockingDataSource):
 
         snuba_queries = SnubaQueryBuilder(project, query).get_snuba_queries()
         results = {
-            entity: {key: raw_snql_query(query) for key, query in queries.items()}
+            entity: {
+                # TODO: Should we use cache?
+                key: raw_snql_query(query, use_cache=False, referrer=f"api.metrics.{key}")
+                for key, query in queries.items()
+            }
             for entity, queries in snuba_queries.items()
         }
 

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -70,15 +70,17 @@ def test_build_snuba_query(mock_now, mock_now2):
     assert snuba_queries == {
         "metrics_counters": {
             "totals": expected_query("metrics_counters", "value", []),
-            "series": expected_query("metrics_counters", "value", [Column("timestamp")]),
+            "series": expected_query("metrics_counters", "value", [Column("bucketed_time")]),
         },
         "metrics_sets": {
             "totals": expected_query("metrics_sets", "value", []),
-            "series": expected_query("metrics_sets", "value", [Column("timestamp")]),
+            "series": expected_query("metrics_sets", "value", [Column("bucketed_time")]),
         },
         "metrics_distributions": {
             "totals": expected_query("metrics_distributions", "percentiles", []),
-            "series": expected_query("metrics_distributions", "percentiles", [Column("timestamp")]),
+            "series": expected_query(
+                "metrics_distributions", "percentiles", [Column("bucketed_time")]
+            ),
         },
     }
 
@@ -123,25 +125,25 @@ def test_translate_results(_1, _2):
                     {
                         "metric_id": 9,  # session
                         "tags[8]": 4,
-                        "timestamp": datetime(2021, 8, 24, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 24, tzinfo=pytz.utc),
                         "value": 100,
                     },
                     {
                         "metric_id": 9,  # session
                         "tags[8]": 0,
-                        "timestamp": datetime(2021, 8, 24, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 24, tzinfo=pytz.utc),
                         "value": 110,
                     },
                     {
                         "metric_id": 9,  # session
                         "tags[8]": 4,
-                        "timestamp": datetime(2021, 8, 25, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 25, tzinfo=pytz.utc),
                         "value": 200,
                     },
                     {
                         "metric_id": 9,  # session
                         "tags[8]": 0,
-                        "timestamp": datetime(2021, 8, 25, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 25, tzinfo=pytz.utc),
                         "value": 220,
                     },
                 ],
@@ -169,28 +171,28 @@ def test_translate_results(_1, _2):
                     {
                         "metric_id": 7,  # session.duration
                         "tags[8]": 4,
-                        "timestamp": datetime(2021, 8, 24, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 24, tzinfo=pytz.utc),
                         "max": 10.1,
                         "percentiles": [1.1, 2.1, 3.1, 4.1, 5.1],
                     },
                     {
                         "metric_id": 7,  # session.duration
                         "tags[8]": 0,
-                        "timestamp": datetime(2021, 8, 24, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 24, tzinfo=pytz.utc),
                         "max": 20.2,
                         "percentiles": [1.2, 2.2, 3.2, 4.2, 5.2],
                     },
                     {
                         "metric_id": 7,  # session.duration
                         "tags[8]": 4,
-                        "timestamp": datetime(2021, 8, 25, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 25, tzinfo=pytz.utc),
                         "max": 30.3,
                         "percentiles": [1.3, 2.3, 3.3, 4.3, 5.3],
                     },
                     {
                         "metric_id": 7,  # session.duration
                         "tags[8]": 0,
-                        "timestamp": datetime(2021, 8, 25, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 25, tzinfo=pytz.utc),
                         "max": 40.4,
                         "percentiles": [1.4, 2.4, 3.4, 4.4, 5.4],
                     },
@@ -261,13 +263,13 @@ def test_translate_results_missing_slots(_1, _2):
                 "data": [
                     {
                         "metric_id": 9,  # session
-                        "timestamp": datetime(2021, 8, 23, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 23, tzinfo=pytz.utc),
                         "value": 100,
                     },
                     # no data for 2021-08-24
                     {
                         "metric_id": 9,  # session
-                        "timestamp": datetime(2021, 8, 25, tzinfo=pytz.utc),
+                        "bucketed_time": datetime(2021, 8, 25, tzinfo=pytz.utc),
                         "value": 300,
                     },
                 ],

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -208,20 +208,12 @@ def test_translate_results(_1, _2):
                 "p50(session.duration)": 1,
                 "p95(session.duration)": 4,
             },
-            "series": [
-                {
-                    "sum(session)": 100,
-                    "max(session.duration)": 10.1,
-                    "p50(session.duration)": 1.1,
-                    "p95(session.duration)": 4.1,
-                },
-                {
-                    "sum(session)": 200,
-                    "max(session.duration)": 30.3,
-                    "p50(session.duration)": 1.3,
-                    "p95(session.duration)": 4.3,
-                },
-            ],
+            "series": {
+                "sum(session)": [100, 200],
+                "max(session.duration)": [10.1, 30.3],
+                "p50(session.duration)": [1.1, 1.3],
+                "p95(session.duration)": [4.1, 4.3],
+            },
         },
         {
             "by": {"session.status": "abnormal"},
@@ -231,20 +223,12 @@ def test_translate_results(_1, _2):
                 "p50(session.duration)": 1.5,
                 "p95(session.duration)": 4.5,
             },
-            "series": [
-                {
-                    "sum(session)": 110,
-                    "max(session.duration)": 20.2,
-                    "p50(session.duration)": 1.2,
-                    "p95(session.duration)": 4.2,
-                },
-                {
-                    "sum(session)": 220,
-                    "max(session.duration)": 40.4,
-                    "p50(session.duration)": 1.4,
-                    "p95(session.duration)": 4.4,
-                },
-            ],
+            "series": {
+                "sum(session)": [110, 220],
+                "max(session.duration)": [20.2, 40.4],
+                "p50(session.duration)": [1.2, 1.4],
+                "p95(session.duration)": [4.2, 4.4],
+            },
         },
     ]
 
@@ -298,16 +282,9 @@ def test_translate_results_missing_slots(_1, _2):
             "totals": {
                 "sum(session)": 400,
             },
-            "series": [
-                {
-                    "sum(session)": 100,
-                },
-                {  # No data for 2021-08-24
-                    "sum(session)": 0,
-                },
-                {
-                    "sum(session)": 300,
-                },
-            ],
+            "series": {
+                # No data for 2021-08-24
+                "sum(session)": [100, 0, 300],
+            },
         },
     ]


### PR DESCRIPTION
Fix a couple of bugs that surfaced during end-to-end testing of extracted session metrics:

* Use the correct Snuba column for temporal grouping (`bucketed_time` instead of `timestamp`),
* handle missing intervals in Snuba response (intervals where there is no data),
* fix output format to match that of the sessions API (`{"series": {"foo": [1.0]}}` instead of `{"series": [{"foo": 1.0}]}`).

https://getsentry.atlassian.net/browse/INGEST-351