### PR TITLE
feat(store): Projects util now updates render-props projects when store emits updates

### DIFF
--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -164,9 +164,7 @@ class Projects extends React.Component<Props, State> {
     const {allProjects, projects, slugs} = this.props;
 
     if (allProjects) {
-      this.setState({
-        fetchedProjects: projects,
-      });
+      this.setState({fetchedProjects: projects});
       return;
     }
 
@@ -174,9 +172,7 @@ class Projects extends React.Component<Props, State> {
       // Extract the requested projects from the store based on props.slugs
       const projectsMap = this.getProjectsMap(projects);
       const projectsFromStore = slugs.map(slug => projectsMap.get(slug)).filter(defined);
-      this.setState({
-        projectsFromStore,
-      });
+      this.setState({projectsFromStore});
     }
   };
 

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -149,6 +149,36 @@ class Projects extends React.Component<Props, State> {
     }
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const {projects} = this.props;
+    if (projects !== prevProps.projects) {
+      this.updateProjectsFromStore();
+    }
+  }
+
+  /**
+   * Function to update projects when the store emits updates
+   */
+  updateProjectsFromStore = () => {
+    const {allProjects, projects, slugs} = this.props;
+
+    if (allProjects) {
+      this.setState({
+        fetchedProjects: projects,
+      });
+      return;
+    }
+
+    if (slugs && !!slugs.length) {
+      // Extract the requested projects from the store based on props.slugs
+      const projectsMap = this.getProjectsMap(projects);
+      const projectsFromStore = slugs.map(slug => projectsMap.get(slug)).filter(defined);
+      this.setState({
+        projectsFromStore,
+      });
+    }
+  };
+
   /**
    * List of projects that need to be fetched via API
    */

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -142,7 +142,7 @@ class Projects extends React.Component<Props, State> {
   componentDidMount() {
     const {slugs} = this.props;
 
-    if (slugs && !!slugs.length) {
+    if (!!slugs?.length) {
       this.loadSpecificProjects();
     } else {
       this.loadAllProjects();
@@ -160,7 +160,7 @@ class Projects extends React.Component<Props, State> {
   /**
    * Function to update projects when the store emits updates
    */
-  updateProjectsFromStore = () => {
+  updateProjectsFromStore() {
     const {allProjects, projects, slugs} = this.props;
 
     if (allProjects) {
@@ -168,13 +168,13 @@ class Projects extends React.Component<Props, State> {
       return;
     }
 
-    if (slugs && !!slugs.length) {
+    if (!!slugs?.length) {
       // Extract the requested projects from the store based on props.slugs
       const projectsMap = this.getProjectsMap(projects);
       const projectsFromStore = slugs.map(slug => projectsMap.get(slug)).filter(defined);
       this.setState({projectsFromStore});
     }
-  };
+  }
 
   /**
    * List of projects that need to be fetched via API

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -151,6 +151,7 @@ class Projects extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     const {projects} = this.props;
+
     if (projects !== prevProps.projects) {
       this.updateProjectsFromStore();
     }

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -206,6 +206,56 @@ describe('utils.projects', function () {
         })
       );
     });
+
+    it('responds to updated projects from the project store', async function () {
+      const wrapper = createWrapper({slugs: ['foo', 'bar']});
+      await tick();
+      wrapper.update();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: null,
+          projects: [
+            expect.objectContaining({
+              id: '1',
+              slug: 'foo',
+            }),
+            expect.objectContaining({
+              id: '2',
+              slug: 'bar',
+            }),
+          ],
+        })
+      );
+
+      const newTeam = TestStubs.Team();
+      ProjectActions.addTeamSuccess(newTeam, 'foo');
+
+      await tick();
+      wrapper.update();
+
+      // Expect new team information to be available
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: null,
+          projects: [
+            expect.objectContaining({
+              id: '1',
+              slug: 'foo',
+              teams: [newTeam],
+            }),
+            expect.objectContaining({
+              id: '2',
+              slug: 'bar',
+            }),
+          ],
+        })
+      );
+    });
   });
 
   describe('with no pre-defined projects', function () {
@@ -526,6 +576,51 @@ describe('utils.projects', function () {
       );
       expect(request).not.toHaveBeenCalled();
       expect(loadProjects).not.toHaveBeenCalled();
+    });
+
+    it('responds to updated projects from the project store', async function () {
+      ProjectsStore.loadInitialData(mockProjects);
+      const wrapper = createWrapper({allProjects: true});
+      wrapper.update();
+
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: false,
+          projects: mockProjects,
+        })
+      );
+
+      const newTeam = TestStubs.Team();
+      ProjectActions.addTeamSuccess(newTeam, 'a');
+
+      await tick();
+      wrapper.update();
+
+      // Expect new team information to be available
+      expect(renderer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetching: false,
+          isIncomplete: null,
+          hasMore: false,
+          projects: [
+            expect.objectContaining({
+              id: '100',
+              slug: 'a',
+              teams: [newTeam],
+            }),
+            expect.objectContaining({
+              id: '101',
+              slug: 'b',
+            }),
+            expect.objectContaining({
+              id: '102',
+              slug: 'c',
+            }),
+          ],
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Currently, the `<Projects>` util component does not react to updates from the `ProjectsStore`. This means there can be instances when `project` data has changed, but the application doesn't seem to reflect it. One such example is creating an issue alert or metric alert. Adding a team to a project should affect the state of both of these components as adding a team to a project in one dropdown should enable it in the other dropdown.

However, `<Projects>` doesn't send new store information down through render props leading to behavior like this:
![image](https://user-images.githubusercontent.com/9372512/133503748-9e0d239b-2fac-4403-bdfb-f96256bc8583.png)

We have added `captain-planet` to the project in the bottom dropdown but the upper dropdown still thinks it is not part of the project.

In this PR I add `componentDidUpdate` to `<Projects>` and place updated projects in the correct part of state depending on how the util component is being used.