### PR TITLE
feat(ui): Do not show event type filter on sessions alert page

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -14,6 +14,7 @@ import Duration from 'app/components/duration';
 import IdBadge from 'app/components/idBadge';
 import {KeyValueTable, KeyValueTableRow} from 'app/components/keyValueTable';
 import * as Layout from 'app/components/layouts/thirds';
+import NotAvailable from 'app/components/notAvailable';
 import {Panel, PanelBody} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {parseSearch} from 'app/components/searchSyntax/parser';
@@ -105,15 +106,23 @@ export default class DetailsBody extends React.Component<Props> {
 
   getFilter() {
     const {rule} = this.props;
+    const {dataset, query} = rule ?? {};
     if (!rule) {
       return null;
     }
 
-    const eventType = extractEventTypeFilterFromRule(rule);
-    const parsedQuery = parseSearch([eventType, rule.query].join(' '));
+    const eventType =
+      dataset === Dataset.SESSIONS ? null : extractEventTypeFilterFromRule(rule);
+    const parsedQuery = parseSearch([eventType, query].join(' '));
 
     return (
-      <Filters>{parsedQuery && <HighlightQuery parsedQuery={parsedQuery} />}</Filters>
+      <Filters>
+        {query || eventType ? (
+          <HighlightQuery parsedQuery={parsedQuery ?? []} />
+        ) : (
+          <NotAvailable />
+        )}
+      </Filters>
     );
   }
 


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/9060071/134908804-87053d8c-6423-4f3f-a1f4-fbf14147a279.png)


## After
![image](https://user-images.githubusercontent.com/9060071/134908384-f0c2413a-99e5-4f8a-8f16-31c189345111.png)

Sessions are not a real event.type from the discover point of view, so just hiding it from the filter.