### PR TITLE
feat(perf): Add page error context

### DIFF
--- a/static/app/utils/performance/contexts/pageError.tsx
+++ b/static/app/utils/performance/contexts/pageError.tsx
@@ -1,0 +1,41 @@
+import {createContext, useContext, useState} from 'react';
+
+import Alert from 'app/components/alert';
+import {IconFlag} from 'app/icons';
+
+const pageErrorContext = createContext<{
+  pageError?: string;
+  setPageError: (error: string | undefined) => void;
+}>({
+  pageError: undefined,
+  setPageError: (_: string | undefined) => {},
+});
+
+export const PageErrorProvider = ({children}: {children: React.ReactNode}) => {
+  const [pageError, setPageError] = useState<string | undefined>();
+  return (
+    <pageErrorContext.Provider
+      value={{
+        pageError,
+        setPageError,
+      }}
+    >
+      {children}
+    </pageErrorContext.Provider>
+  );
+};
+
+export const PageErrorAlert = () => {
+  const {pageError} = useContext(pageErrorContext);
+  if (!pageError) {
+    return null;
+  }
+
+  return (
+    <Alert type="error" icon={<IconFlag size="md" />}>
+      {pageError}
+    </Alert>
+  );
+};
+
+export const usePageError = () => useContext(pageErrorContext);

--- a/tests/js/spec/utils/performance/contexts/pageError.spec.jsx
+++ b/tests/js/spec/utils/performance/contexts/pageError.spec.jsx
@@ -1,0 +1,42 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
+
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+  usePageError,
+} from 'app/utils/performance/contexts/pageError';
+
+function SimpleErrorButton() {
+  const context = usePageError();
+  return (
+    <button
+      data-test-id="pageErrorButton"
+      onClick={() => context.setPageError('Fresh new error')}
+    />
+  );
+}
+
+describe('Performance > Contexts > pageError', function () {
+  const {routerContext} = initializeOrg({
+    router: {orgId: 'orgId'},
+  });
+
+  it('Check that pageError context will render error alert', async function () {
+    const wrapper = mountWithTheme(
+      <PageErrorProvider>
+        <div data-test-id="errorAlert">
+          <PageErrorAlert />
+        </div>
+        <SimpleErrorButton />
+      </PageErrorProvider>,
+      {context: routerContext}
+    );
+
+    const button = await wrapper.findByTestId('pageErrorButton');
+
+    await fireEvent.click(button);
+
+    expect(await wrapper.findByTestId('errorAlert')).toHaveTextContent('Fresh new error');
+  });
+});


### PR DESCRIPTION
### Summary
Splitting off more pieces from the perf. landing v3. This is just a page error context which can be used without drilling setError everywhere. Added a simple test so it's not just implicitly tested.