### PR TITLE
fix(ui): Actions dropdowns now show teams correctly

### DIFF
--- a/static/app/components/selectMembers/index.tsx
+++ b/static/app/components/selectMembers/index.tsx
@@ -32,7 +32,6 @@ type Props = {
   project?: Project;
   organization: Organization;
   value: any;
-  showTeam: boolean;
   onChange: (value: any) => any;
   onInputChange?: (value: any) => any;
   disabled?: boolean;
@@ -198,7 +197,7 @@ class SelectMembers extends React.Component<Props, State> {
         onChange={this.handleChange}
         value={this.state.options?.find(({value}) => value === this.props.value)}
         styles={{
-          styles,
+          ...(styles ?? {}),
           option: (provided, state: any) => ({
             ...provided,
             svg: {

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import SelectControl from 'app/components/forms/selectControl';
+import TeamSelector from 'app/components/forms/teamSelector';
 import SelectMembers from 'app/components/selectMembers';
 import {Organization, Project, SelectValue} from 'app/types';
 import {
@@ -54,11 +55,20 @@ export default function ActionTargetSelector(props: Props) {
     case TargetType.USER:
       const isTeam = action.targetType === TargetType.TEAM;
 
-      return (
+      return isTeam ? (
+        <TeamSelector
+          disabled={disabled}
+          key="team"
+          project={project}
+          value={action.targetIdentifier}
+          onChange={handleChangeTargetIdentifier}
+          useId
+          includeUnassigned
+        />
+      ) : (
         <SelectMembers
           disabled={disabled}
-          key={isTeam ? 'team' : 'member'}
-          showTeam={isTeam}
+          key="member"
           project={project}
           organization={organization}
           value={action.targetIdentifier}

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
@@ -63,7 +63,6 @@ export default function ActionTargetSelector(props: Props) {
           value={action.targetIdentifier}
           onChange={handleChangeTargetIdentifier}
           useId
-          includeUnassigned
         />
       ) : (
         <SelectMembers

--- a/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
+++ b/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 
 import SelectControl from 'app/components/forms/selectControl';
+import TeamSelector from 'app/components/forms/teamSelector';
 import {PanelItem} from 'app/components/panels';
 import SelectMembers from 'app/components/selectMembers';
 import space from 'app/styles/space';
@@ -86,11 +87,22 @@ class MemberTeamFields extends React.Component<Props> {
           options={options}
           onChange={this.handleChangeActorType}
         />
-        {teamSelected || memberSelected ? (
+        {teamSelected ? (
+          <TeamSelector
+            disabled={disabled}
+            key={teamValue}
+            project={project}
+            // The value from the endpoint is of type `number`, `SelectMembers` require value to be of type `string`
+            value={`${ruleData.targetIdentifier}`}
+            styles={selectControlStyles}
+            onChange={this.handleChangeActorId}
+            useId
+            includeUnassigned
+          />
+        ) : memberSelected ? (
           <SelectMembers
             disabled={disabled}
             key={teamSelected ? teamValue : memberValue}
-            showTeam={teamSelected}
             project={project}
             organization={organization}
             // The value from the endpoint is of type `number`, `SelectMembers` require value to be of type `string`
@@ -98,9 +110,7 @@ class MemberTeamFields extends React.Component<Props> {
             styles={selectControlStyles}
             onChange={this.handleChangeActorId}
           />
-        ) : (
-          <span />
-        )}
+        ) : null}
       </PanelItemGrid>
     );
   }

--- a/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
+++ b/static/app/views/alerts/issueRuleEditor/memberTeamFields.tsx
@@ -97,7 +97,6 @@ class MemberTeamFields extends React.Component<Props> {
             styles={selectControlStyles}
             onChange={this.handleChangeActorId}
             useId
-            includeUnassigned
           />
         ) : memberSelected ? (
           <SelectMembers


### PR DESCRIPTION
Due to the unification of team selectors in the app we remove the functionality for `SelectMembers` to show team information. However, I forgot to migrate this instance of team dropdown over. 

Fixes the ability to show teams inside of the actions section of creating alert rules (both for issue and metric rules)

before:
![image](https://user-images.githubusercontent.com/9372512/133314558-558c47b5-11da-4e9a-9e3e-4415be20649d.png)

after:
![image](https://user-images.githubusercontent.com/9372512/133314528-b813c8a0-dfce-474a-b0c3-17da04ef4879.png)


