### PR TITLE
build(ci): Increase # of backend test instances

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     name: backend test
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       matrix:
-        instance: [0, 1]
+        instance: [0, 1, 2]
 
     env:
       MIGRATIONS_TEST_MIGRATE: 1


### PR DESCRIPTION
Increase total # of backend test instances from 2 --> 3. We want to keep all CI instances to run less than 15 minutes.