### PR TITLE
feat(dev): Use arm64 ClickHouse image on Apple arm64 machines

### DIFF
--- a/config/clickhouse/dist_config.xml
+++ b/config/clickhouse/dist_config.xml
@@ -1,5 +1,6 @@
 <yandex>
-    <max_server_memory_usage_to_ram_ratio from_env="MAX_MEMORY_USAGE_RATIO" />
+    <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
+
 
     <remote_servers>
         <cluster_one_sh>

--- a/config/clickhouse/loc_config.xml
+++ b/config/clickhouse/loc_config.xml
@@ -1,3 +1,3 @@
 <yandex>
-    <max_server_memory_usage_to_ram_ratio from_env="MAX_MEMORY_USAGE_RATIO" />
+    <max_server_memory_usage_to_ram_ratio>0.3</max_server_memory_usage_to_ram_ratio>
 </yandex>

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1802,15 +1802,21 @@ SENTRY_DEVSERVICES = {
     ),
     "clickhouse": lambda settings, options: (
         {
-            "image": "yandex/clickhouse-server:20.3.9.70",
+            # altinity provides clickhouse support to other companies
+            # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
+            "image": "altinity/clickhouse-server:21.6.1.6734-testing-arm"
+            if APPLE_ARM64
+            else "yandex/clickhouse-server:20.3.9.70",
             "pull": True,
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
-            "environment": {"MAX_MEMORY_USAGE_RATIO": "0.3"},
+            # The arm image does not properly load the MAX_MEMORY_USAGE_RATIO
+            # from the environment in loc_config.xml, thus, hard-coding it there
             "volumes": {
                 "clickhouse_dist"
                 if settings.SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES
                 else "clickhouse": {"bind": "/var/lib/clickhouse"},
+                "clickhouse_logs": {"bind": "/var/log/clickhouse-server"},
                 os.path.join(
                     settings.DEVSERVICES_CONFIG_DIR,
                     "clickhouse",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1817,7 +1817,6 @@ SENTRY_DEVSERVICES = {
                 "clickhouse_dist"
                 if settings.SENTRY_DISTRIBUTED_CLICKHOUSE_TABLES
                 else "clickhouse": {"bind": "/var/lib/clickhouse"},
-                "clickhouse_logs": {"bind": "/var/log/clickhouse-server"},
                 os.path.join(
                     settings.DEVSERVICES_CONFIG_DIR,
                     "clickhouse",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1805,9 +1805,9 @@ SENTRY_DEVSERVICES = {
             # altinity provides clickhouse support to other companies
             # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
             # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
-            "image": "altinity/clickhouse-server:20.10.1.4844-testing-arm"
-            if APPLE_ARM64
-            else "yandex/clickhouse-server:20.3.9.70",
+            "image": "yandex/clickhouse-server:20.3.9.70"
+            if not APPLE_ARM64
+            else "altinity/clickhouse-server:20.10.1.4844-testing-arm",
             "pull": True,
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1805,7 +1805,7 @@ SENTRY_DEVSERVICES = {
             # altinity provides clickhouse support to other companies
             # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
             # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
-            "image": "altinity/clickhouse-server:21.6.1.6734-testing-arm"
+            "image": "altinity/clickhouse-server:20.10.1.4844-testing-arm"
             if APPLE_ARM64
             else "yandex/clickhouse-server:20.3.9.70",
             "pull": True,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1804,6 +1804,7 @@ SENTRY_DEVSERVICES = {
         {
             # altinity provides clickhouse support to other companies
             # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
+            # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
             "image": "altinity/clickhouse-server:21.6.1.6734-testing-arm"
             if APPLE_ARM64
             else "yandex/clickhouse-server:20.3.9.70",


### PR DESCRIPTION
ClickHouse, currently, [does not provide an `arm64` Docker image for the clickhouse-server][issue].

Until they do, we can use the [experimental image that Altinity produces][image].
I believe this image is built by this [script][script] on an `aarch64` host.

Fixes #28564

[issue]: https://github.com/ClickHouse/ClickHouse/issues/22222
[image]: https://hub.docker.com/layers/altinity/clickhouse-server/21.6.1.6734-testing-arm/images/sha256-9a4516444fef9e0f11ee6b2de716d3b97b36bf05d9cc2d44c4596cfb0584dea6?context=explore
[script]: https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d