### PR TITLE
feat(discover): allow up to 10 top events

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -546,7 +546,7 @@ INTERNAL_INTEGRATION_TOKEN_COUNT_MAX = 20
 ALL_ACCESS_PROJECTS = {-1}
 
 # Most number of events for the top-n graph
-MAX_TOP_EVENTS = 5
+MAX_TOP_EVENTS = 10
 
 # org option default values
 PROJECT_RATE_LIMIT_DEFAULT = 100

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -7,6 +7,7 @@ import pytest
 from django.urls import reverse
 from pytz import utc
 
+from sentry.constants import MAX_TOP_EVENTS
 from sentry.models.transaction_threshold import ProjectTransactionThreshold, TransactionMetric
 from sentry.snuba.discover import OTHER_KEY
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -1060,7 +1061,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             "field": ["count()", "message", "user.email"],
         }
         with self.feature(self.enabled_features):
-            data["topEvents"] = 50
+            data["topEvents"] = MAX_TOP_EVENTS + 1
             response = self.client.get(self.url, data, format="json")
             assert response.status_code == 400
 


### PR DESCRIPTION
- This updates the top events **endpoint** so it allows up to 10 top events instead of the current limit of 5
- Also updated the test so its more dynamic instead of a hardcoded 50