### PR TITLE
chore(performance): Delete is-key-transaction endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -7,7 +7,6 @@ from sentry.api.endpoints.project_transaction_threshold_override import (
 from sentry.data_export.endpoints.data_export import DataExportEndpoint
 from sentry.data_export.endpoints.data_export_details import DataExportDetailsEndpoint
 from sentry.discover.endpoints.discover_key_transactions import (
-    IsKeyTransactionEndpoint,
     KeyTransactionEndpoint,
     KeyTransactionListEndpoint,
 )
@@ -836,11 +835,6 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/key-transactions-list/$",
                     KeyTransactionListEndpoint.as_view(),
                     name="sentry-api-0-organization-key-transactions-list",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/is-key-transactions/$",
-                    IsKeyTransactionEndpoint.as_view(),
-                    name="sentry-api-0-organization-is-key-transactions",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/related-issues/$",

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -11,7 +11,7 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.utils import InvalidParams
 from sentry.discover.endpoints import serializers
-from sentry.discover.models import KeyTransaction, TeamKeyTransaction
+from sentry.discover.models import TeamKeyTransaction
 from sentry.models import ProjectTeam, Team
 
 
@@ -22,30 +22,6 @@ class KeyTransactionPermission(OrganizationPermission):
         "PUT": ["org:read"],
         "DELETE": ["org:read"],
     }
-
-
-class IsKeyTransactionEndpoint(KeyTransactionBase):
-    permission_classes = (KeyTransactionPermission,)
-
-    def get(self, request, organization):
-        """Get the Key Transactions for a user"""
-        if not self.has_feature(request, organization):
-            return Response(status=404)
-
-        project = self.get_project(request, organization)
-
-        transaction = request.GET.get("transaction")
-
-        try:
-            KeyTransaction.objects.get(
-                organization=organization,
-                owner=request.user,
-                project=project,
-                transaction=transaction,
-            )
-            return Response({"isKey": True}, status=200)
-        except KeyTransaction.DoesNotExist:
-            return Response({"isKey": False}, status=200)
 
 
 class KeyTransactionEndpoint(KeyTransactionBase):

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -50,11 +50,6 @@ describe('Performance > TransactionSummary', function () {
     });
     // @ts-expect-error
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/is-key-transactions/',
-      body: [],
-    });
-    // @ts-expect-error
-    MockApiClient.addMockResponse({
       url: '/prompts-activity/',
       body: {},
     });

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -90,10 +90,6 @@ describe('Performance > TransactionSummary', function () {
       url: '/prompts-activity/',
       body: {},
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/is-key-transactions/',
-      body: [],
-    });
 
     // Mock totals for the sidebar and other summary data
     MockApiClient.addMockResponse(

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -74,11 +74,6 @@ describe('Performance Transaction Events Content', function () {
     });
     // @ts-expect-error
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/is-key-transactions/',
-      body: [],
-    });
-    // @ts-expect-error
-    MockApiClient.addMockResponse({
       url: '/prompts-activity/',
       body: {},
     });

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -78,11 +78,6 @@ describe('Performance GridEditable Table', function () {
     });
     // @ts-expect-error
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/is-key-transactions/',
-      body: [],
-    });
-    // @ts-expect-error
-    MockApiClient.addMockResponse({
       url: '/prompts-activity/',
       body: {},
     });

--- a/tests/js/spec/views/performance/transactionTags/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionTags/index.spec.jsx
@@ -47,10 +47,6 @@ describe('Performance > Transaction Tags', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/is-key-transactions/',
-      body: [],
-    });
-    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-facets-performance/',
       body: {
         meta: {

--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -72,10 +72,6 @@ describe('Performance > Web Vitals', function () {
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/is-key-transactions/',
-      body: [],
-    });
-    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/project-transaction-threshold-override/',
       method: 'GET',
       body: {


### PR DESCRIPTION
This is the last reference to the original key transaction table. Once this is
removed, we can drop the table.