### PR TITLE
fix(api): Fix logging so that it shows properly on stackdriver

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -176,9 +176,9 @@ class Endpoint(APIView):
                 user=str(self.request.user),
                 token_type=token_name,
             )
-            api_access_logger.info(log_metrics)
+            api_access_logger.info("api.access", extra=log_metrics)
         except Exception:
-            api_access_logger.exception("Unexpected exception when attempting to log api access")
+            api_access_logger.exception("api.access")
 
     def initialize_request(self, request, *args, **kwargs):
         # XXX: Since DRF 3.x, when the request is passed into


### PR DESCRIPTION
Log messages were not showing up on stack driver because they were not in the correct format.