### PR TITLE
ref(sdk): Testing default idleTimeout

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 5000,
+      idleTimeout: 1000,
       _metricOptions: {
         _reportAllChanges: true,
       },


### PR DESCRIPTION
### Summary
The default idleTimeout for our sdk is 1000ms, many months back we increased the number from the default to increase our collection of LCP, but we don't have any hard numbers on the impact. This will help us test our LCP collection **temporarily**, to see if we need to increase our default idleTimeouts. 

**Other:**
There could be some temporary impact on trends when changing this. 