### PR TITLE
feat(snql): Use aliased expression instead of function hack

### DIFF
--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -1534,7 +1534,7 @@ class QueryFilter(QueryFields):
         # Handle "has" queries
         if search_filter.value.raw_value == "":
             return Condition(
-                self.resolve_field_alias(search_filter.key.name),
+                self.resolve_field(search_filter.key.name),
                 Op.IS_NULL if search_filter.operator == "=" else Op.IS_NOT_NULL,
             )
         if search_filter.is_in_filter:
@@ -1544,7 +1544,7 @@ class QueryFilter(QueryFields):
         else:
             internal_value = translate_transaction_status(search_filter.value.raw_value)
         return Condition(
-            self.resolve_field_alias(search_filter.key.name),
+            self.resolve_field(search_filter.key.name),
             Op(search_filter.operator),
             internal_value,
         )

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -2,6 +2,7 @@ import datetime
 import re
 
 from django.utils import timezone
+from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op, Or
 from snuba_sdk.function import Function
@@ -49,7 +50,7 @@ class QueryBuilderTest(TestCase):
         self.assertCountEqual(
             query.select,
             [
-                Function("toString", [Column("email")], "user.email"),
+                AliasedExpression(Column("email"), "user.email"),
                 Column("release"),
             ],
         )
@@ -66,7 +67,7 @@ class QueryBuilderTest(TestCase):
         self.assertCountEqual(query.where, self.default_conditions)
         self.assertCountEqual(
             query.orderby,
-            [OrderBy(Function("toString", [Column("email")], "user.email"), Direction.ASC)],
+            [OrderBy(Column("email"), Direction.ASC)],
         )
         query.get_snql_query().validate()
 
@@ -80,7 +81,7 @@ class QueryBuilderTest(TestCase):
         self.assertCountEqual(query.where, self.default_conditions)
         self.assertCountEqual(
             query.orderby,
-            [OrderBy(Function("toString", [Column("email")], "user.email"), Direction.DESC)],
+            [OrderBy(Column("email"), Direction.DESC)],
         )
         query.get_snql_query().validate()
 


### PR DESCRIPTION
Given the `AliasedExpression` from the sdk, we can now remove the hack we were
previously using with noop functions to get aliases.