### PR TITLE
fix(alert-rules): Set the correct default value for new SelectControl

### DIFF
--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -71,7 +71,9 @@ class RuleNode extends React.Component<Props> {
           initialVal = fieldConfig.choices[0][0];
         }
       } else {
-        initialVal = data[name];
+        initialVal = isNaN(parseInt(data[name] as string, 10))
+          ? parseInt(data[name] as string, 10)
+          : data[name];
       }
     }
 
@@ -90,7 +92,6 @@ class RuleNode extends React.Component<Props> {
         onPropertyChange(index, name, value);
       }
     };
-
     return (
       <InlineSelectControl
         isClearable={false}

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -72,8 +72,8 @@ class RuleNode extends React.Component<Props> {
         }
       } else {
         initialVal = isNaN(parseInt(data[name] as string, 10))
-          ? parseInt(data[name] as string, 10)
-          : data[name];
+          ? data[name]
+          : parseInt(data[name] as string, 10);
       }
     }
 


### PR DESCRIPTION
Fixes a bug preventing defaults from showing up in Select Control dropdowns:

Before: 
![Screen Shot 2021-09-23 at 1 49 38 PM](https://user-images.githubusercontent.com/35509934/134558335-dd28f63e-460c-4b85-85e4-41ec68d0cf9d.png)

After:
![image](https://user-images.githubusercontent.com/35509934/134558201-80169534-1a22-46a3-9b29-5899e0645cb2.png)

**Demo**

Workflow is unaffected:
https://user-images.githubusercontent.com/35509934/134570235-412ae4ff-90d9-4ef5-83c3-07b125bfd73c.mov

Updates are reflected and deleting still works:
https://user-images.githubusercontent.com/35509934/134570483-95af5754-12e5-4c6b-933a-27e6dffedd41.mov


