### PR TITLE
feat(alerts): Support Crash Rate Alerts for Users

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -571,5 +571,5 @@ ALERTS_MEMBER_WRITE_DEFAULT = True
 # Defined at https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs
 DataCategory = sentry_relay.DataCategory
 
-CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_sessions"
+CRASH_RATE_ALERT_SESSION_COUNT_ALIAS = "_total_count"
 CRASH_RATE_ALERT_AGGREGATE_ALIAS = "_crash_rate_alert_aggregate"

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -406,13 +406,19 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             )
 
     def validate_event_types(self, event_types):
-        try:
-            return [SnubaQueryEventType.EventType[event_type.upper()] for event_type in event_types]
-        except KeyError:
-            raise serializers.ValidationError(
-                "Invalid event_type, valid values are %s"
-                % [item.name.lower() for item in SnubaQueryEventType.EventType]
-            )
+        dataset: Dataset = Dataset(self.initial_data["dataset"])
+        if dataset == Dataset.Sessions:
+            self._validate_crash_rate_alerts_event_types(event_types=event_types)
+        else:
+            try:
+                return [
+                    SnubaQueryEventType.EventType[event_type.upper()] for event_type in event_types
+                ]
+            except KeyError:
+                raise serializers.ValidationError(
+                    "Invalid event_type, valid values are %s"
+                    % [item.name.lower() for item in SnubaQueryEventType.EventType]
+                )
 
     def validate_threshold_type(self, threshold_type):
         try:
@@ -550,6 +556,21 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     "Invalid Time Window: Allowed time windows for crash rate alerts are: "
                     "30min, 1h, 2h, 4h, 12h and 24h"
                 )
+
+    @staticmethod
+    def _validate_crash_rate_alerts_event_types(event_types):
+        if not len(event_types) == 1:
+            raise serializers.ValidationError(
+                "Crash rate alerts are expected to have only 1 event type"
+            )
+        if event_types[0] not in [
+            SnubaQueryEventType.EventType.SESSION,
+            SnubaQueryEventType.EventType.USER,
+        ]:
+            raise serializers.ValidationError(
+                "Crash rate alerts event types are expected "
+                "to be either of type `session` or type `user`"
+            )
 
     def _validate_trigger_thresholds(self, threshold_type, trigger, resolve_threshold):
         if resolve_threshold is None:

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -70,6 +70,7 @@ dataset_valid_event_types = {
     QueryDatasets.TRANSACTIONS: {SnubaQueryEventType.EventType.TRANSACTION},
     QueryDatasets.SESSIONS: {
         SnubaQueryEventType.EventType.SESSION,
+        SnubaQueryEventType.EventType.USER,
     },
 }
 

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -54,6 +54,7 @@ class SnubaQueryEventType(Model):
         DEFAULT = 1
         TRANSACTION = 2
         SESSION = 3
+        USER = 4
 
     snuba_query = FlexibleForeignKey("sentry.SnubaQuery")
     type = models.SmallIntegerField()

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -53,8 +53,6 @@ class SnubaQueryEventType(Model):
         ERROR = 0
         DEFAULT = 1
         TRANSACTION = 2
-        SESSION = 3
-        USER = 4
 
     snuba_query = FlexibleForeignKey("sentry.SnubaQuery")
     type = models.SmallIntegerField()

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import timedelta
 
 import sentry_sdk
@@ -8,7 +9,7 @@ from snuba_sdk.legacy import json_to_snql
 from sentry.constants import CRASH_RATE_ALERT_SESSION_COUNT_ALIAS
 from sentry.search.events.fields import resolve_field_list
 from sentry.search.events.filter import get_filter
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
+from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics
 from sentry.utils.snuba import (
@@ -28,10 +29,6 @@ logger = logging.getLogger(__name__)
 DATASET_CONDITIONS = {
     QueryDatasets.EVENTS: "event.type:error",
     QueryDatasets.TRANSACTIONS: "event.type:transaction",
-}
-SESSIONS_EVENT_TYPES_TO_COLUMNS = {
-    SnubaQueryEventType.EventType.SESSION: "sessions",
-    SnubaQueryEventType.EventType.USER: "users",
 }
 SUBSCRIPTION_STATUS_MAX_AGE = timedelta(minutes=10)
 
@@ -189,8 +186,10 @@ def build_snuba_filter(dataset, query, aggregate, environment, event_types, para
     if dataset == QueryDatasets.SESSIONS:
         # This aggregation is added to return the total number of sessions in crash
         # rate alerts that is used to identify if we are below a general minimum alert threshold
-        count_col = SESSIONS_EVENT_TYPES_TO_COLUMNS[event_types[0]]
-        aggregations += [f"identity({count_col}) AS {CRASH_RATE_ALERT_SESSION_COUNT_ALIAS}"]
+        count_col = re.search(r"(sessions|users)", aggregate)
+        count_col_matched = count_col.group()
+
+        aggregations += [f"identity({count_col_matched}) AS {CRASH_RATE_ALERT_SESSION_COUNT_ALIAS}"]
         functions_acl = ["identity"]
 
     query = apply_dataset_query_conditions(dataset, query, event_types)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -85,7 +85,7 @@ TRANSACTIONS_SNUBA_MAP = {
     if col.value.transaction_name is not None
 }
 
-SESSIONS_FIELD_LIST = ["sessions", "sessions_crashed", "release"]
+SESSIONS_FIELD_LIST = ["release", "sessions", "sessions_crashed", "users", "users_crashed"]
 
 SESSIONS_SNUBA_MAP = {column: column for column in SESSIONS_FIELD_LIST}
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -578,7 +578,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             "owner": self.user.id,
             "name": "JustAValidTestRule",
             "dataset": "sessions",
-            "eventTypes": ["session"],
+            "eventTypes": [],
         }
         # Login
         self.create_member(
@@ -610,7 +610,6 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
     def test_simple_crash_rate_alerts_for_users(self):
         self.valid_alert_rule.update(
             {
-                "eventTypes": ["user"],
                 "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             }
         )
@@ -621,39 +620,6 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
-
-    def test_simple_crash_rate_alerts_for_users_incorrect_event_type(self):
-        self.valid_alert_rule.update(
-            {
-                "eventTypes": ["user-3"],
-                "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
-            }
-        )
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
-                self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
-            )
-        assert resp.data == {
-            "eventTypes": [
-                "Crash rate alerts event types are expected to be"
-                " either of type `session` or type `user`"
-            ]
-        }
-
-    def test_simple_crash_rate_alerts_for_users_multiple_event_type(self):
-        self.valid_alert_rule.update(
-            {
-                "eventTypes": ["user", "session"],
-                "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
-            }
-        )
-        with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            resp = self.get_valid_response(
-                self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
-            )
-        assert resp.data == {
-            "eventTypes": ["Crash rate alerts are expected to have only 1 event type"]
-        }
 
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
         self.valid_alert_rule["timeWindow"] = "90"

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -607,6 +607,21 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
 
+    def test_simple_crash_rate_alerts_for_users(self):
+        self.valid_alert_rule.update(
+            {
+                "eventTypes": ["user"],
+                "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+            }
+        )
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
+            )
+        assert "id" in resp.data
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+        assert resp.data == serialize(alert_rule, self.user)
+
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
         self.valid_alert_rule["timeWindow"] = "90"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -622,6 +622,39 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
 
+    def test_simple_crash_rate_alerts_for_users_incorrect_event_type(self):
+        self.valid_alert_rule.update(
+            {
+                "eventTypes": ["user-3"],
+                "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+            }
+        )
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
+            )
+        assert resp.data == {
+            "eventTypes": [
+                "Crash rate alerts event types are expected to be"
+                " either of type `session` or type `user`"
+            ]
+        }
+
+    def test_simple_crash_rate_alerts_for_users_multiple_event_type(self):
+        self.valid_alert_rule.update(
+            {
+                "eventTypes": ["user", "session"],
+                "aggregate": "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+            }
+        )
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=400, **self.valid_alert_rule
+            )
+        assert resp.data == {
+            "eventTypes": ["Crash rate alerts are expected to have only 1 event type"]
+        }
+
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
         self.valid_alert_rule["timeWindow"] = "90"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -205,7 +205,7 @@ class BuildSnubaFilterTest(TestCase):
             query="",
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
             environment=None,
-            event_types=[SnubaQueryEventType.EventType.SESSION],
+            event_types=[],
         )
         assert snuba_filter
         assert snuba_filter.aggregations == [
@@ -223,7 +223,7 @@ class BuildSnubaFilterTest(TestCase):
             query="",
             aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             environment=None,
-            event_types=[SnubaQueryEventType.EventType.USER],
+            event_types=[],
         )
         assert snuba_filter
         assert snuba_filter.aggregations == [
@@ -253,7 +253,7 @@ class BuildSnubaFilterTest(TestCase):
             query="release:ahmed@12.2",
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
             environment=env,
-            event_types=[SnubaQueryEventType.EventType.SESSION],
+            event_types=[],
         )
         assert snuba_filter
         assert snuba_filter.aggregations == [
@@ -276,7 +276,7 @@ class BuildSnubaFilterTest(TestCase):
             query="release:ahmed@12.2",
             aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             environment=env,
-            event_types=[SnubaQueryEventType.EventType.USER],
+            event_types=[],
         )
         assert snuba_filter
         assert snuba_filter.aggregations == [
@@ -446,7 +446,7 @@ class TestApplyDatasetQueryConditions(TestCase):
             apply_dataset_query_conditions(
                 QueryDatasets.SESSIONS,
                 "release:123",
-                [SnubaQueryEventType.EventType.SESSION],
+                [],
                 False,
             )
             == "release:123"

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -214,7 +214,25 @@ class BuildSnubaFilterTest(TestCase):
                 None,
                 "_crash_rate_alert_aggregate",
             ],
-            ["identity", "sessions", "_total_sessions"],
+            ["identity", "sessions", "_total_count"],
+        ]
+
+    def test_simple_users(self):
+        snuba_filter = build_snuba_filter(
+            dataset=QueryDatasets.SESSIONS,
+            query="",
+            aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+            environment=None,
+            event_types=[SnubaQueryEventType.EventType.USER],
+        )
+        assert snuba_filter
+        assert snuba_filter.aggregations == [
+            [
+                "if(greater(users,0),divide(users_crashed,users),null)",
+                None,
+                "_crash_rate_alert_aggregate",
+            ],
+            ["identity", "users", "_total_count"],
         ]
 
     def test_aliased_query_events(self):
@@ -244,7 +262,30 @@ class BuildSnubaFilterTest(TestCase):
                 None,
                 "_crash_rate_alert_aggregate",
             ],
-            ["identity", "sessions", "_total_sessions"],
+            ["identity", "sessions", "_total_count"],
+        ]
+        assert snuba_filter.conditions == [
+            ["release", "=", "ahmed@12.2"],
+            ["environment", "=", "development"],
+        ]
+
+    def test_query_and_environment_users(self):
+        env = self.create_environment(self.project, name="development")
+        snuba_filter = build_snuba_filter(
+            dataset=QueryDatasets.SESSIONS,
+            query="release:ahmed@12.2",
+            aggregate="percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+            environment=env,
+            event_types=[SnubaQueryEventType.EventType.USER],
+        )
+        assert snuba_filter
+        assert snuba_filter.aggregations == [
+            [
+                "if(greater(users,0),divide(users_crashed,users),null)",
+                None,
+                "_crash_rate_alert_aggregate",
+            ],
+            ["identity", "users", "_total_count"],
         ]
         assert snuba_filter.conditions == [
             ["release", "=", "ahmed@12.2"],


### PR DESCRIPTION
This PR:
- Allows for crash rate alerts to be made on users present in sessions.
- Adds validation on crash rate alert event types