### PR TITLE
ref(issue-title): Hide title with tree label on non-native/mobile platforms

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -32,6 +32,8 @@ type Props = WithRouterProps<{orgId: string}> & {
   index?: number;
   includeLink?: boolean;
   size?: Size;
+  /* is issue breakdown? */
+  grouping?: boolean;
 };
 
 /**
@@ -49,6 +51,7 @@ function EventOrGroupHeader({
   hideLevel,
   includeLink = true,
   size = 'normal',
+  grouping = false,
   ...props
 }: Props) {
   const hasGroupingTreeUI = !!organization.features?.includes('grouping-tree-ui');
@@ -82,6 +85,7 @@ function EventOrGroupHeader({
             withStackTracePreview
             hasGuideAnchor={index === 0}
             guideAnchorName="issue_stream_title"
+            grouping={grouping}
           />
         </ErrorBoundary>
       </Fragment>

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -7,6 +7,7 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {BaseGroup, GroupTombstone, Organization} from 'app/types';
 import {Event} from 'app/types/event';
 import {getTitle} from 'app/utils/events';
+import {isMobilePlatform, isNativePlatform} from 'app/utils/platform';
 import withOrganization from 'app/utils/withOrganization';
 
 import EventTitleTreeLabel from './eventTitleTreeLabel';
@@ -18,6 +19,8 @@ type Props = Partial<DefaultProps> & {
   hasGuideAnchor?: boolean;
   withStackTracePreview?: boolean;
   guideAnchorName?: string;
+  /* is issue breakdown? */
+  grouping?: boolean;
   className?: string;
 };
 
@@ -31,6 +34,7 @@ function EventOrGroupTitle({
   data,
   withStackTracePreview,
   hasGuideAnchor,
+  grouping = false,
   className,
 }: Props) {
   const event = data as Event;
@@ -42,7 +46,11 @@ function EventOrGroupTitle({
   );
   const {id, eventID, groupID, projectID} = event;
 
-  const {title, subtitle, treeLabel} = getTitle(event, organization?.features);
+  const {title, subtitle, treeLabel} = getTitle(
+    event,
+    organization?.features,
+    grouping || isNativePlatform(event.platform) || isMobilePlatform(event.platform)
+  );
 
   return (
     <Wrapper className={className} hasGroupingTreeUI={hasGroupingTreeUI}>

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -7,7 +7,6 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {BaseGroup, GroupTombstone, Organization} from 'app/types';
 import {Event} from 'app/types/event';
 import {getTitle} from 'app/utils/events';
-import {isMobilePlatform, isNativePlatform} from 'app/utils/platform';
 import withOrganization from 'app/utils/withOrganization';
 
 import EventTitleTreeLabel from './eventTitleTreeLabel';
@@ -46,12 +45,7 @@ function EventOrGroupTitle({
   );
   const {id, eventID, groupID, projectID} = event;
 
-  const {title, subtitle, treeLabel} = getTitle(
-    event,
-    organization?.features,
-    hasGroupingTreeUI &&
-      (grouping || isNativePlatform(event.platform) || isMobilePlatform(event.platform))
-  );
+  const {title, subtitle, treeLabel} = getTitle(event, organization?.features, grouping);
 
   return (
     <Wrapper className={className} hasGroupingTreeUI={hasGroupingTreeUI}>

--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -49,7 +49,8 @@ function EventOrGroupTitle({
   const {title, subtitle, treeLabel} = getTitle(
     event,
     organization?.features,
-    grouping || isNativePlatform(event.platform) || isMobilePlatform(event.platform)
+    hasGroupingTreeUI &&
+      (grouping || isNativePlatform(event.platform) || isMobilePlatform(event.platform))
   );
 
   return (

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -310,6 +310,11 @@ class StreamGroup extends React.Component<Props, State> {
     const {data} = this.state;
     const {statusDetails, count} = data as GroupReprocessing;
     const {info, pendingEvents} = statusDetails;
+
+    if (!info) {
+      return null;
+    }
+
     const {totalEvents, dateCreated} = info;
 
     const remainingEventsToReprocess = totalEvents - pendingEvents;

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -1062,7 +1062,7 @@ export type BaseGroupStatusReprocessing = {
     info: {
       dateCreated: string;
       totalEvents: number;
-    };
+    } | null;
   };
 };
 

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -97,7 +97,11 @@ function computeTitleWithTreeLabel(metadata: EventMetadata, features: string[] =
   };
 }
 
-export function getTitle(event: Event | BaseGroup, features: string[] = []) {
+export function getTitle(
+  event: Event | BaseGroup,
+  features: string[] = [],
+  displayTitleWithTreeLabel = false
+) {
   const {metadata, type, culprit} = event;
 
   const customTitle =
@@ -115,9 +119,17 @@ export function getTitle(event: Event | BaseGroup, features: string[] = []) {
         };
       }
 
+      if (displayTitleWithTreeLabel) {
+        return {
+          subtitle: culprit,
+          ...computeTitleWithTreeLabel(metadata, features),
+        };
+      }
+
       return {
         subtitle: culprit,
-        ...computeTitleWithTreeLabel(metadata, features),
+        title: metadata.type || metadata.function || '<unknown>',
+        treeLabel: undefined,
       };
     }
     case EventOrGroupType.CSP:

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -71,11 +71,11 @@ export function getTreeLabelPartDetails(part: TreeLabelPart) {
   return label || '<unknown>';
 }
 
-function computeTitleWithTreeLabel(metadata: EventMetadata, features: string[] = []) {
+function computeTitleWithTreeLabel(metadata: EventMetadata) {
   const {type, current_tree_label, finest_tree_label} = metadata;
-  const treeLabel = features.includes('grouping-title-ui')
-    ? current_tree_label || finest_tree_label
-    : undefined;
+
+  const treeLabel = current_tree_label || finest_tree_label;
+
   const formattedTreeLabel = treeLabel
     ? treeLabel.map(labelPart => getTreeLabelPartDetails(labelPart)).join(' | ')
     : undefined;
@@ -119,10 +119,10 @@ export function getTitle(
         };
       }
 
-      if (displayTitleWithTreeLabel) {
+      if (displayTitleWithTreeLabel && features.includes('grouping-title-ui')) {
         return {
           subtitle: culprit,
-          ...computeTitleWithTreeLabel(metadata, features),
+          ...computeTitleWithTreeLabel(metadata),
         };
       }
 

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -6,7 +6,7 @@ import {
   TreeLabelPart,
 } from 'app/types';
 import {Event} from 'app/types/event';
-import {isNativePlatform} from 'app/utils/platform';
+import {isMobilePlatform, isNativePlatform} from 'app/utils/platform';
 
 function isTombstone(maybe: BaseGroup | Event | GroupTombstone): maybe is GroupTombstone {
   return !maybe.hasOwnProperty('type');
@@ -100,7 +100,7 @@ function computeTitleWithTreeLabel(metadata: EventMetadata) {
 export function getTitle(
   event: Event | BaseGroup,
   features: string[] = [],
-  displayTitleWithTreeLabel = false
+  grouping = false
 ) {
   const {metadata, type, culprit} = event;
 
@@ -119,7 +119,13 @@ export function getTitle(
         };
       }
 
-      if (displayTitleWithTreeLabel && features.includes('grouping-title-ui')) {
+      const displayTitleWithTreeLabel =
+        features.includes('grouping-title-ui') &&
+        (grouping ||
+          isNativePlatform(event.platform) ||
+          isMobilePlatform(event.platform));
+
+      if (displayTitleWithTreeLabel) {
         return {
           subtitle: culprit,
           ...computeTitleWithTreeLabel(metadata),

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -1,4 +1,6 @@
-export function isNativePlatform(platform: string | undefined): boolean {
+import {mobile} from 'app/data/platformCategories';
+
+export function isNativePlatform(platform: string | undefined) {
   switch (platform) {
     case 'cocoa':
     case 'objc':
@@ -9,4 +11,12 @@ export function isNativePlatform(platform: string | undefined): boolean {
     default:
       return false;
   }
+}
+
+export function isMobilePlatform(platform: string | undefined) {
+  if (!platform) {
+    return false;
+  }
+
+  return ([...mobile] as string[]).includes(platform);
 }

--- a/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/newIssue.tsx
@@ -22,6 +22,7 @@ function NewIssue({sampleEvent, eventCount, organization}: Props) {
         <EventOrGroupHeader
           data={sampleEvent}
           organization={organization}
+          grouping
           hideIcons
           hideLevel
         />


### PR DESCRIPTION
**description:** Disable the new issue title rendering for all platforms except mobile and native. This means, ideally only mobile and native issues show the new title. 

**closes:** INGEST-372 (frontend part)