### PR TITLE
fix(discover): saved queries without y axis default to count() when comparing for changes

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -497,7 +497,6 @@ class EventView {
       'sorts',
       'project',
       'environment',
-      'yAxis',
       'display',
     ];
 
@@ -526,6 +525,14 @@ class EventView {
           return false;
         }
       }
+    }
+
+    // compare yAxis selections
+    // undefined yAxis values default to count()
+    const currentYAxisValue = this.yAxis ?? 'count()';
+    const otherYAxisValue = other.yAxis ?? 'count()';
+    if (!isEqual(currentYAxisValue, otherYAxisValue)) {
+      return false;
     }
 
     return true;

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -94,7 +94,15 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
 
     // For modifying a SavedQuery
     const isEqualQuery = nextEventView.isEqualTo(savedEventView);
-    const isEqualYAxis = isEqual(yAxis, savedQuery.yAxis);
+    // undefined saved yAxis defaults to count() and string values are converted to array
+    const isEqualYAxis = isEqual(
+      yAxis,
+      !savedQuery.yAxis
+        ? ['count()']
+        : typeof savedQuery.yAxis === 'string'
+        ? [savedQuery.yAxis]
+        : savedQuery.yAxis
+    );
     return {
       isNewQuery: false,
       isEditingQuery: !isEqualQuery || !isEqualYAxis,

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -368,6 +368,32 @@ describe('EventView.fromSavedQuery()', function () {
     expect(eventView2.isEqualTo(eventView3)).toBe(true);
   });
 
+  it('saved queries with undefined yAxis are defaulted to count() when comparing with isEqualTo', function () {
+    const saved = {
+      orderby: '-count_timestamp',
+      end: '2019-10-23T19:27:04+0000',
+      name: 'release query',
+      fields: ['release', 'count(timestamp)'],
+      dateCreated: '2019-10-30T05:10:23.718937Z',
+      environment: ['dev', 'production'],
+      start: '2019-10-20T21:02:51+0000',
+      version: 2,
+      createdBy: '1',
+      dateUpdated: '2019-10-30T07:25:58.291917Z',
+      id: '3',
+      projects: [1],
+    };
+
+    const eventView = EventView.fromSavedQuery(saved);
+
+    const eventView2 = EventView.fromSavedQuery({
+      ...saved,
+      yAxis: 'count()',
+    });
+
+    expect(eventView.isEqualTo(eventView2)).toBe(true);
+  });
+
   it('uses the first yAxis from the SavedQuery', function () {
     const saved = {
       id: '42',

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -224,6 +224,46 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       expect(buttonDelete.exists()).toBe(true);
     });
 
+    it('treats undefined yAxis the same as count() when checking for changes', () => {
+      const wrapper = generateWrappedComponent(
+        location,
+        organization,
+        errorsViewSaved,
+        {...savedQuery, yAxis: undefined},
+        ['count()']
+      );
+
+      const buttonSaveAs = wrapper.find(SELECTOR_BUTTON_SAVE_AS);
+      const buttonSaved = wrapper.find(SELECTOR_BUTTON_SAVED);
+      const buttonUpdate = wrapper.find(SELECTOR_BUTTON_UPDATE);
+      const buttonDelete = wrapper.find(SELECTOR_BUTTON_DELETE);
+
+      expect(buttonSaveAs.exists()).toBe(false);
+      expect(buttonSaved.exists()).toBe(true);
+      expect(buttonUpdate.exists()).toBe(false);
+      expect(buttonDelete.exists()).toBe(true);
+    });
+
+    it('converts string yAxis values to array when checking for changes', () => {
+      const wrapper = generateWrappedComponent(
+        location,
+        organization,
+        errorsViewSaved,
+        {...savedQuery, yAxis: 'count()'},
+        ['count()']
+      );
+
+      const buttonSaveAs = wrapper.find(SELECTOR_BUTTON_SAVE_AS);
+      const buttonSaved = wrapper.find(SELECTOR_BUTTON_SAVED);
+      const buttonUpdate = wrapper.find(SELECTOR_BUTTON_UPDATE);
+      const buttonDelete = wrapper.find(SELECTOR_BUTTON_DELETE);
+
+      expect(buttonSaveAs.exists()).toBe(false);
+      expect(buttonSaved.exists()).toBe(true);
+      expect(buttonUpdate.exists()).toBe(false);
+      expect(buttonDelete.exists()).toBe(true);
+    });
+
     it('deletes the saved query', async () => {
       const wrapper = generateWrappedComponent(
         location,


### PR DESCRIPTION
Some saved queries may be saved with `yAxis: undefined`.
Sentry frontend will default these saved discover queries to `yAxis: count()` when displaying the results chart.
Because `count() !== undefined`, the `Save Query` button will always be enabled even when no changes are made to the query.
This pr fixes this issue by defaulting undefined and string yAxis values before condition checking.