### PR TITLE
fix(trends): Removed feature check that was breaking ops on trends

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -23,8 +23,8 @@ import {YAxis} from 'app/views/releases/detail/overview/chart/releaseChartContro
 import {TrendColumnField, TrendFunctionField} from '../../trends/types';
 import {
   generateTrendFunctionAsString,
-  getTrendsParameters,
   TRENDS_FUNCTIONS,
+  TRENDS_PARAMETERS,
 } from '../../trends/utils';
 import {SpanOperationBreakdownFilter} from '../filter';
 
@@ -120,12 +120,12 @@ class TransactionSummaryCharts extends Component<Props> {
       withoutZerofill,
     } = this.props;
 
-    const TREND_PARAMETERS_OPTIONS: SelectValue<string>[] = getTrendsParameters({
-      canSeeSpanOpTrends: organization.features.includes('performance-ops-breakdown'),
-    }).map(({column, label}) => ({
-      value: column,
-      label,
-    }));
+    const TREND_PARAMETERS_OPTIONS: SelectValue<string>[] = TRENDS_PARAMETERS.map(
+      ({column, label}) => ({
+        value: column,
+        label,
+      })
+    );
 
     let display = decodeScalar(location.query.display, DisplayModes.DURATION);
     let trendFunction = decodeScalar(

--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -31,10 +31,10 @@ import {
   getCurrentTrendFunction,
   getCurrentTrendParameter,
   getSelectedQueryKey,
-  getTrendsParameters,
   modifyTrendsViewDefaultPeriod,
   resetCursors,
   TRENDS_FUNCTIONS,
+  TRENDS_PARAMETERS,
 } from './utils';
 
 type Props = {
@@ -194,10 +194,6 @@ class TrendsContent extends React.Component<Props, State> {
     const currentTrendFunction = getCurrentTrendFunction(location);
     const currentTrendParameter = getCurrentTrendParameter(location);
     const query = getTransactionSearchQuery(location);
-
-    const TRENDS_PARAMETERS = getTrendsParameters({
-      canSeeSpanOpTrends: organization.features.includes('performance-ops-breakdown'),
-    });
 
     return (
       <GlobalSelectionHeader

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -64,7 +64,7 @@ export const TRENDS_FUNCTIONS: TrendFunction[] = [
   },
 ];
 
-const TRENDS_PARAMETERS: TrendParameter[] = [
+export const TRENDS_PARAMETERS: TrendParameter[] = [
   {
     label: 'Duration',
     column: TrendColumnField.DURATION,
@@ -85,10 +85,6 @@ const TRENDS_PARAMETERS: TrendParameter[] = [
     label: 'CLS',
     column: TrendColumnField.CLS,
   },
-];
-
-// TODO(perf): Merge with above after ops breakdown feature is mainlined.
-const SPANS_TRENDS_PARAMETERS: TrendParameter[] = [
   {
     label: 'Spans (http)',
     column: TrendColumnField.SPANS_HTTP,
@@ -106,12 +102,6 @@ const SPANS_TRENDS_PARAMETERS: TrendParameter[] = [
     column: TrendColumnField.SPANS_RESOURCE,
   },
 ];
-
-export function getTrendsParameters({canSeeSpanOpTrends} = {canSeeSpanOpTrends: false}) {
-  return canSeeSpanOpTrends
-    ? [...TRENDS_PARAMETERS, ...SPANS_TRENDS_PARAMETERS]
-    : [...TRENDS_PARAMETERS];
-}
 
 export const trendToColor = {
   [TrendChangeType.IMPROVED]: {

--- a/tests/js/spec/views/performance/trends/index.spec.jsx
+++ b/tests/js/spec/views/performance/trends/index.spec.jsx
@@ -7,8 +7,8 @@ import ProjectsStore from 'app/stores/projectsStore';
 import TrendsIndex from 'app/views/performance/trends/';
 import {
   DEFAULT_MAX_DURATION,
-  getTrendsParameters,
   TRENDS_FUNCTIONS,
+  TRENDS_PARAMETERS,
 } from 'app/views/performance/trends/utils';
 
 const trendsViewQuery = {
@@ -393,7 +393,7 @@ describe('Performance > Trends', function () {
     await tick();
     wrapper.update();
 
-    for (const parameter of getTrendsParameters()) {
+    for (const parameter of TRENDS_PARAMETERS) {
       selectTrendParameter(wrapper, parameter.label);
 
       await tick();


### PR DESCRIPTION
### Summary
Span ops weren't working on trends because of the different parameter consts, this removes the ops breakdown feature check and merges the list.

Was also able to remove a todo 😄 