### PR TITLE
Revert ref(sdk): Testing default idleTimeout

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -31,7 +31,7 @@ function getSentryIntegrations(hasReplays: boolean = false, routes?: Function) {
             ),
           }
         : {}),
-      idleTimeout: 1000,
+      idleTimeout: 5000,
       _metricOptions: {
         _reportAllChanges: true,
       },


### PR DESCRIPTION
### Summary
Changes our idleTimeout back to 5000. The experiment was successful to show the impact of idleTimeout on LCP 👍 


Reverts getsentry/sentry#28868