### PR TITLE
feat(releases): Clear the commits associated to a release

### DIFF
--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -527,14 +527,21 @@ class OrganizationReleaseDetailsEndpoint(
 
             refs = result.get("refs")
             if not refs:
-                refs = [
-                    {
-                        "repository": r["repository"],
-                        "previousCommit": r.get("previousId"),
-                        "commit": r["currentId"],
-                    }
-                    for r in result.get("headCommits", [])
-                ]
+                # Handle legacy
+                if result.get("headCommits", []):
+                    refs = [
+                        {
+                            "repository": r["repository"],
+                            "previousCommit": r.get("previousId"),
+                            "commit": r["currentId"],
+                        }
+                        for r in result.get("headCommits", [])
+                    ]
+                # Clear commits in release
+                else:
+                    if result.get("refs") == []:
+                        release.clear_commits()
+
             scope.set_tag("has_refs", bool(refs))
             if refs:
                 if not request.user.is_authenticated:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1090,7 +1090,7 @@ class Release(Model):
                 organization_id=self.organization_id, release=self
             ).delete()
 
-            self.authors = 0
+            self.authors = []
             self.commit_count = 0
             self.last_commit_id = None
             self.save()

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1076,6 +1076,25 @@ class Release(Model):
         counts = get_artifact_counts([self.id])
         return counts.get(self.id, 0)
 
+    def clear_commits(self):
+        """
+        Delete all release-specific commit data associated to this release. We will not delete the Commit model values because other releases may use these commits.
+        """
+        with sentry_sdk.start_span(op="clear_commits"):
+            from sentry.models import ReleaseCommit, ReleaseHeadCommit
+
+            ReleaseHeadCommit.objects.get(
+                organization_id=self.organization_id, release=self
+            ).delete()
+            ReleaseCommit.objects.filter(
+                organization_id=self.organization_id, release=self
+            ).delete()
+
+            self.authors = 0
+            self.commit_count = 0
+            self.last_commit_id = None
+            self.save()
+
 
 def get_artifact_counts(release_ids: List[int]) -> Mapping[int, int]:
     """Get artifact count grouped by IDs"""


### PR DESCRIPTION
## Objective:
This PR creates a new `clear_commits` method on the Release model to delete the associated ReleaseCommits and ReleaseHeadCommit and reset the commit related metadata for the release. We will not delete the rows in the Commit table because they may be used for another release.