### PR TITLE
fix(alert-rules): Force the RuleNode select values to be strings

### DIFF
--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -71,19 +71,17 @@ class RuleNode extends React.Component<Props> {
           initialVal = fieldConfig.choices[0][0];
         }
       } else {
-        initialVal = isNaN(parseInt(data[name] as string, 10))
-          ? data[name]
-          : parseInt(data[name] as string, 10);
+        initialVal = data[name];
       }
     }
 
-    // Cast `key` to string, this problem pops up because of react-select v3 where
-    // `value` requires the `option` object (e.g. {label, object}) - we have
-    // helpers in `SelectControl` to filter `choices` to produce the value object
-    //
-    // However there are integrations that give the form field choices with the value as number, but
+    // Cast `value` to string
+    // There are integrations that give the form field choices with the value as number, but
     // when the integration configuration gets saved, it gets saved and returned as a string
-    const options = fieldConfig.choices.map(([value, label]) => ({value, label}));
+    const options = fieldConfig.choices.map(([value, label]) => ({
+      value: `${value}`,
+      label,
+    }));
 
     const handleChange = ({value}) => {
       if (fieldConfig.resetsForm) {


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry/pull/28804

Parsing the backend string to mesh with the frontend number was the wrong way to go about solving that bug. I missed a helpful comment from @billyvg from 2 years ago that mentionned that we coerce frontend number -> strings, since thats what they look like when they come from the backend. It was also missed when we switched from the `choices` prop to the `options` prop. This reintroduces that behavior, and solves the bug for good.

**Before:**

Fields that use numerical-ish values were being wrongly interpreted by parseInt:
(e.g. `parseInt('5m') -> 5', or log levels where 'fatal' is represented by the value '50' as a string)
![image](https://user-images.githubusercontent.com/35509934/134707513-dba36f8b-fd8b-47ab-abfe-42bb7ebabcf0.png)


**After:**
Default values appear properly since every value is being interpreted as a string, frontend and backend.
![image](https://user-images.githubusercontent.com/35509934/134708107-c9b0c9f9-69fc-402f-87ad-f5416cc0112b.png)

