### PR TITLE
perf(ui): Prevent unnecessary endpoint requests

### DIFF
--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -39,6 +39,7 @@ type Props = {
   projectId: string;
   orgId: string;
   children: ((props: ChildFuncProps) => React.ReactNode) | React.ReactNode;
+  loadingProjects: boolean;
 };
 
 type State = {
@@ -79,8 +80,13 @@ class ProjectContext extends Component<Props, State> {
     };
   }
 
-  componentWillMount() {
-    this.fetchData();
+  componentDidMount() {
+    // Wait for withProjects to fetch projects before making request
+    // Once loaded we can fetchData in componentDidUpdate
+    const {loadingProjects} = this.props;
+    if (!loadingProjects) {
+      this.fetchData();
+    }
   }
 
   componentWillReceiveProps(nextProps: Props) {


### PR DESCRIPTION
## Objective:
Identify and remove duplicate API queries by our frontend client for our slowest pages. One endpoint that gets called multiple times unnecessarily is `/api/0/projects/{organization_slug}/{project_slug}/`. P95 for this query is 334.00ms. This is the low hanging fruit for page speed optimization.

https://sentry.io/organizations/sentry/performance/summary/?project=1&query=transaction.duration%3A%3C15m+transaction%3A%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2F+event.type%3Atransaction+http.method%3AGET&showTransactions=slow&statsPeriod=24h&transaction=%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2F&unselectedSeries=p100%28%29