### PR TITLE
feat(alert-rules): Add rule settings modal to alert-rule-actions

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -81,7 +81,12 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                         component=component, install=install, project=project
                     )
                     action_list.append(
-                        serialize(component, request.user, SentryAppAlertRuleActionSerializer())
+                        serialize(
+                            component,
+                            request.user,
+                            SentryAppAlertRuleActionSerializer(),
+                            install=install,
+                        )
                     )
 
                 except APIError:

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -26,5 +26,5 @@ class SentryAppAlertRuleActionSerializer(Serializer):
             "prompt": f"{obj.sentry_app.name}",
             "enabled": True,
             "label": f"{obj.schema.get('title', obj.sentry_app.name)} with these ",
-            "formfields": obj.schema.get("settings", {}),
+            "formFields": obj.schema.get("settings", {}),
         }

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -18,10 +18,11 @@ class SentryAppComponentSerializer(Serializer):
 
 
 class SentryAppAlertRuleActionSerializer(Serializer):
-    def serialize(self, obj, attrs, user, **kwargs):
+    def serialize(self, obj, attrs, user, install, **kwargs):
         return {
             "id": f"sentry.sentryapp.{obj.sentry_app.slug}",
             "uuid": str(obj.uuid),
+            "sentryAppInstallationUuid": f"{install.uuid}",
             "actionType": "sentryapp",
             "prompt": f"{obj.sentry_app.name}",
             "enabled": True,

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -61,7 +61,7 @@ export class SentryAppExternalIssueForm extends Component<Props> {
   render() {
     return (
       <SentryAppExternalForm
-        sentryAppInstallation={this.props.sentryAppInstallation}
+        sentryAppInstallationId={this.props.sentryAppInstallation.uuid}
         appName={this.props.appName}
         config={this.props.config}
         action={this.props.action}

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -7,15 +7,15 @@ import {Event} from 'app/types/event';
 import getStacktraceBody from 'app/utils/getStacktraceBody';
 import {addQueryParamsToExistingUrl} from 'app/utils/queryString';
 import SentryAppExternalForm, {
-  Config,
   FieldFromSchema,
+  SchemaFormConfig,
 } from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type Props = {
   group: Group;
   sentryAppInstallation: SentryAppInstallation;
   appName: string;
-  config: Config;
+  config: SchemaFormConfig;
   action: 'create' | 'link';
   event: Event;
   onSubmitSuccess: (externalIssue: PlatformExternalIssue) => void;

--- a/static/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/static/app/components/group/sentryAppExternalIssueForm.tsx
@@ -61,7 +61,7 @@ export class SentryAppExternalIssueForm extends Component<Props> {
   render() {
     return (
       <SentryAppExternalForm
-        sentryAppInstallationId={this.props.sentryAppInstallation.uuid}
+        sentryAppInstallationUuid={this.props.sentryAppInstallation.uuid}
         appName={this.props.appName}
         config={this.props.config}
         action={this.props.action}

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -1,5 +1,5 @@
 import {IssueConfigField} from 'app/types/index';
-import {Config} from 'app/views/organizationIntegrations/sentryAppExternalForm';
+import {SchemaFormConfig} from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type IssueAlertRuleFormField =
   | {
@@ -33,7 +33,7 @@ export type IssueAlertRuleActionTemplate = {
     | {
         [key: string]: IssueAlertRuleFormField;
       }
-    | Config;
+    | SchemaFormConfig;
   ticketType?: string;
   link?: string;
   sentryAppInstallationUuid?: string;

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -36,6 +36,7 @@ export type IssueAlertRuleActionTemplate = {
     | Config;
   ticketType?: string;
   link?: string;
+  uuid?: string;
 };
 export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;
 

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -37,6 +37,7 @@ export type IssueAlertRuleActionTemplate = {
   ticketType?: string;
   link?: string;
   uuid?: string;
+  sentryAppInstallationUuid?: string;
 };
 export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;
 

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -1,4 +1,5 @@
 import {IssueConfigField} from 'app/types/index';
+import {Config} from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type IssueAlertRuleFormField =
   | {
@@ -28,9 +29,11 @@ export type IssueAlertRuleActionTemplate = {
   prompt: string;
   enabled: boolean;
   actionType?: 'ticket' | 'sentryapp';
-  formFields?: {
-    [key: string]: IssueAlertRuleFormField;
-  };
+  formFields?:
+    | {
+        [key: string]: IssueAlertRuleFormField;
+      }
+    | Config;
   ticketType?: string;
   link?: string;
 };

--- a/static/app/types/alerts.tsx
+++ b/static/app/types/alerts.tsx
@@ -36,7 +36,6 @@ export type IssueAlertRuleActionTemplate = {
     | Config;
   ticketType?: string;
   link?: string;
-  uuid?: string;
   sentryAppInstallationUuid?: string;
 };
 export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -24,7 +24,7 @@ import {
 import MemberTeamFields from 'app/views/alerts/issueRuleEditor/memberTeamFields';
 import SentryAppRuleModal from 'app/views/alerts/issueRuleEditor/sentryAppRuleModal';
 import TicketRuleModal from 'app/views/alerts/issueRuleEditor/ticketRuleModal';
-import {Config} from 'app/views/organizationIntegrations/sentryAppExternalForm';
+import {SchemaFormConfig} from 'app/views/organizationIntegrations/sentryAppExternalForm';
 import {EVENT_FREQUENCY_PERCENT_CONDITION} from 'app/views/projectInstall/issueAlertOptions';
 import Input from 'app/views/settings/components/forms/controls/input';
 
@@ -368,9 +368,8 @@ class RuleNode extends React.Component<Props> {
 
   isSchemaConfig(
     formFields: IssueAlertRuleActionTemplate['formFields']
-  ): formFields is Config {
-    if (!formFields) return false;
-    return (formFields as Config).uri !== undefined;
+  ): formFields is SchemaFormConfig {
+    return !formFields ? false : (formFields as SchemaFormConfig).uri !== undefined;
   }
 
   render() {
@@ -420,7 +419,7 @@ class RuleNode extends React.Component<Props> {
                       <SentryAppRuleModal
                         {...deps}
                         sentryAppInstallationUuid={sentryAppInstallationUuid}
-                        config={node.formFields as Config}
+                        config={node.formFields as SchemaFormConfig}
                         appName={node.prompt}
                         onSubmitSuccess={this.updateParentFromSentryAppRule}
                         // Ignore the `id` field, as that is related to the Rule Node, not the Sentry App

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -366,6 +366,7 @@ class RuleNode extends React.Component<Props> {
     const ticketRule = node?.actionType === 'ticket';
     const sentryAppRule = node?.actionType === 'sentryapp';
     const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
+    console.log({data, node});
     return (
       <RuleRowContainer>
         <RuleRow>
@@ -405,7 +406,7 @@ class RuleNode extends React.Component<Props> {
                   openModal(deps => (
                     <SentryAppRuleModal
                       {...deps}
-                      sentryAppInstallationId={node.uuid || ''}
+                      sentryAppInstallationUuid={node.sentryAppInstallationUuid || ''}
                       config={node.formFields as Config}
                       appName={node.prompt}
                       action="create"

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -366,7 +366,6 @@ class RuleNode extends React.Component<Props> {
     const ticketRule = node?.actionType === 'ticket';
     const sentryAppRule = node?.actionType === 'sentryapp';
     const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
-    console.log({node, data});
     return (
       <RuleRowContainer>
         <RuleRow>
@@ -406,7 +405,7 @@ class RuleNode extends React.Component<Props> {
                   openModal(deps => (
                     <SentryAppRuleModal
                       {...deps}
-                      sentryAppInstallation={null}
+                      sentryAppInstallationId={node.uuid || ''}
                       config={node.formFields as Config}
                       appName={node.prompt}
                       action="create"

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -20,11 +20,12 @@ import {
   IssueAlertRuleConditionTemplate,
   MailActionTargetType,
 } from 'app/types/alerts';
+import MemberTeamFields from 'app/views/alerts/issueRuleEditor/memberTeamFields';
+import SentryAppRuleModal from 'app/views/alerts/issueRuleEditor/sentryAppRuleModal';
+import TicketRuleModal from 'app/views/alerts/issueRuleEditor/ticketRuleModal';
+import {Config} from 'app/views/organizationIntegrations/sentryAppExternalForm';
 import {EVENT_FREQUENCY_PERCENT_CONDITION} from 'app/views/projectInstall/issueAlertOptions';
 import Input from 'app/views/settings/components/forms/controls/input';
-
-import MemberTeamFields from './memberTeamFields';
-import TicketRuleModal from './ticketRuleModal';
 
 export type FormField = {
   // Type of form fields
@@ -327,6 +328,7 @@ class RuleNode extends React.Component<Props> {
    * @param formData Form data
    * @param fetchedFieldOptionsCache Object
    */
+  // Create UpdateParent for new Modal class
   updateParent = (
     formData: {[key: string]: string},
     fetchedFieldOptionsCache: Record<string, Choices>
@@ -352,11 +354,19 @@ class RuleNode extends React.Component<Props> {
     }
   };
 
+  isSchemaConfig(
+    formFields: IssueAlertRuleActionTemplate['formFields']
+  ): formFields is Config {
+    if (!formFields) return false;
+    return (formFields as Config).uri !== undefined;
+  }
+
   render() {
     const {data, disabled, index, node, organization} = this.props;
     const ticketRule = node?.actionType === 'ticket';
     const sentryAppRule = node?.actionType === 'sentryapp';
     const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
+    console.log({node, data});
     return (
       <RuleRowContainer>
         <RuleRow>
@@ -393,7 +403,16 @@ class RuleNode extends React.Component<Props> {
                 icon={<IconSettings size="xs" />}
                 type="button"
                 onClick={() => {
-                  // TODO(nisanthan): Placeholder. Modal will be implemented in next PR.
+                  openModal(deps => (
+                    <SentryAppRuleModal
+                      {...deps}
+                      sentryAppInstallation={null}
+                      config={node.formFields as Config}
+                      appName={node.prompt}
+                      action="create"
+                      onSubmitSuccess={this.updateParent}
+                    />
+                  ));
                 }}
               >
                 {t('Settings')}

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -45,15 +45,7 @@ type Props = {
   onReset: (rowIndex: number, name: string, value: string) => void;
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
-
-type State = {
-  /** Used to preserve values after modal closes, in case of edits */
-  sentryAppFormData: {[key: string]: any};
-};
-
-class RuleNode extends React.Component<Props, State> {
-  state: State = {sentryAppFormData: {}};
-
+class RuleNode extends React.Component<Props> {
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);
@@ -362,13 +354,10 @@ class RuleNode extends React.Component<Props, State> {
 
   /**
    * Update all the AlertRuleAction's fields from the SentryAppRuleModal together
-   * only after the user clicks "Save Changes". Also saves the form state from the modal
-   * to repopulate it if the user makes changes
+   * only after the user clicks "Save Changes".
    * @param formData Form data
-   * @param fetchedFieldOptionsCache Object
    */
   updateParentFromSentryAppRule = (formData: {[key: string]: string}): void => {
-    this.setState({sentryAppFormData: formData});
     const {index, onPropertyChange} = this.props;
 
     for (const [name, value] of Object.entries(formData)) {
@@ -433,7 +422,7 @@ class RuleNode extends React.Component<Props, State> {
                         config={node.formFields as Config}
                         appName={node.prompt}
                         onSubmitSuccess={this.updateParentFromSentryAppRule}
-                        resetValues={this.state.sentryAppFormData}
+                        resetValues={data}
                       />
                     ),
                     {allowClickClose: false}

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -362,9 +362,10 @@ class RuleNode extends React.Component<Props> {
 
   render() {
     const {data, disabled, index, node, organization} = this.props;
-    const ticketRule = node?.actionType === 'ticket';
-    const sentryAppRule = node?.actionType === 'sentryapp';
-    const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
+    const {actionType, id, sentryAppInstallationUuid} = node || {};
+    const ticketRule = actionType === 'ticket';
+    const sentryAppRule = actionType === 'sentryapp' && sentryAppInstallationUuid;
+    const isNew = id === EVENT_FREQUENCY_PERCENT_CONDITION;
     return (
       <RuleRowContainer>
         <RuleRow>
@@ -404,7 +405,7 @@ class RuleNode extends React.Component<Props> {
                   openModal(deps => (
                     <SentryAppRuleModal
                       {...deps}
-                      sentryAppInstallationUuid={node.sentryAppInstallationUuid || ''}
+                      sentryAppInstallationUuid={sentryAppInstallationUuid}
                       config={node.formFields as Config}
                       appName={node.prompt}
                       action="create"

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -328,7 +328,6 @@ class RuleNode extends React.Component<Props> {
    * @param formData Form data
    * @param fetchedFieldOptionsCache Object
    */
-  // Create UpdateParent for new Modal class
   updateParent = (
     formData: {[key: string]: string},
     fetchedFieldOptionsCache: Record<string, Choices>
@@ -366,7 +365,6 @@ class RuleNode extends React.Component<Props> {
     const ticketRule = node?.actionType === 'ticket';
     const sentryAppRule = node?.actionType === 'sentryapp';
     const isNew = node?.id === EVENT_FREQUENCY_PERCENT_CONDITION;
-    console.log({data, node});
     return (
       <RuleRowContainer>
         <RuleRow>

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
+import omit from 'lodash/omit';
 
 import {openModal} from 'app/actionCreators/modal';
 import Alert from 'app/components/alert';
@@ -422,7 +423,8 @@ class RuleNode extends React.Component<Props> {
                         config={node.formFields as Config}
                         appName={node.prompt}
                         onSubmitSuccess={this.updateParentFromSentryAppRule}
-                        resetValues={data}
+                        // Ignore the `id` field, as that is related to the Rule Node, not the Sentry App
+                        resetValues={omit(data, 'id')}
                       />
                     ),
                     {allowClickClose: false}

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import styled from '@emotion/styled';
-import omit from 'lodash/omit';
 
 import {openModal} from 'app/actionCreators/modal';
 import Alert from 'app/components/alert';
@@ -422,8 +421,7 @@ class RuleNode extends React.Component<Props> {
                         config={node.formFields as SchemaFormConfig}
                         appName={node.prompt}
                         onSubmitSuccess={this.updateParentFromSentryAppRule}
-                        // Ignore the `id` field, as that is related to the Rule Node, not the Sentry App
-                        resetValues={omit(data, 'id')}
+                        resetValues={data}
                       />
                     ),
                     {allowClickClose: false}

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Fragment} from 'react';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import {tct} from 'app/locale';
@@ -11,29 +11,32 @@ type Props = ModalRenderProps & {
   appName: string;
   config: Config;
   action: 'create' | 'update';
-  onSubmitSuccess: (...params: any[]) => void;
+  onSubmitSuccess: Function;
 };
 
-class SentryAppRuleModal extends Component<Props> {
-  render() {
-    const {Header, Body, sentryAppInstallationUuid, appName, config, action} = this.props;
-    return (
-      <Fragment>
-        <Header closeButton>{tct('[name] Settings', {name: appName})}</Header>
-        <Body>
-          <SentryAppExternalForm
-            sentryAppInstallationUuid={sentryAppInstallationUuid}
-            appName={appName}
-            element="alert-rule-action"
-            config={config}
-            action={action}
-            onSubmitSuccess={this.props.onSubmitSuccess}
-            // TODO(leander): Add new defaulting fields for alerts
-          />
-        </Body>
-      </Fragment>
-    );
-  }
-}
+const SentryAppRuleModal = ({
+  Header,
+  Body,
+  sentryAppInstallationUuid,
+  appName,
+  config,
+  action,
+  onSubmitSuccess,
+}: Props) => (
+  <Fragment>
+    <Header closeButton>{tct('[name] Settings', {name: appName})}</Header>
+    <Body>
+      <SentryAppExternalForm
+        sentryAppInstallationUuid={sentryAppInstallationUuid}
+        appName={appName}
+        element="alert-rule-action"
+        config={config}
+        action={action}
+        onSubmitSuccess={onSubmitSuccess}
+        // TODO(leander): Add new defaulting fields for alerts
+      />
+    </Body>
+  </Fragment>
+);
 
 export default SentryAppRuleModal;

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -36,7 +36,7 @@ const SentryAppRuleModal = ({
           onSubmitSuccess(...params);
           closeModal();
         }}
-        resetValues={resetValues}
+        resetValues={{settings: resetValues?.settings}}
       />
     </Body>
   </Fragment>

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -1,0 +1,45 @@
+import {Component, Fragment} from 'react';
+
+import {ModalRenderProps} from 'app/actionCreators/modal';
+import {tct} from 'app/locale';
+import {SentryAppInstallation} from 'app/types';
+import SentryAppExternalForm, {
+  Config,
+} from 'app/views/organizationIntegrations/sentryAppExternalForm';
+
+type Props = ModalRenderProps & {
+  sentryAppInstallation: SentryAppInstallation;
+  appName: string;
+  config: Config;
+  action: 'create' | 'update';
+  //   extraFields?: {[key: string]: any};
+  //   extraRequestBody?: {[key: string]: any};
+  onSubmitSuccess: (...params: any[]) => void;
+};
+
+class SentryAppRuleModal extends Component<Props> {
+  render() {
+    const {Header, Body, sentryAppInstallation, appName, config, action} = this.props;
+    return (
+      <Fragment>
+        <Header closeButton>{tct('[name] Settings', {name: 'TODO Integration'})}</Header>
+        <Body>
+          {config?.uri === 'asdf' && (
+            <SentryAppExternalForm
+              sentryAppInstallation={sentryAppInstallation}
+              appName={appName}
+              element="alert-rule-action"
+              config={config}
+              action={action}
+              onSubmitSuccess={this.props.onSubmitSuccess}
+              // TODO(leander): Add new defaulting fields for alerts
+            />
+          )}
+          <p>testing</p>
+        </Body>
+      </Fragment>
+    );
+  }
+}
+
+export default SentryAppRuleModal;

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -3,15 +3,15 @@ import {Fragment} from 'react';
 import {closeModal, ModalRenderProps} from 'app/actionCreators/modal';
 import {tct} from 'app/locale';
 import SentryAppExternalForm, {
-  Config,
+  SchemaFormConfig,
 } from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type Props = ModalRenderProps & {
   sentryAppInstallationUuid: string;
   appName: string;
-  config: Config;
+  config: SchemaFormConfig;
   resetValues: {[key: string]: any};
-  onSubmitSuccess: Function;
+  onSubmitSuccess: React.ComponentProps<typeof SentryAppExternalForm>['onSubmitSuccess'];
 };
 
 const SentryAppRuleModal = ({
@@ -33,8 +33,8 @@ const SentryAppRuleModal = ({
         element="alert-rule-action"
         action="create"
         onSubmitSuccess={(...params) => {
-          closeModal();
           onSubmitSuccess(...params);
+          closeModal();
         }}
         resetValues={resetValues}
       />

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -7,7 +7,7 @@ import SentryAppExternalForm, {
 } from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type Props = ModalRenderProps & {
-  sentryAppInstallationId: string;
+  sentryAppInstallationUuid: string;
   appName: string;
   config: Config;
   action: 'create' | 'update';
@@ -16,13 +16,13 @@ type Props = ModalRenderProps & {
 
 class SentryAppRuleModal extends Component<Props> {
   render() {
-    const {Header, Body, sentryAppInstallationId, appName, config, action} = this.props;
+    const {Header, Body, sentryAppInstallationUuid, appName, config, action} = this.props;
     return (
       <Fragment>
         <Header closeButton>{tct('[name] Settings', {name: appName})}</Header>
         <Body>
           <SentryAppExternalForm
-            sentryAppInstallationId={sentryAppInstallationId}
+            sentryAppInstallationUuid={sentryAppInstallationUuid}
             appName={appName}
             element="alert-rule-action"
             config={config}

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -2,13 +2,12 @@ import {Component, Fragment} from 'react';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import {tct} from 'app/locale';
-import {SentryAppInstallation} from 'app/types';
 import SentryAppExternalForm, {
   Config,
 } from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 type Props = ModalRenderProps & {
-  sentryAppInstallation: SentryAppInstallation;
+  sentryAppInstallationId: string;
   appName: string;
   config: Config;
   action: 'create' | 'update';
@@ -19,23 +18,20 @@ type Props = ModalRenderProps & {
 
 class SentryAppRuleModal extends Component<Props> {
   render() {
-    const {Header, Body, sentryAppInstallation, appName, config, action} = this.props;
+    const {Header, Body, sentryAppInstallationId, appName, config, action} = this.props;
     return (
       <Fragment>
-        <Header closeButton>{tct('[name] Settings', {name: 'TODO Integration'})}</Header>
+        <Header closeButton>{tct('[name] Settings', {name: appName})}</Header>
         <Body>
-          {config?.uri === 'asdf' && (
-            <SentryAppExternalForm
-              sentryAppInstallation={sentryAppInstallation}
-              appName={appName}
-              element="alert-rule-action"
-              config={config}
-              action={action}
-              onSubmitSuccess={this.props.onSubmitSuccess}
-              // TODO(leander): Add new defaulting fields for alerts
-            />
-          )}
-          <p>testing</p>
+          <SentryAppExternalForm
+            sentryAppInstallationId={sentryAppInstallationId}
+            appName={appName}
+            element="alert-rule-action"
+            config={config}
+            action={action}
+            onSubmitSuccess={this.props.onSubmitSuccess}
+            // TODO(leander): Add new defaulting fields for alerts
+          />
         </Body>
       </Fragment>
     );

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import {ModalRenderProps} from 'app/actionCreators/modal';
+import {closeModal, ModalRenderProps} from 'app/actionCreators/modal';
 import {tct} from 'app/locale';
 import SentryAppExternalForm, {
   Config,
@@ -10,7 +10,7 @@ type Props = ModalRenderProps & {
   sentryAppInstallationUuid: string;
   appName: string;
   config: Config;
-  action: 'create' | 'update';
+  resetValues: {[key: string]: any};
   onSubmitSuccess: Function;
 };
 
@@ -20,7 +20,7 @@ const SentryAppRuleModal = ({
   sentryAppInstallationUuid,
   appName,
   config,
-  action,
+  resetValues,
   onSubmitSuccess,
 }: Props) => (
   <Fragment>
@@ -29,11 +29,14 @@ const SentryAppRuleModal = ({
       <SentryAppExternalForm
         sentryAppInstallationUuid={sentryAppInstallationUuid}
         appName={appName}
-        element="alert-rule-action"
         config={config}
-        action={action}
-        onSubmitSuccess={onSubmitSuccess}
-        // TODO(leander): Add new defaulting fields for alerts
+        element="alert-rule-action"
+        action="create"
+        onSubmitSuccess={(...params) => {
+          closeModal();
+          onSubmitSuccess(...params);
+        }}
+        resetValues={resetValues}
       />
     </Body>
   </Fragment>

--- a/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
+++ b/static/app/views/alerts/issueRuleEditor/sentryAppRuleModal.tsx
@@ -11,8 +11,6 @@ type Props = ModalRenderProps & {
   appName: string;
   config: Config;
   action: 'create' | 'update';
-  //   extraFields?: {[key: string]: any};
-  //   extraRequestBody?: {[key: string]: any};
   onSubmitSuccess: (...params: any[]) => void;
 };
 

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -92,6 +92,8 @@ export class SentryAppExternalForm extends Component<Props, State> {
       required_fields: config.required_fields,
       optional_fields: config.optional_fields,
     });
+    // For alert-rule-actions, the forms are entirely custom, extra fields are
+    // passed in on submission, not as part of the form. See handleAlertRuleSubmit().
     if (element !== 'alert-rule-action') {
       this.model.setInitialData({
         ...extraFields,

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -321,7 +321,9 @@ export class SentryAppExternalForm extends Component<Props, State> {
         key={action}
         apiEndpoint={this.getSubmitEndpoint()}
         apiMethod="POST"
-        onSubmitSuccess={this.props.onSubmitSuccess}
+        onSubmitSuccess={(...params) => {
+          this.props.onSubmitSuccess(...params);
+        }}
         onSubmitError={this.onSubmitError}
         onFieldChange={this.handleFieldChange}
         model={this.model}

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -79,17 +79,21 @@ export class SentryAppExternalForm extends Component<Props, State> {
 
   // reset the state when we mount or the action changes
   resetStateFromProps() {
-    const {config, action, extraFields} = this.props;
+    const {config, action, extraFields, element} = this.props;
     this.setState({
       required_fields: config.required_fields,
       optional_fields: config.optional_fields,
     });
-    // we need to pass these fields in the API so just set them as values so we don't need hidden form fields
-    this.model.setInitialData({
-      ...extraFields,
-      action,
-      uri: config.uri,
-    });
+    this.model.setInitialData(
+      element === 'alert-rule-action'
+        ? {...extraFields}
+        : {
+            ...extraFields,
+            // we need to pass these fields in the API so just set them as values so we don't need hidden form fields
+            action,
+            uri: config.uri,
+          }
+    );
   }
 
   onSubmitError = () => {

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -102,7 +102,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     switch (this.props.element) {
       case 'alert-rule-action':
         // TODO(leander): Send request to the correct endpoint
-        return 'TODO';
+        return '/404/';
       case 'issue-link':
       default:
         return `/sentry-app-installations/${sentryAppInstallationId}/external-issue-actions/`;

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -41,7 +41,7 @@ type Props = {
   sentryAppInstallation: SentryAppInstallation;
   appName: string;
   config: Config;
-  action: 'create' | 'link';
+  action: 'create' | 'update' | 'link';
   element: 'issue-link' | 'alert-rule-action';
   extraFields?: {[key: string]: any};
   extraRequestBody?: {[key: string]: any};
@@ -97,6 +97,18 @@ export class SentryAppExternalForm extends Component<Props, State> {
     new Promise(resolve => {
       this.debouncedOptionLoad(field, input, resolve);
     });
+
+  getEndpoint() {
+    const {sentryAppInstallation} = this.props;
+    switch (this.props.element) {
+      case 'alert-rule-action':
+        // TODO(leander): Send request to the correct endpoint
+        return 'TODO';
+      case 'issue-link':
+      default:
+        return `/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`;
+    }
+  }
 
   getElementText = () => {
     const {element} = this.props;
@@ -309,7 +321,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     return (
       <Form
         key={action}
-        apiEndpoint={`/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`}
+        apiEndpoint={this.getEndpoint()}
         apiMethod="POST"
         onSubmitSuccess={this.props.onSubmitSuccess}
         onSubmitError={this.onSubmitError}

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -5,7 +5,6 @@ import debounce from 'lodash/debounce';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
-import {SentryAppInstallation} from 'app/types';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
 import withApi from 'app/utils/withApi';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
@@ -38,7 +37,7 @@ type State = Omit<Config, 'uri'> & {
 
 type Props = {
   api: Client;
-  sentryAppInstallation: SentryAppInstallation;
+  sentryAppInstallationId: string;
   appName: string;
   config: Config;
   action: 'create' | 'update' | 'link';
@@ -99,14 +98,14 @@ export class SentryAppExternalForm extends Component<Props, State> {
     });
 
   getEndpoint() {
-    const {sentryAppInstallation} = this.props;
+    const {sentryAppInstallationId} = this.props;
     switch (this.props.element) {
       case 'alert-rule-action':
         // TODO(leander): Send request to the correct endpoint
         return 'TODO';
       case 'issue-link':
       default:
-        return `/sentry-app-installations/${sentryAppInstallation.uuid}/external-issue-actions/`;
+        return `/sentry-app-installations/${sentryAppInstallationId}/external-issue-actions/`;
     }
   }
 
@@ -140,8 +139,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
   );
 
   makeExternalRequest = async (field: FieldFromSchema, input: FieldValue) => {
-    const install = this.props.sentryAppInstallation;
-    const {extraRequestBody = {}} = this.props;
+    const {extraRequestBody = {}, sentryAppInstallationId} = this.props;
     const query: {[key: string]: any} = {
       ...extraRequestBody,
       uri: field.uri,
@@ -158,7 +156,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     }
 
     const {choices} = await this.props.api.requestPromise(
-      `/sentry-app-installations/${install.uuid}/external-requests/`,
+      `/sentry-app-installations/${sentryAppInstallationId}/external-requests/`,
       {
         query,
       }
@@ -309,12 +307,12 @@ export class SentryAppExternalForm extends Component<Props, State> {
   };
 
   render() {
-    const {sentryAppInstallation, action} = this.props;
+    const {sentryAppInstallationId, action} = this.props;
 
     const requiredFields = this.state.required_fields || [];
     const optionalFields = this.state.optional_fields || [];
 
-    if (!sentryAppInstallation) {
+    if (!sentryAppInstallationId) {
       return '';
     }
 

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -37,7 +37,7 @@ type State = Omit<Config, 'uri'> & {
 
 type Props = {
   api: Client;
-  sentryAppInstallationId: string;
+  sentryAppInstallationUuid: string;
   appName: string;
   config: Config;
   action: 'create' | 'update' | 'link';
@@ -97,15 +97,15 @@ export class SentryAppExternalForm extends Component<Props, State> {
       this.debouncedOptionLoad(field, input, resolve);
     });
 
-  getEndpoint() {
-    const {sentryAppInstallationId} = this.props;
+  getSubmitEndpoint() {
+    const {sentryAppInstallationUuid} = this.props;
     switch (this.props.element) {
       case 'alert-rule-action':
         // TODO(leander): Send request to the correct endpoint
         return '/404/';
       case 'issue-link':
       default:
-        return `/sentry-app-installations/${sentryAppInstallationId}/external-issue-actions/`;
+        return `/sentry-app-installations/${sentryAppInstallationUuid}/external-issue-actions/`;
     }
   }
 
@@ -139,7 +139,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
   );
 
   makeExternalRequest = async (field: FieldFromSchema, input: FieldValue) => {
-    const {extraRequestBody = {}, sentryAppInstallationId} = this.props;
+    const {extraRequestBody = {}, sentryAppInstallationUuid} = this.props;
     const query: {[key: string]: any} = {
       ...extraRequestBody,
       uri: field.uri,
@@ -156,7 +156,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     }
 
     const {choices} = await this.props.api.requestPromise(
-      `/sentry-app-installations/${sentryAppInstallationId}/external-requests/`,
+      `/sentry-app-installations/${sentryAppInstallationUuid}/external-requests/`,
       {
         query,
       }
@@ -307,19 +307,19 @@ export class SentryAppExternalForm extends Component<Props, State> {
   };
 
   render() {
-    const {sentryAppInstallationId, action} = this.props;
+    const {sentryAppInstallationUuid, action} = this.props;
 
     const requiredFields = this.state.required_fields || [];
     const optionalFields = this.state.optional_fields || [];
 
-    if (!sentryAppInstallationId) {
+    if (!sentryAppInstallationUuid) {
       return '';
     }
 
     return (
       <Form
         key={action}
-        apiEndpoint={this.getEndpoint()}
+        apiEndpoint={this.getSubmitEndpoint()}
         apiMethod="POST"
         onSubmitSuccess={this.props.onSubmitSuccess}
         onSubmitError={this.onSubmitError}

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -44,7 +44,7 @@ type Props = {
   element: 'issue-link' | 'alert-rule-action';
   extraFields?: {[key: string]: any};
   extraRequestBody?: {[key: string]: any};
-  onSubmitSuccess: (...params: any[]) => void;
+  onSubmitSuccess: Function;
   getFieldDefault?: (field: FieldFromSchema) => string;
 };
 

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -24,14 +24,14 @@ export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
   async?: boolean;
 };
 
-export type Config = {
+export type SchemaFormConfig = {
   uri: string;
   required_fields?: FieldFromSchema[];
   optional_fields?: FieldFromSchema[];
 };
 
 // only need required_fields and optional_fields
-type State = Omit<Config, 'uri'> & {
+type State = Omit<SchemaFormConfig, 'uri'> & {
   optionsByField: Map<string, Array<{label: string; value: any}>>;
 };
 
@@ -39,16 +39,24 @@ type Props = {
   api: Client;
   sentryAppInstallationUuid: string;
   appName: string;
-  config: Config;
+  config: SchemaFormConfig;
   action: 'create' | 'link';
   element: 'issue-link' | 'alert-rule-action';
-  /** Addtional form data to submit with the request */
+  /**
+   * Addtional form data to submit with the request
+   */
   extraFields?: {[key: string]: any};
-  /** Addtional body parameters to submit with the request */
+  /**
+   * Addtional body parameters to submit with the request
+   */
   extraRequestBody?: {[key: string]: any};
-  /** Object containing reset values for fields if previously entered, in case this   form is unmounted */
+  /**
+   * Object containing reset values for fields if previously entered, in case this form is unmounted
+   */
   resetValues?: {[key: string]: any};
-  /** Function to provide fields with pre-written data if a default is specified */
+  /**
+   * Function to provide fields with pre-written data if a default is specified
+   */
   getFieldDefault?: (field: FieldFromSchema) => string;
   onSubmitSuccess: Function;
 };
@@ -107,15 +115,12 @@ export class SentryAppExternalForm extends Component<Props, State> {
     });
 
   getSubmitEndpoint() {
-    const {sentryAppInstallationUuid} = this.props;
-    switch (this.props.element) {
-      case 'alert-rule-action':
-        // TODO(leander): Send request to the correct endpoint
-        return '/404/';
-      case 'issue-link':
-      default:
-        return `/sentry-app-installations/${sentryAppInstallationUuid}/external-issue-actions/`;
+    const {sentryAppInstallationUuid, element} = this.props;
+    if (element === 'alert-rule-action') {
+      // TODO(leander): Send request to the correct endpoint
+      return '/404/';
     }
+    return `/sentry-app-installations/${sentryAppInstallationUuid}/external-issue-actions/`;
   }
 
   getElementText = () => {

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -111,7 +111,8 @@ export default class SelectField<
               // Support 'confirming' selections. This only works with
               // `val` objects that use the new-style options format
               const previousValue = props.value?.toString();
-              const newValue = val.value?.toString();
+              // `val` may be null if clearing the select for an optional field
+              const newValue = val?.value?.toString();
 
               // Value not marked for confirmation, or hasn't changed
               if (!confirm[newValue] || previousValue === newValue) {

--- a/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
@@ -1,6 +1,3 @@
-// TODO(leander): Remove this once the test is configured
-/* eslint-disable jest/no-disabled-tests */
-
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {changeInputValue, selectByValue} from 'sentry-test/select-new';
 
@@ -53,10 +50,10 @@ describe('SentryAppRuleModal', function () {
         type: 'select',
         label: 'Team Channel',
         name: 'channel',
-        options: [
-          ['#valor', 'valor'],
-          ['#mystic', 'mystic'],
-          ['#instinct', 'instinct'],
+        choices: [
+          ['valor', 'valor'],
+          ['mystic', 'mystic'],
+          ['instinct', 'instinct'],
         ],
       },
     ],
@@ -73,7 +70,7 @@ describe('SentryAppRuleModal', function () {
     return mountWithTheme(
       <SentryAppRuleModal
         {...modalElements}
-        sentryAppInstallationId={sentryAppInstallation.uuid}
+        sentryAppInstallationUuid={sentryAppInstallation.uuid}
         appName={sentryApp.name}
         config={defaultConfig}
         action="create"
@@ -104,75 +101,24 @@ describe('SentryAppRuleModal', function () {
 
     it('should submit when "Save Changes" is clicked with valid data', async function () {
       const wrapper = createWrapper();
-      const projectInput = wrapper.find('[data-test-id="channel"] input').at(0);
-      changeInputValue(projectInput, '#');
+      const titleInput = wrapper.find('[data-test-id="title"] input').at(0);
+      const descriptionInput = wrapper
+        .find('[data-test-id="description"] textarea')
+        .at(0);
+      const channelInput = wrapper.find('[data-test-id="channel"] input').at(0);
+      changeInputValue(titleInput, 'v');
+      changeInputValue(descriptionInput, 'v');
+      changeInputValue(channelInput, 'v');
+      selectByValue(wrapper, 'valor', {name: 'channel', control: true});
 
-      await tick();
-      wrapper.update();
-
-      expect(wrapper.find('[label="#valor"]').exists()).toBe(true);
-      expect(wrapper.find('[label="#mystic"]').exists()).toBe(true);
-      expect(wrapper.find('[label="#instinct"]').exists()).toBe(true);
-
-      await tick();
-      wrapper.update();
-      selectByValue(wrapper, 'valor', {name: 'channel'});
+      MockApiClient.addMockResponse({
+        // TODO(leander): Replace with real endpoint for alert rule actions
+        url: '/404/',
+        method: 'POST',
+        body: {it: 'worked'},
+      });
 
       submitSuccess(wrapper);
     });
   });
-
-  // describe.skip('Create Rule', function () {
-  //   it('should save the modal data when "Apply Changes" is clicked with valid data', async function () {
-  //     const wrapper = createWrapper();
-  //     selectByValue(wrapper, 'a', {name: 'reporter'});
-  //     submitSuccess(wrapper);
-  //   });
-
-  //   it('should raise validation errors when "Apply Changes" is clicked with invalid data', async function () {
-  //     // This doesn't test anything TicketRules specific but I'm leaving it here as an example.
-  //     const wrapper = createWrapper();
-  //     submitErrors(wrapper, 1);
-  //   });
-
-  //   it('should reload fields when an "updatesForm" field changes', async function () {
-  //     const wrapper = createWrapper();
-  //     selectByValue(wrapper, 'a', {name: 'reporter'});
-
-  //     addMockConfigsAPICall({
-  //       label: 'Assignee',
-  //       required: true,
-  //       choices: [['b', 'b']],
-  //       type: 'select',
-  //       name: 'assignee',
-  //     });
-
-  //     selectByValue(wrapper, '10000', {name: 'issuetype'});
-  //     selectByValue(wrapper, 'b', {name: 'assignee'});
-
-  //     submitSuccess(wrapper);
-  //   });
-
-  //   it('should persist values when the modal is reopened', async function () {
-  //     const wrapper = createWrapper({data: {reporter: 'a'}});
-  //     submitSuccess(wrapper);
-  //   });
-
-  //   it('should get async options from URL', async function () {
-  //     const wrapper = createWrapper();
-  //     addMockConfigsAPICall({
-  //       label: 'Assignee',
-  //       required: true,
-  //       url: 'http://example.com',
-  //       type: 'select',
-  //       name: 'assignee',
-  //     });
-  //     selectByValue(wrapper, '10000', {name: 'issuetype'});
-
-  //     addMockUsersAPICall(['Marcos']);
-  //     await selectByQuery(wrapper, 'Marcos', {name: 'assignee'});
-
-  //     submitSuccess(wrapper);
-  //   });
-  // });
 });

--- a/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
@@ -1,0 +1,178 @@
+// TODO(leander): Remove this once the test is configured
+/* eslint-disable jest/no-disabled-tests */
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {changeInputValue, selectByValue} from 'sentry-test/select-new';
+
+import SentryAppRuleModal from 'app/views/alerts/issueRuleEditor/sentryAppRuleModal';
+
+describe('SentryAppRuleModal', function () {
+  const modalElements = {
+    Header: p => p.children,
+    Body: p => p.children,
+    Footer: p => p.children,
+  };
+  let sentryApp;
+  let sentryAppInstallation;
+
+  beforeEach(function () {
+    sentryApp = TestStubs.SentryApp();
+    sentryAppInstallation = TestStubs.SentryAppInstallation({sentryApp});
+  });
+
+  const _submit = wrapper => {
+    wrapper.find('Button[data-test-id="form-submit"]').simulate('submit');
+    return wrapper.find('FieldErrorReason');
+  };
+
+  const submitSuccess = wrapper => {
+    const errors = _submit(wrapper);
+    expect(errors).toHaveLength(0);
+  };
+
+  const submitErrors = (wrapper, errorCount) => {
+    const errors = _submit(wrapper);
+    expect(errors).toHaveLength(errorCount);
+    expect(errors.first().text()).toEqual('Field is required');
+  };
+
+  const defaultConfig = {
+    uri: '/integration/test/',
+    required_fields: [
+      {
+        type: 'text',
+        label: 'Alert Title',
+        name: 'title',
+      },
+      {
+        type: 'textarea',
+        label: 'Alert Description',
+        name: 'description',
+      },
+      {
+        type: 'select',
+        label: 'Team Channel',
+        name: 'channel',
+        options: [
+          ['#valor', 'valor'],
+          ['#mystic', 'mystic'],
+          ['#instinct', 'instinct'],
+        ],
+      },
+    ],
+    optional_fields: [
+      {
+        type: 'text',
+        label: 'Extra Details',
+        name: 'extra',
+      },
+    ],
+  };
+
+  const createWrapper = (props = {}) => {
+    return mountWithTheme(
+      <SentryAppRuleModal
+        {...modalElements}
+        sentryAppInstallationId={sentryAppInstallation.uuid}
+        appName={sentryApp.name}
+        config={defaultConfig}
+        action="create"
+        onSubmitSuccess={() => {}}
+        {...props}
+      />,
+      TestStubs.routerContext()
+    );
+  };
+
+  describe('Create UI Alert Rule', function () {
+    it('should render the Alert Rule modal with the config fields', async function () {
+      const wrapper = createWrapper();
+      const formFields = wrapper.find('FormField');
+      const {required_fields, optional_fields} = defaultConfig;
+      const allFields = [...required_fields, ...optional_fields];
+
+      allFields.forEach((field, index) => {
+        expect(formFields.at(index).prop('label')).toEqual(field.label);
+        expect(formFields.at(index).prop('name')).toEqual(field.name);
+      });
+    });
+
+    it('should raise validation errors when "Save Changes" is clicked with invalid data', async function () {
+      const wrapper = createWrapper();
+      submitErrors(wrapper, 3);
+    });
+
+    it('should submit when "Save Changes" is clicked with valid data', async function () {
+      const wrapper = createWrapper();
+      const projectInput = wrapper.find('[data-test-id="channel"] input').at(0);
+      changeInputValue(projectInput, '#');
+
+      await tick();
+      wrapper.update();
+
+      expect(wrapper.find('[label="#valor"]').exists()).toBe(true);
+      expect(wrapper.find('[label="#mystic"]').exists()).toBe(true);
+      expect(wrapper.find('[label="#instinct"]').exists()).toBe(true);
+
+      await tick();
+      wrapper.update();
+      selectByValue(wrapper, 'valor', {name: 'channel'});
+
+      submitSuccess(wrapper);
+    });
+  });
+
+  // describe.skip('Create Rule', function () {
+  //   it('should save the modal data when "Apply Changes" is clicked with valid data', async function () {
+  //     const wrapper = createWrapper();
+  //     selectByValue(wrapper, 'a', {name: 'reporter'});
+  //     submitSuccess(wrapper);
+  //   });
+
+  //   it('should raise validation errors when "Apply Changes" is clicked with invalid data', async function () {
+  //     // This doesn't test anything TicketRules specific but I'm leaving it here as an example.
+  //     const wrapper = createWrapper();
+  //     submitErrors(wrapper, 1);
+  //   });
+
+  //   it('should reload fields when an "updatesForm" field changes', async function () {
+  //     const wrapper = createWrapper();
+  //     selectByValue(wrapper, 'a', {name: 'reporter'});
+
+  //     addMockConfigsAPICall({
+  //       label: 'Assignee',
+  //       required: true,
+  //       choices: [['b', 'b']],
+  //       type: 'select',
+  //       name: 'assignee',
+  //     });
+
+  //     selectByValue(wrapper, '10000', {name: 'issuetype'});
+  //     selectByValue(wrapper, 'b', {name: 'assignee'});
+
+  //     submitSuccess(wrapper);
+  //   });
+
+  //   it('should persist values when the modal is reopened', async function () {
+  //     const wrapper = createWrapper({data: {reporter: 'a'}});
+  //     submitSuccess(wrapper);
+  //   });
+
+  //   it('should get async options from URL', async function () {
+  //     const wrapper = createWrapper();
+  //     addMockConfigsAPICall({
+  //       label: 'Assignee',
+  //       required: true,
+  //       url: 'http://example.com',
+  //       type: 'select',
+  //       name: 'assignee',
+  //     });
+  //     selectByValue(wrapper, '10000', {name: 'issuetype'});
+
+  //     addMockUsersAPICall(['Marcos']);
+  //     await selectByQuery(wrapper, 'Marcos', {name: 'assignee'});
+
+  //     submitSuccess(wrapper);
+  //   });
+  // });
+});

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -161,7 +161,7 @@ class ProjectRuleConfigurationTest(APITestCase):
             schema={"elements": [self.create_alert_rule_action_schema()]},
             is_alertable=True,
         )
-        self.create_sentry_app_installation(
+        install = self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization, user=self.user
         )
         component = SentryAppComponent.objects.get(
@@ -182,6 +182,7 @@ class ProjectRuleConfigurationTest(APITestCase):
                 "uri": "/sentry/alert-rule",
                 "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
             },
+            "sentryAppInstallationUuid": str(install.uuid),
         } in response.data["actions"]
         assert len(response.data["conditions"]) == 6
         assert len(response.data["filters"]) == 7

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -177,7 +177,7 @@ class ProjectRuleConfigurationTest(APITestCase):
             "prompt": sentry_app.name,
             "enabled": True,
             "label": "Create Task with App with these ",
-            "formfields": {
+            "formFields": {
                 "type": "alert-rule-settings",
                 "uri": "/sentry/alert-rule",
                 "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],


### PR DESCRIPTION
See [API-2109](https://getsentry.atlassian.net/browse/API-2109)
Also solves JAVASCRIPT-25GA

Add the settings modal to the settings button when creating an alert rule with UI components. The modal persists the values when dismissed and this can likely be used to fill the values when we look at updating existing rules. It can't post to an existing endpoint because [API-2078](https://getsentry.atlassian.net/browse/API-2078) has not been implemented just yet, and sentry apps still aren't a part of the rule registry to be able to create alert rules yet.

**New Demo**

![before](https://user-images.githubusercontent.com/35509934/133507029-a2bf1a0a-ab8c-46aa-9fdb-6208c997e90a.gif)
