### PR TITLE
py38: replace invalid assertRaises kwargs with simpler assertRaisesMessage

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -388,8 +388,8 @@ class ParseSearchQueryBackendTest(unittest.TestCase):
             parse_search_query("avg(stack.colno):>500s")
 
     def test_invalid_numeric_aggregate_filter(self):
-        with self.assertRaisesRegexp(
-            InvalidSearchQuery, expected_regex="is not a valid number suffix, must be k, m or b"
+        with self.assertRaisesMessage(
+            InvalidSearchQuery, "is not a valid number suffix, must be k, m or b"
         ):
             parse_search_query("min(measurements.size):3s")
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1,9 +1,9 @@
 import datetime
 import os
-import unittest
 from datetime import timedelta
 
 import pytest
+from django.test import SimpleTestCase
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -143,7 +143,7 @@ def result_transformer(result):
     return [token for token in map(node_visitor, result) if token is not None]
 
 
-class ParseSearchQueryTest(unittest.TestCase):
+class ParseSearchQueryTest(SimpleTestCase):
     """
     All test cases in this class are dynamically defined via the test fixtures
     which are shared with the frontend.
@@ -197,7 +197,7 @@ shared_tests_skipped = [
 register_fixture_tests(ParseSearchQueryTest, shared_tests_skipped)
 
 
-class ParseSearchQueryBackendTest(unittest.TestCase):
+class ParseSearchQueryBackendTest(SimpleTestCase):
     """
     These test cases cannot be represented by the test data used to drive the
     ParseSearchQueryTest.
@@ -384,7 +384,10 @@ class ParseSearchQueryBackendTest(unittest.TestCase):
         ]
 
     def test_invalid_aggregate_column_with_duration_filter(self):
-        with self.assertRaises(InvalidSearchQuery, regex="not a duration column"):
+        with self.assertRaisesMessage(
+            InvalidSearchQuery,
+            expected_message="avg(stack.colno): column argument invalid: stack.colno is not a numeric column",
+        ):
             parse_search_query("avg(stack.colno):>500s")
 
     def test_invalid_numeric_aggregate_filter(self):

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -119,7 +119,7 @@ class ParseSearchQueryTest(TestCase):
             'times_seen:"<10"',
         ]
         for invalid_query in invalid_queries:
-            with self.assertRaises(InvalidSearchQuery, expected_regex="Invalid number"):
+            with self.assertRaisesMessage(InvalidSearchQuery, "Invalid number"):
                 parse_search_query(invalid_query)
 
     def test_boolean_operators_not_allowed(self):
@@ -130,9 +130,9 @@ class ParseSearchQueryTest(TestCase):
             "user.email:foo@example.com AND user.email:bar@example.com AND user.email:foobar@example.com",
         ]
         for invalid_query in invalid_queries:
-            with self.assertRaises(
+            with self.assertRaisesMessage(
                 InvalidSearchQuery,
-                expected_regex='Boolean statements containing "OR" or "AND" are not supported in this search',
+                'Boolean statements containing "OR" or "AND" are not supported in this search',
             ):
                 parse_search_query(invalid_query)
 
@@ -179,13 +179,13 @@ class ConvertStatusValueTest(TestCase):
 
     def test_invalid(self):
         filters = [SearchFilter(SearchKey("status"), "=", SearchValue("wrong"))]
-        with self.assertRaises(InvalidSearchQuery, expected_regex="invalid status value"):
+        with self.assertRaisesMessage(InvalidSearchQuery, "invalid status value"):
             convert_query_values(filters, [self.project], self.user, None)
 
         filters = [AggregateFilter(AggregateKey("count_unique(user)"), ">", SearchValue("1"))]
-        with self.assertRaises(
+        with self.assertRaisesMessage(
             InvalidSearchQuery,
-            expected_regex="Aggregate filters (count_unique(user)) are not supported in issue searches.",
+            "Aggregate filters (count_unique(user)) are not supported in issue searches.",
         ):
             convert_query_values(filters, [self.project], self.user, None)
 


### PR DESCRIPTION
In Python 3.8, regex and expected_regex are invalid kwargs to assertRaises. django.test.SimpleTestCase has a simpler and faster assertRaisesMessage - we already have that in our base TestCase but for tests that are using unittest.TestCase, can just use SimpleTestCase.