### PR TITLE
ref(js): Improve app boot ordering

### DIFF
--- a/static/app/index.tsx
+++ b/static/app/index.tsx
@@ -66,12 +66,16 @@
 //                                 details for the org, projects, and teams.
 
 async function app() {
-  const [{bootstrap}, {initializeMain}] = await Promise.all([
-    import('app/bootstrap'),
-    import('app/bootstrap/initializeMain'),
-  ]);
-  const data = await bootstrap();
-  initializeMain(data);
+  // We won't need initalizeMainImport until we complete bootstrapping.
+  // Initaite the fetch, just don't await it until we need it.
+  const initalizeMainImport = import('app/bootstrap/initializeMain');
+  const bootstrapImport = import('app/bootstrap');
+
+  const {bootstrap} = await bootstrapImport;
+  const config = await bootstrap();
+
+  const {initializeMain} = await initalizeMainImport;
+  initializeMain(config);
 }
 
 app();


### PR DESCRIPTION
We don't actually need to wait on initializeMain until after we've completed bootstrapping, which can be done in parallel.