### PR TITLE
feat(discover): render multi y axis on discover result chart based on y axis checkbox dropdown

### DIFF
--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -553,7 +553,6 @@ class EventsChart extends React.Component<EventsChartProps> {
             interval={intervalVal}
             query={query}
             includePrevious={includePrevious}
-            // TODO
             currentSeriesName={currentSeriesName[0]}
             previousSeriesName={previousSeriesName[0]}
             yAxis={yAxis}

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -22,6 +22,7 @@ import {Series} from 'app/types/echarts';
 import {defined} from 'app/utils';
 import {axisLabelFormatter, tooltipFormatter} from 'app/utils/discover/charts';
 import {aggregateMultiPlotType, getEquation, isEquation} from 'app/utils/discover/fields';
+import {decodeList} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
 
 import EventsRequest from './eventsRequest';
@@ -285,7 +286,7 @@ export type EventsChartProps = {
   /**
    * The aggregate/metric to plot.
    */
-  yAxis: string[];
+  yAxis: string | string[];
   /**
    * Relative datetime expression. eg. 14d
    */
@@ -388,7 +389,11 @@ type ChartDataProps = {
 
 class EventsChart extends React.Component<EventsChartProps> {
   isStacked() {
-    return typeof this.props.topEvents === 'number' && this.props.topEvents > 0;
+    const {topEvents, yAxis} = this.props;
+    return (
+      (typeof topEvents === 'number' && topEvents > 0) ||
+      (Array.isArray(yAxis) && yAxis.length > 1)
+    );
   }
 
   render() {
@@ -434,7 +439,8 @@ class EventsChart extends React.Component<EventsChartProps> {
     // Include previous only on relative dates (defaults to relative if no start and end)
     const includePrevious = !disablePrevious && !start && !end;
 
-    const yAxisSeriesNames = yAxis.map(name => {
+    const yAxisArray = decodeList(yAxis);
+    const yAxisSeriesNames = yAxisArray.map(name => {
       let yAxisLabel = name && isEquation(name) ? getEquation(name) : name;
       if (yAxisLabel && yAxisLabel.length > 60) {
         yAxisLabel = yAxisLabel.substr(0, 60) + '...';
@@ -492,7 +498,7 @@ class EventsChart extends React.Component<EventsChartProps> {
             seriesTransformer={seriesTransformer}
             previousSeriesTransformer={previousSeriesTransformer}
             stacked={this.isStacked()}
-            yAxis={yAxis[0]}
+            yAxis={yAxisArray[0]}
             showDaily={showDaily}
             colors={colors}
             legendOptions={legendOptions}

--- a/static/app/components/charts/optionCheckboxSelector.tsx
+++ b/static/app/components/charts/optionCheckboxSelector.tsx
@@ -10,10 +10,10 @@ import {DropdownItem} from 'app/components/dropdownControl';
 import DropdownMenu from 'app/components/dropdownMenu';
 import Tooltip from 'app/components/tooltip';
 import Truncate from 'app/components/truncate';
+import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {SelectValue} from 'app/types';
-import {aggregateMultiPlotType} from 'app/utils/discover/fields';
 
 const defaultProps = {
   menuWidth: 'auto',
@@ -58,6 +58,10 @@ class OptionCheckboxSelector extends Component<Props, State> {
 
   constructNewSelected(value: string) {
     const {selected} = this.props;
+    // Cannot have no option selected
+    if (selected.length === 1 && selected[0] === value) {
+      return selected;
+    }
     // Check if the value is already selected.
     // Return a new updated array with the value either selected or deselected depending on previous selected state.
     if (selected.includes(value)) {
@@ -76,8 +80,6 @@ class OptionCheckboxSelector extends Component<Props, State> {
         .filter(opt => selected.includes(opt.value))
         .map(({label}) => label)
         .join(', ') || 'None';
-    const selectedPlotType =
-      selected.length > 0 ? aggregateMultiPlotType(selected[0]) : undefined;
 
     return (
       <InlineContainer>
@@ -99,11 +101,8 @@ class OptionCheckboxSelector extends Component<Props, State> {
                   blendCorner
                 >
                   {options.map(opt => {
-                    // field plot type should match currently selected plot type otherwise we can't display both yAxis in the same chart
-                    const disabled =
-                      opt.disabled ||
-                      (selectedPlotType &&
-                        aggregateMultiPlotType(opt.value) !== selectedPlotType);
+                    // Y-Axis is capped at 3 fields
+                    const disabled = selected.length > 2 && !selected.includes(opt.value);
                     return (
                       <StyledDropdownItem
                         key={opt.value}
@@ -118,7 +117,9 @@ class OptionCheckboxSelector extends Component<Props, State> {
                         <StyledTooltip
                           title={
                             disabled
-                              ? 'This field cannot be plotted with currently selected fields.'
+                              ? t(
+                                  'Only a maximum of 3 fields can be displayed on the Y-Axis at a time'
+                                )
                               : undefined
                           }
                         >

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -301,7 +301,9 @@ class Results extends React.Component<Props, State> {
       // If using Multi Y-axis and not in a supported display, change to the default display mode
       display:
         value.length > 1 && !isDisplayMultiYAxisSupported
-          ? DisplayModes.DEFAULT
+          ? location.query.display === DisplayModes.DAILYTOP5
+            ? DisplayModes.DAILY
+            : DisplayModes.DEFAULT
           : location.query.display,
     };
 

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -32,7 +32,7 @@ import {defined, generateQueryWithTag} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {generateAggregateFields} from 'app/utils/discover/fields';
-import {CHART_AXIS_OPTIONS} from 'app/utils/discover/types';
+import {CHART_AXIS_OPTIONS, DisplayModes} from 'app/utils/discover/types';
 import localStorage from 'app/utils/localStorage';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
 import withApi from 'app/utils/withApi';
@@ -290,10 +290,19 @@ class Results extends React.Component<Props, State> {
 
   handleYAxisChange = (value: string[]) => {
     const {router, location} = this.props;
+    const isDisplayMultiYAxisSupported = [
+      DisplayModes.DEFAULT,
+      DisplayModes.DAILY,
+    ].includes(location.query.display as DisplayModes);
 
     const newQuery = {
       ...location.query,
       yAxis: value,
+      // If using Multi Y-axis and not in a supported display, change to the default display mode
+      display:
+        value.length > 1 && !isDisplayMultiYAxisSupported
+          ? DisplayModes.DEFAULT
+          : location.query.display,
     };
 
     router.push({

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -446,8 +446,7 @@ class Results extends React.Component<Props, State> {
       : eventView.fields;
     const query = eventView.query;
     const title = this.getDocumentTitle();
-    const yAxis = location.query.yAxis;
-    const yAxisArray = yAxis ? (typeof yAxis === 'string' ? [yAxis] : yAxis) : [];
+    const yAxisArray = decodeList(location.query.yAxis);
 
     return (
       <SentryDocumentTitle title={title} orgSlug={organization.slug}>

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -205,7 +205,7 @@ class ResultsChartContainer extends Component<ContainerProps> {
             confirmedQuery={confirmedQuery}
             yAxisValue={yAxisValue}
           />
-        )) || <NoChartContainer>{'No Y-Axis selected.'}</NoChartContainer>}
+        )) || <NoChartContainer>{t('No Y-Axis selected.')}</NoChartContainer>}
         <ChartFooter
           organization={organization}
           total={total}

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -5,7 +5,7 @@ import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {Client} from 'app/api';
-import Feature from 'app/components/acl/feature';
+import AreaChart from 'app/components/charts/areaChart';
 import EventsChart from 'app/components/charts/eventsChart';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
@@ -49,6 +49,9 @@ class ResultsChart extends Component<ResultsChartProps> {
 
     const hasPerformanceChartInterpolation = organization.features.includes(
       'performance-chart-interpolation'
+    );
+    const hasConnectDiscoverAndDashboards = organization.features.includes(
+      'connect-discover-and-dashboards'
     );
 
     const globalSelection = eventView.getGlobalSelection();
@@ -95,6 +98,9 @@ class ResultsChart extends Component<ResultsChartProps> {
               utc={utc === 'true'}
               confirmedQuery={confirmedQuery}
               withoutZerofill={hasPerformanceChartInterpolation}
+              chartComponent={
+                hasConnectDiscoverAndDashboards && !isDaily ? AreaChart : undefined
+              }
             />
           ),
           fixed: <Placeholder height="200px" testId="skeleton-ui" />,
@@ -149,6 +155,9 @@ class ResultsChartContainer extends Component<ContainerProps> {
     } = this.props;
 
     const hasQueryFeature = organization.features.includes('discover-query');
+    const hasConnectDiscoverAndDashboards = organization.features.includes(
+      'connect-discover-and-dashboards'
+    );
     const displayOptions = eventView
       .getDisplayOptions()
       .filter(opt => {
@@ -182,9 +191,11 @@ class ResultsChartContainer extends Component<ContainerProps> {
         return opt;
       });
 
+    const yAxisValue = hasConnectDiscoverAndDashboards ? yAxis : [eventView.getYAxis()];
+
     return (
       <StyledPanel>
-        {(yAxis && yAxis.length > 0 && (
+        {(yAxisValue.length > 0 && (
           <ResultsChart
             api={api}
             eventView={eventView}
@@ -192,26 +203,19 @@ class ResultsChartContainer extends Component<ContainerProps> {
             organization={organization}
             router={router}
             confirmedQuery={confirmedQuery}
-            yAxisValue={yAxis}
+            yAxisValue={yAxisValue}
           />
         )) || <NoChartContainer>{'No Y-Axis selected.'}</NoChartContainer>}
-        <Feature
+        <ChartFooter
           organization={organization}
-          features={['connect-discover-and-dashboards']}
-        >
-          {({hasFeature}) => (
-            <ChartFooter
-              organization={organization}
-              total={total}
-              yAxisValue={hasFeature ? yAxis : [eventView.getYAxis()]}
-              yAxisOptions={eventView.getYAxisOptions()}
-              onAxisChange={onAxisChange}
-              displayOptions={displayOptions}
-              displayMode={eventView.getDisplayMode()}
-              onDisplayChange={onDisplayChange}
-            />
-          )}
-        </Feature>
+          total={total}
+          yAxisValue={yAxisValue}
+          yAxisOptions={eventView.getYAxisOptions()}
+          onAxisChange={onAxisChange}
+          displayOptions={displayOptions}
+          displayMode={eventView.getDisplayMode()}
+          onDisplayChange={onDisplayChange}
+        />
       </StyledPanel>
     );
   }

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -184,7 +184,7 @@ class ResultsChartContainer extends Component<ContainerProps> {
             ...opt,
             disabled: true,
             tooltip: t(
-              'Change the Y-Axis dropdown to display only 1 field to use this view.'
+              'Change the Y-Axis dropdown to display only 1 function to use this view.'
             ),
           };
         }

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -184,15 +184,17 @@ class ResultsChartContainer extends Component<ContainerProps> {
 
     return (
       <StyledPanel>
-        <ResultsChart
-          api={api}
-          eventView={eventView}
-          location={location}
-          organization={organization}
-          router={router}
-          confirmedQuery={confirmedQuery}
-          yAxisValue={yAxis}
-        />
+        {(yAxis && yAxis.length > 0 && (
+          <ResultsChart
+            api={api}
+            eventView={eventView}
+            location={location}
+            organization={organization}
+            router={router}
+            confirmedQuery={confirmedQuery}
+            yAxisValue={yAxis}
+          />
+        )) || <NoChartContainer>{'No Y-Axis selected.'}</NoChartContainer>}
         <Feature
           organization={organization}
           features={['connect-discover-and-dashboards']}
@@ -221,4 +223,21 @@ const StyledPanel = styled(Panel)`
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     margin: 0;
   }
+`;
+
+const NoChartContainer = styled('div')<{height?: string}>`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  flex: 1;
+  flex-shrink: 0;
+  overflow: hidden;
+  height: ${p => p.height || '200px'};
+  position: relative;
+  border-color: transparent;
+  margin-bottom: 0;
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
 `;

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -33,6 +33,7 @@ import {
 } from 'app/utils/discover/fields';
 import {DisplayModes, TOP_N} from 'app/utils/discover/types';
 import {eventDetailsRouteWithEventView, generateEventSlug} from 'app/utils/discover/urls';
+import {decodeList} from 'app/utils/queryString';
 import {MutableSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
 import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
@@ -193,6 +194,8 @@ class TableView extends React.Component<TableViewProps> {
 
       const nextEventView = eventView.sortOnField(field, tableMeta);
       const queryStringObject = nextEventView.generateQueryStringObject();
+      // Need to pull yAxis from location since eventView only stores 1 yAxis field at time
+      queryStringObject.yAxis = decodeList(location.query.yAxis);
 
       return {
         ...location,
@@ -427,7 +430,7 @@ class TableView extends React.Component<TableViewProps> {
   };
 
   handleUpdateColumns = (columns: Column[]): void => {
-    const {organization, eventView} = this.props;
+    const {organization, eventView, location} = this.props;
 
     // metrics
     trackAnalyticsEvent({
@@ -437,7 +440,13 @@ class TableView extends React.Component<TableViewProps> {
     });
 
     const nextView = eventView.withColumns(columns);
-    browserHistory.push(nextView.getResultsViewUrlTarget(organization.slug));
+    const resultsViewUrlTarget = nextView.getResultsViewUrlTarget(organization.slug);
+    // Need to pull yAxis from location since eventView only stores 1 yAxis field at time
+    const previousYAxis = decodeList(location.query.yAxis);
+    resultsViewUrlTarget.query.yAxis = previousYAxis.filter(yAxis =>
+      nextView.getYAxisOptions().find(({value}) => value === yAxis)
+    );
+    browserHistory.push(resultsViewUrlTarget);
   };
 
   renderHeaderButtons = () => {

--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -24,6 +24,7 @@ type Props = Omit<
   onTotalValuesChange: (value: number | null) => void;
   theme: Theme;
   help?: string;
+  yAxis: string;
 };
 
 class ProjectBaseEventsChart extends Component<Props> {

--- a/tests/js/spec/components/charts/optionCheckboxSelector.spec.tsx
+++ b/tests/js/spec/components/charts/optionCheckboxSelector.spec.tsx
@@ -11,6 +11,7 @@ describe('EventsV2 > OptionCheckboxSelector', function () {
     {label: 'count()', value: 'count()'},
     {label: 'failure_count()', value: 'failure_count()'},
     {label: 'count_unique(user)', value: 'count_unique(user)'},
+    {label: 'avg(transaction.duration)', value: 'avg(transaction.duration)'},
   ];
   let organization, initialData, selected, wrapper, onChangeStub, dropdownItem;
 
@@ -81,5 +82,29 @@ describe('EventsV2 > OptionCheckboxSelector', function () {
     expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
     dropdownItem.at(1).find('span').first().simulate('click');
     expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
+  });
+
+  it('only allows up to 3 options to be checked at one time', function () {
+    dropdownItem.at(2).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith([
+      'count()',
+      'failure_count()',
+      'count_unique(user)',
+    ]);
+    dropdownItem.at(3).find('span').first().simulate('click');
+    expect(onChangeStub).not.toHaveBeenCalledWith([
+      'count()',
+      'failure_count()',
+      'count_unique(user)',
+      'avg(transaction.duration)',
+    ]);
+    dropdownItem.at(2).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['count()', 'failure_count()']);
+    dropdownItem.at(3).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith([
+      'count()',
+      'failure_count()',
+      'avg(transaction.duration)',
+    ]);
   });
 });

--- a/tests/js/spec/components/charts/optionCheckboxSelector.spec.tsx
+++ b/tests/js/spec/components/charts/optionCheckboxSelector.spec.tsx
@@ -6,7 +6,7 @@ import {t} from 'app/locale';
 
 describe('EventsV2 > OptionCheckboxSelector', function () {
   const features = ['discover-basic'];
-  const yAxisValue = ['count()'];
+  const yAxisValue = ['count()', 'failure_count()'];
   const yAxisOptions = [
     {label: 'count()', value: 'count()'},
     {label: 'failure_count()', value: 'failure_count()'},
@@ -55,36 +55,31 @@ describe('EventsV2 > OptionCheckboxSelector', function () {
       'count_unique(user)'
     );
     expect(dropdownItem.at(0).props().isChecked).toEqual(true);
-    expect(dropdownItem.at(1).props().isChecked).toEqual(false);
+    expect(dropdownItem.at(1).props().isChecked).toEqual(true);
     expect(dropdownItem.at(2).props().isChecked).toEqual(false);
   });
 
   it('calls onChange prop with new checkbox option state', function () {
-    wrapper.setProps({selected: ['failure_count()', 'count_unique(user)']});
-    dropdownItem.at(2).find('span').first().simulate('click');
+    dropdownItem.at(0).find('span').first().simulate('click');
     expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
+    dropdownItem.at(0).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()', 'count()']);
+    dropdownItem.at(1).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['count()']);
+    dropdownItem.at(1).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['count()', 'failure_count()']);
     dropdownItem.at(2).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()', 'count_unique(user)']);
-    dropdownItem.at(1).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['count_unique(user)']);
-    dropdownItem.at(1).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['count_unique(user)', 'failure_count()']);
-    dropdownItem.at(1).find('span').first().simulate('click');
-    dropdownItem.at(2).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith([]);
+    expect(onChangeStub).toHaveBeenCalledWith([
+      'count()',
+      'failure_count()',
+      'count_unique(user)',
+    ]);
   });
 
-  it('cannot select a Y-Axis field that is not compatible with already selected Y-Axis', function () {
-    wrapper.setProps({selected: ['failure_count()', 'count_unique(user)']});
+  it('does not uncheck options when clicked if only one option is currently selected', function () {
     dropdownItem.at(0).find('span').first().simulate('click');
-    expect(onChangeStub).not.toHaveBeenCalled();
-  });
-
-  it('can select a Y-Axis with a different plot type if all Y-Axis were deselected', function () {
-    dropdownItem.at(0).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith([]);
+    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
     dropdownItem.at(1).find('span').first().simulate('click');
-    dropdownItem.at(2).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()', 'count_unique(user)']);
+    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
   });
 });

--- a/tests/js/spec/components/charts/optionCheckboxSelector.spec.tsx
+++ b/tests/js/spec/components/charts/optionCheckboxSelector.spec.tsx
@@ -6,7 +6,7 @@ import {t} from 'app/locale';
 
 describe('EventsV2 > OptionCheckboxSelector', function () {
   const features = ['discover-basic'];
-  const yAxisValue = ['count()', 'failure_count()'];
+  const yAxisValue = ['count()'];
   const yAxisOptions = [
     {label: 'count()', value: 'count()'},
     {label: 'failure_count()', value: 'failure_count()'},
@@ -55,31 +55,36 @@ describe('EventsV2 > OptionCheckboxSelector', function () {
       'count_unique(user)'
     );
     expect(dropdownItem.at(0).props().isChecked).toEqual(true);
-    expect(dropdownItem.at(1).props().isChecked).toEqual(true);
+    expect(dropdownItem.at(1).props().isChecked).toEqual(false);
     expect(dropdownItem.at(2).props().isChecked).toEqual(false);
   });
 
   it('calls onChange prop with new checkbox option state', function () {
-    dropdownItem.at(0).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
-    dropdownItem.at(0).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()', 'count()']);
-    dropdownItem.at(1).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['count()']);
-    dropdownItem.at(1).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['count()', 'failure_count()']);
+    wrapper.setProps({selected: ['failure_count()', 'count_unique(user)']});
     dropdownItem.at(2).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith([
-      'count()',
-      'failure_count()',
-      'count_unique(user)',
-    ]);
+    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
+    dropdownItem.at(2).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()', 'count_unique(user)']);
+    dropdownItem.at(1).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['count_unique(user)']);
+    dropdownItem.at(1).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['count_unique(user)', 'failure_count()']);
+    dropdownItem.at(1).find('span').first().simulate('click');
+    dropdownItem.at(2).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith([]);
   });
 
-  it('does not uncheck options when clicked if only one option is currently selected', function () {
+  it('cannot select a Y-Axis field that is not compatible with already selected Y-Axis', function () {
+    wrapper.setProps({selected: ['failure_count()', 'count_unique(user)']});
     dropdownItem.at(0).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
+    expect(onChangeStub).not.toHaveBeenCalled();
+  });
+
+  it('can select a Y-Axis with a different plot type if all Y-Axis were deselected', function () {
+    dropdownItem.at(0).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith([]);
     dropdownItem.at(1).find('span').first().simulate('click');
-    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()']);
+    dropdownItem.at(2).find('span').first().simulate('click');
+    expect(onChangeStub).toHaveBeenCalledWith(['failure_count()', 'count_unique(user)']);
   });
 });

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -339,7 +339,7 @@ describe('EventsV2 > Results', function () {
     wrapper.update();
 
     const eventsRequest = wrapper.find('EventsChart');
-    expect(eventsRequest.props().yAxis).toEqual('count()');
+    expect(eventsRequest.props().yAxis).toEqual(['count()']);
     wrapper.unmount();
   });
 
@@ -352,7 +352,7 @@ describe('EventsV2 > Results', function () {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {...generateFields(), display: 'previoux'}},
+        location: {query: {...generateFields(), display: 'default', yAxis: 'count'}},
       },
     });
 
@@ -398,7 +398,7 @@ describe('EventsV2 > Results', function () {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {...generateFields(), display: 'previoux'}},
+        location: {query: {...generateFields(), display: 'previous'}},
       },
     });
 
@@ -706,7 +706,7 @@ describe('EventsV2 > Results', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '14d',
-          yAxis: 'count()',
+          yAxis: ['count()'],
         }),
       })
     );
@@ -728,7 +728,7 @@ describe('EventsV2 > Results', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '14d',
-          yAxis: 'count_unique(user)',
+          yAxis: ['count_unique(user)'],
         }),
       })
     );
@@ -744,7 +744,7 @@ describe('EventsV2 > Results', function () {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {...generateFields(), display: 'default'}},
+        location: {query: {...generateFields(), display: 'default', yAxis: 'count()'}},
       },
     });
 
@@ -769,7 +769,7 @@ describe('EventsV2 > Results', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '14d',
-          yAxis: 'count()',
+          yAxis: ['count()'],
         }),
       })
     );
@@ -777,7 +777,7 @@ describe('EventsV2 > Results', function () {
     // Update location simulating a browser back button action
     wrapper.setProps({
       location: {
-        query: {...generateFields(), display: 'previous'},
+        query: {...generateFields(), display: 'previous', yAxis: 'count()'},
       },
     });
     await tick();
@@ -791,7 +791,7 @@ describe('EventsV2 > Results', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '28d',
-          yAxis: 'count()',
+          yAxis: ['count()'],
         }),
       })
     );
@@ -832,7 +832,7 @@ describe('EventsV2 > Results', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '14d',
-          yAxis: 'count()',
+          yAxis: ['count()'],
         }),
       })
     );
@@ -854,7 +854,7 @@ describe('EventsV2 > Results', function () {
       expect.objectContaining({
         query: expect.objectContaining({
           statsPeriod: '28d',
-          yAxis: 'count_unique(user)',
+          yAxis: ['count_unique(user)'],
         }),
       })
     );

--- a/tests/js/spec/views/eventsV2/resultsChart.spec.tsx
+++ b/tests/js/spec/views/eventsV2/resultsChart.spec.tsx
@@ -1,0 +1,83 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {t} from 'app/locale';
+import EventView from 'app/utils/discover/eventView';
+import {DisplayModes} from 'app/utils/discover/types';
+import ResultsChart from 'app/views/eventsV2/resultsChart';
+
+describe('EventsV2 > ResultsChart', function () {
+  const features = ['discover-basic', 'connect-discover-and-dashboards'];
+  const location = {
+    query: {query: 'tag:value'},
+    pathname: '/',
+  };
+
+  let organization, eventView, initialData;
+
+  beforeEach(() => {
+    // @ts-expect-error
+    organization = TestStubs.Organization({
+      features,
+      // @ts-expect-error
+      projects: [TestStubs.Project()],
+    });
+    initialData = initializeOrg({
+      organization,
+      router: {
+        location,
+      },
+      project: 1,
+      projects: [],
+    });
+    // @ts-expect-error
+    eventView = EventView.fromSavedQueryOrLocation(undefined, location);
+  });
+
+  it('only allows default and daily display modes when multiple y axis are selected', async function () {
+    const wrapper = mountWithTheme(
+      <ResultsChart
+        // @ts-expect-error
+        router={TestStubs.router()}
+        organization={organization}
+        eventView={eventView}
+        // @ts-expect-error
+        location={location}
+        onAxisChange={() => undefined}
+        onDisplayChange={() => undefined}
+        total={1}
+        confirmedQuery
+        yAxis={['count()', 'failure_count()']}
+      />,
+      initialData.routerContext
+    );
+    const displayOptions = wrapper.find('ChartFooter').props().displayOptions;
+    displayOptions.forEach(({value, disabled}) => {
+      if (![DisplayModes.DEFAULT, DisplayModes.DAILY].includes(value)) {
+        expect(disabled).toBe(true);
+      }
+    });
+  });
+
+  it('does not display a chart if no y axis is selected', async function () {
+    const wrapper = mountWithTheme(
+      <ResultsChart
+        // @ts-expect-error
+        router={TestStubs.router()}
+        organization={organization}
+        eventView={eventView}
+        // @ts-expect-error
+        location={location}
+        onAxisChange={() => undefined}
+        onDisplayChange={() => undefined}
+        total={1}
+        confirmedQuery
+        yAxis={[]}
+      />,
+      initialData.routerContext
+    );
+    expect(wrapper.find('NoChartContainer').children().children().html()).toEqual(
+      t('No Y-Axis selected.')
+    );
+  });
+});


### PR DESCRIPTION
Enables rendering multi y axis on Discover results chart behind feature flag.

![image](https://user-images.githubusercontent.com/83961295/133620851-06b4840f-3b26-487f-960b-f9050fd9232d.png)
![image](https://user-images.githubusercontent.com/83961295/133316156-f760ddcf-9eef-41a4-a2c0-356c84637ffc.png)

Only Display options allowed for Multi Y Axis are `Total Period` and `Total Daily` for now.
`Total Period` always displays in stacked area graph for simplicity.
`Total Daily` always displays in stacked bar graph.
When more than 1 Y-Axis is selected, the other Display options are greyed out with the following tooltip:
![image](https://user-images.githubusercontent.com/83961295/133621289-ae5481ae-b4d7-4cc9-92ef-01c0348a3a20.png)

Only a max of 3 Y-Axis can be displayed at a time, this is to mirror Dashboard widgets:
![image](https://user-images.githubusercontent.com/83961295/133621679-5ce6d350-6886-45dd-96c0-9daf253d1470.png)

