### PR TITLE
feat(discover): Allow more options for the topEvents

### DIFF
--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -1655,6 +1655,7 @@ export type NewQuery = {
   // Graph
   yAxis?: string[];
   display?: string;
+  topEvents?: string;
 
   teams?: Readonly<('myteams' | number)[]>;
 };

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -29,6 +29,13 @@ import {
   Sort,
   WebVital,
 } from 'app/utils/discover/fields';
+import {
+  CHART_AXIS_OPTIONS,
+  DISPLAY_MODE_FALLBACK_OPTIONS,
+  DISPLAY_MODE_OPTIONS,
+  DisplayModes,
+  TOP_N,
+} from 'app/utils/discover/types';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
 import {
   FieldValueKind,
@@ -43,12 +50,6 @@ import {statsPeriodToDays} from '../dates';
 import {MutableSearch} from '../tokenizeSearch';
 
 import {getSortField} from './fieldRenderers';
-import {
-  CHART_AXIS_OPTIONS,
-  DISPLAY_MODE_FALLBACK_OPTIONS,
-  DISPLAY_MODE_OPTIONS,
-  DisplayModes,
-} from './types';
 
 // Metadata mapping for discover results.
 export type MetaType = Record<string, ColumnType>;
@@ -270,6 +271,7 @@ class EventView {
   environment: Readonly<string[]>;
   yAxis: string | undefined;
   display: string | undefined;
+  topEvents: string | undefined;
   interval: string | undefined;
   expired?: boolean;
   createdBy: User | undefined;
@@ -289,6 +291,7 @@ class EventView {
     environment: Readonly<string[]>;
     yAxis: string | undefined;
     display: string | undefined;
+    topEvents: string | undefined;
     interval?: string;
     expired?: boolean;
     createdBy: User | undefined;
@@ -334,6 +337,7 @@ class EventView {
     this.environment = environment;
     this.yAxis = props.yAxis;
     this.display = props.display;
+    this.topEvents = props.topEvents;
     this.interval = props.interval;
     this.createdBy = props.createdBy;
     this.expired = props.expired;
@@ -359,6 +363,7 @@ class EventView {
       environment: collectQueryStringByKey(location.query, 'environment'),
       yAxis: decodeScalar(location.query.yAxis),
       display: decodeScalar(location.query.display),
+      topEvents: decodeScalar(location.query.topEvents),
       interval: decodeScalar(location.query.interval),
       createdBy: undefined,
       additionalConditions: new MutableSearch([]),
@@ -432,6 +437,7 @@ class EventView {
       // Workaround to only use the first yAxis since eventView yAxis doesn't accept string[]
       yAxis: Array.isArray(saved.yAxis) ? saved.yAxis[0] : saved.yAxis,
       display: saved.display,
+      topEvents: saved.topEvents,
       createdBy: saved.createdBy,
       expired: saved.expired,
       additionalConditions: new MutableSearch([]),
@@ -468,6 +474,8 @@ class EventView {
           // Workaround to only use the first yAxis since eventView yAxis doesn't accept string[]
           (Array.isArray(saved.yAxis) ? saved.yAxis[0] : saved.yAxis),
         display: decodeScalar(location.query.display) || saved.display,
+        topEvents:
+          decodeScalar(location.query.topEvents) || saved.topEvents || TOP_N.toString(),
         interval: decodeScalar(location.query.interval),
         createdBy: saved.createdBy,
         expired: saved.expired,
@@ -498,6 +506,7 @@ class EventView {
       'project',
       'environment',
       'display',
+      'topEvents',
     ];
 
     for (const key of keys) {
@@ -556,6 +565,7 @@ class EventView {
       environment: this.environment,
       yAxis: this.yAxis ? [this.yAxis] : undefined,
       display: this.display,
+      topEvents: this.topEvents,
     };
 
     if (!newQuery.query) {
@@ -616,6 +626,7 @@ class EventView {
       query: undefined,
       yAxis: undefined,
       display: undefined,
+      topEvents: undefined,
       interval: undefined,
     };
 
@@ -638,6 +649,7 @@ class EventView {
       query: this.query,
       yAxis: this.yAxis || this.getYAxis(),
       display: this.display,
+      topEvents: this.topEvents,
       interval: this.interval,
     };
 
@@ -727,6 +739,7 @@ class EventView {
       environment: this.environment,
       yAxis: this.yAxis,
       display: this.display,
+      topEvents: this.topEvents,
       interval: this.interval,
       expired: this.expired,
       createdBy: this.createdBy,

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -437,7 +437,7 @@ class EventView {
       // Workaround to only use the first yAxis since eventView yAxis doesn't accept string[]
       yAxis: Array.isArray(saved.yAxis) ? saved.yAxis[0] : saved.yAxis,
       display: saved.display,
-      topEvents: saved.topEvents,
+      topEvents: saved.topEvents ? saved.topEvents.toString() : undefined,
       createdBy: saved.createdBy,
       expired: saved.expired,
       additionalConditions: new MutableSearch([]),
@@ -474,8 +474,11 @@ class EventView {
           // Workaround to only use the first yAxis since eventView yAxis doesn't accept string[]
           (Array.isArray(saved.yAxis) ? saved.yAxis[0] : saved.yAxis),
         display: decodeScalar(location.query.display) || saved.display,
-        topEvents:
-          decodeScalar(location.query.topEvents) || saved.topEvents || TOP_N.toString(),
+        topEvents: (
+          decodeScalar(location.query.topEvents) ||
+          saved.topEvents ||
+          TOP_N
+        ).toString(),
         interval: decodeScalar(location.query.interval),
         createdBy: saved.createdBy,
         expired: saved.expired,

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -11,6 +11,8 @@ export enum DisplayModes {
   DAILYTOP5 = 'dailytop5',
 }
 
+export const TOP_EVENT_MODES: string[] = [DisplayModes.TOP5, DisplayModes.DAILYTOP5];
+
 export const DISPLAY_MODE_OPTIONS: SelectValue<string>[] = [
   {value: DisplayModes.DEFAULT, label: t('Total Period')},
   {value: DisplayModes.PREVIOUS, label: t('Previous Period')},

--- a/static/app/views/eventsV2/chartFooter.tsx
+++ b/static/app/views/eventsV2/chartFooter.tsx
@@ -11,6 +11,7 @@ import {
 } from 'app/components/charts/styles';
 import {t} from 'app/locale';
 import {Organization, SelectValue} from 'app/types';
+import {TOP_EVENT_MODES} from 'app/utils/discover/types';
 
 type Props = {
   organization: Organization;
@@ -21,6 +22,8 @@ type Props = {
   displayMode: string;
   displayOptions: SelectValue<string>[];
   onDisplayChange: (value: string) => void;
+  onTopEventsChange: (value: string) => void;
+  topEvents: string;
 };
 
 export default function ChartFooter({
@@ -32,6 +35,8 @@ export default function ChartFooter({
   displayMode,
   displayOptions,
   onDisplayChange,
+  onTopEventsChange,
+  topEvents,
 }: Props) {
   const elements: React.ReactNode[] = [];
 
@@ -45,6 +50,10 @@ export default function ChartFooter({
       <SectionValue key="total-value">{total.toLocaleString()}</SectionValue>
     )
   );
+  const topEventOptions: SelectValue<string>[] = [];
+  for (let i = 2; i <= 10; i++) {
+    topEventOptions.push({value: i.toString(), label: i.toString()});
+  }
 
   return (
     <ChartControls>
@@ -57,6 +66,23 @@ export default function ChartFooter({
           onChange={onDisplayChange}
           menuWidth="170px"
         />
+        <Feature organization={organization} features={['discover-top-events']}>
+          {({hasFeature}) => {
+            if (hasFeature && TOP_EVENT_MODES.includes(displayMode)) {
+              return (
+                <OptionSelector
+                  title={t('Limit')}
+                  selected={topEvents}
+                  options={topEventOptions}
+                  onChange={onTopEventsChange}
+                  menuWidth="170px"
+                />
+              );
+            } else {
+              return null;
+            }
+          }}
+        </Feature>
         <Feature
           organization={organization}
           features={['connect-discover-and-dashboards']}

--- a/static/app/views/eventsV2/chartFooter.tsx
+++ b/static/app/views/eventsV2/chartFooter.tsx
@@ -51,7 +51,7 @@ export default function ChartFooter({
     )
   );
   const topEventOptions: SelectValue<string>[] = [];
-  for (let i = 2; i <= 10; i++) {
+  for (let i = 1; i <= 10; i++) {
     topEventOptions.push({value: i.toString(), label: i.toString()});
   }
 
@@ -75,7 +75,7 @@ export default function ChartFooter({
                   selected={topEvents}
                   options={topEventOptions}
                   onChange={onTopEventsChange}
-                  menuWidth="170px"
+                  menuWidth="60px"
                 />
               );
             } else {

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -363,6 +363,25 @@ class Results extends React.Component<Props, State> {
     }
   };
 
+  handleTopEventsChange = (value: string) => {
+    const {router, location} = this.props;
+
+    const newQuery = {
+      ...location.query,
+      topEvents: value,
+    };
+
+    router.push({
+      pathname: location.pathname,
+      query: newQuery,
+    });
+
+    // Treat display changing like the user already confirmed the query
+    if (!this.state.needConfirmation) {
+      this.handleConfirmed();
+    }
+  };
+
   getDocumentTitle(): string {
     const {organization} = this.props;
     const {eventView} = this.state;
@@ -490,6 +509,7 @@ class Results extends React.Component<Props, State> {
                   location={location}
                   onAxisChange={this.handleYAxisChange}
                   onDisplayChange={this.handleDisplayChange}
+                  onTopEventsChange={this.handleTopEventsChange}
                   total={totalValues}
                   confirmedQuery={confirmedQuery}
                   yAxis={yAxisArray}

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -53,6 +53,7 @@ class ResultsChart extends Component<ResultsChartProps> {
     const hasConnectDiscoverAndDashboards = organization.features.includes(
       'connect-discover-and-dashboards'
     );
+    const hasTopEvents = organization.features.includes('discover-top-events');
 
     const globalSelection = eventView.getGlobalSelection();
     const start = globalSelection.datetime.start
@@ -72,6 +73,8 @@ class ResultsChart extends Component<ResultsChartProps> {
     const isDaily = display === DisplayModes.DAILYTOP5 || display === DisplayModes.DAILY;
     const isPrevious = display === DisplayModes.PREVIOUS;
     const referrer = `api.discover.${display}-chart`;
+    const topEvents =
+      hasTopEvents && eventView.topEvents ? parseInt(eventView.topEvents, 10) : TOP_N;
 
     return (
       <Fragment>
@@ -94,7 +97,7 @@ class ResultsChart extends Component<ResultsChartProps> {
               field={isTopEvents ? apiPayload.field : undefined}
               interval={eventView.interval}
               showDaily={isDaily}
-              topEvents={isTopEvents ? TOP_N : undefined}
+              topEvents={isTopEvents ? topEvents : undefined}
               orderby={isTopEvents ? decodeScalar(apiPayload.sort) : undefined}
               utc={utc === 'true'}
               confirmedQuery={confirmedQuery}
@@ -125,6 +128,7 @@ type ContainerProps = {
   total: number | null;
   onAxisChange: (value: string[]) => void;
   onDisplayChange: (value: string) => void;
+  onTopEventsChange: (value: string) => void;
 };
 
 class ResultsChartContainer extends Component<ContainerProps> {
@@ -151,6 +155,7 @@ class ResultsChartContainer extends Component<ContainerProps> {
       total,
       onAxisChange,
       onDisplayChange,
+      onTopEventsChange,
       organization,
       confirmedQuery,
       yAxis,
@@ -160,6 +165,7 @@ class ResultsChartContainer extends Component<ContainerProps> {
     const hasConnectDiscoverAndDashboards = organization.features.includes(
       'connect-discover-and-dashboards'
     );
+    const hasTopEvents = organization.features.includes('discover-top-events');
     const displayOptions = eventView
       .getDisplayOptions()
       .filter(opt => {
@@ -190,6 +196,18 @@ class ResultsChartContainer extends Component<ContainerProps> {
             ),
           };
         }
+        if (hasTopEvents && DisplayModes.TOP5 === opt.value) {
+          return {
+            value: opt.value,
+            label: 'Top Period',
+          };
+        }
+        if (hasTopEvents && DisplayModes.DAILYTOP5 === opt.value) {
+          return {
+            value: opt.value,
+            label: 'Top Daily',
+          };
+        }
         return opt;
       });
 
@@ -217,6 +235,8 @@ class ResultsChartContainer extends Component<ContainerProps> {
           displayOptions={displayOptions}
           displayMode={eventView.getDisplayMode()}
           onDisplayChange={onDisplayChange}
+          onTopEventsChange={onTopEventsChange}
+          topEvents={eventView.topEvents ?? TOP_N.toString()}
         />
       </StyledPanel>
     );

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -244,7 +244,8 @@ class TableView extends React.Component<TableViewProps> {
     const isTopEvents =
       display === DisplayModes.TOP5 || display === DisplayModes.DAILYTOP5;
 
-    const count = Math.min(tableData?.data?.length ?? TOP_N, TOP_N);
+    const topEvents = eventView.topEvents ? parseInt(eventView.topEvents, 10) : TOP_N;
+    const count = Math.min(tableData?.data?.length ?? topEvents, topEvents);
 
     let cell = fieldRenderer(dataRow, {organization, location});
 
@@ -310,7 +311,7 @@ class TableView extends React.Component<TableViewProps> {
 
     return (
       <React.Fragment>
-        {isFirstPage && isTopEvents && rowIndex < TOP_N && columnIndex === 0 ? (
+        {isFirstPage && isTopEvents && rowIndex < topEvents && columnIndex === 0 ? (
           // Add one if we need to include Other in the series
           <TopResultsIndicator count={count + (hasOther ? 1 : 0)} index={rowIndex} />
         ) : null}

--- a/tests/js/spec/views/eventsV2/chartFooter.spec.tsx
+++ b/tests/js/spec/views/eventsV2/chartFooter.spec.tsx
@@ -43,6 +43,8 @@ describe('EventsV2 > ChartFooter', function () {
         displayMode={DisplayModes.DEFAULT}
         displayOptions={[{label: DisplayModes.DEFAULT, value: DisplayModes.DEFAULT}]}
         onDisplayChange={() => undefined}
+        onTopEventsChange={() => undefined}
+        topEvents="5"
       />,
       initialData.routerContext
     );
@@ -82,6 +84,8 @@ describe('EventsV2 > ChartFooter', function () {
         displayMode={DisplayModes.DEFAULT}
         displayOptions={[{label: DisplayModes.DEFAULT, value: DisplayModes.DEFAULT}]}
         onDisplayChange={() => undefined}
+        onTopEventsChange={() => undefined}
+        topEvents="5"
       />,
       initialData.routerContext
     );

--- a/tests/js/spec/views/eventsV2/chartFooter.spec.tsx
+++ b/tests/js/spec/views/eventsV2/chartFooter.spec.tsx
@@ -98,4 +98,44 @@ describe('EventsV2 > ChartFooter', function () {
     expect(optionCheckboxSelector.props().title).toEqual(t('Y-Axis'));
     expect(optionCheckboxSelector.props().selected).toEqual(yAxisValue);
   });
+
+  it('renders display limits with default limit when top 5 mode is selected', async function () {
+    // @ts-expect-error
+    const organization = TestStubs.Organization({
+      features: [...features, 'discover-top-events'],
+    });
+
+    // Start off with an invalid view (empty is invalid)
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {query: 'tag:value'}},
+      },
+      project: 1,
+      projects: [],
+    });
+
+    const wrapper = mountWithTheme(
+      <ChartFooter
+        organization={organization}
+        total={100}
+        yAxisValue={yAxisValue}
+        yAxisOptions={yAxisOptions}
+        onAxisChange={() => undefined}
+        displayMode={DisplayModes.TOP5}
+        displayOptions={[{label: DisplayModes.DEFAULT, value: DisplayModes.DEFAULT}]}
+        onDisplayChange={() => undefined}
+        onTopEventsChange={() => undefined}
+        topEvents="5"
+      />,
+      initialData.routerContext
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    const optionSelector = wrapper.find('OptionSelector[title="Limit"]');
+    expect(optionSelector.props().selected).toEqual('5');
+  });
 });


### PR DESCRIPTION
- This allows up to 10 top events on the discover frontend
- This changes the display *text* to `Top Daily` and `Top Display` and
  adds a new dropdown for the limit
  
### Preview
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/4205004/135181947-1c6ebd3a-72d0-41eb-ac64-ddceb0c33354.png">
