### PR TITLE
fix(ui): Merged Issues fill color in dark mode

### DIFF
--- a/static/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
@@ -162,7 +162,7 @@ const Controls = styled('div')<{expanded: boolean}>`
   display: flex;
   justify-content: space-between;
   border-top: 1px solid ${p => p.theme.innerBorder};
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   padding: ${space(0.5)} ${space(1)};
   ${p => p.expanded && `border-bottom: 1px solid ${p.theme.innerBorder}`};
 
@@ -193,6 +193,7 @@ const Collapse = styled('span')`
 const MergedEventList = styled('div')`
   overflow: hidden;
   border: none;
+  background-color: ${p => p.theme.background};
 `;
 
 const EventDetails = styled('div')`


### PR DESCRIPTION
Use the adaptive background color aliases (`theme.background` and `theme.backgroundSecondary`) for the table in Issue Details > Merged Issues.

Current:
<img width="1335" alt="Screen Shot 2021-09-29 at 3 22 44 PM" src="https://user-images.githubusercontent.com/44172267/135357738-973734e3-9edf-4704-9b39-68beb3b92c47.png">

With fix:
<img width="1159" alt="Screen Shot 2021-09-29 at 3 28 35 PM" src="https://user-images.githubusercontent.com/44172267/135357757-142ee2d2-80b6-413a-9906-6b5bbbacb941.png">

However, this also changes the light-mode appearance:

- Current
  <img width="1146" alt="Screen Shot 2021-09-29 at 3 29 55 PM" src="https://user-images.githubusercontent.com/44172267/135357961-ad183a81-212e-443d-9356-162bbb7d05a4.png">

- With fix:
  <img width="1155" alt="Screen Shot 2021-09-29 at 3 30 02 PM" src="https://user-images.githubusercontent.com/44172267/135357981-5d9fe8aa-a4f9-469f-a107-11bc5507c323.png">

In my opinion, this looks fine and is in line with our current color system. The embossed effect is still preserved with the inset box shadow. Gray 100 should only be used for lines, not as a fill color.
