### PR TITLE
fix(ui): Dont show a dash when alert activity date is missing

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -237,7 +237,7 @@ export default class DetailsBody extends React.Component<Props> {
           <Status>
             <AlertBadge status={status} hideText />
             {activeIncident ? t('Triggered') : t('Resolved')}
-            {activityDate ? <TimeSince date={activityDate} /> : '-'}
+            {activityDate ? <TimeSince date={activityDate} /> : ''}
           </Status>
         </HeaderItem>
       </StatusContainer>


### PR DESCRIPTION
This removes the `-` for when the last incident date is missing for an alert, so next to alert status there's nothing.

Before
a. Normally:
<img width="247" alt="Screen Shot 2021-09-14 at 4 44 31 PM" src="https://user-images.githubusercontent.com/15015880/133348256-033907bc-33dc-4414-8d3c-4830a39e5ef8.png">
b. When date is missing:
<img width="158" alt="Screen Shot 2021-09-14 at 4 43 59 PM" src="https://user-images.githubusercontent.com/15015880/133348265-b94115ab-1b81-442b-93fa-d04b6126cd21.png">

After
When date is missing:
<img width="158" alt="Screen Shot 2021-09-14 at 4 44 07 PM" src="https://user-images.githubusercontent.com/15015880/133348273-bea88acf-7e1a-4903-aaa0-ec0a4c94ee47.png">

Jira: [WOR-1160](https://getsentry.atlassian.net/browse/WOR-1160)