### PR TITLE
feat(team-store): Support user teams state in TeamStore

### DIFF
--- a/static/app/actionCreators/teams.tsx
+++ b/static/app/actionCreators/teams.tsx
@@ -47,6 +47,12 @@ export function fetchTeams(api: Client, params: OrgSlug, options: CallbackOption
   });
 }
 
+// Fetch user teams for current org and place them in the team store
+export async function fetchUserTeams(api: Client, params: OrgSlug) {
+  const teams = await api.requestPromise(`/organizations/${params.orgId}/user-teams/`);
+  TeamActions.loadUserTeams(teams);
+}
+
 export function fetchTeamDetails(
   api: Client,
   params: OrgAndTeamSlug,

--- a/static/app/actions/teamActions.tsx
+++ b/static/app/actions/teamActions.tsx
@@ -11,6 +11,7 @@ const TeamActions = Reflux.createActions([
   'fetchDetailsError',
   'fetchDetailsSuccess',
   'loadTeams',
+  'loadUserTeams',
   'removeTeam',
   'removeTeamError',
   'removeTeamSuccess',

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -67,6 +67,7 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
       acc[team.id] = team;
       return acc;
     }, {});
+
     // Replace or insert new user teams
     userTeams.reduce((acc: Record<string, Team>, userTeam: Team) => {
       acc[userTeam.id] = userTeam;
@@ -79,6 +80,7 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
       loadedUserTeams: true,
       teams,
     };
+
     this.trigger(new Set(Object.keys(teamIdMap)));
   },
 

--- a/tests/js/spec/stores/teamStore.spec.jsx
+++ b/tests/js/spec/stores/teamStore.spec.jsx
@@ -1,0 +1,93 @@
+import TeamActions from 'app/actions/teamActions';
+import TeamStore from 'app/stores/teamStore';
+
+describe('TeamStore', function () {
+  const teamFoo = TestStubs.Team({
+    slug: 'team-foo',
+  });
+  const teamBar = TestStubs.Team({
+    slug: 'team-bar',
+  });
+
+  describe('setting data', function () {
+    beforeEach(function () {
+      TeamStore.reset();
+    });
+
+    it('populate teams correctly', async function () {
+      expect(TeamStore.get()).toMatchObject({
+        teams: [],
+        loading: true,
+        hasMore: null,
+        loadedUserTeams: false,
+      });
+
+      TeamActions.loadTeams([teamFoo, teamBar]);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamBar, teamFoo],
+        loading: false,
+        hasMore: null,
+        loadedUserTeams: true,
+      });
+    });
+
+    it('loads user teams', async function () {
+      expect(TeamStore.get()).toMatchObject({
+        teams: [],
+        loadedUserTeams: false,
+      });
+
+      TeamActions.loadUserTeams([teamFoo]);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamFoo],
+        loadedUserTeams: true,
+      });
+    });
+  });
+
+  describe('updating teams', function () {
+    it('adds new teams', async function () {
+      TeamActions.loadTeams([teamFoo]);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamFoo],
+      });
+
+      TeamActions.createTeamSuccess(teamBar);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamBar, teamFoo],
+      });
+    });
+
+    it('removes teams', async function () {
+      TeamActions.loadTeams([teamFoo]);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamFoo],
+      });
+
+      TeamActions.removeTeamSuccess(teamFoo.slug);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [],
+      });
+    });
+
+    it('updates teams', async function () {
+      TeamActions.loadTeams([teamFoo]);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamFoo],
+      });
+
+      TeamActions.updateSuccess(teamFoo.slug, teamBar);
+      await tick();
+      expect(TeamStore.get()).toMatchObject({
+        teams: [teamBar],
+      });
+    });
+  });
+});


### PR DESCRIPTION
Augment the team store with state relating to whether or not the user's teams are loaded. This will be useful to avoid continually refetching the user's teams. 