### PR TITLE
ref(teamwork): Shadow deprecate teamwork plugin

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -66,7 +66,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             for action in (
                 safe_execute(plugin.get_actions, request, group, _with_transaction=False) or ()
             ):
-
                 action_list.append(action)
 
         return action_list
@@ -76,7 +75,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         plugin_issues = []
         for plugin in plugins.for_project(project, version=1):
-            if isinstance(plugin, IssueTrackingPlugin2) and plugin.is_enabled:
+            if isinstance(plugin, IssueTrackingPlugin2):
                 plugin_issues = safe_execute(
                     plugin.plugin_issues, request, group, plugin_issues, _with_transaction=False
                 )

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from django.utils import timezone
 from rest_framework.response import Response
 
-from sentry import tagstore, tsdb
+from sentry import features, tagstore, tsdb
 from sentry.api import client
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases import GroupEndpoint
@@ -18,7 +18,7 @@ from sentry.api.helpers.group_index import (
     update_groups,
 )
 from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serialize
-from sentry.api.serializers.models.plugin import PluginSerializer
+from sentry.api.serializers.models.plugin import SHADOW_DEPRECATED_PLUGINS, PluginSerializer
 from sentry.models import Activity, Group, GroupSeen, GroupSubscriptionManager, UserReport
 from sentry.models.groupinbox import get_inbox_details
 from sentry.plugins.base import plugins
@@ -44,6 +44,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         action_list = []
         for plugin in plugins.for_project(project, version=1):
+            if plugin.slug in SHADOW_DEPRECATED_PLUGINS and not features.has(
+                SHADOW_DEPRECATED_PLUGINS.get(plugin.slug), getattr(project, "organization", None)
+            ):
+                continue
+
             results = safe_execute(
                 plugin.actions, request, group, action_list, _with_transaction=False
             )
@@ -54,9 +59,14 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             action_list = results
 
         for plugin in plugins.for_project(project, version=2):
+            if plugin.slug in SHADOW_DEPRECATED_PLUGINS and not features.has(
+                SHADOW_DEPRECATED_PLUGINS.get(plugin.slug), getattr(project, "organization", None)
+            ):
+                continue
             for action in (
                 safe_execute(plugin.get_actions, request, group, _with_transaction=False) or ()
             ):
+
                 action_list.append(action)
 
         return action_list
@@ -66,7 +76,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
 
         plugin_issues = []
         for plugin in plugins.for_project(project, version=1):
-            if isinstance(plugin, IssueTrackingPlugin2):
+            if isinstance(plugin, IssueTrackingPlugin2) and plugin.is_enabled:
                 plugin_issues = safe_execute(
                     plugin.plugin_issues, request, group, plugin_issues, _with_transaction=False
                 )

--- a/src/sentry/api/endpoints/organization_plugins_configs.py
+++ b/src/sentry/api/endpoints/organization_plugins_configs.py
@@ -85,7 +85,7 @@ class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
         for plugin in desired_plugins:
             serialized_plugin = serialize(plugin, request.user, PluginSerializer())
             if serialized_plugin["isDeprecated"] and serialized_plugin["isHidden"]:
-                raise Http404
+                continue
 
             serialized_plugin["projectList"] = []
 
@@ -114,6 +114,10 @@ class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
                 )
             # sort by the projectSlug
             serialized_plugin["projectList"].sort(key=lambda x: x["projectSlug"])
+
             serialized_plugins.append(serialized_plugin)
+
+        if not serialized_plugins:
+            raise Http404
 
         return Response(serialized_plugins)

--- a/src/sentry/api/endpoints/organization_plugins_configs.py
+++ b/src/sentry/api/endpoints/organization_plugins_configs.py
@@ -1,3 +1,4 @@
+from django.http.response import Http404
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -83,6 +84,8 @@ class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
         serialized_plugins = []
         for plugin in desired_plugins:
             serialized_plugin = serialize(plugin, request.user, PluginSerializer())
+            if serialized_plugin["isDeprecated"] and serialized_plugin["isHidden"]:
+                raise Http404
 
             serialized_plugin["projectList"] = []
 

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.http.response import Http404
 from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.response import Response
@@ -39,6 +40,8 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             context["config_error"] = str(e)
             context["auth_url"] = reverse("socialauth_associate", args=[plugin.slug])
 
+        if context["isDeprecated"] and context["isHidden"]:
+            raise Http404
         return Response(context)
 
     def post(self, request, project, plugin_id):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -991,6 +991,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-stacktrace-link": False,
     # Allow orgs to install a custom source code management integration
     "organizations:integrations-custom-scm": False,
+    # Allow orgs to view the Teamwork plugin
+    "organizations:integrations-ignore-teamwork-deprecation": False,
     # Allow orgs to debug internal/unpublished sentry apps with logging
     "organizations:sentry-app-debugging": False,
     # Temporary safety measure, turned on for specific orgs only if

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -96,6 +96,9 @@ default_manager.add("organizations:integrations-issue-sync", OrganizationFeature
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature, True)
 default_manager.add("organizations:integrations-vsts-limited-scopes", OrganizationFeature)
+default_manager.add(
+    "organizations:integrations-ignore-teamwork-deprecation", OrganizationFeature, True
+)
 default_manager.add("organizations:invite-members", OrganizationFeature)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)

--- a/src/sentry/web/frontend/group_plugin_action.py
+++ b/src/sentry/web/frontend/group_plugin_action.py
@@ -2,6 +2,8 @@ from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.utils.http import is_safe_url
 
+from sentry import features
+from sentry.api.serializers.models.plugin import SHADOW_DEPRECATED_PLUGINS
 from sentry.models import Group, GroupMeta
 from sentry.plugins.base import plugins
 from sentry.web.frontend.base import ProjectView
@@ -14,6 +16,10 @@ class GroupPluginActionView(ProjectView):
         group = get_object_or_404(Group, pk=group_id, project=project)
 
         try:
+            if slug in SHADOW_DEPRECATED_PLUGINS and not features.has(
+                SHADOW_DEPRECATED_PLUGINS.get(slug), getattr(project, "organization", None)
+            ):
+                raise Http404("Plugin not found")
             plugin = plugins.get(slug)
         except KeyError:
             raise Http404("Plugin not found")

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -11,13 +11,15 @@ type ConfigParams = {
 const pathPrefix = '/settings/:orgId/projects/:projectId';
 
 // Object with the pluginId as the key, and enablingFeature as the value
-const DEPRECATED_PLUGINS = {
+const SHADOW_DEPRECATED_PLUGINS = {
   teamwork: 'integrations-ignore-teamwork-deprecation',
 };
 
 const canViewPlugin = (pluginId: string, organization?: Organization) => {
-  const isDeprecated = DEPRECATED_PLUGINS.hasOwnProperty(pluginId);
-  const hasFeature = organization?.features?.includes(DEPRECATED_PLUGINS[pluginId]);
+  const isDeprecated = SHADOW_DEPRECATED_PLUGINS.hasOwnProperty(pluginId);
+  const hasFeature = organization?.features?.includes(
+    SHADOW_DEPRECATED_PLUGINS[pluginId]
+  );
   return isDeprecated ? hasFeature : true;
 };
 

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -10,6 +10,17 @@ type ConfigParams = {
 
 const pathPrefix = '/settings/:orgId/projects/:projectId';
 
+// Object with the pluginId as the key, and enablingFeature as the value
+const DEPRECATED_PLUGINS = {
+  teamwork: 'integrations-ignore-teamwork-deprecation',
+};
+
+const canViewPlugin = (pluginId: string, organization?: Organization) => {
+  const isDeprecated = DEPRECATED_PLUGINS.hasOwnProperty(pluginId);
+  const hasFeature = organization?.features?.includes(DEPRECATED_PLUGINS[pluginId]);
+  return isDeprecated ? hasFeature : true;
+};
+
 export default function getConfiguration({
   project,
   organization,
@@ -160,7 +171,8 @@ export default function getConfiguration({
         ...plugins.map(plugin => ({
           path: `${pathPrefix}/plugins/${plugin.id}/`,
           title: plugin.name,
-          show: opts => opts?.access?.has('project:write'),
+          show: opts =>
+            opts?.access?.has('project:write') && canViewPlugin(plugin.id, organization),
           id: 'plugin_details',
           recordAnalytics: true,
         })),

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -1,5 +1,3 @@
-from django.urls import reverse
-
 from sentry.models import AuditLogEntry, ProjectOption
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.notify import NotificationPlugin
@@ -7,108 +5,84 @@ from sentry.testutils import APITestCase
 from sentry.utils.compat import mock
 
 
-class ProjectPluginDetailsTest(APITestCase):
-    def test_simple(self):
-        project = self.create_project()
+class ProjectPluginDetailsTestBase(APITestCase):
+    endpoint = "sentry-api-0-project-plugin-details"
 
+    def setUp(self):
+        super().setUp()
         self.login_as(user=self.user)
 
-        url = reverse(
-            "sentry-api-0-project-plugin-details",
-            kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-                "plugin_id": "webhooks",
-            },
+        assert not AuditLogEntry.objects.filter(target_object=self.project.id).exists()
+
+
+class ProjectPluginDetailsTest(ProjectPluginDetailsTestBase):
+    def test_simple(self):
+        response = self.get_success_response(
+            self.project.organization.slug, self.project.slug, "webhooks"
         )
-        response = self.client.get(url)
-        assert response.status_code == 200, (response.status_code, response.content)
         assert response.data["id"] == "webhooks"
         assert response.data["config"] == [
             {
-                "readonly": False,
                 "choices": None,
-                "placeholder": "https://sentry.io/callback/url",
-                "name": "urls",
-                "help": "Enter callback URLs to POST new events to (one per line).",
                 "defaultValue": None,
+                "help": "Enter callback URLs to POST new events to (one per line).",
+                "label": "Callback URLs",
+                "name": "urls",
+                "placeholder": "https://sentry.io/callback/url",
+                "readonly": False,
                 "required": False,
                 "type": "textarea",
                 "value": None,
-                "label": "Callback URLs",
             }
         ]
 
 
-class UpdateProjectPluginTest(APITestCase):
+class UpdateProjectPluginTest(ProjectPluginDetailsTestBase):
+    method = "put"
+
     def test_simple(self):
-        project = self.create_project()
-
-        self.login_as(user=self.user)
-
-        url = reverse(
-            "sentry-api-0-project-plugin-details",
-            kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-                "plugin_id": "webhooks",
-            },
+        self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            "webhooks",
+            **{"urls": "http://example.com/foo"},
         )
-        audit = AuditLogEntry.objects.filter(target_object=project.id)
 
-        assert not audit
-
-        response = self.client.put(url, data={"urls": "http://example.com/foo"})
-        audit = AuditLogEntry.objects.get(target_object=project.id)
-
+        audit = AuditLogEntry.objects.get(target_object=self.project.id)
         assert audit.event == 111
-        assert response.status_code == 200, (response.status_code, response.content)
         assert (
-            ProjectOption.objects.get(key="webhooks:urls", project=project).value
+            ProjectOption.objects.get(key="webhooks:urls", project=self.project).value
             == "http://example.com/foo"
         )
 
 
-class EnableProjectPluginTest(APITestCase):
+class EnableProjectPluginTest(ProjectPluginDetailsTestBase):
+    method = "post"
+
     @mock.patch.object(NotificationPlugin, "test_configuration", side_effect="test_configuration")
     def test_simple(self, test_configuration):
-        project = self.create_project()
+        plugins.get("webhooks").disable(self.project)
 
-        self.login_as(user=self.user)
+        self.get_success_response(self.project.organization.slug, self.project.slug, "webhooks")
 
-        plugins.get("webhooks").disable(project)
-
-        url = reverse(
-            "sentry-api-0-project-plugin-details",
-            kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-                "plugin_id": "webhooks",
-            },
-        )
-        audit = AuditLogEntry.objects.filter(target_object=project.id)
-
-        assert not audit
-
-        response = self.client.post(url)
-        audit = AuditLogEntry.objects.get(target_object=project.id)
-
+        audit = AuditLogEntry.objects.get(target_object=self.project.id)
         assert audit.event == 110
-        assert response.status_code == 201, (response.status_code, response.content)
-        assert ProjectOption.objects.get(key="webhooks:enabled", project=project).value is True
+        assert ProjectOption.objects.get(key="webhooks:enabled", project=self.project).value is True
         audit.delete()
 
         # Testing the Plugin
-        response = self.client.post(url, {"test": True})
-        test_configuration.assert_called_once_with(project)
-        assert response.status_code == 200, (response.status_code, response.content)
+        self.get_success_response(
+            self.project.organization.slug, self.project.slug, "webhooks", **{"test": True}
+        )
+        test_configuration.assert_called_once_with(self.project)
 
         # Reset the plugin
-        response = self.client.post(url, {"reset": True})
-        audit = AuditLogEntry.objects.get(target_object=project.id)
-        test_configuration.assert_called_once_with(project)
+        response = self.get_success_response(
+            self.project.organization.slug, self.project.slug, "webhooks", **{"reset": True}
+        )
+        audit = AuditLogEntry.objects.get(target_object=self.project.id)
+        test_configuration.assert_called_once_with(self.project)
         assert audit.event == 111
-        assert response.status_code == 200, (response.status_code, response.content)
 
         configs = response.data.get("config")
 
@@ -116,29 +90,16 @@ class EnableProjectPluginTest(APITestCase):
             assert config.get("value") is None
 
 
-class DisableProjectPluginTest(APITestCase):
+class DisableProjectPluginTest(ProjectPluginDetailsTestBase):
+    method = "delete"
+
     def test_simple(self):
-        project = self.create_project()
+        plugins.get("webhooks").enable(self.project)
 
-        self.login_as(user=self.user)
+        self.get_success_response(self.project.organization.slug, self.project.slug, "webhooks")
 
-        plugins.get("webhooks").enable(project)
-
-        url = reverse(
-            "sentry-api-0-project-plugin-details",
-            kwargs={
-                "organization_slug": project.organization.slug,
-                "project_slug": project.slug,
-                "plugin_id": "webhooks",
-            },
-        )
-        audit = AuditLogEntry.objects.filter(target_object=project.id)
-
-        assert not audit
-
-        response = self.client.delete(url)
-        audit = AuditLogEntry.objects.get(target_object=project.id)
-
+        audit = AuditLogEntry.objects.get(target_object=self.project.id)
         assert audit.event == 112
-        assert response.status_code == 204, (response.status_code, response.content)
-        assert ProjectOption.objects.get(key="webhooks:enabled", project=project).value is False
+        assert (
+            ProjectOption.objects.get(key="webhooks:enabled", project=self.project).value is False
+        )

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -26,6 +26,8 @@ class ProjectPluginDetailsTest(ProjectPluginDetailsTestBase):
                 "choices": None,
                 "defaultValue": None,
                 "help": "Enter callback URLs to POST new events to (one per line).",
+                "isDeprecated": False,
+                "isHidden": False,
                 "label": "Callback URLs",
                 "name": "urls",
                 "placeholder": "https://sentry.io/callback/url",


### PR DESCRIPTION
This PR shadow deprecates the teamwork plugin, preventing those without the organization feature from viewing, updating or using the plugin. The feature is `organizations:integrations-ignore-teamwork-deprecation` and will be removed after the full deprecation has been done. 

### With the feature enabled:

- Issue linking is still visible:

<img width="1693" alt="image" src="https://user-images.githubusercontent.com/35509934/135918981-6ea05b19-90fa-4bd0-9a72-5d402f06d80c.png">

- still available in the plugin list
- still displayed when installed on the sidebar
- still available in the integration directory (regardless of installation)


https://user-images.githubusercontent.com/35509934/135921037-9d58350d-d422-4550-941e-a450bcb3ad64.mov


- still available with a direct link to the plugin (settings/:orgId/plugins/teamwork/)

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/35509934/135920076-f1d40264-f917-472a-8c96-f65345f91b79.png">



---


### Without the feature enabled


- Issue linking disappears

<img width="1621" alt="image" src="https://user-images.githubusercontent.com/35509934/135921509-a13d9aa8-069a-4b9c-8c8b-aab549cd7661.png">


- None of the plugin pages show teamwork
- Individual view throws a 404 (we don't handle it well so it errors, but that is out of scope of this ticket)

https://user-images.githubusercontent.com/35509934/135921211-a165920c-9b3a-4c45-b9e3-e630b7664792.mov

- No longer on the integration directory (regardless of whether or not it is installed)

https://user-images.githubusercontent.com/35509934/135921236-187a4e48-2bfa-47fe-87c1-cfdaa6a189f2.mov

- Direct link throws 404 (we don't handle it well so it errors, but that is out of scope of this ticket)

https://user-images.githubusercontent.com/35509934/135920469-d00a9b47-de71-4782-86e1-597c03b52381.mov



