### PR TITLE
ref(js): Remove heavyweight organization

### DIFF
--- a/src/sentry/templates/sentry/partial/preload-data.html
+++ b/src/sentry/templates/sentry/partial/preload-data.html
@@ -13,7 +13,7 @@
             this.status >= 200 && this.status < 300
               ? resolve(JSON.parse(xhr.response))
               : reject([this.status, this.statusText]);
-          } catch(e) {
+          } catch (e) {
             reject();
           }
         };
@@ -28,16 +28,17 @@
       return '/api/0/organizations/' + slug + suffix;
     }
 
-
     // There are probably more, but this is at least one case where
     // this should not be treated as a slug
     if (slug !== 'new') {
-      var preloadPromises = { orgSlug: slug };
+      var preloadPromises = {orgSlug: slug};
       window.__sentry_preload = preloadPromises;
 
-      preloadPromises['organization?detailed=0'] = promiseRequest(makeUrl('/?detailed=0'));
-      preloadPromises.projects =  promiseRequest(makeUrl('/projects/?all_projects=1&collapse=latestDeploys'));
+      preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0'));
+      preloadPromises.projects = promiseRequest(
+        makeUrl('/projects/?all_projects=1&collapse=latestDeploys')
+      );
       preloadPromises.teams = promiseRequest(makeUrl('/teams/'));
     }
-  } catch(_) {}
+  } catch (_) {}
 </script>

--- a/static/app/actionCreators/organization.tsx
+++ b/static/app/actionCreators/organization.tsx
@@ -7,27 +7,21 @@ import OrganizationActions from 'app/actions/organizationActions';
 import ProjectActions from 'app/actions/projectActions';
 import TeamActions from 'app/actions/teamActions';
 import {Client} from 'app/api';
-import ProjectsStore from 'app/stores/projectsStore';
-import TeamStore from 'app/stores/teamStore';
 import {Organization, Project, Team} from 'app/types';
 import {getPreloadedDataPromise} from 'app/utils/getPreloadedData';
 
 async function fetchOrg(
   api: Client,
   slug: string,
-  detailed: boolean,
   isInitialFetch?: boolean
 ): Promise<Organization> {
-  const detailedQueryParam = detailed ? 1 : 0;
   const org = await getPreloadedDataPromise(
-    `organization?detailed=${detailedQueryParam}`,
+    'organization',
     slug,
     () =>
       // This data should get preloaded in static/sentry/index.ejs
       // If this url changes make sure to update the preload
-      api.requestPromise(`/organizations/${slug}/`, {
-        query: {detailed: detailedQueryParam},
-      }),
+      api.requestPromise(`/organizations/${slug}/`, {query: {detailed: 0}}),
     isInitialFetch
   );
 
@@ -47,60 +41,58 @@ async function fetchProjectsAndTeams(
 ): Promise<[Project[], Team[]]> {
   // Create a new client so the request is not cancelled
   const uncancelableApi = new Client();
-  try {
-    const [projects, teams] = await Promise.all([
-      getPreloadedDataPromise(
-        'projects',
-        slug,
-        () =>
-          // This data should get preloaded in static/sentry/index.ejs
-          // If this url changes make sure to update the preload
-          uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
-            query: {
-              all_projects: 1,
-              collapse: 'latestDeploys',
-            },
-          }),
-        isInitialFetch
-      ),
-      getPreloadedDataPromise(
-        'teams',
-        slug,
-        // This data should get preloaded in static/sentry/index.ejs
-        // If this url changes make sure to update the preload
-        () => uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),
-        isInitialFetch
-      ),
-    ]);
 
-    return [projects, teams];
+  const projectsPromise = getPreloadedDataPromise(
+    'projects',
+    slug,
+    () =>
+      // This data should get preloaded in static/sentry/index.ejs
+      // If this url changes make sure to update the preload
+      uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
+        query: {
+          all_projects: 1,
+          collapse: 'latestDeploys',
+        },
+      }),
+    isInitialFetch
+  );
+
+  const teamsPromise = getPreloadedDataPromise(
+    'teams',
+    slug,
+    // This data should get preloaded in static/sentry/index.ejs
+    // If this url changes make sure to update the preload
+    () => uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),
+    isInitialFetch
+  );
+
+  try {
+    return await Promise.all([projectsPromise, teamsPromise]);
   } catch (err) {
-    // It's possible these requests fail with a 403 if the user has a role with insufficient access
-    // to projects and teams, but *can* access org details (e.g. billing).
-    // An example of this is in org settings.
+    // It's possible these requests fail with a 403 if the user has a role with
+    // insufficient access to projects and teams, but *can* access org details
+    // (e.g. billing). An example of this is in org settings.
     //
     // Ignore 403s and bubble up other API errors
     if (err.status !== 403) {
       throw err;
     }
   }
+
   return [[], []];
 }
 
 /**
- * Fetches an organization's details with an option for the detailed representation
- * with teams and projects
+ * Fetches an organization's details
  *
  * @param api A reference to the api client
  * @param slug The organization slug
- * @param detailed Whether or not the detailed org details should be retrieved
  * @param silent Should we silently update the organization (do not clear the
  *               current organization in the store)
  */
 export async function fetchOrganizationDetails(
   api: Client,
   slug: string,
-  detailed: boolean,
   silent: boolean,
   isInitialFetch?: boolean
 ) {
@@ -110,49 +102,40 @@ export async function fetchOrganizationDetails(
     GlobalSelectionActions.reset();
   }
 
-  try {
-    const promises: Array<Promise<any>> = [fetchOrg(api, slug, detailed, isInitialFetch)];
-    if (!detailed) {
-      promises.push(fetchProjectsAndTeams(slug, isInitialFetch));
-    }
-
-    const [org, projectsAndTeams] = await Promise.all(promises);
-
-    if (!detailed) {
-      const [projects, teams] = projectsAndTeams as [Project[], Team[]];
-      ProjectActions.loadProjects(projects);
-      TeamActions.loadTeams(teams);
-    }
-
-    if (org && detailed) {
-      // TODO(davidenwang): Change these to actions after organization.projects
-      // and organization.teams no longer exists. Currently if they were changed
-      // to actions it would cause OrganizationContext to rerender many times
-      TeamStore.loadInitialData(org.teams);
-      ProjectsStore.loadInitialData(org.projects);
-    }
-  } catch (err) {
-    if (!err) {
-      return;
-    }
-
-    OrganizationActions.fetchOrgError(err);
-
-    if (err.status === 403 || err.status === 401) {
-      const errMessage =
-        typeof err.responseJSON?.detail === 'string'
-          ? err.responseJSON?.detail
-          : typeof err.responseJSON?.detail?.message === 'string'
-          ? err.responseJSON?.detail.message
-          : null;
-
-      if (errMessage) {
-        addErrorMessage(errMessage);
+  const loadOrganization = async () => {
+    try {
+      await fetchOrg(api, slug, isInitialFetch);
+    } catch (err) {
+      if (!err) {
+        return;
       }
 
-      return;
-    }
+      OrganizationActions.fetchOrgError(err);
 
-    Sentry.captureException(err);
-  }
+      if (err.status === 403 || err.status === 401) {
+        const errMessage =
+          typeof err.responseJSON?.detail === 'string'
+            ? err.responseJSON?.detail
+            : typeof err.responseJSON?.detail?.message === 'string'
+            ? err.responseJSON?.detail.message
+            : null;
+
+        if (errMessage) {
+          addErrorMessage(errMessage);
+        }
+
+        return;
+      }
+
+      Sentry.captureException(err);
+    }
+  };
+
+  const loadTeamsAndProjects = async () => {
+    const [projects, teams] = await fetchProjectsAndTeams(slug, isInitialFetch);
+    ProjectActions.loadProjects(projects);
+    TeamActions.loadTeams(teams);
+  };
+
+  return Promise.all([loadOrganization(), loadTeamsAndProjects()]);
 }

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -19,9 +19,7 @@ import AuthLayout from 'app/views/auth/layout';
 import IssueListContainer from 'app/views/issueList/container';
 import IssueListOverview from 'app/views/issueList/overview';
 import OrganizationContextContainer from 'app/views/organizationContext';
-import OrganizationDetails, {
-  LightWeightOrganizationDetails,
-} from 'app/views/organizationDetails';
+import OrganizationDetails from 'app/views/organizationDetails';
 import {Tab} from 'app/views/organizationGroupDetails/types';
 import OrganizationRoot from 'app/views/organizationRoot';
 import ProjectEventRedirect from 'app/views/projectEventRedirect';
@@ -868,11 +866,7 @@ function routes() {
           </Route>
         </Route>
 
-        {/* A route tree for lightweight organizational detail views. We place
-      this above the heavyweight organization detail views because there
-      exist some redirects from deprecated routes which should not take
-      precedence over these lightweight routes */}
-        <Route component={errorHandler(LightWeightOrganizationDetails)}>
+        <Route component={errorHandler(OrganizationDetails)}>
           <Route
             path="/organizations/:orgId/projects/"
             componentPromise={() => import('app/views/projectsDashboard')}
@@ -1582,7 +1576,6 @@ function routes() {
           </Route>
         </Route>
 
-        {/* The heavyweight organization detail views */}
         <Route path="/:orgId/" component={errorHandler(OrganizationDetails)}>
           <Route component={errorHandler(OrganizationRoot)}>
             {hook('routes:organization-root')}
@@ -1692,9 +1685,7 @@ function routes() {
           </Route>
         </Route>
 
-        {/* A route tree for lightweight organizational detail views.
-          This is strictly for deprecated URLs that we need to maintain */}
-        <Route component={errorHandler(LightWeightOrganizationDetails)}>
+        <Route component={errorHandler(OrganizationDetails)}>
           {/* This is in the bottom lightweight group because "/organizations/:orgId/projects/new/" in heavyweight needs to be matched first */}
           <Route
             path="/organizations/:orgId/projects/:projectId/"

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -1,9 +1,8 @@
 import Reflux from 'reflux';
 
 import OrganizationActions from 'app/actions/organizationActions';
-import ProjectActions from 'app/actions/projectActions';
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'app/constants';
-import {Organization, Project} from 'app/types';
+import {Organization} from 'app/types';
 import RequestError from 'app/utils/requestError/requestError';
 
 type UpdateOptions = {
@@ -23,8 +22,6 @@ type OrganizationStoreInterface = {
   reset: () => void;
   onUpdate: (org: Organization, options: UpdateOptions) => void;
   onFetchOrgError: (err: RequestError) => void;
-  onProjectsChange: () => void;
-  onLoadProjects: (projects: Project[]) => void;
   get: () => State;
 };
 
@@ -34,16 +31,6 @@ const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {
     this.listenTo(OrganizationActions.update, this.onUpdate);
     this.listenTo(OrganizationActions.fetchOrg, this.reset);
     this.listenTo(OrganizationActions.fetchOrgError, this.onFetchOrgError);
-
-    // fill in projects if they are loaded
-    this.listenTo(ProjectActions.loadProjects, this.onLoadProjects);
-
-    // mark the store as dirty if projects change
-    this.listenTo(ProjectActions.createSuccess, this.onProjectsChange);
-    this.listenTo(ProjectActions.updateSuccess, this.onProjectsChange);
-    this.listenTo(ProjectActions.changeSlug, this.onProjectsChange);
-    this.listenTo(ProjectActions.addTeamSuccess, this.onProjectsChange);
-    this.listenTo(ProjectActions.removeTeamSuccess, this.onProjectsChange);
   },
 
   reset() {
@@ -81,20 +68,6 @@ const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {
     this.error = err;
     this.dirty = false;
     this.trigger(this.get());
-  },
-
-  onProjectsChange() {
-    // mark the store as dirty so the next fetch will trigger an org details refetch
-    this.dirty = true;
-  },
-
-  onLoadProjects(projects: Project[]) {
-    if (this.organization) {
-      // sort projects to mimic how they are received from backend
-      projects.sort((a, b) => a.slug.localeCompare(b.slug));
-      this.organization = {...this.organization, projects};
-      this.trigger(this.get());
-    }
   },
 
   get() {

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -196,10 +196,8 @@ export type RelaysByPublickey = {
 
 /**
  * Detailed organization (e.g. when requesting details for a single org)
- *
- * Lightweight in this case means it does not contain `projects` or `teams`
  */
-export type LightWeightOrganization = OrganizationSummary & {
+export type Organization = OrganizationSummary & {
   relayPiiConfig: string;
   scrubIPAddresses: boolean;
   attachmentsRole: string;
@@ -235,11 +233,11 @@ export type LightWeightOrganization = OrganizationSummary & {
 };
 
 /**
- * Full organization details
+ * @deprecated This was used before we removed projects and teams as
+ *             normalized data on the organization object. This will be
+ *             removed very soon.
  */
-export type Organization = LightWeightOrganization & {
-  projects: Project[];
-};
+export type LightWeightOrganization = Organization;
 
 /**
  * Minimal organization shape used on shared issue views.

--- a/static/app/utils/__mocks__/withOrganization.tsx
+++ b/static/app/utils/__mocks__/withOrganization.tsx
@@ -19,7 +19,4 @@ const withOrganizationMock = WrappedComponent =>
     }
   };
 
-const isLightweightOrganization = () => {};
-
 export default withOrganizationMock;
-export {isLightweightOrganization};

--- a/static/app/utils/withOrganization.tsx
+++ b/static/app/utils/withOrganization.tsx
@@ -32,11 +32,4 @@ const withOrganization = <P extends InjectedOrganizationProps>(
     }
   };
 
-export function isLightweightOrganization(
-  organization: Organization | LightWeightOrganization
-): organization is LightWeightOrganization {
-  const castedOrg = organization as Organization;
-  return !castedOrg.projects;
-}
-
 export default withOrganization;

--- a/static/app/views/issueList/container.tsx
+++ b/static/app/views/issueList/container.tsx
@@ -4,32 +4,13 @@ import DocumentTitle from 'react-document-title';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {Organization} from 'app/types';
-import {metric} from 'app/utils/analytics';
-import withOrganization, {isLightweightOrganization} from 'app/utils/withOrganization';
+import withOrganization from 'app/utils/withOrganization';
 
 type Props = {
   organization: Organization;
 };
 
 class IssueListContainer extends Component<Props> {
-  componentDidMount() {
-    // Setup here as render() may be expensive
-    this.startMetricCollection();
-  }
-
-  /**
-   * The user can (1) land on IssueList as the first page as they enter Sentry,
-   * or (2) navigate into IssueList with the stores preloaded with data.
-   *
-   * Case (1) will be slower and we can easily identify it as it uses the
-   * lightweight organization
-   */
-  startMetricCollection() {
-    const isLightWeight: boolean = isLightweightOrganization(this.props.organization);
-    const startType: string = isLightWeight ? 'cold-start' : 'warm-start';
-    metric.mark({name: 'page-issue-list-start', data: {start_type: startType}});
-  }
-
   getTitle() {
     return `Issues - ${this.props.organization.slug} - Sentry`;
   }

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -48,7 +48,7 @@ import {
   TagCollection,
 } from 'app/types';
 import {defined} from 'app/utils';
-import {analytics, metric, trackAnalyticsEvent} from 'app/utils/analytics';
+import {analytics, trackAnalyticsEvent} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import CursorPoller from 'app/utils/cursorPoller';
 import {getUtcDateString} from 'app/utils/dates';
@@ -193,31 +193,6 @@ class IssueListOverview extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    // Fire off profiling/metrics first
-    if (prevState.issuesLoading && !this.state.issuesLoading) {
-      // First Meaningful Paint for /organizations/:orgId/issues/
-      if (prevState.queryCount === null) {
-        metric.measure({
-          name: 'app.page.perf.issue-list',
-          start: 'page-issue-list-start',
-          data: {
-            // start_type is set on 'page-issue-list-start'
-            org_id: parseInt(this.props.organization.id, 10),
-            group: this.props.organization.features.includes('enterprise-perf')
-              ? 'enterprise-perf'
-              : 'control',
-            milestone: 'first-meaningful-paint',
-            is_enterprise: this.props.organization.features
-              .includes('enterprise-orgs')
-              .toString(),
-            is_outlier: this.props.organization.features
-              .includes('enterprise-orgs-outliers')
-              .toString(),
-          },
-        });
-      }
-    }
-
     if (prevState.realtimeActive !== this.state.realtimeActive) {
       // User toggled realtime button
       if (this.state.realtimeActive) {

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -20,7 +20,7 @@ import ConfigStore from 'app/stores/configStore';
 import HookStore from 'app/stores/hookStore';
 import OrganizationStore from 'app/stores/organizationStore';
 import space from 'app/styles/space';
-import {LightWeightOrganization, Organization} from 'app/types';
+import {Organization} from 'app/types';
 import {metric} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
@@ -28,20 +28,14 @@ import RequestError from 'app/utils/requestError/requestError';
 import withApi from 'app/utils/withApi';
 import withOrganizations from 'app/utils/withOrganizations';
 
-const defaultProps = {
-  detailed: true,
-};
-
-type Props = {
+type Props = RouteComponentProps<{orgId: string}, {}> & {
   api: Client;
   routes: PlainRoute[];
   includeSidebar: boolean;
   useLastOrganization: boolean;
   organizationsLoading: boolean;
   organizations: Organization[];
-  detailed: boolean;
-} & typeof defaultProps &
-  RouteComponentProps<{orgId: string}, {}>;
+};
 
 type State = {
   organization: Organization | null;
@@ -57,9 +51,8 @@ type State = {
   };
 };
 
-const OrganizationContext = createContext<Organization | LightWeightOrganization | null>(
-  null
-);
+const OrganizationContext = createContext<Organization | null>(null);
+
 class OrganizationContextContainer extends React.Component<Props, State> {
   static getDerivedStateFromProps(props: Readonly<Props>, prevState: State): State {
     const {prevProps} = prevState;
@@ -149,22 +142,14 @@ class OrganizationContextContainer extends React.Component<Props, State> {
   }
 
   static isOrgStorePopulatedCorrectly(props: Props) {
-    const {detailed} = props;
     const {organization, dirty} = OrganizationStore.get();
 
-    return (
-      !dirty &&
-      organization &&
-      !OrganizationContextContainer.isOrgChanging(props) &&
-      (!detailed || (detailed && organization.projects))
-    );
+    return !dirty && organization && !OrganizationContextContainer.isOrgChanging(props);
   }
 
   static childContextTypes = {
     organization: SentryTypes.Organization,
   };
-
-  static defaultProps = defaultProps;
 
   constructor(props: Props) {
     super(props);
@@ -227,11 +212,8 @@ class OrganizationContextContainer extends React.Component<Props, State> {
     if (!OrganizationContextContainer.getOrganizationSlug(this.props)) {
       return this.props.organizationsLoading;
     }
-    // The following loading logic exists because we could either be waiting for
-    // the whole organization object to come in or just the teams and projects.
-    const {loading, error, organization} = this.state;
-    const {detailed} = this.props;
-    return loading || (!error && detailed && (!organization || !organization.projects));
+
+    return this.state.loading;
   }
 
   fetchData(isInitialFetch = false) {
@@ -247,7 +229,6 @@ class OrganizationContextContainer extends React.Component<Props, State> {
     fetchOrganizationDetails(
       this.props.api,
       OrganizationContextContainer.getOrganizationSlug(this.props),
-      this.props.detailed,
       !OrganizationContextContainer.isOrgChanging(this.props), // if true, will preserve a lightweight org that was fetched,
       isInitialFetch
     );
@@ -383,6 +364,7 @@ class OrganizationContextContainer extends React.Component<Props, State> {
 export default withApi(
   withOrganizations(Sentry.withProfiler(OrganizationContextContainer))
 );
+
 export {OrganizationContextContainer as OrganizationLegacyContext, OrganizationContext};
 
 const ErrorWrapper = styled('div')`

--- a/static/app/views/organizationDetails/index.tsx
+++ b/static/app/views/organizationDetails/index.tsx
@@ -150,9 +150,7 @@ const OrganizationDetailsBody = withOrganization(function OrganizationDetailsBod
   );
 });
 
-type Props = {
-  detailed: boolean;
-} & RouteComponentProps<{orgId: string}, {}>;
+type Props = RouteComponentProps<{orgId: string}, {}>;
 
 export default class OrganizationDetails extends Component<Props> {
   componentDidMount() {
@@ -173,6 +171,7 @@ export default class OrganizationDetails extends Component<Props> {
       switchOrganization();
     }
   }
+
   render() {
     return (
       <OrganizationContextContainer includeSidebar useLastOrganization {...this.props}>
@@ -182,8 +181,4 @@ export default class OrganizationDetails extends Component<Props> {
       </OrganizationContextContainer>
     );
   }
-}
-
-export function LightWeightOrganizationDetails(props: Omit<Props, 'detailed'>) {
-  return <OrganizationDetails detailed={false} {...props} />;
 }

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -25,7 +25,6 @@ import {
   Project,
 } from 'app/types';
 import {Event} from 'app/types/event';
-import {metric} from 'app/utils/analytics';
 import fetchSentryAppInstallations from 'app/utils/fetchSentryAppInstallations';
 
 import GroupEventToolbar from '../eventToolbar';
@@ -66,26 +65,6 @@ class GroupEventDetails extends Component<Props, State> {
 
   componentDidMount() {
     this.fetchData();
-
-    // First Meaningful Paint for /organizations/:orgId/issues/:groupId/
-    metric.measure({
-      name: 'app.page.perf.issue-details',
-      start: 'page-issue-details-start',
-      data: {
-        // start_type is set on 'page-issue-details-start'
-        org_id: parseInt(this.props.organization.id, 10),
-        group: this.props.organization.features.includes('enterprise-perf')
-          ? 'enterprise-perf'
-          : 'control',
-        milestone: 'first-meaningful-paint',
-        is_enterprise: this.props.organization.features
-          .includes('enterprise-orgs')
-          .toString(),
-        is_outlier: this.props.organization.features
-          .includes('enterprise-orgs-outliers')
-          .toString(),
-      },
-    });
   }
 
   componentDidUpdate(prevProps: Props) {

--- a/static/app/views/organizationGroupDetails/index.tsx
+++ b/static/app/views/organizationGroupDetails/index.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {GlobalSelection, Organization, Project} from 'app/types';
-import {analytics, metric} from 'app/utils/analytics';
+import {analytics} from 'app/utils/analytics';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import withOrganization, {isLightweightOrganization} from 'app/utils/withOrganization';
+import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 
 import GroupDetails from './groupDetails';
@@ -18,28 +18,11 @@ type Props = {
 } & RouteComponentProps<{orgId: string; groupId: string}, {}>;
 
 class OrganizationGroupDetails extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-
-    // Setup in the constructor as render() may be expensive
-    this.startMetricCollection();
-  }
-
   componentDidMount() {
     analytics('issue_page.viewed', {
       group_id: parseInt(this.props.params.groupId, 10),
       org_id: parseInt(this.props.organization.id, 10),
     });
-  }
-
-  /**
-   * See "page-issue-list-start" for explanation on hot/cold-starts
-   */
-  startMetricCollection() {
-    const startType = isLightweightOrganization(this.props.organization)
-      ? 'cold-start'
-      : 'warm-start';
-    metric.mark({name: 'page-issue-details-start', data: {start_type: startType}});
   }
 
   render() {

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -40,7 +40,7 @@
       window.__sentry_preload = preloadPromises;
 
       if (slug !== 'new') {
-        preloadPromises['organization?detailed=0'] = promiseRequest(makeUrl('/?detailed=0'));
+        preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0'));
         preloadPromises.projects =  promiseRequest(makeUrl('/projects/?all_projects=1&collapse=latestDeploys'));
         preloadPromises.teams = promiseRequest(makeUrl('/teams/'));
       }

--- a/tests/js/spec/actionCreators/organization.spec.jsx
+++ b/tests/js/spec/actionCreators/organization.spec.jsx
@@ -4,26 +4,20 @@ import OrganizationActions from 'app/actions/organizationActions';
 import ProjectActions from 'app/actions/projectActions';
 import TeamActions from 'app/actions/teamActions';
 import OrganizationStore from 'app/stores/organizationStore';
-import ProjectsStore from 'app/stores/projectsStore';
-import TeamStore from 'app/stores/teamStore';
 
 describe('OrganizationActionCreator', function () {
-  const detailedOrg = TestStubs.Organization({
-    teams: [TestStubs.Team()],
-    projects: [TestStubs.Project()],
-  });
+  const org = TestStubs.Organization();
+  delete org.teams;
+  delete org.projects;
 
-  const lightOrg = TestStubs.Organization();
-  delete lightOrg.teams;
-  delete lightOrg.projects;
+  const teams = [TestStubs.Team()];
+  const projects = [TestStubs.Project()];
 
   const api = new MockApiClient();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
-    jest.spyOn(TeamStore, 'loadInitialData');
     jest.spyOn(TeamActions, 'loadTeams');
-    jest.spyOn(ProjectsStore, 'loadInitialData');
     jest.spyOn(ProjectActions, 'loadProjects');
     jest.spyOn(OrganizationActions, 'fetchOrg');
     jest.spyOn(OrganizationActions, 'update');
@@ -36,105 +30,95 @@ describe('OrganizationActionCreator', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('fetches heavyweight organization details', async function () {
+  it('fetches organization details', async function () {
     const getOrgMock = MockApiClient.addMockResponse({
-      url: `/organizations/${detailedOrg.slug}/`,
-      body: detailedOrg,
-    });
-
-    fetchOrganizationDetails(api, detailedOrg.slug, true);
-    await tick();
-    expect(OrganizationActions.fetchOrg).toHaveBeenCalled();
-
-    expect(getOrgMock).toHaveBeenCalledWith(
-      `/organizations/${detailedOrg.slug}/`,
-      expect.anything()
-    );
-    expect(OrganizationActions.update).toHaveBeenCalledWith(detailedOrg, {replace: true});
-    expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
-
-    expect(TeamStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.teams);
-    expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.projects);
-  });
-
-  it('fetches lightweight organization details', async function () {
-    const getOrgMock = MockApiClient.addMockResponse({
-      url: `/organizations/${lightOrg.slug}/`,
-      body: lightOrg,
+      url: `/organizations/${org.slug}/`,
+      body: org,
     });
     const getProjectsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${lightOrg.slug}/projects/`,
-      body: detailedOrg.projects,
+      url: `/organizations/${org.slug}/projects/`,
+      body: projects,
     });
     const getTeamsMock = MockApiClient.addMockResponse({
-      url: `/organizations/${lightOrg.slug}/teams/`,
-      body: detailedOrg.teams,
+      url: `/organizations/${org.slug}/teams/`,
+      body: teams,
     });
 
-    fetchOrganizationDetails(api, lightOrg.slug, false);
+    fetchOrganizationDetails(api, org.slug, false);
     await tick();
     await tick();
     expect(OrganizationActions.fetchOrg).toHaveBeenCalled();
 
     expect(getOrgMock).toHaveBeenCalledWith(
-      `/organizations/${lightOrg.slug}/`,
+      `/organizations/${org.slug}/`,
       expect.anything()
     );
     expect(getProjectsMock).toHaveBeenCalledWith(
-      `/organizations/${lightOrg.slug}/projects/`,
+      `/organizations/${org.slug}/projects/`,
       expect.anything()
     );
     expect(getTeamsMock).toHaveBeenCalledWith(
-      `/organizations/${lightOrg.slug}/teams/`,
+      `/organizations/${org.slug}/teams/`,
       expect.anything()
     );
-    expect(OrganizationActions.update).toHaveBeenCalledWith(lightOrg, {replace: true});
+    expect(OrganizationActions.update).toHaveBeenCalledWith(org, {replace: true});
     expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
 
-    expect(TeamStore.loadInitialData).not.toHaveBeenCalled();
-    expect(ProjectsStore.loadInitialData).not.toHaveBeenCalled();
+    expect(TeamActions.loadTeams).toHaveBeenCalledWith(teams);
+    expect(ProjectActions.loadProjects).toHaveBeenCalledWith(projects);
 
-    expect(TeamActions.loadTeams).toHaveBeenCalledWith(detailedOrg.teams);
-    expect(ProjectActions.loadProjects).toHaveBeenCalledWith(detailedOrg.projects);
-
-    expect(OrganizationStore.organization).toEqual({
-      ...lightOrg,
-      projects: detailedOrg.projects,
-    });
+    expect(OrganizationStore.organization).toEqual(org);
   });
 
   it('silently fetches organization details', async function () {
     const getOrgMock = MockApiClient.addMockResponse({
-      url: `/organizations/${detailedOrg.slug}/`,
-      body: detailedOrg,
+      url: `/organizations/${org.slug}/`,
+      body: org,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: projects,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: teams,
     });
 
-    fetchOrganizationDetails(api, detailedOrg.slug, true, true);
+    fetchOrganizationDetails(api, org.slug, true, true);
     await tick();
     expect(OrganizationActions.fetchOrg).not.toHaveBeenCalled();
 
     expect(getOrgMock).toHaveBeenCalledWith(
-      `/organizations/${detailedOrg.slug}/`,
+      `/organizations/${org.slug}/`,
       expect.anything()
     );
-    expect(OrganizationActions.update).toHaveBeenCalledWith(detailedOrg, {replace: true});
+
+    expect(OrganizationActions.update).toHaveBeenCalledWith(org, {replace: true});
     expect(OrganizationsActionCreator.setActiveOrganization).toHaveBeenCalled();
 
-    expect(TeamStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.teams);
-    expect(ProjectsStore.loadInitialData).toHaveBeenCalledWith(detailedOrg.projects);
+    expect(TeamActions.loadTeams).toHaveBeenCalledWith(teams);
+    expect(ProjectActions.loadProjects).toHaveBeenCalledWith(projects);
   });
 
   it('errors out correctly', async function () {
     const getOrgMock = MockApiClient.addMockResponse({
-      url: `/organizations/${detailedOrg.slug}/`,
+      url: `/organizations/${org.slug}/`,
       statusCode: 400,
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: projects,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: teams,
+    });
 
-    fetchOrganizationDetails(api, detailedOrg.slug, true);
+    fetchOrganizationDetails(api, org.slug, false);
     await tick();
     expect(OrganizationActions.fetchOrg).toHaveBeenCalled();
     expect(getOrgMock).toHaveBeenCalledWith(
-      `/organizations/${detailedOrg.slug}/`,
+      `/organizations/${org.slug}/`,
       expect.anything()
     );
     expect(OrganizationActions.fetchOrgError).toHaveBeenCalled();

--- a/tests/js/spec/stores/organizationStore.spec.jsx
+++ b/tests/js/spec/stores/organizationStore.spec.jsx
@@ -1,6 +1,5 @@
 import {updateOrganization} from 'app/actionCreators/organizations';
 import OrganizationActions from 'app/actions/organizationActions';
-import ProjectActions from 'app/actions/projectActions';
 import OrganizationStore from 'app/stores/organizationStore';
 
 describe('OrganizationStore', function () {
@@ -68,22 +67,5 @@ describe('OrganizationStore', function () {
       organization: null,
       dirty: false,
     });
-  });
-
-  it('loads in sorted projects', async function () {
-    const organization = TestStubs.Organization();
-    OrganizationActions.update(organization);
-    // wait for action to get dispatched to store
-    await tick();
-
-    const projectA = TestStubs.Project({slug: 'a'});
-    const projectB = TestStubs.Project({slug: 'b'});
-    const projects = [projectB, projectA];
-    ProjectActions.loadProjects(projects);
-    // wait for action to get dispatched to store
-    await tick();
-
-    // verify existence and sorted order of loaded projects
-    expect(OrganizationStore.get().organization.projects).toEqual([projectA, projectB]);
   });
 });

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -2,13 +2,14 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import OrganizationStore from 'app/stores/organizationStore';
 import ProjectsStore from 'app/stores/projectsStore';
-import OrganizationDetails, {
-  LightWeightOrganizationDetails,
-} from 'app/views/organizationDetails';
+import OrganizationDetails from 'app/views/organizationDetails';
 
 let wrapper;
 
 describe('OrganizationDetails', function () {
+  let getTeamsMock;
+  let getProjectsMock;
+
   beforeEach(async function () {
     OrganizationStore.reset();
     // wait for store reset changes to propagate
@@ -23,6 +24,14 @@ describe('OrganizationDetails', function () {
       url: '/organizations/org-slug/environments/',
       body: [],
     });
+    getTeamsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/teams/',
+      body: [TestStubs.Team()],
+    });
+    getProjectsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [TestStubs.Project()],
+    });
   });
 
   afterEach(function () {
@@ -30,91 +39,7 @@ describe('OrganizationDetails', function () {
     wrapper.unmount();
   });
 
-  describe('render()', function () {
-    describe('pending deletion', () => {
-      it('should render a restoration prompt', async function () {
-        MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/',
-          body: TestStubs.Organization({
-            slug: 'org-slug',
-            status: {
-              id: 'pending_deletion',
-              name: 'pending deletion',
-            },
-          }),
-        });
-        wrapper = mountWithTheme(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
-          TestStubs.routerContext()
-        );
-        await tick();
-        await tick();
-        wrapper.update();
-        expect(wrapper.text()).toContain('Deletion Scheduled');
-        expect(wrapper.text()).toContain(
-          'Would you like to cancel this process and restore the organization back to the original state?'
-        );
-        expect(wrapper.find('button[aria-label="Restore Organization"]')).toHaveLength(1);
-      });
-      it('should render a restoration prompt without action for members', async function () {
-        MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/',
-          body: TestStubs.Organization({
-            slug: 'org-slug',
-            access: [],
-            status: {
-              id: 'pending_deletion',
-              name: 'pending deletion',
-            },
-          }),
-        });
-        wrapper = mountWithTheme(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
-          TestStubs.routerContext()
-        );
-        await tick();
-        await tick();
-        wrapper.update();
-        expect(wrapper.text()).toContain(
-          [
-            'The org-slug organization is currently scheduled for deletion.',
-            'If this is a mistake, contact an organization owner and ask them to restore this organization.',
-          ].join('')
-        );
-        expect(wrapper.find('button[aria-label="Restore Organization"]')).toHaveLength(0);
-      });
-    });
-
-    describe('deletion in progress', () => {
-      beforeEach(() => {
-        MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/',
-          body: TestStubs.Organization({
-            slug: 'org-slug',
-            status: {
-              id: 'deletion_in_progress',
-              name: 'deletion in progress',
-            },
-          }),
-        });
-      });
-
-      it('should render a deletion in progress prompt', async function () {
-        wrapper = mountWithTheme(
-          <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
-          TestStubs.routerContext()
-        );
-        await tick();
-        await tick();
-        wrapper.update();
-        expect(wrapper.text()).toContain(
-          'The org-slug organization is currently in the process of being deleted from Sentry'
-        );
-        expect(wrapper.find('button[aria-label="Restore Organization"]')).toHaveLength(0);
-      });
-    });
-  });
-  it('can render a lightweight version of itself and fetches teams', async function () {
+  it('can fetch projects and teams', async function () {
     ProjectsStore.reset();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/',
@@ -122,23 +47,15 @@ describe('OrganizationDetails', function () {
         slug: 'org-slug',
       }),
     });
-    const getTeamsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/teams/',
-      body: [TestStubs.Team()],
-    });
-    const getProjectsMock = MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
-      body: [TestStubs.Project()],
-    });
     wrapper = mountWithTheme(
-      <LightWeightOrganizationDetails
+      <OrganizationDetails
         params={{orgId: 'org-slug'}}
         location={{}}
         routes={[]}
         includeSidebar={false}
       >
         {null}
-      </LightWeightOrganizationDetails>,
+      </OrganizationDetails>,
       TestStubs.routerContext()
     );
     await tick();
@@ -147,6 +64,89 @@ describe('OrganizationDetails', function () {
     wrapper.update();
     expect(getTeamsMock).toHaveBeenCalled();
     expect(getProjectsMock).toHaveBeenCalled();
-    expect(wrapper.find('OrganizationContextContainer').prop('detailed')).toBe(false);
+  });
+
+  describe('pending deletion', () => {
+    it('should render a restoration prompt', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        body: TestStubs.Organization({
+          slug: 'org-slug',
+          status: {
+            id: 'pending_deletion',
+            name: 'pending deletion',
+          },
+        }),
+      });
+      wrapper = mountWithTheme(
+        <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
+        TestStubs.routerContext()
+      );
+      await tick();
+      await tick();
+      wrapper.update();
+      expect(wrapper.text()).toContain('Deletion Scheduled');
+      expect(wrapper.text()).toContain(
+        'Would you like to cancel this process and restore the organization back to the original state?'
+      );
+      expect(wrapper.find('button[aria-label="Restore Organization"]')).toHaveLength(1);
+    });
+
+    it('should render a restoration prompt without action for members', async function () {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        body: TestStubs.Organization({
+          slug: 'org-slug',
+          access: [],
+          status: {
+            id: 'pending_deletion',
+            name: 'pending deletion',
+          },
+        }),
+      });
+      wrapper = mountWithTheme(
+        <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
+        TestStubs.routerContext()
+      );
+      await tick();
+      await tick();
+      wrapper.update();
+      expect(wrapper.text()).toContain(
+        [
+          'The org-slug organization is currently scheduled for deletion.',
+          'If this is a mistake, contact an organization owner and ask them to restore this organization.',
+        ].join('')
+      );
+      expect(wrapper.find('button[aria-label="Restore Organization"]')).toHaveLength(0);
+    });
+  });
+
+  describe('deletion in progress', () => {
+    beforeEach(() => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/',
+        body: TestStubs.Organization({
+          slug: 'org-slug',
+          status: {
+            id: 'deletion_in_progress',
+            name: 'deletion in progress',
+          },
+        }),
+      });
+    });
+
+    it('should render a deletion in progress prompt', async function () {
+      wrapper = mountWithTheme(
+        <OrganizationDetails params={{orgId: 'org-slug'}} location={{}} routes={[]} />,
+        TestStubs.routerContext()
+      );
+      await tick();
+      await tick();
+      wrapper.update();
+      expect(wrapper.text()).toContain(
+        'The org-slug organization is currently in the process of being deleted from Sentry'
+      );
+      expect(wrapper.find('button[aria-label="Restore Organization"]')).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
Completely removes the `LightweightOranization` type. **All organizations are now lightweight**.

All usages of `org.teams` and `org.projects` have been removed, all components now read out of the projects and teams store, meaning there is no need to ever hydrate the full object.