### PR TITLE
feat(alerts): Use percentage discover fn for crash rate alert

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -473,10 +473,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                         "30min, 1h, 2h, 4h, 12h and 24h"
                     )
 
-                # Add Rollup/Granularity
-                rollup = 60 if time_window <= CRASH_RATE_ALERTS_RAW_CUTOFF_MIN else 3600
-                raw_query_dict.update({"rollup": rollup})
-
             try:
                 raw_query(**raw_query_dict)
             except Exception:

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2147,11 +2147,6 @@ FUNCTIONS = {
                 ],
             ],
         ),
-        DiscoverFunction(
-            "crash_free_percentage",
-            aggregate=["multiply(minus(1, divide(sessions_crashed, sessions)), 100)", None, None],
-            default_result_type="number",
-        ),
     ]
 }
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -551,7 +551,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
     def setUp(self):
         super().setUp()
         self.valid_alert_rule = {
-            "aggregate": "crash_free_percentage()",
+            "aggregate": "percentage(sessions_crashed, sessions) AS crash_rate_alert_aggregate",
             "query": "",
             "timeWindow": "60",
             "resolveThreshold": 90,

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -116,7 +116,7 @@ class ProcessUpdateTest(TestCase):
             dataset=QueryDatasets.SESSIONS,
             name="JustAValidRule",
             query="",
-            aggregate="crash_free_percentage()",
+            aggregate="percentage(sessions_crashed, sessions) AS crash_rate_alert_aggregate",
             time_window=1,
             threshold_type=AlertRuleThresholdType.BELOW,
             threshold_period=1,
@@ -1043,9 +1043,10 @@ class ProcessUpdateTest(TestCase):
         action_critical = self.crash_rate_alert_critical_action
 
         # Send Critical Update
+        update_value = (1 - trigger.alert_threshold / 100) + 0.05
         self.send_update(
             rule,
-            trigger.alert_threshold - 1,
+            update_value,
             timedelta(minutes=-10),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1053,9 +1054,10 @@ class ProcessUpdateTest(TestCase):
         self.assert_actions_fired_for_incident(incident, [action_critical])
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
 
+        update_value = (1 - trigger.alert_threshold / 100) - 0.05
         self.send_update(
             rule,
-            trigger.alert_threshold + 5,
+            update_value,
             timedelta(minutes=-1),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1072,9 +1074,10 @@ class ProcessUpdateTest(TestCase):
         action_warning = self.crash_rate_alert_warning_action
 
         # Send Warning Update
+        update_value = (1 - trigger_warning.alert_threshold / 100) + 0.05
         self.send_update(
             rule,
-            trigger_warning.alert_threshold - 5,
+            update_value,
             timedelta(minutes=-3),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1083,9 +1086,10 @@ class ProcessUpdateTest(TestCase):
         self.assert_actions_fired_for_incident(incident, [action_warning])
         self.assert_trigger_exists_with_status(incident, trigger_warning, TriggerStatus.ACTIVE)
 
+        update_value = (1 - trigger_warning.alert_threshold / 100) - 0.05
         self.send_update(
             rule,
-            trigger_warning.alert_threshold + 5,
+            update_value,
             timedelta(minutes=-1),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1105,9 +1109,10 @@ class ProcessUpdateTest(TestCase):
         action_warning = self.crash_rate_alert_warning_action
 
         # Send Critical Update
+        update_value = (1 - trigger.alert_threshold / 100) + 0.05
         self.send_update(
             rule,
-            trigger.alert_threshold - 1,
+            update_value,
             timedelta(minutes=-10),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1116,9 +1121,10 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
 
         # Send Warning Update
+        update_value = (1 - trigger_warning.alert_threshold / 100) + 0.05
         self.send_update(
             rule,
-            trigger_warning.alert_threshold - 5,
+            update_value,
             timedelta(minutes=-3),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1128,9 +1134,10 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, trigger_warning, TriggerStatus.ACTIVE)
 
         # Send update higher than warning threshold
+        update_value = (1 - trigger_warning.alert_threshold / 100) - 0.05
         self.send_update(
             rule,
-            trigger_warning.alert_threshold + 1,
+            update_value,
             timedelta(minutes=-1),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1152,9 +1159,10 @@ class ProcessUpdateTest(TestCase):
         action_warning = self.crash_rate_alert_warning_action
 
         # Send Critical Update
+        update_value = (1 - trigger.alert_threshold / 100) + 0.05
         self.send_update(
             rule,
-            trigger.alert_threshold - 1,
+            update_value,
             timedelta(minutes=-10),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1163,9 +1171,10 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, trigger, TriggerStatus.ACTIVE)
 
         # Send Warning Update
+        update_value = (1 - trigger_warning.alert_threshold / 100) + 0.05
         self.send_update(
             rule,
-            trigger_warning.alert_threshold - 5,
+            update_value,
             timedelta(minutes=-3),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
@@ -1175,9 +1184,10 @@ class ProcessUpdateTest(TestCase):
         self.assert_trigger_exists_with_status(incident, trigger_warning, TriggerStatus.ACTIVE)
 
         # Send update higher than warning threshold but lower than resolve threshold
+        update_value = (1 - trigger_warning.alert_threshold / 100) - 0.05
         self.send_update(
             rule,
-            trigger_warning.alert_threshold + 1,
+            update_value,
             timedelta(minutes=-1),
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -169,7 +169,6 @@ def test_get_json_meta_type(field_alias, snuba_type, function, expected):
             r'to_other(release,"asdf @ \"qwer: (3,2)")',
             ("to_other", ["release", r'"asdf @ \"qwer: (3,2)"'], None),
         ),
-        ("crash_free_percentage()", ("crash_free_percentage", [], None)),
     ],
 )
 def test_parse_function(function, expected):
@@ -1067,20 +1066,6 @@ class ResolveFieldListTest(unittest.TestCase):
             ],
             ["minus", ["percentile_range_2", "percentile_range_1"], "trend_difference"],
         ]
-
-    def test_crash_free_percentage(self):
-        fields = ["crash_free_percentage()"]
-        result = resolve_field_list(fields, eventstore.Filter())
-
-        assert result["selected_columns"] == []
-        assert result["aggregations"] == [
-            [
-                "multiply(minus(1, divide(sessions_crashed, sessions)), 100)",
-                None,
-                "crash_free_percentage",
-            ],
-        ]
-        assert result["groupby"] == []
 
     def test_invalid_alias(self):
         bad_function_aliases = [


### PR DESCRIPTION
This PR:
- Uses percentage discover function to calculate crash_free_percentage rather than using a new function to do that. 
- Updates SubscriptionProcessor to transform return from percentage function into a crash free percentage.
- Removes the granularity from snuba query as it is now calculated on snuba side. Ref: https://github.com/getsentry/snuba/pull/2094/files#diff-fd0df02e6d42c489b776b141292c684cb53369b0cc5cadcb6a0d15ea3da63b29R225-R228