### PR TITLE
fix(js): Make `confirm` prop of SelectField less complex

### DIFF
--- a/static/app/components/confirm.tsx
+++ b/static/app/components/confirm.tsx
@@ -27,7 +27,6 @@ export type ConfirmMessageRenderProps = {
    * This should be called in the components componentDidMount.
    */
   setConfirmCallback: (cb: () => void) => void;
-  selectedValue?: any;
 };
 
 export type ConfirmButtonsRenderProps = {
@@ -43,14 +42,14 @@ export type ConfirmButtonsRenderProps = {
 };
 
 type ChildrenRenderProps = {
-  open: (e?: React.MouseEvent, selectedValue?: string) => void;
+  open: () => void;
 };
 
 export type OpenConfirmOptions = {
   /**
    * Callback when user confirms
    */
-  onConfirm?: (selectedValue?: any) => void;
+  onConfirm?: () => void;
   /**
    * Custom function to render the confirm button
    */
@@ -107,7 +106,6 @@ export type OpenConfirmOptions = {
    * Text to show in the confirmation button
    */
   confirmText?: React.ReactNode;
-  selectedValue?: string;
 };
 
 type Props = OpenConfirmOptions & {
@@ -169,7 +167,7 @@ function Confirm({
   stopPropagation = false,
   ...openConfirmOptions
 }: Props) {
-  const triggerModal = (e?: React.MouseEvent, selectedValue?: string) => {
+  const triggerModal = (e?: React.MouseEvent) => {
     if (stopPropagation) {
       e?.stopPropagation();
     }
@@ -178,7 +176,7 @@ function Confirm({
       return;
     }
 
-    openConfirmModal({...openConfirmOptions, ...(selectedValue && {selectedValue})});
+    openConfirmModal(openConfirmOptions);
   };
 
   if (typeof children === 'function') {
@@ -207,7 +205,6 @@ type ModalProps = ModalRenderProps &
     | 'onConfirm'
     | 'onCancel'
     | 'disableConfirmButton'
-    | 'selectedValue'
   >;
 
 type ModalState = {
@@ -241,12 +238,12 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
   };
 
   handleConfirm = () => {
-    const {onConfirm, closeModal, selectedValue} = this.props;
+    const {onConfirm, closeModal} = this.props;
 
     // `confirming` is used to ensure `onConfirm` or the confirm callback is
     // only called once
     if (!this.confirming) {
-      onConfirm?.(selectedValue);
+      onConfirm?.();
       this.state.confirmCallback?.();
     }
 
@@ -256,7 +253,7 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
   };
 
   get confirmMessage() {
-    const {message, renderMessage, selectedValue} = this.props;
+    const {message, renderMessage} = this.props;
 
     if (typeof renderMessage === 'function') {
       return renderMessage({
@@ -266,7 +263,6 @@ class ConfirmModal extends React.Component<ModalProps, ModalState> {
           this.setState({disableConfirmButton: state}),
         setConfirmCallback: (confirmCallback: () => void) =>
           this.setState({confirmCallback}),
-        selectedValue,
       });
     }
 

--- a/static/app/views/settings/components/forms/selectField.tsx
+++ b/static/app/views/settings/components/forms/selectField.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {OptionsType, ValueType} from 'react-select';
 
-import Confirm from 'app/components/confirm';
+import {openConfirmModal} from 'app/components/confirm';
 import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
 import {t} from 'app/locale';
 import {Choices, SelectValue} from 'app/types';
@@ -24,6 +24,17 @@ type Props<OptionType> = InputFieldProps &
      * A label that is shown inside the select control.
      */
     inFieldLabel?: string;
+    /**
+     * Allow specific options to be 'confirmed' with a confirmation message.
+     *
+     * The key is the value that should be confirmed, the value is the message
+     * to display in the confirmation modal.
+     *
+     * XXX: This only works when using the new-style options format, and _only_
+     * if the value object has a `value` attribute in the option. The types do
+     * not correctly reflect this so be careful!
+     */
+    confirm?: Record<string, React.ReactNode>;
   };
 
 function getChoices<T>(props: Props<T>): Choices {
@@ -87,33 +98,33 @@ export default class SelectField<
         {...otherProps}
         alignRight={small}
         field={({onChange, onBlur, required: _required, ...props}) => (
-          <Confirm
-            renderMessage={({selectedValue}) =>
-              confirm && selectedValue
-                ? confirm[selectedValue.value]
-                : // Set a default confirm message
-                  t('Continue with these changes?')
-            }
-            onCancel={() => {}}
-            onConfirm={this.handleChange.bind(this, onBlur, onChange)}
-          >
-            {({open}) => (
-              <SelectControl
-                {...props}
-                clearable={allowClear}
-                multiple={multiple}
-                onChange={val => {
-                  const previousValue = props.value?.toString();
-                  const newValue = val.value?.toString();
-                  if (confirm && confirm[newValue] && previousValue !== newValue) {
-                    open(undefined, val);
-                    return;
-                  }
-                  this.handleChange.bind(this, onBlur, onChange)(val);
-                }}
-              />
-            )}
-          </Confirm>
+          <SelectControl
+            {...props}
+            clearable={allowClear}
+            multiple={multiple}
+            onChange={val => {
+              if (!confirm) {
+                this.handleChange(onBlur, onChange, val);
+                return;
+              }
+
+              // Support 'confirming' selections. This only works with
+              // `val` objects that use the new-style options format
+              const previousValue = props.value?.toString();
+              const newValue = val.value?.toString();
+
+              // Value not marked for confirmation, or hasn't changed
+              if (!confirm[newValue] || previousValue === newValue) {
+                this.handleChange(onBlur, onChange, val);
+                return;
+              }
+
+              openConfirmModal({
+                onConfirm: () => this.handleChange(onBlur, onChange, val),
+                message: confirm[val?.value] ?? t('Continue with these changes?'),
+              });
+            }}
+          />
         )}
       />
     );


### PR DESCRIPTION
- Removes the changes made to the Confirm modal in favor of keeping that state inn the closure of the `onChange` of `openConfirmModal`

- Stops _every_ SelectField from being wrapped in a `Confirm`, since most selects will not be doing confirmation. This is replaced with a simpler call to openConfirmModal.