### PR TITLE
ref(notification platform): Enforce 1 team to 1 Slack channel relationship

### DIFF
--- a/src/sentry/integrations/slack/endpoints/command.py
+++ b/src/sentry/integrations/slack/endpoints/command.py
@@ -11,7 +11,14 @@ from sentry.integrations.slack.requests.base import SlackRequest, SlackRequestEr
 from sentry.integrations.slack.requests.command import SlackCommandRequest
 from sentry.integrations.slack.views.link_team import build_team_linking_url
 from sentry.integrations.slack.views.unlink_team import build_team_unlinking_url
-from sentry.models import ExternalActor, Identity, IdentityProvider, OrganizationMember
+from sentry.models import (
+    ExternalActor,
+    Identity,
+    IdentityProvider,
+    Integration,
+    Organization,
+    OrganizationMember,
+)
 from sentry.types.integrations import ExternalProviders
 
 from ..utils import is_valid_role
@@ -23,6 +30,7 @@ LINK_TEAM_MESSAGE = (
     "Link your Sentry team to this Slack channel! <{associate_url}|Link your team now> to receive "
     "notifications of issues in Sentry in Slack."
 )
+CHANNEL_ALREADY_LINKED_MESSAGE = "This channel already has a team linked to it."
 LINK_USER_FIRST_MESSAGE = (
     "You must first link your identity to Sentry by typing /sentry link. Be aware that you "
     "must be an admin or higher in your Sentry organization to link your team."
@@ -72,8 +80,19 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
             }
         )
 
-    def link_team(self, slack_request: SlackCommandRequest) -> Response:
+    def get_team_linked_to_channel(
+        self, organization: Organization, integration: Integration, slack_request: SlackRequest
+    ) -> bool:
+        """Check if a Slack channel already has a team linked to it"""
+        return ExternalActor.objects.filter(
+            organization=organization,
+            integration=integration,
+            provider=ExternalProviders.SLACK.value,
+            external_name=slack_request.channel_name,
+            external_id=slack_request.channel_id,
+        ).exists()
 
+    def link_team(self, slack_request: SlackCommandRequest) -> Response:
         if slack_request.channel_name == DIRECT_MESSAGE_CHANNEL_NAME:
             return self.reply(slack_request, LINK_FROM_CHANNEL_MESSAGE)
 
@@ -84,6 +103,9 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
         integration = slack_request.integration
         organization = integration.organizations.all()[0]
         org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
+
+        if self.get_team_linked_to_channel(organization, integration, slack_request):
+            return self.reply(slack_request, CHANNEL_ALREADY_LINKED_MESSAGE)
 
         if not is_valid_role(org_member):
             return self.reply(slack_request, INSUFFICIENT_ROLE_MESSAGE)

--- a/src/sentry/integrations/slack/endpoints/command.py
+++ b/src/sentry/integrations/slack/endpoints/command.py
@@ -80,7 +80,7 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
             }
         )
 
-    def get_team_linked_to_channel(
+    def is_team_linked_to_channel(
         self, organization: Organization, integration: Integration, slack_request: SlackRequest
     ) -> bool:
         """Check if a Slack channel already has a team linked to it"""
@@ -104,7 +104,7 @@ class SlackCommandsEndpoint(SlackDMEndpoint):  # type: ignore
         organization = integration.organizations.all()[0]
         org_member = OrganizationMember.objects.get(user=identity.user, organization=organization)
 
-        if self.get_team_linked_to_channel(organization, integration, slack_request):
+        if self.is_team_linked_to_channel(organization, integration, slack_request):
             return self.reply(slack_request, CHANNEL_ALREADY_LINKED_MESSAGE)
 
         if not is_valid_role(org_member):

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -1,4 +1,3 @@
-from django.db import IntegrityError
 from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -58,16 +57,15 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
         channel_name = params["channel_name"]
         channel_id = params["channel_id"]
 
-        try:
-            external_teams = ExternalActor.objects.filter(
-                organization=organization,
-                integration=integration,
-                provider=ExternalProviders.SLACK.value,
-                external_name=channel_name,
-                external_id=channel_id,
-            )
-        except IntegrityError as e:
-            logger.error("slack.team.unlink.integrity-error", extra=e)
+        external_teams = ExternalActor.objects.filter(
+            organization=organization,
+            integration=integration,
+            provider=ExternalProviders.SLACK.value,
+            external_name=channel_name,
+            external_id=channel_id,
+        )
+        if len(external_teams) == 0:
+            logger.error("slack.team.unlink.no_external_teams")
             raise Http404
 
         teams = Team.objects.filter(

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -59,7 +59,7 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
         channel_id = params["channel_id"]
 
         try:
-            external_team = ExternalActor.objects.get(
+            external_teams = ExternalActor.objects.filter(
                 organization=organization,
                 integration=integration,
                 provider=ExternalProviders.SLACK.value,
@@ -70,13 +70,15 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
             logger.error("slack.team.unlink.integrity-error", extra=e)
             raise Http404
 
-        team = Team.objects.get(actor=external_team.actor)
+        teams = Team.objects.filter(
+            actor__in=[external_team.actor for external_team in external_teams]
+        )
         if request.method != "POST":
             return render_to_response(
                 "sentry/integrations/slack-unlink-team.html",
                 request=request,
                 context={
-                    "team": team,
+                    "team": teams[0],
                     "channel_name": channel_name,
                     "provider": integration.get_provider(),
                 },
@@ -92,10 +94,10 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
 
         if not Identity.objects.filter(idp=idp, external_id=params["slack_id"]).exists():
             return render_error_page(request, body_text="HTTP 403: User identity does not exist")
-
-        external_team.delete()
-        NotificationSetting.objects.remove_for_team(team, ExternalProviders.SLACK)
-
+        for external_team in external_teams:
+            external_team.delete()
+        for team in teams:
+            NotificationSetting.objects.remove_for_team(team, ExternalProviders.SLACK)
         return send_confirmation(
             integration,
             channel_id,


### PR DESCRIPTION
A customer accidentally linked a second team to a Slack channel and when they went to unlink it, we threw an error. We never anticipated anyone would do this, but since it can happen we now check if there's already a team linked to the channel the command is executed in, and if so, inform the user and exit. To support the customer who is stuck and can't unlink, allow the unlink command to unlink all teams from the channel the command is executed in. They will need to re-link the originally intended team.

Fixes [SENTRY-S5D](https://sentry.io/organizations/sentry/issues/2641247397/)