### PR TITLE
fix(ui): Remove % from failure rate alert threshold

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/form.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/form.tsx
@@ -142,7 +142,6 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
     }
 
     if (
-      aggregate.includes('failure_rate') ||
       aggregate === SessionsAggregate.CRASH_FREE_SESSIONS ||
       aggregate === SessionsAggregate.CRASH_FREE_USERS
     ) {


### PR DESCRIPTION
Removing the `%` from failure rate alert threshold placeholder as it's not really in range 0-100, but rather 0-1.

The better long-term solution would be to transform it on the frontend so that it's more intuitive. This will require further discussion.