### PR TITLE
ref(select): Choices -> options integrationListDirectory

### DIFF
--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -478,9 +478,12 @@ export class IntegrationListDirectory extends AsyncComponent<
                   name="select-categories"
                   onChange={this.onCategorySelect}
                   value={selectedCategory}
-                  choices={[
-                    ['', t('All Categories')],
-                    ...categoryList.map(category => [category, startCase(category)]),
+                  options={[
+                    {value: '', label: t('All Categories')},
+                    ...categoryList.map(category => ({
+                      value: category,
+                      label: startCase(category),
+                    })),
                   ]}
                 />
                 <SearchBar


### PR DESCRIPTION
Changes from legacy react-select `choices` to `options` here:

![image](https://user-images.githubusercontent.com/9372512/134266313-f0706dd1-9002-4072-9744-6ca8bcc77896.png)
