### PR TITLE
test: stop relying on slash to replace since % is no longer escaped to \\% in python 3.7+

### DIFF
--- a/src/sentry/lang/javascript/errorlocale.py
+++ b/src/sentry/lang/javascript/errorlocale.py
@@ -26,7 +26,7 @@ def populate_target_locale_lookup_table():
                 else:
                     translation_regexp = re.escape(translation)
                     translation_regexp = translation_regexp.replace(
-                        r"\%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
+                        r"%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
                     )
                     # Some errors are substrings of more detailed ones, so we need exact match
                     translation_regexp = re.compile("^" + translation_regexp + "$")

--- a/src/sentry/lang/javascript/errorlocale.py
+++ b/src/sentry/lang/javascript/errorlocale.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 
 from sentry.utils.safe import get_path
 
@@ -8,6 +9,9 @@ TARGET_LOCALE = "en-US"
 
 translation_lookup_table = set()
 target_locale_lookup_table = dict()
+
+# TODO(python3.8): inline me
+_to_replace = r"\%s" if sys.version_info[:2] < (3, 7) else r"%s"
 
 
 def populate_target_locale_lookup_table():
@@ -26,7 +30,7 @@ def populate_target_locale_lookup_table():
                 else:
                     translation_regexp = re.escape(translation)
                     translation_regexp = translation_regexp.replace(
-                        r"%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
+                        _to_replace, r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
                     )
                     # Some errors are substrings of more detailed ones, so we need exact match
                     translation_regexp = re.compile("^" + translation_regexp + "$")


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/23880.

In Python 3.6, % gets escaped to \\%:
```
>>> re.escape("Impossible de définir une propriété « %s » : objet non extensible")
'Impossible\\ de\\ d\\éfinir\\ une\\ propri\\ét\\é\\ \\«\\ \\%s\\ \\»\\ \\:\\ objet\\ non\\ extensible'
```

In 3.7+, it's no longer the case:
```
>>> re.escape("Impossible de définir une propriété « %s » : objet non extensible")
'Impossible\\ de\\ définir\\ une\\ propriété\\ «\\ %s\\ »\\ :\\ objet\\ non\\ extensible'
```

We used to rely on `\%s` to  know where to replace with our format_string_data thing but that won't work anymore in 3.7+.