### PR TITLE
feat(workflow): Save selected insights team in localstorage

### DIFF
--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -17,6 +17,7 @@ import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {DateString, Organization, RelativePeriod, TeamWithProjects} from 'app/types';
+import localStorage from 'app/utils/localStorage';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withTeamsForUser from 'app/utils/withTeamsForUser';
@@ -56,11 +57,17 @@ function TeamInsightsOverview({
   router,
 }: Props) {
   const query = location?.query ?? {};
-  const currentTeamId = query.team ?? teams[0]?.id;
+  const localStorageKey = `teamInsightsSelectedTeamId:${organization.slug}`;
+  let localTeamId = localStorage.getItem(localStorageKey);
+  if (localTeamId && !teams.find(team => team.id === localTeamId)) {
+    localTeamId = null;
+  }
+  const currentTeamId = query.team ?? localTeamId ?? teams[0]?.id;
   const currentTeam = teams.find(team => team.id === currentTeamId);
   const projects = currentTeam?.projects ?? [];
 
   function handleChangeTeam(teamId: string) {
+    localStorage.setItem(localStorageKey, teamId);
     setStateOnUrl({team: teamId});
   }
 

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -58,11 +58,13 @@ function TeamInsightsOverview({
 }: Props) {
   const query = location?.query ?? {};
   const localStorageKey = `teamInsightsSelectedTeamId:${organization.slug}`;
-  let localTeamId = localStorage.getItem(localStorageKey);
+
+  let localTeamId: string | null | undefined =
+    query.team ?? localStorage.getItem(localStorageKey);
   if (localTeamId && !teams.find(team => team.id === localTeamId)) {
     localTeamId = null;
   }
-  const currentTeamId = query.team ?? localTeamId ?? teams[0]?.id;
+  const currentTeamId = localTeamId ?? teams[0]?.id;
   const currentTeam = teams.find(team => team.id === currentTeamId);
   const projects = currentTeam?.projects ?? [];
 

--- a/tests/js/spec/views/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/teamInsights/overview.spec.jsx
@@ -1,6 +1,9 @@
 import {fireEvent, mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import localStorage from 'app/utils/localStorage';
 import {TeamInsightsOverview} from 'app/views/teamInsights/overview';
+
+jest.mock('app/utils/localStorage');
 
 describe('TeamInsightsOverview', () => {
   const project1 = TestStubs.Project({id: '2', name: 'js', slug: 'js'});
@@ -98,6 +101,10 @@ describe('TeamInsightsOverview', () => {
     fireEvent.click(wrapper.getByText('Team: frontend'));
     expect(wrapper.getByText('backend')).toBeInTheDocument();
     fireEvent.click(wrapper.getByText('backend'));
-    expect(mockRouter.push).toHaveBeenCalledWith({query: {team: '3'}});
+    expect(mockRouter.push).toHaveBeenCalledWith({query: {team: team2.id}});
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'teamInsightsSelectedTeamId:org-slug',
+      team2.id
+    );
   });
 });


### PR DESCRIPTION
Preserves your selected team on the team insights page. 

In order of priority - the selected team will be
query param -> localstorage -> whatever team happens to be first