### PR TITLE
feat(deploy): Use full commit SHA for Sentry releases

### DIFF
--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -34,13 +34,6 @@ def get_revision():
     return None
 
 
-def get_short_revision(revision):
-    if not revision:
-        return ""
-
-    return revision[:12]
-
-
 def get_version():
     if __build__:
         return f"{__version__}.{__build__}"
@@ -62,7 +55,7 @@ __docformat__ = "restructuredtext en"
 # A semantic version that combines the CalVer in `__version__` (e.g.
 # 21.10.0.dev0) with a shortened commit SHA as the build. This is used for
 # example, in Sentry releases
-__semantic_version__ = __version__ if __build__ is None else f"{__version__}+{__build__[:12]}"
+__semantic_version__ = __version__ if __build__ is None else f"{__version__}+{__build__}"
 
 # This triggers monkey patches that don't require django initialization.
 # There are other monkey patches in sentry's runner initializer.

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -243,7 +243,9 @@ def configure_sdk():
     internal_project_key = get_project_key()
     upstream_dsn = sdk_options.pop("dsn", None)
     sdk_options["traces_sampler"] = traces_sampler
-    sdk_options["release"] = f"backend@{sdk_options['release']}"
+    sdk_options["release"] = (
+        f"backend@{sdk_options['release']}" if "release" in sdk_options else None
+    )
 
     if upstream_dsn:
         transport = make_transport(get_options(dsn=upstream_dsn, **sdk_options))


### PR DESCRIPTION
Engineers will end up copying the full commit SHA and using that for querying for releases, making the shortened SHA useless.