### PR TITLE
feat: Add option for low priority metrics submission rate [NATIVE-185]

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -363,3 +363,6 @@ register("post-process-forwarder:concurrency", default=1)
 
 # Subscription queries sampling rate
 register("subscriptions-query.sample-rate", default=0.01)
+
+# The ratio of symbolication requests for which metrics will be submitted to redis.
+register("symbolicate-event.low-priority.metrics.submission-rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -365,4 +365,7 @@ register("post-process-forwarder:concurrency", default=1)
 register("subscriptions-query.sample-rate", default=0.01)
 
 # The ratio of symbolication requests for which metrics will be submitted to redis.
+#
+# This is to allow gradual rollout of metrics collection for symbolication requests and can be
+# removed once it is fully rolled out.
 register("symbolicate-event.low-priority.metrics.submission-rate", default=0.0)


### PR DESCRIPTION
This adds an option `symbolicate-event.low-priority.metrics.submission-rate` (open to naming suggestions) that determines whether metrics (counter, processing duration) should be sent to redis for a request.