### PR TITLE
feat(mail): Add header arguments to send_mail.

### DIFF
--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -446,17 +446,23 @@ def get_connection(fail_silently=False):
     )
 
 
-def send_mail(subject, message, from_email, recipient_list, fail_silently=False, **kwargs):
+def send_mail(
+    subject, message, from_email, recipient_list, fail_silently=False, headers=None, **kwargs
+):
     """
     Wrapper that forces sending mail through our connection.
     Uses EmailMessage class which has more options than the simple send_mail
     """
+    if headers is None:
+        headers = {}
+
     email = mail.EmailMessage(
         subject,
         message,
         from_email,
         recipient_list,
         connection=get_connection(fail_silently=fail_silently),
+        headers=headers,
         **kwargs,
     )
     return email.send(fail_silently=fail_silently)

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -454,7 +454,11 @@ def send_mail(
     Uses EmailMessage class which has more options than the simple send_mail
     """
     if headers is None:
-        headers = {}
+        headers = {
+            "X-Auto-Response-Suppress": "All",
+            "Precedence": "bulk",
+            "Auto-Submitted": "auto-generated",
+        }
 
     email = mail.EmailMessage(
         subject,


### PR DESCRIPTION
Add optional header argument from kwargs to positional arguments instead. This uses Django's header property such that extra headers can be easily given, i.e. the X-Auto-Response-Suppress header.

This was added in turn to the attached issue, as the feature would reduce unwanted mails in the mailbox.

Resolves issue: #13784

(For some reason I can't assign reviewers nor ping workflow so I'm not sure what to do)