### PR TITLE
feat(ui): Add session chart to alert creation page

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -608,7 +608,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       organization,
       projects: this.state.projects,
       triggers,
-      query: queryWithTypeFilter,
+      query: dataset === Dataset.SESSIONS ? query : queryWithTypeFilter,
       aggregate,
       timeWindow,
       environment,
@@ -617,20 +617,21 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     };
     const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
 
-    const wizardBuilderChart =
-      dataset === Dataset.SESSIONS ? null : (
-        <TriggersChart
-          {...chartProps}
-          header={
-            <ChartHeader>
-              <AlertName>{AlertWizardAlertNames[alertType]}</AlertName>
+    const wizardBuilderChart = (
+      <TriggersChart
+        {...chartProps}
+        header={
+          <ChartHeader>
+            <AlertName>{AlertWizardAlertNames[alertType]}</AlertName>
+            {dataset !== Dataset.SESSIONS && (
               <AlertInfo>
                 {aggregate} | event.type:{eventTypes?.join(',')}
               </AlertInfo>
-            </ChartHeader>
-          }
-        />
-      );
+            )}
+          </ChartHeader>
+        }
+      />
+    );
 
     const ownerId = rule.owner?.split(':')[1];
     const canEdit =

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -164,9 +164,10 @@ class TriggersChart extends React.PureComponent<Props, State> {
   componentDidMount() {
     if (this.isSessionAggregate) {
       this.fetchSessionTimeSeries();
-    } else {
-      this.fetchTotalCount();
+      return;
     }
+
+    this.fetchTotalCount();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -180,9 +181,10 @@ class TriggersChart extends React.PureComponent<Props, State> {
     ) {
       if (this.isSessionAggregate) {
         this.fetchSessionTimeSeries();
-      } else {
-        this.fetchTotalCount();
+        return;
       }
+
+      this.fetchTotalCount();
     }
   }
 
@@ -305,14 +307,10 @@ class TriggersChart extends React.PureComponent<Props, State> {
         )}
         <ChartControls>
           <InlineContainer>
-            <React.Fragment>
-              <SectionHeading>{t('Total Events')}</SectionHeading>
-              {totalCount !== null ? (
-                <SectionValue>{totalCount.toLocaleString()}</SectionValue>
-              ) : (
-                <SectionValue>&mdash;</SectionValue>
-              )}
-            </React.Fragment>
+            <SectionHeading>{t('Total Events')}</SectionHeading>
+            <SectionValue>
+              {totalCount !== null ? totalCount.toLocaleString() : '\u2014'}
+            </SectionValue>
           </InlineContainer>
           <InlineContainer>
             <OptionSelector


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/134876760-8c3b6b8f-f130-49ad-9551-488dd0005d97.png)

Adding session chart on top of crash rate alert creation page.

Things I still need to address in follow-up PRs:
- format tooltip and yAxis labels
- scale the chart (I ran into some problems with threshold rectangles not aligning properly when chart scaling is turned on)