### PR TITLE
fix(notifications): Do not truncate version string

### DIFF
--- a/src/sentry/__init__.py
+++ b/src/sentry/__init__.py
@@ -34,13 +34,6 @@ def get_revision():
     return None
 
 
-def get_short_revision(revision):
-    if not revision:
-        return ""
-
-    return revision[:12]
-
-
 def get_version():
     if __build__:
         return f"{__version__}.{__build__}"

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -735,7 +735,7 @@ class Release(Model):
             repos_by_name = {r.name: r for r in repos}
             invalid_repos = names - set(repos_by_name.keys())
             if invalid_repos:
-                raise InvalidRepository("Invalid repository names: %s" % ",".join(invalid_repos))
+                raise InvalidRepository(f"Invalid repository names: {','.join(invalid_repos)}")
 
             self.handle_commit_ranges(refs)
 

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -436,7 +436,7 @@ class Release(Model):
     build_number = models.BigIntegerField(null=True)
 
     # HACK HACK HACK
-    # As a transitionary step we permit release rows to exist multiple times
+    # As a transitional step we permit release rows to exist multiple times
     # where they are "specialized" for a specific project.  The goal is to
     # later split up releases by project again.  This is for instance used
     # by the org release listing.
@@ -1124,8 +1124,8 @@ def follows_semver_versioning_scheme(org_id, project_id, release_version=None):
         # ToDo(ahmed): re-visit/replace these conditions once we enable project wide `semver` setting
         # A project is said to be following semver versioning schemes if it satisfies the following
         # conditions:-
-        # 1: Atleast one semver compliant in the most recent 3 releases
-        # 2: Atleast 3 semver compliant releases in the most recent 10 releases
+        # 1: At least one semver compliant in the most recent 3 releases
+        # 2: At least 3 semver compliant releases in the most recent 10 releases
         if len(releases_list) <= 2:
             # Most recent release is considered to decide if project follows semver
             follows_semver = releases_list[0].is_semver_release
@@ -1137,12 +1137,12 @@ def follows_semver_versioning_scheme(org_id, project_id, release_version=None):
             # Count number of semver releases in the last ten
             semver_matches = sum(map(lambda release: release.is_semver_release, releases_list))
 
-            atleast_three_in_last_ten = semver_matches >= 3
-            atleast_one_in_last_three = any(
+            at_least_three_in_last_ten = semver_matches >= 3
+            at_least_one_in_last_three = any(
                 release.is_semver_release for release in releases_list[0:3]
             )
 
-            follows_semver = atleast_one_in_last_three and atleast_three_in_last_ten
+            follows_semver = at_least_one_in_last_three and at_least_three_in_last_ten
         cache.set(cache_key, follows_semver, 3600)
 
     # Check release_version that is passed is semver compliant

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -107,9 +107,11 @@ class ReleaseActivityNotification(ActivityNotification):
         return self.get_subject()
 
     def get_notification_title(self) -> str:
-        text = "this project"
-        if len(self.projects) > 1:
-            text = "these projects"
+        projects_text = ""
+        if len(self.projects) == 1:
+            projects_text = " for this project"
+        elif len(self.projects) > 1:
+            projects_text = " for these projects"
         return f"Release {self.version} was deployed to {self.environment}{projects_text}"
 
     def get_filename(self) -> str:

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -110,7 +110,7 @@ class ReleaseActivityNotification(ActivityNotification):
         text = "this project"
         if len(self.projects) > 1:
             text = "these projects"
-        return f"Release {self.version[:12]} was deployed to {self.environment} for {text}"
+        return f"Release {self.version} was deployed to {self.environment}{projects_text}"
 
     def get_filename(self) -> str:
         return "activity/release"

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -482,7 +482,7 @@ class SlackActivityNotificationTest(ActivityTestCase, TestCase):
         attachment, text = get_attachment()
         assert (
             text
-            == f"Release {release.version[:12]} was deployed to {self.environment.name} for these projects"
+            == f"Release {release.version} was deployed to {self.environment.name} for these projects"
         )
         assert attachment["actions"][0]["text"] == self.project.slug
         assert (

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1019,8 +1019,8 @@ class FollowsSemverVersioningSchemeTestCase(TestCase):
     def test_follows_semver_user_accidentally_stopped_using_semver_a_few_times(self):
         """
         Test that ensures that when a user accidentally stops using semver versioning for a few
-        times but there exists atleast one semver compliant release in the last 3 releases and
-        atleast 3 releases that are semver compliant in the last 10 then we still consider
+        times but there exists at least one semver compliant release in the last 3 releases and
+        at least 3 releases that are semver compliant in the last 10 then we still consider
         project to be following semantic versioning
         """
         proj = self.create_project(organization=self.org)
@@ -1043,7 +1043,7 @@ class FollowsSemverVersioningSchemeTestCase(TestCase):
         """
         Test that ensures that if a user stops using semver and so the last 3 releases in the last
         10 releases are all non-semver releases, then the project does not follow semver anymore
-        since 1st condition of atleast one semver release in the last 3 has to be a semver
+        since 1st condition of at least one semver release in the last 3 has to be a semver
         release is not satisfied
         """
         proj = self.create_project(organization=self.org)
@@ -1083,7 +1083,7 @@ class FollowsSemverVersioningSchemeTestCase(TestCase):
 
     def test_follows_semver_user_starts_using_semver(self):
         """
-        Test that ensures if a user starts using semver by having atleast the last 3 releases
+        Test that ensures if a user starts using semver by having at least the last 3 releases
         using semver then we consider the project to be using semver
         """
         proj = self.create_project(organization=self.org)
@@ -1103,7 +1103,7 @@ class FollowsSemverVersioningSchemeTestCase(TestCase):
 
     def test_follows_semver_user_starts_using_semver_with_less_than_10_recent_releases(self):
         """
-        Test that ensures that a project with only 5 (<10) releases and atleast one semver
+        Test that ensures that a project with only 5 (<10) releases and at least one semver
         release in the most recent releases is considered to be following semver
         """
         proj = self.create_project(organization=self.org)

--- a/tests/sentry/notifications/test_notifications.py
+++ b/tests/sentry/notifications/test_notifications.py
@@ -239,7 +239,7 @@ class ActivityNotificationTest(APITestCase):
 
         assert (
             text
-            == f"Release {release.version[:12]} was deployed to {self.environment.name} for this project"
+            == f"Release {release.version} was deployed to {self.environment.name} for this project"
         )
         assert (
             attachment["actions"][0]["url"]


### PR DESCRIPTION
In Deploy Notifications, we currently truncate the name of the release to 12 characters. This makes sense when the release name is a long string of hexadecimal but can cause problems when for users with different formats. For example if you had a previous release `release@v1.9` and then deployed `release@v1.10`, you'd only see `release@v1.1` which could be really bad.

This PR just removes the truncation.