### PR TITLE
ref(ui): Adjust idleTimeout back to 5000

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 4000,
+      idleTimeout: 5000,
       _metricOptions: {
         _reportAllChanges: true,
       },


### PR DESCRIPTION
### Summary
It was originally 5000 but we were experimenting with lowering it to see how it affected LCP.

See: https://github.com/getsentry/sentry/pull/27801