### PR TITLE
ref(integrations): Move functions to Model Managers

### DIFF
--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -42,7 +42,9 @@ class ProjectPermission(OrganizationPermission):
             if is_active_superuser(request):
                 return True
             elif request.user.is_sentry_app:
-                return SentryApp.check_project_permission_for_sentry_app_user(request.user, project)
+                return SentryApp.objects.check_project_permission_for_sentry_app_user(
+                    request.user, project
+                )
             try:
                 role = (
                     OrganizationMember.objects.filter(

--- a/src/sentry/api/endpoints/group_activities.py
+++ b/src/sentry/api/endpoints/group_activities.py
@@ -11,7 +11,7 @@ class GroupActivitiesEndpoint(GroupEndpoint, EnvironmentMixin):
         """
         Retrieve all the Activities for a Group
         """
-        activity = Activity.get_activities_for_group(group, num=100)
+        activity = Activity.objects.get_activities_for_group(group, num=100)
         return Response(
             {
                 "activity": serialize(activity, request.user),

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -31,7 +31,7 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
     def _get_activity(self, request, group, num):
-        return Activity.get_activities_for_group(group, num)
+        return Activity.objects.get_activities_for_group(group, num)
 
     def _get_seen_by(self, request, group):
         seen_by = list(

--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -10,6 +10,7 @@ from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
 from sentry.models import Activity, GroupSubscription
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.types.activity import ActivityType
 from sentry.utils.functional import extract_lazy_object
 
 
@@ -65,15 +66,9 @@ class GroupNotesEndpoint(GroupEndpoint):
             reason=GroupSubscriptionReason.team_mentioned,
         )
 
-        activity = Activity.objects.create(
-            group=group,
-            project=group.project,
-            type=Activity.NOTE,
-            user=extract_lazy_object(request.user),
-            data=data,
+        activity = Activity.objects.create_group_activity(
+            group, ActivityType.NOTE, user=extract_lazy_object(request.user), data=data
         )
-
-        activity.send_notification()
 
         self.create_external_comment(request, group, activity)
         return Response(serialize(activity, request.user), status=201)

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -225,7 +225,7 @@ class OrganizationSerializer(serializers.Serializer):
 
     def validate_requireEmailVerification(self, value):
         user = self.context["user"]
-        has_verified = UserEmail.get_primary_email(user).is_verified
+        has_verified = UserEmail.objects.get_primary_email(user).is_verified
         if value and not has_verified:
             raise serializers.ValidationError(ERR_EMAIL_VERIFICATION)
         return value

--- a/src/sentry/api/endpoints/shared_group_details.py
+++ b/src/sentry/api/endpoints/shared_group_details.py
@@ -28,7 +28,7 @@ class SharedGroupDetailsEndpoint(Endpoint, EnvironmentMixin):
 
         """
         try:
-            group = Group.from_share_id(share_id)
+            group = Group.objects.from_share_id(share_id)
         except Group.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/endpoints/user_emails.py
+++ b/src/sentry/api/endpoints/user_emails.py
@@ -211,7 +211,7 @@ class UserEmailsEndpoint(UserEndpoint):
             return self.respond(validator.errors, status=400)
 
         email = validator.validated_data["email"]
-        primary_email = UserEmail.get_primary_email(user)
+        primary_email = UserEmail.objects.get_primary_email(user)
         del_email = UserEmail.objects.filter(user=user, email__iexact=email).first()
         del_useroption_email_list = UserOption.objects.filter(
             user=user, key="mail:email", value=email

--- a/src/sentry/api/endpoints/user_subscriptions.py
+++ b/src/sentry/api/endpoints/user_subscriptions.py
@@ -64,7 +64,7 @@ class UserSubscriptionsEndpoint(UserEndpoint):
             return self.respond(validator.errors, status=400)
 
         result = validator.validated_data
-        email = UserEmail.get_primary_email(user)
+        email = UserEmail.objects.get_primary_email(user)
 
         kwargs = {
             "list_id": result["listId"],
@@ -94,7 +94,7 @@ class UserSubscriptionsEndpoint(UserEndpoint):
             return self.respond(validator.errors, status=400)
 
         result = validator.validated_data
-        email = UserEmail.get_primary_email(user)
+        email = UserEmail.objects.get_primary_email(user)
 
         kwargs = {
             "subscribed": result["subscribed"],

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -1024,7 +1024,8 @@ def update_groups(request, group_ids, projects, organization_id, search_fn):
                 GroupResolution.Type.in_release,
             ):
                 result["activity"] = serialize(
-                    Activity.get_activities_for_group(group=group_list[0], num=100), acting_user
+                    Activity.objects.get_activities_for_group(group=group_list[0], num=100),
+                    acting_user,
                 )
     except UnboundLocalError:
         pass

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -227,7 +227,7 @@ class ApiInviteHelper:
 
         user = self.request.user
         primary_email_is_verified = (
-            isinstance(user, User) and UserEmail.get_primary_email(user).is_verified
+            isinstance(user, User) and UserEmail.objects.get_primary_email(user).is_verified
         )
         return not primary_email_is_verified
 

--- a/src/sentry/api/serializers/models/useremail.py
+++ b/src/sentry/api/serializers/models/useremail.py
@@ -5,7 +5,7 @@ from sentry.models import UserEmail
 @register(UserEmail)
 class UserEmailSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        primary_email = UserEmail.get_primary_email(user)
+        primary_email = UserEmail.objects.get_primary_email(user)
         return {
             "email": obj.email,
             "isPrimary": obj.email == primary_email.email,

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -396,7 +396,9 @@ class IssueSyncMixin(IssueBasicMixin):
                 groups_to_resolve.append(group)
 
         if groups_to_resolve:
-            Group.objects.update_group_status(groups_to_resolve, GroupStatus.RESOLVED, ActivityType.SET_RESOLVED)
+            Group.objects.update_group_status(
+                groups_to_resolve, GroupStatus.RESOLVED, ActivityType.SET_RESOLVED
+            )
 
         if groups_to_unresolve:
             Group.objects.update_group_status(

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 
 from sentry import features
-from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
+from sentry.models import ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.models.useroption import UserOption
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.types.activity import ActivityType

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -5,6 +5,7 @@ from sentry import features
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.models.useroption import UserOption
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.types.activity import ActivityType
 from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
@@ -352,19 +353,6 @@ class IssueSyncMixin(IssueBasicMixin):
         """
         raise NotImplementedError
 
-    def update_group_status(self, groups, status, activity_type):
-        updated = (
-            Group.objects.filter(id__in=[g.id for g in groups])
-            .exclude(status=status)
-            .update(status=status)
-        )
-        if updated:
-            for group in groups:
-                activity = Activity.objects.create(
-                    project=group.project, group=group, type=activity_type
-                )
-                activity.send_notification()
-
     def sync_status_inbound(self, issue_key, data):
         if not self.should_sync("inbound_status"):
             return
@@ -408,9 +396,9 @@ class IssueSyncMixin(IssueBasicMixin):
                 groups_to_resolve.append(group)
 
         if groups_to_resolve:
-            self.update_group_status(groups_to_resolve, GroupStatus.RESOLVED, Activity.SET_RESOLVED)
+            Group.objects.update_group_status(groups_to_resolve, GroupStatus.RESOLVED, ActivityType.SET_RESOLVED)
 
         if groups_to_unresolve:
-            self.update_group_status(
-                groups_to_unresolve, GroupStatus.UNRESOLVED, Activity.SET_UNRESOLVED
+            Group.objects.update_group_status(
+                groups_to_unresolve, GroupStatus.UNRESOLVED, ActivityType.SET_UNRESOLVED
             )

--- a/src/sentry/integrations/msteams/link_identity.py
+++ b/src/sentry/integrations/msteams/link_identity.py
@@ -64,7 +64,7 @@ class MsTeamsLinkIdentityView(BaseView):
             if not created:
                 identity.update(**defaults)
         except IntegrityError:
-            Identity.reattach(idp, params["teams_user_id"], request.user, defaults)
+            Identity.objects.reattach(idp, params["teams_user_id"], request.user, defaults)
 
         card = build_linked_card()
         client = MsTeamsClient(integration)

--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -133,7 +133,7 @@ class IntegrationPipeline(Pipeline):
                 except Identity.DoesNotExist:
                     # The user is linked to a different external_id. It's ok to relink
                     # here because they'll still be able to log in with the new external_id.
-                    identity_model = Identity.update_external_id_and_defaults(
+                    identity_model = Identity.objects.update_external_id_and_defaults(
                         idp, identity["external_id"], self.request.user, identity_data
                     )
                 else:

--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -72,7 +72,7 @@ class SlackLinkIdentityView(BaseView):  # type: ignore
             if not created:
                 identity.update(**defaults)
         except IntegrityError:
-            Identity.reattach(idp, params["slack_id"], request.user, defaults)
+            Identity.objects.reattach(idp, params["slack_id"], request.user, defaults)
 
         send_slack_response(integration, SUCCESS_LINKED_MESSAGE, params, command="link")
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -307,10 +307,7 @@ class GroupManager(BaseManager):
         )
         if updated_count:
             for group in groups:
-                activity = Activity.objects.create(
-                    project=group.project, group=group, type=activity_type.value
-                )
-                activity.send_notification()
+                Activity.objects.create_group_activity(group, activity_type)
 
 
 class Group(Model):

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -9,6 +9,7 @@ from sentry.db.models import BaseManager, FlexibleForeignKey, Model, sane_repr
 from sentry.models.activity import Activity
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_assigned
+from sentry.types.activity import ActivityType
 from sentry.utils import metrics
 
 
@@ -160,10 +161,9 @@ class GroupAssigneeManager(BaseManager):
             )
 
         if affected:
-            activity = Activity.objects.create(
-                project=group.project,
-                group=group,
-                type=Activity.ASSIGNED,
+            Activity.objects.create_group_activity(
+                group,
+                ActivityType.ASSIGNED,
                 user=acting_user,
                 data={
                     "assignee": str(assigned_to.id),

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -171,7 +171,7 @@ class GroupAssigneeManager(BaseManager):
                     "assigneeType": assignee_type,
                 },
             )
-            activity.send_notification()
+
             metrics.incr("group.assignee.change", instance="assigned", skip_internal=True)
             # sync Sentry assignee to external issues
             if assignee_type == "user" and features.has(

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -84,6 +84,12 @@ class OrganizationMemberManager(BaseManager):
             user__isnull=False,
         )
 
+    def delete_expired(self, threshold: int) -> None:
+        """Delete un-accepted member invitations that expired `threshold` days ago."""
+        self.filter(token_expires_at__lt=threshold, user_id__exact=None).exclude(
+            email__exact=None
+        ).delete()
+
 
 class OrganizationMember(Model):
     """
@@ -380,13 +386,3 @@ class OrganizationMember(Model):
 
         scopes = frozenset(s for s in scopes if s not in disabled_scopes)
         return scopes
-
-    @classmethod
-    def delete_expired(cls, threshold):
-        """
-        Delete un-accepted member invitations that expired
-        ``threshold`` days ago.
-        """
-        cls.objects.filter(token_expires_at__lt=threshold, user_id__exact=None).exclude(
-            email__exact=None
-        ).delete()

--- a/src/sentry/models/useremail.py
+++ b/src/sentry/models/useremail.py
@@ -67,3 +67,8 @@ class UserEmail(Model):
 
     def is_primary(self):
         return self.user.email == self.email
+
+    @classmethod
+    def get_primary_email(cls, user: "User") -> "UserEmail":
+        """@deprecated"""
+        return cls.objects.get_primary_email(user)

--- a/src/sentry/newsletter/dummy.py
+++ b/src/sentry/newsletter/dummy.py
@@ -27,7 +27,7 @@ class NewsletterSubscription:
         self.list_name = list_name
         # is the email address verified?
         self.verified = (
-            UserEmail.get_primary_email(user).is_verified if verified is None else verified
+            UserEmail.objects.get_primary_email(user).is_verified if verified is None else verified
         )
         # are they subscribed to ``list_id``
         self.subscribed = subscribed

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -204,7 +204,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
             click.echo(">> Skipping OrganizationMember")
     else:
         expired_threshold = timezone.now() - timedelta(days=days)
-        models.OrganizationMember.delete_expired(expired_threshold)
+        models.OrganizationMember.objects.delete_expired(expired_threshold)
 
     for model in [models.ApiGrant, models.ApiToken]:
         if not silent:

--- a/src/sentry/tasks/auth.py
+++ b/src/sentry/tasks/auth.py
@@ -155,7 +155,7 @@ class VerifiedEmailComplianceTask(OrganizationComplianceTask):
     log_label = "verified email"
 
     def is_compliant(self, member: OrganizationMember) -> bool:
-        return UserEmail.get_primary_email(member.user).is_verified
+        return UserEmail.objects.get_primary_email(member.user).is_verified
 
     def call_to_action(self, org: Organization, user: User, member: OrganizationMember):
         import django.contrib.auth.models
@@ -169,7 +169,7 @@ class VerifiedEmailComplianceTask(OrganizationComplianceTask):
         elif not isinstance(user, User):
             raise TypeError(user)
 
-        email = UserEmail.get_primary_email(user)
+        email = UserEmail.objects.get_primary_email(user)
         email_context = {
             "confirm_url": absolute_uri(
                 reverse("sentry-account-confirm-email", args=[user.id, email.validation_hash])

--- a/src/sentry/web/forms/__init__.py
+++ b/src/sentry/web/forms/__init__.py
@@ -1,6 +1,7 @@
 from django import forms
 
 from sentry.models import Activity
+from sentry.types.activity import ActivityType
 
 
 class NewNoteForm(forms.Form):
@@ -9,13 +10,6 @@ class NewNoteForm(forms.Form):
     )
 
     def save(self, group, user, event=None):
-        activity = Activity.objects.create(
-            group=group,
-            project=group.project,
-            type=Activity.NOTE,
-            user=user,
-            data=self.cleaned_data,
+        return Activity.objects.create_group_activity(
+            group, ActivityType.NOTE, user=user, data=self.cleaned_data
         )
-        activity.send_notification()
-
-        return activity

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -197,7 +197,7 @@ class ReleaseSerializerTest(TestCase, SnubaTestCase):
         user = User.objects.create(
             email="Stebe@sentry.io"
         )  # upper case so we can test case sensitivity
-        UserEmail.get_primary_email(user=user)
+        UserEmail.objects.get_primary_email(user=user)
         project = self.create_project()
         self.create_member(user=user, organization=project.organization)
         release = Release.objects.create(

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -153,7 +153,7 @@ class GroupTest(TestCase, SnubaTestCase):
 
     def test_invalid_shared_id(self):
         with pytest.raises(Group.DoesNotExist):
-            Group.from_share_id("adc7a5b902184ce3818046302e94f8ec")
+            Group.objects.from_share_id("adc7a5b902184ce3818046302e94f8ec")
 
     def test_qualified_share_id(self):
         project = self.create_project(name="foo bar")

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -128,7 +128,7 @@ class OrganizationMemberTest(TestCase):
             token="abc-def",
             token_expires_at=ninety_one_days,
         )
-        OrganizationMember.delete_expired(timezone.now())
+        OrganizationMember.objects.delete_expired(timezone.now())
         assert OrganizationMember.objects.filter(id=member.id).first() is None
 
     def test_delete_expired_miss(self):
@@ -141,7 +141,7 @@ class OrganizationMemberTest(TestCase):
             token="abc-def",
             token_expires_at=tomorrow,
         )
-        OrganizationMember.delete_expired(timezone.now())
+        OrganizationMember.objects.delete_expired(timezone.now())
         assert OrganizationMember.objects.get(id=member.id)
 
     def test_delete_expired_leave_claimed(self):
@@ -155,7 +155,7 @@ class OrganizationMemberTest(TestCase):
             token="abc-def",
             token_expires_at="2018-01-01 10:00:00",
         )
-        OrganizationMember.delete_expired(timezone.now())
+        OrganizationMember.objects.delete_expired(timezone.now())
         assert OrganizationMember.objects.get(id=member.id)
 
     def test_delete_expired_leave_null_expires(self):
@@ -167,7 +167,7 @@ class OrganizationMemberTest(TestCase):
             token="abc-def",
             token_expires_at=None,
         )
-        OrganizationMember.delete_expired(timezone.now())
+        OrganizationMember.objects.delete_expired(timezone.now())
         assert OrganizationMember.objects.get(id=member.id)
 
     def test_approve_invite(self):

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -143,7 +143,7 @@ class ResolvedInCommitTest(TestCase):
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        email = UserEmail.get_primary_email(user=user)
+        email = UserEmail.objects.get_primary_email(user=user)
         email.is_verified = True
         email.save()
         repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)
@@ -178,7 +178,7 @@ class ResolvedInCommitTest(TestCase):
         group = self.create_group()
         add_group_to_inbox(group, GroupInboxReason.MANUAL)
         user = self.create_user(name="Foo Bar", email="foo@example.com", is_active=True)
-        email = UserEmail.get_primary_email(user=user)
+        email = UserEmail.objects.get_primary_email(user=user)
         email.is_verified = True
         email.save()
         repo = Repository.objects.create(name="example", organization_id=self.group.organization.id)

--- a/tests/sentry/tasks/test_activity.py
+++ b/tests/sentry/tasks/test_activity.py
@@ -1,6 +1,7 @@
 from sentry.models import Activity
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.testutils import PluginTestCase
+from sentry.types.activity import ActivityType
 from sentry.utils.compat import mock
 
 
@@ -18,14 +19,7 @@ class ActivityNotificationsTest(PluginTestCase):
     @mock.patch("sentry.tasks.activity.send_activity_notifications")
     def test_simple(self, mock_func):
         group = self.create_group()
-
-        activity = Activity.objects.create(
-            project=group.project,
-            group=group,
-            type=Activity.ASSIGNED,
-            user=self.user,
-            data={"assignee": None},
+        Activity.objects.create_group_activity(
+            group, ActivityType.ASSIGNED, user=self.user, data={"assignee": None}
         )
-        activity.send_notification()
-
         assert mock_func.delay.call_count == 1


### PR DESCRIPTION
This PR tries to move toward a pattern of using Django's `Manager` classes to centralize and encapsulate reusable business logic. 
- I'm DRYing up a pattern where we fetch the `project` for a `group` just to get its ID when creating an `Activity`. Also every time we create an `Activity`, we generally also call `activity.send_notification()` so I pulled that into the method. 
- I'm moving `get_activities_for_group()` from a class method on the model to manager method.
- Moving `update_group_status()` from the `sentry.integrations` module to the `GroupManager`.