### PR TITLE
fix(python3): Remove itertools.ifilter use

### DIFF
--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -16,7 +16,7 @@ def get_application_chunks(exception):
     """
     return map(
         lambda in_app__frames: list(in_app__frames[1]),
-        itertools.ifilter(
+        filter(
             lambda in_app__frames: in_app__frames[0],
             itertools.groupby(exception.stacktrace.frames, key=lambda frame: frame.in_app),
         ),


### PR DESCRIPTION
Seen in e.g. [SENTRY-S2M](https://sentry.io/organizations/sentry/issues/2615310209/events/c3836425c01f4633bf818e6db33e9c9d/?project=1)

```
Could not extract features from <sentry.eventstore.models.Event object at 0x7f794a597470> for 'exception:stacktrace:application-chunks' due to error: AttributeError("module 'itertools' has no attribute 'ifilter'",)
```
