### PR TITLE
feat(release-archives): Max. archive size option for disk caching

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -51,6 +51,13 @@ register(
     flags=FLAG_PRIORITIZE_DISK,
 )
 register("releasefile.cache-limit", type=Int, default=10 * 1024 * 1024, flags=FLAG_PRIORITIZE_DISK)
+register(
+    "releasefile.cache-max-archive-size",
+    type=Int,
+    default=1024 * 1024 * 1024,
+    flags=FLAG_PRIORITIZE_DISK,
+)
+
 
 # Mail
 register("mail.backend", default="smtp", flags=FLAG_NOSTORE)


### PR DESCRIPTION
Add an option which limits the caching of release archives to a certain size.

This prepares for https://github.com/getsentry/sentry/pull/28818.

https://getsentry.atlassian.net/browse/INGEST-116