### PR TITLE
ref(select): Choices -> options adminQueue

### DIFF
--- a/static/app/views/admin/adminQueue.tsx
+++ b/static/app/views/admin/adminQueue.tsx
@@ -95,7 +95,10 @@ export default class AdminQueue extends AsyncView<{}, State> {
               onChange={value => this.changeTask(value as string)}
               value={activeTask}
               clearable
-              choices={taskList.map(t => [t, t])}
+              options={taskList.map(t => ({
+                value: t,
+                label: t,
+              }))}
             />
           </div>
           {activeTask ? (


### PR DESCRIPTION
Changes from legacy react-select `choices` to `options` here

![image](https://user-images.githubusercontent.com/9372512/133858925-b0288167-2bea-4187-891b-97d173205e62.png)
