### PR TITLE
fix(metrics): Remove UseCase from indexer calls

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -19,35 +19,34 @@ from sentry.release_health.base import (
     ReleasesAdoption,
 )
 from sentry.sentry_metrics import indexer
-from sentry.sentry_metrics.indexer.base import UseCase
 from sentry.snuba.dataset import Dataset
 from sentry.utils.snuba import raw_snql_query
 
 
 def metric_id(org_id: int, name: str) -> int:
-    index = indexer.resolve(org_id, UseCase.TAG_KEY, name)  # type: ignore
+    index = indexer.resolve(org_id, name)  # type: ignore
     assert index is not None  # TODO: assert too strong?
     return index  # type: ignore
 
 
 def tag_key(org_id: int, name: str) -> str:
-    index = indexer.resolve(org_id, UseCase.TAG_KEY, name)  # type: ignore
+    index = indexer.resolve(org_id, name)  # type: ignore
     assert index is not None
     return f"tags[{index}]"
 
 
 def tag_value(org_id: int, name: str) -> int:
-    index = indexer.resolve(org_id, UseCase.TAG_VALUE, name)  # type: ignore
+    index = indexer.resolve(org_id, name)  # type: ignore
     assert index is not None
     return index  # type: ignore
 
 
 def try_get_tag_value(org_id: int, name: str) -> Optional[int]:
-    return indexer.resolve(org_id, UseCase.TAG_VALUE, name)  # type: ignore
+    return indexer.resolve(org_id, name)  # type: ignore
 
 
 def reverse_tag_value(org_id: int, index: int) -> str:
-    str_value = indexer.reverse_resolve(org_id, UseCase.TAG_VALUE, index)  # type: ignore
+    str_value = indexer.reverse_resolve(org_id, index)  # type: ignore
     assert str_value is not None
     return str_value  # type: ignore
 
@@ -210,7 +209,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 environment_tag_values = []
 
                 for environment in environments:
-                    value = indexer.resolve(org_id, UseCase.TAG_VALUE, environment)  # type: ignore
+                    value = indexer.resolve(org_id, environment)  # type: ignore
                     if value is not None:
                         environment_tag_values.append(value)
 
@@ -222,7 +221,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 release_tag_values = []
 
                 for _, release in project_releases:
-                    value = indexer.resolve(org_id, UseCase.TAG_VALUE, release)  # type: ignore
+                    value = indexer.resolve(org_id, release)  # type: ignore
                     if value is not None:
                         # We should not append the value if it hasn't been
                         # observed before.
@@ -320,7 +319,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         rv = {}
 
         for project_id, release in project_releases:
-            release_tag_value = indexer.resolve(org_id, UseCase.TAG_VALUE, release)  # type: ignore
+            release_tag_value = indexer.resolve(org_id, release)  # type: ignore
             if release_tag_value is None:
                 # Don't emit empty releases -- for exact compatibility with
                 # sessions table backend.

--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -1,13 +1,6 @@
-from enum import Enum
 from typing import Dict, List, Optional
 
 from sentry.utils.services import Service
-
-
-class UseCase(Enum):
-    METRIC = 0
-    TAG_KEY = 1
-    TAG_VALUE = 2
 
 
 class StringIndexer(Service):  # type: ignore

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -80,7 +80,6 @@ from sentry.models import (
 from sentry.plugins.base import plugins
 from sentry.rules import EventState
 from sentry.sentry_metrics import indexer
-from sentry.sentry_metrics.indexer.base import UseCase
 from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils import json
@@ -978,17 +977,17 @@ class SessionMetricsTestCase(SnubaTestCase):
     @classmethod
     def _push_metric(cls, session, type, name, tags, value):
         def metric_id(name):
-            res = indexer.record(session["org_id"], UseCase.METRIC, name)
+            res = indexer.record(session["org_id"], name)
             assert res is not None, name
             return res
 
         def tag_key(name):
-            res = indexer.record(session["org_id"], UseCase.TAG_KEY, name)
+            res = indexer.record(session["org_id"], name)
             assert res is not None, name
             return res
 
         def tag_value(name):
-            res = indexer.record(session["org_id"], UseCase.TAG_KEY, name)
+            res = indexer.record(session["org_id"], name)
             assert res is not None, name
             return res
 


### PR DESCRIPTION
The `UseCase` arg was removed in https://github.com/getsentry/sentry/pull/28431.