### PR TITLE
feat(symbolicator): Check manual low priority queue kill switch when pre-processing events

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -607,6 +607,9 @@ CELERY_QUEUES = [
     Queue(
         "events.reprocessing.symbolicate_event", routing_key="events.reprocessing.symbolicate_event"
     ),
+    Queue(
+        "events.reprocessing.symbolicate_event_low_priority", routing_key="events.reprocessing.symbolicate_event_low_priority"
+    ),
     Queue("events.save_event", routing_key="events.save_event"),
     Queue("events.symbolicate_event", routing_key="events.symbolicate_event"),
     Queue(

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -608,7 +608,8 @@ CELERY_QUEUES = [
         "events.reprocessing.symbolicate_event", routing_key="events.reprocessing.symbolicate_event"
     ),
     Queue(
-        "events.reprocessing.symbolicate_event_low_priority", routing_key="events.reprocessing.symbolicate_event_low_priority"
+        "events.reprocessing.symbolicate_event_low_priority",
+        routing_key="events.reprocessing.symbolicate_event_low_priority",
     ),
     Queue("events.save_event", routing_key="events.save_event"),
     Queue("events.symbolicate_event", routing_key="events.symbolicate_event"),

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -144,12 +144,19 @@ def _do_preprocess_event(cache_key, data, start_time, event_id, process_task, pr
     if should_process_with_symbolicator(data):
         reprocessing2.backup_unprocessed_event(project=project, data=original_data)
 
-        is_low_priority = killswitch_matches_context(
+        always_lowpri = killswitch_matches_context(
             "store.symbolicate-event-lpq-always",
             {
                 "project_id": project_id,
             },
         )
+        never_lowpri = killswitch_matches_context(
+            "store.symbolicate-event-lpq-never",
+            {
+                "project_id": project_id,
+            },
+        )
+        is_low_priority = not never_lowpri and always_lowpri
 
         task = submit_symbolicate_low_priority if is_low_priority else submit_symbolicate
         task(

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -111,8 +111,8 @@ def submit_symbolicate_low_priority(
 ):
     task = (
         symbolicate_event_from_reprocessing_low_priority
-        # if from_reprocessing
-        # else symbolicate_event_low_priority
+        if from_reprocessing
+        else symbolicate_event_low_priority
     )
     task.delay(cache_key=cache_key, start_time=start_time, event_id=event_id)
 

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -87,6 +87,17 @@ def submit_symbolicate(project, from_reprocessing, cache_key, event_id, start_ti
     task.delay(cache_key=cache_key, start_time=start_time, event_id=event_id)
 
 
+def submit_symbolicate_low_priority(
+    project, from_reprocessing, cache_key, event_id, start_time, data
+):
+    task = (
+        symbolicate_event_from_reprocessing_low_priority
+        # if from_reprocessing
+        # else symbolicate_event_low_priority
+    )
+    task.delay(cache_key=cache_key, start_time=start_time, event_id=event_id)
+
+
 def submit_save_event(project, from_reprocessing, cache_key, event_id, start_time, data):
     if cache_key:
         data = None
@@ -132,8 +143,22 @@ def _do_preprocess_event(cache_key, data, start_time, event_id, process_task, pr
 
     if should_process_with_symbolicator(data):
         reprocessing2.backup_unprocessed_event(project=project, data=original_data)
-        submit_symbolicate(
-            project, from_reprocessing, cache_key, event_id, start_time, original_data
+
+        is_low_priority = killswitch_matches_context(
+            "store.symbolicate-event-lpq-always",
+            {
+                "project_id": project_id,
+            },
+        )
+
+        task = submit_symbolicate_low_priority if is_low_priority else submit_symbolicate
+        task(
+            project,
+            from_reprocessing,
+            cache_key,
+            event_id,
+            start_time,
+            original_data,
         )
         return
 
@@ -383,6 +408,24 @@ def symbolicate_event_from_reprocessing(cache_key, start_time=None, event_id=Non
         start_time=start_time,
         event_id=event_id,
         symbolicate_task=symbolicate_event_from_reprocessing,
+    )
+
+
+@instrumented_task(
+    name="sentry.tasks.store.symbolicate_event_from_reprocessing_low_priority",
+    queue="events.reprocessing.symbolicate_event_low_priority",
+    time_limit=settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT + 30,
+    soft_time_limit=settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT + 20,
+    acks_late=True,
+)
+def symbolicate_event_from_reprocessing_low_priority(
+    cache_key, start_time=None, event_id=None, **kwargs
+):
+    return _do_symbolicate_event(
+        cache_key=cache_key,
+        start_time=start_time,
+        event_id=event_id,
+        symbolicate_task=symbolicate_event_from_reprocessing_low_priority,
     )
 
 

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -446,20 +446,24 @@ def test_time_synthetic_monitoring_event_in_save_event(mock_metrics_timing):
     assert to_process.kwargs == {"tags": tags, "sample_rate": 1.0}
 
 
+@pytest.mark.django_db
 def test_should_demote_symbolication_empty(default_project):
     assert not should_demote_symbolication(default_project.id)
 
 
+@pytest.mark.django_db
 def test_should_demote_symbolication_always(default_project):
     with override_options({"store.symbolicate-event-lpq-always": [default_project.id]}):
         assert should_demote_symbolication(default_project.id)
 
 
+@pytest.mark.django_db
 def test_should_demote_symbolication_never(default_project):
     with override_options({"store.symbolicate-event-lpq-never": [default_project.id]}):
         assert should_demote_symbolication(default_project.id)
 
 
+@pytest.mark.django_db
 def test_should_demote_symbolication_always_and_never(default_project):
     with override_options(
         {

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -460,7 +460,7 @@ def test_should_demote_symbolication_always(default_project):
 @pytest.mark.django_db
 def test_should_demote_symbolication_never(default_project):
     with override_options({"store.symbolicate-event-lpq-never": [default_project.id]}):
-        assert should_demote_symbolication(default_project.id)
+        assert not should_demote_symbolication(default_project.id)
 
 
 @pytest.mark.django_db

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -461,5 +461,10 @@ def test_should_demote_symbolication_never(default_project):
 
 
 def test_should_demote_symbolication_always_and_never(default_project):
-    with override_options({"store.symbolicate-event-lpq-never": [default_project.id], "store.symbolicate-event-lpq-always": [default_project.id]}):
+    with override_options(
+        {
+            "store.symbolicate-event-lpq-never": [default_project.id],
+            "store.symbolicate-event-lpq-always": [default_project.id],
+        }
+    ):
         assert not should_demote_symbolication(default_project.id)


### PR DESCRIPTION
Starter work to push symbolicator events to the low priority queue when the appropriate manual kill switch is specified.

Some code is commented out because it relies on changes made in #28561.

This follows up on the work done in #28576; This PR is the companion that finally uses the switches registered in #28576.