### PR TITLE
feat(alert-rule): Render Alert Rule UI Component in Metric Alerts

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -47,6 +47,7 @@ def build_action_response(
     elif sentry_app_installation:
         action_response["sentryAppName"] = sentry_app_installation.sentry_app.name
         action_response["sentryAppId"] = sentry_app_installation.sentry_app_id
+        action_response["sentryAppInstallationUuid"] = sentry_app_installation.uuid
         action_response["status"] = SentryAppStatus.as_str(
             sentry_app_installation.sentry_app.status
         )

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -3,12 +3,13 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
+import {openModal} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import SelectControl from 'app/components/forms/selectControl';
 import ListItem from 'app/components/list/listItem';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {PanelItem} from 'app/components/panels';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconSettings} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project, SelectValue} from 'app/types';
@@ -26,6 +27,7 @@ import {
   TargetLabel,
   Trigger,
 } from 'app/views/alerts/incidentRules/types';
+import SentryAppRuleModal from 'app/views/alerts/issueRuleEditor/sentryAppRuleModal';
 
 type Props = {
   availableActions: MetricActionTemplate[] | null;
@@ -307,6 +309,33 @@ class ActionsPanel extends PureComponent<Props> {
                           actionIdx
                         )}
                       />
+                    ) : availableAction &&
+                      availableAction.type === 'sentry_app' &&
+                      availableAction.settings ? (
+                      <Button
+                        icon={<IconSettings />}
+                        type="button"
+                        onClick={() => {
+                          openModal(
+                            deps => (
+                              <SentryAppRuleModal
+                                {...deps}
+                                // Using ! for keys that will exist for sentryapps
+                                sentryAppInstallationUuid={
+                                  availableAction.sentryAppInstallationUuid!
+                                }
+                                config={availableAction.settings!}
+                                appName={availableAction.sentryAppName!}
+                                onSubmitSuccess={() => {}}
+                                resetValues={availableAction}
+                              />
+                            ),
+                            {allowClickClose: false}
+                          );
+                        }}
+                      >
+                        {t('Settings')}
+                      </Button>
                     ) : null}
                     <ActionTargetSelector
                       action={action}

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -206,6 +206,30 @@ class ActionsPanel extends PureComponent<Props> {
     onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
   };
 
+  /**
+   * Update the Trigger's Action fields from the SentryAppRuleModal together
+   * only after the user clicks "Save Changes".
+   * @param formData Form data
+   */
+  updateParentFromSentryAppRule = (
+    triggerIndex: number,
+    actionIndex: number,
+    formData: {[key: string]: string}
+  ): void => {
+    const {triggers, onChange} = this.props;
+    const {actions} = triggers[triggerIndex];
+    const newAction = {
+      ...actions[actionIndex],
+      ...formData,
+    };
+
+    onChange(
+      triggerIndex,
+      triggers,
+      replaceAtArrayIndex(actions, actionIndex, newAction)
+    );
+  };
+
   render() {
     const {
       availableActions,
@@ -326,8 +350,14 @@ class ActionsPanel extends PureComponent<Props> {
                                 }
                                 config={availableAction.settings!}
                                 appName={availableAction.sentryAppName!}
-                                onSubmitSuccess={() => {}}
-                                resetValues={availableAction}
+                                onSubmitSuccess={this.updateParentFromSentryAppRule.bind(
+                                  this,
+                                  triggerIndex,
+                                  actionIdx
+                                )}
+                                resetValues={
+                                  triggers[triggerIndex].actions[actionIdx] || {}
+                                }
                               />
                             ),
                             {allowClickClose: false}

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -1,4 +1,5 @@
 import {t} from 'app/locale';
+import {SchemaFormConfig} from 'app/views/organizationIntegrations/sentryAppExternalForm';
 
 export enum AlertRuleThresholdType {
   ABOVE,
@@ -185,6 +186,7 @@ export type MetricActionTemplate = {
    */
   sentryAppId?: number;
 
+  sentryAppInstallationUuid?: string;
   /**
    * For some available actions, we pass in the list of available targets.
    */
@@ -194,6 +196,11 @@ export type MetricActionTemplate = {
    * If this is a `sentry_app` action, this is the Sentry App's status.
    */
   status?: 'unpublished' | 'published' | 'internal';
+
+  /**
+   * Sentry App Alert Rule UI Component settings
+   */
+  settings?: SchemaFormConfig;
 };
 
 /**


### PR DESCRIPTION
## Objective
Initial UI skeleton for Metric Alerts. This PR does not include saving and editing.

## UI
![Metric Alert Rule UI Component - node](https://user-images.githubusercontent.com/10491193/136137855-f2623b3e-61a8-4747-8a7e-d2b00869eab2.png)
![Metric Alert Rule UI Component - modal](https://user-images.githubusercontent.com/10491193/136137861-a0970fec-883a-4e34-a9ba-776e1098e559.png)
