### PR TITLE
py38: cannot set_result more than once

### DIFF
--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -92,10 +92,9 @@ class TimedFuture(Future):
 
     def set_result(self, *args, **kwargs):
         with self._condition:
-            # This method always overwrites the result, so we always overwrite
-            # the timing, even if another timing was already recorded.
+            result = super().set_result(*args, **kwargs)
             self.__timing[1] = time()
-            return super().set_result(*args, **kwargs)
+            return result
 
     def set_exception(self, *args, **kwargs):
         with self._condition:

--- a/src/sentry/utils/concurrent.py
+++ b/src/sentry/utils/concurrent.py
@@ -92,8 +92,9 @@ class TimedFuture(Future):
 
     def set_result(self, *args, **kwargs):
         with self._condition:
+            _time = time()
             result = super().set_result(*args, **kwargs)
-            self.__timing[1] = time()
+            self.__timing[1] = _time
             return result
 
     def set_exception(self, *args, **kwargs):

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,6 +1,6 @@
 import _thread
 import sys
-from concurrent.futures import CancelledError, Future, InvalidStateError
+from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
 from queue import Full
 from threading import Event
@@ -116,6 +116,8 @@ def test_time_is_not_overwritten_if_fail_to_set_result():
         future.set_running_or_notify_cancel()
         future.set_result(1)
         assert future.get_timing() == (1.0, 1.0)
+
+    from concurrent.futures import InvalidStateError
 
     with timestamp(2.0):
         try:

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,4 +1,5 @@
 import _thread
+import sys
 from concurrent.futures import CancelledError, Future, InvalidStateError
 from contextlib import contextmanager
 from queue import Full
@@ -106,13 +107,23 @@ def test_timed_future_success():
         future.set_result(None)
         assert future.get_timing() == (1.0, 2.0)
 
-    with timestamp(3.0):
+
+@pytest.mark.skipif(sys.version_info[:2] < (3, 8), reason="doesn't apply to this python version")
+def test_time_is_not_overwritten_if_fail_to_set_result():
+    future = TimedFuture()
+
+    with timestamp(1.0):
+        future.set_running_or_notify_cancel()
+        future.set_result(1)
+        assert future.get_timing() == (1.0, 1.0)
+
+    with timestamp(2.0):
         try:
             future.set_result(1)
         except InvalidStateError:
             pass
         # If set_result fails, the time shouldn't be overwritten.
-        assert future.get_timing() == (1.0, 2.0)
+        assert future.get_timing() == (1.0, 1.0)
 
 
 def test_timed_future_error():

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,5 +1,5 @@
 import _thread
-from concurrent.futures import CancelledError, Future
+from concurrent.futures import CancelledError, Future, InvalidStateError
 from contextlib import contextmanager
 from queue import Full
 from threading import Event
@@ -104,6 +104,14 @@ def test_timed_future_success():
 
     with timestamp(2.0):
         future.set_result(None)
+        assert future.get_timing() == (1.0, 2.0)
+
+    with timestamp(3.0):
+        try:
+            future.set_result(1)
+        except InvalidStateError:
+            pass
+        # If set_result fails, the time shouldn't be overwritten.
         assert future.get_timing() == (1.0, 2.0)
 
 

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -1,5 +1,4 @@
 import _thread
-import sys
 from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
 from queue import Full
@@ -17,7 +16,6 @@ from sentry.utils.concurrent import (
 )
 
 
-@pytest.mark.skipif(sys.version_info[0] == 3, reason="TODO(python3): stalls on python3")
 def test_execute():
     assert execute(_thread.get_ident).result() != _thread.get_ident()
 

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -108,10 +108,6 @@ def test_timed_future_success():
         future.set_result(None)
         assert future.get_timing() == (1.0, 2.0)
 
-    with timestamp(3.0):
-        future.set_result(None)
-        assert future.get_timing() == (1.0, 3.0)
-
 
 def test_timed_future_error():
     future = TimedFuture()
@@ -124,10 +120,6 @@ def test_timed_future_error():
     with timestamp(2.0):
         future.set_exception(None)
         assert future.get_timing() == (1.0, 2.0)
-
-    with timestamp(3.0):
-        future.set_exception(None)
-        assert future.get_timing() == (1.0, 3.0)
 
 
 def test_timed_future_cancel():


### PR DESCRIPTION
https://docs.python.org/3.8/library/concurrent.futures.html?highlight=concurrent%20futures#concurrent.futures.Future.set_result

In Python 3.8, set_result is gonna raise concurrent.futures.InvalidStateError if we call it more than once. I think this is desirable and we should just adjust the test cases to not do that. 