### PR TITLE
feat(growth): Sending analytics for admin requests

### DIFF
--- a/src/sentry/analytics/events/admin_request.py
+++ b/src/sentry/analytics/events/admin_request.py
@@ -1,0 +1,16 @@
+from sentry import analytics
+
+
+class InviteRequestSent(analytics.Event):
+    type = "admin_request.sent"
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("user_id"),
+        analytics.Attribute("target_user_id"),
+        analytics.Attribute("providers"),
+        analytics.Attribute("ty"),
+        analytics.Attribute("subtype", required=False),
+    )
+
+
+analytics.register(InviteRequestSent)

--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -4,7 +4,7 @@ from sentry import analytics
 class InAppRequestSentEvent(analytics.Event):
     attributes = (
         analytics.Attribute("organization_id"),
-        analytics.Attribute("user_id"),
+        analytics.Attribute("user_id", required=False),
         analytics.Attribute("target_user_id"),
         analytics.Attribute("providers"),
         analytics.Attribute("subtype", required=False),

--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -1,7 +1,7 @@
 from sentry import analytics
 
 
-class InAppRequestSent(analytics.Event):
+class InAppRequestSentEvent(analytics.Event):
     attributes = (
         analytics.Attribute("organization_id"),
         analytics.Attribute("user_id"),
@@ -11,8 +11,8 @@ class InAppRequestSent(analytics.Event):
     )
 
 
-class InviteRequestSent(InAppRequestSent):
+class InviteRequestSentEvent(InAppRequestSentEvent):
     type = "invite_request.sent"
 
 
-analytics.register(InviteRequestSent)
+analytics.register(InviteRequestSentEvent)

--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -1,16 +1,18 @@
 from sentry import analytics
 
 
-class InviteRequestSent(analytics.Event):
-    type = "admin_request.sent"
+class InAppRequestSent(analytics.Event):
     attributes = (
         analytics.Attribute("organization_id"),
         analytics.Attribute("user_id"),
         analytics.Attribute("target_user_id"),
         analytics.Attribute("providers"),
-        analytics.Attribute("ty"),
         analytics.Attribute("subtype", required=False),
     )
+
+
+class InviteRequestSent(InAppRequestSent):
+    type = "invite_request.sent"
 
 
 analytics.register(InviteRequestSent)

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -66,7 +66,7 @@ def send_invite_request_notification_email(member_id):
         analytics.record(
             "invite_request.sent",
             organization_id=om.organization.id,
-            user_id=om.inviter.id,
+            user_id=om.inviter.id if om.inviter else None,
             target_user_id=recipient.id,
             providers="email",
         )

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -66,7 +66,7 @@ def send_invite_request_notification_email(member_id):
         analytics.record(
             "invite_request.sent",
             organization_id=om.organization.id,
-            user_id=member_id,
+            user_id=om.inviter.id,
             target_user_id=recipient.id,
             providers="email",
         )

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -64,10 +64,9 @@ def send_invite_request_notification_email(member_id):
             logger = get_logger(name="sentry.mail")
             logger.exception(e)
         analytics.record(
-            "admin_request.sent",
+            "invite_request.sent",
             organization_id=om.organization.id,
             user_id=member_id,
             target_user_id=recipient.id,
             providers="email",
-            ty="invite_request",
         )

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from structlog import get_logger
 
-from sentry import roles
+from sentry import analytics, roles
 from sentry.models import InviteStatus, OrganizationMember
 from sentry.tasks.base import instrumented_task
 from sentry.utils.email import MessageBuilder
@@ -63,3 +63,11 @@ def send_invite_request_notification_email(member_id):
         except Exception as e:
             logger = get_logger(name="sentry.mail")
             logger.exception(e)
+        analytics.record(
+            "admin_request.sent",
+            organization_id=om.organization.id,
+            user_id=member_id,
+            target_user_id=recipient.id,
+            providers="email",
+            ty="invite_request",
+        )


### PR DESCRIPTION
Add an analytics event on the backend for each time we send a request email for Invite Requests
