### PR TITLE
 ref(clubhouse): Shadow deprecate clubhouse plugin

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from sentry import tagstore, tsdb
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer
+from sentry.api.serializers.models.plugin import is_plugin_deprecated
 from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import LOG_LEVELS, StatsPeriod
@@ -344,6 +345,8 @@ class GroupSerializerBase(Serializer):
             # note that the model GroupMeta where all the information is stored is already cached at the top of this function
             # so these for loops doesn't make a bunch of queries
             for plugin in plugins.for_project(project=item.project, version=1):
+                if is_plugin_deprecated(plugin, item.project):
+                    continue
                 safe_execute(plugin.tags, None, item, annotations, _with_transaction=False)
             for plugin in plugins.for_project(project=item.project, version=2):
                 annotations.extend(

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -7,7 +7,10 @@ from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 
 # Dict with the plugin_name as the key, and enabling_feature_name as the value
-SHADOW_DEPRECATED_PLUGINS = {"teamwork": "organizations:integrations-ignore-teamwork-deprecation"}
+SHADOW_DEPRECATED_PLUGINS = {
+    "teamwork": "organizations:integrations-ignore-teamwork-deprecation",
+    "clubhouse": "organizations:integrations-ignore-clubhouse-deprecation",
+}
 
 
 class PluginSerializer(Serializer):

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -3,6 +3,7 @@ from django.utils.text import slugify
 from sentry import features
 from sentry.api.serializers import Serializer
 from sentry.models import ProjectOption
+from sentry.models.project import Project
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 
@@ -11,6 +12,12 @@ SHADOW_DEPRECATED_PLUGINS = {
     "teamwork": "organizations:integrations-ignore-teamwork-deprecation",
     "clubhouse": "organizations:integrations-ignore-clubhouse-deprecation",
 }
+
+
+def is_plugin_deprecated(plugin, project: Project) -> bool:
+    return plugin.slug in SHADOW_DEPRECATED_PLUGINS and not features.has(
+        SHADOW_DEPRECATED_PLUGINS.get(plugin.slug), getattr(project, "organization", None)
+    )
 
 
 class PluginSerializer(Serializer):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -996,6 +996,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-custom-scm": False,
     # Allow orgs to view the Teamwork plugin
     "organizations:integrations-ignore-teamwork-deprecation": False,
+    # Allow orgs to view the Clubhouse/Shortcut plugin
+    "organizations:integrations-ignore-clubhouse-deprecation": False,
     # Allow orgs to debug internal/unpublished sentry apps with logging
     "organizations:sentry-app-debugging": False,
     # Temporary safety measure, turned on for specific orgs only if

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -100,6 +100,10 @@ default_manager.add("organizations:integrations-vsts-limited-scopes", Organizati
 default_manager.add(
     "organizations:integrations-ignore-teamwork-deprecation", OrganizationFeature, True
 )
+
+default_manager.add(
+    "organizations:integrations-ignore-clubhouse-deprecation", OrganizationFeature, True
+)
 default_manager.add("organizations:invite-members", OrganizationFeature)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)

--- a/src/sentry/templatetags/sentry_plugins.py
+++ b/src/sentry/templatetags/sentry_plugins.py
@@ -1,5 +1,6 @@
 from django import template
 
+from sentry.api.serializers.models.plugin import is_plugin_deprecated
 from sentry.plugins.base import Annotation, plugins
 from sentry.utils.safe import safe_execute
 
@@ -34,6 +35,8 @@ def get_annotations(group, request=None):
 
     annotation_list = []
     for plugin in plugins.for_project(project, version=2):
+        if is_plugin_deprecated(plugin, project):
+            continue
         for value in (
             safe_execute(plugin.get_annotations, group=group, _with_transaction=False) or ()
         ):

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -13,6 +13,7 @@ const pathPrefix = '/settings/:orgId/projects/:projectId';
 // Object with the pluginId as the key, and enablingFeature as the value
 const SHADOW_DEPRECATED_PLUGINS = {
   teamwork: 'integrations-ignore-teamwork-deprecation',
+  clubhouse: 'integrations-ignore-clubhouse-deprecation',
 };
 
 const canViewPlugin = (pluginId: string, organization?: Organization) => {

--- a/tests/acceptance/sentry_plugins/test_clubhouse.py
+++ b/tests/acceptance/sentry_plugins/test_clubhouse.py
@@ -13,7 +13,8 @@ class ClubhouseTest(AcceptanceTestCase):
         self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/clubhouse/"
 
     def test_simple(self):
-        self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
-        self.browser.snapshot("clubhouse settings")
-        assert self.browser.element_exists(".ref-plugin-config-clubhouse")
+        with self.feature("organizations:integrations-ignore-clubhouse-deprecation"):
+            self.browser.get(self.path)
+            self.browser.wait_until_not(".loading-indicator")
+            self.browser.snapshot("clubhouse settings")
+            assert self.browser.element_exists(".ref-plugin-config-clubhouse")


### PR DESCRIPTION
See: [API-2137](https://getsentry.atlassian.net/browse/API-2137)

This PR adds the clubhouse plugin to the map of shadow deprecated plugins. It prevents access to the plugin from the plugin directory and integration directory. This plugin is already hidden by default for those who don't have it installed already, but now even they won't see it listed.

## With feature-flag enabled:

- External issue annotations are still visible

<img width="722" alt="image" src="https://user-images.githubusercontent.com/35509934/136113044-b418ab83-f6c0-4b16-810b-8d66fdbd5dbd.png">
<img width="918" alt="image" src="https://user-images.githubusercontent.com/35509934/136113109-a741c6c6-73df-4871-9f1b-de11c4e9567b.png">

- Linked stories appear in the sidebar

<img width="320" alt="image" src="https://user-images.githubusercontent.com/35509934/136113132-5deaba0d-6b57-4112-bb4d-7e1de5252c11.png">

- New stories can be created/linked in the sidebar

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/35509934/136113310-dd864d13-4676-42c0-97d4-702a60a2c074.png">

- Clubhouse appears in the integration + plugin directory (if installed)

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/35509934/136113375-df604805-ff5b-43b9-86ac-30ca84a5d894.png">
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/35509934/136113407-1077f264-0517-4582-8bef-f2b71b980283.png">
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/35509934/136113486-939fec76-f89c-461f-974d-b46b1ef9112f.png">



---

## Without feature-flag enabled:

- External issue annotations are gone

<img width="1125" alt="image" src="https://user-images.githubusercontent.com/35509934/136114177-cef89892-a612-45e7-9056-dd29a570e51f.png">
 <img width="1125" alt="image" src="https://user-images.githubusercontent.com/35509934/136114157-99b7aa6a-cb2b-46cb-97db-bfd1d128f284.png">

- Clubhouse stories are gone (and can no longer be created/linked)

<img width="424" alt="image" src="https://user-images.githubusercontent.com/35509934/136114237-c677c222-661e-4c10-9f6d-e0278866f015.png">

- Clubhouse is missing from the integration + plugin directory (regardless of installation)

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/35509934/136113963-b470ea8d-1b77-443e-ac67-6db8ffb88967.png">
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/35509934/136113932-9659cb67-402b-4e77-be56-efc51dca8cda.png">
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/35509934/136113875-9c45bc5b-ba24-427e-b9c9-85a632c542c1.png">
