### PR TITLE
fix(ui): Show adoption stats on releases list

### DIFF
--- a/static/app/views/releases/list/releaseHealth/content.tsx
+++ b/static/app/views/releases/list/releaseHealth/content.tsx
@@ -149,10 +149,6 @@ const Content = ({
             activeDisplay
           );
           const adoption = getHealthData.getAdoption(releaseVersion, id, activeDisplay);
-          // we currently don't support sub-hour session intervals, we rather hide the count histogram than to show only two bars
-          const hasCountHistogram =
-            timeSeries?.[0].data.length > 7 &&
-            timeSeries[0].data.some(item => item.value > 0);
 
           const adoptionStage =
             showReleaseAdoptionStages &&
@@ -198,17 +194,15 @@ const Content = ({
                 <AdoptionColumn>
                   {showPlaceholders ? (
                     <StyledPlaceholder width="100px" />
-                  ) : adoption && hasCountHistogram ? (
+                  ) : (
                     <AdoptionWrapper>
-                      <span>{Math.round(adoption)}%</span>
+                      <span>{adoption ? Math.round(adoption) : '0'}%</span>
                       <HealthStatsChart
                         data={timeSeries}
                         height={20}
                         activeDisplay={activeDisplay}
                       />
                     </AdoptionWrapper>
-                  ) : (
-                    <NotAvailable />
                   )}
                 </AdoptionColumn>
 

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -80,7 +80,7 @@ describe('ReleasesList', function () {
     expect(items.at(0).text()).toContain('1.0.0');
     expect(items.at(0).text()).toContain('Adoption');
     expect(items.at(1).text()).toContain('1.0.1');
-    expect(items.at(1).find('AdoptionColumn').at(1).text()).toContain('\u2014');
+    expect(items.at(1).find('AdoptionColumn').at(1).text()).toContain('0%');
     expect(items.at(2).text()).toContain('af4f231ec9a8');
     expect(items.at(2).find('Header').text()).toContain('Project');
   });


### PR DESCRIPTION
Show adoption stats on releases list even if 0/not available. Display as 0% and gray bars/graph.

[FIXES WOR-1177](https://getsentry.atlassian.net/browse/WOR-1177)

# Before
<img width="1189" alt="Screen Shot 2021-09-20 at 7 58 27 PM" src="https://user-images.githubusercontent.com/20312973/134106608-f1f4d508-dc74-4c01-abd0-c7eef60c7be9.png">

# After
<img width="1202" alt="Screen Shot 2021-09-20 at 7 56 23 PM" src="https://user-images.githubusercontent.com/20312973/134106673-2bce52bc-2685-4785-afe1-2d962e7ffe2e.png">
