### PR TITLE
fix(symbolicator): Correctly start tasks asynchronously

### DIFF
--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -34,7 +34,7 @@ def _scan_for_suspect_projects() -> None:
 
     for project_id in realtime_metrics.projects():
         suspect_projects.add(project_id)
-        update_lpq_eligibility(project_id).apply_async()
+        update_lpq_eligibility.delay(project_id=project_id)
 
     # Prune projects we definitely know shouldn't be in the queue any more.
     # `update_lpq_eligibility` should handle removing suspect projects from the list if it turns

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -1,12 +1,23 @@
 import pytest
 
-from sentry.tasks.low_priority_symbolication import calculation_magic
+from sentry.processing import realtime_metrics
+from sentry.tasks.low_priority_symbolication import _scan_for_suspect_projects, calculation_magic
+from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.utils import redis
+from sentry.utils.compat import mock
 
 
 @pytest.fixture
 def redis_cluster() -> redis._RedisCluster:
     return redis.redis_clusters.get("default")
+
+
+@mock.patch("sentry.tasks.low_priority_symbolication.calculation_magic", lambda x, y: True)
+def test_scan_for_suspect_projects() -> None:
+    realtime_metrics.increment_project_event_counter(17, 0)
+    with TaskRunner():
+        _scan_for_suspect_projects()
+    assert realtime_metrics.get_lpq_projects() == {17}
 
 
 def test_calculation_magic():


### PR DESCRIPTION
An incorrect `apply_async` invocation was added in https://github.com/getsentry/sentry/pull/28757 which promptly threw out a bunch of errors. This fixes that invocation.