### PR TITLE
fix(ui): Semver guide for releases

### DIFF
--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -534,6 +534,7 @@ class ReleasesList extends AsyncView<Props, State> {
       .some(project => project?.platform && isProjectMobileForReleases(project.platform));
     const showReleaseAdoptionStages =
       hasReleaseStages && hasAnyMobileProject && selection.environments.length === 1;
+    const hasReleasesSetup = releases && releases.length > 0;
 
     return (
       <GlobalSelectionHeader
@@ -551,7 +552,7 @@ class ReleasesList extends AsyncView<Props, State> {
             {this.renderHealthCta()}
 
             <SortAndFilterWrapper>
-              {hasSemver ? (
+              {hasSemver && hasReleasesSetup ? (
                 <GuideAnchor target="releases_search" position="bottom">
                   <GuideAnchorWrapper
                     target="release_stages"


### PR DESCRIPTION
Fix the Semver guide showing up when there are no releases.

[FIXES WOR-1191](https://getsentry.atlassian.net/browse/WOR-1192)

# Before
<img width="1200" alt="Screen Shot 2021-09-13 at 10 49 57 PM" src="https://user-images.githubusercontent.com/20312973/133209225-598fbf93-a2a1-413c-9066-fed77e7e84d0.png">

# After
<img width="1191" alt="Screen Shot 2021-09-13 at 11 02 01 PM" src="https://user-images.githubusercontent.com/20312973/133209254-53497afe-3e6a-416d-a1d3-8d05975d6cc7.png">