### PR TITLE
feat(comparison_alerts): Return comparison delta in the metric alert rule apis.

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -110,6 +110,7 @@ class AlertRuleSerializer(Serializer):
             "includeAllProjects": obj.include_all_projects,
             "owner": attrs.get("owner", None),
             "originalAlertRuleId": attrs.get("originalAlertRuleId", None),
+            "comparisonDelta": obj.comparison_delta / 60 if obj.comparison_delta else None,
             "dateModified": obj.date_modified,
             "dateCreated": obj.date_added,
             "createdBy": attrs.get("created_by", None),

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -311,7 +311,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
     )
     threshold_period = serializers.IntegerField(default=1, min_value=1, max_value=20)
     comparison_delta = serializers.IntegerField(
-        required=False, min_value=1, max_value=int(timedelta(days=89).total_seconds() / 60)
+        required=False,
+        min_value=1,
+        max_value=int(timedelta(days=89).total_seconds() / 60),
+        allow_null=True,
     )
     aggregate = serializers.CharField(required=True, min_length=1)
     owner = serializers.CharField(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -942,6 +942,7 @@ class Factories:
         resolve_threshold=None,
         user=None,
         event_types=None,
+        comparison_delta=None,
     ):
         if not name:
             name = petname.Generate(2, " ", letters=10).title()
@@ -963,6 +964,7 @@ class Factories:
             excluded_projects=excluded_projects,
             user=user,
             event_types=event_types,
+            comparison_delta=comparison_delta,
         )
 
         if date_added is not None:

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -51,6 +51,11 @@ class BaseAlertRuleSerializerTest:
         else:
             assert result["owner"] is None
 
+        if alert_rule.comparison_delta:
+            assert result["comparisonDelta"] == alert_rule.comparison_delta / 60
+        else:
+            assert result["comparisonDelta"] is None
+
     def create_issue_alert_rule(self, data):
         """data format
         {
@@ -128,6 +133,11 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         result = serialize(alert_rule)
         self.assert_alert_rule_serialized(alert_rule, result)
         assert alert_rule.owner == self.team.actor
+
+    def test_comparison_delta(self):
+        alert_rule = self.create_alert_rule(comparison_delta=60)
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result)
 
 
 class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -12,6 +12,7 @@ from sentry.incidents.endpoints.serializers import (
     string_to_action_type,
 )
 from sentry.incidents.logic import (
+    DEFAULT_ALERT_RULE_RESOLUTION,
     DEFAULT_CMP_ALERT_RULE_RESOLUTION,
     ChannelLookupTimeoutError,
     create_alert_rule_trigger,
@@ -538,6 +539,15 @@ class TestAlertRuleSerializer(TestCase):
         alert_rule = serializer.save()
         assert alert_rule.comparison_delta == 60 * 60
         assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
+
+        params["comparison_delta"] = None
+        serializer = AlertRuleSerializer(
+            context=self.context, instance=alert_rule, data=params, partial=True
+        )
+        assert serializer.is_valid()
+        alert_rule = serializer.save()
+        assert alert_rule.comparison_delta is None
+        assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60
 
 
 class TestAlertRuleTriggerSerializer(TestCase):


### PR DESCRIPTION
This returns the comparison delta to all metric alert apis. The value is in minutes, to match the
input value.