### PR TITLE
fix(ui): Adjust platform lists for mobile

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -53,6 +53,10 @@ export const mobile = [
   'dart-flutter',
   'unity',
   'dotnet-xamarin',
+  // Old platforms
+  'java-android',
+  'cocoa-objc',
+  'cocoa-swift',
 ] as const;
 
 export const backend = [

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -80,9 +80,7 @@ const supportedTags = {
 };
 
 export const isProjectMobileForReleases = (projectPlatform: PlatformKey) =>
-  (
-    [...mobile, ...desktop, 'java-android', 'cocoa-objc', 'cocoa-swift'] as string[]
-  ).includes(projectPlatform);
+  ([...mobile, ...desktop] as string[]).includes(projectPlatform);
 
 type RouteParams = {
   orgId: string;


### PR DESCRIPTION
### Summary
The platform lists in platform categories should at least have a comprehensive list of platforms including outdated platforms due to doc changes, so that older projects can be matched against. 

Long term we should probably export `PLATFORM_TO_ICONS` from our **platformicons** library and run tests to ensure platforms in the platform categories files always match against our platform badge list at least.

The mobile category is used in only one case outside of performance that I can see after a quick look, which is the `isMobilePlatform` check in events titles. 