### PR TITLE
fix(ui): Remove inset shadows

### DIFF
--- a/static/app/components/checkboxFancy/checkboxFancy.tsx
+++ b/static/app/components/checkboxFancy/checkboxFancy.tsx
@@ -46,7 +46,6 @@ const CheckboxFancy = styled(
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 1px 1px 5px 0px rgba(0, 0, 0, 0.05) inset;
   width: ${p => p.size};
   height: ${p => p.size};
   border-radius: 5px;

--- a/static/app/components/errorRobot.tsx
+++ b/static/app/components/errorRobot.tsx
@@ -146,7 +146,6 @@ const ErrorRobotWrapper = styled('div')<{gradient: boolean}>`
   display: flex;
   justify-content: center;
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
   border-radius: 0 0 3px 3px;
   padding: 40px ${space(3)} ${space(3)};
   min-height: 260px;

--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -137,7 +137,6 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
         color: theme.formText,
         background: theme.background,
         border: `1px solid ${theme.border}`,
-        boxShadow: `inset ${theme.dropShadowLight}`,
       },
       borderRadius: theme.borderRadius,
       transition: 'border 0.1s linear',

--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -107,7 +107,6 @@ const OpenInDiscoverButton = styled(Button)`
 
 const Container = styled('div')`
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowLight};
   background: ${p => p.theme.backgroundSecondary};
   padding: 7px ${space(1)};
   position: relative;

--- a/static/app/components/progressBar.tsx
+++ b/static/app/components/progressBar.tsx
@@ -28,7 +28,6 @@ const getVariantStyle = ({
       height: 24px;
       border-radius: 24px;
       border: 1px solid ${theme.border};
-      box-shadow: inset 0px 1px 3px rgba(0, 0, 0, 0.06);
       :before {
         left: 6px;
         right: 6px;

--- a/static/app/components/radio.tsx
+++ b/static/app/components/radio.tsx
@@ -30,7 +30,6 @@ const Radio = styled('input')<Props>`
   align-items: center;
   justify-content: center;
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.04);
   background: none;
   appearance: none;
 

--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -126,7 +126,6 @@ class SearchBar extends React.PureComponent<Props, State> {
 const StyledInput = styled(Input)`
   width: ${p => (p.width ? p.width : undefined)};
   &.focus-visible {
-    box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04), 0 0 6px rgba(177, 171, 225, 0.3);
     border-color: #a598b2;
     outline: none;
   }

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1421,7 +1421,6 @@ export {SmartSearchBar};
 
 const Container = styled('div')<{isOpen: boolean}>`
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowLight};
   background: ${p => p.theme.background};
   padding: 7px ${space(1)};
   position: relative;

--- a/static/app/components/switchButton.tsx
+++ b/static/app/components/switchButton.tsx
@@ -67,7 +67,6 @@ const SwitchButton = styled('button')<StyleProps>`
   padding: 0;
   border: 1px solid ${p => p.theme.border};
   position: relative;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.04);
   transition: 0.15s border ease;
   cursor: ${p => (p.isLoading || p.isDisabled ? 'not-allowed' : 'pointer')};
   pointer-events: ${p => (p.isLoading || p.isDisabled ? 'none' : null)};

--- a/static/app/styles/input.tsx
+++ b/static/app/styles/input.tsx
@@ -19,7 +19,6 @@ const inputStyles = (props: Props) =>
     background: ${props.theme.background};
     border: 1px solid ${props.theme.border};
     border-radius: ${props.theme.borderRadius};
-    box-shadow: inset ${props.theme.dropShadowLight};
     padding: ${INPUT_PADDING}px;
     transition: border 0.1s linear;
     resize: vertical;

--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -278,7 +278,6 @@ export default class ArithmeticInput extends PureComponent<Props, State> {
 
 const Container = styled('div')<{isOpen: boolean}>`
   border: 1px solid ${p => p.theme.border};
-  box-shadow: inset ${p => p.theme.dropShadowLight};
   background: ${p => p.theme.background};
   position: relative;
 

--- a/static/app/views/settings/components/settingsSearch/index.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.tsx
@@ -75,8 +75,6 @@ const SearchInput = styled('input')`
   border-radius: 30px;
   height: 28px;
 
-  box-shadow: inset ${p => p.theme.dropShadowLight};
-
   &:focus {
     outline: none;
     border: 1px solid ${p => p.theme.border};

--- a/static/less/shared/forms.less
+++ b/static/less/shared/forms.less
@@ -22,11 +22,8 @@
   // Set the border and box shadow on specific inputs to match
   .form-control {
     border-color: @border-color;
-    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075); // Redeclare so transitions work
     &:focus {
       border-color: darken(@border-color, 10%);
-      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075),
-        0 0 6px lighten(@border-color, 20%);
     }
   }
   // Optional feedback icon
@@ -52,7 +49,6 @@
   &:focus {
     border-color: @color;
     outline: 0;
-    box-shadow: ~'inset 0 1px 1px rgba(0, 0, 0, .075), 0 0 8px @{color-rgba}';
   }
 }
 
@@ -220,7 +216,6 @@ output {
   background-image: none; // Reset unusual Firefox-on-Android default style; see https://github.com/necolas/normalize.css/issues/214
   border: 1px solid @input-border;
   border-radius: @input-border-radius; // Note: This has no effect on <select>s in some browsers, due to the limited stylability of <select>s in CSS.
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 
   // Customize the `:focus` state to imitate native WebKit styles.
@@ -668,7 +663,6 @@ output {
 */
 
 .form-control {
-  box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04);
   height: auto;
   border: 1px solid lighten(@gray-lighter, 10);
   padding: 8px 12px 7px;
@@ -695,7 +689,6 @@ output {
 
   &:focus {
     border-color: darken(@gray-lighter, 4);
-    box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04), 0 0 6px rgba(177, 171, 225, 0.3);
     outline: none;
   }
 
@@ -828,12 +821,10 @@ label {
 
 .has-error .form-control {
   border-color: #c9c0d1;
-  box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04);
 }
 
 .has-error .form-control:focus {
   border-color: #a598b2;
-  box-shadow: inset 0 2px 0 rgba(0, 0, 0, 0.04), 0 0 6px rgba(177, 171, 225, 0.3);
   outline: none;
 }
 


### PR DESCRIPTION
Removing inset shadows, which mostly appear in input fields across the app. See comments below for before-after screenshots.