### PR TITLE
fix(notification platform): Remove hardcoded email provider

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -84,8 +84,8 @@ class MailAdapter:
         Return a collection of USERS that are eligible to receive
         notifications for the provided project.
         """
-        recipients = NotificationSetting.objects.get_notification_recipients(project)
-        return set.union(*recipients.values()) if recipients else {}
+        recipients_by_provider = NotificationSetting.objects.get_notification_recipients(project)
+        return set.union(*recipients_by_provider.values()) if recipients_by_provider else {}
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -12,7 +12,6 @@ from sentry.notifications.notifications.user_report import UserReportNotificatio
 from sentry.notifications.types import ActionTargetType
 from sentry.plugins.base.structs import Notification
 from sentry.tasks.digests import deliver_digest
-from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -85,9 +84,8 @@ class MailAdapter:
         Return a collection of USERS that are eligible to receive
         notifications for the provided project.
         """
-        return NotificationSetting.objects.get_notification_recipients(project)[
-            ExternalProviders.EMAIL
-        ]
+        recipients = NotificationSetting.objects.get_notification_recipients(project)
+        return set.union(*recipients.values()) if recipients else {}
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -85,7 +85,7 @@ class MailAdapter:
         notifications for the provided project.
         """
         recipients_by_provider = NotificationSetting.objects.get_notification_recipients(project)
-        return set.union(*recipients_by_provider.values()) if recipients_by_provider else {}
+        return {user for users in recipients_by_provider.values() for user in users}
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -80,6 +80,8 @@ def _get_setting_mapping_from_mapping(
 ) -> Mapping[ExternalProviders, NotificationSettingOptionValues]:
     # XXX(CEO): may not respect granularity of a setting for Slack a setting for email
     # but we'll worry about that later since we don't have a FE for it yet
+    from sentry.notifications.notify import notification_providers
+
     specific_scope = get_scope_type(type)
     notification_settings_mapping = notification_settings_by_user.get(user)
     if notification_settings_mapping:
@@ -91,7 +93,7 @@ def _get_setting_mapping_from_mapping(
 
     return {
         provider: _get_notification_setting_default(provider, type, user=user)
-        for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]
+        for provider in notification_providers()
     }
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -91,7 +91,7 @@ def _get_setting_mapping_from_mapping(
 
     return {
         provider: _get_notification_setting_default(provider, type, user=user)
-        for provider in [ExternalProviders.EMAIL]
+        for provider in [ExternalProviders.EMAIL, ExternalProviders.SLACK]
     }
 
 


### PR DESCRIPTION
Remove the hard coded email provider and just check for any provider - I believe this was leftover from a refactor before we were ready to launch. This fixes an issue where if a user's delivery method for issue alerts was set to Slack (and not Slack _and_ email) and a rule fired which was set to send a notification to issue owners, it would not send.