### PR TITLE
feat: Use semantic versioning for Sentry releases

### DIFF
--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -34,6 +34,13 @@ def get_revision():
     return None
 
 
+def get_short_revision(revision):
+    if not revision:
+        return ""
+
+    return revision[:12]
+
+
 def get_version():
     if __build__:
         return f"{__version__}.{__build__}"
@@ -51,6 +58,9 @@ def is_docker():
 __version__ = VERSION
 __build__ = get_revision()
 __docformat__ = "restructuredtext en"
+
+_build_or_empty = "" if __build__ is None else f"+{get_short_revision(__build__)}"
+__full_version__ = f"{__version__}{_build_or_empty}"
 
 # This triggers monkey patches that don't require django initialization.
 # There are other monkey patches in sentry's runner initializer.

--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -59,8 +59,10 @@ __version__ = VERSION
 __build__ = get_revision()
 __docformat__ = "restructuredtext en"
 
-_build_or_empty = "" if __build__ is None else f"+{get_short_revision(__build__)}"
-__full_version__ = f"{__version__}{_build_or_empty}"
+# A semantic version that combines the CalVer in `__version__` (e.g.
+# 21.10.0.dev0) with a shortened commit SHA as the build. This is used for
+# example, in Sentry releases
+__semantic_version__ = __version__ if __build__ is None else f"{__version__}+{__build__[:12]}"
 
 # This triggers monkey patches that don't require django initialization.
 # There are other monkey patches in sentry's runner initializer.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1899,7 +1899,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 
 
 SENTRY_SDK_CONFIG = {
-    "release": sentry.__build__,
+    "release": sentry.__full_version__,
     "environment": ENVIRONMENT,
     "in_app_include": ["sentry", "sentry_plugins"],
     "debug": True,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1899,7 +1899,7 @@ SENTRY_DEFAULT_INTEGRATIONS = (
 
 
 SENTRY_SDK_CONFIG = {
-    "release": sentry.__full_version__,
+    "release": sentry.__semantic_version__,
     "environment": ENVIRONMENT,
     "in_app_include": ["sentry", "sentry_plugins"],
     "debug": True,

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -15,7 +15,7 @@ from sentry.utils.imports import import_string
 datetime.datetime.strptime("", "")
 
 # Parse out a pretty version for use with --version
-version_string = sentry.__full_version__
+version_string = sentry.__semantic_version__
 
 
 @click.group(context_settings={"max_content_width": 150})

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -15,10 +15,7 @@ from sentry.utils.imports import import_string
 datetime.datetime.strptime("", "")
 
 # Parse out a pretty version for use with --version
-if sentry.__build__ is None:
-    version_string = sentry.VERSION
-else:
-    version_string = f"{sentry.VERSION} ({sentry.__build__[:12]})"
+version_string = sentry.__full_version__
 
 
 @click.group(context_settings={"max_content_width": 150})

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -242,6 +242,7 @@ def configure_sdk():
     internal_project_key = get_project_key()
     upstream_dsn = sdk_options.pop("dsn", None)
     sdk_options["traces_sampler"] = traces_sampler
+    sdk_options["release"] = f"backend@{sdk_options['release']}"
 
     if upstream_dsn:
         transport = make_transport(get_options(dsn=upstream_dsn, **sdk_options))

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -167,7 +167,7 @@ def get_client_config(request=None):
         "csrfCookieName": settings.CSRF_COOKIE_NAME,
         "sentryConfig": {
             "dsn": public_dsn,
-            "release": settings.SENTRY_SDK_CONFIG["release"],
+            "release": f"frontend@{settings.SENTRY_SDK_CONFIG['release']}",
             "environment": settings.SENTRY_SDK_CONFIG["environment"],
             # By default `ALLOWED_HOSTS` is [*], however the JS SDK does not support globbing
             "whitelistUrls": (


### PR DESCRIPTION
Instead of using the commit SHA for our Sentry releases, use a more semantic version: CalVer+<build SHA>

This also splits up the backend/frontend Sentry releases where previously they were in the same release (which implies they are always deployed together). This will be needed for independent frontend deploys.