### PR TITLE
fix(discover): updated discover table cell actions to keep all selected y axis

### DIFF
--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -359,7 +359,7 @@ class TableView extends React.Component<TableViewProps> {
 
   handleCellAction = (dataRow: TableDataRow, column: TableColumn<keyof TableDataRow>) => {
     return (action: Actions, value: React.ReactText) => {
-      const {eventView, organization, projects} = this.props;
+      const {eventView, organization, projects, location} = this.props;
 
       const query = new MutableSearch(eventView.query);
 
@@ -431,7 +431,10 @@ class TableView extends React.Component<TableViewProps> {
       }
       nextView.query = query.formatString();
 
-      browserHistory.push(nextView.getResultsViewUrlTarget(organization.slug));
+      const target = nextView.getResultsViewUrlTarget(organization.slug);
+      // Get yAxis from location
+      target.query.yAxis = decodeList(location.query.yAxis);
+      browserHistory.push(target);
     };
   };
 

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -138,6 +138,21 @@ describe('TableView > CellActions', function () {
     });
   });
 
+  it('handles add cell action with multiple y axis', function () {
+    location.query.yAxis = ['count()', 'failure_count()'];
+    const wrapper = makeWrapper(initialData, rows, eventView);
+    const menu = openContextMenu(wrapper, 0);
+    menu.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+    expect(browserHistory.push).toHaveBeenCalledWith({
+      pathname: location.pathname,
+      query: expect.objectContaining({
+        query: 'title:"some title"',
+        yAxis: ['count()', 'failure_count()'],
+      }),
+    });
+  });
+
   it('handles exclude cell action on string value', function () {
     const wrapper = makeWrapper(initialData, rows, eventView);
     const menu = openContextMenu(wrapper, 0);


### PR DESCRIPTION
Cell Actions only redirect with a single Y-Axis even when multiple Y-Axis are selected, due to using EventView to construct new target. Updated to pull Y-Axis from location when creating new target.
![image](https://user-images.githubusercontent.com/83961295/135915887-de422c17-85aa-498a-a9c7-21201e7692fb.png)
