### PR TITLE
fix(team-selector): Make searching more clear

### DIFF
--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -42,11 +42,33 @@ const unassignedOption = {
 
 // Ensures that the svg icon is white when selected
 const unassignedSelectStyles: StylesConfig = {
-  option: (provided, state: any) => ({
+  option: (provided, state) => ({
     ...provided,
     svg: {
       color: state.isSelected && state.theme.white,
     },
+  }),
+};
+
+const placeholderSelectStyles: StylesConfig = {
+  input: (provided, state) => ({
+    ...provided,
+    display: 'grid',
+    gridTemplateColumns: 'max-content 1fr',
+    alignItems: 'center',
+    gridGap: space(1),
+    ':before': {
+      backgroundColor: state.theme.backgroundSecondary,
+      height: 24,
+      width: 24,
+      borderRadius: 3,
+      content: '""',
+      display: 'block',
+    },
+  }),
+  placeholder: provided => ({
+    ...provided,
+    paddingLeft: 32,
   }),
 };
 
@@ -231,6 +253,7 @@ function TeamSelector(props: Props) {
       styles={{
         ...(styles ?? {}),
         ...(includeUnassigned ? unassignedSelectStyles : {}),
+        ...placeholderSelectStyles,
       }}
       {...extraProps}
     />


### PR DESCRIPTION
Uses a placeholder for the icon before the input to match the team icon after selection

![image](https://user-images.githubusercontent.com/1421724/133146914-8fd0e134-51af-4c14-8aa6-11bbd0bbdbe6.png)

![image](https://user-images.githubusercontent.com/1421724/133146939-483d10fc-72ba-4c91-bd97-b01dcfefc70b.png)
