### PR TITLE
fix(sso): allow orgs to modify/delete existing sso regardless of feature flag

### DIFF
--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -79,18 +79,11 @@ class OrganizationAuthSettingsPermissionTest(PermissionTestCase):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
 
-    def test_superuser_can_load(self):
+    def test_load_if_already_set_up(self):
         owner = self.create_owner_and_attach_identity()
 
-        # owner can't load without feature
+        # can load without feature since already set up
         self.login_as(owner, organization_id=self.organization.id)
-        with self.feature({"organizations:sso-basic": False}):
-            resp = self.client.get(self.path)
-            assert resp.status_code == 302
-
-        # superuser can load without feature
-        superuser = self.create_user(is_superuser=True)
-        self.login_as(superuser, superuser=True)
         with self.feature({"organizations:sso-basic": False}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
@@ -171,6 +164,18 @@ class OrganizationAuthSettingsTest(AuthProviderTestCase):
 
         assert resp.status_code == 200
         assert resp.content.decode("utf-8") == self.provider.TEMPLATE
+
+    def test_cannot_start_auth_flow_feature_missing(self):
+        organization = self.create_organization(name="foo", owner=self.user)
+
+        path = reverse("sentry-organization-auth-provider-settings", args=[organization.slug])
+
+        self.login_as(self.user)
+
+        with self.feature({"organizations:sso-basic": False}):
+            resp = self.client.post(path, {"provider": "dummy", "init": True})
+
+        assert resp.status_code == 401
 
     @patch("sentry.auth.helper.logger")
     def test_basic_flow(self, logger):


### PR DESCRIPTION
Recently, we did an A/B test to enable SSO during trials. However, I realized there was a bug that prevented organizations from disabling their SSO when trial ends (something I missed b/c I was a superuser when I tested). This PR allows organizations to disable their SSO config even when they lack the feature flag for it.

Note that even though we are bypassing the feature flag here, there isn't any potential to abuse a feature that's only available on a paid plan. This is because any members added through SSO while the organization is limited to 1 user (aka free plans) will be added in a disabled state. Furthermore, we still prevent organizations from setting up a new SSO provider if they don't have the feature flag enabled (turns out there was no test for that so I had to add it). The only net change is allowing orgs to disable SSO if they have it set up which isn't a problem at all.