### PR TITLE
ref(js): Use `State` type for organizationStore

### DIFF
--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -11,7 +11,7 @@ type UpdateOptions = {
   replace?: boolean;
 };
 
-type OutputState = {
+type State = {
   organization: Organization | null;
   loading: boolean;
   dirty: boolean;
@@ -27,7 +27,7 @@ type OrganizationStoreInterface = {
   onProjectOrTeamChange: () => void;
   onLoadProjects: (projects: Project[]) => void;
   onLoadTeams: (teams: Team[]) => void;
-  get: () => OutputState;
+  get: () => State;
 };
 
 const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {


### PR DESCRIPTION
This is consistent with some of our other stores