### PR TITLE
fix(appconnect): Improve unauthorized handling

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -83,8 +83,6 @@ def _get_appstore_json(
         logger.debug(f"GET {full_url}")
         with sentry_sdk.start_span(op="http", description="AppStoreConnect request"):
             response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT)
-        if response.status_code == HTTPStatus.UNAUTHORIZED:
-            raise UnauthorizedError(full_url, response.status_code, response.text)
         if not response.ok:
             err_info = {
                 "url": full_url,


### PR DESCRIPTION
This is an attempt at improving handling of unauthorized errors:

- It makes the error more specific, making it clear what it is in
  sentry.

- It adds extra information about the request into the captured
  exception instead of piling it into the exception message.

- It should create a new sentry issue per distinct App because the
  application ID is contained within the URL.  This will mean if the
  authentication code actually breaks we will get a flood of these for
  all apps at the same time.

Fixes: SENTRY-SAN