### PR TITLE
feat(comparison_alerts): Add `comparison_delta` to metric alerts api. (WOR-1219)

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -310,6 +310,9 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         required=True, min_value=1, max_value=int(timedelta(days=1).total_seconds() / 60)
     )
     threshold_period = serializers.IntegerField(default=1, min_value=1, max_value=20)
+    comparison_delta = serializers.IntegerField(
+        required=False, min_value=1, max_value=int(timedelta(days=89).total_seconds() / 60)
+    )
     aggregate = serializers.CharField(required=True, min_length=1)
     owner = serializers.CharField(
         required=False,
@@ -328,6 +331,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "threshold_type",
             "resolve_threshold",
             "threshold_period",
+            "comparison_delta",
             "aggregate",
             "projects",
             "include_all_projects",

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -633,12 +633,11 @@ def create_alert_rule(
 
     :return: The created `AlertRule`
     """
-    # Since comparison alerts make twice as many queries, run the queries less frequently.
-    resolution = (
-        DEFAULT_ALERT_RULE_RESOLUTION
-        if comparison_delta is None
-        else DEFAULT_CMP_ALERT_RULE_RESOLUTION
-    )
+    resolution = DEFAULT_ALERT_RULE_RESOLUTION
+    if comparison_delta is not None:
+        # Since comparison alerts make twice as many queries, run the queries less frequently.
+        resolution = DEFAULT_CMP_ALERT_RULE_RESOLUTION
+        comparison_delta = int(timedelta(minutes=comparison_delta).total_seconds())
     validate_alert_rule_query(query)
     if AlertRule.objects.filter(organization=organization, name=name).exists():
         raise AlertRuleNameAlreadyUsedError()
@@ -807,11 +806,12 @@ def update_alert_rule(
     if owner is not None:
         updated_fields["owner"] = owner.resolve_to_actor()
     if comparison_delta is not NOT_SET:
-        resolution = (
-            DEFAULT_ALERT_RULE_RESOLUTION
-            if comparison_delta is None
-            else DEFAULT_CMP_ALERT_RULE_RESOLUTION
-        )
+        resolution = DEFAULT_ALERT_RULE_RESOLUTION
+        if comparison_delta is not None:
+            # Since comparison alerts make twice as many queries, run the queries less frequently.
+            resolution = DEFAULT_CMP_ALERT_RULE_RESOLUTION
+            comparison_delta = int(timedelta(minutes=comparison_delta).total_seconds())
+
         updated_query_fields["resolution"] = timedelta(minutes=resolution)
         updated_fields["comparison_delta"] = comparison_delta
 

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -833,7 +833,7 @@ def update_alert_rule(
                 "time_window", timedelta(seconds=snuba_query.time_window)
             )
             updated_query_fields.setdefault("event_types", None)
-            updated_query_fields.setdefault("resolution", timedelta(minutes=snuba_query.resolution))
+            updated_query_fields.setdefault("resolution", timedelta(seconds=snuba_query.resolution))
             update_snuba_query(
                 alert_rule.snuba_query,
                 environment=environment,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from itertools import chain
+from typing import Optional
 
 from django.db import transaction
 from django.db.models.signals import post_save
@@ -578,7 +579,9 @@ class AlertRuleNameAlreadyUsedError(Exception):
     pass
 
 
+# Default values for `SnubaQuery.resolution`, in minutes.
 DEFAULT_ALERT_RULE_RESOLUTION = 1
+DEFAULT_CMP_ALERT_RULE_RESOLUTION = 2
 
 
 def create_alert_rule(
@@ -598,6 +601,7 @@ def create_alert_rule(
     dataset=QueryDatasets.EVENTS,
     user=None,
     event_types=None,
+    comparison_delta: Optional[int] = None,
     **kwargs,
 ):
     """
@@ -624,10 +628,17 @@ def create_alert_rule(
     `include_all_projects`.
     :param dataset: The dataset that this query will be executed on
     :param event_types: List of `EventType` that this alert will be related to
+    :param comparison_delta: An optional int representing the time delta to use to determine the
+    comparison period. In minutes.
 
     :return: The created `AlertRule`
     """
-    resolution = DEFAULT_ALERT_RULE_RESOLUTION
+    # Since comparison alerts make twice as many queries, run the queries less frequently.
+    resolution = (
+        DEFAULT_ALERT_RULE_RESOLUTION
+        if comparison_delta is None
+        else DEFAULT_CMP_ALERT_RULE_RESOLUTION
+    )
     validate_alert_rule_query(query)
     if AlertRule.objects.filter(organization=organization, name=name).exists():
         raise AlertRuleNameAlreadyUsedError()
@@ -654,6 +665,7 @@ def create_alert_rule(
             threshold_period=threshold_period,
             include_all_projects=include_all_projects,
             owner=actor,
+            comparison_delta=comparison_delta,
         )
 
         if include_all_projects:
@@ -732,6 +744,7 @@ def update_alert_rule(
     excluded_projects=None,
     user=None,
     event_types=None,
+    comparison_delta=NOT_SET,
     **kwargs,
 ):
     """
@@ -757,6 +770,8 @@ def update_alert_rule(
     :param excluded_projects: List of projects to exclude if we're using
     `include_all_projects`. Ignored otherwise.
     :param event_types: List of `EventType` that this alert will be related to
+    :param comparison_delta: An optional int representing the time delta to use to determine the
+    comparison period. In minutes.
     :return: The updated `AlertRule`
     """
     if (
@@ -791,6 +806,14 @@ def update_alert_rule(
         updated_query_fields["event_types"] = event_types
     if owner is not None:
         updated_fields["owner"] = owner.resolve_to_actor()
+    if comparison_delta is not NOT_SET:
+        resolution = (
+            DEFAULT_ALERT_RULE_RESOLUTION
+            if comparison_delta is None
+            else DEFAULT_CMP_ALERT_RULE_RESOLUTION
+        )
+        updated_query_fields["resolution"] = timedelta(minutes=resolution)
+        updated_fields["comparison_delta"] = comparison_delta
 
     with transaction.atomic():
         incidents = Incident.objects.filter(alert_rule=alert_rule).exists()
@@ -810,9 +833,9 @@ def update_alert_rule(
                 "time_window", timedelta(seconds=snuba_query.time_window)
             )
             updated_query_fields.setdefault("event_types", None)
+            updated_query_fields.setdefault("resolution", timedelta(minutes=snuba_query.resolution))
             update_snuba_query(
                 alert_rule.snuba_query,
-                resolution=timedelta(minutes=DEFAULT_ALERT_RULE_RESOLUTION),
                 environment=environment,
                 **updated_query_fields,
             )

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -110,6 +110,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             "projects": [self.project.slug],
             "owner": self.user.id,
             "name": "JustAValidTestRule",
+            "comparisonDelta": 60,
         }
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_valid_response(

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -536,7 +536,7 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
         assert serializer.is_valid()
         alert_rule = serializer.save()
-        assert alert_rule.comparison_delta == 60
+        assert alert_rule.comparison_delta == 60 * 60
         assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -11,7 +11,11 @@ from sentry.incidents.endpoints.serializers import (
     string_to_action_target_type,
     string_to_action_type,
 )
-from sentry.incidents.logic import ChannelLookupTimeoutError, create_alert_rule_trigger
+from sentry.incidents.logic import (
+    DEFAULT_CMP_ALERT_RULE_RESOLUTION,
+    ChannelLookupTimeoutError,
+    create_alert_rule_trigger,
+)
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTriggerAction
 from sentry.models import ACTOR_TYPES, Environment, Integration
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
@@ -525,6 +529,15 @@ class TestAlertRuleSerializer(TestCase):
         alert_rule = serializer.save()
         assert alert_rule.owner == self.user.actor
         assert alert_rule.owner.type == ACTOR_TYPES["user"]
+
+    def test_comparison_delta(self):
+        params = self.valid_params.copy()
+        params["comparison_delta"] = 60
+        serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
+        assert serializer.is_valid()
+        alert_rule = serializer.save()
+        assert alert_rule.comparison_delta == 60
+        assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
 
 class TestAlertRuleTriggerSerializer(TestCase):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -898,7 +898,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             comparison_delta=comparison_delta,
         )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
-        assert alert_rule.comparison_delta == comparison_delta
+        assert alert_rule.comparison_delta == comparison_delta * 60
         assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
 
@@ -1155,12 +1155,12 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         comparison_delta = 60
 
         update_alert_rule(self.alert_rule, comparison_delta=comparison_delta)
-        assert self.alert_rule.comparison_delta == comparison_delta
+        assert self.alert_rule.comparison_delta == comparison_delta * 60
         assert self.alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
         # Should be no change if we don't specify `comparison_delta` for update at all.
         update_alert_rule(self.alert_rule)
-        assert self.alert_rule.comparison_delta == comparison_delta
+        assert self.alert_rule.comparison_delta == comparison_delta * 60
         assert self.alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
         # Should change if we explicitly set it to None.


### PR DESCRIPTION
This allows `comparison_delta` to be passed to the metric alerts create/update api. When passed, it
will set it on the alert rule, and also set the `resolution` of the underlying query to be two
minutes instead of one. We do this to offset the extra load caused by making two queries.