### PR TITLE
fix(alerts): Add logic that drops event types for crash rate alerts

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -402,6 +402,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             )
 
     def validate_event_types(self, event_types):
+        if self.initial_data.get("dataset") == Dataset.Sessions.value:
+            return []
         try:
             return [SnubaQueryEventType.EventType[event_type.upper()] for event_type in event_types]
         except KeyError:

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -489,7 +489,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
         event_types = data.get("event_types")
 
-        valid_event_types = dataset_valid_event_types[data["dataset"]]
+        valid_event_types = dataset_valid_event_types.get(data["dataset"], set())
         if event_types and set(event_types) - valid_event_types:
             raise serializers.ValidationError(
                 "Invalid event types for this dataset. Valid event types are %s"

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -269,9 +269,9 @@ class SubscriptionProcessor:
         else:
             aggregation_value = list(subscription_update["values"]["data"][0].values())[0]
             # In some cases Snuba can return a None value for an aggregation. This means
-            # there were no rows present when we made the query for certain types of aggregations like
-            # avg. Defaulting this to 0 for now. It might turn out that we'd prefer to skip the update
-            # in the future.
+            # there were no rows present when we made the query for certain types of aggregations
+            # like avg. Defaulting this to 0 for now. It might turn out that we'd prefer to skip
+            # the update in the future.
             if aggregation_value is None:
                 aggregation_value = 0
 

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -85,7 +85,6 @@ SEARCH_MAP = {
 }
 SEARCH_MAP.update(**DATASETS[Dataset.Events])
 SEARCH_MAP.update(**DATASETS[Dataset.Discover])
-SEARCH_MAP.update(**DATASETS[Dataset.Sessions])
 
 DEFAULT_PROJECT_THRESHOLD_METRIC = "duration"
 DEFAULT_PROJECT_THRESHOLD = 300

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -53,6 +53,7 @@ from sentry.search.utils import InvalidQuery, parse_duration
 from sentry.utils.compat import zip
 from sentry.utils.numbers import format_grouped_length
 from sentry.utils.snuba import (
+    SESSIONS_SNUBA_MAP,
     Dataset,
     get_json_type,
     is_duration_measurement,
@@ -1338,6 +1339,16 @@ class StringArrayColumn(ColumnArg):
         raise InvalidFunctionArgument(f"{value} is not a valid string array column")
 
 
+class SessionColumnArg(ColumnArg):
+    # XXX(ahmed): hack to get this to work with crash rate alerts over the sessions dataset until
+    # we deprecate the logic that is tightly coupled with the events dataset. At which point,
+    # we will just rely on dataset specific logic and refactor this class out
+    def normalize(self, value: str, _) -> str:
+        if value in SESSIONS_SNUBA_MAP:
+            return value
+        raise InvalidFunctionArgument(f"{value} is not a valid sessions dataset column")
+
+
 def with_default(default, argument):
     argument.has_default = True
     argument.get_default = lambda *_: default
@@ -2148,7 +2159,7 @@ FUNCTIONS = {
         ),
         DiscoverFunction(
             "identity",
-            required_args=[ColumnArg("column")],
+            required_args=[SessionColumnArg("column")],
             aggregate=["identity", ArgValue("column"), None],
             private=True,
         ),

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -621,6 +621,16 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
 
+    def test_simple_crash_rate_alerts_for_sessions_drops_event_types(self):
+        self.valid_alert_rule["eventTypes"] = ["sessions", "events"]
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            resp = self.get_valid_response(
+                self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule
+            )
+        assert "id" in resp.data
+        alert_rule = AlertRule.objects.get(id=resp.data["id"])
+        assert resp.data == serialize(alert_rule, self.user)
+
     def test_simple_crash_rate_alerts_for_sessions_with_invalid_time_window(self):
         self.valid_alert_rule["timeWindow"] = "90"
         with self.feature(["organizations:incidents", "organizations:performance-view"]):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1268,8 +1268,11 @@ class ProcessUpdateTest(TestCase, SnubaTestCase):
             value=None,
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
-        self.metrics.incr.assert_called_once_with(
-            "incidents.alert_rules.ignore_update_no_session_data"
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_no_session_data"),
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
         )
 
     @patch("sentry.incidents.subscription_processor.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)
@@ -1287,8 +1290,11 @@ class ProcessUpdateTest(TestCase, SnubaTestCase):
             subscription=rule.snuba_query.subscriptions.filter(project=self.project).get(),
         )
         self.assert_no_active_incident(rule)
-        self.metrics.incr.assert_called_once_with(
-            "incidents.alert_rules.ignore_update_count_lower_than_min_threshold"
+        self.metrics.incr.assert_has_calls(
+            [
+                call("incidents.alert_rules.ignore_update_count_lower_than_min_threshold"),
+                call("incidents.alert_rules.skipping_update_invalid_aggregation_value"),
+            ]
         )
 
     @patch("sentry.incidents.subscription_processor.CRASH_RATE_ALERT_MINIMUM_THRESHOLD", 30)


### PR DESCRIPTION
Crash Rate alerts do not expect any event types since they are over the sessions dataset, and so this PR adds validation
to drop any event types sent with a Crash Rate Alert creation. Also, for the time being, frontend sends event tyeps for
crash rate alerts because event.type is a first class citizen in the frontend infrastructure of alerts and it is expected to be set,
and so this is expected to act as a safe guard until FE refactors this functionality