### PR TITLE
Feat(project-quota): Added Audit Log related items to Model for Project quotas

### DIFF
--- a/src/sentry/models/auditlogentry.py
+++ b/src/sentry/models/auditlogentry.py
@@ -97,6 +97,10 @@ class AuditLogEntryEvent:
     INVITE_REQUEST_ADD = 140
     INVITE_REQUEST_REMOVE = 141
 
+    PROJECT_QUOTA_ADD = 150
+    PROJECT_QUOTA_EDIT = 151
+    PROJECT_QUOTA_REMOVE = 152
+
 
 class AuditLogEntry(Model):
     __include_in_export__ = False
@@ -186,6 +190,9 @@ class AuditLogEntry(Model):
             (AuditLogEntryEvent.PLAN_CANCELLED, "plan.cancelled"),
             (AuditLogEntryEvent.INVITE_REQUEST_ADD, "invite-request.create"),
             (AuditLogEntryEvent.INVITE_REQUEST_REMOVE, "invite-request.remove"),
+            (AuditLogEntryEvent.PROJECT_QUOTA_ADD, "project-quota.add"),
+            (AuditLogEntryEvent.PROJECT_QUOTA_EDIT, "project-quota.edit"),
+            (AuditLogEntryEvent.PROJECT_QUOTA_REMOVE, "project-quota.remove"),
         )
     )
     ip_address = models.GenericIPAddressField(null=True, unpack_ipv4=True)
@@ -429,5 +436,18 @@ class AuditLogEntry(Model):
             return "request added to invite {}".format(self.data["email"])
         elif self.event == AuditLogEntryEvent.INVITE_REQUEST_REMOVE:
             return "removed the invite request for {}".format(self.data["email"])
-
+        elif self.event == AuditLogEntryEvent.PROJECT_QUOTA_ADD:
+            return (
+                "created project quota for {} with {} as the event type and a limit of {} ".format(
+                    self.data["slug"], self.data["billing_metric"], self.data["limit"]
+                )
+            )
+        elif self.event == AuditLogEntryEvent.PROJECT_QUOTA_EDIT:
+            return "changed project quota for {} with {} as the event type to have a limit of {} ".format(
+                self.data["slug"], self.data["billing_metric"], self.data["limit"]
+            )
+        elif self.event == AuditLogEntryEvent.PROJECT_QUOTA_REMOVE:
+            return "removed project quota for {} with {} as the event type".format(
+                self.data["slug"], self.data["billing_metric"]
+            )
         return ""


### PR DESCRIPTION
Added Project Quota as an event to Audit Log entry model. 

Will look like the following when a Project Quota is created, modified or deleted:
![image](https://user-images.githubusercontent.com/22259802/133524852-c62e4fcd-7249-4eec-a4fb-0164f322f2ed.png)
