### PR TITLE
ref(hooks): Remove routes:organization-root hook

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1600,7 +1600,6 @@ function routes() {
   // me why we need the OrganizationRoot root container.
   const legacyOrganizationRootRoutes = (
     <Route component={errorHandler(OrganizationRoot)}>
-      {hook('routes:organization-root')}
       <Route
         path="/organizations/:orgId/teams/new/"
         componentPromise={() => import('app/views/teamCreate')}

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -69,7 +69,6 @@ const validHookNames = new Set<HookName>([
   'routes:admin',
   'routes:api',
   'routes:organization',
-  'routes:organization-root',
   'settings:api-navigation-config',
   'settings:organization-navigation',
   'settings:organization-navigation-config',

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -41,7 +41,6 @@ export type RouteHooks = {
   'routes:admin': RoutesHook;
   'routes:api': RoutesHook;
   'routes:organization': RoutesHook;
-  'routes:organization-root': RoutesHook;
 };
 
 /**


### PR DESCRIPTION
This is unused and is pretty legacy