### PR TITLE
fix(dependencies): Add typing_extensions as dependency

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -101,3 +101,7 @@ sqlparse==0.2.4
 # We're still using mock in Python 3.6 because it contains a fix to Python issue37972.
 # We should be able to fully swap it out for stdlib once we're on 3.8.
 mock==4.0.3
+
+# this is already a transitive dependency via structlog, and we started
+# implicitly relying on it because of that. Can probably be removed with 3.8
+typing-extensions==3.10.0.2


### PR DESCRIPTION
I believe somebody at some point decided that we don't want to have this
as a runtime dependency (and use `if TYPE_CHECKING` everywhere), however
it turns out that we already do depend on it in form of a transitive
dependency. So, pin it.