### PR TITLE
fix(ui): made event issue look like a link

### DIFF
--- a/static/app/components/shortId.tsx
+++ b/static/app/components/shortId.tsx
@@ -33,6 +33,7 @@ const StyledShortId = styled('div')`
 const StyledAutoSelectText = styled(AutoSelectText, {shouldForwardProp: isPropValid})<{
   avatar: boolean;
 }>`
+  color: ${p => p.theme.linkColor};
   margin-left: ${p => p.avatar && '0.5em'};
   min-width: 0;
 `;

--- a/static/app/components/shortId.tsx
+++ b/static/app/components/shortId.tsx
@@ -33,9 +33,12 @@ const StyledShortId = styled('div')`
 const StyledAutoSelectText = styled(AutoSelectText, {shouldForwardProp: isPropValid})<{
   avatar: boolean;
 }>`
-  color: ${p => p.theme.linkColor};
   margin-left: ${p => p.avatar && '0.5em'};
   min-width: 0;
+
+  a & {
+    color: ${p => p.theme.linkColor};
+  }
 `;
 
 export default ShortId;


### PR DESCRIPTION
Within Discover > Event Detail there's a section on the right that links to the Issue Details page but it doesn’t look clickable, so fixing that here.

### Before 
![CleanShot 2021-09-27 at 16 42 23](https://user-images.githubusercontent.com/1900676/134999685-9939191f-cdf4-4dac-8b56-56604f52b429.png)

### After
![CleanShot 2021-09-27 at 16 41 25](https://user-images.githubusercontent.com/1900676/134999701-fc067eea-62d2-45f7-b7a5-bfca6d71dc5f.png)


