### PR TITLE
feat(symbolicator): Add a backoff timer when projects move in/out of the LPQ

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2387,6 +2387,12 @@ SENTRY_REALTIME_METRICS_OPTIONS = {
     # priority queue. This setting determines how long we keep these duration values
     # around.
     "duration_time_window": 900,
+    # Number of seconds to wait after a project is made eligible or ineligible for the LPQ
+    # before its eligibility can be changed again.
+    #
+    # This backoff is only applied to automatic changes to project eligibility, and has zero effect
+    # on any manually-triggered changes to a project's presence in the LPQ.
+    "backoff_timer": 5 * 60,
 }
 
 # XXX(meredith): Temporary metrics indexer

--- a/src/sentry/processing/realtime_metrics/__init__.py
+++ b/src/sentry/processing/realtime_metrics/__init__.py
@@ -27,5 +27,3 @@ if TYPE_CHECKING:
     is_lpq_project = realtime_metrics_store.is_lpq_project
     add_project_to_lpq = realtime_metrics_store.add_project_to_lpq
     remove_projects_from_lpq = realtime_metrics_store.remove_projects_from_lpq
-    was_recently_moved = realtime_metrics_store.was_recently_moved
-    recently_moved_projects = realtime_metrics_store.recently_moved_projects

--- a/src/sentry/processing/realtime_metrics/__init__.py
+++ b/src/sentry/processing/realtime_metrics/__init__.py
@@ -27,3 +27,5 @@ if TYPE_CHECKING:
     is_lpq_project = realtime_metrics_store.is_lpq_project
     add_project_to_lpq = realtime_metrics_store.add_project_to_lpq
     remove_projects_from_lpq = realtime_metrics_store.remove_projects_from_lpq
+    was_recently_moved = realtime_metrics_store.was_recently_moved
+    recently_moved_projects = realtime_metrics_store.recently_moved_projects

--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -127,13 +127,14 @@ class RealtimeMetricsStore(Service):  # type: ignore
         from the queue while that timer is active.
 
         Returns True if the project was a new addition to the list. Returns False if it was already
-        assigned to the low priority queue.
+        assigned to the low priority queue. This may throw an exception if there is some sort of
+        issue registering the project with the queue.
         """
         raise NotImplementedError
 
     def remove_projects_from_lpq(self, project_ids: Set[int]) -> int:
         """
-        Removes projects from the low priority queue.
+        Unassigns projects from the low priority queue.
 
         This registers an intent to restore all specified projects back to the regular queue.
 
@@ -142,20 +143,21 @@ class RealtimeMetricsStore(Service):  # type: ignore
 
         Returns the number of projects that were actively removed from the queue. Any projects that
         were not assigned to the low priority queue to begin with will be omitted from the return
-        value.
+        value. This may throw an exception if there is some sort of issue deregistering the projects
+        from the queue.
         """
         raise NotImplementedError
 
     def was_recently_moved(self, project_id: int) -> bool:
         """
         Returns whether a project is currently in the middle of its backoff timer from having
-        recently moved in or out of the LPQ.
+        recently been assigned to or unassigned from the LPQ.
         """
         raise NotImplementedError
 
     def recently_moved_projects(self) -> Set[int]:
         """
         Returns a list of projects currently in the middle of their backoff timers from having
-        recently moved in or out of the LPQ.
+        recently been assigned to or unassigned from the LPQ.
         """
         raise NotImplementedError

--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -46,6 +46,8 @@ class RealtimeMetricsStore(Service):  # type: ignore
         "get_lpq_projects",
         "add_project_to_lpq",
         "remove_projects_from_lpq",
+        "was_recently_moved",
+        "recently_moved_projects",
     )
 
     def increment_project_event_counter(self, project_id: int, timestamp: int) -> None:
@@ -121,6 +123,9 @@ class RealtimeMetricsStore(Service):  # type: ignore
         This registers an intent to redirect all symbolication events triggered by the specified
         project to be redirected to the low priority queue.
 
+        Applies a backoff timer to the project which prevents it from being automatically evicted
+        from the queue while that timer is active.
+
         Returns True if the project was a new addition to the list. Returns False if it was already
         assigned to the low priority queue.
         """
@@ -132,8 +137,25 @@ class RealtimeMetricsStore(Service):  # type: ignore
 
         This registers an intent to restore all specified projects back to the regular queue.
 
+        Applies a backoff timer to the project which prevents it from being automatically assigned
+        to the queue while that timer is active.
+
         Returns the number of projects that were actively removed from the queue. Any projects that
         were not assigned to the low priority queue to begin with will be omitted from the return
         value.
+        """
+        raise NotImplementedError
+
+    def was_recently_moved(self, project_id: int) -> bool:
+        """
+        Returns whether a project is currently in the middle of its backoff timer from having
+        recently moved in or out of the LPQ.
+        """
+        raise NotImplementedError
+
+    def recently_moved_projects(self) -> Set[int]:
+        """
+        Returns a list of projects currently in the middle of their backoff timers from having
+        recently moved in or out of the LPQ.
         """
         raise NotImplementedError

--- a/src/sentry/processing/realtime_metrics/base.py
+++ b/src/sentry/processing/realtime_metrics/base.py
@@ -46,8 +46,6 @@ class RealtimeMetricsStore(Service):  # type: ignore
         "get_lpq_projects",
         "add_project_to_lpq",
         "remove_projects_from_lpq",
-        "was_recently_moved",
-        "recently_moved_projects",
     )
 
     def increment_project_event_counter(self, project_id: int, timestamp: int) -> None:
@@ -145,19 +143,5 @@ class RealtimeMetricsStore(Service):  # type: ignore
         were not assigned to the low priority queue to begin with will be omitted from the return
         value. This may throw an exception if there is some sort of issue deregistering the projects
         from the queue.
-        """
-        raise NotImplementedError
-
-    def was_recently_moved(self, project_id: int) -> bool:
-        """
-        Returns whether a project is currently in the middle of its backoff timer from having
-        recently been assigned to or unassigned from the LPQ.
-        """
-        raise NotImplementedError
-
-    def recently_moved_projects(self) -> Set[int]:
-        """
-        Returns a list of projects currently in the middle of their backoff timers from having
-        recently been assigned to or unassigned from the LPQ.
         """
         raise NotImplementedError

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -43,7 +43,7 @@ def _scan_for_suspect_projects() -> None:
     # out they need to be evicted.
     current_lpq_projects = realtime_metrics.get_lpq_projects() or set()
     expired_projects = current_lpq_projects.difference(suspect_projects)
-    if len(expired_projects) == 0:
+    if not expired_projects:
         return
 
     realtime_metrics.remove_projects_from_lpq(expired_projects)

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -33,8 +33,12 @@ def scan_for_suspect_projects() -> None:
 def _scan_for_suspect_projects() -> None:
     suspect_projects = set()
     now = int(time.time())
+    recently_moved_projects = realtime_metrics.recently_moved_projects()
 
     for project_id in realtime_metrics.projects():
+        # currently in the middle of a backoff timer
+        if project_id in recently_moved_projects:
+            continue
         suspect_projects.add(project_id)
         update_lpq_eligibility.delay(project_id=project_id, cutoff=now)
 
@@ -42,13 +46,13 @@ def _scan_for_suspect_projects() -> None:
     # `update_lpq_eligibility` should handle removing suspect projects from the list if it turns
     # out they need to be evicted.
     current_lpq_projects = realtime_metrics.get_lpq_projects() or set()
-    deleted_projects = current_lpq_projects.difference(suspect_projects)
-    if len(deleted_projects) == 0:
+    expired_projects = current_lpq_projects.difference(suspect_projects, recently_moved_projects)
+    if len(expired_projects) == 0:
         return
 
-    realtime_metrics.remove_projects_from_lpq(deleted_projects)
+    realtime_metrics.remove_projects_from_lpq(expired_projects)
 
-    for project_id in deleted_projects:
+    for project_id in expired_projects:
         # TODO: add metrics!
         logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
 
@@ -72,6 +76,9 @@ def update_lpq_eligibility(project_id: int, cutoff: int) -> None:
 
 
 def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
+    if realtime_metrics.was_recently_moved(project_id):
+        return
+
     # TODO: It may be a good idea to figure out how to debounce especially if this is
     # executing more than 10s after cutoff.
     counts = realtime_metrics.get_counts_for_project(project_id, cutoff)

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -92,7 +92,7 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
             logger.warning("Moved project to symbolicator's low priority queue: %s", project_id)
     elif not is_eligible:
         was_removed = realtime_metrics.remove_projects_from_lpq({project_id})
-        if was_removed > 0:
+        if was_removed:
             logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
 
 

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -92,7 +92,7 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
             logger.warning("Moved project to symbolicator's low priority queue: %s", project_id)
     elif not is_eligible:
         was_removed = realtime_metrics.remove_projects_from_lpq({project_id})
-        if was_removed:
+        if was_removed > 0:
             logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
 
 

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -1,8 +1,6 @@
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict
 
 import pytest
-from freezegun import freeze_time
 
 from sentry.processing import realtime_metrics
 from sentry.processing.realtime_metrics.base import (
@@ -696,7 +694,7 @@ def test_get_durations_for_projects_with_gap(
 
 
 def test_was_recently_moved_noop(store: RedisRealtimeMetricsStore) -> None:
-    store.remove_projects_from_lpq([42])
+    store.remove_projects_from_lpq({42})
     assert store.was_recently_moved(42)
 
 
@@ -709,7 +707,7 @@ def test_was_recently_moved_removed(
     store: RedisRealtimeMetricsStore, redis_cluster: redis._RedisCluster
 ) -> None:
     redis_cluster.sadd(LPQ_MEMBERS_KEY, 42)
-    store.remove_projects_from_lpq([42])
+    store.remove_projects_from_lpq({42})
     assert store.was_recently_moved(42)
 
 
@@ -719,7 +717,7 @@ def test_was_recently_moved_removed(
 
 
 def test_recently_moved_projects_noop(store: RedisRealtimeMetricsStore) -> None:
-    store.remove_projects_from_lpq([42])
+    store.remove_projects_from_lpq({42})
     assert store.recently_moved_projects() == {42}
 
 
@@ -732,5 +730,5 @@ def test_recently_moved_projects_removed(
     store: RedisRealtimeMetricsStore, redis_cluster: redis._RedisCluster
 ) -> None:
     redis_cluster.sadd(LPQ_MEMBERS_KEY, 42)
-    store.remove_projects_from_lpq([42])
+    store.remove_projects_from_lpq({42})
     assert store.recently_moved_projects() == {42}

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -66,6 +66,7 @@ def test_invalid_config() -> None:
         "counter_time_window": -1,
         "duration_bucket_size": -10,
         "duration_time_window": 0,
+        "backoff_timer": -100,
     }
     RedisRealtimeMetricsStore(**invalid_config)
 

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -32,6 +32,7 @@ def config() -> Dict[str, Any]:
         "counter_time_window": 0,
         "duration_bucket_size": 10,
         "duration_time_window": 0,
+        "backoff_timer": 1,
     }
 
 

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -116,7 +116,6 @@ class TestScanForSuspectProjects:
             _scan_for_suspect_projects()
 
         assert store.get_lpq_projects() == {17}
-        assert store.was_recently_moved(17)
 
     def test_add_recently_moved_project(self, store) -> None:
         store._backoff_timer = 10
@@ -128,7 +127,6 @@ class TestScanForSuspectProjects:
             _scan_for_suspect_projects()
 
         assert store.get_lpq_projects() == set()
-        assert store.was_recently_moved(17)
 
 
 class UpdateLpqEligibility:

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -107,6 +107,27 @@ class TestScanForSuspectProjects:
 
         assert store.get_lpq_projects() == {17}
 
+    def test_remove_recently_moved_project(self, store) -> None:
+        store.add_project_to_lpq(17)
+        assert store.get_lpq_projects() == {17}
+
+        with TaskRunner():
+            _scan_for_suspect_projects()
+
+        assert store.get_lpq_projects() == {17}
+        assert store.was_recently_moved(17)
+
+    def test_add_recently_moved_project(self, store) -> None:
+        store.increment_project_event_counter(17, 0)
+        store.remove_projects_from_lpq([17])
+        assert store.get_lpq_projects() == set()
+
+        with TaskRunner():
+            _scan_for_suspect_projects()
+
+        assert store.get_lpq_projects() == set()
+        assert store.was_recently_moved(17)
+
 
 class UpdateLpqEligibility:
     @pytest.fixture
@@ -189,6 +210,23 @@ class UpdateLpqEligibility:
     def test_not_eligible_not_lpq(self, store) -> None:
         _update_lpq_eligibility(project_id=17, cutoff=10)
         assert store.get_lpq_projects() == set()
+
+    # TODO: Remove patch and update test once calculation_magic is implemented
+    @freeze_time(datetime.fromtimestamp(0))
+    @mock.patch("sentry.tasks.low_priority_symbolication.calculation_magic", lambda x, y: True)
+    def test_is_eligible_recently_moved(self, store) -> None:
+        # Abusing the fact that removing always updates the backoff timer even if it's a noop
+        store.remove_projects_from_lpq({17})
+
+        _update_lpq_eligibility(17, 10)
+        assert store.get_lpq_projects() == set()
+
+    # TODO: Update once calculation_magic is implemented
+    def test_not_eligible_recently_moved(self, store) -> None:
+        store.add_project_to_lpq(17)
+
+        _update_lpq_eligibility(17, 10)
+        assert store.get_lpq_projects() == {17}
 
 
 class TestCalculationMagic(TestCase):

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -41,6 +41,7 @@ class TestScanForSuspectProjects:
                 "counter_time_window": 0,
                 "duration_bucket_size": 10,
                 "duration_time_window": 0,
+                "backoff_timer": 0,
             },
         )
 

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -108,18 +108,10 @@ class TestScanForSuspectProjects:
 
         assert store.get_lpq_projects() == {17}
 
-    def test_remove_recently_moved_project(self, store) -> None:
-        store.add_project_to_lpq(17)
-        assert store.get_lpq_projects() == {17}
-
-        with TaskRunner():
-            _scan_for_suspect_projects()
-
-        assert store.get_lpq_projects() == {17}
-
     def test_add_recently_moved_project(self, store) -> None:
         store._backoff_timer = 10
         store.increment_project_event_counter(17, 0)
+        # Abusing the fact that removing always updates the backoff timer even if it's a noop
         store.remove_projects_from_lpq([17])
         assert store.get_lpq_projects() == set()
 
@@ -127,6 +119,16 @@ class TestScanForSuspectProjects:
             _scan_for_suspect_projects()
 
         assert store.get_lpq_projects() == set()
+
+    def test_remove_recently_moved_project(self, store) -> None:
+        store._backoff_timer = 10
+        store.add_project_to_lpq(17)
+        assert store.get_lpq_projects() == {17}
+
+        with TaskRunner():
+            _scan_for_suspect_projects()
+
+        assert store.get_lpq_projects() == {17}
 
 
 class UpdateLpqEligibility:

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -119,6 +119,7 @@ class TestScanForSuspectProjects:
         assert store.was_recently_moved(17)
 
     def test_add_recently_moved_project(self, store) -> None:
+        store._backoff_timer = 10
         store.increment_project_event_counter(17, 0)
         store.remove_projects_from_lpq([17])
         assert store.get_lpq_projects() == set()
@@ -142,6 +143,7 @@ class UpdateLpqEligibility:
                 "counter_time_window": 0,
                 "duration_bucket_size": 10,
                 "duration_time_window": 0,
+                "backoff_timer": 0,
             },
         )
 
@@ -216,6 +218,7 @@ class UpdateLpqEligibility:
     @freeze_time(datetime.fromtimestamp(0))
     @mock.patch("sentry.tasks.low_priority_symbolication.calculation_magic", lambda x, y: True)
     def test_is_eligible_recently_moved(self, store) -> None:
+        store._backoff_timer = 10
         # Abusing the fact that removing always updates the backoff timer even if it's a noop
         store.remove_projects_from_lpq({17})
 
@@ -224,6 +227,7 @@ class UpdateLpqEligibility:
 
     # TODO: Update once calculation_magic is implemented
     def test_not_eligible_recently_moved(self, store) -> None:
+        store._backoff_timer = 10
         store.add_project_to_lpq(17)
 
         _update_lpq_eligibility(17, 10)


### PR DESCRIPTION
This adds in a customizable backoff timer to the LPQ. The timer is 5 minutes by default.

The timer is not meant to block all actions related to the LPQ such as metric-gathering after a project has had its eligibility changed recently. This timer is only meant to prevent projects from rapidly leaving and entering the queue in a short period of time.

NATIVE-211