### PR TITLE
feat(notification settings): Read team settings issueowners

### DIFF
--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -228,7 +228,6 @@ def get_send_to_owners(
                 provider=ExternalProviders.SLACK,
                 type=NotificationSettingTypes.ISSUE_ALERTS,
                 team=team,
-                # project=project,
             )
             if team_slack_settings == NotificationSettingOptionValues.ALWAYS:
                 team_mapping[ExternalProviders.SLACK].add(team)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -228,9 +228,9 @@ def get_send_to_owners(
                 provider=ExternalProviders.SLACK,
                 type=NotificationSettingTypes.ISSUE_ALERTS,
                 team=team,
-                project=project,
+                # project=project,
             )
-            if team_slack_settings == NotificationSettingOptionValues.DEFAULT:
+            if team_slack_settings == NotificationSettingOptionValues.ALWAYS:
                 team_mapping[ExternalProviders.SLACK].add(team)
                 team_ids_to_remove.add(team_id)
         # Get all users in teams that don't have Slack settings.
@@ -245,10 +245,12 @@ def get_send_to_owners(
 
     # combine the user and team mappings
     if team_mapping:
-        if mapping.get(ExternalProviders.SLACK):  # team mapping provider will only ever be Slack
-            mapping[ExternalProviders.SLACK].update(list(team_mapping[ExternalProviders.SLACK]))
-        else:
-            mapping[ExternalProviders.SLACK] = team_mapping[ExternalProviders.SLACK]
+        for provider in set.union(set(team_mapping.keys()), set(mapping.keys())):
+            if mapping.get(provider) and team_mapping.get(provider):
+                mapping[provider].update(list(team_mapping[provider]))
+            else:
+                if not mapping.get(provider) and team_mapping.get(provider):
+                    mapping[provider] = team_mapping[provider]
     return mapping
 
 


### PR DESCRIPTION
Update `get_send_to_owners` such that if an alert rule action says to notify issue owners and the issue owner is a team and the team has Slack team notification settings we send a single Slack notification to the team, rather than the previous behavior of notifying each individual in the team based on their personal notification preferences. This makes no changes to if the issue owner is an individual or if the issue owner is a team but the team doesn't have Slack notification settings.