### PR TITLE
test(ui): Convert checkbox fancy to RTL

### DIFF
--- a/static/app/components/checkboxFancy/checkboxFancy.tsx
+++ b/static/app/components/checkboxFancy/checkboxFancy.tsx
@@ -35,7 +35,7 @@ const CheckboxFancy = styled(
       data-test-id="checkbox-fancy"
       role="checkbox"
       aria-disabled={isDisabled}
-      aria-checked={isChecked}
+      aria-checked={isIndeterminate ? 'mixed' : isChecked}
       className={className}
       onClick={onClick}
     >

--- a/tests/js/spec/components/checkboxFancy.spec.tsx
+++ b/tests/js/spec/components/checkboxFancy.spec.tsx
@@ -1,31 +1,31 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
 
 describe('CheckboxFancy', function () {
   it('renders', function () {
-    const wrapper = mountWithTheme(<CheckboxFancy />);
-    expect(wrapper).toSnapshot();
+    const {container} = mountWithTheme(<CheckboxFancy />);
+    expect(container).toSnapshot();
   });
 
   it('isChecked', function () {
     const wrapper = mountWithTheme(<CheckboxFancy isChecked />);
-    expect(wrapper.props().isChecked).toEqual(true);
-    expect(wrapper.find('[data-test-id="icon-check-mark"]').exists()).toEqual(true);
-    expect(wrapper.find('[data-test-id="icon-subtract"]').exists()).toEqual(false);
+    expect(wrapper.getByRole('checkbox', {checked: true})).toBeTruthy();
+    expect(wrapper.getByTestId('icon-check-mark')).toBeInTheDocument();
+    expect(wrapper.queryByTestId('icon-subtract')).toBeNull();
   });
 
   it('isIndeterminate', function () {
     const wrapper = mountWithTheme(<CheckboxFancy isIndeterminate />);
-    expect(wrapper.props().isIndeterminate).toEqual(true);
-    expect(wrapper.find('[data-test-id="icon-check-mark"]').exists()).toEqual(false);
-    expect(wrapper.find('[data-test-id="icon-subtract"]').exists()).toEqual(true);
+    expect(wrapper.getByRole('checkbox')).toHaveAttribute('aria-checked', 'mixed');
+    expect(wrapper.queryByTestId('icon-check-mark')).toBeNull();
+    expect(wrapper.getByTestId('icon-subtract')).toBeInTheDocument();
   });
 
   it('isDisabled', function () {
     const wrapper = mountWithTheme(<CheckboxFancy isDisabled />);
-    expect(wrapper.props().isDisabled).toEqual(true);
-    expect(wrapper.find('[data-test-id="icon-check-mark"]').exists()).toEqual(false);
-    expect(wrapper.find('[data-test-id="icon-subtract"]').exists()).toEqual(false);
+    expect(wrapper.getByRole('checkbox')).toHaveAttribute('aria-disabled', 'true');
+    expect(wrapper.queryByTestId('icon-check-mark')).toBeNull();
+    expect(wrapper.queryByTestId('icon-subtract')).toBeNull();
   });
 });


### PR DESCRIPTION
adds the "mixed" aria-checked state when the checkbox is indeterminate
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role