### PR TITLE
feat(spans): Display missing instrumentation docs for react-native

### DIFF
--- a/static/app/components/events/interfaces/spans/inlineDocs.tsx
+++ b/static/app/components/events/interfaces/spans/inlineDocs.tsx
@@ -54,6 +54,10 @@ class InlineDocs extends Component<Props, State> {
         tracingPlatform = 'node-tracing';
         break;
       }
+      case 'sentry.javascript.react-native': {
+        tracingPlatform = 'react-native-tracing';
+        break;
+      }
       default: {
         this.setState({loading: false});
         return;

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -139,7 +139,11 @@ export const sourceMaps: PlatformKey[] = [
   'electron',
 ];
 
-export const tracing = ['python-tracing', 'node-tracing'] as const;
+export const tracing = [
+  'python-tracing',
+  'node-tracing',
+  'react-native-tracing',
+] as const;
 
 export const performance: PlatformKey[] = [
   'javascript',


### PR DESCRIPTION
Corresponding copy was added in https://github.com/getsentry/sentry-docs/pull/4130

**Before:**

<img width="1294" alt="Screen Shot 2021-09-13 at 2 28 32 PM" src="https://user-images.githubusercontent.com/139499/133137361-cc4958dd-0fce-43d5-b0f3-18c280b9d292.png">


**After:**

<img width="1295" alt="Screen Shot 2021-09-13 at 2 27 18 PM" src="https://user-images.githubusercontent.com/139499/133137365-a9102b33-facd-4591-81a2-722013db5e94.png">
