### PR TITLE
fix(ui): Trace navigator nodes with errors misaligned

### DIFF
--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -290,7 +290,10 @@ function EventNodeSelector({
   let errors: TraceError[] = events.flatMap(event => event.errors ?? []);
 
   let type: keyof Theme['tag'] = nodeKey === 'current' ? 'black' : 'white';
-  if (errors.length > 0) {
+
+  const hasErrors = errors.length > 0;
+
+  if (hasErrors) {
     type = nodeKey === 'current' ? 'error' : 'warning';
     text = (
       <ErrorNodeContent>
@@ -331,6 +334,7 @@ function EventNodeSelector({
         to={target}
         onClick={() => handleNode(nodeKey, organization)}
         type={type}
+        shouldOffset={hasErrors}
       />
     );
   } else {
@@ -351,7 +355,14 @@ function EventNodeSelector({
       <DropdownContainer>
         <DropdownLink
           caret={false}
-          title={<StyledEventNode text={text} hoverText={hoverText} type={type} />}
+          title={
+            <StyledEventNode
+              text={text}
+              hoverText={hoverText}
+              type={type}
+              shouldOffset={hasErrors}
+            />
+          }
           anchorRight={anchor === 'right'}
         >
           {errors.length > 0 && (
@@ -486,12 +497,26 @@ type EventNodeProps = {
   to?: LocationDescriptor;
   onClick?: (eventKey: any) => void;
   type?: keyof Theme['tag'];
+  shouldOffset?: boolean;
 };
 
-function StyledEventNode({text, hoverText, to, onClick, type = 'white'}: EventNodeProps) {
+function StyledEventNode({
+  text,
+  hoverText,
+  to,
+  onClick,
+  type = 'white',
+  shouldOffset = false,
+}: EventNodeProps) {
   return (
     <Tooltip position="top" containerDisplayMode="inline-flex" title={hoverText}>
-      <EventNode type={type} icon={null} to={to} onClick={onClick}>
+      <EventNode
+        type={type}
+        icon={null}
+        to={to}
+        onClick={onClick}
+        shouldOffset={shouldOffset}
+      >
         {text}
       </EventNode>
     </Tooltip>

--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -46,7 +46,7 @@ const nodeColors = (theme: Theme) => ({
   },
 });
 
-export const EventNode = styled(Tag)`
+export const EventNode = styled(Tag)<{shouldOffset?: boolean}>`
   span {
     display: flex;
     color: ${p => nodeColors(p.theme)[p.type || 'white'].color};
@@ -55,6 +55,12 @@ export const EventNode = styled(Tag)`
     background-color: ${p => nodeColors(p.theme)[p.type || 'white'].background};
     border: 1px solid ${p => nodeColors(p.theme)[p.type || 'white'].border};
   }
+
+  /*
+   * When the EventNode is contains an icon, we need to offset the
+   * component a little for all the EventNodes to be aligned.
+   */
+  ${p => p.shouldOffset && `margin-top: ${space(0.5)}`}
 `;
 
 export const TraceConnector = styled('div')`


### PR DESCRIPTION
When there is an icon within the node, the node needs to be shifted down so that
it aligns with the other nodes.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/135123361-e44c6a1d-454c-4064-a559-0e69242328ee.png)

## After

![image](https://user-images.githubusercontent.com/10239353/135123400-4cb941d4-8749-4bfb-ae01-c8c1496a6437.png)
