### PR TITLE
fix(webhook): Weird JSON array

### DIFF
--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -97,14 +97,14 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
         for item in data["links"]:
             try:
                 url = item["url"]
-                # We would like to track what types of links users are sharing,
-                # but it's a little difficult to do in sentry since we filter
-                # requests from Slack bots. Instead we just log to Kibana
                 slack_shared_link = parse_link(url)
             except Exception as e:
                 logger.error("slack.parse-link-error", extra={"error": str(e)})
                 continue
 
+            # We would like to track what types of links users are sharing, but
+            # it's a little difficult to do in Sentry because we filter requests
+            # from Slack bots. Instead we just log to Kibana.
             logger.info("slack.link-shared", extra={"slack_shared_link": slack_shared_link})
             link_type, args = match_link(url)
 

--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -94,11 +94,9 @@ class SlackEventEndpoint(SlackDMEndpoint):  # type: ignore
         links_seen = set()
 
         # An unfurl may have multiple links to unfurl
-        for i in range(len(data["links"])):
+        for item in data["links"]:
             try:
-                # Sometimes `links` is an array and sometimes it's a dictionary that
-                # maps indexes to values. In either case this should work.
-                url = data["links"][i]["url"]
+                url = item["url"]
                 # We would like to track what types of links users are sharing,
                 # but it's a little difficult to do in sentry since we filter
                 # requests from Slack bots. Instead we just log to Kibana


### PR DESCRIPTION
For a period of about an hour we were getting malformed JSON data on the Slack Event webhook. When looping over a list of links, we should not crash if any of the URLs are unparsable. So as a baseline we should `continue` if there is a problem. ~~If the list is sent to us as a mapping of indexes to values like:~~
```
{
	0: { "url": ... },
	1: { "url": ... },
	...
}
```
~~then we might as well handle it.~~

Fixes [SENTRY-S5N](https://sentry.io/organizations/sentry/issues/2645983842).