### PR TITLE
ref(workflow): Alerts Triggered start/end improvement and dict key cleanup

### DIFF
--- a/src/sentry/api/endpoints/team_alerts_triggered.py
+++ b/src/sentry/api/endpoints/team_alerts_triggered.py
@@ -24,8 +24,8 @@ class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):
         project_list = Project.objects.get_for_team_ids([team.id])
         owner_ids = [team.actor_id] + list(team.member_set.values_list("user__actor_id", flat=True))
         start, end = get_date_range_from_params(request.GET)
-        end = end.date() + timedelta(days=1)
-        start = start.date() + timedelta(days=1)
+        end = end.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        start = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
 
         bucketed_alert_counts = (
             IncidentActivity.objects.filter(
@@ -53,10 +53,10 @@ class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):
             .annotate(count=Count("id"))
         )
 
-        counts = {str(r["bucket"].date()): r["count"] for r in bucketed_alert_counts}
+        counts = {str(r["bucket"].isoformat()): r["count"] for r in bucketed_alert_counts}
         current_day = start
         while current_day < end:
-            counts.setdefault(str(current_day), 0)
+            counts.setdefault(str(current_day.isoformat()), 0)
             current_day += timedelta(days=1)
 
         return Response(counts)

--- a/src/sentry/api/endpoints/team_alerts_triggered.py
+++ b/src/sentry/api/endpoints/team_alerts_triggered.py
@@ -24,6 +24,9 @@ class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):
         project_list = Project.objects.get_for_team_ids([team.id])
         owner_ids = [team.actor_id] + list(team.member_set.values_list("user__actor_id", flat=True))
         start, end = get_date_range_from_params(request.GET)
+        end = end.date() + timedelta(days=1)
+        start = start.date() + timedelta(days=1)
+
         bucketed_alert_counts = (
             IncidentActivity.objects.filter(
                 (
@@ -37,6 +40,7 @@ class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):
                         ],
                     )
                 ),
+                incident__organization_id=team.organization_id,
                 incident__alert_rule__owner__in=owner_ids,
                 incident_id__in=IncidentProject.objects.filter(project__in=project_list).values(
                     "incident_id"
@@ -49,12 +53,9 @@ class TeamAlertsTriggeredEndpoint(TeamEndpoint, EnvironmentMixin):
             .annotate(count=Count("id"))
         )
 
-        counts = {str(r["bucket"].replace(tzinfo=None)): r["count"] for r in bucketed_alert_counts}
-        current_day = start.replace(
-            hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-        ) + timedelta(days=1)
-        end_day = end.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)
-        while current_day <= end_day:
+        counts = {str(r["bucket"].date()): r["count"] for r in bucketed_alert_counts}
+        current_day = start
+        while current_day < end:
             counts.setdefault(str(current_day), 0)
             current_day += timedelta(days=1)
 

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -48,54 +48,18 @@ class TeamAlertsTriggeredTest(APITestCase):
         response = self.get_success_response(self.team.organization.slug, self.team.slug)
         assert len(response.data) == 90
         for i in range(1, 9):
-            assert (
-                response.data[
-                    str(
-                        before_now(days=i).replace(
-                            hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-                        )
-                    )
-                ]
-                == 1
-            )
+            assert response.data[str(before_now(days=i).date())] == 1
 
         for i in range(10, 90):
-            assert (
-                response.data[
-                    str(
-                        before_now(days=i).replace(
-                            hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-                        )
-                    )
-                ]
-                == 0
-            )
+            assert response.data[str(before_now(days=i).date())] == 0
 
         response = self.get_success_response(
             self.team.organization.slug, self.team.slug, statsPeriod="7d"
         )
         assert len(response.data) == 7
-        assert (
-            response.data[
-                str(
-                    before_now(days=0).replace(
-                        hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-                    )
-                )
-            ]
-            == 0
-        )
+        assert response.data[str(before_now(days=0).date())] == 0
         for i in range(1, 6):
-            assert (
-                response.data[
-                    str(
-                        before_now(days=i).replace(
-                            hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-                        )
-                    )
-                ]
-                == 1
-            )
+            assert response.data[str(before_now(days=i).date())] == 1
 
     def test_not_as_simple(self):
         team_with_user = self.create_team(
@@ -156,26 +120,8 @@ class TeamAlertsTriggeredTest(APITestCase):
         self.login_as(user=self.user)
         response = self.get_success_response(self.team.organization.slug, self.team.slug)
         assert len(response.data) == 90
-        assert (
-            response.data[
-                str(
-                    before_now(days=2).replace(
-                        hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-                    )
-                )
-            ]
-            == 1
-        )
+        assert response.data[str(before_now(days=2).date())] == 1
         # only getting the team owned incident, because the user owned incident is for another project that the team isn't on
         for i in range(0, 90):
             if i != 2:
-                assert (
-                    response.data[
-                        str(
-                            before_now(days=i).replace(
-                                hour=0, minute=0, second=0, microsecond=0, tzinfo=None
-                            )
-                        )
-                    ]
-                    == 0
-                )
+                assert response.data[str(before_now(days=i).date())] == 0

--- a/tests/sentry/api/endpoints/test_team_alerts_triggered.py
+++ b/tests/sentry/api/endpoints/test_team_alerts_triggered.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.incidents.models import (
@@ -48,18 +49,54 @@ class TeamAlertsTriggeredTest(APITestCase):
         response = self.get_success_response(self.team.organization.slug, self.team.slug)
         assert len(response.data) == 90
         for i in range(1, 9):
-            assert response.data[str(before_now(days=i).date())] == 1
+            assert (
+                response.data[
+                    str(
+                        before_now(days=i)
+                        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+                        .isoformat()
+                    )
+                ]
+                == 1
+            )
 
         for i in range(10, 90):
-            assert response.data[str(before_now(days=i).date())] == 0
+            assert (
+                response.data[
+                    str(
+                        before_now(days=i)
+                        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+                        .isoformat()
+                    )
+                ]
+                == 0
+            )
 
         response = self.get_success_response(
             self.team.organization.slug, self.team.slug, statsPeriod="7d"
         )
         assert len(response.data) == 7
-        assert response.data[str(before_now(days=0).date())] == 0
+        assert (
+            response.data[
+                str(
+                    before_now(days=0)
+                    .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+                    .isoformat()
+                )
+            ]
+            == 0
+        )
         for i in range(1, 6):
-            assert response.data[str(before_now(days=i).date())] == 1
+            assert (
+                response.data[
+                    str(
+                        before_now(days=i)
+                        .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+                        .isoformat()
+                    )
+                ]
+                == 1
+            )
 
     def test_not_as_simple(self):
         team_with_user = self.create_team(
@@ -120,8 +157,26 @@ class TeamAlertsTriggeredTest(APITestCase):
         self.login_as(user=self.user)
         response = self.get_success_response(self.team.organization.slug, self.team.slug)
         assert len(response.data) == 90
-        assert response.data[str(before_now(days=2).date())] == 1
+        assert (
+            response.data[
+                str(
+                    before_now(days=2)
+                    .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+                    .isoformat()
+                )
+            ]
+            == 1
+        )
         # only getting the team owned incident, because the user owned incident is for another project that the team isn't on
         for i in range(0, 90):
             if i != 2:
-                assert response.data[str(before_now(days=i).date())] == 0
+                assert (
+                    response.data[
+                        str(
+                            before_now(days=i)
+                            .replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+                            .isoformat()
+                        )
+                    ]
+                    == 0
+                )


### PR DESCRIPTION
Making the key be the "Y-m-d" returned from .date() instead of using `replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=None)`. Could use `.strftime("%Y-%m-%dT%H:%M:%S.%fZ")` if that format is better for the FE to work with.