### PR TITLE
fix(ui): LayoutTitle semantic heading

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -62,7 +62,7 @@ export const HeaderActions = styled('div')`
 /**
  * Heading container that includes margins.
  */
-export const Title = styled('h2')`
+export const Title = styled('h1')`
   font-size: ${p => p.theme.headerFontSize};
   font-weight: normal;
   line-height: 1.2;


### PR DESCRIPTION
Layout.Title was previously a `<h2>` but it should be a `<h1>`.  No visual changes here since Layout.Title overrides the default styles of our `<h1>`