### PR TITLE
ref(select): Change choices to options in http custom repositories modal

### DIFF
--- a/static/app/components/modals/debugFileCustomRepository/http.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/http.tsx
@@ -207,10 +207,10 @@ function Http({Header, Body, Footer, onSubmit, ...props}: Props) {
           name="layout.type"
           label={t('Directory Layout')}
           help={t('The layout of the folder structure.')}
-          choices={Object.keys(DEBUG_SOURCE_LAYOUTS).map(key => [
-            key,
-            DEBUG_SOURCE_LAYOUTS[key],
-          ])}
+          options={Object.keys(DEBUG_SOURCE_LAYOUTS).map(key => ({
+            value: key,
+            label: DEBUG_SOURCE_LAYOUTS[key],
+          }))}
           value={data['layout.type']}
           onChange={value =>
             setData({
@@ -226,10 +226,10 @@ function Http({Header, Body, Footer, onSubmit, ...props}: Props) {
           name="layout.casing"
           label={t('Path Casing')}
           help={t('The case of files and folders.')}
-          choices={Object.keys(DEBUG_SOURCE_CASINGS).map(key => [
-            key,
-            DEBUG_SOURCE_CASINGS[key],
-          ])}
+          options={Object.keys(DEBUG_SOURCE_CASINGS).map(key => ({
+            value: key,
+            label: DEBUG_SOURCE_CASINGS[key],
+          }))}
           value={data['layout.casing']}
           onChange={value =>
             setData({

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -65,7 +65,6 @@ export default class SelectField<
     optionObj: ValueType<OptionType>
   ) => {
     let value: any = undefined;
-
     // If optionObj is empty, then it probably means that the field was "cleared"
     if (!optionObj) {
       value = optionObj;

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -65,6 +65,7 @@ export default class SelectField<
     optionObj: ValueType<OptionType>
   ) => {
     let value: any = undefined;
+
     // If optionObj is empty, then it probably means that the field was "cleared"
     if (!optionObj) {
       value = optionObj;


### PR DESCRIPTION
Converts from legacy react-select choices to options for this modal:

![image](https://user-images.githubusercontent.com/9372512/133174069-edb9f84c-17d3-4862-aa1c-5a96db7eec7d.png)

