### PR TITLE
feat(alert-rules): Properly save alert rules with UI components

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -2,18 +2,18 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.endpoints.project_rules import create_alert_rule_actions
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
 from sentry.integrations.slack import tasks
-from sentry.mediators import alert_rule_actions, project_rules
+from sentry.mediators import project_rules
 from sentry.models import (
     AuditLogEntryEvent,
     Rule,
     RuleActivity,
     RuleActivityType,
     RuleStatus,
-    SentryAppInstallation,
     Team,
     User,
 )
@@ -110,19 +110,9 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
                 return Response(context, status=202)
 
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
-            for action in kwargs.get("actions"):
-                # Only call creator for Sentry Apps with UI Components for alert rules
-                if not action.get("hasSchemaFormConfig"):
-                    continue
-                sentry_app_kwargs = {
-                    "install": SentryAppInstallation.objects.get(
-                        uuid=action.get("sentryAppInstallationUuid")
-                    ),
-                    "fields": action.get("settings"),
-                    "uri": action.get("uri"),
-                    "rule": updated_rule,
-                }
-                alert_rule_actions.AlertRuleActionCreator.run(request=request, **sentry_app_kwargs)
+
+            create_alert_rule_actions(kwargs.get("actions"), rule, request)
+
             RuleActivity.objects.create(
                 rule=updated_rule, user=request.user, type=RuleActivityType.UPDATED.value
             )

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -112,7 +112,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
             for action in kwargs.get("actions"):
                 # Only call creator for Sentry Apps with UI Components for alert rules
-                if not action.get("hasSentryAppUIComponents"):
+                if not action.get("hasSchemaFormConfig"):
                     continue
                 sentry_app_kwargs = {
                     "install": SentryAppInstallation.objects.get(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -2,7 +2,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
-from sentry.api.endpoints.project_rules import create_alert_rule_actions
+from sentry.api.endpoints.project_rules import trigger_alert_rule_action_creators
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
@@ -111,7 +111,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
 
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 
-            create_alert_rule_actions(kwargs.get("actions"), rule, request)
+            trigger_alert_rule_action_creators(kwargs.get("actions"), rule, request)
 
             RuleActivity.objects.create(
                 rule=updated_rule, user=request.user, type=RuleActivityType.UPDATED.value

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -106,7 +106,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             )
             for action in kwargs.get("actions"):
                 # Only call creator for Sentry Apps with UI Components for alert rules
-                if not action.get("hasSentryAppUIComponents"):
+                if not action.get("hasSchemaFormConfig"):
                     continue
                 sentry_app_kwargs = {
                     "install": SentryAppInstallation.objects.get(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -5,7 +5,7 @@ from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import RuleSerializer
 from sentry.integrations.slack import tasks
-from sentry.mediators import project_rules
+from sentry.mediators import alert_rule_actions, project_rules
 from sentry.models import (
     AuditLogEntryEvent,
     Rule,
@@ -15,6 +15,7 @@ from sentry.models import (
     Team,
     User,
 )
+from sentry.models.sentryappinstallation import SentryAppInstallation
 from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
 
@@ -103,6 +104,20 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             RuleActivity.objects.create(
                 rule=rule, user=request.user, type=RuleActivityType.CREATED.value
             )
+            for action in kwargs.get("actions"):
+                # Only call creator for Sentry Apps with UI Components for alert rules
+                if not action.get("hasSentryAppUIComponents"):
+                    continue
+                sentry_app_kwargs = {
+                    "install": SentryAppInstallation.objects.get(
+                        uuid=action.get("sentryAppInstallationUuid")
+                    ),
+                    "fields": action.get("settings"),
+                    "uri": action.get("uri"),
+                    "rule": rule,
+                }
+                alert_rule_actions.AlertRuleActionCreator.run(request=request, **sentry_app_kwargs)
+
             self.create_audit_entry(
                 request=request,
                 organization=project.organization,

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -23,7 +23,7 @@ from sentry.signals import alert_rule_created
 from sentry.web.decorators import transaction_start
 
 
-def create_alert_rule_actions(
+def trigger_alert_rule_action_creators(
     actions: Sequence[Mapping[str, str]],
     rule: Rule,
     request: Request,
@@ -127,7 +127,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 rule=rule, user=request.user, type=RuleActivityType.CREATED.value
             )
 
-            create_alert_rule_actions(kwargs.get("actions"), rule, request)
+            trigger_alert_rule_action_creators(kwargs.get("actions"), rule, request)
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -2,7 +2,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.constants import MIGRATED_CONDITIONS, TICKET_ACTIONS
+from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
 from sentry.rules import rules
 
 
@@ -33,10 +33,9 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if not can_create_tickets and node.id in TICKET_ACTIONS:
                 continue
 
-            # Create as many of these nodes as there are Sentry Apps with UI Alert Rule components
-            if node.id == "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction":
+            if node.id in SCHEMA_FORM_ACTIONS:
                 custom_actions = node.get_custom_actions(project)
-                if len(custom_actions) != 0:
+                if custom_actions:
                     action_list.extend(custom_actions)
                 continue
 

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -2,37 +2,8 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.serializers import serialize
-from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
 from sentry.constants import MIGRATED_CONDITIONS, TICKET_ACTIONS
-from sentry.coreapi import APIError
-from sentry.mediators import sentry_app_components
-from sentry.models import SentryAppComponent, SentryAppInstallation
 from sentry.rules import rules
-
-
-def get_sentry_apps_with_alerts(request, project):
-    action_list = []
-    for install in SentryAppInstallation.get_installed_for_org(project.organization_id):
-        _components = SentryAppComponent.objects.filter(
-            sentry_app_id=install.sentry_app_id, type="alert-rule-action"
-        )
-        for component in _components:
-            try:
-                sentry_app_components.Preparer.run(
-                    component=component, install=install, project=project
-                )
-                action_list.append(
-                    serialize(
-                        component,
-                        request.user,
-                        SentryAppAlertRuleActionSerializer(),
-                        install=install,
-                    )
-                )
-
-            except APIError:
-                continue
 
 
 class ProjectRulesConfigurationEndpoint(ProjectEndpoint):

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -62,8 +62,11 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if not can_create_tickets and node.id in TICKET_ACTIONS:
                 continue
 
-            if node.id == "sentry.rules.actions.notify_event_service.NotifyEventServiceAction":
-                sentry_app_actions = get_sentry_apps_with_alerts(request, project)
+            # Create as many of these nodes as there are Sentry Apps with UI Alert Rule components
+            if node.id == "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction":
+                custom_actions = node.get_custom_actions(project)
+                if len(custom_actions) != 0:
+                    action_list.extend(custom_actions)
                 continue
 
             context = {"id": node.id, "label": node.label, "enabled": node.is_enabled()}

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -18,15 +18,12 @@ class SentryAppComponentSerializer(Serializer):
 
 
 class SentryAppAlertRuleActionSerializer(Serializer):
-    def serialize(self, obj, attrs, user, install, **kwargs):
+    def serialize(self, obj, attrs, user, **kwargs):
+        install = kwargs.get("install")
         return {
-            "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
             "service": obj.sentry_app.slug,
-            "uuid": str(obj.uuid),
             "sentryAppInstallationUuid": f"{install.uuid}",
-            "actionType": "sentryapp",
             "prompt": f"{obj.sentry_app.name}",
-            "enabled": True,
             "label": f"{obj.schema.get('title', obj.sentry_app.name)} with these ",
             "formFields": obj.schema.get("settings", {}),
         }

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -20,7 +20,8 @@ class SentryAppComponentSerializer(Serializer):
 class SentryAppAlertRuleActionSerializer(Serializer):
     def serialize(self, obj, attrs, user, install, **kwargs):
         return {
-            "id": f"sentry.sentryapp.{obj.sentry_app.slug}",
+            "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+            "service": obj.sentry_app.slug,
             "uuid": str(obj.uuid),
             "sentryAppInstallationUuid": f"{install.uuid}",
             "actionType": "sentryapp",

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -20,7 +20,11 @@ class SentryAppComponentSerializer(Serializer):
 class SentryAppAlertRuleActionSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         install = kwargs.get("install")
+        event_action = kwargs.get("event_action")
         return {
+            "id": f"{event_action.id}",
+            "enabled": event_action.is_enabled(),
+            "actionType": event_action.actionType,
             "service": obj.sentry_app.slug,
             "sentryAppInstallationUuid": f"{install.uuid}",
             "prompt": f"{obj.sentry_app.name}",

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -19,8 +19,14 @@ class SentryAppComponentSerializer(Serializer):
 
 class SentryAppAlertRuleActionSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
-        install = kwargs.get("install")
         event_action = kwargs.get("event_action")
+        if not event_action:
+            raise AssertionError("Requires event_action keyword argument of type EventAction")
+
+        install = kwargs.get("install")
+        if not install:
+            raise AssertionError("Requires install keyword argument of type SentryAppInstallation")
+
         return {
             "id": f"{event_action.id}",
             "enabled": event_action.is_enabled(),

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -25,8 +25,6 @@ class RuleNodeField(serializers.Field):
 
         if "id" not in data:
             raise ValidationError("Missing attribute 'id'")
-        print("🔥🔥🔥🔥🔥🔥")
-        print(data)
         cls = rules.get(data["id"], self.type_name)
         if cls is None:
             msg = "Invalid node. Could not find '%s'"

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -25,6 +25,7 @@ class RuleNodeField(serializers.Field):
 
         if "id" not in data:
             raise ValidationError("Missing attribute 'id'")
+
         cls = rules.get(data["id"], self.type_name)
         if cls is None:
             msg = "Invalid node. Could not find '%s'"

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -25,7 +25,8 @@ class RuleNodeField(serializers.Field):
 
         if "id" not in data:
             raise ValidationError("Missing attribute 'id'")
-
+        print("🔥🔥🔥🔥🔥🔥")
+        print(data)
         cls = rules.get(data["id"], self.type_name)
         if cls is None:
             msg = "Invalid node. Could not find '%s'"

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -255,6 +255,10 @@ TICKET_ACTIONS = frozenset(
     ]
 )
 
+SCHEMA_FORM_ACTIONS = frozenset(
+    ["sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"]
+)
+
 # methods as defined by http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html + PATCH
 HTTP_METHODS = ("GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH")
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -219,6 +219,7 @@ _SENTRY_RULES = (
     "sentry.mail.actions.NotifyEmailAction",
     "sentry.rules.actions.notify_event.NotifyEventAction",
     "sentry.rules.actions.notify_event_service.NotifyEventServiceAction",
+    "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
     "sentry.rules.conditions.every_event.EveryEventCondition",
     "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
     "sentry.rules.conditions.regression_event.RegressionEventCondition",

--- a/src/sentry/mediators/alert_rule_actions/__init__.py
+++ b/src/sentry/mediators/alert_rule_actions/__init__.py
@@ -1,0 +1,1 @@
+from .creator import AlertRuleActionCreator  # NOQA

--- a/src/sentry/mediators/alert_rule_actions/__init__.py
+++ b/src/sentry/mediators/alert_rule_actions/__init__.py
@@ -1,1 +1,3 @@
-from .creator import AlertRuleActionCreator  # NOQA
+from .creator import AlertRuleActionCreator
+
+__all__ = ("AlertRuleActionCreator",)

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -17,7 +17,7 @@ class AlertRuleActionCreator(Mediator):
         self.rule.save()
 
     def _make_external_request(self):
-        self.response = external_requests.AlerRuleActionRequester.run(
+        self.response = external_requests.AlertRuleActionRequester.run(
             install=self.install,
             uri=self.uri,
             fields=self.fields,

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -16,6 +16,10 @@ class NotifyEventSentryAppAction(EventAction):
     # Required field for EventAction, value is ignored
     label = ""
 
+    # TODO(Leander): As there is no form_cls (e.g. NotifyEventSentryAppActionForm) the form data will
+    # not be validated on the backend. This is tricky to do since the schema form is dynamic, and will
+    # be implemented on it's own in the future. Frontend validation is still in place in the mean time.
+
     def get_custom_actions(self, project):
         action_list = []
         for install in SentryAppInstallation.get_installed_for_org(project.organization_id):

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -1,9 +1,39 @@
 """
 Used for notifying a *specific* sentry app with a custom webhook payload (i.e. specified UI components)
 """
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
+from sentry.coreapi import APIError
+from sentry.mediators import sentry_app_components
+from sentry.models import SentryAppComponent, SentryAppInstallation
 from sentry.rules.actions.base import EventAction
 
 
 class NotifyEventSentryAppAction(EventAction):
-    label = "This label should be received from the schema"
-    prompt = "Sentry App Title"
+    actionType = "sentryapp"
+    # Required field for EventAction, value is ignored
+    label = ""
+
+    def get_custom_actions(self, project):
+        action_list = []
+        for install in SentryAppInstallation.get_installed_for_org(project.organization_id):
+            _components = SentryAppComponent.objects.filter(
+                sentry_app_id=install.sentry_app_id, type="alert-rule-action"
+            )
+            for component in _components:
+                try:
+                    sentry_app_components.Preparer.run(
+                        component=component, install=install, project=project
+                    )
+                    # These details are unique to the Sentry App
+                    action_details = serialize(
+                        component, None, SentryAppAlertRuleActionSerializer(), install=install
+                    )
+                    # These details are shared among each Sentry App action (with UI)
+                    action_details["id"] = self.id
+                    action_details["enabled"] = self.is_enabled()
+                    action_details["actionType"] = self.actionType
+                    action_list.append(action_details)
+                except APIError:
+                    continue
+        return action_list

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -22,8 +22,6 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
     # not be validated on the backend. This is tricky to do since the schema form is dynamic, and will
     # be implemented on it's own in the future. Frontend validation is still in place in the mean time.
 
-    # src/sentry/rules/actions/notify_event_sentry_app.py:25: error: Function is missing a type annotation
-
     def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
         action_list = []
         for install in SentryAppInstallation.get_installed_for_org(project.organization_id):

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -1,0 +1,9 @@
+"""
+Used for notifying a *specific* sentry app with a custom webhook payload (i.e. specified UI components)
+"""
+from sentry.rules.actions.base import EventAction
+
+
+class NotifyEventSentryAppAction(EventAction):
+    label = "This label should be received from the schema"
+    prompt = "Sentry App Title"

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -1,12 +1,14 @@
 """
 Used for notifying a *specific* sentry app with a custom webhook payload (i.e. specified UI components)
 """
+
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
 from sentry.coreapi import APIError
 from sentry.mediators import sentry_app_components
-from sentry.models import SentryAppComponent, SentryAppInstallation
+from sentry.models import SentryApp, SentryAppComponent, SentryAppInstallation
 from sentry.rules.actions.base import EventAction
+from sentry.tasks.sentry_apps import notify_sentry_app
 
 
 class NotifyEventSentryAppAction(EventAction):
@@ -37,3 +39,26 @@ class NotifyEventSentryAppAction(EventAction):
                 except APIError:
                     continue
         return action_list
+
+    def after(self, event, state):
+        sentry_app_installation_uuid = self.get_option("sentryAppInstallationUuid")
+
+        extra = {"event_id": event.event_id}
+
+        if not sentry_app_installation_uuid:
+            self.logger.info("rules.fail.is_configured", extra=extra)
+
+        app = None
+
+        try:
+            install = SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
+            app = SentryApp.objects.get(id=install.sentry_app_id)
+        except SentryAppInstallation.DoesNotExist:
+            self.logger.info("rules.fail.no_install", extra=extra)
+            pass
+        except SentryApp.DoesNotExist:
+            self.logger.info("rules.fail.no_app", extra=extra)
+            pass
+
+        kwargs = {"sentry_app": app}
+        yield self.future(notify_sentry_app, **kwargs)

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -1,17 +1,19 @@
 """
 Used for notifying a *specific* sentry app with a custom webhook payload (i.e. specified UI components)
 """
+from typing import Any, Mapping, Optional, Sequence
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
 from sentry.coreapi import APIError
+from sentry.eventstore.models import Event
 from sentry.mediators import sentry_app_components
-from sentry.models import SentryApp, SentryAppComponent, SentryAppInstallation
+from sentry.models import Project, SentryApp, SentryAppComponent, SentryAppInstallation
 from sentry.rules.actions.base import EventAction
 from sentry.tasks.sentry_apps import notify_sentry_app
 
 
-class NotifyEventSentryAppAction(EventAction):
+class NotifyEventSentryAppAction(EventAction):  # type: ignore
     actionType = "sentryapp"
     # Required field for EventAction, value is ignored
     label = ""
@@ -20,7 +22,9 @@ class NotifyEventSentryAppAction(EventAction):
     # not be validated on the backend. This is tricky to do since the schema form is dynamic, and will
     # be implemented on it's own in the future. Frontend validation is still in place in the mean time.
 
-    def get_custom_actions(self, project):
+    # src/sentry/rules/actions/notify_event_sentry_app.py:25: error: Function is missing a type annotation
+
+    def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
         action_list = []
         for install in SentryAppInstallation.get_installed_for_org(project.organization_id):
             _components = SentryAppComponent.objects.filter(
@@ -31,38 +35,33 @@ class NotifyEventSentryAppAction(EventAction):
                     sentry_app_components.Preparer.run(
                         component=component, install=install, project=project
                     )
-                    # These details are unique to the Sentry App
+                    kwargs = {
+                        "install": install,
+                        "event_action": self,
+                    }
                     action_details = serialize(
-                        component, None, SentryAppAlertRuleActionSerializer(), install=install
+                        component, None, SentryAppAlertRuleActionSerializer(), **kwargs
                     )
-                    # These details are shared among each Sentry App action (with UI)
-                    action_details["id"] = self.id
-                    action_details["enabled"] = self.is_enabled()
-                    action_details["actionType"] = self.actionType
                     action_list.append(action_details)
                 except APIError:
                     continue
         return action_list
 
-    def after(self, event, state):
-        sentry_app_installation_uuid = self.get_option("sentryAppInstallationUuid")
-
+    def get_sentry_app(self, event: Event) -> Optional[SentryApp]:
         extra = {"event_id": event.event_id}
 
+        sentry_app_installation_uuid = self.get_option("sentryAppInstallationUuid")
         if not sentry_app_installation_uuid:
             self.logger.info("rules.fail.is_configured", extra=extra)
-
-        app = None
+            return None
 
         try:
-            install = SentryAppInstallation.objects.get(uuid=sentry_app_installation_uuid)
-            app = SentryApp.objects.get(id=install.sentry_app_id)
-        except SentryAppInstallation.DoesNotExist:
-            self.logger.info("rules.fail.no_install", extra=extra)
-            pass
+            return SentryApp.objects.get(installations__uuid=sentry_app_installation_uuid)
         except SentryApp.DoesNotExist:
             self.logger.info("rules.fail.no_app", extra=extra)
-            pass
 
-        kwargs = {"sentry_app": app}
-        yield self.future(notify_sentry_app, **kwargs)
+        return None
+
+    def after(self, event: Event, state: str) -> Any:
+        sentry_app = self.get_sentry_app(event)
+        yield self.future(notify_sentry_app, sentry_app=sentry_app)

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -1,5 +1,5 @@
 """
-Used for notifying a *specific* plugin
+Used for notifying a *specific* plugin/sentry app with a generic webhook payload
 """
 
 import logging

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.urls import reverse
 
@@ -778,6 +780,77 @@ class UpdateProjectRuleTest(APITestCase):
             {"id": "sentry.rules.actions.notify_event.NotifyEventAction"}
         ]
         assert rule.data["conditions"] == conditions + filters
+
+        assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()
+
+    @patch("sentry.mediators.alert_rule_actions.AlertRuleActionCreator.run")
+    def test_update_alert_rule_action(self, mock_alert_rule_action_creator):
+        """
+        Ensures that Sentry Apps with schema forms (UI components)
+        receive a payload when an alert rule is updated with them.
+        """
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        rule = Rule.objects.create(project=project, label="my super cool rule")
+
+        self.create_sentry_app(name="Pied Piper", organization=project.organization)
+        install = self.create_sentry_app_installation(
+            slug="pied-piper", organization=project.organization
+        )
+
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "settings": {"assignee": "Team Rocket", "priority": 27},
+                "uri": "/sentry/alerts/",
+                "sentryAppInstallationUuid": install.uuid,
+                "hasSchemaFormConfig": True,
+            },
+        ]
+
+        url = reverse(
+            "sentry-api-0-project-rule-details",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+                "rule_id": rule.id,
+            },
+        )
+
+        response = self.client.put(
+            url,
+            data={
+                "name": "my super cool rule",
+                "actionMatch": "any",
+                "filterMatch": "any",
+                "actions": actions,
+                "conditions": [],
+                "filters": [],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(rule.id)
+
+        rule = Rule.objects.get(id=rule.id)
+        assert rule.data["actions"] == actions
+
+        kwargs = {
+            "install": install,
+            "fields": actions[0].get("settings"),
+            "uri": actions[0].get("uri"),
+            "rule": rule,
+        }
+
+        call_kwargs = mock_alert_rule_action_creator.call_args[1]
+
+        assert call_kwargs["install"].id == kwargs["install"].id
+        assert call_kwargs["fields"] == kwargs["fields"]
+        assert call_kwargs["uri"] == kwargs["uri"]
+        assert call_kwargs["rule"].id == kwargs["rule"].id
 
         assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -411,3 +411,68 @@ class CreateProjectRuleTest(APITestCase):
             str(response.data["conditions"][0])
             == "Select a valid choice. bad data is not one of the available choices."
         )
+
+    @patch("sentry.mediators.alert_rule_actions.AlertRuleActionCreator.run")
+    def test_runs_alert_rule_action_creator(self, mock_alert_rule_action_creator):
+        """
+        Ensures that Sentry Apps with schema forms (UI components)
+        receive a payload when an alert rule is created with them.
+        """
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+
+        self.create_sentry_app(name="Pied Piper", organization=project.organization)
+        install = self.create_sentry_app_installation(
+            slug="pied-piper", organization=project.organization
+        )
+
+        actions = [
+            {
+                "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+                "settings": {"assignee": "Team Rocket", "priority": 27},
+                "uri": "/sentry/alerts/",
+                "sentryAppInstallationUuid": install.uuid,
+                "hasSchemaFormConfig": True,
+            },
+        ]
+
+        url = reverse(
+            "sentry-api-0-project-rules",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        response = self.client.post(
+            url,
+            data={
+                "name": "my super cool rule",
+                "owner": f"user:{self.user.id}",
+                "conditions": [],
+                "filters": [],
+                "actions": actions,
+                "filterMatch": "any",
+                "actionMatch": "any",
+                "frequency": 30,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"]
+
+        rule = Rule.objects.get(id=response.data["id"])
+        assert rule.data["actions"] == actions
+
+        kwargs = {
+            "install": install,
+            "fields": actions[0].get("settings"),
+            "uri": actions[0].get("uri"),
+            "rule": rule,
+        }
+
+        call_kwargs = mock_alert_rule_action_creator.call_args[1]
+
+        assert call_kwargs["install"].id == kwargs["install"].id
+        assert call_kwargs["fields"] == kwargs["fields"]
+        assert call_kwargs["uri"] == kwargs["uri"]
+        assert call_kwargs["rule"].id == kwargs["rule"].id

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -5,6 +5,7 @@ from sentry.utils.compat.mock import Mock, patch
 EMAIL_ACTION = "sentry.mail.actions.NotifyEmailAction"
 APP_ACTION = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
 JIRA_ACTION = "sentry.integrations.jira.notify_action.JiraCreateTicketAction"
+SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
 
 
 class ProjectRuleConfigurationTest(APITestCase):
@@ -162,8 +163,6 @@ class ProjectRuleConfigurationTest(APITestCase):
         assert len(response.data["filters"]) == 7
 
     def test_sentry_app_alert_rules(self):
-        from sentry.models import SentryAppComponent
-
         team = self.create_team()
         project1 = self.create_project(teams=[team], name="foo")
         self.create_project(teams=[team], name="baz")
@@ -176,15 +175,12 @@ class ProjectRuleConfigurationTest(APITestCase):
         install = self.create_sentry_app_installation(
             slug=sentry_app.slug, organization=self.organization, user=self.user
         )
-        component = SentryAppComponent.objects.get(
-            sentry_app_id=sentry_app.id, type="alert-rule-action"
-        )
         response = self.get_valid_response(self.organization.slug, project1.slug)
 
         assert len(response.data["actions"]) == 8
         assert {
-            "id": f"sentry.sentryapp.{sentry_app.slug}",
-            "uuid": str(component.uuid),
+            "id": SENTRY_APP_ALERT_ACTION,
+            "service": sentry_app.slug,
             "actionType": "sentryapp",
             "prompt": sentry_app.name,
             "enabled": True,

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -1,0 +1,78 @@
+from sentry.rules.actions.notify_event_sentry_app import NotifyEventSentryAppAction
+from sentry.tasks.sentry_apps import notify_sentry_app
+from sentry.testutils.cases import RuleTestCase
+
+SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
+
+
+class NotifyEventSentryAppActionTest(RuleTestCase):
+    rule_cls = NotifyEventSentryAppAction
+    schema = {
+        "elements": [
+            {
+                "type": "alert-rule-action",
+                "title": "Create Alert Rule UI Example Task",
+                "settings": {
+                    "type": "alert-rule-settings",
+                    "uri": "/test/",
+                    "required_fields": [
+                        {"type": "text", "label": "Title", "name": "title"},
+                        {"type": "textarea", "label": "Description", "name": "description"},
+                    ],
+                },
+            }
+        ]
+    }
+
+    def test_applies_correctly_for_sentry_apps(self):
+        event = self.get_event()
+
+        self.create_sentry_app(
+            organization=event.organization,
+            name="Test Application",
+            is_alertable=True,
+            schema=self.schema,
+        )
+
+        rule = self.get_rule()
+        assert rule.id == SENTRY_APP_ALERT_ACTION
+
+        futures = list(rule.after(event=event, state=self.get_state()))
+        assert len(futures) == 1
+        assert futures[0].callback is notify_sentry_app
+
+    def test_sentry_app_installed(self):
+        event = self.get_event()
+
+        self.project = self.create_project(organization=event.organization)
+
+        self.app = self.create_sentry_app(
+            organization=event.organization,
+            name="Test Application",
+            is_alertable=True,
+            schema=self.schema,
+        )
+
+        self.install = self.create_sentry_app_installation(
+            slug="test-application", organization=event.organization
+        )
+
+        rule = self.get_rule(
+            data={
+                "sentryAppInstallationUuid": self.install.uuid,
+                "settings": {"title": "foo", "description": "bar"},
+            }
+        )
+
+        action_list = rule.get_custom_actions(self.project)
+        assert len(action_list) == 1
+
+        action = action_list[0]
+        alert_element = self.schema["elements"][0]
+        assert action["id"] == SENTRY_APP_ALERT_ACTION
+        assert action["service"] == self.app.slug
+        assert action["prompt"] == self.app.name
+        assert action["actionType"] == "sentryapp"
+        assert action["enabled"]
+        assert action["formFields"] == alert_element["settings"]
+        assert alert_element["title"] in action["label"]


### PR DESCRIPTION
See [API-2078](https://getsentry.atlassian.net/browse/API-2078)
~~Blocked by: https://github.com/getsentry/sentry/pull/28548~~

This PR allows for alert rules with UI to be written to the database. It calls the creator which also sends the appropriate webhook to the Sentry App. The forms ALSO fill with the data that they were last configured with.

**Demo Video:**
https://user-images.githubusercontent.com/35509934/133848524-74af95dd-1fe9-4781-9f54-e1e9486fca8e.mov


~~**TODO:** Add tests for this behavior on the endpoints~~
