### PR TITLE
chore(chart-unfurl): Revert Project permissions warning

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -54,13 +54,6 @@ setup_alert = {
     "text": "The Slack integration adds a new Alert Rule action to all projects. To enable automatic notifications sent to Slack you must create a rule using the slack workspace action in your project settings.",
 }
 
-discover_unfurl_alert = {
-    "type": "warning",
-    "text": "Project permissions will not apply when unfurling Sentry Discover charts from within your Slack workspace.",
-    "icon": "icon-warning-sm",
-    "feature": "chart-unfurls",
-}
-
 metadata = IntegrationMetadata(
     description=_(DESCRIPTION.strip()),
     features=FEATURES,
@@ -68,7 +61,7 @@ metadata = IntegrationMetadata(
     noun=_("Workspace"),
     issue_url="https://github.com/getsentry/sentry/issues/new?assignees=&labels=Component:%20Integrations&template=bug.yml&title=Slack%20Integration%20Problem",
     source_url="https://github.com/getsentry/sentry/tree/master/src/sentry/integrations/slack",
-    aspects={"alerts": [setup_alert, discover_unfurl_alert]},
+    aspects={"alerts": [setup_alert]},
 )
 
 

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -20,7 +20,6 @@ import {
   IntegrationType,
   Organization,
 } from 'app/types';
-import {defined} from 'app/utils';
 import {
   IntegrationAnalyticsKey,
   IntegrationEventParameters,
@@ -40,7 +39,6 @@ type Tab = 'overview' | 'configurations';
 
 type AlertType = React.ComponentProps<typeof Alert> & {
   text: string;
-  feature?: string;
 };
 
 type State = {
@@ -331,19 +329,13 @@ class AbstractIntegrationDetailedView<
               provider={{key: this.props.params.integrationSlug}}
             />
             {this.renderPermissions()}
-            {this.alerts.map((alert, i) => {
-              return (
-                (defined(alert.feature)
-                  ? this.props.organization.features.includes(alert.feature)
-                  : true) && (
-                  <Alert key={i} type={alert.type} icon={alert.icon}>
-                    <span
-                      dangerouslySetInnerHTML={{__html: singleLineRenderer(alert.text)}}
-                    />
-                  </Alert>
-                )
-              );
-            })}
+            {this.alerts.map((alert, i) => (
+              <Alert key={i} type={alert.type} icon={alert.icon}>
+                <span
+                  dangerouslySetInnerHTML={{__html: singleLineRenderer(alert.text)}}
+                />
+              </Alert>
+            ))}
           </FlexContainer>
           <Metadata>
             {!!this.author && (


### PR DESCRIPTION
We now prompt users to link their Slack identity to
Sentry which we use to honour project permissions.
This warning no longer applies. Revert of #28371

Before
![before](https://user-images.githubusercontent.com/63818634/134556132-79b973ab-af63-49b0-9ded-0d106479b8ec.png)
After
![Screen Shot 2021-09-23 at 1 32 55 PM](https://user-images.githubusercontent.com/63818634/134556067-ab4ab17e-d98f-4be6-9a54-332644a0da3d.png)
