### PR TITLE
feat(interface-breadcrumb): Add breadcrumb eventlink

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -1,4 +1,4 @@
-import {memo, useEffect, useState} from 'react';
+import React, {memo, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';
@@ -55,7 +55,7 @@ const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH =
 
 type ProGuardErrors = Array<Error>;
 
-type Props = {
+type Props = Pick<React.ComponentProps<typeof EventEntry>, 'route' | 'router'> & {
   /**
    * The organization can be the shared view on a public issue view.
    */
@@ -81,6 +81,8 @@ const EventEntries = memo(
     event,
     group,
     className,
+    router,
+    route,
     isShare = false,
     showExampleCommit = false,
     showTagSummary = true,
@@ -320,6 +322,8 @@ const EventEntries = memo(
             organization={organization}
             event={definedEvent}
             entry={entry}
+            route={route}
+            router={router}
           />
         </ErrorBoundary>
       ));

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -15,7 +15,7 @@ import Threads from 'app/components/events/interfaces/threads';
 import {Group, Organization, Project, SharedViewOrganization} from 'app/types';
 import {Entry, EntryType, Event, EventTransaction} from 'app/types/event';
 
-type Props = {
+type Props = Pick<React.ComponentProps<typeof Breadcrumbs>, 'route' | 'router'> & {
   entry: Entry;
   projectSlug: Project['slug'];
   event: Event;
@@ -23,7 +23,15 @@ type Props = {
   group?: Group;
 };
 
-function EventEntry({entry, projectSlug, event, organization, group}: Props) {
+function EventEntry({
+  entry,
+  projectSlug,
+  event,
+  organization,
+  group,
+  route,
+  router,
+}: Props) {
   const hasHierarchicalGrouping =
     !!organization.features?.includes('grouping-stacktrace-ui') &&
     !!(event.metadata.current_tree_label || event.metadata.finest_tree_label);
@@ -87,6 +95,8 @@ function EventEntry({entry, projectSlug, event, organization, group}: Props) {
           data={data}
           organization={organization as Organization}
           event={event}
+          router={router}
+          route={route}
         />
       );
     }

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
@@ -15,26 +15,33 @@ type Props = {
   breadcrumb: BreadcrumbTypeDefault | BreadcrumbTypeNavigation;
   event: Event;
   orgSlug: Organization['slug'];
+  linkedEvent?: React.ReactElement;
 };
 
-const Default = ({breadcrumb, event, orgSlug, searchTerm}: Props) => (
-  <Summary kvData={breadcrumb.data}>
-    {breadcrumb?.message && (
-      <AnnotatedText
-        value={
-          <FormatMessage
-            searchTerm={searchTerm}
-            event={event}
-            orgSlug={orgSlug}
-            breadcrumb={breadcrumb}
-            message={breadcrumb.message}
-          />
-        }
-        meta={getMeta(breadcrumb, 'message')}
-      />
-    )}
-  </Summary>
-);
+function Default({breadcrumb, event, orgSlug, searchTerm, linkedEvent}: Props) {
+  const {message} = breadcrumb;
+  return (
+    <Summary kvData={breadcrumb.data}>
+      {linkedEvent}
+      {message && (
+        <AnnotatedText
+          value={
+            <FormatMessage
+              searchTerm={searchTerm}
+              event={event}
+              orgSlug={orgSlug}
+              breadcrumb={breadcrumb}
+              message={message}
+            />
+          }
+          meta={getMeta(breadcrumb, 'message')}
+        />
+      )}
+    </Summary>
+  );
+}
+
+export default Default;
 
 function isEventId(maybeEventId: string): boolean {
   // maybeEventId is an event id if it's a hex string of 32 characters long
@@ -80,5 +87,3 @@ const FormatMessage = withProjects(function FormatMessageInner({
 
   return content;
 });
-
-export default Default;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.tsx
@@ -11,14 +11,16 @@ import Summary from './summary';
 type Props = {
   searchTerm: string;
   breadcrumb: BreadcrumbTypeDefault;
+  linkedEvent?: React.ReactElement;
 };
 
-const Exception = ({breadcrumb, searchTerm}: Props) => {
-  const {data} = breadcrumb;
+function Exception({breadcrumb, searchTerm, linkedEvent}: Props) {
+  const {data, message} = breadcrumb;
   const dataValue = data?.value;
 
   return (
     <Summary kvData={omit(data, ['type', 'value'])}>
+      {linkedEvent}
       {data?.type && (
         <AnnotatedText
           value={
@@ -39,14 +41,14 @@ const Exception = ({breadcrumb, searchTerm}: Props) => {
           meta={getMeta(data, 'value')}
         />
       )}
-      {breadcrumb?.message && (
+      {message && (
         <AnnotatedText
-          value={<Highlight text={searchTerm}>{breadcrumb.message}</Highlight>}
+          value={<Highlight text={searchTerm}>{message}</Highlight>}
           meta={getMeta(breadcrumb, 'message')}
         />
       )}
     </Summary>
   );
-};
+}
 
 export default Exception;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.tsx
@@ -13,9 +13,10 @@ import Summary from './summary';
 type Props = {
   searchTerm: string;
   breadcrumb: BreadcrumbTypeHTTP;
+  linkedEvent?: React.ReactElement;
 };
 
-const Http = ({breadcrumb, searchTerm}: Props) => {
+function Http({breadcrumb, searchTerm, linkedEvent}: Props) {
   const {data} = breadcrumb;
 
   const renderUrl = (url: any) => {
@@ -41,6 +42,7 @@ const Http = ({breadcrumb, searchTerm}: Props) => {
 
   return (
     <Summary kvData={omit(data, ['method', 'url', 'status_code'])}>
+      {linkedEvent}
       {data?.method && (
         <AnnotatedText
           value={
@@ -67,6 +69,6 @@ const Http = ({breadcrumb, searchTerm}: Props) => {
       )}
     </Summary>
   );
-};
+}
 
 export default Http;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/index.tsx
@@ -5,24 +5,42 @@ import {Event} from 'app/types/event';
 import Default from './default';
 import Exception from './exception';
 import Http from './http';
+import LinkedEvent from './linkedEvent';
 
-type Props = {
+type Props = Pick<React.ComponentProps<typeof LinkedEvent>, 'route' | 'router'> & {
   searchTerm: string;
   breadcrumb: RawCrumb;
   event: Event;
   orgSlug: Organization['slug'];
 };
 
-const Data = ({breadcrumb, event, orgSlug, searchTerm}: Props) => {
+function Data({breadcrumb, event, orgSlug, searchTerm, route, router}: Props) {
+  const linkedEvent = breadcrumb.event_id ? (
+    <LinkedEvent
+      orgSlug={orgSlug}
+      eventId={breadcrumb.event_id}
+      route={route}
+      router={router}
+    />
+  ) : undefined;
+
   if (breadcrumb.type === BreadcrumbType.HTTP) {
-    return <Http breadcrumb={breadcrumb} searchTerm={searchTerm} />;
+    return (
+      <Http breadcrumb={breadcrumb} searchTerm={searchTerm} linkedEvent={linkedEvent} />
+    );
   }
 
   if (
     breadcrumb.type === BreadcrumbType.WARNING ||
     breadcrumb.type === BreadcrumbType.ERROR
   ) {
-    return <Exception breadcrumb={breadcrumb} searchTerm={searchTerm} />;
+    return (
+      <Exception
+        breadcrumb={breadcrumb}
+        searchTerm={searchTerm}
+        linkedEvent={linkedEvent}
+      />
+    );
   }
 
   return (
@@ -31,8 +49,9 @@ const Data = ({breadcrumb, event, orgSlug, searchTerm}: Props) => {
       orgSlug={orgSlug}
       breadcrumb={breadcrumb}
       searchTerm={searchTerm}
+      linkedEvent={linkedEvent}
     />
   );
-};
+}
 
 export default Data;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/linkedEvent.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/linkedEvent.tsx
@@ -1,0 +1,119 @@
+import {useEffect, useState} from 'react';
+import {InjectedRouter, PlainRoute} from 'react-router';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import Placeholder from 'app/components/placeholder';
+import ShortId from 'app/components/shortId';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {EventIdResponse, Group, Organization, Project} from 'app/types';
+import useApi from 'app/utils/useApi';
+import useSessionStorage from 'app/utils/useSessionStorage';
+
+type StoredLinkedEvent = {
+  shortId: string;
+  groupId: string;
+  project: Project;
+  orgSlug: Organization['slug'];
+};
+
+type Props = {
+  orgSlug: Organization['slug'];
+  eventId: string;
+  router: InjectedRouter;
+  route: PlainRoute;
+};
+
+function LinkedEvent({orgSlug, eventId, route, router}: Props) {
+  const [storedLinkedEvent, setStoredLinkedEvent, removeStoredLinkedEvent] =
+    useSessionStorage<undefined | StoredLinkedEvent>(eventId);
+
+  const [eventIdLookup, setEventIdLookup] = useState<undefined | EventIdResponse>();
+
+  const api = useApi();
+
+  useEffect(() => {
+    fetchEventById();
+    router.setRouteLeaveHook(route, onRouteLeave);
+  }, []);
+
+  useEffect(() => {
+    fetchIssueByGroupId();
+  }, [eventIdLookup]);
+
+  function onRouteLeave() {
+    removeStoredLinkedEvent();
+  }
+
+  async function fetchEventById() {
+    if (!!storedLinkedEvent) {
+      return;
+    }
+
+    try {
+      const response = await api.requestPromise(
+        `/organizations/${orgSlug}/eventids/${eventId}/`
+      );
+
+      setEventIdLookup(response);
+    } catch (error) {
+      addErrorMessage(
+        t('An error occured while fetching the data of the breadcrumb event link')
+      );
+      Sentry.captureException(error);
+      // do nothing. The link won't be displayed
+    }
+  }
+
+  async function fetchIssueByGroupId() {
+    if (!!storedLinkedEvent || !eventIdLookup) {
+      return;
+    }
+
+    try {
+      const response = await api.requestPromise(
+        `/organizations/${orgSlug}/issues/${eventIdLookup.groupId}/`
+      );
+
+      const {project, shortId} = response as Group;
+      const {groupId} = eventIdLookup;
+      setStoredLinkedEvent({shortId, project, groupId, orgSlug});
+    } catch (error) {
+      addErrorMessage(
+        t('An error occured while fetching the data of the breadcrumb event link')
+      );
+      Sentry.captureException(error);
+      // do nothing. The link won't be displayed
+    }
+  }
+
+  if (!storedLinkedEvent) {
+    return <StyledPlaceholder height="16px" width="109px" />;
+  }
+
+  const {shortId, project, groupId} = storedLinkedEvent;
+
+  return (
+    <StyledShortId
+      shortId={shortId}
+      avatar={<ProjectBadge project={project} avatarSize={16} hideName />}
+      to={`/${orgSlug}/${project.slug}/issues/${groupId}/events/${eventId}/`}
+    />
+  );
+}
+
+export default LinkedEvent;
+
+const StyledShortId = styled(ShortId)`
+  font-weight: 700;
+  display: inline-grid;
+  margin-right: ${space(1)};
+`;
+
+const StyledPlaceholder = styled(Placeholder)`
+  display: inline-flex;
+  margin-right: ${space(1)};
+`;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/summary.tsx
@@ -59,9 +59,11 @@ const ContextDataWrapper = styled('div')`
 `;
 
 const StyledCode = styled('code')`
-  line-height: 26px;
   font-size: inherit;
   white-space: pre-wrap;
   background: none;
   padding: 0;
+  > * {
+    vertical-align: middle;
+  }
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import {memo} from 'react';
+import React, {memo} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,7 +13,7 @@ import Level from './level';
 import Time from './time';
 import Type from './type';
 
-type Props = {
+type Props = Pick<React.ComponentProps<typeof Data>, 'route' | 'router'> & {
   breadcrumb: Crumb;
   event: Event;
   orgSlug: Organization['slug'];
@@ -37,6 +37,8 @@ const Breadcrumb = memo(function Breadcrumb({
   onLoad,
   scrollbarSize,
   style,
+  route,
+  router,
   ['data-test-id']: dataTestId,
 }: Props) {
   const {type, description, color, level, category, timestamp} = breadcrumb;
@@ -57,6 +59,8 @@ const Breadcrumb = memo(function Breadcrumb({
         orgSlug={orgSlug}
         breadcrumb={breadcrumb}
         searchTerm={searchTerm}
+        route={route}
+        router={router}
       />
       <div>
         <Level level={level} searchTerm={searchTerm} />
@@ -101,6 +105,7 @@ const Wrapper = styled('div')<{error: boolean; scrollbarSize: number}>`
       :nth-child(5n-2) {
         grid-row: 2/2;
         grid-column: 2/-1;
+        padding-top: 0;
         padding-right: ${space(2)};
       }
 

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -26,7 +26,13 @@ const cache = new CellMeasurerCache({
 
 type Props = Pick<
   React.ComponentProps<typeof Breadcrumb>,
-  'event' | 'orgSlug' | 'searchTerm' | 'relativeTime' | 'displayRelativeTime'
+  | 'event'
+  | 'orgSlug'
+  | 'searchTerm'
+  | 'relativeTime'
+  | 'displayRelativeTime'
+  | 'router'
+  | 'route'
 > & {
   breadcrumbs: Crumb[];
   onSwitchTimeFormat: () => void;
@@ -45,6 +51,8 @@ function Breadcrumbs({
   event,
   relativeTime,
   emptyMessage,
+  route,
+  router,
 }: Props) {
   const [scrollToIndex, setScrollToIndex] = useState<number | undefined>(undefined);
   const [scrollbarSize, setScrollbarSize] = useState(0);
@@ -107,6 +115,8 @@ function Breadcrumbs({
                 ? scrollbarSize
                 : 0
             }
+            router={router}
+            route={route}
           />
         )}
       </CellMeasurer>

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -37,7 +37,7 @@ type FilterTypes = {
   levels: BreadcrumbLevelType[];
 };
 
-type Props = {
+type Props = Pick<React.ComponentProps<typeof Breadcrumbs>, 'route' | 'router'> & {
   event: Event;
   organization: Organization;
   type: string;
@@ -56,7 +56,14 @@ type State = {
   relativeTime?: string;
 };
 
-function BreadcrumbsContainer({data, event, organization, type: eventType}: Props) {
+function BreadcrumbsContainer({
+  data,
+  event,
+  organization,
+  type: eventType,
+  route,
+  router,
+}: Props) {
   const [state, setState] = useState<State>({
     searchTerm: '',
     breadcrumbs: [],
@@ -94,7 +101,7 @@ function BreadcrumbsContainer({data, event, organization, type: eventType}: Prop
 
     setState({
       ...state,
-      relativeTime: transformedCrumbs[transformedCrumbs.length - 1]?.timestamp,
+      relativeTime: transformedCrumbs[transformedCrumbs.length - 1].timestamp,
       breadcrumbs: transformedCrumbs,
       filteredByFilter: transformedCrumbs,
       filteredBySearch: transformedCrumbs,
@@ -383,6 +390,8 @@ function BreadcrumbsContainer({data, event, organization, type: eventType}: Prop
     >
       <ErrorBoundary>
         <Breadcrumbs
+          router={router}
+          route={route}
           emptyMessage={getEmptyMessage()}
           breadcrumbs={filteredBySearch}
           event={event}

--- a/static/app/components/events/meta/annotatedText/index.tsx
+++ b/static/app/components/events/meta/annotatedText/index.tsx
@@ -17,9 +17,10 @@ import ValueElement from './valueElement';
 type Props = {
   value: React.ReactNode;
   meta?: Meta;
+  className?: string;
 };
 
-const AnnotatedText = ({value, meta, ...props}: Props) => {
+const AnnotatedText = ({value, meta, className, ...props}: Props) => {
   const renderValue = () => {
     if (meta?.chunks?.length && meta.chunks.length > 1) {
       return <Chunks chunks={meta.chunks} />;
@@ -86,7 +87,7 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
   };
 
   return (
-    <span {...props}>
+    <span className={className} {...props}>
       {renderValue()}
       {meta?.err && renderErrors(meta.err)}
     </span>

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -7,16 +7,16 @@ import flatten from 'lodash/flatten';
 import {Client, ResponseMeta} from 'app/api';
 import {t} from 'app/locale';
 import {
-  Group,
+  EventIdResponse,
   IntegrationProvider,
   Member,
   Organization,
   PluginWithProjectList,
   Project,
   SentryApp,
+  ShortIdResponse,
   Team,
 } from 'app/types';
-import {Event} from 'app/types/event';
 import {defined} from 'app/utils';
 import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import {singleLineRenderer as markedSingleLine} from 'app/utils/marked';
@@ -24,24 +24,6 @@ import withLatestContext from 'app/utils/withLatestContext';
 import {documentIntegrationList} from 'app/views/organizationIntegrations/constants';
 
 import {ChildProps, Result, ResultItem} from './types';
-
-// Response from ShortIdLookupEndpoint
-type ShortIdResponse = {
-  organizationSlug: string;
-  projectSlug: string;
-  groupId: string;
-  group: Group;
-  shortId: string;
-};
-
-// Response from EventIdLookupEndpoint
-type EventIdResponse = {
-  organizationSlug: string;
-  projectSlug: string;
-  groupId: string;
-  eventId: string;
-  event: Event;
-};
 
 // event ids must have string length of 32
 const shouldSearchEventIds = (query?: string) =>

--- a/static/app/components/shortId.tsx
+++ b/static/app/components/shortId.tsx
@@ -1,39 +1,47 @@
 import * as React from 'react';
-import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
 import AutoSelectText from 'app/components/autoSelectText';
+import Link from 'app/components/links/link';
 
 type Props = {
   shortId: string;
   avatar?: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  /**
+   * A router target destination
+   */
+  to?: React.ComponentProps<typeof Link>['to'];
+  className?: string;
 };
 
-const ShortId = ({shortId, avatar, ...props}: Props) => {
+function ShortId({shortId, avatar, onClick, to, className}: Props) {
   if (!shortId) {
     return null;
   }
 
   return (
-    <StyledShortId {...props}>
+    <StyledShortId onClick={onClick} className={className}>
       {avatar}
-      <StyledAutoSelectText avatar={!!avatar}>{shortId}</StyledAutoSelectText>
+      {to ? (
+        <Link to={to}>{shortId}</Link>
+      ) : (
+        <StyledAutoSelectText>{shortId}</StyledAutoSelectText>
+      )}
     </StyledShortId>
   );
-};
+}
 
 const StyledShortId = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: 0.5em;
   align-items: center;
   justify-content: flex-end;
 `;
 
-const StyledAutoSelectText = styled(AutoSelectText, {shouldForwardProp: isPropValid})<{
-  avatar: boolean;
-}>`
-  margin-left: ${p => p.avatar && '0.5em'};
+const StyledAutoSelectText = styled(AutoSelectText)`
   min-width: 0;
 `;
 

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -2234,3 +2234,23 @@ export type CodeownersFile = {
   filepath: string;
   html_url: string;
 };
+
+// Response from ShortIdLookupEndpoint
+// /organizations/${orgId}/shortids/${query}/
+export type ShortIdResponse = {
+  organizationSlug: string;
+  projectSlug: string;
+  groupId: string;
+  group: Group;
+  shortId: string;
+};
+
+// Response from EventIdLookupEndpoint
+// /organizations/${orgSlug}/eventids/${eventId}/
+export type EventIdResponse = {
+  organizationSlug: string;
+  projectSlug: string;
+  groupId: string;
+  eventId: string;
+  event: Event;
+};

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -1,0 +1,49 @@
+import {Dispatch, SetStateAction, useEffect, useState} from 'react';
+
+const isBrowser = typeof window !== 'undefined';
+
+function useSessionStorage<T>(
+  key: string,
+  initialValue?: T
+): [T | undefined, Dispatch<SetStateAction<T | undefined>>, () => void] {
+  if (!isBrowser) {
+    return [initialValue, () => {}, () => {}];
+  }
+
+  const [state, setState] = useState<T | undefined>(() => {
+    try {
+      // Get from session storage by key
+      const sessionStorageValue = sessionStorage.getItem(key);
+
+      if (sessionStorageValue === 'undefined') {
+        return initialValue;
+      }
+
+      // Parse stored json or if none return initialValue
+      return sessionStorageValue ? JSON.parse(sessionStorageValue) : initialValue;
+    } catch {
+      // If user is in private mode or has storage restriction
+      // sessionStorage can throw. JSON.parse and JSON.stringify
+      // can throw, too.
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      const serializedState = JSON.stringify(state);
+      sessionStorage.setItem(key, serializedState);
+    } catch {
+      // If user is in private mode or has storage restriction
+      // sessionStorage can throw. Also JSON.stringify can throw.
+    }
+  }, [state]);
+
+  function removeItem() {
+    sessionStorage.removeItem(key);
+  }
+
+  return [state, setState, removeItem];
+}
+
+export default useSessionStorage;

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -41,6 +41,7 @@ function useSessionStorage<T>(
 
   function removeItem() {
     sessionStorage.removeItem(key);
+    setState(undefined);
   }
 
   return [state, setState, removeItem];

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -50,7 +50,10 @@ import LinkedIssue from './linkedIssue';
  */
 const EXCLUDED_TAG_KEYS = new Set(['release']);
 
-type Props = Pick<RouteComponentProps<{eventSlug: string}, {}>, 'params' | 'location'> & {
+type Props = Pick<
+  RouteComponentProps<{eventSlug: string}, {}>,
+  'params' | 'location' | 'route' | 'router'
+> & {
   organization: Organization;
   eventSlug: string;
   eventView: EventView;
@@ -134,7 +137,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
   }
 
   renderContent(event: Event) {
-    const {organization, location, eventView} = this.props;
+    const {organization, location, eventView, route, router} = this.props;
     const {isSidebarVisible} = this.state;
 
     // metrics
@@ -238,6 +241,8 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                         showExampleCommit={false}
                         showTagSummary={false}
                         api={this.api}
+                        router={router}
+                        route={route}
                         isBorderless
                       />
                     </QuickTraceContext.Provider>

--- a/static/app/views/eventsV2/eventDetails/index.tsx
+++ b/static/app/views/eventsV2/eventDetails/index.tsx
@@ -39,7 +39,7 @@ class EventDetails extends Component<Props> {
       : [t('Discover')];
 
   render() {
-    const {organization, location, params} = this.props;
+    const {organization, location, params, router, route} = this.props;
     const eventView = this.getEventView();
     const eventSlug = this.getEventSlug();
 
@@ -60,6 +60,8 @@ class EventDetails extends Component<Props> {
               params={params}
               eventView={eventView}
               eventSlug={eventSlug}
+              router={router}
+              route={route}
             />
           </LightWeightNoProjectMessage>
         </StyledPageContent>

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -157,6 +157,8 @@ class GroupEventDetails extends Component<Props, State> {
       loadingEvent,
       onRetry,
       eventError,
+      router,
+      route,
     } = this.props;
 
     if (loadingEvent) {
@@ -177,6 +179,8 @@ class GroupEventDetails extends Component<Props, State> {
         project={project}
         location={location}
         showExampleCommit={this.showExampleCommit}
+        router={router}
+        route={route}
       />
     );
   }

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -33,7 +33,10 @@ import {getTransactionDetailsUrl} from '../utils';
 
 import EventMetas from './eventMetas';
 
-type Props = Pick<RouteComponentProps<{eventSlug: string}, {}>, 'params' | 'location'> & {
+type Props = Pick<
+  RouteComponentProps<{eventSlug: string}, {}>,
+  'params' | 'location' | 'router' | 'route'
+> & {
   organization: Organization;
   eventSlug: string;
 };
@@ -103,7 +106,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
   }
 
   renderContent(event: Event) {
-    const {organization, location, eventSlug} = this.props;
+    const {organization, location, eventSlug, route, router} = this.props;
 
     // metrics
     trackAnalyticsEvent({
@@ -198,6 +201,8 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                               showTagSummary={false}
                               location={location}
                               api={this.api}
+                              router={router}
+                              route={route}
                               isBorderless
                             />
                           </QuickTraceContext.Provider>

--- a/static/app/views/performance/transactionDetails/index.tsx
+++ b/static/app/views/performance/transactionDetails/index.tsx
@@ -24,7 +24,7 @@ class EventDetails extends Component<Props> {
   };
 
   render() {
-    const {organization, location, params} = this.props;
+    const {organization, location, params, router, route} = this.props;
     const documentTitle = t('Performance Details');
     const eventSlug = this.getEventSlug();
     const projectSlug = eventSlug.split(':')[0];
@@ -55,6 +55,8 @@ class EventDetails extends Component<Props> {
               location={location}
               params={params}
               eventSlug={eventSlug}
+              router={router}
+              route={route}
             />
           </LightWeightNoProjectMessage>
         </StyledPageContent>

--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -102,7 +102,7 @@ class SharedGroupDetails extends Component<Props, State> {
       return <LoadingError onRetry={this.handleRetry} />;
     }
 
-    const {location, api} = this.props;
+    const {location, api, route, router} = this.props;
     const {permalink, latestEvent, project} = group;
     const title = this.getTitle();
 
@@ -132,6 +132,8 @@ class SharedGroupDetails extends Component<Props, State> {
                     event={latestEvent}
                     project={project}
                     api={api}
+                    route={route}
+                    router={router}
                     isBorderless
                     isShare
                   />

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -1,3 +1,4 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
 import {findAllByTextContent} from 'sentry-test/utils';
 
@@ -7,9 +8,12 @@ import {EntryType} from 'app/types/event';
 
 describe('Breadcrumbs', () => {
   let props: React.ComponentProps<typeof Breadcrumbs>;
+  const {router} = initializeOrg();
 
   beforeEach(() => {
     props = {
+      route: {},
+      router,
       // @ts-expect-error
       organization: TestStubs.Organization(),
       // @ts-expect-error


### PR DESCRIPTION
- [x] created useSessionStorage hook
- [x] created eventLink component
- [x] update code to pass route and router down 

Preview:

![image](https://user-images.githubusercontent.com/29228205/135091239-ac98e073-5a9e-42f8-80b3-728b223efd51.png)

![image](https://user-images.githubusercontent.com/29228205/135091360-b38a2166-ca2b-4ac4-b120-a78c10bdd2b2.png)

ps: Currently, the UI needs to send two requests to get all the necessary data, but we will create a new endpoint in the next Sprint and replace those two requests with just one.