### PR TITLE
feat(suspect-spans): Change ingestion to project scope flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1035,8 +1035,6 @@ SENTRY_FEATURES = {
     "organizations:performance-events-page": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
-    # Enable ingestion for suspect spans
-    "organizations:performance-suspect-spans-ingestion": False,
     # Enable views for suspect tags
     "organizations:performance-suspect-spans-view": False,
     # Enable the new Related Events feature
@@ -1104,6 +1102,8 @@ SENTRY_FEATURES = {
     # Enable functionality for attaching  minidumps to events and displaying
     # then in the group UI.
     "projects:minidump": True,
+    # Enable ingestion for suspect spans
+    "projects:performance-suspect-spans-ingestion": False,
     # Enable functionality for project plugins.
     "projects:plugins": True,
     # Enable alternative version of group creation that is supposed to be less racy.

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1702,9 +1702,8 @@ def _calculate_span_grouping(jobs, projects):
             project = projects[job["project_id"]]
 
             if not features.has(
-                "organizations:performance-suspect-spans-ingestion",
-                project.organization,
-                actor=None,
+                "projects:performance-suspect-spans-ingestion",
+                project=project,
             ):
                 continue
 

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -119,7 +119,6 @@ default_manager.add("organizations:performance-tag-explorer", OrganizationFeatur
 default_manager.add("organizations:performance-tag-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-events-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
-default_manager.add("organizations:performance-suspect-spans-ingestion", OrganizationFeature)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:prompt-dashboards", OrganizationFeature)
@@ -169,6 +168,7 @@ default_manager.add("projects:similarity-indexing", ProjectFeature)
 default_manager.add("projects:similarity-indexing-v2", ProjectFeature)
 default_manager.add("projects:similarity-view", ProjectFeature)
 default_manager.add("projects:similarity-view-v2", ProjectFeature)
+default_manager.add("projects:performance-suspect-spans-ingestion", ProjectFeature)
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -374,3 +374,5 @@ register("subscriptions-query.sample-rate", default=0.01)
 # This is to allow gradual rollout of metrics collection for symbolication requests and can be
 # removed once it is fully rolled out.
 register("symbolicate-event.low-priority.metrics.submission-rate", default=0.0)
+
+register("performance:suspect-spans-ingestion-projects", default={})

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -375,4 +375,4 @@ register("subscriptions-query.sample-rate", default=0.01)
 # removed once it is fully rolled out.
 register("symbolicate-event.low-priority.metrics.submission-rate", default=0.0)
 
-register("performance:suspect-spans-ingestion-projects", default={})
+register("performance.suspect-spans-ingestion-projects", default={})

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -168,7 +168,7 @@ def get_project_config(project, full_config=True, project_keys=None):
 
     if features.has("organizations:performance-ops-breakdown", project.organization):
         cfg["config"]["breakdownsV2"] = project.get_option("sentry:breakdowns")
-    if features.has("organizations:performance-suspect-spans-ingestion", project.organization):
+    if features.has("projects:performance-suspect-spans-ingestion", project=project):
         cfg["config"]["spanAttributes"] = project.get_option("sentry:span_attributes")
     with Hub.current.start_span(op="get_filter_settings"):
         cfg["config"]["filterSettings"] = get_filter_settings(project)

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -186,7 +186,7 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
         with Feature(
             {
                 "organizations:performance-ops-breakdown": True,
-                "organizations:performance-suspect-spans-ingestion": True,
+                "projects:performance-suspect-spans-ingestion": True,
             }
         ):
             event = self.post_and_retrieve_event(event_data)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1240,7 +1240,7 @@ class EventManagerTest(TestCase):
         assert data["type"] == "transaction"
 
     def test_transaction_event_span_grouping(self):
-        with self.feature("organizations:performance-suspect-spans-ingestion"):
+        with self.feature("projects:performance-suspect-spans-ingestion"):
             manager = EventManager(
                 make_event(
                     **{

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -114,7 +114,7 @@ def test_project_config_with_span_attributes(default_project, insta_snapshot):
     cfg = cfg.to_dict()
     assert "spanAttributes" not in cfg["config"]
 
-    with Feature("organizations:performance-suspect-spans-ingestion"):
+    with Feature("projects:performance-suspect-spans-ingestion"):
         cfg = get_project_config(default_project, full_config=True)
 
     cfg = cfg.to_dict()


### PR DESCRIPTION
To limit the scope of the rollout, change the suspect spans ingestion to a
project scope flag to allow us to roll it out by the project.