### PR TITLE
feat(integrations): Make `sync_status_inbound` a Task

### DIFF
--- a/src/sentry/tasks/integrations.py
+++ b/src/sentry/tasks/integrations.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import timedelta
 from time import time
+from typing import Any, Mapping
 
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -21,6 +22,7 @@ from sentry.models import (
 from sentry.models.apitoken import generate_token
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.tasks.base import instrumented_task, retry, track_group_async_operation
+from sentry.types.activity import ActivityType
 
 logger = logging.getLogger("sentry.tasks.integrations")
 
@@ -403,3 +405,44 @@ def vsts_subscription_check(integration_id, organization_id, **kwargs):
 
         integration.metadata["subscription"]["check"] = time()
         integration.save()
+
+
+@instrumented_task(
+    name="sentry.tasks.integrations.sync_status_inbound",
+    queue="integrations",
+    default_retry_delay=60 * 5,
+    max_retries=5,
+)
+@retry(exclude=(Integration.DoesNotExist,))
+@track_group_async_operation
+def sync_status_inbound(
+    integration_id: int, organization_id: int, issue_key: str, data: Mapping[str, Any]
+) -> None:
+    from sentry.integrations.issues import ResolveSyncAction
+
+    integration = Integration.objects.get(id=integration_id)
+    affected_groups = list(
+        Group.objects.get_groups_by_external_issue(integration, issue_key)
+        .filter(project__organization_id=organization_id)
+        .select_related("project")
+    )
+
+    if not affected_groups:
+        return
+
+    installation = integration.get_installation(organization_id=organization_id)
+
+    try:
+        # This makes an API call.
+        action = installation.get_resolve_sync_action(data)
+    except Exception:
+        return
+
+    if action == ResolveSyncAction.RESOLVE:
+        Group.objects.update_group_status(
+            affected_groups, GroupStatus.RESOLVED, ActivityType.SET_RESOLVED
+        )
+    elif action == ResolveSyncAction.UNRESOLVE:
+        Group.objects.update_group_status(
+            affected_groups, GroupStatus.UNRESOLVED, ActivityType.SET_UNRESOLVED
+        )

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -10,32 +10,9 @@ from tests.fixtures.integrations.mock_service import StubService
 
 
 class JiraWebhooksTest(APITestCase):
-    @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
-    def test_simple_assign(self, mock_sync_group_assignee_inbound):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
-        path = reverse("sentry-extensions-jira-issue-updated")
-
-        with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
-        ):
-            data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
-            assert resp.status_code == 200
-            mock_sync_group_assignee_inbound.assert_called_with(
-                integration, "jess@sentry.io", "APP-123", assign=True
-            )
-
-    @override_settings(JIRA_USE_EMAIL_SCOPE=True)
-    @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
-    @responses.activate
-    def test_assign_use_email_api(self, mock_sync_group_assignee_inbound):
-        org = self.organization
-
-        integration = Integration.objects.create(
+    def setUp(self):
+        super().setUp()
+        self.integration = Integration.objects.create(
             provider="jira",
             name="Example Jira",
             metadata={
@@ -45,10 +22,26 @@ class JiraWebhooksTest(APITestCase):
                 "domain_name": "example.atlassian.net",
             },
         )
-        integration.add_organization(org, self.user)
+        self.integration.add_organization(self.organization, self.user)
+        self.path = reverse("sentry-extensions-jira-issue-updated")
 
-        path = reverse("sentry-extensions-jira-issue-updated")
+    @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
+    def test_simple_assign(self, mock_sync_group_assignee_inbound):
+        with patch(
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
+        ):
+            data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            assert resp.status_code == 200
+            mock_sync_group_assignee_inbound.assert_called_with(
+                self.integration, "jess@sentry.io", "APP-123", assign=True
+            )
 
+    @override_settings(JIRA_USE_EMAIL_SCOPE=True)
+    @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
+    @responses.activate
+    def test_assign_use_email_api(self, mock_sync_group_assignee_inbound):
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/3/user/email",
@@ -57,85 +50,62 @@ class JiraWebhooksTest(APITestCase):
         )
 
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
             data["issue"]["fields"]["assignee"]["emailAddress"] = ""
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             assert mock_sync_group_assignee_inbound.called
             assert len(responses.calls) == 1
 
     @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
     def test_assign_missing_email(self, mock_sync_group_assignee_inbound):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
-        path = reverse("sentry-extensions-jira-issue-updated")
-
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_payload.json")
             data["issue"]["fields"]["assignee"]["emailAddress"] = ""
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             assert not mock_sync_group_assignee_inbound.called
 
     @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
     def test_simple_deassign(self, mock_sync_group_assignee_inbound):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
-        path = reverse("sentry-extensions-jira-issue-updated")
-
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_no_assignee_payload.json")
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             mock_sync_group_assignee_inbound.assert_called_with(
-                integration, None, "APP-123", assign=False
+                self.integration, None, "APP-123", assign=False
             )
 
     @patch("sentry.integrations.jira.webhooks.sync_group_assignee_inbound")
     def test_simple_deassign_assignee_missing(self, mock_sync_group_assignee_inbound):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
-        path = reverse("sentry-extensions-jira-issue-updated")
-
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "edit_issue_assignee_missing_payload.json")
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             mock_sync_group_assignee_inbound.assert_called_with(
-                integration, None, "APP-123", assign=False
+                self.integration, None, "APP-123", assign=False
             )
 
     @patch.object(IssueSyncMixin, "sync_status_inbound")
     def test_simple_status_sync_inbound(self, mock_sync_status_inbound):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
-        path = reverse("sentry-extensions-jira-issue-updated")
-
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ) as mock_get_integration_from_jwt:
             data = StubService.get_stub_data("jira", "edit_issue_status_payload.json")
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
             mock_get_integration_from_jwt.assert_called_with(
                 "anexampletoken", "/extensions/jira/issue-updated/", "jira", {}, method="POST"
@@ -160,30 +130,19 @@ class JiraWebhooksTest(APITestCase):
             )
 
     def test_missing_changelog(self):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
-        path = reverse("sentry-extensions-jira-issue-updated")
-
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ):
             data = StubService.get_stub_data("jira", "changelog_missing.json")
-            resp = self.client.post(path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
+            resp = self.client.post(self.path, data=data, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 200
 
     def test_missing_body(self):
-        org = self.organization
-
-        integration = Integration.objects.create(provider="jira", name="Example Jira")
-        integration.add_organization(org, self.user)
-
         path = reverse("sentry-extensions-jira-installed")
-
         with patch(
-            "sentry.integrations.jira.webhooks.get_integration_from_jwt", return_value=integration
+            "sentry.integrations.jira.webhooks.get_integration_from_jwt",
+            return_value=self.integration,
         ):
             resp = self.client.post(path, data={}, HTTP_AUTHORIZATION="JWT anexampletoken")
             assert resp.status_code == 400

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -40,7 +40,7 @@ class JiraServerWebhookEndpointTest(APITestCase):
         link_group(self.organization, self.integration, self.group)
 
         with self.tasks():
-            self.get_error_response(self.jwt_token, **EXAMPLE_PAYLOAD, status_code=400)
+            self.get_success_response(self.jwt_token, **EXAMPLE_PAYLOAD)
 
     def test_post_token_missing_id(self):
         integration = self.integration
@@ -102,4 +102,4 @@ class JiraServerWebhookEndpointTest(APITestCase):
         link_group(self.organization, self.integration, group)
 
         with self.tasks():
-            self.get_error_response(self.jwt_token, **EXAMPLE_PAYLOAD, status_code=400)
+            self.get_success_response(self.jwt_token, **EXAMPLE_PAYLOAD)

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -44,7 +44,7 @@ class IssueSyncIntegration(TestCase):
 
         installation = integration.get_installation(group.organization.id)
 
-        with self.feature("organizations:integrations-issue-sync"):
+        with self.feature("organizations:integrations-issue-sync"), self.tasks():
             installation.sync_status_inbound(
                 external_issue.key,
                 {"project_id": "APP", "status": {"id": "12345", "category": "done"}},
@@ -87,7 +87,7 @@ class IssueSyncIntegration(TestCase):
 
         installation = integration.get_installation(group.organization.id)
 
-        with self.feature("organizations:integrations-issue-sync"):
+        with self.feature("organizations:integrations-issue-sync"), self.tasks():
             installation.sync_status_inbound(
                 external_issue.key,
                 {"project_id": "APP", "status": {"id": "12345", "category": "in_progress"}},

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -167,13 +167,12 @@ class VstsWebhookWorkItemTest(APITestCase):
                 data=work_item,
                 HTTP_SHARED_SECRET=self.shared_secret,
             )
-            assert resp.status_code == 200
-            group_ids = [g.id for g in groups]
-            assert (
-                len(Group.objects.filter(id__in=group_ids, status=GroupStatus.RESOLVED))
-                == num_groups
-            )
-            assert len(Activity.objects.filter(group_id__in=group_ids)) == num_groups
+        assert resp.status_code == 200
+        group_ids = [g.id for g in groups]
+        assert (
+            len(Group.objects.filter(id__in=group_ids, status=GroupStatus.RESOLVED)) == num_groups
+        )
+        assert len(Activity.objects.filter(group_id__in=group_ids)) == num_groups
 
     @responses.activate
     def test_inbound_status_sync_unresolve(self):
@@ -201,13 +200,12 @@ class VstsWebhookWorkItemTest(APITestCase):
                 data=work_item,
                 HTTP_SHARED_SECRET=self.shared_secret,
             )
-            assert resp.status_code == 200
-            group_ids = [g.id for g in groups]
-            assert (
-                len(Group.objects.filter(id__in=group_ids, status=GroupStatus.UNRESOLVED))
-                == num_groups
-            )
-            assert len(Activity.objects.filter(group_id__in=group_ids)) == num_groups
+        assert resp.status_code == 200
+        group_ids = [g.id for g in groups]
+        assert (
+            len(Group.objects.filter(id__in=group_ids, status=GroupStatus.UNRESOLVED)) == num_groups
+        )
+        assert len(Activity.objects.filter(group_id__in=group_ids)) == num_groups
 
     @responses.activate
     def test_inbound_status_sync_new_workitem(self):

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -161,7 +161,7 @@ class VstsWebhookWorkItemTest(APITestCase):
         # Change so that state is changing from unresolved to resolved
         work_item = self.set_workitem_state("Active", "Resolved")
 
-        with self.feature("organizations:integrations-issue-sync"):
+        with self.feature("organizations:integrations-issue-sync"), self.tasks():
             resp = self.client.post(
                 absolute_uri("/extensions/vsts/issue-updated/"),
                 data=work_item,
@@ -194,7 +194,7 @@ class VstsWebhookWorkItemTest(APITestCase):
         # Change so that state is changing from resolved to unresolved
         work_item = self.set_workitem_state("Resolved", "Active")
 
-        with self.feature("organizations:integrations-issue-sync"):
+        with self.feature("organizations:integrations-issue-sync"), self.tasks():
             resp = self.client.post(
                 absolute_uri("/extensions/vsts/issue-updated/"),
                 data=work_item,


### PR DESCRIPTION
Azure Devops webhooks requests are timing out waiting for statuses to sync. This PR makes syncing async. 

Something to note I have to pass an arbitrary JSON blob to the task but I'm not sure if that's kosher.