### PR TITLE
fix(semver): Fix failed semver search in issue search/discover when negative search returns too many results

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -88,11 +88,13 @@ MAX_QUERYABLE_TRANSACTION_THRESHOLDS = 500
 
 OPERATOR_NEGATION_MAP = {
     "=": "!=",
+    "!=": "=",
     "<": ">=",
     "<=": ">",
     ">": "<=",
     ">=": "<",
     "IN": "NOT IN",
+    "NOT IN": "IN",
 }
 OPERATOR_TO_DJANGO = {">=": "gte", "<=": "lte", ">": "gt", "<": "lt", "=": "exact"}
 

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -1634,6 +1634,7 @@ class SemverFilterConverterTest(BaseSemverConverterTest, TestCase):
             self.run_test(">=", "1.2.4", "NOT IN", [release.version])
             self.run_test("<", "1.2.5", "NOT IN", [release_2.version])
             self.run_test("<=", "1.2.4", "NOT IN", [release_2.version])
+            self.run_test("!=", "1.2.3", "NOT IN", [release.version])
 
     def test_invert_fails(self):
         # Tests that when we invert and still receive too many records that we return

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -829,6 +829,24 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             release_1_e_2,
         }
 
+        query = {"field": ["id"], "query": f"{SEMVER_ALIAS}:1.2.3"}
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert {r["id"] for r in response.data["data"]} == {
+            release_1_e_1,
+            release_1_e_2,
+        }
+
+        query = {"field": ["id"], "query": f"!{SEMVER_ALIAS}:1.2.3"}
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert {r["id"] for r in response.data["data"]} == {
+            release_2_e_1,
+            release_2_e_2,
+            release_3_e_1,
+            release_3_e_2,
+        }
+
     def test_release_stage(self):
         replaced_release = self.create_release(
             version="replaced_release", environments=[self.environment]


### PR DESCRIPTION
This fixes a bug when using negative search on semver. When we filter, we fetch up to 1000 releases.
For any org with over 1000 releases, we'll fall  back to flipping the search around to fetching the release
and using `NOT IN` for the snuba query. This fails since the operator negation map doesn't define `!=` 
and `NOT IN` in the negation map.
