### PR TITLE
fix(releases): Create distributions if missing in JS code path [INGEST-240]

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -675,14 +675,6 @@ class Release(Model):
             defaults={"date_added": date_added, "organization_id": self.organization_id},
         )[0]
 
-    def get_dist(self, name):
-        from sentry.models import Distribution
-
-        try:
-            return Distribution.objects.get(name=name, release=self)
-        except Distribution.DoesNotExist:
-            pass
-
     def add_project(self, project):
         """
         Add a project to this release.


### PR DESCRIPTION
In the same way that releases are created when missing in javascript processing (see https://github.com/getsentry/sentry/pull/5472) , add missing distributions to the db.

This fixes https://github.com/getsentry/sentry/issues/28048.

https://getsentry.atlassian.net/browse/INGEST-240