### PR TITLE
fix(alert-rules): Use the data default value for time selectors in SelectControl

### DIFF
--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -71,7 +71,11 @@ class RuleNode extends React.Component<Props> {
           initialVal = fieldConfig.choices[0][0];
         }
       } else {
-        initialVal = data[name];
+        initialVal =
+          /\d+[smhdwy]$/i.test(data[name] as string) ||
+          isNaN(parseInt(data[name] as string, 10))
+            ? data[name]
+            : parseInt(data[name] as string, 10);
       }
     }
 


### PR DESCRIPTION
We've changed the selector value assignment in https://github.com/getsentry/sentry/pull/28804

This restores back using the `data[name]` in time selectors, since the have values such as: `'1m', '1y', '30d', '2w'` they get parsed to int and name-value pairs are not usable in time/period/interval selectors.

Before (prod):

https://user-images.githubusercontent.com/15015880/134607817-9d1283ef-d80f-455a-872c-12ae7dae7c86.mov


After:


https://user-images.githubusercontent.com/15015880/134607901-23e8bf28-7220-4dcd-9625-242ffd2bb0a5.mov



