### PR TITLE
ref(discover): Update timeout message to include transaction

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -16,6 +16,7 @@ from sentry.discover.arithmetic import ArithmeticError, is_equation, strip_equat
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Organization, Team
 from sentry.models.group import Group
+from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.search.events.fields import get_function_alias
 from sentry.search.events.filter import get_filter
 from sentry.snuba import discover
@@ -162,9 +163,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 ),
             ):
                 sentry_sdk.set_tag("query.error_reason", "Timeout")
-                raise ParseError(
-                    detail="Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
-                )
+                raise ParseError(detail=TIMEOUT_ERROR_MESSAGE)
             elif isinstance(error, (snuba.UnqualifiedQueryError)):
                 sentry_sdk.set_tag("query.error_reason", str(error))
                 raise ParseError(detail=str(error))

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.snuba import discover
 from sentry.utils import metrics, snuba
 from sentry.utils.sdk import capture_exception
@@ -44,7 +45,7 @@ def handle_snuba_errors(logger):
                         snuba.QueryTooManySimultaneous,
                     ),
                 ):
-                    message = "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
+                    message = TIMEOUT_ERROR_MESSAGE
                     recoverable = True
                 elif isinstance(
                     error,

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -3,6 +3,10 @@ import re
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import DATASETS
 
+TIMEOUT_ERROR_MESSAGE = """
+Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects. Also consider a
+filter on the transaction field if you're filtering performance data.
+"""
 KEY_TRANSACTION_ALIAS = "key_transaction"
 PROJECT_THRESHOLD_CONFIG_INDEX_ALIAS = "project_threshold_config_index"
 PROJECT_THRESHOLD_OVERRIDE_CONFIG_INDEX_ALIAS = "project_threshold_override_config_index"

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -5,6 +5,7 @@ from sentry.data_export.models import ExportedData
 from sentry.data_export.tasks import assemble_download, merge_export_blobs
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import File
+from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.compat.mock import patch
@@ -499,37 +500,25 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
         with self.tasks():
             assemble_download(de.id, count_down=0)
         error = emailer.call_args[1]["message"]
-        assert (
-            error
-            == "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
-        )
+        assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryMemoryLimitExceeded("test")
         with self.tasks():
             assemble_download(de.id, count_down=0)
         error = emailer.call_args[1]["message"]
-        assert (
-            error
-            == "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
-        )
+        assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryExecutionTimeMaximum("test")
         with self.tasks():
             assemble_download(de.id, count_down=0)
         error = emailer.call_args[1]["message"]
-        assert (
-            error
-            == "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
-        )
+        assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryTooManySimultaneous("test")
         with self.tasks():
             assemble_download(de.id, count_down=0)
         error = emailer.call_args[1]["message"]
-        assert (
-            error
-            == "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
-        )
+        assert error == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = DatasetSelectionError("test")
         with self.tasks():

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -22,6 +22,7 @@ from sentry.search.events.constants import (
     SEMVER_ALIAS,
     SEMVER_BUILD_ALIAS,
     SEMVER_PACKAGE_ALIAS,
+    TIMEOUT_ERROR_MESSAGE,
 )
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
@@ -144,10 +145,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         query = {"field": ["id", "timestamp"], "orderby": ["-timestamp", "-id"]}
         response = self.do_request(query)
         assert response.status_code == 400, response.content
-        assert (
-            response.data["detail"]
-            == "Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
-        )
+        assert response.data["detail"] == TIMEOUT_ERROR_MESSAGE
 
         mock_query.side_effect = QueryExecutionError("test")
 


### PR DESCRIPTION
- This is cause transaction filters can significantly improve
  the performance of discover queries, adding it to the message to help
  users out