### PR TITLE
test: Fix setup in test_flow_authenticated_without_verified_without_password

### DIFF
--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -553,7 +553,7 @@ class Factories:
         kwargs.setdefault("is_superuser", False)
 
         user = User(email=email, **kwargs)
-        if not kwargs.get("password"):
+        if kwargs.get("password") is None:
             user.set_password("admin")
         user.save()
 

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -577,6 +577,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # setup a 'previous' identity, such as when we migrated Google from
         # the old idents to the new
         user = self.create_user("bar@example.com", is_managed=False, password="")
+        assert not user.has_usable_password()
         UserEmail.objects.filter(user=user, email="bar@example.com").update(is_verified=False)
         self.create_member(organization=self.organization, user=user)
 

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -591,7 +591,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(path, {"email": "bar@example.com"})
         self.assertTemplateUsed(resp, "sentry/auth-confirm-identity.html")
         assert resp.status_code == 200
-        assert resp.context["existing_user"] == user
+        assert resp.context["existing_user"] is None
 
     def test_flow_managed_duplicate_users_without_membership(self):
         """


### PR DESCRIPTION
Change `create_user` so that calling it with `password=""` sets up the user in a state where it does not have a usable password, as the test case intended. Previously, any falsy value would give it a default password.

This exposes an incorrect assertion. The test case is currently failing.