### PR TITLE
fix(deletions) Improve AlertRule deletions

### DIFF
--- a/src/sentry/deletions/__init__.py
+++ b/src/sentry/deletions/__init__.py
@@ -87,9 +87,11 @@ default_manager = DeletionTaskManager(default_task=ModelDeletionTask)
 
 def load_defaults():
     from sentry import models
+    from sentry.incidents.models import AlertRule
 
     from . import defaults
 
+    default_manager.register(AlertRule, defaults.AlertRuleDeletionTask)
     default_manager.register(models.Activity, BulkModelDeletionTask)
     default_manager.register(models.ApiApplication, defaults.ApiApplicationDeletionTask)
     default_manager.register(models.ApiKey, BulkModelDeletionTask)

--- a/src/sentry/deletions/defaults/alertrule.py
+++ b/src/sentry/deletions/defaults/alertrule.py
@@ -1,0 +1,7 @@
+from ..base import ModelDeletionTask
+
+
+class AlertRuleDeletionTask(ModelDeletionTask):
+    # The default manager for alert rules excludes snapshots
+    # which we want to include when deleting an organization.
+    manager_name = "objects_with_snapshots"

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from sentry.incidents.models import AlertRule
+from sentry.incidents.models import AlertRule, AlertRuleStatus
 from sentry.models import (
     Commit,
     CommitAuthor,
@@ -200,6 +200,8 @@ class DeleteOrganizationTest(TransactionTestCase):
             name="rule with environment",
             threshold_period=1,
             snuba_query=snuba_query,
+            # This status is hidden from the default finder.
+            status=AlertRuleStatus.SNAPSHOT.value,
         )
 
         org.update(status=OrganizationStatus.PENDING_DELETION)


### PR DESCRIPTION
While the previous fix solved for active alert rules I didn't notice that the default object manager for AlertRules excludes snapshot status records. These records are causing deletions to fail now as they hold references to Environment via SnubaQuery. When Django cascades deletes for Environment records it ends up in the post_delete signal and fails.

Fixes SENTRY-SAB