### PR TITLE
ref(select): Choices -> options metricWidget

### DIFF
--- a/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
@@ -233,8 +233,8 @@ class MetricWidget extends AsyncView<Props, State> {
               <VisualizationWrapper>
                 <StyledSelectField
                   name="displayType"
-                  choices={[DisplayType.LINE, DisplayType.BAR, DisplayType.AREA].map(
-                    value => [value, displayTypes[value]]
+                  options={[DisplayType.LINE, DisplayType.BAR, DisplayType.AREA].map(
+                    value => ({value, label: displayTypes[value]})
                   )}
                   value={displayType}
                   onChange={value => {
@@ -267,7 +267,7 @@ class MetricWidget extends AsyncView<Props, State> {
             >
               <StyledSelectField
                 name="project"
-                choices={projects.map(project => [project, project.slug])}
+                options={projects.map(project => ({value: project, label: project.slug}))}
                 onChange={project => this.handleProjectChange(project.id)}
                 value={selectedProject}
                 components={{


### PR DESCRIPTION
switches from legacy react-select `choices` to `options` here:

![image](https://user-images.githubusercontent.com/9372512/134262591-c402b70e-3ddb-4daf-ad03-0c79b1bdf9d2.png)
