### PR TITLE
fix(ui): Firefox font smoothing

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -27,6 +27,7 @@ body {
   color: @gray-darker;
   background: @white-dark;
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
   min-height: 100vh;
 }


### PR DESCRIPTION
Currently, we use anti-aliasing to smooth fonts in the app and in our Figma designs. We already have the CSS declaration `-webkit-font-smoothing: antialiased` on `body`, which works in Safari and Chrome but not Firefox. For Firefox, we need an additional declaration: `-moz-osx-font-smoothing: grayscale`. (This is specific to font rendering in MacOS only.)

Before, in Firefox in MacOS:

<img width="632" alt="Screen Shot 2021-10-01 at 12 23 56 PM" src="https://user-images.githubusercontent.com/44172267/135675619-ade99c49-93a0-479f-a810-2cfc347b8c4e.png">


After, in Firefox in MacOS:

<img width="632" alt="Screen Shot 2021-10-01 at 12 23 12 PM" src="https://user-images.githubusercontent.com/44172267/135675555-f84dd3b9-939e-47c5-8a1d-f0b44ff717b2.png">


