### PR TITLE
fix(workflow): Add alpha badge to project reports, add title

### DIFF
--- a/static/app/views/teamInsights/headerTabs.tsx
+++ b/static/app/views/teamInsights/headerTabs.tsx
@@ -1,3 +1,4 @@
+import FeatureBadge from 'app/components/featureBadge';
 import * as Layout from 'app/components/layouts/thirds';
 import Link from 'app/components/links/link';
 import {t} from 'app/locale';
@@ -12,13 +13,12 @@ function HeaderTabs({organization, activeTab}: Props) {
   return (
     <Layout.HeaderNavTabs underlined>
       <li className={`${activeTab === 'projects' ? 'active' : ''}`}>
-        <Link to={`/organizations/${organization.slug}/projects/`}>
-          {t('Projects Overview')}
-        </Link>
+        <Link to={`/organizations/${organization.slug}/projects/`}>{t('Overview')}</Link>
       </li>
       <li className={`${activeTab === 'teamInsights' ? 'active' : ''}`}>
         <Link to={`/organizations/${organization.slug}/teamInsights/`}>
-          {t('Team Insights')}
+          {t('Reports')}
+          <FeatureBadge type="alpha" />
         </Link>
       </li>
     </Layout.HeaderNavTabs>

--- a/static/app/views/teamInsights/index.tsx
+++ b/static/app/views/teamInsights/index.tsx
@@ -1,6 +1,8 @@
-import {cloneElement, Fragment, isValidElement} from 'react';
+import {cloneElement, isValidElement} from 'react';
 
 import Feature from 'app/components/acl/feature';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -12,13 +14,13 @@ type Props = {
 function TeamInsightsContainer({children, organization}: Props) {
   return (
     <Feature organization={organization} features={['team-insights']}>
-      <Fragment>
+      <SentryDocumentTitle title={t('Project Reports')} orgSlug={organization.slug}>
         {children && isValidElement(children)
           ? cloneElement(children, {
               organization,
             })
           : children}
-      </Fragment>
+      </SentryDocumentTitle>
     </Feature>
   );
 }

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -155,7 +155,7 @@ function TeamInsightsOverview({
     <Fragment>
       <BorderlessHeader>
         <StyledHeaderContent>
-          <StyledLayoutTitle>{t('Team Insights')}</StyledLayoutTitle>
+          <StyledLayoutTitle>{t('Projects')}</StyledLayoutTitle>
         </StyledHeaderContent>
       </BorderlessHeader>
       <Layout.Header>

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -226,6 +226,8 @@ export {TeamInsightsOverview};
 export default withApi(withOrganization(withTeamsForUser(TeamInsightsOverview)));
 
 const Body = styled(Layout.Body)`
+  margin-bottom: -20px;
+
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     display: block;
   }

--- a/static/app/views/teamInsights/teamMisery.tsx
+++ b/static/app/views/teamInsights/teamMisery.tsx
@@ -61,7 +61,7 @@ function TeamMisery({
       headers={[
         t('Key transaction'),
         t('Project'),
-        tct('[period] Average', {period}),
+        tct('Last [period]', {period}),
         t('This Week'),
         <RightAligned key="diff">{t('Difference')}</RightAligned>,
       ]}
@@ -187,6 +187,7 @@ function TeamMiseryWrapper({
 export default TeamMiseryWrapper;
 
 const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: 1fr 0.5fr 116px 116px 0.25fr;
   font-size: ${p => p.theme.fontSizeMedium};
   white-space: nowrap;
   margin-bottom: 0;

--- a/static/app/views/teamInsights/teamMisery.tsx
+++ b/static/app/views/teamInsights/teamMisery.tsx
@@ -187,7 +187,7 @@ function TeamMiseryWrapper({
 export default TeamMiseryWrapper;
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: 1fr 0.5fr 116px 116px 0.25fr;
+  grid-template-columns: 1fr 0.5fr 112px 112px 0.25fr;
   font-size: ${p => p.theme.fontSizeMedium};
   white-space: nowrap;
   margin-bottom: 0;


### PR DESCRIPTION
Adds alpha tag and adjusts the copy in the tabs
![image](https://user-images.githubusercontent.com/1400464/134414944-1b5039b6-a00d-48d6-8cab-903c9252db77.png)


Adds a document title "Project Reports"

Fixes a column size issue with user misery
![image](https://user-images.githubusercontent.com/1400464/134415179-53a9d47a-abdc-4528-85c5-d1c137cffae7.png)
