### PR TITLE
chore(flag): Remove last references to threshold flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1065,10 +1065,6 @@ SENTRY_FEATURES = {
     "organizations:release-archives": False,
     # Enable the new release details experience
     "organizations:release-comparison": False,
-    # Enable the project level transaction thresholds
-    "organizations:project-transaction-threshold": False,
-    # Enable the transaction level thresholds
-    "organizations:project-transaction-threshold-override": False,
     # Enable percent displays in issue stream
     "organizations:issue-percent-display": False,
     # Enable team insights page

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -120,10 +120,6 @@ default_manager.add("organizations:performance-chart-interpolation", Organizatio
 default_manager.add("organizations:performance-suspect-spans-ingestion", OrganizationFeature)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
-default_manager.add("organizations:project-transaction-threshold", OrganizationFeature, True)
-default_manager.add(
-    "organizations:project-transaction-threshold-override", OrganizationFeature, True
-)
 default_manager.add("organizations:prompt-dashboards", OrganizationFeature)
 default_manager.add("organizations:prompt-additional-volume", OrganizationFeature)
 default_manager.add("organizations:prompt-additional-volume-on-demand", OrganizationFeature)


### PR DESCRIPTION
Remove the project transaction thresholds since all
the references to the flags have been removed.