### PR TITLE
feat(internal-metrics): Add gauge support

### DIFF
--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -25,3 +25,6 @@ class MetricsBackend(local):
 
     def timing(self, key, value, instance=None, tags=None, sample_rate=1):
         raise NotImplementedError
+
+    def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
+        raise NotImplementedError

--- a/src/sentry/metrics/datadog.py
+++ b/src/sentry/metrics/datadog.py
@@ -57,3 +57,16 @@ class DatadogMetricsBackend(MetricsBackend):
         self.stats.timing(
             self._get_key(key), value, sample_rate=sample_rate, tags=tags, host=self.host
         )
+
+    def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
+        if tags is None:
+            tags = {}
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+        if tags:
+            tags = [f"{k}:{v}" for k, v in tags.items()]
+        self.stats.gauge(
+            self._get_key(key), value, sample_rate=sample_rate, tags=tags, host=self.host
+        )

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -33,3 +33,14 @@ class DogStatsdMetricsBackend(MetricsBackend):
         if tags:
             tags = [f"{k}:{v}" for k, v in tags.items()]
         statsd.timing(self._get_key(key), value, sample_rate=sample_rate, tags=tags)
+
+    def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
+        if tags is None:
+            tags = {}
+        if self.tags:
+            tags.update(self.tags)
+        if instance:
+            tags["instance"] = instance
+        if tags:
+            tags = [f"{k}:{v}" for k, v in tags.items()]
+        statsd.gauge(self._get_key(key), value, sample_rate=sample_rate, tags=tags)

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -4,10 +4,10 @@ from .base import MetricsBackend
 
 
 class DummyMetricsBackend(MetricsBackend):
-    def incr(self, key, instance=None, tags=None, amount=1, rate=1):
+    def incr(self, key, instance=None, tags=None, amount=1, sample_rate=1):
         pass
 
-    def timing(self, key, value, instance=None, tags=None, rate=1):
+    def timing(self, key, value, instance=None, tags=None, sample_rate=1):
         pass
 
     def gauge(self, key, value, instance=None, tags=None, sample_rate=1):

--- a/src/sentry/metrics/dummy.py
+++ b/src/sentry/metrics/dummy.py
@@ -9,3 +9,6 @@ class DummyMetricsBackend(MetricsBackend):
 
     def timing(self, key, value, instance=None, tags=None, rate=1):
         pass
+
+    def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
+        pass

--- a/src/sentry/metrics/logging.py
+++ b/src/sentry/metrics/logging.py
@@ -13,3 +13,6 @@ class LoggingBackend(MetricsBackend):
         logger.debug(
             "%r: %g ms", key, value * 1000, extra={"instance": instance, "tags": tags or {}}
         )
+
+    def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
+        logger.debug("%r: %+g", key, value, extra={"instance": instance, "tags": tags or {}})

--- a/src/sentry/metrics/statsd.py
+++ b/src/sentry/metrics/statsd.py
@@ -20,3 +20,6 @@ class StatsdMetricsBackend(MetricsBackend):
 
     def timing(self, key, value, instance=None, tags=None, sample_rate=1):
         self.client.timing(self._full_key(self._get_key(key)), value, sample_rate)
+
+    def gauge(self, key, value, instance=None, tags=None, sample_rate=1):
+        self.client.gauge(self._full_key(self._get_key(key)), value, sample_rate)

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -166,7 +166,7 @@ def gauge(
         current_tags.update(tags)
 
     try:
-        backend.gauge(key, instance, current_tags, value, sample_rate)
+        backend.gauge(key, value, instance, current_tags, sample_rate)
     except Exception:
         logger = logging.getLogger("sentry.errors")
         logger.exception("Unable to record backend metric")

--- a/src/sentry/utils/metrics.py
+++ b/src/sentry/utils/metrics.py
@@ -154,6 +154,24 @@ def incr(
         logger.exception("Unable to record backend metric")
 
 
+def gauge(
+    key: str,
+    value,
+    instance: Optional[str] = None,
+    tags: Optional[Mapping[str, str]] = None,
+    sample_rate: float = settings.SENTRY_METRICS_SAMPLE_RATE,
+) -> None:
+    current_tags = _get_current_global_tags()
+    if tags is not None:
+        current_tags.update(tags)
+
+    try:
+        backend.gauge(key, instance, current_tags, value, sample_rate)
+    except Exception:
+        logger = logging.getLogger("sentry.errors")
+        logger.exception("Unable to record backend metric")
+
+
 def timing(key, value, instance=None, tags=None, sample_rate=settings.SENTRY_METRICS_SAMPLE_RATE):
     current_tags = _get_current_global_tags()
     if tags is not None:

--- a/tests/sentry/metrics/test_datadog.py
+++ b/tests/sentry/metrics/test_datadog.py
@@ -22,3 +22,10 @@ class DatadogMetricsBackendTest(TestCase):
         mock_timing.assert_called_once_with(
             "sentrytest.foo", 30, sample_rate=1, tags=["instance:bar"], host=get_hostname()
         )
+
+    @patch("datadog.threadstats.base.ThreadStats.gauge")
+    def test_gauge(self, mock_gauge):
+        self.backend.gauge("foo", 5, instance="bar")
+        mock_gauge.assert_called_once_with(
+            "sentrytest.foo", 5, sample_rate=1, tags=["instance:bar"], host=get_hostname()
+        )

--- a/tests/sentry/metrics/test_statsd.py
+++ b/tests/sentry/metrics/test_statsd.py
@@ -16,3 +16,8 @@ class StatsdMetricsBackendTest(TestCase):
     def test_timing(self, mock_timing):
         self.backend.timing("foo", 30)
         mock_timing.assert_called_once_with("sentrytest.foo", 30, 1)
+
+    @patch("statsd.StatsClient.gauge")
+    def test_gauge(self, mock_gauge):
+        self.backend.gauge("foo", 5)
+        mock_gauge.assert_called_once_with("sentrytest.foo", 5, 1)


### PR DESCRIPTION
There's a metric that the native team would like to record as a gauge instead of a counter, as it is meant to track a snapshot of a value at some given period of time instead of the total number of occurrences of some event. For those who are familiar with the symbolicator reliability project, I'd like to track the number of projects assigned to the currently-disabled LPQ to get an idea of its behaviour before rolling it out to production.

This adds in baseline support for gauges, mostly based on what's already there.