### PR TITLE
fix(cdc_search): Fix bug with groups that have no users when sorting by unique users

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -641,19 +641,37 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
         "event": Entity("events", alias="e"),
         "group": Entity("groupedmessage", alias="g"),
     }
-    times_seen_aggregation = Function("count", [Column("group_id", entities["event"])])
+    times_seen_aggregation = Function(
+        "ifNull", [Function("count", [Column("group_id", entities["event"])]), 0]
+    )
     first_seen_aggregation = Function(
-        "multiply",
+        "ifNull",
         [
-            Function("toUInt64", [Function("min", [Column("timestamp", entities["event"])])]),
-            1000,
+            Function(
+                "multiply",
+                [
+                    Function(
+                        "toUInt64", [Function("min", [Column("timestamp", entities["event"])])]
+                    ),
+                    1000,
+                ],
+            ),
+            0,
         ],
     )
     last_seen_aggregation = Function(
-        "multiply",
+        "ifNull",
         [
-            Function("toUInt64", [Function("max", [Column("timestamp", entities["event"])])]),
-            1000,
+            Function(
+                "multiply",
+                [
+                    Function(
+                        "toUInt64", [Function("max", [Column("timestamp", entities["event"])])]
+                    ),
+                    1000,
+                ],
+            ),
+            0,
         ],
     )
 
@@ -683,7 +701,9 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
                 )
             ],
         ),
-        "user_count": Function("uniq", [Column("tags[sentry:user]", entities["event"])]),
+        "user_count": Function(
+            "ifNull", [Function("uniq", [Column("tags[sentry:user]", entities["event"])]), 0]
+        ),
     }
 
     def calculate_start_end(
@@ -806,7 +826,7 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             ][0]["count"]
 
         paginator_results = SequencePaginator(
-            [(row["score"] if row["score"] is not None else 0, row["g.id"]) for row in data],
+            [(row["score"], row["g.id"]) for row in data],
             reverse=True,
             **paginator_options,
         ).get_result(limit, cursor, known_hits=hits, max_hits=max_hits)

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -806,7 +806,9 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             ][0]["count"]
 
         paginator_results = SequencePaginator(
-            [(row["score"], row["g.id"]) for row in data], reverse=True, **paginator_options
+            [(row["score"] if row["score"] else 0, row["g.id"]) for row in data],
+            reverse=True,
+            **paginator_options,
         ).get_result(limit, cursor, known_hits=hits, max_hits=max_hits)
         # We filter against `group_queryset` here so that we recheck all conditions in Postgres.
         # Since replag between Postgres and Clickhouse can happen, we might get back results that

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -806,7 +806,7 @@ class CdcPostgresSnubaQueryExecutor(PostgresSnubaQueryExecutor):
             ][0]["count"]
 
         paginator_results = SequencePaginator(
-            [(row["score"] if row["score"] else 0, row["g.id"]) for row in data],
+            [(row["score"] if row["score"] is not None else 0, row["g.id"]) for row in data],
             reverse=True,
             **paginator_options,
         ).get_result(limit, cursor, known_hits=hits, max_hits=max_hits)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2165,10 +2165,18 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
+        # Test group with no users, which can return a null count
+        group3 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group3"],
+                "timestamp": iso_format(self.base_datetime + timedelta(days=1)),
+            },
+            project_id=self.project.id,
+        ).group
 
         self.run_test(
             "is:unresolved",
-            [self.group2, self.group1],
+            [self.group2, self.group1, group3],
             None,
             sort_by="user",
             # Change the date range to bust the cache


### PR DESCRIPTION
When sorting by unique users, if no events within the group have users then this can return None for
the score, which causes problems in the paginator. Just default any `None` scores to 0.

Fixes SENTRY-S68
Fixes SENTRY-S61