### PR TITLE
feat(js): Handle in_app detection for webpack namespace output

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -62,6 +62,9 @@ CLEAN_MODULE_RE = re.compile(
 )
 VERSION_RE = re.compile(r"^[a-f0-9]{32}|[a-f0-9]{40}$", re.I)
 NODE_MODULES_RE = re.compile(r"\bnode_modules/")
+# Default Webpack output path using multiple namespace - https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate
+# eg. webpack://myproject/./src/lib/hellothere.js
+WEBPACK_NAMESPACE_RE = re.compile(r"^webpack://[a-zA-Z0-9_\-@\.]+/\./")
 SOURCE_MAPPING_URL_RE = re.compile(b"//# sourceMappingURL=(.*)$")
 CACHE_CONTROL_RE = re.compile(r"max-age=(\d+)")
 CACHE_CONTROL_MAX = 7200
@@ -1006,6 +1009,8 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                     # (i.e. node_modules)
                     if "/~/" in filename:
                         filename = "~/" + abs_path.split("/~/", 1)[-1]
+                    elif WEBPACK_NAMESPACE_RE.match(filename):
+                        filename = re.sub(WEBPACK_NAMESPACE_RE, "./", abs_path)
                     else:
                         filename = filename.split("webpack:///", 1)[-1]
 


### PR DESCRIPTION
This change fixes detection of `InApp` frames when webpack project is built using multiple namespaces.

This will produce a path in form of `webpack://[namespace]/[path]` which ends up being something like `webpack://mylib/./some/file.js`. Where previously, non-namespaced paths were in form of `webpack:///./some/file.js`, as `namespace` ended up being an empty string.

Currently, we use to allow `a-zA-Z0-9.-_@` as namespace characters, as I don't expect anyone to use anything else. We can change it if anyone ever requests it.

I'd love to write tests for it, but it would require some more refactoring, as calling the whole `process_frame` is not trivial, and I didn't want to make this PR difficult to review.

webpack docs ref: https://webpack.js.org/configuration/output/#outputdevtoolnamespace
webpack docs ref: https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate

ref: https://github.com/getsentry/sentry-javascript/issues/3853
ref: https://github.com/getsentry/sentry-javascript/issues/4012#issuecomment-927818402