### PR TITLE
fix(semver): Fix bug when sorting by unique users on the release page.

### DIFF
--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -273,9 +273,10 @@ def get_project_releases_count(
         where=where,
         having=having,
     )
-    return snuba.raw_snql_query(query, referrer="snuba.sessions.check_releases_have_health_data")[
+    data = snuba.raw_snql_query(query, referrer="snuba.sessions.check_releases_have_health_data")[
         "data"
-    ][0]["count"]
+    ]
+    return data[0]["count"] if data else 0
 
 
 def _make_stats(start, rollup, buckets, default=0):

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1785,11 +1785,7 @@ class GetProjectReleasesCountTest(TestCase, SnubaTestCase):
         org = self.create_organization()
         proj = self.create_project(organization=org)
         assert (
-            get_project_releases_count(
-                org.id,
-                [proj.id],
-                "",
-            )
+            get_project_releases_count(org.id, [proj.id], "crash_free_users", stats_period="14d")
             == 0
         )
 


### PR DESCRIPTION
This fixes a bug where when sorting by users, if there are no users in the period we're sorting over
we hit an `IndexError`.

Fixes SENTRY-S36