### PR TITLE
test(metrics): Write all session metrics in test [INGEST-386]

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -58,7 +58,6 @@ files = src/sentry/api/bases/external_actor.py,
         src/sentry/utils/dates.py,
         src/sentry/utils/jwt.py,
         src/sentry/utils/kvstore,
-        src/sentry/utils/snql.py,
         src/sentry/web/decorators.py,
         tests/sentry/utils/appleconnect/
 

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -1,26 +1,27 @@
 import itertools
+from collections import defaultdict
 from typing import DefaultDict, Dict, Optional
 
 from sentry.models import Organization
 
 from .base import StringIndexer, UseCase
 
-_STRINGS = {
-    "abnormal": 0,
-    "crashed": 1,
-    "environment": 2,
-    "errored": 3,
-    "healthy": 4,
-    "production": 5,
-    "release": 6,
-    "session.duration": 7,
-    "session.status": 8,
-    "session": 9,
-    "staging": 10,
-    "user": 11,
-    "init": 12,
-    "session.error": 13,
-}
+_STRINGS = (
+    "abnormal",
+    "crashed",
+    "environment",
+    "errored",
+    "healthy",
+    "production",
+    "release",
+    "session.duration",
+    "session.status",
+    "session",
+    "staging",
+    "user",
+    "init",
+    "session.error",
+)
 
 
 class SimpleIndexer(StringIndexer):
@@ -29,7 +30,7 @@ class SimpleIndexer(StringIndexer):
 
     def __init__(self) -> None:
         self._counter = itertools.count(start=len(_STRINGS))
-        self._strings: Dict[str, int] = DefaultDict(self._counter.__next__)
+        self._strings: DefaultDict[str, int] = defaultdict(self._counter.__next__)
         self._reverse: Dict[int, str] = {}
 
     def record(self, organization: Organization, use_case: UseCase, string: str) -> int:
@@ -56,6 +57,6 @@ class MockIndexer(SimpleIndexer):
 
     def __init__(self) -> None:
         super().__init__()
-        for string, index in _STRINGS.items():
+        for index, string in enumerate(_STRINGS):
             self._strings[string] = index
             self._reverse[index] = string

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -29,15 +29,13 @@ class SimpleIndexer(StringIndexer):
     """Simple indexer with in-memory store. Do not use in production."""
 
     def __init__(self) -> None:
-        self._counter = itertools.count(start=len(_STRINGS))
+        self._counter = itertools.count()
         self._strings: DefaultDict[str, int] = defaultdict(self._counter.__next__)
         self._reverse: Dict[int, str] = {}
 
     def record(self, organization: Organization, use_case: UseCase, string: str) -> int:
         # NOTE: Ignores ``use_case`` for simplicity.
-        index = self._strings[string]
-        self._reverse[index] = string
-        return index
+        return self._record(string)
 
     def resolve(self, organization: Organization, use_case: UseCase, string: str) -> Optional[int]:
         # NOTE: Ignores ``use_case`` for simplicity.
@@ -49,6 +47,11 @@ class SimpleIndexer(StringIndexer):
         # NOTE: Ignores ``use_case`` for simplicity.
         return self._reverse.get(id)
 
+    def _record(self, string: str) -> int:
+        index = self._strings[string]
+        self._reverse[index] = string
+        return index
+
 
 class MockIndexer(SimpleIndexer):
     """
@@ -57,6 +60,5 @@ class MockIndexer(SimpleIndexer):
 
     def __init__(self) -> None:
         super().__init__()
-        for index, string in enumerate(_STRINGS):
-            self._strings[string] = index
-            self._reverse[index] = string
+        for string in _STRINGS:
+            self._record(string)

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import DefaultDict, Optional
+from typing import DefaultDict, Dict, Optional
 
 from sentry.models import Organization
 
@@ -27,10 +27,10 @@ class SimpleIndexer(StringIndexer):
 
     """Simple indexer with in-memory store. Do not use in production."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._counter = itertools.count(start=len(_STRINGS))
-        self._strings = DefaultDict(self._counter.__next__)
-        self._reverse = {}
+        self._strings: Dict[str, int] = DefaultDict(self._counter.__next__)
+        self._reverse: Dict[int, str] = {}
 
     def record(self, organization: Organization, use_case: UseCase, string: str) -> int:
         # NOTE: Ignores ``use_case`` for simplicity.
@@ -54,7 +54,7 @@ class MockIndexer(SimpleIndexer):
     Mock string indexer. Comes with a prepared set of strings.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         for string, index in _STRINGS.items():
             self._strings[string] = index


### PR DESCRIPTION
Write more session metrics to snuba in metrics test case, mimicking the `extract_session_metrics` function in relay.

This prepares for https://getsentry.atlassian.net/browse/INGEST-386.