### PR TITLE
fix(deletion) Fix snuba query deletion problem

### DIFF
--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -39,6 +39,8 @@ class OrganizationDeletionTask(ModelDeletionTask):
             Repository,
             ServiceHook,
             CommitAuthor,
+            Incident,
+            AlertRule,
             Release,
             Project,
             Environment,
@@ -48,8 +50,6 @@ class OrganizationDeletionTask(ModelDeletionTask):
             TeamKeyTransaction,
             ExternalIssue,
             PromptsActivity,
-            Incident,
-            AlertRule,
             ProjectTransactionThreshold,
         )
         relations.extend([ModelRelation(m, {"organization_id": instance.id}) for m in model_list])

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -1,5 +1,6 @@
 from uuid import uuid4
 
+from sentry.incidents.models import AlertRule
 from sentry.models import (
     Commit,
     CommitAuthor,
@@ -18,6 +19,7 @@ from sentry.models import (
     Repository,
     ScheduledDeletion,
 )
+from sentry.snuba.models import SnubaQuery
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TransactionTestCase
 
@@ -184,3 +186,30 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert not Organization.objects.filter(id=org.id).exists()
         assert not Commit.objects.filter(id=commit.id).exists()
         assert not CommitAuthor.objects.filter(id=author.id).exists()
+
+    def test_alert_rule(self):
+        org = self.create_organization(name="test", owner=self.user)
+        self.create_team(organization=org, name="test1")
+
+        env = Environment.objects.create(organization_id=org.id, name="foo")
+        snuba_query = SnubaQuery.objects.create(
+            dataset="events", aggregate="count()", time_window=60, resolution=60, environment=env
+        )
+        alert_rule = AlertRule.objects.create(
+            organization=org,
+            name="rule with environment",
+            threshold_period=1,
+            snuba_query=snuba_query,
+        )
+
+        org.update(status=OrganizationStatus.PENDING_DELETION)
+        deletion = ScheduledDeletion.schedule(org, days=0)
+        deletion.update(in_progress=True)
+
+        with self.tasks():
+            run_deletion(deletion.id)
+
+        assert not Organization.objects.filter(id=org.id).exists()
+        assert not Environment.objects.filter(id=env.id).exists()
+        assert not AlertRule.objects.filter(id=alert_rule.id).exists()
+        assert not SnubaQuery.objects.filter(id=snuba_query.id).exists()


### PR DESCRIPTION
Organization's that use AlertRules are getting stuck in the deletion queues because the `post_delete` signal is failing. The chain of events is:

- Org deletion starts
- Environment is deleted.
- SnubaQuery has a foreign key to Environment, so django deletes
  SnubaQuery
- AlertRule has a foreign key to SnubaQuery, so django deletes it.
- AlertRule post_deletion is fired, and the snuba_query is gone causing
  the read to fail

Reordering the relation deletion so AlertRules are removed first breaks this chain and ensures that alert rules are removed before their snuba queries are removed.

Fixes SENTRY-SAB