### PR TITLE
re(api): Initial attempt at api access logging

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -166,13 +166,15 @@ class Endpoint(APIView):
         Create a log entry to be used for api metrics gathering
         """
         try:
-            token_type = str(getattr(self.request.auth, "__class__", None))
+            token_class = getattr(self.request.auth, "__class__", None)
+            token_name = token_class.__name__
+            view_obj = self.request.parser_context["view"]
             log_metrics = dict(
                 method=self.request.method,
-                view=str(self.request.parser_context["view"].__class__),
+                view=f"{view_obj.__module__}.{view_obj.__class__.__name__}",
                 response=self.response.status_code,
                 user=str(self.request.user),
-                token_type=token_type,
+                token_type=token_name,
             )
             api_access_logger.info(log_metrics)
         except Exception as exc:

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -165,15 +165,20 @@ class Endpoint(APIView):
         """
         Create a log entry to be used for api metrics gathering
         """
-        token_type = getattr(self.request.auth, "__class__", None)
-        log_metrics = dict(
-            method=self.request.method,
-            view=str(self.request.parser_context["view"].__class__),
-            response=self.response.status_code,
-            user=str(self.request.user),
-            token_type=token_type,
-        )
-        api_access_logger.info(log_metrics)
+        try:
+            token_type = str(getattr(self.request.auth, "__class__", None))
+            log_metrics = dict(
+                method=self.request.method,
+                view=str(self.request.parser_context["view"].__class__),
+                response=self.response.status_code,
+                user=str(self.request.user),
+                token_type=token_type,
+            )
+            api_access_logger.info(log_metrics)
+        except Exception as exc:
+            api_access_logger.error(
+                f"Unexpected exception when attempting to log api access: {exc}"
+            )
 
     def initialize_request(self, request, *args, **kwargs):
         # XXX: Since DRF 3.x, when the request is passed into

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -177,10 +177,8 @@ class Endpoint(APIView):
                 token_type=token_name,
             )
             api_access_logger.info(log_metrics)
-        except Exception as exc:
-            api_access_logger.error(
-                f"Unexpected exception when attempting to log api access: {exc}"
-            )
+        except Exception:
+            api_access_logger.exception("Unexpected exception when attempting to log api access")
 
     def initialize_request(self, request, *args, **kwargs):
         # XXX: Since DRF 3.x, when the request is passed into


### PR DESCRIPTION
From discussions last week. We are going to log api access information and leverage logging services to create metrics. This commit has some initial metrics to be logged with more that can be added later

Log messages will look like:
```
00:13:37 [INFO] sentry.access.api: {'method': 'POST', 'view': "<class 'sentry.api.endpoints.relay_projectconfigs.RelayProjectConfigsEndpoint'>", 'response': 200, 'user': 'AnonymousUser', 'token_type': <class 'NoneType'>}
```