### PR TITLE
feat(team): Allow useTeams to provide user teams or teams by slug

### DIFF
--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -134,7 +134,7 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     fetchError: null,
   });
 
-  const slugsRef = useRef<Set<string>>(new Set(slugs));
+  const slugsRef = useRef(new Set(slugs));
   if (
     slugs &&
     (slugs.length !== slugsRef.current.size ||

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -134,13 +134,19 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     fetchError: null,
   });
 
-  const slugsRef = useRef(new Set(slugs));
-  if (
-    slugs &&
-    (slugs.length !== slugsRef.current.size ||
-      slugs.some(slug => !slugsRef.current.has(slug)))
-  ) {
-    slugsRef.current = new Set(slugs);
+  const slugsRef = useRef<Set<string> | null>(null);
+  // Only initialize slugsRef.current once and modify it when we receive new slugs determined through set equality
+  if (slugs !== undefined) {
+    if (slugsRef.current === null) {
+      slugsRef.current = new Set(slugs);
+    }
+
+    if (
+      slugs.length !== slugsRef.current.size ||
+      slugs.some(slug => !slugsRef.current?.has(slug))
+    ) {
+      slugsRef.current = new Set(slugs);
+    }
   }
 
   async function loadUserTeams() {

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -56,11 +56,11 @@ type Options = {
    */
   limit?: number;
   /**
-   * Slugs of teams to immediately fetch
+   * When provided, fetches specified teams by slug if necessary and only provides those teams.
    */
   slugs?: string[];
   /**
-   * Whether to provide user teams
+   * When true, fetches user's teams if necessary and only provides user's teams (isMember = true).
    */
   provideUserTeams?: boolean;
 };
@@ -158,8 +158,8 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
       return;
     }
 
+    setState({...state, fetching: true});
     try {
-      setState({...state, fetching: true});
       const {results, hasMore, nextCursor} = await fetchTeams(api, orgId, {
         slugs,
         limit,


### PR DESCRIPTION
Expand the functionality of useTeams with two new props (`slugs`, `provideUserTeams`). Will be useful as we start to replace `withTeams` usages with our `Teams` render prop component and actually have more than 100 teams in the frontend. 