### PR TITLE
 build(sdk): Lock Python SDK to 1.3.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,7 +52,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay==0.8.8
-sentry-sdk>=1.4.0,<1.5.0
+sentry-sdk>=1.3.0,<1.4.0
 snuba-sdk>=0.0.25,<1.0.0
 simplejson==3.17.2
 statsd==3.3

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -246,7 +246,6 @@ def configure_sdk():
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )
-    sdk_options["send_client_reports"] = True
 
     if upstream_dsn:
         transport = make_transport(get_options(dsn=upstream_dsn, **sdk_options))


### PR DESCRIPTION
`1.4.0` introduced some issues around tracing that need to be resolved first.
For now this need to be locked to `1.3.0` to unlock the deploys.

Broken tests: https://github.com/getsentry/getsentry/runs/3664445873