### PR TITLE
fix: Remove clone annotations during function trimming (NATIVE-110)

### DIFF
--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -89,6 +89,15 @@ from sentry.stacktraces.functions import (
         ["main::{lambda()#42}", "main::lambda"],
         ["lambda_7156c3ceaa11256748687ab67e3ef4cd", "lambda"],
         ["<lambda_7156c3ceaa11256748687ab67e3ef4cd>::operator()", "<lambda>::operator()"],
+        ["trigger_crash_a(int*) [clone .constprop.0]", "trigger_crash_a"],
+        [
+            "__gnu_cxx::__verbose_terminate_handler() [clone .cold]",
+            "__gnu_cxx::__verbose_terminate_handler",
+        ],
+        [
+            "std::__1::unique_ptr<X,std::default_delete<X> >::operator->",
+            "std::__1::unique_ptr<T>::operator->",
+        ],
     ],
 )
 def test_trim_native_function_name(input, output):


### PR DESCRIPTION
Previously, it would *use* the clone annotation as the trimmed function name,
which is plain wrong and was confusing customers (and ourselves as well).

This also has a small fix for `operator->` losing its angle bracket under some
circumstances.