### PR TITLE
build(ci): Use codecov GH action instead of bash script

### DIFF
--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -4,8 +4,10 @@ description: 'Handles uploading coverage/test artifacts to codecov'
 runs:
   using: "composite"
   steps:
+    - shell: bash
+      run: ls .artifacts
     - name: Upload to codecov
       uses: codecov/codecov-action@v2
       with:
-        directory: .artifacts
+        directory: .artifacts/coverage
         verbose: true

--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -5,9 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Upload to codecov
-      shell: bash
-      run: |
-        coverage_files=$(ls .artifacts/*coverage.xml || true)
-        if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
-          bash <(curl -s https://codecov.io/bash) -v
-        fi
+      uses: codecov/codecov-action@v2
+      with:
+        directory: .artifacts
+        verbose: true

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ fetch-release-registry:
 
 run-acceptance:
 	@echo "--> Running acceptance tests"
-	pytest tests/acceptance --cov . --cov-report="xml:.artifacts/acceptance.coverage.xml" --junit-xml=".artifacts/acceptance.junit.xml"
+	pytest tests/acceptance --cov . --cov-report="xml:.artifacts/coverage/acceptance.coverage.xml" --junit-xml=".artifacts/acceptance.junit.xml"
 	@echo ""
 
 test-cli:


### PR DESCRIPTION
This uses a GH Action instead of bash script. The bash script has been intermittently failing and blocking CI.