### PR TITLE
ref(select): Choices -> options metricSelectField

### DIFF
--- a/static/app/views/dashboardsV2/widget/metricWidget/metricSelectField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/metricSelectField.tsx
@@ -26,10 +26,10 @@ function MetricSelectField({metricMetas, metricMeta, aggregation, onChange}: Pro
     <Wrapper>
       <StyledSelectField
         name="metric"
-        choices={metricMetas.map(metricMetaChoice => [
-          metricMetaChoice.name,
-          metricMetaChoice.name,
-        ])}
+        options={metricMetas.map(metricMetaChoice => ({
+          value: metricMetaChoice.name,
+          label: metricMetaChoice.name,
+        }))}
         placeholder={t('Select metric')}
         onChange={value => {
           const newMetric = metricMetas.find(


### PR DESCRIPTION
Changes from legacy react-select `choices` to `options` here:

![image](https://user-images.githubusercontent.com/9372512/134262953-5a0add26-4a37-4085-96f0-6ffaa9b622f6.png)
