### PR TITLE
fix(ui) Stack sidebar panels on top of global-selection

### DIFF
--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -22,6 +22,7 @@ const PanelContainer = styled('div')<PositionProps>`
   box-shadow: 1px 0 2px rgba(0, 0, 0, 0.06);
   text-align: left;
   animation: 200ms ${slideInLeft};
+  z-index: ${p => p.theme.zIndex.sidebar};
 
   ${p =>
     p.orientation === 'top'


### PR DESCRIPTION
Add zindex to the sidebar panels so they stack on top of the global selection header and issue stream toolbar.

Fixes #28716