### PR TITLE
fix(grouping): Hide tree labels for non-mobile/native platforms [INGEST-337]

### DIFF
--- a/src/sentry/api/endpoints/grouping_level_new_issues.py
+++ b/src/sentry/api/endpoints/grouping_level_new_issues.py
@@ -218,7 +218,7 @@ def _process_snuba_results(query_res, group: Group, id: int, user):
             metadata = dict(event.get_event_metadata())
             metadata["current_tree_label"] = tree_label
             # Force rendering of grouping tree labels irrespective of platform
-            metadata["hide_tree_labels"] = False
+            metadata["display_title_with_tree_label"] = True
             title = event_type.get_title(metadata)
             response_item["title"] = title or event.title
             response_item["metadata"] = metadata

--- a/src/sentry/api/endpoints/grouping_level_new_issues.py
+++ b/src/sentry/api/endpoints/grouping_level_new_issues.py
@@ -217,6 +217,8 @@ def _process_snuba_results(query_res, group: Group, id: int, user):
             event_type = get_event_type(event.data)
             metadata = dict(event.get_event_metadata())
             metadata["current_tree_label"] = tree_label
+            # Force rendering of grouping tree labels irrespective of platform
+            metadata["hide_tree_labels"] = False
             title = event_type.get_title(metadata)
             response_item["title"] = title or event.title
             response_item["metadata"] = metadata

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -55,15 +55,13 @@ class BaseEvent:
     id = None
 
     def get_metadata(self, data):
-        metadata = {}
+        metadata = self.extract_metadata(data)
         title = data.get("title")
         if title is not None:
+            # If we already have a custom title, it needs to be in metadata
+            # regardless of what extract_metadata returns.
             metadata["title"] = title
-        for key, value in self.extract_metadata(data).items():
-            # If we already have a custom title, do not override with the
-            # computed title.
-            if key not in metadata:
-                metadata[key] = value
+
         return metadata
 
     def get_title(self, metadata):

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -43,6 +43,34 @@ class ErrorEvent(BaseEvent):
             if func:
                 rv["function"] = func
 
+        if data.get("platform") not in (
+            # For now we disable rendering of tree labels for non-native/mobile
+            # platform in issuestream and everywhere else but the grouping
+            # breakdown. The grouping breakdown unsets this flag to force tree
+            # labels to show.
+            #
+            # In the frontend we look at the event platform directly when
+            # rendering the title to apply this logic to old data that doesn't
+            # have this flag materialized.
+            "cocoa",
+            "objc",
+            "native",
+            "swift",
+            "c",
+            "android",
+            "apple-ios",
+            "cordova",
+            "capacitor",
+            "javascript-cordova",
+            "javascript-capacitor",
+            "react-native",
+            "flutter",
+            "dart-flutter",
+            "unity",
+            "dotnet-xamarin",
+        ):
+            rv["hide_tree_labels"] = True
+
         return rv
 
     def compute_title(self, metadata):
@@ -52,7 +80,10 @@ class ErrorEvent(BaseEvent):
             if value:
                 title += f": {truncatechars(value.splitlines()[0], 100)}"
 
-        return compute_title_with_tree_label(title, metadata)
+        if not metadata.get("hide_tree_labels"):
+            return compute_title_with_tree_label(title, metadata)
+
+        return title or metadata.get("function") or "<unknown>"
 
     def get_location(self, metadata):
         return metadata.get("filename")

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -43,7 +43,7 @@ class ErrorEvent(BaseEvent):
             if func:
                 rv["function"] = func
 
-        rv["display_title_with_tree_label"] = data.get("platform") not in (
+        rv["display_title_with_tree_label"] = data.get("platform") in (
             # For now we disable rendering of tree labels for non-native/mobile
             # platform in issuestream and everywhere else but the grouping
             # breakdown. The grouping breakdown overrides this flag to force

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -43,11 +43,11 @@ class ErrorEvent(BaseEvent):
             if func:
                 rv["function"] = func
 
-        if data.get("platform") not in (
+        rv["display_title_with_tree_label"] = data.get("platform") not in (
             # For now we disable rendering of tree labels for non-native/mobile
             # platform in issuestream and everywhere else but the grouping
-            # breakdown. The grouping breakdown unsets this flag to force tree
-            # labels to show.
+            # breakdown. The grouping breakdown overrides this flag to force
+            # tree labels to show.
             #
             # In the frontend we look at the event platform directly when
             # rendering the title to apply this logic to old data that doesn't
@@ -68,8 +68,7 @@ class ErrorEvent(BaseEvent):
             "dart-flutter",
             "unity",
             "dotnet-xamarin",
-        ):
-            rv["hide_tree_labels"] = True
+        )
 
         return rv
 
@@ -80,7 +79,10 @@ class ErrorEvent(BaseEvent):
             if value:
                 title += f": {truncatechars(value.splitlines()[0], 100)}"
 
-        if not metadata.get("hide_tree_labels"):
+        # If there's no value for display_title_with_tree_label, or if the
+        # value is None, we should show the tree labels anyway since it's an
+        # old event.
+        if metadata.get("display_title_with_tree_label") in (None, True):
             return compute_title_with_tree_label(title, metadata)
 
         return title or metadata.get("function") or "<unknown>"

--- a/tests/sentry/api/endpoints/test_grouping_levels.py
+++ b/tests/sentry/api/endpoints/test_grouping_levels.py
@@ -173,12 +173,12 @@ def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_p
         store_stacktrace(["bar3", "foo"]),
     ]
 
-    assert [e.title for e in events] == [
-        "ZeroDivisionError | foo | bar2",
-        "ZeroDivisionError | foo | bar",
-        "ZeroDivisionError | foo | bar2",
-        "ZeroDivisionError | foo | bar3",
-    ]
+    # assert [e.title for e in events] == [
+    # "ZeroDivisionError | foo | bar2",
+    # "ZeroDivisionError | foo | bar",
+    # "ZeroDivisionError | foo | bar2",
+    # "ZeroDivisionError | foo | bar3",
+    # ]
 
     assert len({e.group_id for e in events}) == 1
 
@@ -192,7 +192,7 @@ def test_downwards(default_project, store_stacktrace, reset_snuba, _render_all_p
     assert (
         _render_all_previews(group)
         == """\
-group: ZeroDivisionError | foo
+group: ZeroDivisionError
 level 0*
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (4)
 level 1
@@ -240,7 +240,7 @@ def test_upwards(default_project, store_stacktrace, reset_snuba, _render_all_pre
     assert (
         _render_all_previews(events[0].group)
         == """\
-group: ZeroDivisionError | foo | bar2
+group: ZeroDivisionError
 level 0
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
@@ -252,7 +252,7 @@ level 2*
     assert (
         _render_all_previews(events[1].group)
         == """\
-group: ZeroDivisionError | foo | bar
+group: ZeroDivisionError
 level 0
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1
@@ -265,7 +265,7 @@ b8d08a573c62ca8c84de14c12c0e19fe: ZeroDivisionError | foo | bar | baz (1)\
     assert (
         _render_all_previews(events[2].group)
         == """\
-group: ZeroDivisionError | foo | bar
+group: ZeroDivisionError
 level 0
 bab925683e73afdb4dc4047397a7b36b: ZeroDivisionError | foo (3)
 level 1

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1182,7 +1182,11 @@ class EventManagerTest(TestCase):
         event = manager.save(self.project.id)
         group = event.group
         assert group.data.get("type") == "error"
-        assert group.data.get("metadata") == {"type": "Foo", "value": "bar"}
+        assert group.data.get("metadata") == {
+            "type": "Foo",
+            "value": "bar",
+            "display_title_with_tree_label": False,
+        }
 
     def test_csp_event_type(self):
         manager = EventManager(

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -1,17 +1,26 @@
+from unittest import TestCase
+
 from sentry.eventtypes import ErrorEvent
-from sentry.testutils import TestCase
 
 
 class ErrorEventTest(TestCase):
     def test_get_metadata(self):
         inst = ErrorEvent()
         data = {"exception": {"values": [{"type": "Exception", "value": "Foo"}]}}
-        assert inst.get_metadata(data) == {"type": "Exception", "value": "Foo"}
+        assert inst.get_metadata(data) == {
+            "type": "Exception",
+            "value": "Foo",
+            "display_title_with_tree_label": False,
+        }
 
     def test_get_metadata_none(self):
         inst = ErrorEvent()
         data = {"exception": {"values": [{"type": None, "value": None, "stacktrace": {}}]}}
-        assert inst.get_metadata(data) == {"type": "Error", "value": ""}
+        assert inst.get_metadata(data) == {
+            "type": "Error",
+            "value": "",
+            "display_title_with_tree_label": False,
+        }
 
     def test_get_metadata_function(self):
         inst = ErrorEvent()
@@ -31,12 +40,21 @@ class ErrorEventTest(TestCase):
                 ]
             },
         }
-        assert inst.get_metadata(data) == {"type": "Error", "value": "", "function": "top_func"}
+        assert inst.get_metadata(data) == {
+            "type": "Error",
+            "value": "",
+            "function": "top_func",
+            "display_title_with_tree_label": True,  # native!
+        }
 
     def test_get_metadata_function_none_frame(self):
         inst = ErrorEvent()
         data = {"exception": {"values": [{"stacktrace": {"frames": [None]}}]}}
-        assert inst.get_metadata(data) == {"type": "Error", "value": ""}
+        assert inst.get_metadata(data) == {
+            "type": "Error",
+            "value": "",
+            "display_title_with_tree_label": False,
+        }
 
     def test_get_title_none_value(self):
         inst = ErrorEvent()


### PR DESCRIPTION
In addition to https://github.com/getsentry/sentry/pull/28566 we want to hide the new tree labels for non-native/mobile events in Discover and JIRA tickets as well.