### PR TITLE
ref(releasehealth): Implement get_release_adoption with metrics [INGEST-249]

### DIFF
--- a/src/sentry/releasehealth/base.py
+++ b/src/sentry/releasehealth/base.py
@@ -87,7 +87,16 @@ class ReleaseHealthBackend(Service):  # type: ignore
         """
         Get the adoption of the last 24 hours (or a difference reference timestamp).
 
-        :param project_releases:
+        :param project_releases: A list of releases to get adoption for. Our
+            backends store session data per-project, so each release has to be
+            scoped down to a project too.
+
+        :param environments: Optional. A list of environments to filter by.
+        :param now: Release adoption information will be provided from 24h ago
+            until this timestamp.
+        :param org_id: An organization ID to filter by. Note that all projects
+            have to be within this organization, and this backend doesn't check for
+            that. Omit if you're not sure.
         """
 
         raise NotImplementedError()

--- a/src/sentry/releasehealth/base.py
+++ b/src/sentry/releasehealth/base.py
@@ -9,7 +9,7 @@ from sentry.utils.services import Service
 class ReleaseHealthBackend(Service):  # type: ignore
     """Abstraction layer for all release health related queries"""
 
-    __all__ = ("get_current_and_previous_crash_free_rates",)
+    __all__ = ("get_current_and_previous_crash_free_rates", "get_release_adoption")
 
     class CurrentAndPreviousCrashFreeRate(TypedDict):
         currentCrashFreeRate: Optional[float]
@@ -54,4 +54,11 @@ class ReleaseHealthBackend(Service):  # type: ignore
                 ...
             }
         """
+        raise NotImplementedError()
+
+    def get_release_adoption(project_releases, environments=None, now=None):
+        """
+        Get the adoption of the last 24 hours (or a difference reference timestamp).
+        """
+
         raise NotImplementedError()

--- a/src/sentry/releasehealth/base.py
+++ b/src/sentry/releasehealth/base.py
@@ -1,9 +1,14 @@
 from datetime import datetime
-from typing import Dict, Optional, Sequence
+from typing import Mapping, Optional, Sequence, Tuple
 
 from typing_extensions import TypedDict
 
 from sentry.utils.services import Service
+
+ProjectId = int
+OrganizationId = int
+ReleaseName = str
+EnvironmentName = str
 
 
 class ReleaseHealthBackend(Service):  # type: ignore
@@ -15,17 +20,17 @@ class ReleaseHealthBackend(Service):  # type: ignore
         currentCrashFreeRate: Optional[float]
         previousCrashFreeRate: Optional[float]
 
-    CurrentAndPreviousCrashFreeRates = Dict[int, CurrentAndPreviousCrashFreeRate]
+    CurrentAndPreviousCrashFreeRates = Mapping[ProjectId, CurrentAndPreviousCrashFreeRate]
 
     def get_current_and_previous_crash_free_rates(
         self,
-        project_ids: Sequence[int],
+        project_ids: Sequence[ProjectId],
         current_start: datetime,
         current_end: datetime,
         previous_start: datetime,
         previous_end: datetime,
         rollup: int,
-        org_id: Optional[int] = None,
+        org_id: Optional[OrganizationId] = None,
     ) -> CurrentAndPreviousCrashFreeRates:
         """
         Function that returns `currentCrashFreeRate` and the `previousCrashFreeRate` of projects
@@ -56,9 +61,33 @@ class ReleaseHealthBackend(Service):  # type: ignore
         """
         raise NotImplementedError()
 
-    def get_release_adoption(project_releases, environments=None, now=None):
+    class ReleaseAdoption(TypedDict):
+        #: Adoption rate (based on usercount) for a project's release from 0..100
+        adoption: Optional[float]
+        #: Adoption rate (based on sessioncount) for a project's release from 0..100
+        sessions_adoption: Optional[float]
+        #: User count for a project's release (past 24h)
+        users_24h: Optional[int]
+        #: Sessions count for a project's release (past 24h)
+        sessions_24h: Optional[int]
+        #: Sessions count for the entire project (past 24h)
+        project_users_24h: Optional[int]
+        #: Sessions count for the entire project (past 24h)
+        project_sessions_24h: Optional[int]
+
+    ReleasesAdoption = Mapping[Tuple[ProjectId, ReleaseName], ReleaseAdoption]
+
+    def get_release_adoption(
+        self,
+        project_releases: Sequence[Tuple[ProjectId, ReleaseName]],
+        environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
+        org_id: Optional[OrganizationId] = None,
+    ) -> ReleasesAdoption:
         """
         Get the adoption of the last 24 hours (or a difference reference timestamp).
+
+        :param project_releases:
         """
 
         raise NotImplementedError()

--- a/src/sentry/releasehealth/metrics.py
+++ b/src/sentry/releasehealth/metrics.py
@@ -3,7 +3,8 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import pytz
 from snuba_sdk import BooleanCondition, Column, Condition, Entity, Op, Query
-from snuba_sdk.expressions import Granularity, SelectableExpression
+from snuba_sdk.expressions import Granularity
+from snuba_sdk.query import SelectableExpression
 
 from sentry.models.project import Project
 from sentry.releasehealth.base import ReleaseHealthBackend

--- a/src/sentry/releasehealth/sessions.py
+++ b/src/sentry/releasehealth/sessions.py
@@ -8,7 +8,7 @@ from sentry.releasehealth.base import (
     ReleaseHealthBackend,
     ReleaseName,
 )
-from sentry.snuba.sessions import get_current_and_previous_crash_free_rates, get_release_adoption
+from sentry.snuba.sessions import _get_release_adoption, get_current_and_previous_crash_free_rates
 
 
 class SessionsReleaseHealthBackend(ReleaseHealthBackend):
@@ -40,6 +40,6 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
         now: Optional[datetime] = None,
         org_id: Optional[OrganizationId] = None,
     ) -> ReleaseHealthBackend.ReleasesAdoption:
-        return get_release_adoption(  # type: ignore
+        return _get_release_adoption(  # type: ignore
             project_releases=project_releases, environments=environments, now=now
         )

--- a/src/sentry/releasehealth/sessions.py
+++ b/src/sentry/releasehealth/sessions.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional, Sequence
 
 from sentry.releasehealth.base import ReleaseHealthBackend
-from sentry.snuba.sessions import get_current_and_previous_crash_free_rates
+from sentry.snuba.sessions import get_current_and_previous_crash_free_rates, get_release_adoption
 
 
 class SessionsReleaseHealthBackend(ReleaseHealthBackend):
@@ -25,4 +25,13 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
             previous_start=previous_start,
             previous_end=previous_end,
             rollup=rollup,
+        )
+
+    def get_release_adoption(self, project_releases, environments=None, now=None):
+        """
+        Get the adoption of the last 24 hours (or a difference reference timestamp).
+        """
+
+        return get_release_adoption(
+            project_releases=project_releases, environments=environments, now=now
         )

--- a/src/sentry/releasehealth/sessions.py
+++ b/src/sentry/releasehealth/sessions.py
@@ -1,7 +1,13 @@
 from datetime import datetime
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
-from sentry.releasehealth.base import ReleaseHealthBackend
+from sentry.releasehealth.base import (
+    EnvironmentName,
+    OrganizationId,
+    ProjectId,
+    ReleaseHealthBackend,
+    ReleaseName,
+)
 from sentry.snuba.sessions import get_current_and_previous_crash_free_rates, get_release_adoption
 
 
@@ -10,13 +16,13 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
 
     def get_current_and_previous_crash_free_rates(
         self,
-        project_ids: Sequence[int],
+        project_ids: Sequence[ProjectId],
         current_start: datetime,
         current_end: datetime,
         previous_start: datetime,
         previous_end: datetime,
         rollup: int,
-        org_id: Optional[int] = None,
+        org_id: Optional[OrganizationId] = None,
     ) -> ReleaseHealthBackend.CurrentAndPreviousCrashFreeRates:
         return get_current_and_previous_crash_free_rates(  # type: ignore
             project_ids=project_ids,
@@ -27,11 +33,13 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
             rollup=rollup,
         )
 
-    def get_release_adoption(self, project_releases, environments=None, now=None):
-        """
-        Get the adoption of the last 24 hours (or a difference reference timestamp).
-        """
-
-        return get_release_adoption(
+    def get_release_adoption(
+        self,
+        project_releases: Sequence[Tuple[ProjectId, ReleaseName]],
+        environments: Optional[Sequence[EnvironmentName]] = None,
+        now: Optional[datetime] = None,
+        org_id: Optional[OrganizationId] = None,
+    ) -> ReleaseHealthBackend.ReleasesAdoption:
+        return get_release_adoption(  # type: ignore
             project_releases=project_releases, environments=environments, now=now
         )

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -9,6 +9,7 @@ from snuba_sdk.function import Function
 from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.query import Query
 
+from sentry import releasehealth
 from sentry.snuba.dataset import Dataset
 from sentry.utils import snuba
 from sentry.utils.dates import to_datetime, to_timestamp
@@ -311,7 +312,7 @@ def get_rollup_starts_and_buckets(period):
     return seconds, start, buckets
 
 
-def get_release_adoption(project_releases, environments=None, now=None):
+def _get_release_adoption(project_releases, environments=None, now=None):
     """Get the adoption of the last 24 hours (or a difference reference timestamp)."""
     conditions, filter_keys = _get_conditions_and_filter_keys(project_releases, environments)
     if now is None:
@@ -479,10 +480,7 @@ def get_release_health_data_overview(
                     health_stats_period: _make_stats(stats_start, stats_rollup, stats_buckets)
                 }
 
-    # Fill in release adoption
-    from sentry.releasehealth import get_release_adoption
-
-    release_adoption = get_release_adoption(project_releases, environments)
+    release_adoption = releasehealth.get_release_adoption(project_releases, environments)
     for key in rv:
         adoption_info = release_adoption.get(key) or {}
         rv[key]["adoption"] = adoption_info.get("adoption")

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -480,6 +480,8 @@ def get_release_health_data_overview(
                 }
 
     # Fill in release adoption
+    from sentry.releasehealth import get_release_adoption
+
     release_adoption = get_release_adoption(project_releases, environments)
     for key in rv:
         adoption_info = release_adoption.get(key) or {}

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -15,7 +15,6 @@ from sentry.snuba.sessions import (
     get_oldest_health_data_for_releases,
     get_project_releases_by_stability,
     get_project_releases_count,
-    get_release_adoption,
     get_release_health_data_overview,
     get_release_sessions_time_bounds,
 )
@@ -59,6 +58,8 @@ class ReleaseHealthMetricsTestCase(SessionMetricsTestCase):
 
 
 class SnubaSessionsTest(TestCase, SnubaTestCase):
+    backend = SessionsReleaseHealthBackend()
+
     def setUp(self):
         super().setUp()
         self.received = time.time()
@@ -290,7 +291,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         ]
 
     def test_get_release_adoption(self):
-        data = get_release_adoption(
+        data = self.backend.get_release_adoption(
             [
                 (self.project.id, self.session_release),
                 (self.project.id, self.session_crashed_release),
@@ -336,7 +337,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             }
         )
 
-        data = get_release_adoption(
+        data = self.backend.get_release_adoption(
             [
                 (self.project.id, self.session_release),
                 (self.project.id, self.session_crashed_release),
@@ -564,6 +565,12 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             "sessions_lower_bound": None,
             "sessions_upper_bound": None,
         }
+
+
+class SnubaSessionsTestMetrics(ReleaseHealthMetricsTestCase, SnubaSessionsTest):
+    """repeat tests with metrics"""
+
+    pass
 
 
 class SnubaReleaseDetailPaginationBaseTestClass:


### PR DESCRIPTION
Like in https://github.com/getsentry/sentry/pull/28598, port another function from sentry.snuba.sessions to metrics.

Also found a couple of bugs in the test infra and made some types stronger.