### PR TITLE
fix(growth): Create sample event btn redirect with project id

### DIFF
--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -156,7 +156,7 @@ class CreateSampleEventButton extends React.Component<Props, State> {
     }
 
     browserHistory.push(
-      `/organizations/${organization.slug}/issues/${eventData.groupID}/`
+      `/organizations/${organization.slug}/issues/${eventData.groupID}/?project=${project.id}`
     );
   };
 

--- a/tests/js/spec/components/createSampleEventButton.spec.jsx
+++ b/tests/js/spec/components/createSampleEventButton.spec.jsx
@@ -69,7 +69,7 @@ describe('CreateSampleEventButton', function () {
     ).toBe(false);
 
     expect(browserHistory.push).toHaveBeenCalledWith(
-      `/organizations/${org.slug}/issues/${groupID}/`
+      `/organizations/${org.slug}/issues/${groupID}/?project=${project.id}`
     );
   });
 
@@ -115,7 +115,7 @@ describe('CreateSampleEventButton', function () {
     await Promise.resolve();
 
     expect(browserHistory.push).toHaveBeenCalledWith(
-      `/organizations/${org.slug}/issues/${groupID}/`
+      `/organizations/${org.slug}/issues/${groupID}/?project=${project.id}`
     );
 
     expect(trackAnalyticsEvent).toHaveBeenCalledWith(


### PR DESCRIPTION
Right now when you click on the sample event button, it will redirect to the issue page without the project parameter. This will make `GlobalSelection.projects` empty which is unexpected. This PR fixes this problem by including `project` in the query parameter.