### PR TITLE
build(sdk): Update to Python SDK 1.4.1 and enable Client Reports

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,7 +52,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay==0.8.8
-sentry-sdk>=1.3.0,<1.4.0
+sentry-sdk>=1.4.1,<1.5.0
 snuba-sdk>=0.0.25,<1.0.0
 simplejson==3.17.2
 statsd==3.3

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -246,6 +246,7 @@ def configure_sdk():
     sdk_options["release"] = (
         f"backend@{sdk_options['release']}" if "release" in sdk_options else None
     )
+    sdk_options["send_client_reports"] = True
 
     if upstream_dsn:
         transport = make_transport(get_options(dsn=upstream_dsn, **sdk_options))


### PR DESCRIPTION
This release includes a fix that prevented us from bumping to `1.4.0`. 

More details here: https://github.com/getsentry/sentry-python/pull/1203