### PR TITLE
fix(symbolicator): Fix unit tests that were failing due to a missing decorator

### DIFF
--- a/tests/sentry/lang/native/test_ignoredsourcesfiltering.py
+++ b/tests/sentry/lang/native/test_ignoredsourcesfiltering.py
@@ -43,6 +43,7 @@ class TestIgnoredSourcesFiltering:
         return {"sentry:ios-source": "sentry:ios", "sentry:tvos-source": "sentry:ios"}
 
     # Explicitly empty list of sources
+    @pytest.mark.django_db
     def test_sources_included_and_ignored_empty(self):
         with override_options({"symbolicator.ignored_sources": []}):
             sources = filter_ignored_sources([])
@@ -50,6 +51,7 @@ class TestIgnoredSourcesFiltering:
             assert sources == []
 
     # Default/unset list of sources
+    @pytest.mark.django_db
     def test_sources_ignored_unset(self, sources):
         sources = filter_ignored_sources(sources)
 
@@ -62,6 +64,7 @@ class TestIgnoredSourcesFiltering:
             "custom",
         ]
 
+    @pytest.mark.django_db
     def test_sources_ignored_empty(self, sources):
         with override_options({"symbolicator.ignored_sources": []}):
             sources = filter_ignored_sources(sources)
@@ -75,6 +78,7 @@ class TestIgnoredSourcesFiltering:
                 "custom",
             ]
 
+    @pytest.mark.django_db
     def test_sources_ignored_builtin(self, sources):
         with override_options({"symbolicator.ignored_sources": ["sentry:microsoft"]}):
             sources = filter_ignored_sources(sources)
@@ -87,6 +91,7 @@ class TestIgnoredSourcesFiltering:
                 "custom",
             ]
 
+    @pytest.mark.django_db
     def test_sources_ignored_alias(self, sources, reversed_alias_map):
         with override_options({"symbolicator.ignored_sources": ["sentry:ios"]}):
             sources = filter_ignored_sources(sources, reversed_alias_map)
@@ -94,6 +99,7 @@ class TestIgnoredSourcesFiltering:
             source_ids = map(lambda s: s["id"], sources)
             assert source_ids == ["sentry:microsoft", "sentry:electron", "custom"]
 
+    @pytest.mark.django_db
     def test_sources_ignored_bypass_alias(self, sources, reversed_alias_map):
         with override_options({"symbolicator.ignored_sources": ["sentry:ios-source"]}):
             sources = filter_ignored_sources(sources, reversed_alias_map)
@@ -106,6 +112,7 @@ class TestIgnoredSourcesFiltering:
                 "custom",
             ]
 
+    @pytest.mark.django_db
     def test_sources_ignored_custom(self, sources):
         with override_options({"symbolicator.ignored_sources": ["custom"]}):
             sources = filter_ignored_sources(sources)
@@ -118,6 +125,7 @@ class TestIgnoredSourcesFiltering:
                 "sentry:tvos-source",
             ]
 
+    @pytest.mark.django_db
     def test_sources_ignored_unrecognized(self, sources):
         with override_options({"symbolicator.ignored_sources": ["honk"]}):
             sources = filter_ignored_sources(sources)


### PR DESCRIPTION
I misinterpreted a comment when initially implementing a set of tests and they've been failing to execute because they were missing a decorator this entire time.