### PR TITLE
feat(cmp_alerts): Support `comparisonDelta` parameter in `OrganizationEventsStatsEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -256,7 +256,9 @@ class OrganizationEventsTrendsStatsEndpoint(OrganizationEventsTrendsEndpointBase
         self, request, organization, params, trend_function, selected_columns, orderby, query
     ):
         def on_results(events_results):
-            def get_event_stats(query_columns, query, params, rollup, zerofill_results):
+            def get_event_stats(
+                query_columns, query, params, rollup, zerofill_results, comparison_delta=None
+            ):
                 return discover.top_events_timeseries(
                     query_columns,
                     selected_columns,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1,6 +1,9 @@
 import logging
 import math
 from collections import namedtuple
+from copy import deepcopy
+from datetime import timedelta
+from typing import Dict, Optional, Sequence
 
 import sentry_sdk
 
@@ -26,7 +29,9 @@ from sentry.utils.snuba import (
     SNUBA_AND,
     SNUBA_OR,
     Dataset,
+    SnubaQueryParams,
     SnubaTSResult,
+    bulk_raw_query,
     get_array_column_alias,
     get_array_column_field,
     get_measurement_name,
@@ -450,7 +455,15 @@ def get_timeseries_snuba_filter(selected_columns, query, params):
     return snuba_filter, translated_columns
 
 
-def timeseries_query(selected_columns, query, params, rollup, referrer=None, zerofill_results=True):
+def timeseries_query(
+    selected_columns: Sequence[str],
+    query: str,
+    params: Dict[str, str],
+    rollup: int,
+    referrer: Optional[str] = None,
+    zerofill_results: bool = True,
+    comparison_delta: Optional[timedelta] = None,
+):
     """
     High-level API for doing arbitrary user timeseries queries against events.
 
@@ -469,6 +482,9 @@ def timeseries_query(selected_columns, query, params, rollup, referrer=None, zer
     params (Dict[str, str]) Filtering parameters with start, end, project_id, environment,
     rollup (int) The bucket width in seconds
     referrer (str|None) A referrer string to help locate the origin of this query.
+    comparison_delta: A timedelta used to convert this into a comparison query. We make a second
+    query time-shifted back by comparison_delta, and compare the results to get the % change for each
+    time bucket. Requires that we only pass
     """
     with sentry_sdk.start_span(
         op="discover.discover", description="timeseries.filter_transform"
@@ -477,7 +493,7 @@ def timeseries_query(selected_columns, query, params, rollup, referrer=None, zer
         snuba_filter, _ = get_timeseries_snuba_filter(selected_columns, query, params)
 
     with sentry_sdk.start_span(op="discover.discover", description="timeseries.snuba_query"):
-        result = raw_query(
+        base_query_params = SnubaQueryParams(
             # Hack cause equations on aggregates have to go in selected columns instead of aggregations
             selected_columns=[
                 column
@@ -499,18 +515,44 @@ def timeseries_query(selected_columns, query, params, rollup, referrer=None, zer
             limit=10000,
             referrer=referrer,
         )
+        query_params_list = [base_query_params]
+        if comparison_delta:
+            if len(base_query_params.aggregations) != 1:
+                raise InvalidSearchQuery("Only one column can be selected for comparison queries")
+            comp_query_params = deepcopy(base_query_params)
+            comp_query_params.start -= comparison_delta
+            comp_query_params.end -= comparison_delta
+            query_params_list.append(comp_query_params)
+        query_results = bulk_raw_query(query_params_list)
 
     with sentry_sdk.start_span(
         op="discover.discover", description="timeseries.transform_results"
     ) as span:
-        span.set_data("result_count", len(result.get("data", [])))
-        result = (
-            zerofill(result["data"], snuba_filter.start, snuba_filter.end, rollup, "time")
-            if zerofill_results
-            else result["data"]
-        )
+        results = []
+        for query_params, query_results in zip(query_params_list, query_results):
+            span.set_data("result_count", len(query_results.get("data", [])))
+            results.append(
+                zerofill(
+                    query_results["data"], query_params.start, query_params.end, rollup, "time"
+                )
+                if zerofill_results
+                else query_results["data"]
+            )
 
-        return SnubaTSResult({"data": result}, snuba_filter.start, snuba_filter.end, rollup)
+    if len(results) == 2:
+        col_name = base_query_params.aggregations[0][2]
+        # If we have two sets of results then we're doing a comparison queries. Divide the primary
+        # results by the comparison results.
+        for result, cmp_result in zip(results[0], results[1]):
+            result_val, cmp_result_val = result.get(col_name, 0), cmp_result.get(col_name, 0)
+            comparison_value = 0
+            if cmp_result_val:
+                comparison_value = ((result_val / cmp_result_val) - 1) * 100
+            result[col_name] = comparison_value
+
+    results = results[0]
+
+    return SnubaTSResult({"data": results}, snuba_filter.start, snuba_filter.end, rollup)
 
 
 def create_result_key(result_row, fields, issues) -> str:

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2871,7 +2871,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         for t, ev in enumerate(events):
             val = ev[0] * 32
             for i in range(ev[1]):
-                data = load_data("transaction", timestamp=before_now(seconds=3 * t + 1))
+                data = load_data("transaction", timestamp=self.now - timedelta(seconds=3 * t + 1))
                 data["transaction"] = f"{val}"
                 self.store_event(data=data, project_id=self.project.id)
 
@@ -2879,8 +2879,8 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             results = discover.query(
                 selected_columns=["transaction", "count()"],
                 query="event.type:transaction AND (timestamp:<{} OR timestamp:>{})".format(
-                    iso_format(before_now(seconds=5)),
-                    iso_format(before_now(seconds=3)),
+                    iso_format(self.now - timedelta(seconds=5)),
+                    iso_format(self.now - timedelta(seconds=3)),
                 ),
                 params={
                     "project_id": [self.project.id],

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -5665,6 +5665,101 @@ class TimeseriesQueryTest(TimeseriesBase):
         assert "count_unique_user" in keys
         assert "time" in keys
 
+    def test_comparison_aggregate_function_invalid(self):
+        with pytest.raises(
+            InvalidSearchQuery, match="Only one column can be selected for comparison queries"
+        ):
+            discover.timeseries_query(
+                selected_columns=["count()", "count_unique(user)"],
+                query="",
+                params={
+                    "start": self.day_ago,
+                    "end": self.day_ago + timedelta(hours=2),
+                    "project_id": [self.project.id],
+                },
+                rollup=3600,
+                comparison_delta=timedelta(days=1),
+            )
+
+    def test_comparison_aggregate_function(self):
+        self.store_event(
+            data={
+                "timestamp": iso_format(self.day_ago + timedelta(hours=1)),
+                "user": {"id": 1},
+            },
+            project_id=self.project.id,
+        )
+
+        result = discover.timeseries_query(
+            selected_columns=["count()"],
+            query="",
+            params={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2),
+                "project_id": [self.project.id],
+            },
+            rollup=3600,
+            comparison_delta=timedelta(days=1),
+        )
+        assert len(result.data["data"]) == 3
+        # Values should all be 0, since there is no comparison period data at all.
+        assert [0, 0, 0] == [val["count"] for val in result.data["data"] if "count" in val]
+
+        self.store_event(
+            data={
+                "timestamp": iso_format(self.day_ago + timedelta(days=-1, hours=1)),
+                "user": {"id": 1},
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(self.day_ago + timedelta(days=-1, hours=1, minutes=2)),
+                "user": {"id": 2},
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(self.day_ago + timedelta(days=-1, hours=2, minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+
+        result = discover.timeseries_query(
+            selected_columns=["count()"],
+            query="",
+            params={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2, minutes=1),
+                "project_id": [self.project.id],
+            },
+            rollup=3600,
+            comparison_delta=timedelta(days=1),
+        )
+        assert len(result.data["data"]) == 3
+        # In the second bucket we have 3 events in the current period and 2 in the comparison, so
+        # we get a result of 50% increase
+        assert [0, 50, 0] == [val["count"] for val in result.data["data"] if "count" in val]
+
+        result = discover.timeseries_query(
+            selected_columns=["count_unique(user)"],
+            query="",
+            params={
+                "start": self.day_ago,
+                "end": self.day_ago + timedelta(hours=2, minutes=2),
+                "project_id": [self.project.id],
+            },
+            rollup=3600,
+            comparison_delta=timedelta(days=1),
+        )
+        assert len(result.data["data"]) == 3
+        # In the second bucket we have 1 unique user in the current period and 2 in the comparison, so
+        # we get a result of -50%
+        assert [0, -50, 0] == [
+            val["count_unique_user"] for val in result.data["data"] if "count_unique_user" in val
+        ]
+
     def test_count_miserable(self):
         event_data = load_data("transaction")
         # Half of duration so we don't get weird rounding differences when comparing the results

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -737,7 +737,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
 
         assert mock_query.call_count == 1
 
-    @mock.patch("sentry.snuba.discover.raw_query", return_value={"data": []})
+    @mock.patch("sentry.snuba.discover.bulk_raw_query", return_value=[{"data": []}])
     def test_invalid_interval(self, mock_query):
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
@@ -754,7 +754,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert mock_query.call_count == 1
         # Should've reset to the default for 24h
-        assert mock_query.mock_calls[0].kwargs["rollup"] == 300
+        assert mock_query.mock_calls[0].args[0][0].rollup == 300
 
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
@@ -771,7 +771,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert mock_query.call_count == 2
         # Should've reset to the default for 24h
-        assert mock_query.mock_calls[1].kwargs["rollup"] == 300
+        assert mock_query.mock_calls[0].args[0][0].rollup == 300
 
     def test_out_of_retention(self):
         with self.options({"system.event-retention-days": 10}):
@@ -1808,8 +1808,9 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert other["order"] == 5
         assert [{"count": 0.03}] in [attrs for _, attrs in other["data"]]
 
+    @mock.patch("sentry.snuba.discover.bulk_raw_query", return_value=[{"data": [], "meta": []}])
     @mock.patch("sentry.snuba.discover.raw_query", return_value={"data": [], "meta": []})
-    def test_invalid_interval(self, mock_query):
+    def test_invalid_interval(self, mock_raw_query, mock_bulk_query):
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
                 self.url,
@@ -1825,7 +1826,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 200
-        assert mock_query.call_count == 1
+        assert mock_bulk_query.call_count == 1
 
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
@@ -1843,9 +1844,9 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 200
-        assert mock_query.call_count == 3
+        assert mock_raw_query.call_count == 2
         # Should've reset to the default for between 1 and 24h
-        assert mock_query.mock_calls[2].kwargs["rollup"] == 300
+        assert mock_raw_query.mock_calls[1].kwargs["rollup"] == 300
 
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
@@ -1863,9 +1864,9 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 200
-        assert mock_query.call_count == 5
+        assert mock_raw_query.call_count == 4
         # Should've left the interval alone since we're just below the limit
-        assert mock_query.mock_calls[4].kwargs["rollup"] == 1
+        assert mock_raw_query.mock_calls[3].kwargs["rollup"] == 1
 
         with self.feature("organizations:discover-basic"):
             response = self.client.get(
@@ -1882,9 +1883,9 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                 },
             )
         assert response.status_code == 200
-        assert mock_query.call_count == 7
+        assert mock_raw_query.call_count == 6
         # Should've default to 24h's default of 5m
-        assert mock_query.mock_calls[6].kwargs["rollup"] == 300
+        assert mock_raw_query.mock_calls[5].kwargs["rollup"] == 300
 
     def test_top_events_timestamp_fields(self):
         with self.feature("organizations:discover-basic"):


### PR DESCRIPTION
This adds the `comparisonDelta` parameter to `OrganizationEventsStatsEndpoint`. This value is in
seconds, and is used to determine the comparison period we use when generating comparison stats.

If the comparisonDelta caused the comparison period to go outside of the orgs retention window then
we'll return an error.