### PR TITLE
build(ui): Allow usage of env var for Sentry Release in frontend

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -5,7 +5,7 @@ import SentryRRWeb from '@sentry/rrweb';
 import {Integrations} from '@sentry/tracing';
 import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 
-import {DISABLE_RR_WEB, SPA_DSN} from 'app/constants';
+import {DISABLE_RR_WEB, SENTRY_RELEASE_VERSION, SPA_DSN} from 'app/constants';
 import {Config} from 'app/types';
 import {init as initApiSentryClient} from 'app/utils/apiSentryClient';
 
@@ -76,6 +76,11 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
      * as well as `whitelistUrls`
      */
     dsn: SPA_DSN || sentryConfig?.dsn,
+    /**
+     * Frontend can be built with a `SENTRY_RELEASE_VERSION` environment variable for release string, useful if frontend is
+     * deployed separately from backend.
+     */
+    release: SENTRY_RELEASE_VERSION || sentryConfig?.release,
     whitelistUrls: SPA_DSN
       ? ['localhost', 'dev.getsentry.net', 'sentry.dev', 'webpack-internal://']
       : sentryConfig?.whitelistUrls,

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -80,7 +80,7 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
      * Frontend can be built with a `SENTRY_RELEASE_VERSION` environment variable for release string, useful if frontend is
      * deployed separately from backend.
      */
-    release: SENTRY_RELEASE_VERSION || sentryConfig?.release,
+    release: SENTRY_RELEASE_VERSION ?? sentryConfig?.release,
     whitelistUrls: SPA_DSN
       ? ['localhost', 'dev.getsentry.net', 'sentry.dev', 'webpack-internal://']
       : sentryConfig?.whitelistUrls,

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -253,6 +253,7 @@ export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;
 export const NODE_ENV = process.env.NODE_ENV;
 export const DISABLE_RR_WEB = !!process.env.DISABLE_RR_WEB;
 export const SPA_DSN = process.env.SPA_DSN;
+export const SENTRY_RELEASE_VERSION = process.env.SENTRY_RELEASE_VERSION;
 
 export const DEFAULT_ERROR_JSON = {
   detail: t('Unknown error. Please try again.'),


### PR DESCRIPTION
This allows the use of an environment variable for the release version when configuring the Sentry SDK. This will allow the frontend release version to diverge from the backend response.