### PR TITLE
ref(ui): Rename RuleConditionsFormForWizard and change legacy choices to options

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -54,7 +54,7 @@ type State = {
   environments: Environment[] | null;
 };
 
-class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
+class RuleConditionsForm extends React.PureComponent<Props, State> {
   state: State = {
     environments: null,
   };
@@ -316,7 +316,10 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
               minWidth: 130,
               maxWidth: 300,
             }}
-            choices={Object.entries(TIME_WINDOW_MAP)}
+            options={Object.entries(TIME_WINDOW_MAP).map(([value, label]) => ({
+              value,
+              label,
+            }))}
             required
             isDisabled={disabled}
             getValue={value => Number(value)}
@@ -374,4 +377,4 @@ const FormRowText = styled('div')`
   margin: ${space(1)};
 `;
 
-export default RuleConditionsFormForWizard;
+export default RuleConditionsForm;

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -34,7 +34,7 @@ import FormModel from 'app/views/settings/components/forms/model';
 
 import {addOrUpdateRule} from '../actions';
 import {createDefaultTrigger} from '../constants';
-import RuleConditionsFormForWizard from '../ruleConditionsFormForWizard';
+import RuleConditionsForm from '../ruleConditionsForm';
 import {
   AlertRuleThresholdType,
   Dataset,
@@ -700,7 +700,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             submitLabel={t('Save Rule')}
           >
             <List symbol="colored-numeric">
-              <RuleConditionsFormForWizard
+              <RuleConditionsForm
                 api={this.api}
                 projectSlug={params.projectId}
                 organization={organization}


### PR DESCRIPTION
This was previously named `ForWizard` because the alert wizard was feature flagged and there existed a non wizard version of the alert builder, but now we can just rename it to `RuleConditionsForm`. 

Also changed choices -> options to get rid of this legacy react-select stuff.

![image](https://user-images.githubusercontent.com/9372512/133862951-57f253bd-237f-486c-ad42-05416efc718c.png)
