### PR TITLE
fix(release-archives): Do not attempt to cache large ZIP files 

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -51,6 +51,13 @@ register(
     flags=FLAG_PRIORITIZE_DISK,
 )
 register("releasefile.cache-limit", type=Int, default=10 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
+register(
+    "releasefile.cache-max-archive-size",
+    type=Int,
+    default=1024 * 1024 * 1024,
+    flags=FLAG_PRIORITIZE_DISK,
+)
+
 
 # Mail
 register("mail.backend", default="smtp", flags=FLAG_NOSTORE)

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -33,6 +33,7 @@ from sentry.lang.javascript.processor import (
 from sentry.models import EventError, File, Release, ReleaseFile
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, update_artifact_index
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.utils.compat.mock import ANY, MagicMock, call, patch
 from sentry.utils.strings import truncatechars
@@ -578,6 +579,27 @@ class FetchFileTest(TestCase):
         result2 = fetch_file("/example.js", release=release)
         assert result2 == result
 
+    def _create_archive(self, release, url):
+        pseudo_archive = File.objects.create(name="", type="release.bundle")
+        pseudo_archive.putfile(BytesIO(b"0123456789"))
+        releasefile = ReleaseFile.objects.create(
+            name=pseudo_archive.name,
+            release_id=release.id,
+            organization_id=self.organization.id,
+            dist_id=None,
+            file=pseudo_archive,
+        )
+        file = File.objects.create(name=ARTIFACT_INDEX_FILENAME, type="release.artifact-index")
+        file.putfile(
+            BytesIO(json.dumps({"files": {url: {"archive_ident": releasefile.ident}}}).encode())
+        )
+        ReleaseFile.objects.create(
+            name=ARTIFACT_INDEX_FILENAME,
+            release_id=release.id,
+            organization_id=self.project.organization_id,
+            file=file,
+        )
+
     @patch("sentry.lang.javascript.processor.cache.set", side_effect=cache.set)
     @patch("sentry.lang.javascript.processor.cache.get", side_effect=cache.get)
     def test_archive_caching(self, cache_get, cache_set):
@@ -613,27 +635,8 @@ class FetchFileTest(TestCase):
         cache_set.reset_mock()
 
         # With existing release file:
-
         release2 = Release.objects.create(version="2", organization_id=self.project.organization_id)
-        pseudo_archive = File.objects.create(name="", type="release.bundle")
-        pseudo_archive.putfile(BytesIO(b"i_am_an_archive"))
-        releasefile = ReleaseFile.objects.create(
-            name=pseudo_archive.name,
-            release_id=release2.id,
-            organization_id=self.organization.id,
-            dist_id=None,
-            file=pseudo_archive,
-        )
-        file = File.objects.create(name=ARTIFACT_INDEX_FILENAME, type="release.artifact-index")
-        file.putfile(
-            BytesIO(json.dumps({"files": {"foo": {"archive_ident": releasefile.ident}}}).encode())
-        )
-        ReleaseFile.objects.create(
-            name=ARTIFACT_INDEX_FILENAME,
-            release_id=release2.id,
-            organization_id=self.project.organization_id,
-            file=file,
-        )
+        self._create_archive(release2, "foo")
 
         # No we have one, call set again
         result = fetch_release_archive_for_url(release2, dist=None, url="foo")
@@ -667,7 +670,7 @@ class FetchFileTest(TestCase):
 
     @patch("sentry.lang.javascript.processor.CACHE_MAX_VALUE_SIZE", 9)
     @patch("sentry.lang.javascript.processor.cache.set", side_effect=cache.set)
-    def test_archive_too_large_for_cache(self, cache_set):
+    def test_archive_too_large_for_mem_cache(self, cache_set):
         """cache.set is never called if the archive is too large"""
 
         def relevant_calls(mock, prefix):
@@ -680,30 +683,42 @@ class FetchFileTest(TestCase):
             ]
 
         release = Release.objects.create(version="1", organization_id=self.project.organization_id)
-        pseudo_archive = File.objects.create(name="", type="release.bundle")
-        pseudo_archive.putfile(BytesIO(b"0123456789"))
-        releasefile = ReleaseFile.objects.create(
-            name=pseudo_archive.name,
-            release_id=release.id,
-            organization_id=self.organization.id,
-            dist_id=None,
-            file=pseudo_archive,
-        )
-        file = File.objects.create(name=ARTIFACT_INDEX_FILENAME, type="release.artifact-index")
-        file.putfile(
-            BytesIO(json.dumps({"files": {"foo": {"archive_ident": releasefile.ident}}}).encode())
-        )
-        ReleaseFile.objects.create(
-            name=ARTIFACT_INDEX_FILENAME,
-            release_id=release.id,
-            organization_id=self.project.organization_id,
-            file=file,
-        )
+        self._create_archive(release, "foo")
 
-        # No we have one, call set again
         result = fetch_release_archive_for_url(release, dist=None, url="foo")
         assert result is not None
         assert len(relevant_calls(cache_set, "releasefile")) == 0
+
+    @patch(
+        "sentry.lang.javascript.processor.ReleaseFile.cache.getfile",
+        side_effect=ReleaseFile.cache.getfile,
+    )
+    def test_archive_too_large_for_disk_cache(self, cache_getfile):
+        """ReleaseFile.cache is not used if the archive is too large"""
+
+        release = Release.objects.create(version="1", organization_id=self.project.organization_id)
+        self._create_archive(release, "foo")
+
+        # cache.getfile is only called for index, not for the archive
+        with override_options({"releasefile.cache-max-archive-size": 9}):
+            result = fetch_release_archive_for_url(release, dist=None, url="foo")
+        assert result is not None
+        assert len(cache_getfile.mock_calls) == 1
+
+    @patch(
+        "sentry.lang.javascript.processor.ReleaseFile.cache.getfile",
+        side_effect=ReleaseFile.cache.getfile,
+    )
+    def test_archive_small_enough_for_disk_cache(self, cache_getfile):
+        """ReleaseFile.cache is not used if the archive is too large"""
+
+        release = Release.objects.create(version="1", organization_id=self.project.organization_id)
+        self._create_archive(release, "foo")
+
+        # cache.getfile is called once for the index, and once for the archive:
+        result = fetch_release_archive_for_url(release, dist=None, url="foo")
+        assert result is not None
+        assert len(cache_getfile.mock_calls) == 2
 
     @responses.activate
     def test_unicode_body(self):


### PR DESCRIPTION
For very large release archives, loading the entire zip file may exceed the time limit for the current processing task. The only use case for loading an entire zip file at once is caching -- in order to extract a single entry from a zip file, only the central directory and the file entry itself are required.

This PR prevents loading large zip files for both disk and memory caching.