### PR TITLE
feat(symbolicator): Register manual kill switches for symbolicator's low priority queue

### DIFF
--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -79,7 +79,7 @@ ALL_KILLSWITCH_OPTIONS = {
     ),
     "store.symbolicate-event-lpq-never": KillswitchInfo(
         description="""
-        Never allow a project's symbolication events to be demoted to symbolicator's Low Priority queue.
+        Never allow a project's symbolication events to be demoted to symbolicator's low priority queue.
 
         If a project is in both store.symbolicate-event-lpq-never and store.symbolicate-event-lpq-always,
         store.symbolicate-event-lpq-never will always take precedence.
@@ -90,7 +90,7 @@ ALL_KILLSWITCH_OPTIONS = {
     ),
     "store.symbolicate-event-lpq-always": KillswitchInfo(
         description="""
-        Always push a project's symbolication events to symbolicator's Low Priority queue.
+        Always push a project's symbolication events to symbolicator's low priority queue.
 
         If a project is in both store.symbolicate-event-lpq-never and store.symbolicate-event-lpq-always,
         store.symbolicate-event-lpq-never will always take precedence.

--- a/src/sentry/killswitches.py
+++ b/src/sentry/killswitches.py
@@ -77,6 +77,28 @@ ALL_KILLSWITCH_OPTIONS = {
             "platform": "The event platform as defined in the event payload's platform field, or 'none'",
         },
     ),
+    "store.symbolicate-event-lpq-never": KillswitchInfo(
+        description="""
+        Never allow a project's symbolication events to be demoted to symbolicator's Low Priority queue.
+
+        If a project is in both store.symbolicate-event-lpq-never and store.symbolicate-event-lpq-always,
+        store.symbolicate-event-lpq-never will always take precedence.
+        """,
+        fields={
+            "project_id": "A project ID to filter events by.",
+        },
+    ),
+    "store.symbolicate-event-lpq-always": KillswitchInfo(
+        description="""
+        Always push a project's symbolication events to symbolicator's Low Priority queue.
+
+        If a project is in both store.symbolicate-event-lpq-never and store.symbolicate-event-lpq-always,
+        store.symbolicate-event-lpq-never will always take precedence.
+        """,
+        fields={
+            "project_id": "A project ID to filter events by.",
+        },
+    ),
 }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -324,6 +324,8 @@ register("store.load-shed-parsed-pipeline-projects", type=Any, default=[])
 register("store.load-shed-save-event-projects", type=Any, default=[])
 register("store.load-shed-process-event-projects", type=Any, default=[])
 register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
+register("store.symbolicate-event-dlq-never", type=Any, default=[])
+register("store.symbolicate-event-dlq-always", type=Any, default=[])
 
 # Switch for more performant project counter incr
 register("store.projectcounter-modern-upsert-sample-rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -324,8 +324,8 @@ register("store.load-shed-parsed-pipeline-projects", type=Any, default=[])
 register("store.load-shed-save-event-projects", type=Any, default=[])
 register("store.load-shed-process-event-projects", type=Any, default=[])
 register("store.load-shed-symbolicate-event-projects", type=Any, default=[])
-register("store.symbolicate-event-dlq-never", type=Any, default=[])
-register("store.symbolicate-event-dlq-always", type=Any, default=[])
+register("store.symbolicate-event-lpq-never", type=Sequence, default=[])
+register("store.symbolicate-event-lpq-always", type=Sequence, default=[])
 
 # Switch for more performant project counter incr
 register("store.projectcounter-modern-upsert-sample-rate", default=0.0)


### PR DESCRIPTION
kill switches added:
- `store.symbolicate-event-lpq-never`
- `store.symbolicate-event-lpq-always`

This registers the two manual kill switches meant for ops use. As
mentioned in their description, adding a project to these switches
will either always or never redirect all symbolication(?) events for 
that project towards symbolicator's low priority queue. The low
priority queue provides "worse" guarantees on how quickly an 
event will be processed, i.e. it will take longer for an event to be
completed in the low priority queue.

I've added @untitaker as a reviewer because this uses killswitch
infra that he's most familiar with, being its author and all that. It 
would be helpful to know whether I'm using that correctly, and
if it's better to use the "legacy" kill switch for what I'm trying to
accomplish here.

Note that this is merely the registration step. Actual use of this
switch will follow in a second PR.
