### PR TITLE
fix(ui): Revert change to disabled button tooltips

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -129,7 +129,7 @@ class BaseButton extends React.Component<ButtonProps, {}> {
     // Doing this instead of using `Tooltip`'s `disabled` prop so that we can minimize snapshot nesting
     if (title) {
       return (
-        <Tooltip skipWrapper={!disabled} {...tooltipProps} title={title}>
+        <Tooltip skipWrapper {...tooltipProps} title={title}>
           {button}
         </Tooltip>
       );


### PR DESCRIPTION
Quickly mousing over a disabled button with a tooltip would cause the tooltip to persist forever