### PR TITLE
ref(js): Replace react-keydown with react-hotkeys-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "react-date-range": "^1.3.0",
     "react-document-title": "2.0.3",
     "react-dom": "17.0.2",
+    "react-hotkeys-hook": "^3.4.3",
     "react-keydown": "^1.9.7",
     "react-lazyload": "^2.3.0",
     "react-mentions": "4.3.0",

--- a/static/app/views/settings/components/settingsSearch/index.tsx
+++ b/static/app/views/settings/components/settingsSearch/index.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import keydown from 'react-keydown';
+import {useRef} from 'react';
+import {useHotkeys} from 'react-hotkeys-hook';
 import styled from '@emotion/styled';
 
 import Search from 'app/components/search';
@@ -9,45 +9,30 @@ import {t} from 'app/locale';
 const MIN_SEARCH_LENGTH = 1;
 const MAX_RESULTS = 10;
 
-type Props = {};
+function SettingsSearch() {
+  const searchInput = useRef<HTMLInputElement>(null);
 
-class SettingsSearch extends React.Component<Props> {
-  searchInput = React.createRef<HTMLInputElement>();
-
-  @keydown('/')
-  handleFocusSearch(e: React.FormEvent<HTMLInputElement>) {
-    if (!this.searchInput.current) {
-      return;
-    }
-    if (e.target === this.searchInput.current) {
-      return;
-    }
-
+  useHotkeys('/', e => {
     e.preventDefault();
-    this.searchInput.current.focus();
-  }
+    searchInput.current?.focus();
+  });
 
-  render() {
-    return (
-      <Search
-        entryPoint="settings_search"
-        minSearch={MIN_SEARCH_LENGTH}
-        maxResults={MAX_RESULTS}
-        renderInput={({getInputProps}) => (
-          <SearchInputWrapper>
-            <SearchInputIcon size="14px" />
-            <SearchInput
-              {...getInputProps({
-                type: 'text',
-                placeholder: t('Search'),
-              })}
-              ref={this.searchInput}
-            />
-          </SearchInputWrapper>
-        )}
-      />
-    );
-  }
+  return (
+    <Search
+      entryPoint="settings_search"
+      minSearch={MIN_SEARCH_LENGTH}
+      maxResults={MAX_RESULTS}
+      renderInput={({getInputProps}) => (
+        <SearchInputWrapper>
+          <SearchInputIcon size="14px" />
+          <SearchInput
+            {...getInputProps({type: 'text', placeholder: t('Search')})}
+            ref={searchInput}
+          />
+        </SearchInputWrapper>
+      )}
+    />
+  );
 }
 
 export default SettingsSearch;

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -1,4 +1,4 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import {navigateTo} from 'app/actionCreators/navigation';
 import FormSearchStore from 'app/stores/formSearchStore';
@@ -7,7 +7,6 @@ import SettingsSearch from 'app/views/settings/components/settingsSearch';
 jest.mock('app/actionCreators/formSearch');
 jest.mock('app/actionCreators/navigation');
 
-const SETTINGS_SEARCH_PLACEHOLDER = 'Search';
 describe('SettingsSearch', function () {
   let orgsMock;
   const routerContext = TestStubs.routerContext([
@@ -61,58 +60,33 @@ describe('SettingsSearch', function () {
   });
 
   it('renders', async function () {
-    const wrapper = mountWithTheme(
-      <SettingsSearch params={{orgId: 'org-slug'}} />,
-      routerContext
+    const {getByPlaceholderText} = mountWithTheme(
+      <SettingsSearch params={{orgId: 'org-slug'}} />
     );
 
     // renders input
-    expect(wrapper.find('SearchInput')).toHaveLength(1);
-    expect(wrapper.find('input').prop('placeholder')).toBe(SETTINGS_SEARCH_PLACEHOLDER);
+    expect(getByPlaceholderText('Search')).toBeInTheDocument();
   });
 
-  it('can focus when `handleFocusSearch` is called and target is not search input', function () {
-    const wrapper = mountWithTheme(
-      <SettingsSearch params={{orgId: 'org-slug'}} />,
-      routerContext
+  it('can focus when hotkey is pressed', function () {
+    const {getByPlaceholderText} = mountWithTheme(
+      <SettingsSearch params={{orgId: 'org-slug'}} />
     );
-    const searchInput = wrapper.find('SearchInput input').instance();
-    const focusSpy = jest.spyOn(searchInput, 'focus');
 
-    wrapper.instance().handleFocusSearch({
-      preventDefault: () => {},
-      target: null,
-    });
-
-    expect(focusSpy).toHaveBeenCalled();
-  });
-
-  it('does not focus search input if it is current target and `handleFocusSearch` is called', function () {
-    const wrapper = mountWithTheme(
-      <SettingsSearch params={{orgId: 'org-slug'}} />,
-      routerContext
-    );
-    const searchInput = wrapper.find('SearchInput input').instance();
-    const focusSpy = jest.spyOn(searchInput, 'focus');
-
-    wrapper.instance().handleFocusSearch({
-      preventDefault: () => {},
-      target: searchInput,
-    });
-
-    expect(focusSpy).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, {code: 'Slash', key: '/', keyCode: 191});
+    expect(document.activeElement).toEqual(getByPlaceholderText('Search'));
   });
 
   it('can search', async function () {
-    const wrapper = mountWithTheme(
+    const {getByPlaceholderText, getAllByTestId} = mountWithTheme(
       <SettingsSearch params={{orgId: 'org-slug'}} />,
-      routerContext
+      {context: routerContext}
     );
 
-    wrapper.find('input').simulate('change', {target: {value: 'bil'}});
+    const input = getByPlaceholderText('Search');
+    fireEvent.change(input, {target: {value: 'bil'}});
 
     await tick();
-    wrapper.update();
 
     expect(orgsMock).toHaveBeenCalledWith(
       expect.anything(),
@@ -122,19 +96,15 @@ describe('SettingsSearch', function () {
       })
     );
 
-    expect(
-      wrapper.find('SearchResult [data-test-id="badge-display-name"]').first().text()
-    ).toBe('billy-org Dashboard');
+    const results = getAllByTestId('badge-display-name');
 
-    expect(wrapper.find('SearchResultWrapper').first().prop('highlighted')).toBe(true);
+    const firstResult = results
+      .filter(e => e.textContent === 'billy-org Dashboard')
+      .pop();
 
-    expect(wrapper.find('SearchResultWrapper').at(1).prop('highlighted')).toBe(false);
+    expect(firstResult).toBeDefined();
 
-    wrapper
-      .find('SearchResult [data-test-id="badge-display-name"]')
-      .first()
-      .simulate('click');
-
+    fireEvent.click(firstResult);
     expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything(), undefined);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8320,6 +8320,11 @@ hosted-git-info@^4.0.1:
   dependencies:
     lru-cache "^6.0.0"
 
+hotkeys-js@3.8.7:
+  version "3.8.7"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.8.7.tgz#c16cab978b53d7242f860ca3932e976b92399981"
+  integrity sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
@@ -12766,6 +12771,13 @@ react-helmet-async@^1.0.7:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-hotkeys-hook@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.4.3.tgz#74da79c2a5106f8d203f543794833c1af39030ac"
+  integrity sha512-rb8wjXItbZ0ItX1lHKd1lVfqoiGhzrnNo+rtqNoTkxMdyUcxI3RIdP8wmAHoK9Z/0F+aHo2yWAeKgv3pUvmGpw==
+  dependencies:
+    hotkeys-js "3.8.7"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
I removed react-keydown from the platform picker here https://github.com/getsentry/sentry/pull/28932

I also have a WIP refactor of the App container component that will use this, at which point we can just remove react-keydown