### PR TITLE
fix(dynamic-sampling): Fix sampling rule not remembering  trace flag - INGEST-411

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -129,7 +129,7 @@ class BaseButton extends React.Component<ButtonProps, {}> {
     // Doing this instead of using `Tooltip`'s `disabled` prop so that we can minimize snapshot nesting
     if (title) {
       return (
-        <Tooltip skipWrapper {...tooltipProps} title={title}>
+        <Tooltip skipWrapper={!disabled} {...tooltipProps} title={title}>
           {button}
         </Tooltip>
       );

--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -6,6 +6,7 @@ import {IconDelete} from 'app/icons/iconDelete';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {DynamicSamplingInnerName, LegacyBrowser} from 'app/types/dynamicSampling';
+import FieldRequiredBadge from 'app/views/settings/components/forms/field/fieldRequiredBadge';
 import TextareaField from 'app/views/settings/components/forms/textareaField';
 
 import {getInnerNameLabel} from '../utils';
@@ -44,7 +45,12 @@ function Conditions({conditions, onDelete, onChange}: Props) {
 
         return (
           <ConditionWrapper key={index}>
-            <LeftCell>{getInnerNameLabel(category)}</LeftCell>
+            <LeftCell>
+              <span>
+                {getInnerNameLabel(category)}
+                <FieldRequiredBadge />
+              </span>
+            </LeftCell>
             <CenterCell>
               {!isABooleanField && (
                 <StyledTextareaField
@@ -108,6 +114,7 @@ const Cell = styled('div')`
 
 const LeftCell = styled(Cell)`
   padding-right: ${space(2)};
+  line-height: 16px;
 `;
 
 const CenterCell = styled(Cell)`

--- a/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
@@ -279,6 +279,7 @@ function RuleModal({
           <Button
             priority="primary"
             onClick={() => onSubmit({conditions, sampleRate, submitRules})}
+            title={submitDisabled ? t('Required fields must be filled out') : undefined}
             disabled={submitDisabled}
           >
             {t('Save Rule')}

--- a/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
@@ -53,10 +53,6 @@ function TransactionRuleModal({
     !!rule?.condition.inner.length
   );
 
-  if (rule) {
-    const x = rule.condition;
-  }
-
   function handleChange({
     conditions,
   }: Parameters<NonNullable<RuleModalProps['onChange']>>[0]) {

--- a/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
@@ -48,8 +48,14 @@ function TransactionRuleModal({
   theme,
   ...props
 }: Props) {
-  const [tracing, setTracing] = useState(true);
-  const [isTracingDisabled, setIsTracingDisabled] = useState(false);
+  const [tracing, setTracing] = useState(rule?.type === DynamicSamplingRuleType.TRACE);
+  const [isTracingDisabled, setIsTracingDisabled] = useState(
+    !!rule?.condition.inner.length
+  );
+
+  if (rule) {
+    const x = rule.condition;
+  }
 
   function handleChange({
     conditions,
@@ -138,7 +144,6 @@ function TransactionRuleModal({
       extraFields={
         <Field
           label={t('Tracing')}
-          // help={t('this is a description')} // TODO(Priscila): Add correct descriptions
           inline={false}
           flexibleControlStateSize
           stacked

--- a/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
@@ -48,7 +48,10 @@ function TransactionRuleModal({
   theme,
   ...props
 }: Props) {
-  const [tracing, setTracing] = useState(rule?.type === DynamicSamplingRuleType.TRACE);
+  const [tracing, setTracing] = useState(
+    rule ? rule.type === DynamicSamplingRuleType.TRACE : true
+  );
+
   const [isTracingDisabled, setIsTracingDisabled] = useState(
     !!rule?.condition.inner.length
   );

--- a/static/app/views/settings/project/filtersAndSampling/rules/rule/index.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rules/rule/index.tsx
@@ -121,6 +121,7 @@ const Column = styled('div')`
   align-items: center;
   padding: ${space(2)};
   cursor: default;
+  white-space: pre-wrap;
 `;
 
 const GrabColumn = styled(Column)`

--- a/static/app/views/settings/project/filtersAndSampling/rulesPanel.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/rulesPanel.tsx
@@ -36,7 +36,7 @@ function RulesPanel({
         emptyMessage={t('There are no %s rules to display', panelType)}
       />
       <StyledPanelFooter>
-        <ButtonBar gap={1}>
+        <StyledButtonBar gap={1}>
           <Button href={DYNAMIC_SAMPLING_DOC_LINK} external>
             {t('Read the docs')}
           </Button>
@@ -52,7 +52,7 @@ function RulesPanel({
           >
             {t('Add %s rule', panelType)}
           </Button>
-        </ButtonBar>
+        </StyledButtonBar>
       </StyledPanelFooter>
     </Panel>
   );
@@ -62,7 +62,16 @@ export default RulesPanel;
 
 const StyledPanelFooter = styled(PanelFooter)`
   padding: ${space(1)} ${space(2)};
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    grid-auto-flow: row;
+    grid-row-gap: ${space(1)};
+  }
 `;


### PR DESCRIPTION
- [x] Fix sampling rule not remembering trace flag 

Before:

![image](https://user-images.githubusercontent.com/29228205/134532043-ab8e443e-6956-4295-8573-21ac8a6a1491.png)

After:
![image](https://user-images.githubusercontent.com/29228205/134531666-b8fa5a4f-01e0-496b-9a71-e988bd19e4f2.png)


- [x] Display a message saying why the button is disabled

![image](https://user-images.githubusercontent.com/29228205/134525170-424f0b9e-a6d4-45a9-80eb-9911157362a7.png)


- [x] Fix buttons/overlap on smaller screens

Before:

![image](https://user-images.githubusercontent.com/29228205/134531892-14c59167-5b04-4143-8bac-0741353ce07d.png)


After:

![image](https://user-images.githubusercontent.com/29228205/134530441-5973c738-bc86-4006-bcb5-03f545c751f1.png)


- [x] Fix buttons/overlap on smaller screens

closes: INGEST-411