### PR TITLE
feat(comparison_alerts): Translate delta percents into comparison percents in the api layer.

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.incidents.endpoints.utils import translate_threshold
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import (
     AlertRule,
@@ -98,7 +99,7 @@ class AlertRuleSerializer(Serializer):
             "query": obj.snuba_query.query,
             "aggregate": aggregate,
             "thresholdType": obj.threshold_type,
-            "resolveThreshold": obj.resolve_threshold,
+            "resolveThreshold": translate_threshold(obj, obj.resolve_threshold),
             # TODO: Start having the frontend expect seconds
             "timeWindow": obj.snuba_query.time_window / 60,
             "environment": env.name if env else None,

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.incidents.endpoints.utils import translate_threshold
 from sentry.incidents.models import (
     AlertRuleTrigger,
     AlertRuleTriggerAction,
@@ -37,8 +38,10 @@ class AlertRuleTriggerSerializer(Serializer):
             "alertRuleId": str(obj.alert_rule_id),
             "label": obj.label,
             "thresholdType": obj.alert_rule.threshold_type,
-            "alertThreshold": obj.alert_threshold,
-            "resolveThreshold": obj.alert_rule.resolve_threshold,
+            "alertThreshold": translate_threshold(obj.alert_rule, obj.alert_threshold),
+            "resolveThreshold": translate_threshold(
+                obj.alert_rule, obj.alert_rule.resolve_threshold
+            ),
             "dateCreated": obj.date_added,
             "actions": attrs.get("actions", []),
         }

--- a/src/sentry/incidents/endpoints/utils.py
+++ b/src/sentry/incidents/endpoints/utils.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from sentry.api.helpers.teams import get_teams
+from sentry.incidents.models import AlertRule, AlertRuleThresholdType
 
 
 def parse_team_params(request, organization, teams):
@@ -12,3 +15,22 @@ def parse_team_params(request, organization, teams):
     teams = get_teams(request, organization, teams=teams_set)
 
     return (teams, unassigned)
+
+
+threshold_translators = {
+    AlertRuleThresholdType.ABOVE: lambda threshold: threshold - 100,
+    AlertRuleThresholdType.BELOW: lambda threshold: 100 - threshold,
+}
+
+
+def translate_threshold(alert_rule: AlertRule, threshold: Optional[float]):
+    """
+    Translates our internal percent representation into a delta percentage.
+    For ABOVE: A percentage like 170% would become 70% increase
+    For BELOW: A percentage like 40% would become 60% decrease.
+    """
+    if alert_rule.comparison_delta is None or threshold is None:
+        return threshold
+
+    threshold_type = AlertRuleThresholdType(alert_rule.threshold_type)
+    return threshold_translators[threshold_type](threshold)

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -28,10 +28,8 @@ class BaseAlertRuleSerializerTest:
         assert result["query"] == alert_rule.snuba_query.query
         assert result["aggregate"] == alert_rule.snuba_query.aggregate
         assert result["thresholdType"] == alert_rule.threshold_type
-        assert (
-            result["resolveThreshold"] == alert_rule.resolve_threshold
-            if resolve_threshold is NOT_SET
-            else resolve_threshold
+        assert result["resolveThreshold"] == (
+            alert_rule.resolve_threshold if resolve_threshold is NOT_SET else resolve_threshold
         )
         assert result["timeWindow"] == alert_rule.snuba_query.time_window / 60
         assert result["resolution"] == alert_rule.snuba_query.resolution / 60

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -9,9 +9,13 @@ from sentry.models import Rule
 from sentry.snuba.models import SnubaQueryEventType
 from sentry.testutils import APITestCase, TestCase
 
+NOT_SET = object()
+
 
 class BaseAlertRuleSerializerTest:
-    def assert_alert_rule_serialized(self, alert_rule, result, skip_dates=False):
+    def assert_alert_rule_serialized(
+        self, alert_rule, result, skip_dates=False, resolve_threshold=NOT_SET
+    ):
         alert_rule_projects = sorted(
             AlertRule.objects.filter(id=alert_rule.id).values_list(
                 "snuba_query__subscriptions__project__slug", flat=True
@@ -24,7 +28,11 @@ class BaseAlertRuleSerializerTest:
         assert result["query"] == alert_rule.snuba_query.query
         assert result["aggregate"] == alert_rule.snuba_query.aggregate
         assert result["thresholdType"] == alert_rule.threshold_type
-        assert result["resolveThreshold"] == alert_rule.resolve_threshold
+        assert (
+            result["resolveThreshold"] == alert_rule.resolve_threshold
+            if resolve_threshold is NOT_SET
+            else resolve_threshold
+        )
         assert result["timeWindow"] == alert_rule.snuba_query.time_window / 60
         assert result["resolution"] == alert_rule.snuba_query.resolution / 60
         assert result["thresholdPeriod"] == alert_rule.threshold_period
@@ -134,10 +142,17 @@ class AlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):
         self.assert_alert_rule_serialized(alert_rule, result)
         assert alert_rule.owner == self.team.actor
 
-    def test_comparison_delta(self):
-        alert_rule = self.create_alert_rule(comparison_delta=60)
+    def test_comparison_delta_above(self):
+        alert_rule = self.create_alert_rule(comparison_delta=60, resolve_threshold=110)
         result = serialize(alert_rule)
-        self.assert_alert_rule_serialized(alert_rule, result)
+        self.assert_alert_rule_serialized(alert_rule, result, resolve_threshold=10)
+
+    def test_comparison_delta_below(self):
+        alert_rule = self.create_alert_rule(
+            comparison_delta=60, resolve_threshold=90, threshold_type=AlertRuleThresholdType.BELOW
+        )
+        result = serialize(alert_rule)
+        self.assert_alert_rule_serialized(alert_rule, result, resolve_threshold=10)
 
 
 class DetailedAlertRuleSerializerTest(BaseAlertRuleSerializerTest, TestCase):

--- a/tests/sentry/api/serializers/test_alert_rule_trigger.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger.py
@@ -3,14 +3,20 @@ from sentry.api.serializers.models.alert_rule_trigger import DetailedAlertRuleTr
 from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.testutils import TestCase
 
+NOT_SET = object()
+
 
 class BaseAlertRuleTriggerSerializerTest:
-    def assert_alert_rule_trigger_serialized(self, trigger, result):
+    def assert_alert_rule_trigger_serialized(self, trigger, result, alert_threshold=NOT_SET):
         assert result["id"] == str(trigger.id)
         assert result["alertRuleId"] == str(trigger.alert_rule_id)
         assert result["label"] == trigger.label
         assert result["thresholdType"] == trigger.alert_rule.threshold_type
-        assert result["alertThreshold"] == trigger.alert_threshold
+        assert (
+            result["alertThreshold"] == trigger.alert_threshold
+            if alert_threshold is NOT_SET
+            else alert_threshold
+        )
         assert result["resolveThreshold"] == trigger.alert_rule.resolve_threshold
         assert result["dateCreated"] == trigger.date_added
 
@@ -27,6 +33,18 @@ class AlertRuleTriggerSerializerTest(BaseAlertRuleTriggerSerializerTest, TestCas
         trigger = create_alert_rule_trigger(alert_rule, "hi", 1000.50)
         result = serialize(trigger)
         self.assert_alert_rule_trigger_serialized(trigger, result)
+
+    def test_comparison_above(self):
+        alert_rule = self.create_alert_rule(comparison_delta=60)
+        trigger = create_alert_rule_trigger(alert_rule, "hi", 80)
+        result = serialize(trigger)
+        self.assert_alert_rule_trigger_serialized(trigger, result, 180)
+
+    def test_comparison_below(self):
+        alert_rule = self.create_alert_rule(comparison_delta=60)
+        trigger = create_alert_rule_trigger(alert_rule, "hi", 80)
+        result = serialize(trigger)
+        self.assert_alert_rule_trigger_serialized(trigger, result, 20)
 
 
 class DetailedAlertRuleTriggerSerializerTest(BaseAlertRuleTriggerSerializerTest, TestCase):

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -538,7 +538,7 @@ class TestAlertRuleSerializer(TestCase):
         params["triggers"][0]["alertThreshold"] = 50
         params["triggers"][1]["alertThreshold"] = 40
         serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
-        assert serializer.is_valid()
+        assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
         assert alert_rule.comparison_delta == 60 * 60
         assert alert_rule.resolve_threshold == 110
@@ -555,7 +555,7 @@ class TestAlertRuleSerializer(TestCase):
         params["triggers"][0]["alertThreshold"] = 50
         params["triggers"][1]["alertThreshold"] = 40
         serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
-        assert serializer.is_valid()
+        assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
         assert alert_rule.comparison_delta == 60 * 60
         assert alert_rule.resolve_threshold == 90
@@ -565,10 +565,13 @@ class TestAlertRuleSerializer(TestCase):
         assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
         params["comparison_delta"] = None
+        params["resolveThreshold"] = 100
+        params["triggers"][0]["alertThreshold"] = 40
+        params["triggers"][1]["alertThreshold"] = 50
         serializer = AlertRuleSerializer(
             context=self.context, instance=alert_rule, data=params, partial=True
         )
-        assert serializer.is_valid()
+        assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
         assert alert_rule.comparison_delta is None
         assert alert_rule.snuba_query.resolution == DEFAULT_ALERT_RULE_RESOLUTION * 60

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -531,13 +531,37 @@ class TestAlertRuleSerializer(TestCase):
         assert alert_rule.owner == self.user.actor
         assert alert_rule.owner.type == ACTOR_TYPES["user"]
 
-    def test_comparison_delta(self):
+    def test_comparison_delta_above(self):
         params = self.valid_params.copy()
         params["comparison_delta"] = 60
+        params["resolveThreshold"] = 10
+        params["triggers"][0]["alertThreshold"] = 50
+        params["triggers"][1]["alertThreshold"] = 40
         serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
         assert serializer.is_valid()
         alert_rule = serializer.save()
         assert alert_rule.comparison_delta == 60 * 60
+        assert alert_rule.resolve_threshold == 110
+        triggers = {trigger.label: trigger for trigger in alert_rule.alertruletrigger_set.all()}
+        assert triggers["critical"].alert_threshold == 150
+        assert triggers["warning"].alert_threshold == 140
+        assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
+
+    def test_comparison_delta_below(self):
+        params = self.valid_params.copy()
+        params["threshold_type"] = AlertRuleThresholdType.BELOW.value
+        params["comparison_delta"] = 60
+        params["resolveThreshold"] = 10
+        params["triggers"][0]["alertThreshold"] = 50
+        params["triggers"][1]["alertThreshold"] = 40
+        serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
+        assert serializer.is_valid()
+        alert_rule = serializer.save()
+        assert alert_rule.comparison_delta == 60 * 60
+        assert alert_rule.resolve_threshold == 90
+        triggers = {trigger.label: trigger for trigger in alert_rule.alertruletrigger_set.all()}
+        assert triggers["critical"].alert_threshold == 50
+        assert triggers["warning"].alert_threshold == 60
         assert alert_rule.snuba_query.resolution == DEFAULT_CMP_ALERT_RULE_RESOLUTION * 60
 
         params["comparison_delta"] = None


### PR DESCRIPTION
The frontend represents percentages as delta change percents. For example:
 - 30% increase
 - 40% decrease.

This makes sense from a user point of view, but doesn't fit as well into how our system handles
thesholds. For example, with decrease, if we had threshold like:

- critical at 40% below the comparison period
- resolve at 30% below the comparison period

This would fail our validation, since resolve thresholds on below alerts need to be greater than the
critical/warning thresholds. It also makes comparisons in the subscription processor more difficult.

To work around this, we convert these delta percents into comparison percents. This means that:

 - 30% increase -> 130% comparison percent
 - 40% decrease -> 60% comparison percent.

This fits well into our validation, since now if we have a decrease % alert like

- critical at 40% below the comparison period (60% of comparison period)
- resolve at 30% below the comparison period (70% of comparison period)

The resolve threshold is now higher than the critical, and validation will succeed.

Handling this complexity at the api layer seems to work the best, so that internally we can assume
that all of these threshold are comparison percents.

I also considered making increase deltas positive and decrease deltas negative, but I felt like this
reads weirdly in terms of our data schema (we'd have a below trigger that looks like < -30%, if you
just looked at the data).