### PR TITLE
fix(org-stats): error when interval > statsPeriod

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -306,6 +306,10 @@ def get_constrained_date_range(
 ) -> Tuple[datetime, datetime, int]:
     interval = parse_stats_period(params.get("interval", "1h"))
     interval = int(3600 if interval is None else interval.total_seconds())
+    stats_period = int(parse_stats_period(params.get("statsPeriod")).total_seconds())
+
+    if interval > stats_period:
+        raise InvalidParams("The interval can not exceed the date range.")
 
     smallest_interval = ONE_MINUTE if allow_minute_resolution else ONE_HOUR
     if interval % smallest_interval != 0 or interval < smallest_interval:


### PR DESCRIPTION
Currently if the interval > statsPeriod, it will return the data within the interval as long as the interval < 24h. When the statsPeriod is lower than the interval, it will still return all data within the interval. 

before: 
![image](https://user-images.githubusercontent.com/22259802/135933370-6239421f-b22f-4420-8a7f-9c5ad66fa37b.png)


after: 
![image](https://user-images.githubusercontent.com/22259802/135933316-30d9e452-b54f-4da2-ac13-864b1ca47080.png)

ticket: https://getsentry.atlassian.net/browse/ER-666