### PR TITLE
fix(dev): Use full path for Kafka container

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1757,7 +1757,7 @@ SENTRY_DEVSERVICES = {
                 "KAFKA_MESSAGE_MAX_BYTES": "50000000",
                 "KAFKA_MAX_REQUEST_SIZE": "50000000",
             },
-            "volumes": {"kafka": {"bind": "/var/lib/kafka"}},
+            "volumes": {"kafka": {"bind": "/var/lib/kafka/data"}},
             "only_if": "kafka" in settings.SENTRY_EVENTSTREAM
             or settings.SENTRY_USE_RELAY
             or settings.SENTRY_DEV_PROCESS_SUBSCRIPTIONS,


### PR DESCRIPTION
Follow up to #28574.

When we [upgraded the kafka and zookeeper images we use][1], we did not update the volume to
use the full path (as the [instructions indicate][2]), thus, started to see this error:

>  Command [/usr/local/bin/dub path /var/lib/kafka/data writable] FAILED !

This change adds the full path.

[1]: https://github.com/getsentry/sentry/pull/28574
[2]: https://docs.confluent.io/platform/current/installation/docker/operations/external-volumes.html#data-volumes-for-kafka-and-zk