### PR TITLE
fix(api) Don't 500 on invalid broadcast id values

### DIFF
--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -25,10 +25,9 @@ class BroadcastDetailsEndpoint(Endpoint):
             queryset = Broadcast.objects.filter(
                 Q(date_expires__isnull=True) | Q(date_expires__gt=timezone.now()), is_active=True
             )
-
         try:
-            return queryset.get(id=broadcast_id)
-        except Broadcast.DoesNotExist:
+            return queryset.get(id=int(broadcast_id))
+        except (Broadcast.DoesNotExist, ValueError):
             raise ResourceDoesNotExist
 
     def _get_validator(self, request):

--- a/tests/sentry/api/endpoints/test_broadcast_details.py
+++ b/tests/sentry/api/endpoints/test_broadcast_details.py
@@ -13,6 +13,12 @@ class BroadcastDetailsTest(APITestCase):
         assert response.status_code == 200
         assert response.data["id"] == str(broadcast1.id)
 
+    def test_invalid_id(self):
+        self.login_as(user=self.user)
+
+        response = self.client.get("/api/0/broadcasts/nope/")
+        assert response.status_code == 404
+
 
 class BroadcastUpdateTest(APITestCase):
     def test_regular_user(self):


### PR DESCRIPTION
Fixes SENTRY-QAC