### PR TITLE
feat(symbolication): Add symbolication status to project details (NATIVE-209)

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -365,10 +365,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
-        data["eventProcessing"] = {
-            "symbolicationDegraded": False,
-        }
-
         include = set(filter(bool, request.GET.get("include", "").split(",")))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -365,6 +365,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
+        data["eventProcessing"] = {
+            "symbolicationDegraded": False,
+        }
+
         include = set(filter(bool, request.GET.get("include", "").split(",")))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -795,6 +795,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "relayPiiConfig": attrs["options"].get("sentry:relay_pii_config"),
                 "builtinSymbolSources": get_value_with_default("sentry:builtin_symbol_sources"),
                 "dynamicSampling": get_value_with_default("sentry:dynamic_sampling"),
+                "eventProcessing": {
+                    "symbolicationDegraded": False,
+                },
             }
         )
         custom_symbol_sources_json = attrs["options"].get("sentry:symbol_sources")


### PR DESCRIPTION
This adds a field in the project details which exposes the health of
the project's symbolication processing.  The aim is to let the UI show
warnings on the project if we are experiencing processing problems.

Currently returns dummy data, but a followup will change this to read
from 3 sentry options and compute the correct value from those.

NATIVE-209

---

Adding dynamic status information to the project details endpoint is perhaps a little weird, since currently it is entirely controlled via serialisers.  The other option would be to create a new project endpoint to return the status (e.g. `/{org_slug}/{proj_slug/health` or `/{org_slug}/{proj_slug}/status`), but the downside is that the UI now needs to query a new endpoint everywhere it needs to show this and project details is already needed in all those places.