### PR TITLE
fix(ui): Fix alerts supported search tags

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -127,14 +127,8 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {
-      organization,
-      disabled,
-      onFilterSearch,
-      allowChangeEventTypes,
-      alertType,
-      dataset,
-    } = this.props;
+    const {organization, disabled, onFilterSearch, allowChangeEventTypes, alertType} =
+      this.props;
     const {environments} = this.state;
 
     const environmentOptions: SelectValue<string | null>[] =
@@ -323,7 +317,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                   {...(this.searchSupportedTags
                     ? {supportedTags: this.searchSupportedTags}
                     : {})}
-                  hasRecentSearches={dataset !== Dataset.SESSIONS}
+                  hasRecentSearches={this.props.dataset !== Dataset.SESSIONS}
                 />
               </SearchContainer>
             )}

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -114,7 +114,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   }
 
   get searchSupportedTags() {
-    if (this.props.dataset) {
+    if (this.props.dataset === Dataset.SESSIONS) {
       return {
         release: {
           key: 'release',

--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -127,8 +127,14 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {organization, disabled, onFilterSearch, allowChangeEventTypes, alertType} =
-      this.props;
+    const {
+      organization,
+      disabled,
+      onFilterSearch,
+      allowChangeEventTypes,
+      alertType,
+      dataset,
+    } = this.props;
     const {environments} = this.state;
 
     const environmentOptions: SelectValue<string | null>[] =
@@ -314,8 +320,10 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     onFilterSearch(query);
                     onChange(query, {});
                   }}
-                  supportedTags={this.searchSupportedTags}
-                  hasRecentSearches={false}
+                  {...(this.searchSupportedTags
+                    ? {supportedTags: this.searchSupportedTags}
+                    : {})}
+                  hasRecentSearches={dataset !== Dataset.SESSIONS}
                 />
               </SearchContainer>
             )}


### PR DESCRIPTION
There was a regression introduced here in this PR: https://github.com/getsentry/sentry/pull/28720.
Only sessions dataset should have search tags limited to just `release`. 

Fixes https://github.com/getsentry/sentry/issues/28898