### PR TITLE
ref(select): Choices -> options AppStoreConnect

### DIFF
--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepFifth.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepFifth.tsx
@@ -16,10 +16,10 @@ function StepFifth({appleStoreOrgs, stepFifthData, onSetStepFifthData}: Props) {
     <StyledSelectField
       name="organization"
       label={t('iTunes Organization')}
-      choices={appleStoreOrgs.map(appleStoreOrg => [
-        appleStoreOrg.organizationId,
-        appleStoreOrg.name,
-      ])}
+      options={appleStoreOrgs.map(appleStoreOrg => ({
+        value: appleStoreOrg.organizationId,
+        label: appleStoreOrg.name,
+      }))}
       placeholder={t('Select organization')}
       onChange={organizationId => {
         const selectedAppleStoreOrg = appleStoreOrgs.find(

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepTwo.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/stepTwo.tsx
@@ -16,7 +16,10 @@ function StepTwo({stepTwoData, onSetStepTwoData, appStoreApps}: Props) {
     <StyledSelectField
       name="application"
       label={t('App Store Connect application')}
-      choices={appStoreApps.map(appStoreApp => [appStoreApp.appId, appStoreApp.name])}
+      options={appStoreApps.map(appStoreApp => ({
+        value: appStoreApp.appId,
+        label: appStoreApp.name,
+      }))}
       placeholder={t('Select application')}
       onChange={appId => {
         const selectedAppStoreApp = appStoreApps.find(


### PR DESCRIPTION
Changes from legacy react-select `choices` to `options` in step 2 and step 5 of this modal
![image](https://user-images.githubusercontent.com/9372512/133516159-787fde39-b992-489a-a766-8140f4f1f94e.png)
