### PR TITLE
ref(discover): Introduce some order to discover columns

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -112,6 +112,7 @@ const CONDITIONS_ARGUMENTS: SelectValue<string>[] = [
 ];
 
 // Refer to src/sentry/search/events/fields.py
+// Try to keep functions logically sorted, ie. all the count functions are grouped together
 export const AGGREGATIONS = {
   count: {
     parameters: [],
@@ -130,6 +131,74 @@ export const AGGREGATIONS = {
     outputType: 'number',
     isSortable: true,
     multiPlotType: 'line',
+  },
+  count_miserable: {
+    getFieldOverrides({parameter, organization}: DefaultValueInputs) {
+      if (parameter.kind === 'column') {
+        return {defaultValue: 'user'};
+      }
+      return {
+        defaultValue: organization.apdexThreshold?.toString() ?? parameter.defaultValue,
+      };
+    },
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: validateAllowedColumns(['user']),
+        defaultValue: 'user',
+        required: true,
+      },
+      {
+        kind: 'value',
+        dataType: 'number',
+        defaultValue: '300',
+        required: true,
+      },
+    ],
+    outputType: 'number',
+    isSortable: true,
+    multiPlotType: 'area',
+  },
+  count_if: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: validateDenyListColumns(
+          ['string', 'duration'],
+          ['id', 'issue', 'user.display']
+        ),
+        defaultValue: 'transaction.duration',
+        required: true,
+      },
+      {
+        kind: 'dropdown',
+        options: CONDITIONS_ARGUMENTS,
+        dataType: 'string',
+        defaultValue: CONDITIONS_ARGUMENTS[0].value,
+        required: true,
+      },
+      {
+        kind: 'value',
+        dataType: 'string',
+        defaultValue: '300',
+        required: true,
+      },
+    ],
+    outputType: 'number',
+    isSortable: true,
+    multiPlotType: 'area',
+  },
+  eps: {
+    parameters: [],
+    outputType: 'number',
+    isSortable: true,
+    multiPlotType: 'area',
+  },
+  epm: {
+    parameters: [],
+    outputType: 'number',
+    isSortable: true,
+    multiPlotType: 'area',
   },
   failure_count: {
     parameters: [],
@@ -173,19 +242,6 @@ export const AGGREGATIONS = {
     isSortable: true,
     multiPlotType: 'line',
   },
-  avg: {
-    parameters: [
-      {
-        kind: 'column',
-        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
-        defaultValue: 'transaction.duration',
-        required: true,
-      },
-    ],
-    outputType: null,
-    isSortable: true,
-    multiPlotType: 'line',
-  },
   sum: {
     parameters: [
       {
@@ -209,13 +265,6 @@ export const AGGREGATIONS = {
     outputType: null,
     isSortable: true,
   },
-  last_seen: {
-    parameters: [],
-    outputType: 'date',
-    isSortable: true,
-  },
-
-  // Tracing functions.
   p50: {
     parameters: [
       {
@@ -301,9 +350,16 @@ export const AGGREGATIONS = {
     isSortable: true,
     multiPlotType: 'line',
   },
-  failure_rate: {
-    parameters: [],
-    outputType: 'percentage',
+  avg: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: validateForNumericAggregate(['duration', 'number', 'percentage']),
+        defaultValue: 'transaction.duration',
+        required: true,
+      },
+    ],
+    outputType: null,
     isSortable: true,
     multiPlotType: 'line',
   },
@@ -343,73 +399,16 @@ export const AGGREGATIONS = {
     isSortable: true,
     multiPlotType: 'area',
   },
-  eps: {
+  failure_rate: {
     parameters: [],
-    outputType: 'number',
+    outputType: 'percentage',
     isSortable: true,
-    multiPlotType: 'area',
+    multiPlotType: 'line',
   },
-  epm: {
+  last_seen: {
     parameters: [],
-    outputType: 'number',
+    outputType: 'date',
     isSortable: true,
-    multiPlotType: 'area',
-  },
-  count_miserable: {
-    getFieldOverrides({parameter, organization}: DefaultValueInputs) {
-      if (parameter.kind === 'column') {
-        return {defaultValue: 'user'};
-      }
-      return {
-        defaultValue: organization.apdexThreshold?.toString() ?? parameter.defaultValue,
-      };
-    },
-    parameters: [
-      {
-        kind: 'column',
-        columnTypes: validateAllowedColumns(['user']),
-        defaultValue: 'user',
-        required: true,
-      },
-      {
-        kind: 'value',
-        dataType: 'number',
-        defaultValue: '300',
-        required: true,
-      },
-    ],
-    outputType: 'number',
-    isSortable: true,
-    multiPlotType: 'area',
-  },
-  count_if: {
-    parameters: [
-      {
-        kind: 'column',
-        columnTypes: validateDenyListColumns(
-          ['string', 'duration'],
-          ['id', 'issue', 'user.display']
-        ),
-        defaultValue: 'transaction.duration',
-        required: true,
-      },
-      {
-        kind: 'dropdown',
-        options: CONDITIONS_ARGUMENTS,
-        dataType: 'string',
-        defaultValue: CONDITIONS_ARGUMENTS[0].value,
-        required: true,
-      },
-      {
-        kind: 'value',
-        dataType: 'string',
-        defaultValue: '300',
-        required: true,
-      },
-    ],
-    outputType: 'number',
-    isSortable: true,
-    multiPlotType: 'area',
   },
 } as const;
 

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -439,7 +439,7 @@ export function generateFieldOptions({
   aggregations = AGGREGATIONS,
   fields = FIELDS,
 }: FieldGeneratorOpts) {
-  let fieldKeys = Object.keys(fields);
+  let fieldKeys = Object.keys(fields).sort();
   let functions = Object.keys(aggregations);
 
   // Strip tracing features if the org doesn't have access.
@@ -491,6 +491,7 @@ export function generateFieldOptions({
   });
 
   if (tagKeys !== undefined && tagKeys !== null) {
+    tagKeys.sort();
     tagKeys.forEach(tag => {
       const tagValue =
         fields.hasOwnProperty(tag) || AGGREGATIONS.hasOwnProperty(tag)
@@ -507,6 +508,7 @@ export function generateFieldOptions({
   }
 
   if (measurementKeys !== undefined && measurementKeys !== null) {
+    measurementKeys.sort();
     measurementKeys.forEach(measurement => {
       fieldOptions[`measurement:${measurement}`] = {
         label: measurement,
@@ -519,6 +521,7 @@ export function generateFieldOptions({
   }
 
   if (Array.isArray(spanOperationBreakdownKeys)) {
+    spanOperationBreakdownKeys.sort();
     spanOperationBreakdownKeys.forEach(breakdownField => {
       fieldOptions[`span_op_breakdown:${breakdownField}`] = {
         label: breakdownField,


### PR DESCRIPTION
- This sorts fields, tags, measurements and breakdowns alphabetically
- This regroups functions slightly so that they're next to other similar
  functions (eg. avg + percentile)
  - Not sorting alphabetically cause the order of some things become
    strange (eg. p100 before p50)