### PR TITLE
fix(api-logging): leverage getattrs to reduce errors

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -166,17 +166,29 @@ class Endpoint(APIView):
         Create a log entry to be used for api metrics gathering
         """
         try:
+
             token_class = getattr(self.request.auth, "__class__", None)
             token_name = token_class.__name__
+
             view_obj = self.request.parser_context["view"]
+
+            request_user = getattr(self.request, "user", None)
+            user_id = getattr(request_user, "id", None)
+
+            request_access = getattr(self.request, "access", None)
+            org_id = getattr(request_access, "organization_id", None)
+
+            request_auth = getattr(self.request, "auth", None)
+            auth_id = getattr(request_auth, "id", None)
+
             log_metrics = dict(
                 method=self.request.method,
                 view=f"{view_obj.__module__}.{view_obj.__class__.__name__}",
                 response=self.response.status_code,
-                user_id=str(self.request.user.id),
+                user_id=user_id,
                 token_type=token_name,
-                organization_id=str(self.request.access.organization_id),
-                auth_id=getattr(self.request.auth, "id", None),
+                organization_id=org_id,
+                auth_id=auth_id,
                 path=self.request.path,
                 caller_ip=self.request.META.get("REMOTE_ADDR"),
             )


### PR DESCRIPTION
Instead of assuming things like request.access is available, it now leverages getattr to default values to None if they aren't