### PR TITLE
fix(workflow): Move insights description on smaller screens

### DIFF
--- a/static/app/views/teamInsights/descriptionCard.tsx
+++ b/static/app/views/teamInsights/descriptionCard.tsx
@@ -28,12 +28,22 @@ const Wrapper = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
   display: flex;
   margin-bottom: ${space(3)};
+  flex-direction: column;
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    flex-direction: row;
+  }
 `;
 
 const LeftPanel = styled('div')`
-  max-width: 250px;
-  border-right: 1px solid ${p => p.theme.border};
   padding: ${space(2)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    max-width: 250px;
+    border-right: 1px solid ${p => p.theme.border};
+    border-bottom: 0;
+  }
 `;
 
 const Title = styled('div')`


### PR DESCRIPTION
instead of side by side, rotates the card to be top/bottom on smaller screens

![image](https://user-images.githubusercontent.com/1400464/134427491-c22aae7d-0673-4c83-809c-c1fb9c284e62.png)
