### PR TITLE
feat(workflow): Restyle team insights page with cards

### DIFF
--- a/static/app/views/teamInsights/descriptionCard.tsx
+++ b/static/app/views/teamInsights/descriptionCard.tsx
@@ -1,0 +1,50 @@
+import {ReactNode} from 'react';
+import styled from '@emotion/styled';
+
+import space from 'app/styles/space';
+
+type Props = {
+  title: string;
+  description: ReactNode;
+  children: ReactNode;
+};
+
+function DescriptionCard({title, description, children}: Props) {
+  return (
+    <Wrapper>
+      <LeftPanel>
+        <Title>{title}</Title>
+        <Description>{description}</Description>
+      </LeftPanel>
+      <RightPanel>{children}</RightPanel>
+    </Wrapper>
+  );
+}
+
+export default DescriptionCard;
+
+const Wrapper = styled('div')`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  display: flex;
+  margin-bottom: ${space(3)};
+`;
+
+const LeftPanel = styled('div')`
+  max-width: 250px;
+  border-right: 1px solid ${p => p.theme.border};
+  padding: ${space(2)} ${space(2)};
+`;
+
+const Title = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  margin: 0 0 ${space(0.5)};
+`;
+
+const Description = styled('div')`
+  color: ${p => p.theme.subText};
+`;
+
+const RightPanel = styled('div')`
+  flex-grow: 1;
+`;

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -21,6 +21,7 @@ import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withTeamsForUser from 'app/utils/withTeamsForUser';
 
+import DescriptionCard from './descriptionCard';
 import HeaderTabs from './headerTabs';
 import TeamKeyTransactions from './keyTransactions';
 import TeamDropdown from './teamDropdown';
@@ -161,7 +162,7 @@ function TeamInsightsOverview({
         <HeaderTabs organization={organization} activeTab="teamInsights" />
       </Layout.Header>
 
-      <Layout.Body>
+      <Body>
         {loadingTeams && <LoadingIndicator />}
         {!loadingTeams && (
           <Layout.Main fullWidth>
@@ -171,28 +172,34 @@ function TeamInsightsOverview({
                 selectedTeam={currentTeamId}
                 handleChangeTeam={handleChangeTeam}
               />
-              <PageTimeRangeSelector
+              <StyledPageTimeRangeSelector
                 organization={organization}
                 relative={period ?? ''}
                 start={start ?? null}
                 end={end ?? null}
                 utc={utc ?? null}
                 onUpdate={handleUpdateDatetime}
-                relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h'])}
+                relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h', '24h'])}
               />
             </ControlsWrapper>
 
-            <SectionTitle>{t('Stability')}</SectionTitle>
-            <TeamStability
-              projects={projects}
-              organization={organization}
-              period={period}
-              start={start}
-              end={end}
-              utc={utc}
-            />
+            <SectionTitle>{t('Project Health')}</SectionTitle>
+            <DescriptionCard
+              title={t('Crash Free Sessions')}
+              description={t(
+                'The percentage of healthy, errored, and abnormal sessions that did not cause a crash.'
+              )}
+            >
+              <TeamStability
+                projects={projects}
+                organization={organization}
+                period={period}
+                start={start}
+                end={end}
+                utc={utc}
+              />
+            </DescriptionCard>
 
-            <SectionTitle>{t('Performance')}</SectionTitle>
             <TeamKeyTransactions
               organization={organization}
               projects={projects}
@@ -203,13 +210,19 @@ function TeamInsightsOverview({
             />
           </Layout.Main>
         )}
-      </Layout.Body>
+      </Body>
     </Fragment>
   );
 }
 
 export {TeamInsightsOverview};
 export default withApi(withOrganization(withTeamsForUser(TeamInsightsOverview)));
+
+const Body = styled(Layout.Body)`
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    display: block;
+  }
+`;
 
 const BorderlessHeader = styled(Layout.Header)`
   border-bottom: 0;
@@ -228,6 +241,10 @@ const ControlsWrapper = styled('div')`
   align-items: center;
   gap: ${space(1)};
   margin-bottom: ${space(2)};
+`;
+
+const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
+  flex-grow: 1;
 `;
 
 const SectionTitle = styled(Layout.Title)`

--- a/static/app/views/teamInsights/teamStability.tsx
+++ b/static/app/views/teamInsights/teamStability.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 import round from 'lodash/round';
 
 import AsyncComponent from 'app/components/asyncComponent';
@@ -84,13 +85,14 @@ class TeamStability extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const {start, end, period, utc} = this.props;
+    const {projects, start, end, period, utc} = this.props;
 
     if (
       prevProps.start !== start ||
       prevProps.end !== end ||
       prevProps.period !== period ||
-      prevProps.utc !== utc
+      prevProps.utc !== utc ||
+      !isEqual(prevProps.projects, projects)
     ) {
       this.remountComponent();
     }

--- a/static/app/views/teamInsights/teamStability.tsx
+++ b/static/app/views/teamInsights/teamStability.tsx
@@ -160,7 +160,7 @@ class TeamStability extends AsyncComponent<Props, State> {
 
     return (
       <SubText color={trend >= 0 ? 'green300' : 'red300'}>
-        {`${round(trend, 3)}\u0025`}
+        {`${round(Math.abs(trend), 3)}\u0025`}
         <PaddedIconArrow direction={trend >= 0 ? 'up' : 'down'} size="xs" />
       </SubText>
     );
@@ -170,12 +170,12 @@ class TeamStability extends AsyncComponent<Props, State> {
     const {projects, period} = this.props;
 
     return (
-      <PanelTable
+      <StyledPanelTable
         headers={[
           t('Project'),
-          tct('Last [period]', {period}),
-          t('This Week'),
-          t('Difference'),
+          <RightAligned key="last">{tct('Last [period]', {period})}</RightAligned>,
+          <RightAligned key="curr">{t('This Week')}</RightAligned>,
+          <RightAligned key="diff">{t('Difference')}</RightAligned>,
         ]}
       >
         {projects.map(project => (
@@ -189,16 +189,29 @@ class TeamStability extends AsyncComponent<Props, State> {
             <ScoreWrapper>{this.renderTrend(project.id)}</ScoreWrapper>
           </Fragment>
         ))}
-      </PanelTable>
+      </StyledPanelTable>
     );
   }
 }
 
 export default TeamStability;
 
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: 1fr 0.2fr 0.2fr 0.2fr;
+  white-space: nowrap;
+  margin-bottom: 0;
+  border: 0;
+`;
+
+const RightAligned = styled('span')`
+  text-align: right;
+`;
+
 const ScoreWrapper = styled('div')`
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  text-align: right;
 `;
 
 const PaddedIconArrow = styled(IconArrow)`
@@ -211,7 +224,7 @@ const SubText = styled('div')<{color: Color}>`
 `;
 
 const ProjectBadgeContainer = styled('div')`
-  width: 100%;
+  display: flex;
 `;
 
 const ProjectBadge = styled(IdBadge)`


### PR DESCRIPTION
Adds the card component and restyles crash free sessions to work within it. Fixes a bug when projects props change and crash free sessions didn't fetch new data.
https://www.figma.com/file/flmhC425Ep2finU8qywUTr/Reports?node-id=225%3A46189

before
![image](https://user-images.githubusercontent.com/1400464/134255841-41b2efde-1e49-4725-8aa2-5a97d4fdb380.png)

after
![image](https://user-images.githubusercontent.com/1400464/134255758-1ee41f69-ebdd-4382-b18c-f3a206830569.png)
