### PR TITLE
fix(dashboards): Add y-axis selections to new search filter

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -259,7 +259,9 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
   handleAddSearchConditions = () => {
     this.setState(prevState => {
       const newState = cloneDeep(prevState);
-      newState.queries.push(cloneDeep(newQuery));
+      const query = cloneDeep(newQuery);
+      query.fields = this.state.queries[0].fields;
+      newState.queries.push(query);
 
       return newState;
     });


### PR DESCRIPTION
When multiple y-axes are selected in a widget,
we want to apply those selections to any new
queries added. Also addresses the case where
a y axis other than `count()` is selected and a new
search filter is added and that gets assigned
`count()` as the field.