### PR TITLE
feat(ui): Remove session alert 30m window

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -88,7 +88,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
 
     if (this.props.dataset === Dataset.SESSIONS) {
       options = pick(TIME_WINDOW_MAP, [
-        TimeWindow.THIRTY_MINUTES,
+        // TimeWindow.THIRTY_MINUTES, leaving this option out until we figure out the sub-hour session resolution chart limitations
         TimeWindow.ONE_HOUR,
         TimeWindow.TWO_HOURS,
         TimeWindow.FOUR_HOURS,


### PR DESCRIPTION
We are for now removing the 30m window option from session alerts.
The reason is that sub-hour intervals with sessions are only possible with time periods that are shorter than 6 hours (backend limit).
We can't guarantee that on the incident detail page - we might do some frontend time clamping in the future or wait till metrics support this kind of use case.