### PR TITLE
feat(alerts): Add minimum threshold to crash rate alerts

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -570,3 +570,6 @@ ALERTS_MEMBER_WRITE_DEFAULT = True
 
 # Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
 DataCategory = sentry_relay.DataCategory
+
+CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_sessions"
+CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -81,6 +81,7 @@ SEARCH_MAP = {
 }
 SEARCH_MAP.update(**DATASETS[Dataset.Events])
 SEARCH_MAP.update(**DATASETS[Dataset.Discover])
+SEARCH_MAP.update(**DATASETS[Dataset.Sessions])
 
 DEFAULT_PROJECT_THRESHOLD_METRIC = "duration"
 DEFAULT_PROJECT_THRESHOLD = 300

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2147,6 +2147,12 @@ FUNCTIONS = {
                 ],
             ],
         ),
+        DiscoverFunction(
+            "identity",
+            required_args=[ColumnArg("column")],
+            aggregate=["identity", ArgValue("column"), None],
+            private=True,
+        ),
     ]
 }
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -86,6 +86,10 @@ TRANSACTIONS_SNUBA_MAP = {
     if col.value.transaction_name is not None
 }
 
+SESSIONS_FIELD_LIST = ["sessions", "sessions_crashed"]
+
+SESSIONS_SNUBA_MAP = {column: column for column in SESSIONS_FIELD_LIST}
+
 # This maps the public column aliases to the discover dataset column names.
 # Longer term we would like to not expose the transactions dataset directly
 # to end users and instead have all ad-hoc queries go through the discover
@@ -101,6 +105,7 @@ DATASETS = {
     Dataset.Events: SENTRY_SNUBA_MAP,
     Dataset.Transactions: TRANSACTIONS_SNUBA_MAP,
     Dataset.Discover: DISCOVER_COLUMN_MAP,
+    Dataset.Sessions: SESSIONS_SNUBA_MAP,
 }
 
 # Store the internal field names to save work later on.
@@ -110,6 +115,7 @@ DATASET_FIELDS = {
     Dataset.Events: list(SENTRY_SNUBA_MAP.values()),
     Dataset.Transactions: list(TRANSACTIONS_SNUBA_MAP.values()),
     Dataset.Discover: list(DISCOVER_COLUMN_MAP.values()),
+    Dataset.Sessions: SESSIONS_FIELD_LIST,
 }
 
 SNUBA_OR = "or"
@@ -986,8 +992,6 @@ def resolve_column(dataset):
         if dataset == Dataset.Discover:
             if isinstance(col, (list, tuple)) or col == "project_id":
                 return col
-        elif dataset == Dataset.Sessions:
-            return col
         else:
             if (
                 col in DATASET_FIELDS[dataset]

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -551,7 +551,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
     def setUp(self):
         super().setUp()
         self.valid_alert_rule = {
-            "aggregate": "percentage(sessions_crashed, sessions) AS crash_rate_alert_aggregate",
+            "aggregate": "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
             "query": "",
             "timeWindow": "60",
             "resolveThreshold": 90,

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -169,6 +169,7 @@ def test_get_json_meta_type(field_alias, snuba_type, function, expected):
             r'to_other(release,"asdf @ \"qwer: (3,2)")',
             ("to_other", ["release", r'"asdf @ \"qwer: (3,2)"'], None),
         ),
+        ("identity(sessions)", ("identity", ["sessions"], None)),
     ],
 )
 def test_parse_function(function, expected):
@@ -360,14 +361,15 @@ class ResolveFieldListTest(unittest.TestCase):
         ]
 
     def test_aggregate_function_expansion(self):
-        fields = ["count_unique(user)", "count(id)", "min(timestamp)"]
-        result = resolve_field_list(fields, eventstore.Filter())
+        fields = ["count_unique(user)", "count(id)", "min(timestamp)", "identity(sessions)"]
+        result = resolve_field_list(fields, eventstore.Filter(), functions_acl=["identity"])
         # Automatic fields should be inserted, count() should have its column dropped.
         assert result["selected_columns"] == []
         assert result["aggregations"] == [
             ["uniq", "user", "count_unique_user"],
             ["count", None, "count_id"],
             ["min", "timestamp", "min_timestamp"],
+            ["identity", "sessions", "identity_sessions"],
         ]
         assert result["groupby"] == []
 


### PR DESCRIPTION
This PR:-
- Refactors validating `time_window` for crash rate alerts to its own function
- Adds ability to set a minimum threshold under which the subscription update is dropped. 
- Adds ability to return total count of sessions in crash rate alert subscriptions.
- Adds private `identity` function as a Discover function to be able to use `sessions` as an aggregation