### PR TITLE
fix(discover): Update the top-5 label regardless of flag

### DIFF
--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -185,6 +185,12 @@ class ResultsChartContainer extends Component<ContainerProps> {
       .map(opt => {
         // Can only use default display or total daily with multi y axis
         if (
+          hasTopEvents &&
+          [DisplayModes.TOP5, DisplayModes.DAILYTOP5].includes(opt.value as DisplayModes)
+        ) {
+          opt.label = DisplayModes.TOP5 === opt.value ? 'Top Period' : 'Top Daily';
+        }
+        if (
           yAxis.length > 1 &&
           ![DisplayModes.DEFAULT, DisplayModes.DAILY].includes(opt.value as DisplayModes)
         ) {
@@ -194,18 +200,6 @@ class ResultsChartContainer extends Component<ContainerProps> {
             tooltip: t(
               'Change the Y-Axis dropdown to display only 1 function to use this view.'
             ),
-          };
-        }
-        if (hasTopEvents && DisplayModes.TOP5 === opt.value) {
-          return {
-            value: opt.value,
-            label: 'Top Period',
-          };
-        }
-        if (hasTopEvents && DisplayModes.DAILYTOP5 === opt.value) {
-          return {
-            value: opt.value,
-            label: 'Top Daily',
           };
         }
         return opt;


### PR DESCRIPTION
- This fixes a bug where the top 5 displays weren't the correct value
  when mixed with the multiaxis feature flag
  
<img width="313" alt="image" src="https://user-images.githubusercontent.com/4205004/136113601-63c16463-e2bd-4518-82d2-57548775ad75.png">
