### PR TITLE
fix(logging): Add severity to struct logging

### DIFF
--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -67,9 +67,7 @@ class HumanRenderer:
 class StructLogHandler(logging.StreamHandler):
     def get_log_kwargs(self, record, logger):
         kwargs = {k: v for k, v in vars(record).items() if k not in throwaways and v is not None}
-        kwargs.update(
-            {"level": record.levelno, "event": record.msg, "severity": record.levelname.upper()}
-        )
+        kwargs.update({"level": record.levelno, "event": record.msg, "severity": record.levelname})
 
         if record.args:
             # record.args inside of LogRecord.__init__ gets unrolled

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -67,7 +67,7 @@ class HumanRenderer:
 class StructLogHandler(logging.StreamHandler):
     def get_log_kwargs(self, record, logger):
         kwargs = {k: v for k, v in vars(record).items() if k not in throwaways and v is not None}
-        kwargs.update({"level": record.levelno, "event": record.msg})
+        kwargs.update({"level": record.levelno, "event": record.msg, "severity": record.levelname})
 
         if record.args:
             # record.args inside of LogRecord.__init__ gets unrolled

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -67,7 +67,9 @@ class HumanRenderer:
 class StructLogHandler(logging.StreamHandler):
     def get_log_kwargs(self, record, logger):
         kwargs = {k: v for k, v in vars(record).items() if k not in throwaways and v is not None}
-        kwargs.update({"level": record.levelno, "event": record.msg, "severity": record.levelname})
+        kwargs.update(
+            {"level": record.levelno, "event": record.msg, "severity": record.levelname.upper()}
+        )
 
         if record.args:
             # record.args inside of LogRecord.__init__ gets unrolled

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -42,7 +42,7 @@ def make_logrecord(**extra):
 def test_emit(record, out, handler, logger):
     record = make_logrecord(**record)
     handler.emit(record, logger=logger)
-    expected = dict(level=logging.INFO, event="msg", name="name")
+    expected = dict(level=logging.INFO, event="msg", name="name", severity="INFO")
     expected.update(out)
     logger.log.assert_called_once_with(**expected)
 


### PR DESCRIPTION
Stackdriver was defaulting log messages to error as it expected a "severity" field to determine log levels.
Luckily directly converting levelname to severity should just work.