### PR TITLE
ci: Add native as code owners to LPQ-related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -249,8 +249,10 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/api/endpoints/chunk.py                                  @getsentry/owners-native
 /src/sentry/api/endpoints/project_app_store_connect_credentials.py  @getsentry/owners-native
 /src/sentry/lang/native/                                            @getsentry/owners-native
+src/sentry/processing/realtime_metrics/                             @getsentry/owners-native
 /src/sentry/tasks/app_store_connect.py                              @getsentry/owners-native
 /src/sentry/tasks/assemble.py                                       @getsentry/owners-native
+/src/sentry/tasks/low_priority_symbolication.py                     @getsentry/owners-native
 /src/sentry/utils/appleconnect/                                     @getsentry/owners-native
 
 ## End of Native ##

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -253,6 +253,7 @@ src/sentry/processing/realtime_metrics/                             @getsentry/o
 /src/sentry/tasks/app_store_connect.py                              @getsentry/owners-native
 /src/sentry/tasks/assemble.py                                       @getsentry/owners-native
 /src/sentry/tasks/low_priority_symbolication.py                     @getsentry/owners-native
+/tests/sentry/tasks/test_low_priority_symbolication.py              @getsentry/owners-native
 /src/sentry/utils/appleconnect/                                     @getsentry/owners-native
 
 ## End of Native ##


### PR DESCRIPTION
native should probably be code owners of files that are for features/infra they're responsible for