### PR TITLE
feat(perf): Add tables to all tabs in landing v3

### DIFF
--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -1,5 +1,13 @@
+import {usePageError} from 'app/utils/performance/contexts/pageError';
+
+import Table from '../../table';
+
 import {BasePerformanceViewProps} from './types';
 
-export function AllTransactionsView(_: BasePerformanceViewProps) {
-  return <div />;
+export function AllTransactionsView(props: BasePerformanceViewProps) {
+  return (
+    <div>
+      <Table {...props} setError={usePageError().setPageError} />
+    </div>
+  );
 }

--- a/static/app/views/performance/landing/views/backendView.tsx
+++ b/static/app/views/performance/landing/views/backendView.tsx
@@ -1,5 +1,18 @@
+import {usePageError} from 'app/utils/performance/contexts/pageError';
+
+import Table from '../../table';
+import {BACKEND_COLUMN_TITLES} from '../data';
+
 import {BasePerformanceViewProps} from './types';
 
-export function BackendView(_: BasePerformanceViewProps) {
-  return <div />;
+export function BackendView(props: BasePerformanceViewProps) {
+  return (
+    <div>
+      <Table
+        {...props}
+        columnTitles={BACKEND_COLUMN_TITLES}
+        setError={usePageError().setPageError}
+      />
+    </div>
+  );
 }

--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -1,5 +1,18 @@
+import {usePageError} from 'app/utils/performance/contexts/pageError';
+
+import Table from '../../table';
+import {FRONTEND_OTHER_COLUMN_TITLES} from '../data';
+
 import {BasePerformanceViewProps} from './types';
 
-export function FrontendOtherView(_: BasePerformanceViewProps) {
-  return <div />;
+export function FrontendOtherView(props: BasePerformanceViewProps) {
+  return (
+    <div>
+      <Table
+        {...props}
+        columnTitles={FRONTEND_OTHER_COLUMN_TITLES}
+        setError={usePageError().setPageError}
+      />
+    </div>
+  );
 }

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -1,5 +1,18 @@
+import {usePageError} from 'app/utils/performance/contexts/pageError';
+
+import Table from '../../table';
+import {FRONTEND_PAGELOAD_COLUMN_TITLES} from '../data';
+
 import {BasePerformanceViewProps} from './types';
 
-export function FrontendPageloadView(_: BasePerformanceViewProps) {
-  return <div data-test-id="frontend-pageload-view" />;
+export function FrontendPageloadView(props: BasePerformanceViewProps) {
+  return (
+    <div data-test-id="frontend-pageload-view">
+      <Table
+        {...props}
+        columnTitles={FRONTEND_PAGELOAD_COLUMN_TITLES}
+        setError={usePageError().setPageError}
+      />
+    </div>
+  );
 }

--- a/static/app/views/performance/landing/views/mobileView.tsx
+++ b/static/app/views/performance/landing/views/mobileView.tsx
@@ -1,5 +1,18 @@
+import {usePageError} from 'app/utils/performance/contexts/pageError';
+
+import Table from '../../table';
+import {MOBILE_COLUMN_TITLES} from '../data';
+
 import {BasePerformanceViewProps} from './types';
 
-export function MobileView(_: BasePerformanceViewProps) {
-  return <div />;
+export function MobileView(props: BasePerformanceViewProps) {
+  return (
+    <div>
+      <Table
+        {...props}
+        columnTitles={MOBILE_COLUMN_TITLES} // TODO(k-fish): Add react native column titles
+        setError={usePageError().setPageError}
+      />
+    </div>
+  );
 }

--- a/static/app/views/performance/landing/views/types.tsx
+++ b/static/app/views/performance/landing/views/types.tsx
@@ -1,1 +1,11 @@
-export type BasePerformanceViewProps = {};
+import {Location} from 'history';
+
+import {Organization, Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+
+export type BasePerformanceViewProps = {
+  eventView: EventView;
+  location: Location;
+  projects: Project[];
+  organization: Organization;
+};

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -54,7 +54,7 @@ type Props = {
   organization: Organization;
   location: Location;
   setError: (msg: string | undefined) => void;
-  summaryConditions: string;
+  summaryConditions?: string;
 
   projects: Project[];
   columnTitles?: string[];
@@ -66,7 +66,7 @@ type State = {
   transactionThreshold: number | undefined;
   transactionThresholdMetric: TransactionThresholdMetric | undefined;
 };
-class Table extends React.Component<Props, State> {
+class _Table extends React.Component<Props, State> {
   state: State = {
     widths: [],
     transaction: undefined,
@@ -443,6 +443,13 @@ class Table extends React.Component<Props, State> {
       </div>
     );
   }
+}
+
+function Table(props: Omit<Props, 'summaryConditions'> & {summaryConditions?: string}) {
+  const summaryConditions =
+    props.summaryConditions ?? props.eventView.getQueryWithAdditionalConditions();
+
+  return <_Table {...props} summaryConditions={summaryConditions} />;
 }
 
 export default Table;

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -110,5 +110,59 @@ describe('Performance > Landing > Index', function () {
     expect(wrapper.find('div[data-test-id="frontend-pageload-view"]').exists()).toBe(
       true
     );
+
+    expect(wrapper.find('Table').exists()).toBe(true);
+  });
+
+  it('renders frontend other view', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.FRONTEND_OTHER},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('Table').exists()).toBe(true);
+  });
+
+  it('renders backend view', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.BACKEND},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('Table').exists()).toBe(true);
+  });
+
+  it('renders mobile view', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.MOBILE},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('Table').exists()).toBe(true);
+  });
+
+  it('renders all transactions view', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.ALL},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('Table').exists()).toBe(true);
   });
 });


### PR DESCRIPTION
### Summary
This just adds the tables with their columns for all the landing v3 tables. The mobile tab still needs the react native check, but that can be addressed when I get to filling the rest of that tab out. Makes `summaryConditions` optional with an FC wrapper, which I'll likely add `usePageError` to as well in the future, but for now I don't want to change too much. Also adds basic tests for all the tabs.