### PR TITLE
fix(notifications): Include experiment fallback in the serializer

### DIFF
--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -96,7 +96,6 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
         """
         type_option: Optional[NotificationSettingTypes] = kwargs.get("type")
         types_to_serialize = {type_option} if type_option else set(VALID_VALUES_FOR_KEY.keys())
-        user = obj if type(obj) == User else None
 
         project_ids = {_.id for _ in attrs["projects"]}
         organization_ids = {_.id for _ in attrs["organizations"]}
@@ -105,10 +104,10 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
             types_to_serialize,
             project_ids,
             organization_ids,
-            user,
+            recipient=obj,
             should_use_slack_automatic=any_organization_has_feature(
                 "organizations:notification-slack-automatic",
-                user.get_orgs(),
+                organizations=[obj.organization] if isinstance(obj, Team) else obj.get_orgs(),
                 actor=user,
             ),
         )

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -2,7 +2,6 @@ from sentry.models import NotificationSetting
 from sentry.notifications.helpers import (
     _get_setting_mapping_from_mapping,
     collect_groups_by_project,
-    get_fallback_settings,
     get_scope_type,
     get_settings_by_provider,
     get_subscription_from_attributes,
@@ -199,34 +198,5 @@ class NotificationHelpersTest(TestCase):
         assert get_settings_by_provider(settings) == {
             ExternalProviders.EMAIL: {
                 NotificationScopeType.USER: NotificationSettingOptionValues.NEVER
-            }
-        }
-
-    def test_get_fallback_settings_minimal(self):
-        assert get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {}, {}) == {}
-
-    def test_get_fallback_settings_user(self):
-        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {}, {}, self.user)
-        assert data == {
-            "alerts": {
-                "user": {
-                    self.user.id: {
-                        "email": "always",
-                        "slack": "never",
-                    }
-                }
-            }
-        }
-
-    def test_get_fallback_settings_projects(self):
-        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {self.project.id}, {})
-        assert data == {
-            "alerts": {
-                "project": {
-                    self.project.id: {
-                        "email": "default",
-                        "slack": "default",
-                    }
-                }
             }
         }

--- a/tests/sentry/notifications/utils/test_get_fallback_settings.py
+++ b/tests/sentry/notifications/utils/test_get_fallback_settings.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+
+from sentry.models import Project, User
+from sentry.notifications.helpers import get_fallback_settings
+from sentry.notifications.types import NotificationSettingTypes
+
+
+class GetFallbackSettingsTest(TestCase):
+    def setUp(self) -> None:
+        self.user = User(id=1)
+        self.project = Project(id=123)
+
+    def test_get_fallback_settings_minimal(self):
+        assert get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {}, {}) == {}
+
+    def test_get_fallback_settings_user(self):
+        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {}, {}, self.user)
+        assert data == {
+            "alerts": {
+                "user": {
+                    self.user.id: {
+                        "email": "always",
+                        "slack": "never",
+                    }
+                }
+            }
+        }
+
+    def test_get_fallback_settings_feature_flag(self):
+        data = get_fallback_settings(
+            {NotificationSettingTypes.DEPLOY},
+            {},
+            {},
+            self.user,
+            should_use_slack_automatic=True,
+        )
+        assert data == {
+            "deploy": {
+                "user": {
+                    self.user.id: {
+                        "email": "committed_only",
+                        "slack": "committed_only",
+                    }
+                }
+            }
+        }
+
+    def test_get_fallback_settings_projects(self):
+        data = get_fallback_settings({NotificationSettingTypes.ISSUE_ALERTS}, {self.project.id}, {})
+        assert data == {
+            "alerts": {
+                "project": {
+                    self.project.id: {
+                        "email": "default",
+                        "slack": "default",
+                    }
+                }
+            }
+        }


### PR DESCRIPTION
So my current theory is that the `notification-slack-automatic` feature flag is causing users to be opted into new Slack notifications, but when they're checking their settings, they only see that EMAIL is selected.

In the DB, this example user only has EMAIL notification settings. 
```SQL
-- 0 rows
select count(*) 
from sentry_notificationsetting
where target_id = ...
and provider = 110
;
```

My solution is to change the way we calculate "fallback" settings in the serializer to check the feature flag. It won't turn off notifications for the user, but it will allow them to turn them off themselves.