### PR TITLE
feat(workflow): Sort group tags alphabetically

### DIFF
--- a/static/app/views/organizationGroupDetails/groupTags.tsx
+++ b/static/app/views/organizationGroupDetails/groupTags.tsx
@@ -2,13 +2,11 @@ import * as React from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
-import {Client} from 'app/api';
 import Alert from 'app/components/alert';
+import AsyncComponent from 'app/components/asyncComponent';
 import Count from 'app/components/count';
 import DeviceName from 'app/components/deviceName';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
-import LoadingError from 'app/components/loadingError';
-import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import Version from 'app/components/version';
 import {t, tct} from 'app/locale';
@@ -16,144 +14,112 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Group, TagWithTopValues} from 'app/types';
 import {percent} from 'app/utils';
-import withApi from 'app/utils/withApi';
 
-type Props = {
+type Props = AsyncComponent['props'] & {
   baseUrl: string;
   group: Group;
-  api: Client;
   environments: string[];
 };
 
-type State = {
+type State = AsyncComponent['state'] & {
   tagList: null | TagWithTopValues[];
-  loading: boolean;
-  error: boolean;
 };
 
-class GroupTags extends React.Component<Props, State> {
-  state: State = {
-    tagList: null,
-    loading: true,
-    error: false,
-  };
+class GroupTags extends AsyncComponent<Props, State> {
+  getDefaultState(): State {
+    return {
+      ...super.getDefaultState(),
+      tagList: null,
+    };
+  }
 
-  componentDidMount() {
-    this.fetchData();
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {group, environments} = this.props;
+    return [
+      [
+        'tagList',
+        `/issues/${group.id}/tags/`,
+        {
+          query: {environment: environments},
+        },
+      ],
+    ];
   }
 
   componentDidUpdate(prevProps: Props) {
     if (!isEqual(prevProps.environments, this.props.environments)) {
-      this.fetchData();
+      this.remountComponent();
     }
   }
 
-  fetchData = () => {
-    const {api, group, environments} = this.props;
-    this.setState({
-      loading: true,
-      error: false,
-    });
-
-    api.request(`/issues/${group.id}/tags/`, {
-      query: {environment: environments},
-      success: data => {
-        this.setState({
-          tagList: data,
-          error: false,
-          loading: false,
-        });
-      },
-      error: () => {
-        this.setState({
-          error: true,
-          loading: false,
-        });
-      },
-    });
-  };
-
-  getTagsDocsUrl() {
-    return 'https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags';
-  }
-
-  render() {
+  renderTags() {
     const {baseUrl} = this.props;
+    const {tagList} = this.state;
 
-    let children: React.ReactNode[] = [];
+    const alphabeticalTags = (tagList ?? []).sort((a, b) => a.key.localeCompare(b.key));
 
-    if (this.state.loading) {
-      return <LoadingIndicator />;
-    } else if (this.state.error) {
-      return <LoadingError onRetry={this.fetchData} />;
-    }
-
-    if (this.state.tagList) {
-      children = this.state.tagList.map((tag, tagIdx) => {
-        const valueChildren = tag.topValues.map((tagValue, tagValueIdx) => {
-          let label: React.ReactNode = null;
-          const pct = percent(tagValue.count, tag.totalValues);
-          const query = tagValue.query || `${tag.key}:"${tagValue.value}"`;
-
-          switch (tag.key) {
-            case 'release':
-              label = <Version version={tagValue.name} anchor={false} />;
-              break;
-            default:
-              label = <DeviceName value={tagValue.name} />;
-          }
-
-          return (
-            <li key={tagValueIdx} data-test-id={tag.key}>
-              <TagBarGlobalSelectionLink
-                to={{
-                  pathname: `${baseUrl}events/`,
-                  query: {query},
-                }}
-              >
-                <TagBarBackground style={{width: pct + '%'}} />
-                <TagBarLabel>{label}</TagBarLabel>
-                <TagBarCount>
-                  <Count value={tagValue.count} />
-                </TagBarCount>
-              </TagBarGlobalSelectionLink>
-            </li>
-          );
-        });
-
-        return (
+    return (
+      <Container>
+        {alphabeticalTags.map((tag, tagIdx) => (
           <TagItem key={tagIdx}>
             <Panel>
-              <PanelHeader hasButtons style={{textTransform: 'none'}}>
-                <div style={{fontSize: 16}}>{tag.key}</div>
-                <DetailsLinkWrapper>
-                  <GlobalSelectionLink
-                    className="btn btn-default btn-sm"
-                    to={`${baseUrl}tags/${tag.key}/`}
-                  >
-                    {t('More Details')}
-                  </GlobalSelectionLink>
-                </DetailsLinkWrapper>
-              </PanelHeader>
+              <StyledPanelHeader hasButtons>
+                <TagHeading>{tag.key}</TagHeading>
+                <GlobalSelectionLink
+                  className="btn btn-default btn-sm"
+                  to={`${baseUrl}tags/${tag.key}/`}
+                >
+                  {t('More Details')}
+                </GlobalSelectionLink>
+              </StyledPanelHeader>
               <PanelBody withPadding>
-                <ul style={{listStyleType: 'none', padding: 0, margin: 0}}>
-                  {valueChildren}
-                </ul>
+                <UnstyledUnorderedList>
+                  {tag.topValues.map((tagValue, tagValueIdx) => (
+                    <li key={tagValueIdx} data-test-id={tag.key}>
+                      <TagBarGlobalSelectionLink
+                        to={{
+                          pathname: `${baseUrl}events/`,
+                          query: {
+                            query: tagValue.query || `${tag.key}:"${tagValue.value}"`,
+                          },
+                        }}
+                      >
+                        <TagBarBackground
+                          widthPercent={percent(tagValue.count, tag.totalValues) + '%'}
+                        />
+                        <TagBarLabel>
+                          {tag.key === 'release' ? (
+                            <Version version={tagValue.name} anchor={false} />
+                          ) : (
+                            <DeviceName value={tagValue.name} />
+                          )}
+                        </TagBarLabel>
+                        <TagBarCount>
+                          <Count value={tagValue.count} />
+                        </TagBarCount>
+                      </TagBarGlobalSelectionLink>
+                    </li>
+                  ))}
+                </UnstyledUnorderedList>
               </PanelBody>
             </Panel>
           </TagItem>
-        );
-      });
-    }
+        ))}
+      </Container>
+    );
+  }
 
+  renderBody() {
     return (
       <div>
-        <Container>{children}</Container>
+        {this.renderTags()}
         <Alert type="info">
           {tct(
             'Tags are automatically indexed for searching and breakdown charts. Learn how to [link: add custom tags to issues]',
             {
-              link: <a href={this.getTagsDocsUrl()} />,
+              link: (
+                <a href="https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags" />
+              ),
             }
           )}
         </Alert>
@@ -162,13 +128,23 @@ class GroupTags extends React.Component<Props, State> {
   }
 }
 
-const DetailsLinkWrapper = styled('div')`
-  display: flex;
-`;
-
 const Container = styled('div')`
   display: flex;
   flex-wrap: wrap;
+`;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  text-transform: none;
+`;
+
+const TagHeading = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const UnstyledUnorderedList = styled('ul')`
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: 0;
 `;
 
 const TagItem = styled('div')`
@@ -176,13 +152,14 @@ const TagItem = styled('div')`
   width: 50%;
 `;
 
-const TagBarBackground = styled('div')`
+const TagBarBackground = styled('div')<{widthPercent: string}>`
   position: absolute;
   top: 0;
   bottom: 0;
   left: 0;
   background: ${p => p.theme.tagBar};
   border-radius: ${p => p.theme.borderRadius};
+  width: ${p => p.widthPercent};
 `;
 
 const TagBarGlobalSelectionLink = styled(GlobalSelectionLink)`
@@ -217,4 +194,4 @@ const TagBarCount = styled('div')`
   font-variant-numeric: tabular-nums;
 `;
 
-export default withApi(GroupTags);
+export default GroupTags;

--- a/static/app/views/organizationGroupDetails/groupTags.tsx
+++ b/static/app/views/organizationGroupDetails/groupTags.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
+import Button from 'app/components/button';
 import Count from 'app/components/count';
 import DeviceName from 'app/components/deviceName';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
+import ExternalLink from 'app/components/links/externalLink';
+import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import Version from 'app/components/version';
 import {t, tct} from 'app/locale';
@@ -19,7 +23,7 @@ type Props = AsyncComponent['props'] & {
   baseUrl: string;
   group: Group;
   environments: string[];
-};
+} & RouteComponentProps<{}, {}>;
 
 type State = AsyncComponent['state'] & {
   tagList: null | TagWithTopValues[];
@@ -53,7 +57,7 @@ class GroupTags extends AsyncComponent<Props, State> {
   }
 
   renderTags() {
-    const {baseUrl} = this.props;
+    const {baseUrl, location} = this.props;
     const {tagList} = this.state;
 
     const alphabeticalTags = (tagList ?? []).sort((a, b) => a.key.localeCompare(b.key));
@@ -65,12 +69,15 @@ class GroupTags extends AsyncComponent<Props, State> {
             <Panel>
               <StyledPanelHeader hasButtons>
                 <TagHeading>{tag.key}</TagHeading>
-                <GlobalSelectionLink
-                  className="btn btn-default btn-sm"
-                  to={`${baseUrl}tags/${tag.key}/`}
+                <Button
+                  size="small"
+                  to={{
+                    pathname: `${baseUrl}tags/${tag.key}/`,
+                    query: extractSelectionParameters(location.query),
+                  }}
                 >
                   {t('More Details')}
-                </GlobalSelectionLink>
+                </Button>
               </StyledPanelHeader>
               <PanelBody withPadding>
                 <UnstyledUnorderedList>
@@ -118,7 +125,7 @@ class GroupTags extends AsyncComponent<Props, State> {
             'Tags are automatically indexed for searching and breakdown charts. Learn how to [link: add custom tags to issues]',
             {
               link: (
-                <a href="https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags" />
+                <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=/enriching-events/tags" />
               ),
             }
           )}

--- a/static/app/views/organizationGroupDetails/groupTags.tsx
+++ b/static/app/views/organizationGroupDetails/groupTags.tsx
@@ -137,8 +137,9 @@ const StyledPanelHeader = styled(PanelHeader)`
   text-transform: none;
 `;
 
-const TagHeading = styled('div')`
+const TagHeading = styled('h5')`
   font-size: ${p => p.theme.fontSizeLarge};
+  margin-bottom: 0;
 `;
 
 const UnstyledUnorderedList = styled('ul')`

--- a/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import GroupTags from 'app/views/organizationGroupDetails/groupTags';
 
@@ -18,9 +18,7 @@ describe('GroupTags', function () {
     const wrapper = mountWithTheme(
       <GroupTags
         group={group}
-        query={{}}
         environments={['dev']}
-        params={{orgId: 'org-slug', groupId: group.id}}
         baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
       />,
       {context: routerContext}
@@ -33,7 +31,11 @@ describe('GroupTags', function () {
       })
     );
 
-    wrapper.find('li[data-test-id="user"] Link').first().simulate('click', {button: 0});
+    const headers = wrapper.getAllByRole('heading').map(header => header.innerHTML);
+    // Check headers have been sorted alphabetically
+    expect(headers).toEqual(['browser', 'device', 'environment', 'url', 'user']);
+
+    fireEvent.click(wrapper.getByText('david'));
 
     expect(router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/issues/1/events/',

--- a/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
@@ -19,6 +19,7 @@ describe('GroupTags', function () {
       <GroupTags
         group={group}
         environments={['dev']}
+        location={{}}
         baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
       />,
       {context: routerContext}

--- a/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupTags.spec.jsx
@@ -1,5 +1,5 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import GroupTags from 'app/views/organizationGroupDetails/groupTags';
 
@@ -23,7 +23,7 @@ describe('GroupTags', function () {
         params={{orgId: 'org-slug', groupId: group.id}}
         baseUrl={`/organizations/${organization.slug}/issues/${group.id}/`}
       />,
-      routerContext
+      {context: routerContext}
     );
 
     expect(tagsMock).toHaveBeenCalledWith(


### PR DESCRIPTION
When the page is loaded the backend sends them in `-count` order which can seem almost random. This sorts them by tag name.

- **sort tags alphabetically**
- switch to RTL from enzyme
- use AsyncComponent instead of custom component
- removes some inline styles

![image](https://user-images.githubusercontent.com/1400464/135539455-dca12328-4172-43b8-879c-78d38cb7cf73.png)
