### PR TITLE
fix(deletions) Handle organizations with orphaned commits

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -39,7 +39,7 @@ def load_defaults():
     default_manager.register(models.ApiGrant, BulkModelDeletionTask)
     default_manager.register(models.ApiToken, BulkModelDeletionTask)
     default_manager.register(models.Commit, defaults.CommitDeletionTask)
-    default_manager.register(models.CommitAuthor, BulkModelDeletionTask)
+    default_manager.register(models.CommitAuthor, defaults.CommitAuthorDeletionTask)
     default_manager.register(models.CommitFileChange, BulkModelDeletionTask)
     default_manager.register(models.Deploy, BulkModelDeletionTask)
     default_manager.register(models.Distribution, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/commitauthor.py
+++ b/src/sentry/deletions/defaults/commitauthor.py
@@ -1,0 +1,10 @@
+from ..base import ModelDeletionTask, ModelRelation
+
+
+class CommitAuthorDeletionTask(ModelDeletionTask):
+    def get_child_relations(self, instance):
+        from sentry.models import Commit
+
+        return [
+            ModelRelation(Commit, {"author_id": instance.id}),
+        ]

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -36,7 +36,7 @@ class OrganizationDeletionTask(ModelDeletionTask):
         model_list = (
             OrganizationMember,
             Repository,
-            CommitAuthor,  # Depends on commit deletions, a child of Repository
+            CommitAuthor,
             Release,
             Project,
             Environment,


### PR DESCRIPTION
We have a few organization that have 0 repositories, but still have commits. Make CommitAuthor deletions record based so we can also remove commits that would block a commit author deletion.

Fixes SENTRY-S5Y