### PR TITLE
fix(discover): Handle field aliases with others correctly

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -596,27 +596,42 @@ def top_events_timeseries(
             if field in ["project", "project.id"] and top_events["data"]:
                 snuba_filter.project_ids = [event["project.id"] for event in top_events["data"]]
                 continue
+
             if field in FIELD_ALIASES:
-                field = FIELD_ALIASES[field].alias
+                alias = FIELD_ALIASES[field].alias
+            else:
+                alias = field
             # Note that because orderby shouldn't be an array field its not included in the values
             values = list(
                 {
-                    event.get(field)
+                    event.get(alias)
                     for event in top_events["data"]
                     if field in event and not isinstance(event.get(field), list)
                 }
             )
             if values:
+                if field in FIELD_ALIASES:
+                    # Fallback to the alias if for whatever reason we can't find it
+                    resolved_field = alias
+                    # Search selected columns for the resolved version of the alias
+                    for column in snuba_filter.selected_columns:
+                        if isinstance(column, list) and column[-1] == field:
+                            resolved_field = column
+                            break
+                else:
+                    resolved_field = resolve_discover_column(field)
+
                 if field == "timestamp" or field.startswith("timestamp.to_"):
                     # timestamp fields needs special handling, creating a big OR instead
                     snuba_filter.conditions.append(
-                        [[field, "=", value] for value in sorted(values)]
+                        [[resolved_field, "=", value] for value in sorted(values)]
                     )
+
                     # Needs to be a big AND when negated
-                    other_condition = [field, "!=", values[0]]
+                    other_condition = [resolved_field, "!=", values[0]]
                     for value in sorted(values[1:]):
                         other_condition = [
-                            [SNUBA_AND, [other_condition, [field, "!=", value]]],
+                            [SNUBA_AND, [other_condition, [resolved_field, "!=", value]]],
                             "=",
                             1,
                         ]
@@ -624,15 +639,15 @@ def top_events_timeseries(
                 elif None in values:
                     # one of the values was null, but we can't do an in with null values, so split into two conditions
                     non_none_values = [value for value in values if value is not None]
-                    condition = [[["isNull", [resolve_discover_column(field)]], "=", 1]]
-                    other_condition = [["isNull", [resolve_discover_column(field)]], "!=", 1]
+                    condition = [[["isNull", [resolved_field]], "=", 1]]
+                    other_condition = [["isNull", [resolved_field]], "!=", 1]
                     if non_none_values:
-                        condition.append([resolve_discover_column(field), "IN", non_none_values])
+                        condition.append([resolved_field, "IN", non_none_values])
                         other_condition = [
                             [
                                 SNUBA_AND,
                                 [
-                                    [resolve_discover_column(field), "NOT IN", non_none_values],
+                                    [resolved_field, "NOT IN", non_none_values],
                                     other_condition,
                                 ],
                             ],
@@ -641,12 +656,9 @@ def top_events_timeseries(
                         ]
                     snuba_filter.conditions.append(condition)
                     other_conditions.append(other_condition)
-                elif field in FIELD_ALIASES:
-                    snuba_filter.conditions.append([field, "IN", values])
-                    other_conditions.append([field, "NOT IN", values])
                 else:
-                    snuba_filter.conditions.append([resolve_discover_column(field), "IN", values])
-                    other_conditions.append([resolve_discover_column(field), "NOT IN", values])
+                    snuba_filter.conditions.append([resolved_field, "IN", values])
+                    other_conditions.append([resolved_field, "NOT IN", values])
 
     with sentry_sdk.start_span(op="discover.discover", description="top_events.snuba_query"):
         result = raw_query(

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -5941,6 +5941,8 @@ class TopEventsTimeseriesQueryTest(TimeseriesBase):
             limit=10000,
             organization=self.organization,
         )
+        to_hour = ["toStartOfHour", ["timestamp"], "timestamp.to_hour"]
+        to_day = ["toStartOfDay", ["timestamp"], "timestamp.to_day"]
         mock_query.assert_called_with(
             aggregations=[["count", None, "count"]],
             conditions=[
@@ -5952,26 +5954,26 @@ class TopEventsTimeseriesQueryTest(TimeseriesBase):
                 ],
                 [
                     [
-                        "timestamp.to_day",
+                        to_day,
                         "=",
                         iso_format(timestamp1.replace(hour=0, minute=0, second=0)),
                     ],
                     [
-                        "timestamp.to_day",
+                        to_day,
                         "=",
                         iso_format(timestamp2.replace(hour=0, minute=0, second=0)),
                     ],
                 ],
                 [
-                    ["timestamp.to_hour", "=", iso_format(timestamp1.replace(minute=0, second=0))],
-                    ["timestamp.to_hour", "=", iso_format(timestamp2.replace(minute=0, second=0))],
+                    [to_hour, "=", iso_format(timestamp1.replace(minute=0, second=0))],
+                    [to_hour, "=", iso_format(timestamp2.replace(minute=0, second=0))],
                 ],
             ],
             filter_keys={"project_id": [self.project.id]},
             selected_columns=[
                 "timestamp",
-                ["toStartOfDay", ["timestamp"], "timestamp.to_day"],
-                ["toStartOfHour", ["timestamp"], "timestamp.to_hour"],
+                to_day,
+                to_hour,
             ],
             start=start,
             end=end,


### PR DESCRIPTION
- The Other query doesn't include any selected columns which means that
  using the FIELD_ALIAS's alias won't have a corresponding column
- This fixes that issue by pulling the column from the selected columns
  and uses it in the conditions