### PR TITLE
feat(discover): Allow saving queries with topEvents

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -22,6 +22,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "limit",
             "yAxis",
             "display",
+            "topEvents",
         ]
         data = {
             "id": str(obj.id),

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -163,9 +163,10 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
     widths = ListField(child=serializers.CharField(), required=False, allow_null=True)
     yAxis = ListField(child=serializers.CharField(), required=False, allow_null=True)
     display = serializers.CharField(required=False, allow_null=True)
+    topEvents = serializers.CharField(required=False, allow_null=True)
 
     disallowed_fields = {
-        1: {"environment", "query", "yAxis", "display"},
+        1: {"environment", "query", "yAxis", "display", "topEvents"},
         2: {"groupby", "rollup", "aggregations", "conditions", "limit"},
     }
 
@@ -198,6 +199,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
             "widths",
             "yAxis",
             "display",
+            "topEvents",
         ]
 
         for key in query_keys:

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -163,7 +163,7 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
     widths = ListField(child=serializers.CharField(), required=False, allow_null=True)
     yAxis = ListField(child=serializers.CharField(), required=False, allow_null=True)
     display = serializers.CharField(required=False, allow_null=True)
-    topEvents = serializers.CharField(required=False, allow_null=True)
+    topEvents = serializers.IntegerField(min_value=1, max_value=10, required=False, allow_null=True)
 
     disallowed_fields = {
         1: {"environment", "query", "yAxis", "display", "topEvents"},


### PR DESCRIPTION
- This adds the ability to save the topEvents property on discover
  queries
- Allows a variable number of topEvents