### PR TITLE
feat(discover): discover add to dashboard button uses y axis from query

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -56,6 +56,7 @@ export type DashboardWidgetModalOptions = {
   onUpdateWidget?: (nextWidget: Widget) => void;
   defaultWidgetQuery?: WidgetQuery;
   defaultTableColumns?: readonly string[];
+  defaultTitle?: string;
   fromDiscover?: boolean;
   start?: DateString;
   end?: DateString;
@@ -96,11 +97,11 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const {widget, defaultWidgetQuery, fromDiscover} = props;
+    const {widget, defaultWidgetQuery, defaultTitle, fromDiscover} = props;
 
     if (!widget) {
       this.state = {
-        title: defaultWidgetQuery?.name ?? '',
+        title: defaultTitle ?? '',
         displayType: DisplayType.LINE,
         interval: '5m',
         queries: [defaultWidgetQuery ? {...defaultWidgetQuery} : {...newQuery}],

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -24,6 +24,7 @@ import EventView from 'app/utils/discover/eventView';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import {decodeList} from 'app/utils/queryString';
 import withApi from 'app/utils/withApi';
+import {WidgetQuery} from 'app/views/dashboardsV2/types';
 
 import {handleCreateQuery, handleDeleteQuery} from './savedQuery/utils';
 import MiniGraph from './miniGraph';
@@ -93,14 +94,25 @@ class QueryList extends React.Component<Props> {
       const {organization} = this.props;
       event.preventDefault();
       event.stopPropagation();
+
+      const defaultWidgetQuery: WidgetQuery = {
+        name: '',
+        fields: savedQuery?.yAxis ?? ['count()'],
+        conditions: eventView.query,
+        orderby: '',
+      };
+
       openAddDashboardWidgetModal({
         organization,
-        defaultQuery: eventView.query,
         start: eventView.start,
         end: eventView.end,
         statsPeriod: eventView.statsPeriod,
         fromDiscover: true,
-        defaultTitle: savedQuery?.name ?? eventView.name,
+        defaultWidgetQuery,
+        defaultTableColumns: eventView.fields.map(({field}) => field),
+        defaultTitle:
+          savedQuery?.name ??
+          (eventView.name !== 'All Events' ? eventView.name : undefined),
       });
     };
 

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -25,6 +25,7 @@ import EventView from 'app/utils/discover/eventView';
 import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import withApi from 'app/utils/withApi';
 import withProjects from 'app/utils/withProjects';
+import {WidgetQuery} from 'app/views/dashboardsV2/types';
 import InputControl from 'app/views/settings/components/forms/controls/input';
 
 import DiscoverQueryMenu from './discoverQueryMenu';
@@ -224,13 +225,22 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
   };
 
   handleAddDashboardWidget = () => {
-    const {organization, eventView, savedQuery} = this.props;
+    const {organization, eventView, savedQuery, yAxis} = this.props;
+    const defaultWidgetQuery: WidgetQuery = {
+      name:
+        savedQuery?.name ??
+        (eventView.name !== 'All Events' ? eventView.name : undefined) ??
+        '',
+      fields: yAxis ?? ['count()'],
+      conditions: eventView.query,
+      orderby: '',
+    };
+
     openAddDashboardWidgetModal({
       organization,
-      defaultQuery: eventView.query,
-      defaultTitle:
-        savedQuery?.name ?? eventView.name !== 'All Events' ? eventView.name : undefined,
       fromDiscover: true,
+      defaultWidgetQuery,
+      defaultTableColumns: eventView.fields.map(({field}) => field),
     });
   };
 

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -227,10 +227,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
   handleAddDashboardWidget = () => {
     const {organization, eventView, savedQuery, yAxis} = this.props;
     const defaultWidgetQuery: WidgetQuery = {
-      name:
-        savedQuery?.name ??
-        (eventView.name !== 'All Events' ? eventView.name : undefined) ??
-        '',
+      name: '',
       fields: yAxis ?? ['count()'],
       conditions: eventView.query,
       orderby: '',
@@ -241,6 +238,9 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
       fromDiscover: true,
       defaultWidgetQuery,
       defaultTableColumns: eventView.fields.map(({field}) => field),
+      defaultTitle:
+        savedQuery?.name ??
+        (eventView.name !== 'All Events' ? eventView.name : undefined),
     });
   };
 

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -10,7 +10,14 @@ import TagStore from 'app/stores/tagStore';
 
 const stubEl = props => <div>{props.children}</div>;
 
-function mountModal({initialData, onAddWidget, onUpdateWidget, widget, fromDiscover}) {
+function mountModal({
+  initialData,
+  onAddWidget,
+  onUpdateWidget,
+  widget,
+  fromDiscover,
+  defaultWidgetQuery,
+}) {
   return mountWithTheme(
     <AddDashboardWidgetModal
       Header={stubEl}
@@ -22,6 +29,7 @@ function mountModal({initialData, onAddWidget, onUpdateWidget, widget, fromDisco
       widget={widget}
       closeModal={() => void 0}
       fromDiscover={fromDiscover}
+      defaultWidgetQuery={defaultWidgetQuery}
     />,
     initialData.routerContext
   );
@@ -838,6 +846,30 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       1
     );
 
+    wrapper.unmount();
+  });
+
+  it('should use defaultWidgetQuery Y-Axis and Conditions if given a defaultWidgetQuery', async function () {
+    const wrapper = mountModal({
+      initialData,
+      onAddWidget: () => undefined,
+      onUpdateWidget: () => undefined,
+      widget: undefined,
+      fromDiscover: true,
+      defaultWidgetQuery: {
+        name: '',
+        fields: ['count()', 'failure_count()', 'count_unique(user)'],
+        conditions: 'tag:value',
+        orderby: '',
+      },
+    });
+
+    expect(wrapper.find('SearchBar').props().query).toEqual('tag:value');
+    const queryFields = wrapper.find('QueryField');
+    expect(queryFields.length).toEqual(3);
+    expect(queryFields.at(0).props().fieldValue.function[0]).toEqual('count');
+    expect(queryFields.at(1).props().fieldValue.function[0]).toEqual('failure_count');
+    expect(queryFields.at(2).props().fieldValue.function[0]).toEqual('count_unique');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
Add to Dashboard now defaults the widget Y-Axis to the selected Y-Axis on the Discover Results Chart.
When switching the widget to the Table visualization, the widget will use columns from the Discover table as the Y-Axis instead

![image](https://user-images.githubusercontent.com/83961295/135896863-8702b9cd-af1c-484a-90c5-8c606de2ed31.png)
![image](https://user-images.githubusercontent.com/83961295/135897194-0aa74a0d-78ea-494c-be00-a0ae90a57801.png)
