### PR TITLE
feat(ui): Add session chart to alert rule details page

### DIFF
--- a/static/app/components/charts/sessionsRequest.tsx
+++ b/static/app/components/charts/sessionsRequest.tsx
@@ -32,7 +32,7 @@ type Props = {
   query?: string;
   groupBy?: string[];
   interval?: string;
-  disable?: boolean;
+  disabled?: boolean;
 };
 
 type State = {
@@ -99,9 +99,9 @@ class SessionsRequest extends React.Component<Props, State> {
   }
 
   fetchData = async () => {
-    const {api, disable} = this.props;
+    const {api, disabled} = this.props;
 
-    if (disable) {
+    if (disabled) {
       return;
     }
 

--- a/static/app/components/charts/sessionsRequest.tsx
+++ b/static/app/components/charts/sessionsRequest.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import isEqual from 'lodash/isEqual';
+import omitBy from 'lodash/omitBy';
+
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {Client} from 'app/api';
+import {t} from 'app/locale';
+import {DateString, Organization, SessionApiResponse, SessionField} from 'app/types';
+import {getSessionsInterval} from 'app/utils/sessions';
+
+const propNamesToIgnore = ['api', 'children', 'organization'];
+const omitIgnoredProps = (props: Props) =>
+  omitBy(props, (_value, key) => propNamesToIgnore.includes(key));
+
+export type SessionsRequestRenderProps = {
+  loading: boolean;
+  reloading: boolean;
+  errored: boolean;
+  response: SessionApiResponse | null;
+};
+
+type Props = {
+  api: Client;
+  organization: Organization;
+  children: (renderProps: SessionsRequestRenderProps) => React.ReactNode;
+  field: SessionField[];
+  project?: number[];
+  environment?: string[];
+  statsPeriod?: string;
+  start?: DateString;
+  end?: DateString;
+  query?: string;
+  groupBy?: string[];
+  interval?: string;
+  disable?: boolean;
+};
+
+type State = {
+  reloading: boolean;
+  errored: boolean;
+  response: SessionApiResponse | null;
+};
+
+class SessionsRequest extends React.Component<Props, State> {
+  state: State = {
+    reloading: false,
+    errored: false,
+    response: null,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (isEqual(omitIgnoredProps(prevProps), omitIgnoredProps(this.props))) {
+      return;
+    }
+
+    this.fetchData();
+  }
+
+  get path() {
+    const {organization} = this.props;
+
+    return `/organizations/${organization.slug}/sessions/`;
+  }
+
+  get baseQueryParams() {
+    const {
+      project,
+      environment,
+      field,
+      statsPeriod,
+      start,
+      end,
+      query,
+      groupBy,
+      interval,
+      organization,
+    } = this.props;
+
+    return {
+      project,
+      environment,
+      field,
+      statsPeriod,
+      query,
+      groupBy,
+      start,
+      end,
+      interval: interval
+        ? interval
+        : getSessionsInterval(
+            {start, end, period: statsPeriod},
+            {highFidelity: organization.features.includes('minute-resolution-sessions')}
+          ),
+    };
+  }
+
+  fetchData = async () => {
+    const {api, disable} = this.props;
+
+    if (disable) {
+      return;
+    }
+
+    api.clear();
+    this.setState(state => ({
+      reloading: state.response !== null,
+      errored: false,
+    }));
+
+    try {
+      const response: SessionApiResponse = await api.requestPromise(this.path, {
+        query: this.baseQueryParams,
+      });
+
+      this.setState({
+        reloading: false,
+        response,
+      });
+    } catch (error) {
+      addErrorMessage(error.responseJSON?.detail ?? t('Error loading health data'));
+      this.setState({
+        reloading: false,
+        errored: true,
+      });
+    }
+  };
+
+  render() {
+    const {reloading, errored, response} = this.state;
+    const {children} = this.props;
+
+    const loading = response === null;
+
+    return children({
+      loading,
+      reloading,
+      errored,
+      response,
+    });
+  }
+}
+
+export default SessionsRequest;

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -19,22 +19,15 @@ import LoadingMask from 'app/components/loadingMask';
 import Placeholder from 'app/components/placeholder';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Organization, Project, SessionApiResponse, SessionField} from 'app/types';
+import {Organization, Project, SessionApiResponse} from 'app/types';
 import {Series, SeriesDataUnit} from 'app/types/echarts';
 import {getCount, getCrashFreeRateSeries} from 'app/utils/sessions';
 import withApi from 'app/utils/withApi';
-import {isSessionAggregate} from 'app/views/alerts/utils';
+import {isSessionAggregate, SESSION_AGGREGATE_TO_FIELD} from 'app/views/alerts/utils';
 import {AlertWizardAlertNames} from 'app/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
 
-import {
-  Dataset,
-  IncidentRule,
-  SessionsAggregate,
-  TimePeriod,
-  TimeWindow,
-  Trigger,
-} from '../../types';
+import {Dataset, IncidentRule, TimePeriod, TimeWindow, Trigger} from '../../types';
 
 import ThresholdsChart from './thresholdsChart';
 
@@ -113,11 +106,6 @@ const AGGREGATE_FUNCTIONS = {
     Math.max(...seriesChunk.map(series => series.value)),
   min: (seriesChunk: SeriesDataUnit[]) =>
     Math.min(...seriesChunk.map(series => series.value)),
-};
-
-const SESSION_AGGREGATE_TO_FIELD = {
-  [SessionsAggregate.CRASH_FREE_SESSIONS]: SessionField.SESSIONS,
-  [SessionsAggregate.CRASH_FREE_USERS]: SessionField.USERS,
 };
 
 const TIME_WINDOW_TO_SESSION_INTERVAL = {

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -364,7 +364,9 @@ export default class DetailsBody extends React.Component<Props> {
                     projects={projects}
                     interval={this.getInterval()}
                     filter={this.getFilter()}
-                    query={queryWithTypeFilter}
+                    query={
+                      rule.dataset === Dataset.SESSIONS ? query : queryWithTypeFilter
+                    }
                     orgId={orgId}
                     handleZoom={handleZoom}
                   />

--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -1,6 +1,6 @@
 import {Client} from 'app/api';
 import {t} from 'app/locale';
-import {NewQuery, Project} from 'app/types';
+import {NewQuery, Project, SessionField} from 'app/types';
 import {IssueAlertRule} from 'app/types/alerts';
 import {getUtcDateString} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
@@ -274,3 +274,8 @@ export function getQueryDatasource(
 export function isSessionAggregate(aggregate: string) {
   return Object.values(SessionsAggregate).includes(aggregate as SessionsAggregate);
 }
+
+export const SESSION_AGGREGATE_TO_FIELD = {
+  [SessionsAggregate.CRASH_FREE_SESSIONS]: SessionField.SESSIONS,
+  [SessionsAggregate.CRASH_FREE_USERS]: SessionField.USERS,
+};


### PR DESCRIPTION
Adding session chart to rule details page.
This will enable us to display charts of crash rate alert rules.