### PR TITLE
fix(semver): Fix autocomplete tag functionality to use string prefixes rather than semver cols

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -22,11 +22,10 @@ from sentry.search.events.constants import (
     SEMVER_ALIAS,
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
-    SEMVER_WILDCARDS,
     USER_DISPLAY_ALIAS,
 )
 from sentry.search.events.fields import FIELD_ALIASES
-from sentry.search.events.filter import _flip_field_sort, parse_semver
+from sentry.search.events.filter import _flip_field_sort
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore import TagKeyStatus
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT, TagStorage
@@ -727,17 +726,17 @@ class SnubaTagStorage(TagStorage):
             versions = self._get_semver_versions_for_package(projects, organization_id, query)
         else:
             include_package = "@" in query
-            if not query:
-                query = "*"
-            elif query[-1] not in SEMVER_WILDCARDS | {"@"}:
-                if query[-1] != ".":
-                    query += "."
-                query += "*"
+            query = query.replace("*", "")
+            if "@" in query:
+                versions = Release.objects.filter(version__startswith=query)
+            else:
+                versions = Release.objects.filter(version__contains="@" + query)
 
-            versions = Release.objects.filter_by_semver(
-                organization_id,
-                parse_semver(query, "="),
-                project_ids=projects,
+        if projects:
+            versions = versions.filter(
+                id__in=ReleaseProject.objects.filter(project_id__in=projects).values_list(
+                    "release_id", flat=True
+                )
             )
         if environments:
             versions = versions.filter(
@@ -748,7 +747,10 @@ class SnubaTagStorage(TagStorage):
 
         order_by = map(_flip_field_sort, Release.SEMVER_COLS + ["package"])
         versions = (
-            versions.filter_to_semver().order_by(*order_by).values_list("version", flat=True)[:1000]
+            versions.filter_to_semver()
+            .annotate_prerelease_column()
+            .order_by(*order_by)
+            .values_list("version", flat=True)[:1000]
         )
 
         seen = set()

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -776,9 +776,10 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
         env_2 = self.create_environment()
         project_2 = self.create_project()
         self.create_release(version="test@1.0.0.0+123", additional_projects=[project_2])
-        self.create_release(version="test@1.2.0.0-alpha", environments=[self.environment])
-        self.create_release(version="test@1.2.3.0-beta+789", environments=[env_2])
-        self.create_release(version="test@1.2.3.4", environments=[env_2])
+        self.create_release(version="test@1.2.3.4", environments=[self.environment, env_2])
+        self.create_release(version="test@1.20.0.0-alpha", environments=[self.environment])
+        self.create_release(version="test@1.20.3.0-beta+789", environments=[env_2])
+        self.create_release(version="test@1.20.3.4", environments=[env_2])
         self.create_release(version="test2@2.0.0.0+456", environments=[self.environment, env_2])
         self.create_release(version="z_test@1.0.0.0")
         self.create_release(version="z_test@2.0.0.0+456", additional_projects=[project_2])
@@ -789,9 +790,10 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
             None,
             [
                 "2.0.0.0",
+                "1.20.3.4",
+                "1.20.3.0-beta",
+                "1.20.0.0-alpha",
                 "1.2.3.4",
-                "1.2.3.0-beta",
-                "1.2.0.0-alpha",
                 "1.0.0.0",
             ],
         )
@@ -799,26 +801,27 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
             "",
             [
                 "2.0.0.0",
+                "1.20.3.4",
+                "1.20.3.0-beta",
+                "1.20.0.0-alpha",
                 "1.2.3.4",
-                "1.2.3.0-beta",
-                "1.2.0.0-alpha",
                 "1.0.0.0",
             ],
         )
 
         # These should all be equivalent
-        self.run_test("1", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha", "1.0.0.0"])
-        self.run_test("1.", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha", "1.0.0.0"])
-        self.run_test("1.*", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha", "1.0.0.0"])
+        self.run_test("1", ["1.20.3.4", "1.20.3.0-beta", "1.20.0.0-alpha", "1.2.3.4", "1.0.0.0"])
+        self.run_test("1.", ["1.20.3.4", "1.20.3.0-beta", "1.20.0.0-alpha", "1.2.3.4", "1.0.0.0"])
+        self.run_test("1.*", ["1.20.3.4", "1.20.3.0-beta", "1.20.0.0-alpha", "1.2.3.4", "1.0.0.0"])
 
         self.run_test("1.*", ["1.0.0.0"], project=project_2)
 
-        self.run_test("1.2", ["1.2.3.4", "1.2.3.0-beta", "1.2.0.0-alpha"])
+        self.run_test("1.2", ["1.20.3.4", "1.20.3.0-beta", "1.20.0.0-alpha", "1.2.3.4"])
 
-        self.run_test("", ["2.0.0.0", "1.2.0.0-alpha"], self.environment)
-        self.run_test("", ["2.0.0.0", "1.2.3.4", "1.2.3.0-beta"], env_2)
-        self.run_test("1", ["1.2.0.0-alpha"], self.environment)
-        self.run_test("1", ["1.2.3.4", "1.2.3.0-beta"], env_2)
+        self.run_test("", ["2.0.0.0", "1.20.0.0-alpha", "1.2.3.4"], self.environment)
+        self.run_test("", ["2.0.0.0", "1.20.3.4", "1.20.3.0-beta", "1.2.3.4"], env_2)
+        self.run_test("1", ["1.20.0.0-alpha", "1.2.3.4"], self.environment)
+        self.run_test("1", ["1.20.3.4", "1.20.3.0-beta", "1.2.3.4"], env_2)
 
         # Test packages handling
 
@@ -826,9 +829,10 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
             "test",
             [
                 "test2@2.0.0.0",
+                "test@1.20.3.4",
+                "test@1.20.3.0-beta",
+                "test@1.20.0.0-alpha",
                 "test@1.2.3.4",
-                "test@1.2.3.0-beta",
-                "test@1.2.0.0-alpha",
                 "test@1.0.0.0",
             ],
         )
@@ -838,12 +842,29 @@ class GetTagValuePaginatorForProjectsSemverTest(BaseSemverTest, TestCase, SnubaT
         self.run_test("z", ["z_test@2.0.0.0"], project=project_2)
 
         self.run_test(
-            "test@", ["test@1.2.3.4", "test@1.2.3.0-beta", "test@1.2.0.0-alpha", "test@1.0.0.0"]
+            "test@",
+            [
+                "test@1.20.3.4",
+                "test@1.20.3.0-beta",
+                "test@1.20.0.0-alpha",
+                "test@1.2.3.4",
+                "test@1.0.0.0",
+            ],
         )
         self.run_test(
-            "test@*", ["test@1.2.3.4", "test@1.2.3.0-beta", "test@1.2.0.0-alpha", "test@1.0.0.0"]
+            "test@*",
+            [
+                "test@1.20.3.4",
+                "test@1.20.3.0-beta",
+                "test@1.20.0.0-alpha",
+                "test@1.2.3.4",
+                "test@1.0.0.0",
+            ],
         )
-        self.run_test("test@1.2", ["test@1.2.3.4", "test@1.2.3.0-beta", "test@1.2.0.0-alpha"])
+        self.run_test(
+            "test@1.2",
+            ["test@1.20.3.4", "test@1.20.3.0-beta", "test@1.20.0.0-alpha", "test@1.2.3.4"],
+        )
 
 
 class GetTagValuePaginatorForProjectsSemverPackageTest(BaseSemverTest, TestCase, SnubaTestCase):


### PR DESCRIPTION
Previously a search like `1.2` would be converted internally to `1.2.*`. This excludes any versions
like `1.20`, `1.200`, etc. To make this work as the user expects, instead we now just use string
prefixing. This should work in most cases, but if there are versions with 0 prefixes then those will
need to be included in the search string for it to work. So for example, `1.020.0` won't show up if
someone types `1.2`, only if they type `1.`, `1.0`, etc.

We still sort these results using semver sort, so they're returned in the order that the user
expects.