### PR TITLE
ref(discover): Add a deprecated list to discover

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -602,6 +602,8 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   [FieldKey.USER_DISPLAY]: 'string',
 };
 
+export const DEPRECATED_FIELDS: string[] = [FieldKey.CULPRIT];
+
 export type FieldTag = {
   key: FieldKey;
   name: FieldKey;

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -18,6 +18,7 @@ import {
   AggregationKey,
   Column,
   ColumnType,
+  DEPRECATED_FIELDS,
   QueryFieldValue,
   ValidateColumnTypes,
 } from 'app/utils/discover/fields';
@@ -112,7 +113,7 @@ class QueryField extends React.Component<Props> {
       return (
         <components.Option label={label} data={data} {...props}>
           <span data-test-id="label">{label}</span>
-          {this.renderTag(data.value.kind)}
+          {this.renderTag(data.value.kind, label)}
         </components.Option>
       );
     },
@@ -126,7 +127,7 @@ class QueryField extends React.Component<Props> {
       return (
         <components.SingleValue data={data} {...props}>
           <span data-test-id="label">{data.label}</span>
-          {this.renderTag(data.value.kind)}
+          {this.renderTag(data.value.kind, data.label)}
         </components.SingleValue>
       );
     },
@@ -512,7 +513,7 @@ class QueryField extends React.Component<Props> {
     return inputs;
   }
 
-  renderTag(kind) {
+  renderTag(kind: FieldValueKind, label: string) {
     const {shouldRenderTag} = this.props;
     if (shouldRenderTag === false) {
       return null;
@@ -536,7 +537,7 @@ class QueryField extends React.Component<Props> {
         tagType = 'warning';
         break;
       case FieldValueKind.FIELD:
-        text = kind;
+        text = DEPRECATED_FIELDS.includes(label) ? 'deprecated' : kind;
         tagType = 'highlight';
         break;
       default:


### PR DESCRIPTION
- This adds a list of known deprecated fields to discover so we can mark
  them as such in the UI
- Culprit is deprecated based on https://github.com/getsentry/relay/pull/1082

<img width="398" alt="image" src="https://user-images.githubusercontent.com/4205004/134721441-2b3e6020-62f3-4119-8d8c-d1fca39e5b77.png">
