### PR TITLE
fix(discover): Various bugs with top events and Other

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -587,7 +587,8 @@ def top_events_timeseries(
             user_query,
             params,
         )
-        other_conditions = snuba_filter.conditions[:]
+        original_conditions = snuba_filter.conditions[:]
+        other_conditions = []
 
         for field in selected_columns:
             # If we have a project field, we need to limit results by project so we don't hit the result limit
@@ -605,21 +606,38 @@ def top_events_timeseries(
                 }
             )
             if values:
-                # timestamp fields needs special handling, creating a big OR instead
                 if field == "timestamp" or field.startswith("timestamp.to_"):
+                    # timestamp fields needs special handling, creating a big OR instead
                     snuba_filter.conditions.append(
                         [[field, "=", value] for value in sorted(values)]
                     )
-                    other_conditions.append([[field, "!=", value] for value in sorted(values)])
+                    # Needs to be a big AND when negated
+                    other_condition = [field, "!=", values[0]]
+                    for value in sorted(values[1:]):
+                        other_condition = [
+                            [SNUBA_AND, [other_condition, [field, "!=", value]]],
+                            "=",
+                            1,
+                        ]
+                    other_conditions.append(other_condition)
                 elif None in values:
+                    # one of the values was null, but we can't do an in with null values, so split into two conditions
                     non_none_values = [value for value in values if value is not None]
                     condition = [[["isNull", [resolve_discover_column(field)]], "=", 1]]
-                    other_condition = [[["isNull", [resolve_discover_column(field)]], "!=", 1]]
+                    other_condition = [["isNull", [resolve_discover_column(field)]], "!=", 1]
                     if non_none_values:
                         condition.append([resolve_discover_column(field), "IN", non_none_values])
-                        other_condition.append(
-                            [resolve_discover_column(field), "NOT IN", non_none_values]
-                        )
+                        other_condition = [
+                            [
+                                SNUBA_AND,
+                                [
+                                    [resolve_discover_column(field), "NOT IN", non_none_values],
+                                    other_condition,
+                                ],
+                            ],
+                            "=",
+                            1,
+                        ]
                     snuba_filter.conditions.append(condition)
                     other_conditions.append(other_condition)
                 elif field in FIELD_ALIASES:
@@ -645,11 +663,19 @@ def top_events_timeseries(
             referrer=referrer,
         )
         if len(top_events["data"]) == limit and len(result.get("data", [])) and include_other:
-            # TODO(wmak): Conditions are incorrect in some cases, need to properly apply Demorgan's Law
             other_result = raw_query(
                 aggregations=snuba_filter.aggregations,
-                conditions=other_conditions,
+                conditions=[original_conditions, other_conditions],
                 filter_keys=snuba_filter.filter_keys,
+                # Hack cause equations on aggregates have to go in selected columns instead of aggregations
+                selected_columns=[
+                    column
+                    for column in snuba_filter.selected_columns
+                    # Check that the column is a list with 3 items, and the alias in the third item is an equation
+                    if isinstance(column, list)
+                    and len(column) == 3
+                    and column[-1].startswith("equation[")
+                ],
                 start=snuba_filter.start,
                 end=snuba_filter.end,
                 rollup=rollup,
@@ -701,7 +727,7 @@ def top_events_timeseries(
         translated_groupby.sort()
 
         results = (
-            {"Other": {"order": limit + 1, "data": other_result["data"]}}
+            {"Other": {"order": limit, "data": other_result["data"]}}
             if len(other_result.get("data", []))
             else {}
         )

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -875,12 +875,14 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         transaction_data = load_data("transaction")
         transaction_data["start_timestamp"] = iso_format(self.day_ago + timedelta(minutes=2))
         transaction_data["timestamp"] = iso_format(self.day_ago + timedelta(minutes=4))
+        transaction_data["tags"] = {"shared-tag": "yup"}
         self.event_data = [
             {
                 "data": {
                     "message": "poof",
                     "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                     "user": {"email": self.user.email},
+                    "tags": {"shared-tag": "yup"},
                     "fingerprint": ["group1"],
                 },
                 "project": self.project2,
@@ -892,6 +894,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "timestamp": iso_format(self.day_ago + timedelta(hours=1, minutes=2)),
                     "fingerprint": ["group2"],
                     "user": {"email": self.user2.email},
+                    "tags": {"shared-tag": "yup"},
                 },
                 "project": self.project2,
                 "count": 6,
@@ -902,6 +905,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                     "fingerprint": ["group3"],
                     "user": {"email": "foo@example.com"},
+                    "tags": {"shared-tag": "yup"},
                 },
                 "project": self.project,
                 "count": 5,
@@ -912,6 +916,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                     "fingerprint": ["group4"],
                     "user": {"email": "bar@example.com"},
+                    "tags": {"shared-tag": "yup"},
                 },
                 "project": self.project,
                 "count": 4,
@@ -924,6 +929,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                     "fingerprint": ["group5"],
                     "user": {"email": "bar@example.com"},
+                    "tags": {"shared-tag": "yup"},
                 },
                 "project": self.project,
                 "count": 2,
@@ -934,6 +940,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "timestamp": iso_format(self.day_ago + timedelta(minutes=2)),
                     "fingerprint": ["group6"],
                     "user": {"email": "bar@example.com"},
+                    "tags": {"shared-tag": "yup"},
                 },
                 "project": self.project,
                 "count": 1,
@@ -951,6 +958,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         self.enabled_features = {
             "organizations:discover-basic": True,
+            "organizations:discover-top-events": True,
         }
         self.url = reverse(
             "sentry-api-0-organization-events-stats",
@@ -1025,7 +1033,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         data = response.data
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
 
         for index, event in enumerate(self.events[:5]):
             message = event.message or event.transaction
@@ -1034,8 +1042,12 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             ]
             assert results["order"] == index
             assert [{"count": self.event_data[index]["count"]}] in [
-                attrs for time, attrs in results["data"]
+                attrs for _, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 3}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_limits(self):
         data = {
@@ -1078,7 +1090,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         data = response.data
 
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
         for index, event in enumerate(self.events[:5]):
             message = event.message or event.transaction
             results = data[",".join([message, event.project.slug])]
@@ -1086,6 +1098,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"]}] in [
                 attrs for time, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 3}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_with_issue(self):
         # delete a group to make sure if this happens the value becomes unknown
@@ -1111,7 +1127,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         data = response.data
 
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
 
         for index, event in enumerate(self.events[:4]):
             message = event.message
@@ -1126,6 +1142,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"]}] in [
                 attrs for time, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 1}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_with_functions(self):
         with self.feature(self.enabled_features):
@@ -1239,7 +1259,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         data = response.data
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
 
         for index, event in enumerate(self.events[:5]):
             message = event.message or event.transaction
@@ -1250,6 +1270,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"] / (3600.0 / 60.0)}] in [
                 attrs for time, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 0.05}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_with_multiple_yaxis(self):
         with self.feature(self.enabled_features):
@@ -1269,7 +1293,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         data = response.data
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
 
         for index, event in enumerate(self.events[:5]):
             message = event.message or event.transaction
@@ -1286,6 +1310,13 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"]}] in [
                 attrs for time, attrs in results["count()"]["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert other["epm()"]["order"] == 0
+        assert other["count()"]["order"] == 1
+        assert [{"count": 0.05}] in [attrs for _, attrs in other["epm()"]["data"]]
+        assert [{"count": 3}] in [attrs for _, attrs in other["count()"]["data"]]
 
     def test_top_events_with_boolean(self):
         with self.feature(self.enabled_features):
@@ -1305,7 +1336,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         data = response.data
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
 
         for index, event in enumerate(self.events[:5]):
             message = event.message or event.transaction
@@ -1314,6 +1345,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"]}] in [
                 attrs for time, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 3}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_with_error_unhandled(self):
         self.login_as(user=self.user)
@@ -1364,7 +1399,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         data = response.data
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
         # Transactions won't be in the results because of the query
         del self.events[4]
         del self.event_data[4]
@@ -1375,6 +1410,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"]}] in [
                 attrs for time, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 1}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_with_int(self):
         with self.feature(self.enabled_features):
@@ -1642,7 +1681,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         data = response.data
-        assert len(data) == 2
+        assert len(data) == 3
 
         current = data["current"]
         assert current["order"] == 1
@@ -1653,6 +1692,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert sum(attrs[0]["count"] for _, attrs in others["data"]) == sum(
             event_data["count"] for event_data in self.event_data
         )
+
+        other = data["Other"]
+        assert other["order"] == 2
+        assert [{"count": 23}] in [attrs for _, attrs in other["data"]]
 
     def test_top_events_with_equations(self):
         with self.feature(self.enabled_features):
@@ -1672,7 +1715,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
 
         data = response.data
         assert response.status_code == 200, response.content
-        assert len(data) == 5
+        assert len(data) == 6
 
         for index, event in enumerate(self.events[:5]):
             message = event.message or event.transaction
@@ -1683,6 +1726,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             assert [{"count": self.event_data[index]["count"] / 100}] in [
                 attrs for time, attrs in results["data"]
             ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 0.03}] in [attrs for _, attrs in other["data"]]
 
     def test_invalid_interval(self):
         with self.feature("organizations:discover-basic"):
@@ -1786,3 +1833,35 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             )
             results = data[key]
             assert [{"count": count}] in [attrs for time, attrs in results["data"]]
+
+    def test_top_events_other_with_matching_columns(self):
+        with self.feature(self.enabled_features):
+            response = self.client.get(
+                self.url,
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "orderby": ["-count()"],
+                    "field": ["count()", "tags[shared-tag]", "message"],
+                    "topEvents": 5,
+                },
+                format="json",
+            )
+
+        data = response.data
+        assert response.status_code == 200, response.content
+        assert len(data) == 6
+
+        for index, event in enumerate(self.events[:5]):
+            message = event.message or event.transaction
+            results = data[",".join([message, "yup"])]
+            assert results["order"] == index
+            assert [{"count": self.event_data[index]["count"]}] in [
+                attrs for _, attrs in results["data"]
+            ]
+
+        other = data["Other"]
+        assert other["order"] == 5
+        assert [{"count": 3}] in [attrs for _, attrs in other["data"]]


### PR DESCRIPTION
- This corrects how conditions were being constructed for other in top
  events by using demorgans, and OR-ing the top level conditions instead
  of AND-ing them together
- This also flips tests over to use the new feature flag
- Also fixes a bug with the index of Other being off by one
- Also fixes a bug where Other wasn't compatible with equations