### PR TITLE
fix(ui): Force refresh projects/teams on project creation

### DIFF
--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -202,7 +202,7 @@ class OrganizationContextContainer extends React.Component<Props, State> {
       this.props.api,
       OrganizationContextContainer.getOrganizationSlug(this.props),
       true,
-      true
+      false
     );
   }
 

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -3,9 +3,9 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateProjects} from 'app/actionCreators/globalSelection';
+import {fetchOrganizationDetails} from 'app/actionCreators/organization';
 import {fetchTagValues} from 'app/actionCreators/tags';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
 import Breadcrumbs from 'app/components/breadcrumbs';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -16,10 +16,11 @@ import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
 import IdBadge from 'app/components/idBadge';
 import * as Layout from 'app/components/layouts/thirds';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import LoadingError from 'app/components/loadingError';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import MissingProjectMembership from 'app/components/projects/missingProjectMembership';
 import TextOverflow from 'app/components/textOverflow';
-import {IconSettings, IconWarning} from 'app/icons';
+import {IconSettings} from 'app/icons';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
@@ -169,6 +170,11 @@ class ProjectDetail extends AsyncView<Props, State> {
     }
   }
 
+  onRetryProjects = () => {
+    const {params} = this.props;
+    fetchOrganizationDetails(this.api, params.orgId, true, false);
+  };
+
   isProjectStabilized() {
     const {selection, location} = this.props;
     const projectId = this.project?.id;
@@ -197,9 +203,10 @@ class ProjectDetail extends AsyncView<Props, State> {
   renderProjectNotFound() {
     return (
       <PageContent>
-        <Alert type="error" icon={<IconWarning />}>
-          {t('This project could not be found.')}
-        </Alert>
+        <LoadingError
+          message={t('This project could not be found.')}
+          onRetry={this.onRetryProjects}
+        />
       </PageContent>
     );
   }


### PR DESCRIPTION
fixes an issue after project creation where the new project isn't available in the store.

Adds a retry button to the project details page that should attempt to reload projects

![image](https://user-images.githubusercontent.com/1400464/135148515-1a0f579c-db25-4782-899e-96d91e924f92.png)
