### PR TITLE
fix(feature-flag): Lookup `notification-slack-automatic` less often

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 
+from sentry import features
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -125,6 +126,10 @@ class GroupSubscriptionManager(BaseManager):  # type: ignore
             notification_settings, all_possible_users
         )
 
+        should_use_slack_automatic = features.has(
+            "organizations:notification-slack-automatic", group.organization
+        )
+
         result: MutableMapping[ExternalProviders, MutableMapping["User", int]] = defaultdict(dict)
         for user in all_possible_users:
             subscription_option = subscriptions_by_user_id.get(user.id)
@@ -132,6 +137,7 @@ class GroupSubscriptionManager(BaseManager):  # type: ignore
                 user,
                 subscription_option,
                 notification_settings_by_user,
+                should_use_slack_automatic=should_use_slack_automatic,
             )
             for provider in providers:
                 result[provider][user] = (

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -14,7 +14,7 @@ from typing import (
 from django.db import transaction
 from django.db.models import Q, QuerySet
 
-from sentry import analytics
+from sentry import analytics, features
 from sentry.db.models.manager import BaseManager
 from sentry.notifications.helpers import (
     get_scope,
@@ -313,8 +313,13 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
             notification_settings, users
         )
         mapping = defaultdict(set)
+        should_use_slack_automatic = features.has(
+            "organizations:notification-slack-automatic", project.organization
+        )
         for user in users:
-            providers = where_should_user_be_notified(notification_settings_by_user, user)
+            providers = where_should_user_be_notified(
+                notification_settings_by_user, user, should_use_slack_automatic
+            )
             for provider in providers:
                 mapping[provider].add(user)
         return mapping

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -12,6 +12,7 @@ from typing import (
     Union,
 )
 
+from sentry import features
 from sentry.models import (
     Group,
     GroupSubscription,
@@ -123,6 +124,10 @@ def get_participants_for_release(
         notification_settings, users
     )
 
+    should_use_slack_automatic = features.has(
+        "organizations:notification-slack-automatic", organization
+    )
+
     # Map users to their setting value. Prioritize user/org specific, then
     # user default, then product default.
     users_to_reasons_by_provider: MutableMapping[
@@ -134,7 +139,7 @@ def get_participants_for_release(
             notification_settings_by_scope,
             notification_providers(),
             NotificationSettingTypes.DEPLOY,
-            organization=organization,
+            should_use_slack_automatic=should_use_slack_automatic,
         )
         for provider, value in values_by_provider.items():
             reason_option = get_reason(user, value, user_ids)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -93,9 +93,6 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
         expected_queries += 1
 
-        # TODO(mgaeta): Extra queries while we're checking a feature flag in the ProjectSerializer.
-        expected_queries += 4
-
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)
 

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -93,7 +93,6 @@ class NotificationHelpersTest(TestCase):
             {},
             notification_providers(),
             NotificationSettingTypes.DEPLOY,
-            organization=self.organization,
         )
         assert values_by_provider == {
             ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY,
@@ -113,7 +112,6 @@ class NotificationHelpersTest(TestCase):
             notification_settings_by_scope,
             notification_providers(),
             NotificationSettingTypes.DEPLOY,
-            organization=self.organization,
         )
         assert values_by_provider == {
             ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,

--- a/tests/sentry/notifications/utils/test_get_groups_for_query.py
+++ b/tests/sentry/notifications/utils/test_get_groups_for_query.py
@@ -1,4 +1,4 @@
-from sentry.models import Group, Project
+from sentry.models import Group, Organization, Project
 from sentry.notifications.helpers import get_groups_for_query
 from sentry.notifications.types import NotificationScopeType, NotificationSettingOptionValues
 from sentry.testutils import TestCase
@@ -39,9 +39,10 @@ class GetGroupsForQueryTestCase(TestCase):
         )
 
     def test_get_groups_for_query(self):
-        project_0 = Project(id=100)
-        project_1 = Project(id=101)
-        project_2 = Project(id=102)
+        organization = Organization(id=1, slug="organization", name="My Company")
+        project_0 = Project(id=100, organization=organization)
+        project_1 = Project(id=101, organization=organization)
+        project_2 = Project(id=102, organization=organization)
 
         groups_by_project = {
             project_0: {Group(id=10, project=project_0), Group(id=11, project=project_0)},


### PR DESCRIPTION
The performance of pages that use the ProjectSerializer is dramatically worse when there are too many projects. To fix this we should reduce the number of feature flag lookups.