### PR TITLE
Fix(releases): Hide releases with 0 artifacts from source maps [INGEST-428]

### DIFF
--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -433,7 +433,12 @@ class SourceMapsEndpoint(ProjectEndpoint):
         def serialize_results(results):
             file_count_map = get_artifact_counts([r["id"] for r in results])
             return serialize(
-                [expose_release(r, file_count_map.get(r["id"], 0)) for r in results], request.user
+                [
+                    expose_release(r, file_count_map[r["id"]])
+                    for r in results
+                    if r["id"] in file_count_map
+                ],
+                request.user,
             )
 
         return self.paginate(

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -345,6 +345,15 @@ class DebugFilesUploadTest(APITestCase):
         assert response.status_code == 204
         assert not ReleaseFile.objects.filter(release_id=release.id).exists()
 
+        # Check if still listed:
+        url = reverse(
+            "sentry-api-0-source-maps",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data == []
+
     def test_source_maps_release_archive(self):
         project = self.create_project(name="foo")
 


### PR DESCRIPTION
When a user deletes an "archive" on the Source Maps page, all release files of the corresponding release are deleted. Prior to https://github.com/getsentry/sentry/pull/26448, releases with 0 artifacts were simply hidden, so that the "archive" (i.e. release) actually disappeared after deletion. This behavior is restored in this PR.

This fixes https://github.com/getsentry/sentry/issues/28762.