### PR TITLE
fix(slack): Unlink Identity

### DIFF
--- a/src/sentry/integrations/msteams/link_identity.py
+++ b/src/sentry/integrations/msteams/link_identity.py
@@ -4,7 +4,9 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
 
+from sentry.integrations.utils import get_identity_or_404
 from sentry.models import Identity, IdentityStatus
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign, unsign
 from sentry.web.decorators import transaction_start
@@ -13,7 +15,6 @@ from sentry.web.helpers import render_to_response
 
 from .card_builder import build_linked_card
 from .client import MsTeamsClient
-from .utils import get_identity
 
 
 def build_linking_url(integration, organization, teams_user_id, team_id, tenant_id):
@@ -42,8 +43,11 @@ class MsTeamsLinkIdentityView(BaseView):
                 request=request,
             )
 
-        organization, integration, idp = get_identity(
-            request.user, params["organization_id"], params["integration_id"]
+        organization, integration, idp = get_identity_or_404(
+            ExternalProviders.MSTEAMS,
+            request.user,
+            integration_id=params["integration_id"],
+            organization_id=params["organization_id"],
         )
 
         if request.method != "POST":

--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -268,7 +268,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
                 if e.status_code == 403:
                     text = UNLINK_IDENTITY_MESSAGE.format(
                         associate_url=build_unlinking_url(
-                            integration.id, group.organization.id, user_id, channel_id, response_url
+                            integration.id, user_id, channel_id, response_url
                         ),
                         user_email=identity.user,
                         org_name=group.organization.name,
@@ -319,7 +319,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
             if e.status_code == 403:
                 text = UNLINK_IDENTITY_MESSAGE.format(
                     associate_url=build_unlinking_url(
-                        integration.id, group.organization.id, user_id, channel_id, response_url
+                        integration.id, user_id, channel_id, response_url
                     ),
                     user_email=identity.user,
                     org_name=group.organization.name,

--- a/src/sentry/integrations/slack/endpoints/base.py
+++ b/src/sentry/integrations/slack/endpoints/base.py
@@ -76,10 +76,8 @@ class SlackDMEndpoint(Endpoint, abc.ABC):  # type: ignore
             return self.reply(slack_request, NOT_LINKED_MESSAGE)
 
         integration = slack_request.integration
-        organization = integration.organizations.all()[0]
         associate_url = build_unlinking_url(
             integration_id=integration.id,
-            organization_id=organization.id,
             slack_id=slack_request.user_id,
             channel_id=slack_request.channel_id,
             response_url=slack_request.response_url,

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -4,13 +4,14 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.integrations.utils import get_identity_or_404
 from sentry.models import Identity, IdentityStatus, Integration, Organization
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
-from ..utils import get_identity
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, send_slack_response
 
@@ -48,8 +49,11 @@ class SlackLinkIdentityView(BaseView):  # type: ignore
                 request=request,
             )
 
-        organization, integration, idp = get_identity(
-            request.user, params["organization_id"], params["integration_id"]
+        organization, integration, idp = get_identity_or_404(
+            ExternalProviders.SLACK,
+            request.user,
+            integration_id=params["integration_id"],
+            organization_id=params["organization_id"],
         )
 
         if request.method != "POST":

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -4,13 +4,15 @@ from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.integrations.utils import get_identity_or_404
 from sentry.models import Identity
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.signing import unsign
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
-from ..utils import get_identity, logger
+from ..utils import logger
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, send_slack_response
 
@@ -42,8 +44,11 @@ class SlackUnlinkIdentityView(BaseView):  # type: ignore
                 request=request,
             )
 
-        organization, integration, idp = get_identity(
-            request.user, params["organization_id"], params["integration_id"]
+        organization, integration, idp = get_identity_or_404(
+            ExternalProviders.SLACK,
+            request.user,
+            integration_id=params["integration_id"],
+            organization_id=params["organization_id"],
         )
 
         if request.method != "POST":

--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -20,12 +20,11 @@ SUCCESS_UNLINKED_MESSAGE = "Your Slack identity has been unlinked from your Sent
 
 
 def build_unlinking_url(
-    integration_id: str, organization_id: str, slack_id: str, channel_id: str, response_url: str
+    integration_id: str, slack_id: str, channel_id: str, response_url: str
 ) -> str:
     return base_build_linking_url(
         "sentry-integration-slack-unlink-identity",
         integration_id=integration_id,
-        organization_id=organization_id,
         slack_id=slack_id,
         channel_id=channel_id,
         response_url=response_url,
@@ -48,7 +47,6 @@ class SlackUnlinkIdentityView(BaseView):  # type: ignore
             ExternalProviders.SLACK,
             request.user,
             integration_id=params["integration_id"],
-            organization_id=params["organization_id"],
         )
 
         if request.method != "POST":

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -3,6 +3,7 @@ from django.http import Http404
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.integrations.utils import get_identity_or_404
 from sentry.models import (
     ExternalActor,
     Identity,
@@ -17,7 +18,7 @@ from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
-from ..utils import get_identity, logger, render_error_page, send_confirmation
+from ..utils import logger, render_error_page, send_confirmation
 from . import build_linking_url as base_build_linking_url
 from . import never_cache
 
@@ -58,8 +59,11 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
                 request=request,
             )
 
-        organization, integration, idp = get_identity(
-            request.user, params["organization_id"], params["integration_id"]
+        organization, integration, idp = get_identity_or_404(
+            ExternalProviders.SLACK,
+            request.user,
+            integration_id=params["integration_id"],
+            organization_id=params["organization_id"],
         )
         channel_name = params["channel_name"]
         channel_id = params["channel_id"]

--- a/src/sentry/integrations/utils/__init__.py
+++ b/src/sentry/integrations/utils/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ("get_identity_or_404", "get_identities_by_user")
+
+from .identities import get_identities_by_user, get_identity_or_404

--- a/src/sentry/integrations/utils/identities.py
+++ b/src/sentry/integrations/utils/identities.py
@@ -1,0 +1,47 @@
+from typing import Iterable, Mapping, Optional, Tuple
+
+from django.http import Http404
+
+from sentry.models import (
+    Identity,
+    IdentityProvider,
+    IdentityStatus,
+    Integration,
+    Organization,
+    User,
+)
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+
+
+def get_identity_or_404(
+    provider: ExternalProviders,
+    user: User,
+    integration_id: int,
+    organization_id: Optional[int] = None,
+) -> Tuple[Organization, Integration, IdentityProvider]:
+    """For endpoints, short-circuit with a 404 if we cannot find everything we need."""
+    try:
+        integration = Integration.objects.get(id=integration_id)
+        idp = IdentityProvider.objects.get(
+            external_id=integration.external_id, type=EXTERNAL_PROVIDERS[provider]
+        )
+        organization_filters = dict(
+            member_set__user=user,
+            organizationintegration__integration=integration,
+        )
+        # If provided, ensure organization_id is valid.
+        if organization_id:
+            organization_filters.update(dict(id=organization_id))
+        organization = Organization.objects.filter(**organization_filters)[0]
+    except Exception:
+        raise Http404
+    return organization, integration, idp
+
+
+def get_identities_by_user(idp: IdentityProvider, users: Iterable[User]) -> Mapping[User, Identity]:
+    identity_models = Identity.objects.filter(
+        idp=idp,
+        user__in=users,
+        status=IdentityStatus.VALID,
+    )
+    return {identity.user: identity for identity in identity_models}

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -59,11 +59,9 @@ OrganizationStatus._labels = {
 class OrganizationManager(BaseManager):
     def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
         """Returns the QuerySet of all organizations that a set of Users have access to."""
-        from sentry.models import OrganizationMember
-
         return self.filter(
             status=OrganizationStatus.VISIBLE,
-            id__in=OrganizationMember.objects.filter(user_id__in=user_ids).values("organization"),
+            member_set__user_id__in=user_ids,
         )
 
     def get_for_team_ids(self, team_ids: Sequence[int]) -> QuerySet:

--- a/tests/sentry/integrations/slack/endpoints/test_action.py
+++ b/tests/sentry/integrations/slack/endpoints/test_action.py
@@ -310,7 +310,7 @@ class StatusActionTest(BaseEventTest):
         self.group = Group.objects.get(id=self.group.id)
 
         associate_url = build_unlinking_url(
-            self.integration.id, self.organization.id, "slack_id2", "C065W1189", self.response_url
+            self.integration.id, "slack_id2", "C065W1189", self.response_url
         )
 
         assert resp.status_code == 200, resp.content
@@ -375,11 +375,7 @@ class StatusActionTest(BaseEventTest):
         # client_put.assert_called()
 
         associate_url = build_unlinking_url(
-            self.integration.id,
-            self.organization.id,
-            self.external_id,
-            "C065W1189",
-            self.response_url,
+            self.integration.id, self.external_id, "C065W1189", self.response_url
         )
 
         assert resp.status_code == 200, resp.content

--- a/tests/sentry/integrations/slack/endpoints/test_commands.py
+++ b/tests/sentry/integrations/slack/endpoints/test_commands.py
@@ -200,7 +200,6 @@ class SlackCommandsLinkUserTest(SlackCommandsTest):
 
         unlinking_url = build_unlinking_url(
             self.integration.id,
-            self.organization.id,
             "UXXXXXXX1",
             "CXXXXXXX9",
             "http://example.slack.com/response_url",

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -87,8 +87,6 @@ class SlackIntegrationUnlinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
 
         self.unlinking_url = build_unlinking_url(
             self.integration.id,
-            # TODO(mgaeta): Remove parameter.
-            self.organization.id,
             self.external_id,
             self.channel_id,
             self.response_url,

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -2,7 +2,7 @@ import responses
 
 from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.integrations.slack.views.unlink_identity import build_unlinking_url
-from sentry.models import Identity, IdentityStatus
+from sentry.models import Identity, IdentityStatus, OrganizationIntegration
 from sentry.testutils import TestCase
 from tests.sentry.integrations.slack import add_identity, install_slack
 
@@ -98,6 +98,18 @@ class SlackIntegrationUnlinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         response = self.client.get(self.unlinking_url)
         assert response.status_code == 200
         self.assertTemplateUsed(response, "sentry/auth-unlink-identity.html")
+
+        # Unlink identity of user.
+        self.client.post(self.unlinking_url)
+        assert not Identity.objects.filter(external_id="new-slack-id", user=self.user).exists()
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_user_with_multiple_organizations(self):
+        # Create a second organization where the user is _not_ a member.
+        OrganizationIntegration.objects.create(
+            organization=self.create_organization(name="Another Org"), integration=self.integration
+        )
 
         # Unlink identity of user.
         self.client.post(self.unlinking_url)


### PR DESCRIPTION
It looks like the wrong organization_id is passed as a signed parameter. When the page loads the user doesn't have access to the organization so the page 404s. This PR removes the organization from the url and infers it from the user and integration.