### PR TITLE
fix(orgstats): remove client discards from timeseries

### DIFF
--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -257,8 +257,9 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
 
         if (outcome !== Outcome.CLIENT_DISCARD) {
           count.total += group.totals['sum(quantity)'];
-          count[outcome] += group.totals['sum(quantity)'];
         }
+
+        count[outcome] += group.totals['sum(quantity)'];
 
         group.series['sum(quantity)'].forEach((stat, i) => {
           switch (outcome) {

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -255,17 +255,22 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
           return;
         }
 
-        count.total += group.totals['sum(quantity)'];
-        count[outcome] += group.totals['sum(quantity)'];
+        if (outcome !== Outcome.CLIENT_DISCARD) {
+          count.total += group.totals['sum(quantity)'];
+          count[outcome] += group.totals['sum(quantity)'];
+        }
 
         group.series['sum(quantity)'].forEach((stat, i) => {
           if (outcome === Outcome.ACCEPTED || outcome === Outcome.FILTERED) {
             usageStats[i][outcome] += stat;
             return;
+          } else if (
+            outcome === Outcome.DROPPED ||
+            outcome === Outcome.INVALID ||
+            Outcome.RATE_LIMITED
+          ) {
+            usageStats[i].dropped.total += stat;
           }
-
-          // Breaking down into reasons for dropped is not needed
-          usageStats[i].dropped.total += stat;
         });
       });
 

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -261,15 +261,19 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         }
 
         group.series['sum(quantity)'].forEach((stat, i) => {
-          if (outcome === Outcome.ACCEPTED || outcome === Outcome.FILTERED) {
-            usageStats[i][outcome] += stat;
-            return;
-          } else if (
-            outcome === Outcome.DROPPED ||
-            outcome === Outcome.INVALID ||
-            Outcome.RATE_LIMITED
-          ) {
-            usageStats[i].dropped.total += stat;
+          switch (outcome) {
+            case Outcome.ACCEPTED:
+            case Outcome.FILTERED:
+              usageStats[i][outcome] += stat;
+              return;
+            case Outcome.DROPPED:
+            case Outcome.RATE_LIMITED:
+            case Outcome.INVALID:
+              usageStats[i].dropped.total += stat;
+              // TODO: add client discards to dropped?
+              return;
+            default:
+              return;
           }
         });
       });

--- a/tests/js/spec/views/organizationStats/index.spec.jsx
+++ b/tests/js/spec/views/organizationStats/index.spec.jsx
@@ -450,6 +450,18 @@ function getMockResponse() {
             'sum(quantity)': [2, 2, 2, 2, 2, 2, 3],
           },
         },
+        {
+          by: {
+            category: 'error',
+            outcome: 'client_discard',
+          },
+          totals: {
+            'sum(quantity)': 15,
+          },
+          series: {
+            'sum(quantity)': [2, 2, 2, 2, 2, 2, 3],
+          },
+        },
       ],
     },
   };


### PR DESCRIPTION
right now client discards show up in the timeseries but not in the total cards, we'd like to hide this data for now.