### PR TITLE
feat(dynamic-sampling): Add autocomplete - INGEST-434

### DIFF
--- a/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
@@ -106,6 +106,7 @@ function AutoComplete({orgSlug, projectId, category, onChange, value}: Props) {
       required
       stacked
       creatable
+      allowClear
     />
   );
 }

--- a/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
@@ -1,0 +1,117 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
+
+import {fetchTagValues} from 'app/actionCreators/tags';
+import {tct} from 'app/locale';
+import {Organization, Project} from 'app/types';
+import {DynamicSamplingInnerName} from 'app/types/dynamicSampling';
+import useApi from 'app/utils/useApi';
+import SelectField from 'app/views/settings/components/forms/selectField';
+
+import {getMatchFieldPlaceholder} from './utils';
+
+type Tag = {
+  value: string;
+};
+
+type Props = {
+  projectId: Project['id'];
+  orgSlug: Organization['slug'];
+  category:
+    | DynamicSamplingInnerName.TRACE_ENVIRONMENT
+    | DynamicSamplingInnerName.EVENT_ENVIRONMENT
+    | DynamicSamplingInnerName.EVENT_RELEASE
+    | DynamicSamplingInnerName.TRACE_RELEASE
+    | DynamicSamplingInnerName.TRACE_TRANSACTION
+    | DynamicSamplingInnerName.EVENT_TRANSACTION;
+  onChange: (value: string) => void;
+  value?: string;
+};
+
+function AutoComplete({orgSlug, projectId, category, onChange, value}: Props) {
+  const api = useApi();
+  const [tagValues, setTagValues] = useState<Tag[]>([]);
+
+  useEffect(() => {
+    tagValueLoader();
+  }, []);
+
+  function getTagKey() {
+    switch (category) {
+      case DynamicSamplingInnerName.TRACE_RELEASE:
+      case DynamicSamplingInnerName.EVENT_RELEASE:
+        return 'release';
+      case DynamicSamplingInnerName.TRACE_ENVIRONMENT:
+      case DynamicSamplingInnerName.EVENT_ENVIRONMENT:
+        return 'environment';
+      case DynamicSamplingInnerName.TRACE_TRANSACTION:
+      case DynamicSamplingInnerName.EVENT_TRANSACTION:
+        return 'transaction';
+      default:
+        Sentry.captureException(
+          new Error('Unknown dynamic sampling condition inner name')
+        );
+        return ''; // this shall never happen
+    }
+  }
+
+  async function tagValueLoader() {
+    const key = getTagKey();
+
+    if (!key) {
+      return;
+    }
+
+    try {
+      const response = await fetchTagValues(api, orgSlug, key, null, [projectId]);
+      setTagValues(response);
+    } catch {
+      // Do nothing. No results will be suggested
+    }
+  }
+
+  // react-select doesn't seem to work very well when its value contains
+  // a created item that isn't listed in the options
+  const createdOptions: Tag[] = !value
+    ? []
+    : value
+        .split(',')
+        .filter(v => !tagValues.some(tagValue => tagValue.value === v))
+        .map(v => ({value: v}));
+
+  return (
+    <StyledSelectField
+      name="match"
+      multiple
+      options={[...createdOptions, ...tagValues].map(tagValue => ({
+        value: tagValue.value,
+        label: tagValue.value,
+      }))}
+      value={value?.split(',')}
+      onChange={newValue => {
+        onChange(newValue?.join(','));
+      }}
+      styles={{
+        menu: provided => ({
+          ...provided,
+          wordBreak: 'break-all',
+        }),
+      }}
+      formatCreateLabel={label => tct('Add "[newLabel]"', {newLabel: label})}
+      placeholder={getMatchFieldPlaceholder(category)}
+      inline={false}
+      hideControlState
+      flexibleControlStateSize
+      required
+      stacked
+      creatable
+    />
+  );
+}
+
+export default AutoComplete;
+
+const StyledSelectField = styled(SelectField)`
+  width: 100%;
+`;

--- a/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/autoComplete.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react';
-import {components, ContainerProps, MultiValueProps, OptionProps} from 'react-select';
+import {components, MultiValueProps, OptionProps} from 'react-select';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -11,6 +11,9 @@ import useApi from 'app/utils/useApi';
 import SelectField from 'app/views/settings/components/forms/selectField';
 
 import {getMatchFieldPlaceholder} from './utils';
+
+// react-select doesn't seem to expose ContainerProps
+type ContainerProps = React.ComponentProps<typeof components.SelectContainer>;
 
 type Tag = {
   value: string;
@@ -119,13 +122,15 @@ function AutoComplete({orgSlug, projectId, category, onChange, value}: Props) {
         }),
       }}
       components={{
-        SelectContainer: (containerProps: ContainerProps<{}>) => (
+        SelectContainer: (containerProps: ContainerProps) => (
           <components.SelectContainer
             {...containerProps}
-            innerProps={{
-              ...containerProps.innerProps,
-              'data-test-id': `autocomplete-${key}`,
-            }}
+            innerProps={
+              {
+                ...containerProps.innerProps,
+                'data-test-id': `autocomplete-${key}`,
+              } as ContainerProps['innerProps']
+            }
           />
         ),
         MultiValue: (multiValueProps: MultiValueProps<{}>) => (
@@ -137,7 +142,12 @@ function AutoComplete({orgSlug, projectId, category, onChange, value}: Props) {
         Option: (optionProps: OptionProps<{}>) => (
           <components.Option
             {...optionProps}
-            innerProps={{...optionProps.innerProps, 'data-test-id': 'option'}}
+            innerProps={
+              {
+                ...optionProps.innerProps,
+                'data-test-id': 'option',
+              } as OptionProps<{}>['innerProps']
+            }
           />
         ),
       }}

--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -38,7 +38,7 @@ function Conditions({conditions, orgSlug, projectId, onDelete, onChange}: Props)
         const displayLegacyBrowsers =
           category === DynamicSamplingInnerName.EVENT_LEGACY_BROWSER;
 
-        const isABooleanField =
+        const isBooleanField =
           category === DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS ||
           category === DynamicSamplingInnerName.EVENT_LOCALHOST ||
           category === DynamicSamplingInnerName.EVENT_WEB_CRAWLERS ||
@@ -61,7 +61,7 @@ function Conditions({conditions, orgSlug, projectId, onDelete, onChange}: Props)
               </span>
             </LeftCell>
             <CenterCell>
-              {!isABooleanField &&
+              {!isBooleanField &&
                 (isAutoCompleteField ? (
                   <AutoComplete
                     category={category}

--- a/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/conditions.tsx
@@ -11,6 +11,7 @@ import TextareaField from 'app/views/settings/components/forms/textareaField';
 
 import {getInnerNameLabel} from '../utils';
 
+import AutoComplete from './autoComplete';
 import LegacyBrowsers from './legacyBrowsers';
 import {getMatchFieldPlaceholder} from './utils';
 
@@ -20,7 +21,7 @@ type Condition = {
   legacyBrowsers?: Array<LegacyBrowser>;
 };
 
-type Props = {
+type Props = Pick<React.ComponentProps<typeof AutoComplete>, 'orgSlug' | 'projectId'> & {
   conditions: Condition[];
   onDelete: (index: number) => void;
   onChange: <T extends keyof Condition>(
@@ -30,7 +31,7 @@ type Props = {
   ) => void;
 };
 
-function Conditions({conditions, onDelete, onChange}: Props) {
+function Conditions({conditions, orgSlug, projectId, onDelete, onChange}: Props) {
   return (
     <Fragment>
       {conditions.map(({category, match, legacyBrowsers}, index) => {
@@ -43,6 +44,14 @@ function Conditions({conditions, onDelete, onChange}: Props) {
           category === DynamicSamplingInnerName.EVENT_WEB_CRAWLERS ||
           displayLegacyBrowsers;
 
+        const isAutoCompleteField =
+          category === DynamicSamplingInnerName.EVENT_ENVIRONMENT ||
+          category === DynamicSamplingInnerName.EVENT_RELEASE ||
+          category === DynamicSamplingInnerName.EVENT_TRANSACTION ||
+          category === DynamicSamplingInnerName.TRACE_ENVIRONMENT ||
+          category === DynamicSamplingInnerName.TRACE_RELEASE ||
+          category === DynamicSamplingInnerName.TRACE_TRANSACTION;
+
         return (
           <ConditionWrapper key={index}>
             <LeftCell>
@@ -52,21 +61,30 @@ function Conditions({conditions, onDelete, onChange}: Props) {
               </span>
             </LeftCell>
             <CenterCell>
-              {!isABooleanField && (
-                <StyledTextareaField
-                  name="match"
-                  value={match}
-                  onChange={value => onChange(index, 'match', value)}
-                  placeholder={getMatchFieldPlaceholder(category)}
-                  inline={false}
-                  rows={1}
-                  autosize
-                  hideControlState
-                  flexibleControlStateSize
-                  required
-                  stacked
-                />
-              )}
+              {!isABooleanField &&
+                (isAutoCompleteField ? (
+                  <AutoComplete
+                    category={category}
+                    orgSlug={orgSlug}
+                    projectId={projectId}
+                    value={match}
+                    onChange={value => onChange(index, 'match', value)}
+                  />
+                ) : (
+                  <StyledTextareaField
+                    name="match"
+                    value={match}
+                    onChange={value => onChange(index, 'match', value)}
+                    placeholder={getMatchFieldPlaceholder(category)}
+                    inline={false}
+                    rows={1}
+                    autosize
+                    hideControlState
+                    flexibleControlStateSize
+                    required
+                    stacked
+                  />
+                ))}
             </CenterCell>
             <RightCell>
               <Button
@@ -94,7 +112,7 @@ export default Conditions;
 
 const ConditionWrapper = styled('div')`
   display: grid;
-  grid-template-columns: 1fr max-content;
+  grid-template-columns: 1fr minmax(0, 1fr);
   align-items: flex-start;
   padding: ${space(1)} ${space(2)};
   :not(:last-child) {
@@ -102,7 +120,7 @@ const ConditionWrapper = styled('div')`
   }
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-template-columns: 0.6fr 1fr max-content;
+    grid-template-columns: 0.6fr minmax(0, 1fr) max-content;
   }
 `;
 

--- a/static/app/views/settings/project/filtersAndSampling/modal/errorRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/errorRuleModal.tsx
@@ -69,18 +69,18 @@ function ErrorRuleModal({rule, errorRules, transactionRules, ...props}: Props) {
       title={rule ? t('Edit Error Sampling Rule') : t('Add Error Sampling Rule')}
       emptyMessage={t('Apply sampling rate to all errors')}
       conditionCategories={[
-        [DynamicSamplingInnerName.EVENT_RELEASE, t('Releases')],
-        [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environments')],
+        [DynamicSamplingInnerName.EVENT_RELEASE, t('Release')],
+        [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environment')],
         [DynamicSamplingInnerName.EVENT_USER_ID, t('User Id')],
         [DynamicSamplingInnerName.EVENT_USER_SEGMENT, t('User Segment')],
         [DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS, t('Browser Extensions')],
         [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
-        [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browsers')],
+        [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browser')],
         [DynamicSamplingInnerName.EVENT_WEB_CRAWLERS, t('Web Crawlers')],
-        [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Addresses')],
+        [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Address')],
         [DynamicSamplingInnerName.EVENT_CSP, t('Content Security Policy')],
-        [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Messages')],
-        [DynamicSamplingInnerName.EVENT_TRANSACTION, t('Transactions')],
+        [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Message')],
+        [DynamicSamplingInnerName.EVENT_TRANSACTION, t('Transaction')],
       ]}
       rule={rule}
       onSubmit={handleSubmit}

--- a/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/ruleModal.tsx
@@ -252,6 +252,8 @@ function RuleModal({
                   conditions={conditions}
                   onDelete={handleDeleteCondition}
                   onChange={handleChangeCondition}
+                  orgSlug={organization.slug}
+                  projectId={project.id}
                 />
               )}
             </PanelBody>

--- a/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/transactionRuleModal.tsx
@@ -113,15 +113,15 @@ function TransactionRuleModal({
       conditionCategories={
         tracing
           ? [
-              [DynamicSamplingInnerName.TRACE_RELEASE, t('Releases')],
-              [DynamicSamplingInnerName.TRACE_ENVIRONMENT, t('Environments')],
+              [DynamicSamplingInnerName.TRACE_RELEASE, t('Release')],
+              [DynamicSamplingInnerName.TRACE_ENVIRONMENT, t('Environment')],
               [DynamicSamplingInnerName.TRACE_USER_ID, t('User Id')],
               [DynamicSamplingInnerName.TRACE_USER_SEGMENT, t('User Segment')],
-              [DynamicSamplingInnerName.TRACE_TRANSACTION, t('Transactions')],
+              [DynamicSamplingInnerName.TRACE_TRANSACTION, t('Transaction')],
             ]
           : [
-              [DynamicSamplingInnerName.EVENT_RELEASE, t('Releases')],
-              [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environments')],
+              [DynamicSamplingInnerName.EVENT_RELEASE, t('Release')],
+              [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environment')],
               [DynamicSamplingInnerName.EVENT_USER_ID, t('User Id')],
               [DynamicSamplingInnerName.EVENT_USER_SEGMENT, t('User Segment')],
               [
@@ -129,12 +129,12 @@ function TransactionRuleModal({
                 t('Browser Extensions'),
               ],
               [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
-              [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browsers')],
+              [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browser')],
               [DynamicSamplingInnerName.EVENT_WEB_CRAWLERS, t('Web Crawlers')],
-              [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Addresses')],
+              [DynamicSamplingInnerName.EVENT_IP_ADDRESSES, t('IP Address')],
               [DynamicSamplingInnerName.EVENT_CSP, t('Content Security Policy')],
-              [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Messages')],
-              [DynamicSamplingInnerName.EVENT_TRANSACTION, t('Transactions')],
+              [DynamicSamplingInnerName.EVENT_ERROR_MESSAGES, t('Error Message')],
+              [DynamicSamplingInnerName.EVENT_TRANSACTION, t('Transaction')],
             ]
       }
       rule={rule}

--- a/static/app/views/settings/project/filtersAndSampling/modal/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/utils.tsx
@@ -1,4 +1,5 @@
 import {css} from '@emotion/react';
+import * as Sentry from '@sentry/react';
 
 import {t} from 'app/locale';
 import {
@@ -55,21 +56,22 @@ export function getMatchFieldPlaceholder(category: DynamicSamplingInnerName) {
       return t('ex. paid, common (Multiline)');
     case DynamicSamplingInnerName.TRACE_ENVIRONMENT:
     case DynamicSamplingInnerName.EVENT_ENVIRONMENT:
-      return t('ex. prod or dev (Multiline)');
+      return t('ex. prod, dev');
     case DynamicSamplingInnerName.TRACE_RELEASE:
     case DynamicSamplingInnerName.EVENT_RELEASE:
-      return t('ex. 1* or [I3].[0-9].* (Multiline)');
+      return t('ex. 1* or [I3].[0-9].*');
     case DynamicSamplingInnerName.EVENT_IP_ADDRESSES:
       return t('ex. 127.0.0.1 or 10.0.0.0/8 (Multiline)');
     case DynamicSamplingInnerName.EVENT_CSP:
-      return t('ex. file://* or example.com (Multiline)');
+      return t('ex. file://*, example.com (Multiline)');
     case DynamicSamplingInnerName.EVENT_ERROR_MESSAGES:
       return t('ex. TypeError* (Multiline)');
     case DynamicSamplingInnerName.TRACE_TRANSACTION:
     case DynamicSamplingInnerName.EVENT_TRANSACTION:
-      return t('ex. "page-load" (Multiline)');
+      return t('ex. "page-load"');
     default:
-      return '';
+      Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
+      return ''; // this shall never happen this shall never happen
   }
 }
 

--- a/static/app/views/settings/project/filtersAndSampling/modal/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/modal/utils.tsx
@@ -59,7 +59,7 @@ export function getMatchFieldPlaceholder(category: DynamicSamplingInnerName) {
       return t('ex. prod, dev');
     case DynamicSamplingInnerName.TRACE_RELEASE:
     case DynamicSamplingInnerName.EVENT_RELEASE:
-      return t('ex. 1* or [I3].[0-9].*');
+      return t('ex. 1*, [I3].[0-9].*');
     case DynamicSamplingInnerName.EVENT_IP_ADDRESSES:
       return t('ex. 127.0.0.1 or 10.0.0.0/8 (Multiline)');
     case DynamicSamplingInnerName.EVENT_CSP:
@@ -71,7 +71,7 @@ export function getMatchFieldPlaceholder(category: DynamicSamplingInnerName) {
       return t('ex. "page-load"');
     default:
       Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
-      return ''; // this shall never happen this shall never happen
+      return ''; // this shall never happen
   }
 }
 

--- a/static/app/views/settings/project/filtersAndSampling/utils.tsx
+++ b/static/app/views/settings/project/filtersAndSampling/utils.tsx
@@ -63,16 +63,16 @@ export function getInnerNameLabel(name: DynamicSamplingInnerName) {
     case DynamicSamplingInnerName.EVENT_WEB_CRAWLERS:
       return t('Web Crawlers');
     case DynamicSamplingInnerName.EVENT_LEGACY_BROWSER:
-      return t('Legacy Browsers');
+      return t('Legacy Browser');
     case DynamicSamplingInnerName.EVENT_TRANSACTION:
     case DynamicSamplingInnerName.TRACE_TRANSACTION:
-      return t('Transactions');
+      return t('Transaction');
     case DynamicSamplingInnerName.EVENT_ERROR_MESSAGES:
-      return t('Error Messages');
+      return t('Error Message');
     case DynamicSamplingInnerName.EVENT_CSP:
       return t('Content Security Policy');
     case DynamicSamplingInnerName.EVENT_IP_ADDRESSES:
-      return t('IP Addresses');
+      return t('IP Address');
     default: {
       Sentry.captureException(new Error('Unknown dynamic sampling condition inner name'));
       return null; // this shall never happen

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -197,6 +197,7 @@ describe('ProjectAlertsCreate', function () {
       await selectEvent.select(getByText('Add optional condition...'), [
         'A new issue is created',
       ]);
+
       fireEvent.click(getByLabelText('Delete Node'));
 
       expect(trackAnalyticsEvent).toHaveBeenCalledWith({
@@ -212,6 +213,7 @@ describe('ProjectAlertsCreate', function () {
       await selectEvent.select(getByText('Add optional filter...'), [
         'The issue is {comparison_type} than {value} {time}',
       ]);
+
       fireEvent.click(getByLabelText('Delete Node'));
 
       // Add an action and remove it

--- a/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
+++ b/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
@@ -20,18 +20,18 @@ import {
 
 describe('Filters and Sampling', function () {
   const commonConditionCategories = [
-    'Releases',
-    'Environments',
+    'Release',
+    'Environment',
     'User Id',
     'User Segment',
     'Browser Extensions',
     'Localhost',
-    'Legacy Browsers',
+    'Legacy Browser',
     'Web Crawlers',
-    'IP Addresses',
+    'IP Address',
     'Content Security Policy',
-    'Error Messages',
-    'Transactions',
+    'Error Message',
+    'Transaction',
   ];
 
   // @ts-expect-error
@@ -56,13 +56,13 @@ describe('Filters and Sampling', function () {
   }
 
   async function renderModal(
-    screen: BoundFunctions<{findByRole: FindByRole}>,
+    screen2: BoundFunctions<{findByRole: FindByRole}>,
     actionElement: HTMLElement,
     takeScreenshot = false
   ) {
     // Open Modal
     fireEvent.click(actionElement);
-    const dialog = await screen.findByRole('dialog');
+    const dialog = await screen2.findByRole('dialog');
     expect(dialog).toBeInTheDocument();
 
     if (takeScreenshot) {
@@ -340,6 +340,13 @@ describe('Filters and Sampling', function () {
         }),
       });
 
+      // @ts-expect-error
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/release/values/',
+        method: 'GET',
+        body: [{value: '[I3].[0-9]'}],
+      });
+
       const component = renderComponent();
       const {queryAllByText, queryByText, getByText, queryAllByLabelText} = component;
 
@@ -364,13 +371,14 @@ describe('Filters and Sampling', function () {
       expect(modal.queryByText('Tracing')).toBeFalsy();
 
       // Release Field
-      const releaseField = modal.getByPlaceholderText(
-        'ex. 1* or [I3].[0-9].* (Multiline)'
-      );
+      await modal.findByTestId('autocomplete-release');
+      const releaseField = modal.getByTestId('autocomplete-release');
       expect(releaseField).toBeTruthy();
 
       // Release field is not empty
-      expect(releaseField).toHaveValue('1*');
+      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
+      expect(releaseFieldValues).toHaveLength(1);
+      expect(releaseFieldValues[0].textContent).toEqual('1*');
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -384,13 +392,40 @@ describe('Filters and Sampling', function () {
       // Sample rate is not empty
       expect(sampleRateField).toHaveValue(10);
 
+      const releaseFieldInput = within(releaseField).getByLabelText(
+        'Search or add a release'
+      );
+
       // Clear release field
-      fireEvent.change(releaseField, {target: {value: ''}});
+      fireEvent.keyDown(releaseFieldInput, {key: 'Backspace'});
+
+      // Release field is now empty
+      const newReleaseFieldValues = within(
+        modal.getByTestId('autocomplete-release')
+      ).queryAllByTestId('multivalue');
+      expect(newReleaseFieldValues).toHaveLength(0);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
 
-      // Add new value to the release field
-      fireEvent.change(releaseField, {target: {value: '[I3].[0-9]'}});
+      // Type into realease field
+      fireEvent.change(
+        within(modal.getByTestId('autocomplete-release')).getByLabelText(
+          'Search or add a release'
+        ),
+        {
+          target: {value: '[I3].[0-9]'},
+        }
+      );
+
+      // Autocomplete suggests options
+      const autocompleteOptions = within(
+        modal.getByTestId('autocomplete-release')
+      ).queryAllByTestId('option');
+      expect(autocompleteOptions).toHaveLength(1);
+      expect(autocompleteOptions[0].textContent).toEqual('[I3].[0-9]');
+
+      // Click on the suggested option
+      fireEvent.click(autocompleteOptions[0]);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -516,6 +551,13 @@ describe('Filters and Sampling', function () {
         }),
       });
 
+      // @ts-expect-error
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/release/values/',
+        method: 'GET',
+        body: [{value: '[0-9]'}],
+      });
+
       const component = renderComponent();
       const {queryAllByText, queryByText, getByText, queryAllByLabelText} = component;
 
@@ -541,13 +583,14 @@ describe('Filters and Sampling', function () {
       expect(modal.getByRole('checkbox')).toBeChecked();
 
       // Release Field
-      const releaseField = modal.getByPlaceholderText(
-        'ex. 1* or [I3].[0-9].* (Multiline)'
-      );
+      await modal.findByTestId('autocomplete-release');
+      const releaseField = modal.getByTestId('autocomplete-release');
       expect(releaseField).toBeTruthy();
 
       // Release field is not empty
-      expect(releaseField).toHaveValue('1.2.3');
+      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
+      expect(releaseFieldValues).toHaveLength(1);
+      expect(releaseFieldValues[0].textContent).toEqual('1.2.3');
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -561,13 +604,40 @@ describe('Filters and Sampling', function () {
       // Sample rate is not empty
       expect(sampleRateField).toHaveValue(20);
 
+      const releaseFieldInput = within(releaseField).getByLabelText(
+        'Search or add a release'
+      );
+
       // Clear release field
-      fireEvent.change(releaseField, {target: {value: ''}});
+      fireEvent.keyDown(releaseFieldInput, {key: 'Backspace'});
+
+      // Release field is now empty
+      const newReleaseFieldValues = within(
+        modal.getByTestId('autocomplete-release')
+      ).queryAllByTestId('multivalue');
+      expect(newReleaseFieldValues).toHaveLength(0);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
 
-      // Add new value to the release field
-      fireEvent.change(releaseField, {target: {value: '[0-9]'}});
+      // Type into realease field
+      fireEvent.change(
+        within(modal.getByTestId('autocomplete-release')).getByLabelText(
+          'Search or add a release'
+        ),
+        {
+          target: {value: '[0-9]'},
+        }
+      );
+
+      // Autocomplete suggests options
+      const autocompleteOptions = within(
+        modal.getByTestId('autocomplete-release')
+      ).queryAllByTestId('option');
+      expect(autocompleteOptions).toHaveLength(1);
+      expect(autocompleteOptions[0].textContent).toEqual('[0-9]');
+
+      // Click on the suggested option
+      fireEvent.click(autocompleteOptions[0]);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -693,6 +763,13 @@ describe('Filters and Sampling', function () {
         }),
       });
 
+      // @ts-expect-error
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/release/values/',
+        method: 'GET',
+        body: [{value: '[0-9]'}],
+      });
+
       const component = renderComponent();
       const {queryAllByText, queryByText, getByText, queryAllByLabelText} = component;
 
@@ -718,13 +795,13 @@ describe('Filters and Sampling', function () {
       expect(modal.getByRole('checkbox')).not.toBeChecked();
 
       // Release Field
-      const releaseField = modal.getByPlaceholderText(
-        'ex. 1* or [I3].[0-9].* (Multiline)'
-      );
+      await modal.findByTestId('autocomplete-release');
+      const releaseField = modal.getByTestId('autocomplete-release');
       expect(releaseField).toBeTruthy();
 
       // Release field is not empty
-      expect(releaseField).toHaveValue('1.2.3');
+      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
+      expect(releaseFieldValues).toHaveLength(1);
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -738,13 +815,40 @@ describe('Filters and Sampling', function () {
       // Sample rate is not empty
       expect(sampleRateField).toHaveValue(20);
 
+      const releaseFieldInput = within(releaseField).getByLabelText(
+        'Search or add a release'
+      );
+
       // Clear release field
-      fireEvent.change(releaseField, {target: {value: ''}});
+      fireEvent.keyDown(releaseFieldInput, {key: 'Backspace'});
+
+      // Release field is now empty
+      const newReleaseFieldValues = within(
+        modal.getByTestId('autocomplete-release')
+      ).queryAllByTestId('multivalue');
+      expect(newReleaseFieldValues).toHaveLength(0);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
 
-      // Add new value to the release field
-      fireEvent.change(releaseField, {target: {value: '[0-9]'}});
+      // Type into realease field
+      fireEvent.change(
+        within(modal.getByTestId('autocomplete-release')).getByLabelText(
+          'Search or add a release'
+        ),
+        {
+          target: {value: '[0-9]'},
+        }
+      );
+
+      // Autocomplete suggests options
+      const autocompleteOptions = within(
+        modal.getByTestId('autocomplete-release')
+      ).queryAllByTestId('option');
+      expect(autocompleteOptions).toHaveLength(1);
+      expect(autocompleteOptions[0].textContent).toEqual('[0-9]');
+
+      // Click on the suggested option
+      fireEvent.click(autocompleteOptions[0]);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -899,123 +1003,6 @@ describe('Filters and Sampling', function () {
       // There is still one transaction rule
       expect(transactionTraceRules).toHaveLength(1);
     });
-
-    it('transaction rule', async function () {
-      // @ts-expect-error
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/',
-        method: 'GET',
-        // @ts-expect-error
-        body: TestStubs.Project({
-          dynamicSampling: {
-            rules: [
-              {
-                sampleRate: 0.2,
-                type: 'error',
-                condition: {
-                  op: 'and',
-                  inner: [
-                    {
-                      op: 'glob',
-                      name: 'event.release',
-                      value: ['1.2.3'],
-                    },
-                  ],
-                },
-                id: 39,
-              },
-              {
-                sampleRate: 0.2,
-                type: 'trace',
-                condition: {
-                  op: 'and',
-                  inner: [
-                    {
-                      op: 'glob',
-                      name: 'trace.release',
-                      value: ['1.2.3'],
-                    },
-                  ],
-                },
-                id: 40,
-              },
-            ],
-            next_id: 43,
-          },
-        }),
-      });
-
-      // @ts-expect-error
-      MockApiClient.addMockResponse({
-        url: '/projects/org-slug/project-slug/',
-        method: 'PUT',
-        // @ts-expect-error
-        body: TestStubs.Project({
-          dynamicSampling: {
-            rules: [
-              {
-                sampleRate: 0.2,
-                type: 'error',
-                condition: {
-                  op: 'and',
-                  inner: [
-                    {
-                      op: 'glob',
-                      name: 'event.release',
-                      value: ['1.2.3'],
-                    },
-                  ],
-                },
-                id: 39,
-              },
-            ],
-            next_id: 43,
-          },
-        }),
-      });
-
-      const component = renderComponent();
-      const {queryAllByText, queryByText, getByText, queryAllByLabelText} = component;
-
-      // Error rules container
-      expect(queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
-
-      // Transaction traces and individual transactions rules container
-      expect(queryByText('There are no transaction rules to display')).toBeFalsy();
-      const transactionTraceRules = queryAllByText('Transaction traces');
-      expect(transactionTraceRules).toHaveLength(1);
-
-      const deleteRuleButtons = queryAllByLabelText('Delete Rule');
-      expect(deleteRuleButtons).toHaveLength(2);
-
-      // Open deletion confirmation modal - delete transaction rule
-      const modal = await renderModal(component, deleteRuleButtons[1]);
-
-      expect(
-        modal.getByText('Are you sure you wish to delete this dynamic sampling rule?')
-      ).toBeTruthy();
-
-      const modalActionButtons = modal.queryAllByRole('button');
-      expect(modalActionButtons).toHaveLength(2);
-      expect(modalActionButtons[0].textContent).toEqual('Cancel');
-      expect(modalActionButtons[1].textContent).toEqual('Confirm');
-
-      // Confirm deletion
-      fireEvent.click(modalActionButtons[1]);
-
-      // Confirmation modal will close
-      await waitForElementToBeRemoved(() =>
-        getByText('Are you sure you wish to delete this dynamic sampling rule?')
-      );
-
-      // Transaction rules panel is updated
-      expect(queryByText('There are no transaction rules to display')).toBeTruthy();
-
-      // There is still one transaction rule
-      expect(errorRules).toHaveLength(1);
-    });
   });
 
   describe('error rule modal', function () {
@@ -1104,6 +1091,13 @@ describe('Filters and Sampling', function () {
           }),
       });
 
+      // @ts-expect-error
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/tags/release/values/',
+        method: 'GET',
+        body: [{value: '1.2.3'}],
+      });
+
       const component = renderComponent();
       const {getByText, queryByText, queryAllByText} = component;
 
@@ -1124,13 +1118,26 @@ describe('Filters and Sampling', function () {
       fireEvent.click(conditionOptions[0]);
 
       // Release Field
-      const releaseField = modal.getByPlaceholderText(
-        'ex. 1* or [I3].[0-9].* (Multiline)'
-      );
+      await modal.findByTestId('autocomplete-release');
+      const releaseField = modal.getByTestId('autocomplete-release');
       expect(releaseField).toBeTruthy();
 
-      // Fill release field
-      fireEvent.change(releaseField, {target: {value: '1.2.3'}});
+      // Release field is empty
+      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
+      expect(releaseFieldValues).toHaveLength(0);
+
+      // Type into realease field
+      fireEvent.change(within(releaseField).getByLabelText('Search or add a release'), {
+        target: {value: '1.2.3'},
+      });
+
+      // Autocomplete suggests options
+      const autocompleteOptions = within(releaseField).queryAllByTestId('option');
+      expect(autocompleteOptions).toHaveLength(1);
+      expect(autocompleteOptions[0].textContent).toEqual('1.2.3');
+
+      // Click on the suggested option
+      fireEvent.click(autocompleteOptions[0]);
 
       // Button is still disabled
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -1164,11 +1171,11 @@ describe('Filters and Sampling', function () {
 
   describe('transaction rule modal', function () {
     const conditionTracingCategories = [
-      'Releases',
-      'Environments',
+      'Release',
+      'Environment',
       'User Id',
       'User Segment',
-      'Transactions',
+      'Transaction',
     ];
 
     it('renders modal', async function () {
@@ -1285,6 +1292,13 @@ describe('Filters and Sampling', function () {
             }),
         });
 
+        // @ts-expect-error
+        MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/tags/release/values/',
+          method: 'GET',
+          body: [{value: '1.2.3'}],
+        });
+
         const component = renderComponent();
         const {getByText, queryByText, queryAllByText} = component;
 
@@ -1308,13 +1322,28 @@ describe('Filters and Sampling', function () {
         fireEvent.click(conditionOptions[0]);
 
         // Release Field
-        const releaseField = modal.getByPlaceholderText(
-          'ex. 1* or [I3].[0-9].* (Multiline)'
-        );
+        await modal.findByTestId('autocomplete-release');
+        const releaseField = modal.getByTestId('autocomplete-release');
         expect(releaseField).toBeTruthy();
 
-        // Fill release field
-        fireEvent.change(releaseField, {target: {value: '1.2.3'}});
+        // Release field is empty
+        const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
+        expect(releaseFieldValues).toHaveLength(0);
+
+        // Type into realease field
+        fireEvent.change(within(releaseField).getByLabelText('Search or add a release'), {
+          target: {value: '1.2.3'},
+        });
+
+        // Autocomplete suggests options
+        const autocompleteOptions = within(
+          modal.getByTestId('autocomplete-release')
+        ).queryAllByTestId('option');
+        expect(autocompleteOptions).toHaveLength(1);
+        expect(autocompleteOptions[0].textContent).toEqual('1.2.3');
+
+        // Click on the suggested option
+        fireEvent.click(autocompleteOptions[0]);
 
         // Button is still disabled
         const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -1377,6 +1406,13 @@ describe('Filters and Sampling', function () {
               }),
           });
 
+          // @ts-expect-error
+          MockApiClient.addMockResponse({
+            url: '/organizations/org-slug/tags/release/values/',
+            method: 'GET',
+            body: [{value: '1.2.3'}],
+          });
+
           const component = renderComponent();
           const {getByText, queryByText, queryAllByText, findByTestId} = component;
 
@@ -1400,13 +1436,31 @@ describe('Filters and Sampling', function () {
           fireEvent.click(conditionOptions[0]);
 
           // Release Field
-          const releaseField = modal.getByPlaceholderText(
-            'ex. 1* or [I3].[0-9].* (Multiline)'
-          );
+          await modal.findByTestId('autocomplete-release');
+          const releaseField = modal.getByTestId('autocomplete-release');
           expect(releaseField).toBeTruthy();
 
-          // Fill release field
-          fireEvent.change(releaseField, {target: {value: '1.2.3'}});
+          // Release field is empty
+          const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
+          expect(releaseFieldValues).toHaveLength(0);
+
+          // Type into realease field
+          fireEvent.change(
+            within(releaseField).getByLabelText('Search or add a release'),
+            {
+              target: {value: '1.2.3'},
+            }
+          );
+
+          // Autocomplete suggests options
+          const autocompleteOptions = within(
+            modal.getByTestId('autocomplete-release')
+          ).queryAllByTestId('option');
+          expect(autocompleteOptions).toHaveLength(1);
+          expect(autocompleteOptions[0].textContent).toEqual('1.2.3');
+
+          // Click on the suggested option
+          fireEvent.click(autocompleteOptions[0]);
 
           // Button is still disabled
           const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -1565,7 +1619,7 @@ describe('Filters and Sampling', function () {
           expect(queryByText('There are no transaction rules to display')).toBeFalsy();
           const individualTransactionRules = queryAllByText('Individual transactions');
           expect(individualTransactionRules).toHaveLength(1);
-          expect(getByText('Legacy Browsers')).toBeTruthy();
+          expect(getByText('Legacy Browser')).toBeTruthy();
           for (const legacyBrowser of legacyBrowsers) {
             const {title} = LEGACY_BROWSER_LIST[legacyBrowser];
             expect(getByText(title)).toBeTruthy();


### PR DESCRIPTION
**Description**
As a user, I want to be suggested condition values, so that I make fewer mistakes.

**UI updates** 

- [x] The UI shall display an autocomplete component when the selected category is environment, releases, or transaction  (these are the options we currently support)
- [x] The suggested values will be fetched from our database 
- [x]  User can still freely type their own value (react-select creatable)
- [x]  Made a couple of labels singular
- [x ] Fixed Tests 

**Preview**
![autocomplete](https://user-images.githubusercontent.com/29228205/135296037-a6593bf8-05a1-426c-ba79-dbc1ba55e15d.gif)

closes: INGEST-434