### PR TITLE
ref(ui): Fix duplicate TS type in "Filters and Sampling" modal

### DIFF
--- a/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
@@ -28,10 +28,10 @@ import Conditions from './conditions';
 import handleXhrErrorResponse from './handleXhrErrorResponse';
 import {isLegacyBrowser} from './utils';
 
-type Conditions = React.ComponentProps<typeof Conditions>['conditions'];
+type ConditionsProps = React.ComponentProps<typeof Conditions>['conditions'];
 
 type State = {
-  conditions: Conditions;
+  conditions: ConditionsProps;
   errors: {
     sampleRate?: string;
   };
@@ -171,10 +171,10 @@ function RuleModal({
     setData({...data, conditions: newConditions});
   }
 
-  function handleChangeCondition<T extends keyof Conditions[0]>(
+  function handleChangeCondition<T extends keyof ConditionsProps[0]>(
     index: number,
     field: T,
-    value: Conditions[0][T]
+    value: ConditionsProps[0][T]
   ) {
     const newConditions = [...conditions];
     newConditions[index][field] = value;


### PR DESCRIPTION
This fixes a duplicate identifier that will fail a future eslint rule.