### PR TITLE
fix(workflow): Missing project in release monitor

### DIFF
--- a/src/sentry/tasks/releasemonitor.py
+++ b/src/sentry/tasks/releasemonitor.py
@@ -259,6 +259,7 @@ def adopt_releases(org_id, totals):
                                     adopted=timezone.now(),
                                 )
                             except (
+                                Project.DoesNotExist,
                                 Environment.DoesNotExist,
                                 Release.DoesNotExist,
                                 ReleaseEnvironment.DoesNotExist,


### PR DESCRIPTION
There seems to be a case where we can have sessions come in for a project, but it gets deleted before the release monitor runs. In that case, we error out so I added `Project.DoesNotExist` to the list of exceptions we ignore.

Fixes SENTRY-S62