### PR TITLE
feat(dev): Remove zookeeper and upgrade kafka

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -165,7 +165,7 @@ runs:
             -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
             -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
             -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-            confluentinc/cp-kafka:5.1.2
+            confluentinc/cp-kafka:6.2.0
         fi
 
         if [ "$NEED_SNUBA" = "true" ]; then

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -96,7 +96,6 @@ runs:
         # differently if these are set.
         if [ "$NEED_KAFKA" = "true" ]; then
           echo "SENTRY_KAFKA_HOSTS=127.0.0.1:9092" >> $GITHUB_ENV
-          echo "SENTRY_ZOOKEEPER_HOSTS=127.0.0.1:2181" >> $GITHUB_ENV
         fi
 
     - name: Setup python
@@ -158,12 +157,6 @@ runs:
 
         # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
         if [ "$NEED_KAFKA" = "true" ]; then
-          docker run \
-            --name sentry_zookeeper \
-            -d --network host \
-            -e ZOOKEEPER_CLIENT_PORT=2181 \
-            confluentinc/cp-zookeeper:4.1.0
-
           docker run \
             --name sentry_kafka \
             -d --network host \

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -160,7 +160,6 @@ runs:
           docker run \
             --name sentry_kafka \
             -d --network host \
-            -e KAFKA_ZOOKEEPER_CONNECT=127.0.0.1:2181 \
             -e KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \
             -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://127.0.0.1:9093,EXTERNAL://127.0.0.1:9092 \
             -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \

--- a/config/clickhouse/dist_config.xml
+++ b/config/clickhouse/dist_config.xml
@@ -12,13 +12,6 @@
         </cluster_one_sh>
     </remote_servers>
 
-    <zookeeper>
-        <node>
-            <host>sentry_zookeeper</host>
-            <port>2181</port>
-        </node>
-    </zookeeper>
-
     <macros>
         <shard>1</shard>
         <replica>1</replica>

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1722,20 +1722,11 @@ SENTRY_DEVSERVICES = {
             },
         }
     ),
-    "zookeeper": lambda settings, options: (
-        {
-            "image": "confluentinc/cp-zookeeper:5.1.2",
-            "environment": {"ZOOKEEPER_CLIENT_PORT": "2181"},
-            "volumes": {"zookeeper": {"bind": "/var/lib/zookeeper"}},
-            "only_if": "kafka" in settings.SENTRY_EVENTSTREAM or settings.SENTRY_USE_RELAY,
-        }
-    ),
     "kafka": lambda settings, options: (
         {
-            "image": "confluentinc/cp-kafka:5.1.2",
+            "image": "confluentinc/cp-kafka:6.2.0",
             "ports": {"9092/tcp": 9092},
             "environment": {
-                "KAFKA_ZOOKEEPER_CONNECT": "{containers[zookeeper][name]}:2181",
                 "KAFKA_LISTENERS": "INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092",
                 "KAFKA_ADVERTISED_LISTENERS": "INTERNAL://{containers[kafka][name]}:9093,EXTERNAL://{containers[kafka]"
                 "[ports][9092/tcp][0]}:{containers[kafka][ports][9092/tcp][1]}",

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -22,10 +22,7 @@ settings.KAFKA_CLUSTERS["default"] = {
 
 @contextmanager
 def create_topic(partitions=1, replication_factor=1):
-    command = ["docker", "exec", "sentry_kafka", "kafka-topics"] + [
-        "--zookeeper",
-        os.environ["SENTRY_ZOOKEEPER_HOSTS"],
-    ]
+    command = ["docker", "exec", "sentry_kafka", "kafka-topics"]
     topic = f"test-{uuid.uuid1().hex}"
     subprocess.check_call(
         command


### PR DESCRIPTION
Upgrade kafka from version 5.1.2 which does not require zookeeper (see [blog post](https://www.confluent.io/blog/kafka-without-zookeeper-a-sneak-peek/)). zookeeper 5.1.2 does not work well on Apple's arm64 chipset.