### PR TITLE
fix(discover): Move Sessions fields out of SEARCH_MAP

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -489,7 +489,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
         event_types = data.get("event_types")
 
-        valid_event_types = dataset_valid_event_types[data["dataset"]]
+        valid_event_types = dataset_valid_event_types.get(data["dataset"], set())
         if event_types and set(event_types) - valid_event_types:
             raise serializers.ValidationError(
                 "Invalid event types for this dataset. Valid event types are %s"

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -81,7 +81,6 @@ SEARCH_MAP = {
 }
 SEARCH_MAP.update(**DATASETS[Dataset.Events])
 SEARCH_MAP.update(**DATASETS[Dataset.Discover])
-SEARCH_MAP.update(**DATASETS[Dataset.Sessions])
 
 DEFAULT_PROJECT_THRESHOLD_METRIC = "duration"
 DEFAULT_PROJECT_THRESHOLD = 300

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -53,6 +53,7 @@ from sentry.search.utils import InvalidQuery, parse_duration
 from sentry.utils.compat import zip
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.snuba import (
+    SESSIONS_SNUBA_MAP,
     Dataset,
     get_json_type,
     is_duration_measurement,
@@ -1338,6 +1339,16 @@ class StringArrayColumn(ColumnArg):
         raise InvalidFunctionArgument(f"{value} is not a valid string array column")
 
 
+class SessionColumnArg(ColumnArg):
+    # XXX(ahmed): hack to get this to work with crash rate alerts over the sessions dataset until
+    # we deprecate the logic that is tightly coupled with the events dataset. At which point,
+    # we will just rely on dataset specific logic and refactor this class out
+    def normalize(self, value: str, _) -> str:
+        if value in SESSIONS_SNUBA_MAP:
+            return value
+        raise InvalidFunctionArgument(f"{value} is not a valid sessions dataset column")
+
+
 def with_default(default, argument):
     argument.has_default = True
     argument.get_default = lambda *_: default
@@ -2148,7 +2159,7 @@ FUNCTIONS = {
         ),
         DiscoverFunction(
             "identity",
-            required_args=[ColumnArg("column")],
+            required_args=[SessionColumnArg("column")],
             aggregate=["identity", ArgValue("column"), None],
             private=True,
         ),


### PR DESCRIPTION
This PR:
- Adds a SessionCoumnArg class that extends ColumnArg for crash rate alerts over sessions dataset.
- Removes validation against not having event_types in AlertRuleSerializer