### PR TITLE
fix(orgstats): Remove client discards from project totals

### DIFF
--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -13,7 +13,7 @@ import {t} from 'app/locale';
 import {DataCategory, Organization, Project} from 'app/types';
 import withProjects from 'app/utils/withProjects';
 
-import {UsageSeries} from './types';
+import {Outcome, UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';
 
 type Props = {
@@ -334,15 +334,17 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
           stats[projectId] = {...baseStat};
         }
 
-        stats[projectId].total += group.totals['sum(quantity)'];
+        if (outcome !== Outcome.CLIENT_DISCARD) {
+          stats[projectId].total += group.totals['sum(quantity)'];
+        }
 
-        if (
-          outcome === SortBy.ACCEPTED ||
-          outcome === SortBy.FILTERED ||
-          outcome === SortBy.DROPPED
-        ) {
+        if (outcome === Outcome.ACCEPTED || outcome === Outcome.FILTERED) {
           stats[projectId][outcome] += group.totals['sum(quantity)'];
-        } else {
+        } else if (
+          outcome === Outcome.RATE_LIMITED ||
+          outcome === Outcome.INVALID ||
+          outcome === Outcome.DROPPED
+        ) {
           stats[projectId][SortBy.DROPPED] += group.totals['sum(quantity)'];
         }
       });


### PR DESCRIPTION
- Following up to #28763, we also need to remove client discards from the totals in the project rows. 
- Note that we don't have tests for the row totals right now, but I have confirmed locally that this fixes the issue.

## Followup TODOS:

- [ ]  We should try and combine the methods that sort the backend orgstats into the frontend display categories in a common library function, but leaving that off for now to fix the issue.
- [ ] We should add tests for the project row stats.
- [ ] We should filter out client discards from the query if we're going to discard them.