### PR TITLE
chore(integrations): More diagnostic logging for inconsistent sentry apps

### DIFF
--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -167,6 +167,18 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
     event = f"{name}.{action}"
 
     if event not in VALID_EVENTS:
+        org_id = Project.objects.get_from_cache(id=instance.project_id).organization_id
+        org = Organization.objects.get_from_cache(id=org_id)
+        if features.has("organizations:sentry-app-debugging", org):
+            logger.info(
+                "_process_resource_change.invalid_event.debug",
+                extra={
+                    "event_type": event,
+                    "organization_id": org_id,
+                    "project_id": instance.project_id,
+                    "valid_events": VALID_EVENTS,
+                },
+            )
         return
 
     org = None
@@ -287,9 +299,22 @@ def send_webhooks(installation, event, **kwargs):
             organization_id=installation.organization_id, actor_id=installation.id
         )
     except ServiceHook.DoesNotExist:
+        logger.info(
+            "send_webhooks.missing_servicehook",
+            extra={"installation_id": installation.id, "event": event},
+        )
         return
 
     if event not in servicehook.events:
+        organization = Organization.objects.get_from_cache(id=installation.organization_id)
+        if features.has("organizations:sentry-app-debugging", organization):
+            logger.info(
+                "send_webhooks.dropped_event.debug",
+                extra={
+                    "event_type": event,
+                    "organization_id": installation.organization_id,
+                },
+            )
         return
 
     # The service hook applies to all projects if there are no
@@ -391,6 +416,19 @@ def send_and_save_webhook_request(sentry_app, app_platform_event, url=None):
 
     else:
         track_response_code(resp.status_code, slug, event)
+        organization = Organization.objects.get_from_cache(id=org_id)
+        if features.has("organizations:sentry-app-debugging", organization):
+            project_id = app_platform_event.data["error"].get("project")
+            logger.info(
+                "send_and_save_webhook_request.error",
+                extra={
+                    "event_type": event,
+                    "organization_id": org_id,
+                    "integration_slug": sentry_app.slug,
+                    "status": resp.status_code,
+                    "project_id": project_id,
+                },
+            )
         buffer.add_request(
             response_code=resp.status_code,
             org_id=org_id,


### PR DESCRIPTION
See: [ISSUE-1272](https://getsentry.atlassian.net/browse/ISSUE-1272)
Related: https://github.com/getsentry/sentry/pull/28456

Back at it again with another logging PR. This one tries to log at _every_ part that prevents the webhook from being sent. If these logs can't identify the issue, it must be something in post-process or before.