### PR TITLE
feat(alert-rules): Append new alert rule payload for issue alerts w/ ui components

### DIFF
--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -62,4 +62,8 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
 
     def after(self, event: Event, state: str) -> Any:
         sentry_app = self.get_sentry_app(event)
-        yield self.future(notify_sentry_app, sentry_app=sentry_app)
+        yield self.future(
+            notify_sentry_app,
+            sentry_app=sentry_app,
+            schema_defined_settings=self.get_option("settings"),
+        )

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -81,12 +81,16 @@ def _webhook_event_data(event, group_id, project_id):
 
 @instrumented_task(name="sentry.tasks.sentry_apps.send_alert_event", **TASK_OPTIONS)
 @retry(**RETRY_OPTIONS)
-def send_alert_event(event, rule, sentry_app_id):
+def send_alert_event(
+    event, rule, sentry_app_id, additional_payload_key=None, additional_payload=None
+):
     """
     When an incident alert is triggered, send incident data to the SentryApp's webhook.
     :param event: The `Event` for which to build a payload.
     :param rule: The AlertRule that was triggered.
     :param sentry_app_id: The SentryApp to notify.
+    :param additional_payload_key: The key used to attach additional data to the webhook payload
+    :param additional_payload: The extra data attached to the payload body at the key specified by `additional_payload_key`.
     :return:
     """
     group = event.group
@@ -119,6 +123,10 @@ def send_alert_event(event, rule, sentry_app_id):
     event_context = _webhook_event_data(event, group.id, project.id)
 
     data = {"event": event_context, "triggered_rule": rule}
+
+    # Attach extra payload to the webhook
+    if additional_payload_key and additional_payload:
+        data[additional_payload_key] = additional_payload
 
     request_data = AppPlatformEvent(
         resource="event_alert", action="triggered", install=install, data=data
@@ -288,8 +296,23 @@ def notify_sentry_app(event, futures):
         if not f.kwargs.get("sentry_app"):
             continue
 
+        extra_kwargs = {
+            "additional_payload_key": None,
+            "additional_payload": None,
+        }
+        settings = f.kwargs.get("schema_defined_settings")
+        if settings:
+            # extra_kwargs["url"] = f.kwargs.get("schema_defined_uri")
+            extra_kwargs["additional_payload_key"] = "issue_alert"
+            extra_kwargs["additional_payload"] = {
+                "id": f.rule.id,
+                "title": f.rule.label,
+                "sentry_app_id": f.kwargs["sentry_app"].id,
+                "settings": settings,
+            }
+
         send_alert_event.delay(
-            event=event, rule=f.rule.label, sentry_app_id=f.kwargs["sentry_app"].id
+            event=event, rule=f.rule.label, sentry_app_id=f.kwargs["sentry_app"].id, **extra_kwargs
         )
 
 

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -300,9 +300,9 @@ def notify_sentry_app(event, futures):
             "additional_payload_key": None,
             "additional_payload": None,
         }
+        # If the future comes from a rule with a UI component form in the schema, append the issue alert payload
         settings = f.kwargs.get("schema_defined_settings")
         if settings:
-            # extra_kwargs["url"] = f.kwargs.get("schema_defined_uri")
             extra_kwargs["additional_payload_key"] = "issue_alert"
             extra_kwargs["additional_payload"] = {
                 "id": f.rule.id,

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -114,15 +114,6 @@ export class SentryAppExternalForm extends Component<Props, State> {
       this.debouncedOptionLoad(field, input, resolve);
     });
 
-  getSubmitEndpoint() {
-    const {sentryAppInstallationUuid, element} = this.props;
-    if (element === 'alert-rule-action') {
-      // TODO(leander): Send request to the correct endpoint
-      return '/404/';
-    }
-    return `/sentry-app-installations/${sentryAppInstallationUuid}/external-issue-actions/`;
-  }
-
   getElementText = () => {
     const {element} = this.props;
     switch (element) {

--- a/tests/js/spec/views/alerts/issueRuleEditor/ruleNode.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/ruleNode.spec.jsx
@@ -1,6 +1,7 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {getSelector, openMenu, selectByValue} from 'sentry-test/select-new';
 
+import ModalActions from 'app/actions/modalActions';
 import RuleNode from 'app/views/alerts/issueRuleEditor/ruleNode';
 
 describe('RuleNode', function () {
@@ -58,8 +59,31 @@ describe('RuleNode', function () {
   // TODO: Add this node and test if it implements correctly (e.g. Jira Tickets)
   // const ticketNode = {actionType: 'ticket'};
 
-  // TODO(Leander): Add this node and test if it implements correctly (e.g. Integrations w/ Alert Rule UI)
-  // const sentryAppNode = {actionType: 'sentryapp'}
+  const sentryAppNode = {
+    id: 'sentry.rules.schema_form_mock',
+    label: 'Configure SentryApp with these',
+    enabled: true,
+    actionType: 'sentryapp',
+    sentryAppInstallationUuid: '1027',
+    formFields: {
+      exampleStringField: {
+        type: 'string',
+        placeholder: 'placeholder',
+      },
+      exampleNumberField: {
+        type: 'number',
+        placeholder: 100,
+      },
+      exampleStringChoiceField: {
+        type: 'choice',
+        choices: [
+          ['value1', 'label1'],
+          ['value2', 'label2'],
+          ['value3', 'label3'],
+        ],
+      },
+    },
+  };
 
   const createWrapper = node => {
     project = TestStubs.Project();
@@ -182,6 +206,13 @@ describe('RuleNode', function () {
   });
 
   it('renders sentry apps with schema forms correctly', async function () {
-    //   TODO(Leander)
+    wrapper = createWrapper(sentryAppNode);
+    const openModal = jest.spyOn(ModalActions, 'openModal');
+
+    expect(wrapper.text()).toEqual(sentryAppNode.label + 'Settings');
+    expect(wrapper.find('button[aria-label="Settings"]').exists()).toEqual(true);
+    wrapper.find('button[aria-label="Settings"]').simulate('click');
+
+    expect(openModal).toHaveBeenCalled();
   });
 });

--- a/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/sentryAppRuleModal.spec.jsx
@@ -110,14 +110,6 @@ describe('SentryAppRuleModal', function () {
       changeInputValue(descriptionInput, 'v');
       changeInputValue(channelInput, 'v');
       selectByValue(wrapper, 'valor', {name: 'channel', control: true});
-
-      MockApiClient.addMockResponse({
-        // TODO(leander): Replace with real endpoint for alert rule actions
-        url: '/404/',
-        method: 'POST',
-        body: {it: 'worked'},
-      });
-
       submitSuccess(wrapper);
     });
   });


### PR DESCRIPTION
See [API-2082](https://getsentry.atlassian.net/browse/API-2082)

This PR will add the new payload onto the webhook which fires for alert rule components only if they 

**Demo:**

Creating a new rule with UI components:
https://user-images.githubusercontent.com/35509934/134583968-868f1c6f-39c4-42ce-9b48-76a85eddd61c.mov

Edits are reflected in the payloads going forward:
https://user-images.githubusercontent.com/35509934/134583947-5b75de40-81a7-4511-b11f-33ca01a09077.mov

Existing sentry app webhooks are unaffected:
https://user-images.githubusercontent.com/35509934/134585331-e6bdac15-8f7c-419d-9697-94de77b62aad.mov
