### PR TITLE
fix(post_process_group): Fix bug where `has_reappared` can be undefined

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -283,8 +283,14 @@ def post_process_group(
         if not is_reprocessed:
             # we process snoozes before rules as it might create a regression
             # but not if it's new because you can't immediately snooze a new group
+            has_reappeared = not is_new
             try:
-                has_reappeared = False if is_new else process_snoozes(event.group)
+                if has_reappeared:
+                    has_reappeared = process_snoozes(event.group)
+            except Exception:
+                logger.exception("Failed to process snoozes for group")
+
+            try:
                 if not has_reappeared:  # If true, we added the .UNIGNORED reason already
                     if is_new:
                         add_group_to_inbox(event.group, GroupInboxReason.NEW)


### PR DESCRIPTION
This was introduced in https://github.com/getsentry/sentry/pull/28986. If an exception occurs when
calling `process_snoozes` we never end up defining `has_reappeared`, which causes an error later on.

I tried to find instances of `Failed to add group to inbox for non-reprocessed groups` errors in
Sentry and couldn't. I'm not sure why they're not present, but I can't see any other way that
`has_reappeared` could be undefined.

Fixes SENTRY-SAR