### PR TITLE
ref(sdk) Add ThreadingIntegration to sentry_sdk

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -233,6 +233,7 @@ def configure_sdk():
     from sentry_sdk.integrations.django import DjangoIntegration
     from sentry_sdk.integrations.logging import LoggingIntegration
     from sentry_sdk.integrations.redis import RedisIntegration
+    from sentry_sdk.integrations.threading import ThreadingIntegration
 
     assert sentry_sdk.Hub.main.client is None
 
@@ -326,6 +327,7 @@ def configure_sdk():
             LoggingIntegration(event_level=None),
             RustInfoIntegration(),
             RedisIntegration(),
+            ThreadingIntegration(propagate_hub=True),
         ],
         **sdk_options,
     )


### PR DESCRIPTION
This is coming from an issue that was noticed in Snuba, where some of the snuba
queries that were originally traced stopped being traced, and it happened at the
same time that the snuba queries started being called in a separate thread.

Threading was being handled manually in a couple places already, but hopefully
this will catch the other cases. This integration doesn't work with thread pools but
the major thread pool we use is with snuba and that is manually propagated.