### PR TITLE
ref(ts): Store type definition consistency

### DIFF
--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -16,10 +16,10 @@ type Alert = {
 };
 
 type AlertStoreInterface = Reflux.StoreDefinition & {
-  init: () => void;
-  getInitialState: () => Alert[];
-  onAddAlert: (alert: Alert) => void;
-  onCloseAlert: (alert: Alert, duration?: number) => void;
+  init(): void;
+  getInitialState(): Alert[];
+  onAddAlert(alert: Alert): void;
+  onCloseAlert(alert: Alert, duration?: number): void;
 };
 
 type Internals = {

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -3,15 +3,17 @@ import Reflux from 'reflux';
 import CommitterActions from 'app/actions/committerActions';
 import {Committer} from 'app/types';
 
-type CommitterStoreInterface = {
-  state: {
-    // Use `getCommitterStoreKey` to generate key
-    [key: string]: {
-      committers?: Committer[];
-      committersLoading?: boolean;
-      committersError?: Error;
-    };
+type State = {
+  // Use `getCommitterStoreKey` to generate key
+  [key: string]: {
+    committers?: Committer[];
+    committersLoading?: boolean;
+    committersError?: Error;
   };
+};
+
+type CommitterStoreInterface = {
+  state: State;
 
   load(orgSlug: string, projectSlug: string, eventId: string): void;
   loadSuccess(

--- a/static/app/stores/debugMetaStore.tsx
+++ b/static/app/stores/debugMetaStore.tsx
@@ -7,10 +7,10 @@ type State = {
 };
 
 type DebugMetaStoreInterface = {
-  init: () => void;
-  reset: () => void;
-  updateFilter: (word: string) => void;
-  get: () => State;
+  init(): void;
+  reset(): void;
+  updateFilter(word: string): void;
+  get(): State;
 };
 
 type Internals = {

--- a/static/app/stores/eventStore.tsx
+++ b/static/app/stores/eventStore.tsx
@@ -10,14 +10,14 @@ type Internals = {
 };
 
 type EventStoreInterface = {
-  init: () => void;
-  reset: () => void;
-  loadInitialData: (items: Event[]) => void;
-  add: (items: Event[]) => void;
-  remove: (id: string) => void;
-  get: (id: string) => Event | undefined;
-  getAllItemIds: () => string[];
-  getAllItems: () => Event[];
+  init(): void;
+  reset(): void;
+  loadInitialData(items: Event[]): void;
+  add(items: Event[]): void;
+  remove(id: string): void;
+  get(id: string): Event | undefined;
+  getAllItemIds(): string[];
+  getAllItems(): Event[];
 };
 
 const storeConfig: Reflux.StoreDefinition & Internals & EventStoreInterface = {

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -2,7 +2,13 @@ import Reflux from 'reflux';
 
 import {PlatformExternalIssue} from 'app/types';
 
-const ExternalIssueStore = Reflux.createStore({
+type ExternalIssueStoreInterface = {
+  load(items: PlatformExternalIssue[]): void;
+  add(issue: PlatformExternalIssue): void;
+  getInitialState(): PlatformExternalIssue[];
+};
+
+const storeConfig: Reflux.StoreDefinition & ExternalIssueStoreInterface = {
   init() {
     this.items = [];
   },
@@ -30,12 +36,9 @@ const ExternalIssueStore = Reflux.createStore({
       this.trigger(this.items);
     }
   },
-});
-
-type ExternalIssueStoreType = Reflux.Store & {
-  load: (items: PlatformExternalIssue[]) => void;
-  add: (issue: PlatformExternalIssue) => void;
-  getInitialState: () => PlatformExternalIssue[];
 };
 
-export default ExternalIssueStore as ExternalIssueStoreType;
+const ExternalIssueStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  ExternalIssueStoreInterface;
+
+export default ExternalIssueStore;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -14,8 +14,8 @@ export type FormSearchField = {
 };
 
 type StoreInterface = {
-  reset: () => void;
-  get: () => Internals['searchMap'];
+  reset(): void;
+  get(): Internals['searchMap'];
 };
 
 type Internals = {

--- a/static/app/stores/globalSelectionStore.tsx
+++ b/static/app/stores/globalSelectionStore.tsx
@@ -22,19 +22,19 @@ type StoreState = {
 type GlobalSelectionStoreInterface = {
   state: GlobalSelection;
 
-  reset: (state?: GlobalSelection) => void;
-  onReset: () => void;
-  isReady: () => boolean;
-  onSetOrganization: (organization: Organization) => void;
-  onInitializeUrlState: (newSelection: GlobalSelection) => void;
-  get: () => StoreState;
-  updateProjects: (
+  reset(state?: GlobalSelection): void;
+  onReset(): void;
+  isReady(): boolean;
+  onSetOrganization(organization: Organization): void;
+  onInitializeUrlState(newSelection: GlobalSelection): void;
+  get(): StoreState;
+  updateProjects(
     projects: GlobalSelection['projects'],
     environments: null | string[]
-  ) => void;
-  updateDateTime: (datetime: GlobalSelection['datetime']) => void;
-  updateEnvironments: (environments: string[]) => void;
-  onSave: (data: UpdateData) => void;
+  ): void;
+  updateDateTime(datetime: GlobalSelection['datetime']): void;
+  updateEnvironments(environments: string[]): void;
+  onSave(data: UpdateData): void;
 };
 
 const storeConfig: Reflux.StoreDefinition & GlobalSelectionStoreInterface = {

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -15,9 +15,7 @@ import {
 } from 'app/types';
 
 function showAlert(msg, type) {
-  IndicatorStore.addMessage(msg, type, {
-    duration: 4000,
-  });
+  IndicatorStore.addMessage(msg, type, {duration: 4000});
 }
 
 // TODO(ts) Type this any better.
@@ -45,8 +43,10 @@ class PendingChangeQueue {
   }
 }
 
+type Item = BaseGroup | Group | GroupCollapseRelease;
+
 type Internals = {
-  items: any[];
+  items: Item[];
   statuses: Record<string, Record<string, boolean>>;
   pendingChanges: PendingChangeQueue;
 
@@ -59,15 +59,15 @@ type Internals = {
 type GroupStoreInterface = Reflux.StoreDefinition & {
   init: () => void;
   reset: () => void;
-  loadInitialData: (items: BaseGroup[] | Group[] | GroupCollapseRelease[]) => void;
-  add: (items: BaseGroup[] | Group[] | GroupCollapseRelease[]) => void;
+  loadInitialData: (items: Item[]) => void;
+  add: (items: Item[]) => void;
   remove: (itemIds: string[]) => void;
   addStatus: (id: string, status: string) => void;
   clearStatus: (id: string, status: string) => void;
   hasStatus: (id: string, status: string) => boolean;
-  get: (id: string) => BaseGroup | Group | GroupCollapseRelease | undefined;
+  get: (id: string) => Item | undefined;
   getAllItemIds: () => string[];
-  getAllItems: () => BaseGroup[] | Group[] | GroupCollapseRelease[];
+  getAllItems: () => Item[];
   onAssignTo: (changeId: string, itemId: string, data: any) => void;
   onAssignToError: (changeId: string, itemId: string, error: Error) => void;
   onAssignToSuccess: (changeId: string, itemId: string, response: any) => void;
@@ -259,7 +259,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
     // TODO(ts) This needs to be constrained further. It was left as any
     // because the PendingChanges signatures and this were not aligned.
     const pendingForId: any[] = [];
-    this.pendingChanges.forEach((change: any) => {
+    this.pendingChanges.forEach(change => {
       if (change.id === id) {
         pendingForId.push(change);
       }

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -110,30 +110,30 @@ type IdState = {
 };
 
 type GroupingStoreInterface = Reflux.StoreDefinition & {
-  init: () => void;
-  getInitialState: () => State;
-  setStateForId: (
+  init(): void;
+  getInitialState(): State;
+  setStateForId(
     map: Map<string, IdState>,
     idOrIds: Array<string> | string,
     newState: IdState
-  ) => Array<IdState>;
-  isAllUnmergedSelected: () => boolean;
-  onFetch: (
+  ): Array<IdState>;
+  isAllUnmergedSelected(): boolean;
+  onFetch(
     toFetchArray?: Array<{
       dataKey: DataKey;
       endpoint: string;
       queryParams?: Record<string, any>;
     }>
-  ) => Promise<any>;
-  onToggleMerge: (id: string) => void;
-  onToggleUnmerge: (props: [string, string] | string) => void;
-  onUnmerge: (props: {
+  ): Promise<any>;
+  onToggleMerge(id: string): void;
+  onToggleUnmerge(props: [string, string] | string): void;
+  onUnmerge(props: {
     groupId: Group['id'];
     loadingMessage?: string;
     successMessage?: string;
     errorMessage?: string;
-  }) => void;
-  onMerge: (props: {
+  }): void;
+  onMerge(props: {
     params?: {
       orgId: Organization['id'];
       projectId: Project['id'];
@@ -141,10 +141,10 @@ type GroupingStoreInterface = Reflux.StoreDefinition & {
     };
     projectId?: Project['id'];
     query?: string;
-  }) => undefined | Promise<any>;
-  onToggleCollapseFingerprints: () => void;
-  onToggleCollapseFingerprint: (fingerprint: string) => void;
-  triggerFetchState: () => Pick<
+  }): undefined | Promise<any>;
+  onToggleCollapseFingerprints(): void;
+  onToggleCollapseFingerprint(fingerprint: string): void;
+  triggerFetchState(): Pick<
     State,
     | 'similarItems'
     | 'filteredSimilarItems'
@@ -156,7 +156,7 @@ type GroupingStoreInterface = Reflux.StoreDefinition & {
     | 'loading'
     | 'error'
   >;
-  triggerUnmergeState: () => Pick<
+  triggerUnmergeState(): Pick<
     State,
     | 'unmergeDisabled'
     | 'unmergeState'
@@ -164,7 +164,7 @@ type GroupingStoreInterface = Reflux.StoreDefinition & {
     | 'enableFingerprintCompare'
     | 'unmergeLastCollapsed'
   >;
-  triggerMergeState: () => Pick<State, 'mergeState' | 'mergeDisabled' | 'mergeList'>;
+  triggerMergeState(): Pick<State, 'mergeState' | 'mergeDisabled' | 'mergeList'>;
 };
 
 type Internals = {

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -68,11 +68,11 @@ const defaultState: GuideStoreState = {
 type GuideStoreInterface = {
   state: GuideStoreState;
 
-  onFetchSucceeded: (data: GuidesServerData) => void;
-  onRegisterAnchor: (target: string) => void;
-  onUnregisterAnchor: (target: string) => void;
-  recordCue: (guide: string) => void;
-  updatePrevGuide: (nextGuide: Guide | null) => void;
+  onFetchSucceeded(data: GuidesServerData): void;
+  onRegisterAnchor(target: string): void;
+  onUnregisterAnchor(target: string): void;
+  recordCue(guide: string): void;
+  updatePrevGuide(nextGuide: Guide | null): void;
 };
 
 const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -5,10 +5,10 @@ import IndicatorActions from 'app/actions/indicatorActions';
 import {t} from 'app/locale';
 
 type IndicatorStoreInterface = {
-  init: () => void;
-  get: () => Indicator[];
-  addSuccess: (message: string) => Indicator;
-  addError: (message?: string) => Indicator;
+  init(): void;
+  get(): Indicator[];
+  addSuccess(message: string): Indicator;
+  addError(message?: string): Indicator;
   /**
    * Appends a message to be displayed in list of indicators
    *
@@ -16,11 +16,11 @@ type IndicatorStoreInterface = {
    * @param type One of ['error', 'success', '']
    * @param options Options object
    */
-  append: (
+  append(
     message: string,
     type: Indicator['type'],
     options?: Indicator['options']
-  ) => Indicator;
+  ): Indicator;
   /**
    * When this method is called directly via older parts of the application,
    * we want to maintain the old behavior in that it is replaced (and not queued up)
@@ -29,27 +29,27 @@ type IndicatorStoreInterface = {
    * @param type One of ['error', 'success', '']
    * @param options Options object
    */
-  add: (
+  add(
     message: string,
     type?: Indicator['type'],
     options?: Indicator['options']
-  ) => Indicator;
+  ): Indicator;
   /**
    * Alias for add()
    */
-  addMessage: (
+  addMessage(
     message: string,
     type: Indicator['type'],
     options?: Indicator['options']
-  ) => Indicator;
+  ): Indicator;
   /**
    * Remove all current indicators.
    */
-  clear: () => void;
+  clear(): void;
   /**
    * Remove an indicator
    */
-  remove: (indicator: Indicator) => void;
+  remove(indicator: Indicator): void;
 };
 
 type Internals = {

--- a/static/app/stores/latestContextStore.tsx
+++ b/static/app/stores/latestContextStore.tsx
@@ -18,13 +18,13 @@ type State = {
 
 type LatestContextStoreInterface = {
   state: State;
-  reset: () => void;
-  get: () => State;
-  onSetLastRoute: (route: string) => void;
-  onUpdateOrganization: (organization: OrgTypes) => void;
-  onSetActiveOrganization: (organization: OrgTypes) => void;
-  onSetActiveProject: (project: Project | null) => void;
-  onUpdateProject: (project: Project | null) => void;
+  reset(): void;
+  get(): State;
+  onSetLastRoute(route: string): void;
+  onUpdateOrganization(organization: OrgTypes): void;
+  onSetActiveOrganization(organization: OrgTypes): void;
+  onSetActiveProject(project: Project | null): void;
+  onUpdateProject(project: Project | null): void;
 };
 
 // Keeps track of last usable project/org

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -5,11 +5,11 @@ import {User} from 'app/types';
 type MemberListStoreInterface = {
   state: User[];
   loaded: boolean;
-  loadInitialData: (items: User[]) => void;
-  isLoaded: () => boolean;
-  getById: (id: string) => User | undefined;
-  getByEmail: (email: string) => User | undefined;
-  getAll: () => User[];
+  loadInitialData(items: User[]): void;
+  isLoaded(): boolean;
+  getById(id: string): User | undefined;
+  getByEmail(email: string): User | undefined;
+  getAll(): User[];
 };
 
 const memberListStoreConfig: Reflux.StoreDefinition & MemberListStoreInterface = {

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -11,11 +11,11 @@ type ModalStoreState = {
 };
 
 type ModalStoreInterface = {
-  init: () => void;
-  get: () => ModalStoreState;
-  reset: () => void;
-  onCloseModal: () => void;
-  onOpenModal: (renderer: Renderer, options: ModalOptions) => void;
+  init(): void;
+  get(): ModalStoreState;
+  reset(): void;
+  onCloseModal(): void;
+  onOpenModal(renderer: Renderer, options: ModalOptions): void;
 };
 
 const storeConfig: Reflux.StoreDefinition & ModalStoreInterface = {

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -16,11 +16,11 @@ type State = {
 
 type OrganizationEnvironmentsStoreInterface = {
   state: State;
-  init: () => void;
-  onFetchEnvironments: () => void;
-  onFetchEnvironmentsSuccess: (environments: Environment[]) => void;
-  onFetchEnvironmentsError: (error: Error) => void;
-  get: () => State;
+  init(): void;
+  onFetchEnvironments(): void;
+  onFetchEnvironmentsSuccess(environments: Environment[]): void;
+  onFetchEnvironmentsError(error: Error): void;
+  get(): State;
 };
 
 const storeConfig: Reflux.StoreDefinition & OrganizationEnvironmentsStoreInterface = {

--- a/static/app/stores/organizationStore.tsx
+++ b/static/app/stores/organizationStore.tsx
@@ -18,11 +18,11 @@ type State = {
 };
 
 type OrganizationStoreInterface = {
-  init: () => void;
-  reset: () => void;
-  onUpdate: (org: Organization, options: UpdateOptions) => void;
-  onFetchOrgError: (err: RequestError) => void;
-  get: () => State;
+  init(): void;
+  reset(): void;
+  onUpdate(org: Organization, options: UpdateOptions): void;
+  onFetchOrgError(err: RequestError): void;
+  get(): State;
 };
 
 const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {

--- a/static/app/stores/organizationsStore.tsx
+++ b/static/app/stores/organizationsStore.tsx
@@ -7,14 +7,14 @@ type OrganizationsStoreInterface = {
   state: Organization[];
   loaded: boolean;
 
-  onUpdate: (org: Organization) => void;
-  onChangeSlug: (prev: Organization, next: Organization) => void;
-  onRemoveSuccess: (slug: string) => void;
-  get: (slug: string) => Organization | undefined;
-  getAll: () => Organization[];
-  remove: (slug: string) => void;
-  add: (item: Organization) => void;
-  load: (items: Organization[]) => void;
+  onUpdate(org: Organization): void;
+  onChangeSlug(prev: Organization, next: Organization): void;
+  onRemoveSuccess(slug: string): void;
+  get(slug: string): Organization | undefined;
+  getAll(): Organization[];
+  remove(slug: string): void;
+  add(item: Organization): void;
+  load(items: Organization[]): void;
 };
 
 const organizationsStoreConfig: Reflux.StoreDefinition & OrganizationsStoreInterface = {

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -20,23 +20,23 @@ type Internals = {
 };
 
 type ProjectsStoreInterface = {
-  init: () => void;
-  reset: () => void;
-  loadInitialData: (projects: Project[]) => void;
-  onStatsLoadSuccess: (data: StatsData) => void;
-  onChangeSlug: (prevSlug: string, newSlug: string) => void;
-  onCreateSuccess: (project: Project) => void;
-  onUpdateSuccess: (data: Partial<Project>) => void;
-  onDeleteTeam: (slug: string) => void;
-  onRemoveTeam: (teamSlug: string, projectSlug: string) => void;
-  onAddTeam: (team: Team, projectSlug: string) => void;
-  removeTeamFromProject: (teamSlug: string, project: Project) => void;
-  getWithTeam: (teamSlug: string) => Project[];
-  getAll: () => Project[];
-  getBySlugs: (slug: string[]) => Project[];
-  getState: (slugs?: string[]) => State;
-  getById: (id?: string) => Project | undefined;
-  getBySlug: (slug?: string) => Project | undefined;
+  init(): void;
+  reset(): void;
+  loadInitialData(projects: Project[]): void;
+  onStatsLoadSuccess(data: StatsData): void;
+  onChangeSlug(prevSlug: string, newSlug: string): void;
+  onCreateSuccess(project: Project): void;
+  onUpdateSuccess(data: Partial<Project>): void;
+  onDeleteTeam(slug: string): void;
+  onRemoveTeam(teamSlug: string, projectSlug: string): void;
+  onAddTeam(team: Team, projectSlug: string): void;
+  removeTeamFromProject(teamSlug: string, project: Project): void;
+  getWithTeam(teamSlug: string): Project[];
+  getAll(): Project[];
+  getBySlugs(slug: string[]): Project[];
+  getState(slugs?: string[]): State;
+  getById(id?: string): Project | undefined;
+  getBySlug(slug?: string): Project | undefined;
 };
 
 const storeConfig: Reflux.StoreDefinition & Internals & ProjectsStoreInterface = {

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -11,12 +11,12 @@ type State = {
 };
 
 type SavedSearchesStoreInterface = {
-  reset: () => void;
-  get: () => State;
-  getFilteredSearches: (type: SavedSearchType, id?: string) => SavedSearch[];
-  updateExistingSearch: (id: string, changes: Partial<SavedSearch>) => SavedSearch;
-  findByQuery: (query: string, sort: string) => SavedSearch | undefined;
-  onPinSearch: (type: SavedSearchType, query: string, sort: string) => void;
+  reset(): void;
+  get(): State;
+  getFilteredSearches(type: SavedSearchType, id?: string): SavedSearch[];
+  updateExistingSearch(id: string, changes: Partial<SavedSearch>): SavedSearch;
+  findByQuery(query: string, sort: string): SavedSearch | undefined;
+  onPinSearch(type: SavedSearchType, query: string, sort: string): void;
 };
 
 const savedSearchesStoreConfig: Reflux.StoreDefinition & SavedSearchesStoreInterface = {

--- a/static/app/stores/selectedGroupStore.tsx
+++ b/static/app/stores/selectedGroupStore.tsx
@@ -3,19 +3,19 @@ import Reflux from 'reflux';
 import GroupStore from 'app/stores/groupStore';
 
 type SelectedGroupStoreInterface = {
-  init: () => void;
-  onGroupChange: (itemIds: string[]) => void;
-  add: (ids: string[]) => void;
-  prune: () => void;
-  allSelected: () => boolean;
-  anySelected: () => boolean;
-  numSelected: () => number;
-  multiSelected: () => boolean;
-  getSelectedIds: () => Set<string>;
-  isSelected: (itemId: string) => boolean;
-  deselectAll: () => void;
-  toggleSelect: (itemId: string) => void;
-  toggleSelectAll: () => void;
+  init(): void;
+  onGroupChange(itemIds: string[]): void;
+  add(ids: string[]): void;
+  prune(): void;
+  allSelected(): boolean;
+  anySelected(): boolean;
+  numSelected(): number;
+  multiSelected(): boolean;
+  getSelectedIds(): Set<string>;
+  isSelected(itemId: string): boolean;
+  deselectAll(): void;
+  toggleSelect(itemId: string): void;
+  toggleSelectAll(): void;
 };
 
 type Internals = {

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -3,7 +3,15 @@ import Reflux from 'reflux';
 import SentryAppComponentsActions from 'app/actions/sentryAppComponentActions';
 import {SentryAppComponent} from 'app/types';
 
-const SentryAppComponentsStore = Reflux.createStore({
+type SentryAppComponentsStoreInterface = {
+  onLoadComponents: (items: SentryAppComponent[]) => void;
+  getComponentByType: (type: string | undefined) => SentryAppComponent[];
+  getAll: () => SentryAppComponent[];
+  getInitialState: () => SentryAppComponent[];
+  get: (uuid: string) => SentryAppComponent | undefined;
+};
+
+const storeConfig: Reflux.StoreDefinition & SentryAppComponentsStoreInterface = {
   init() {
     this.items = [];
     this.listenTo(SentryAppComponentsActions.loadComponents, this.onLoadComponents);
@@ -34,14 +42,9 @@ const SentryAppComponentsStore = Reflux.createStore({
     const items: SentryAppComponent[] = this.items;
     return items.filter(item => item.type === type);
   },
-});
-
-type SentryAppComponentsStoreType = Reflux.Store & {
-  onLoadComponents: (items: SentryAppComponent[]) => void;
-  getComponentByType: (type: string | undefined) => SentryAppComponent[];
-  getAll: () => SentryAppComponent[];
-  getInitialState: () => SentryAppComponent[];
-  get: () => SentryAppComponent | undefined;
 };
 
-export default SentryAppComponentsStore as SentryAppComponentsStoreType;
+const SentryAppComponentsStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  SentryAppComponentsStoreInterface;
+
+export default SentryAppComponentsStore;

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -2,7 +2,12 @@ import Reflux from 'reflux';
 
 import {SentryAppInstallation} from 'app/types';
 
-const SentryAppInstallationStore = Reflux.createStore({
+type SentryAppInstallationStoreInterface = {
+  load(items: SentryAppInstallation[]): void;
+  getInitialState(): SentryAppInstallation[];
+};
+
+const storeConfig: Reflux.StoreDefinition & SentryAppInstallationStoreInterface = {
   init() {
     this.items = [];
   },
@@ -24,11 +29,9 @@ const SentryAppInstallationStore = Reflux.createStore({
   getAll(): SentryAppInstallation[] {
     return this.items;
   },
-});
-
-type SentryAppInstallationStoreType = Reflux.Store & {
-  load: (items: SentryAppInstallation[]) => void;
-  getInitialState: () => SentryAppInstallation[];
 };
 
-export default SentryAppInstallationStore as SentryAppInstallationStoreType;
+const SentryAppInstallationStore = Reflux.createStore(storeConfig) as Reflux.Store &
+  SentryAppInstallationStoreInterface;
+
+export default SentryAppInstallationStore;

--- a/static/app/stores/settingsBreadcrumbStore.tsx
+++ b/static/app/stores/settingsBreadcrumbStore.tsx
@@ -10,11 +10,11 @@ type UpdateData = {
 };
 
 type SettingsBreadcrumbStoreInterface = {
-  init: () => void;
-  reset: () => void;
-  onUpdateRouteMap: (update: UpdateData) => void;
-  onTrimMappings: (routes: PlainRoute<any>[]) => void;
-  getPathMap: () => Internals['pathMap'];
+  init(): void;
+  reset(): void;
+  onUpdateRouteMap(update: UpdateData): void;
+  onTrimMappings(routes: PlainRoute<any>[]): void;
+  getPathMap(): Internals['pathMap'];
 };
 
 type Internals = {

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -51,11 +51,11 @@ const BUILTIN_TAGS = [
 
 type TagStoreInterface = {
   state: TagCollection;
-  getBuiltInTags: () => TagCollection;
-  getIssueAttributes: () => TagCollection;
-  getAllTags: () => TagCollection;
-  reset: () => void;
-  onLoadTagsSuccess: (data: Tag[]) => void;
+  getBuiltInTags(): TagCollection;
+  getIssueAttributes(): TagCollection;
+  getAllTags(): TagCollection;
+  reset(): void;
+  onLoadTagsSuccess(data: Tag[]): void;
 };
 
 const tagStoreConfig: Reflux.StoreDefinition & TagStoreInterface = {

--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -15,15 +15,15 @@ type State = {
 type TeamStoreInterface = {
   initialized: boolean;
   state: State;
-  reset: () => void;
-  loadInitialData: (items: Team[], hasMore?: boolean | null) => void;
-  onUpdateSuccess: (itemId: string, response: Team) => void;
-  onRemoveSuccess: (slug: string) => void;
-  onCreateSuccess: (team: Team) => void;
-  get: () => State;
-  getAll: () => Team[];
-  getById: (id: string) => Team | null;
-  getBySlug: (slug: string) => Team | null;
+  reset(): void;
+  loadInitialData(items: Team[], hasMore?: boolean | null): void;
+  onUpdateSuccess(itemId: string, response: Team): void;
+  onRemoveSuccess(slug: string): void;
+  onCreateSuccess(team: Team): void;
+  get(): State;
+  getAll(): Team[];
+  getById(id: string): Team | null;
+  getBySlug(slug: string): Team | null;
 };
 
 const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {

--- a/static/app/stores/tooltipStore.tsx
+++ b/static/app/stores/tooltipStore.tsx
@@ -1,11 +1,11 @@
 type TooltipStoreInterface = {
-  addTooltip: (tooltip: React.Component) => void;
-  removeTooltip: (tooltip: React.Component) => void;
-  openAllTooltips: () => boolean;
-  closeAllTooltips: () => void;
+  addTooltip(tooltip: React.Component): void;
+  removeTooltip(tooltip: React.Component): void;
+  openAllTooltips(): boolean;
+  closeAllTooltips(): void;
   tooltips: React.Component[];
-  getOpenableSingleTooltips: () => React.Component[];
-  init: () => TooltipStoreInterface;
+  getOpenableSingleTooltips(): React.Component[];
+  init(): TooltipStoreInterface;
 };
 
 const MAX_TOOLTIPS_TO_OPEN = 100;

--- a/static/app/stores/useLegacyStore.tsx
+++ b/static/app/stores/useLegacyStore.tsx
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 
 type LegacyStoreShape = Reflux.Store & {
   // Store must have `get` function that returns the current state
-  get: () => any;
+  get(): any;
 };
 
 /**


### PR DESCRIPTION
- Uses func(): over func: () => void

- Cleans up some stores where the types were defined away from the
  storeConfig object.

- A few other minor typing cleanups