### PR TITLE
ref(models): Split up Models and Managers

### DIFF
--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -73,6 +73,7 @@ from .organization import *  # NOQA
 from .organizationaccessrequest import *  # NOQA
 from .organizationavatar import *  # NOQA
 from .organizationmember import *  # NOQA
+from .organizationmemberteam import *  # NOQA
 from .organizationonboardingtask import *  # NOQA
 from .organizationoption import *  # NOQA
 from .platformexternalissue import *  # NOQA
@@ -86,6 +87,7 @@ from .projectoption import *  # NOQA
 from .projectownership import *  # NOQA
 from .projectplatform import *  # NOQA
 from .projectredirect import *  # NOQA
+from .projectteam import *  # NOQA
 from .promptsactivity import *  # NOQA
 from .pullrequest import *  # NOQA
 from .rawevent import *  # NOQA

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -1,5 +1,5 @@
 from collections import defaultdict, namedtuple
-from typing import TYPE_CHECKING, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Type, Union
 
 from django.db import models
 from django.db.models.signals import pre_save
@@ -137,7 +137,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
         return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
 
     @classmethod
-    def resolve_dict(cls, actor_dict):
+    def resolve_dict(cls, actor_dict: Mapping[int, "Actor"]) -> Mapping[int, Union["Team", "User"]]:
         actors_by_type = defaultdict(list)
         for actor in actor_dict.values():
             actors_by_type[actor.type].append(actor)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from enum import Enum
 from functools import reduce
 from operator import or_
-from typing import List, Mapping, Optional, Sequence, Set, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Mapping, Optional, Sequence, Set, Union
 
 from django.core.cache import cache
 from django.db import models
@@ -35,7 +35,7 @@ from sentry.utils.numbers import base32_decode, base32_encode
 from sentry.utils.strings import strip, truncatechars
 
 if TYPE_CHECKING:
-    from sentry.models import Integration, Organization, Team, User
+    from sentry.models import Integration, Team, User
 
 logger = logging.getLogger(__name__)
 
@@ -288,10 +288,10 @@ class GroupManager(BaseManager):
     def get_groups_by_external_issue(
         self,
         integration: "Integration",
-        organizations: Sequence["Organization"],
-        external_issue_key: str
+        external_issue_key: str,
     ) -> QuerySet:
         from sentry.models import ExternalIssue, GroupLink
+
         return self.filter(
             id__in=GroupLink.objects.filter(
                 linked_id__in=ExternalIssue.objects.filter(

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -292,8 +292,7 @@ class GroupManager(BaseManager):
         external_issue_key: str
     ) -> QuerySet:
         from sentry.models import ExternalIssue, GroupLink
-
-        return Group.objects.filter(
+        return self.filter(
             id__in=GroupLink.objects.filter(
                 linked_id__in=ExternalIssue.objects.filter(
                     key=external_issue_key,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -7,11 +7,11 @@ from datetime import timedelta
 from enum import Enum
 from functools import reduce
 from operator import or_
-from typing import List, Mapping, Optional, Sequence, Set
+from typing import List, Mapping, Optional, Sequence, Set, Union, TYPE_CHECKING
 
 from django.core.cache import cache
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.http import urlencode, urlquote
 from django.utils.translation import ugettext_lazy as _
@@ -33,6 +33,9 @@ from sentry.types.activity import ActivityType
 from sentry.utils.http import absolute_uri
 from sentry.utils.numbers import base32_decode, base32_encode
 from sentry.utils.strings import strip, truncatechars
+
+if TYPE_CHECKING:
+    from sentry.models import Integration, Group, Organization
 
 logger = logging.getLogger(__name__)
 
@@ -282,7 +285,12 @@ class GroupManager(BaseManager):
 
         return Group.objects.filter(id__in=group_ids)
 
-    def get_groups_by_external_issue(self, integration, external_issue_key):
+    def get_groups_by_external_issue(
+        self,
+        integration: "Integration",
+        organizations: Sequence["Organization"],
+        external_issue_key: str
+    ) -> QuerySet:
         from sentry.models import ExternalIssue, GroupLink
 
         return Group.objects.filter(

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -112,7 +112,7 @@ class GroupAssigneeManager(BaseManager):
             assignee_type = "team"
             other_type = "user"
         else:
-            raise AssertionError("Invalid type to assign to: %r" % type(assigned_to))
+            raise AssertionError(f"Invalid type to assign to: {type(assigned_to)}")
 
         now = timezone.now()
         assignee, created = GroupAssignee.objects.get_or_create(

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from django.conf import settings
 from django.db import models
@@ -10,6 +10,9 @@ from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_assigned
 from sentry.types.activity import ActivityType
 from sentry.utils import metrics
+
+if TYPE_CHECKING:
+    from sentry.models import ActorTuple, Group, Team, User
 
 
 def sync_group_assignee_inbound(integration, email, external_issue_key, assign=True):

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -121,14 +121,14 @@ class GroupAssigneeManager(BaseManager):
             raise AssertionError(f"Invalid type to assign to: {type(assigned_to)}")
 
         now = timezone.now()
-        assignee, created = GroupAssignee.objects.get_or_create(
+        assignee, created = self.get_or_create(
             group=group,
             defaults={"project": group.project, assignee_type: assigned_to, "date_added": now},
         )
 
         if not created:
             affected = (
-                GroupAssignee.objects.filter(group=group)
+                self.filter(group=group)
                 .exclude(**{assignee_type: assigned_to})
                 .update(**{assignee_type: assigned_to, other_type: None, "date_added": now})
             )
@@ -163,8 +163,8 @@ class GroupAssigneeManager(BaseManager):
         from sentry import features
         from sentry.models import Activity
 
-        affected = GroupAssignee.objects.filter(group=group)[:1].count()
-        GroupAssignee.objects.filter(group=group).delete()
+        affected = self.filter(group=group)[:1].count()
+        self.filter(group=group).delete()
 
         if affected > 0:
             activity = Activity.objects.create(

--- a/src/sentry/models/organizationmemberteam.py
+++ b/src/sentry/models/organizationmemberteam.py
@@ -1,0 +1,33 @@
+from django.db import models
+
+from sentry.db.models import BaseModel, BoundedAutoField, FlexibleForeignKey, sane_repr
+
+
+class OrganizationMemberTeam(BaseModel):
+    """
+    Identifies relationships between organization members and the teams they are on.
+    """
+
+    __include_in_export__ = True
+
+    id = BoundedAutoField(primary_key=True)
+    team = FlexibleForeignKey("sentry.Team")
+    organizationmember = FlexibleForeignKey("sentry.OrganizationMember")
+    # an inactive membership simply removes the team from the default list
+    # but still allows them to re-join without request
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_organizationmember_teams"
+        unique_together = (("team", "organizationmember"),)
+
+    __repr__ = sane_repr("team_id", "organizationmember_id")
+
+    def get_audit_log_data(self):
+        return {
+            "team_slug": self.team.slug,
+            "member_id": self.organizationmember_id,
+            "email": self.organizationmember.get_email(),
+            "is_active": self.is_active,
+        }

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -40,6 +40,17 @@ ProjectStatus = ObjectStatus
 
 
 class ProjectManager(BaseManager):
+    def get_by_users(self, users: Iterable["User"]) -> Mapping["User", Iterable["Project"]]:
+        """Given a list of users, return a mapping of each user to the projects they are a member of."""
+        project_rows = self.filter(
+            projectteam__team__organizationmemberteam__organizationmember__user__in=users
+        ).values_list("id", "projectteam__team__organizationmemberteam__organizationmember__user")
+
+        projects_by_user_id = defaultdict(set)
+        for project_id, user_id in project_rows:
+            projects_by_user_id[user_id].add(project_id)
+        return projects_by_user_id
+
     def get_for_user_ids(self, user_ids: Sequence[int]) -> QuerySet:
         """Returns the QuerySet of all projects that a set of Users have access to."""
         from sentry.models import ProjectStatus

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -43,7 +43,8 @@ class ProjectManager(BaseManager):
     def get_by_users(self, users: Iterable["User"]) -> Mapping["User", Iterable["Project"]]:
         """Given a list of users, return a mapping of each user to the projects they are a member of."""
         project_rows = self.filter(
-            projectteam__team__organizationmemberteam__organizationmember__user__in=users
+            projectteam__team__organizationmemberteam__is_active=True,
+            projectteam__team__organizationmemberteam__organizationmember__user__in=users,
         ).values_list("id", "projectteam__team__organizationmemberteam__organizationmember__user")
 
         projects_by_user_id = defaultdict(set)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -81,7 +81,7 @@ class ProjectManager(BaseManager):
             try:
                 team = team_list[team_list.index(team)]
             except ValueError:
-                logging.info("User does not have access to team: %s", team.id)
+                logging.info(f"User does not have access to team: {team.id}")
                 return []
 
         base_qs = self.filter(teams=team, status=ProjectStatus.VISIBLE)
@@ -353,7 +353,7 @@ class Project(Model, PendingDeletionMixin):
             return security_token
 
     def get_lock_key(self):
-        return "project_token:%s" % self.id
+        return f"project_token:{self.id}"
 
     def copy_settings_from(self, project_id):
         """

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -1,14 +1,14 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 from uuid import uuid1
 
 import sentry_sdk
 from django.conf import settings
 from django.db import IntegrityError, models, transaction
 from django.db.models import QuerySet
-from django.db.models.signals import post_delete, post_save, pre_delete
+from django.db.models.signals import pre_delete
 from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
@@ -26,7 +26,6 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.utils import slugify_instance
-from sentry.tasks.code_owners import update_code_owners_schema
 from sentry.utils import metrics
 from sentry.utils.colors import get_hashed_color
 from sentry.utils.http import absolute_uri
@@ -34,45 +33,10 @@ from sentry.utils.integrationdocs import integration_doc_exists
 from sentry.utils.retries import TimedRetryPolicy
 
 if TYPE_CHECKING:
-    from sentry.models import Team
+    from sentry.models import User
 
 # TODO(dcramer): pull in enum library
 ProjectStatus = ObjectStatus
-
-
-class ProjectTeamManager(BaseManager):
-    def get_for_teams_with_org_cache(self, teams: Sequence["Team"]) -> Sequence["ProjectTeam"]:
-        project_teams = (
-            self.filter(team__in=teams, project__status=ProjectStatus.VISIBLE)
-            .order_by("project__name", "project__slug")
-            .select_related("project")
-        )
-
-        # TODO(dcramer): we should query in bulk for ones we're missing here
-        orgs = {i.organization_id: i.organization for i in teams}
-
-        for project_team in project_teams:
-            project_team.project.set_cached_field_value(
-                "organization", orgs[project_team.project.organization_id]
-            )
-
-        return project_teams
-
-
-class ProjectTeam(Model):
-    __include_in_export__ = True
-
-    project = FlexibleForeignKey("sentry.Project")
-    team = FlexibleForeignKey("sentry.Team")
-
-    objects = ProjectTeamManager()
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_projectteam"
-        unique_together = (("project", "team"),)
-
-    __repr__ = sane_repr("project_id", "team_id")
 
 
 class ProjectManager(BaseManager):
@@ -119,6 +83,8 @@ class ProjectManager(BaseManager):
 
 
 class Project(Model, PendingDeletionMixin):
+    from sentry.models.projectteam import ProjectTeam
+
     """
     Projects are permission based namespaces which generally
     are the top level entry point for all data.
@@ -347,6 +313,8 @@ class Project(Model, PendingDeletionMixin):
             self.add_team(team)
 
     def add_team(self, team):
+        from sentry.models.projectteam import ProjectTeam
+
         try:
             with transaction.atomic():
                 ProjectTeam.objects.create(project=self, team=team)
@@ -358,6 +326,7 @@ class Project(Model, PendingDeletionMixin):
     def remove_team(self, team):
         from sentry.incidents.models import AlertRule
         from sentry.models import Rule
+        from sentry.models.projectteam import ProjectTeam
 
         ProjectTeam.objects.filter(project=self, team=team).delete()
         AlertRule.objects.fetch_for_project(self).filter(owner_id=team.actor_id).update(owner=None)
@@ -388,7 +357,13 @@ class Project(Model, PendingDeletionMixin):
         Returns True if the settings have successfully been copied over
         Returns False otherwise
         """
-        from sentry.models import EnvironmentProject, ProjectOption, ProjectOwnership, Rule
+        from sentry.models import (
+            EnvironmentProject,
+            ProjectOption,
+            ProjectOwnership,
+            ProjectTeam,
+            Rule,
+        )
 
         model_list = [EnvironmentProject, ProjectOwnership, ProjectTeam, Rule]
 
@@ -437,23 +412,3 @@ class Project(Model, PendingDeletionMixin):
 
 
 pre_delete.connect(delete_pending_deletion_option, sender=Project, weak=False)
-post_save.connect(
-    lambda instance, **kwargs: update_code_owners_schema.apply_async(
-        kwargs={
-            "organization": instance.project.organization,
-            "projects": [instance.project],
-        }
-    ),
-    sender=ProjectTeam,
-    weak=False,
-)
-post_delete.connect(
-    lambda instance, **kwargs: update_code_owners_schema.apply_async(
-        kwargs={
-            "organization": instance.project.organization,
-            "projects": [instance.project],
-        }
-    ),
-    sender=ProjectTeam,
-    weak=False,
-)

--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -1,0 +1,70 @@
+from typing import TYPE_CHECKING, Sequence
+
+from django.db.models.signals import post_delete, post_save
+
+from sentry.constants import ObjectStatus
+from sentry.db.models import BaseManager, FlexibleForeignKey, Model, sane_repr
+from sentry.tasks.code_owners import update_code_owners_schema
+
+if TYPE_CHECKING:
+    from sentry.models import Team
+
+# TODO(dcramer): pull in enum library
+ProjectStatus = ObjectStatus
+
+
+class ProjectTeamManager(BaseManager):
+    def get_for_teams_with_org_cache(self, teams: Sequence["Team"]) -> Sequence["ProjectTeam"]:
+        project_teams = (
+            self.filter(team__in=teams, project__status=ProjectStatus.VISIBLE)
+            .order_by("project__name", "project__slug")
+            .select_related("project")
+        )
+
+        # TODO(dcramer): we should query in bulk for ones we're missing here
+        orgs = {i.organization_id: i.organization for i in teams}
+
+        for project_team in project_teams:
+            project_team.project.set_cached_field_value(
+                "organization", orgs[project_team.project.organization_id]
+            )
+
+        return project_teams
+
+
+class ProjectTeam(Model):
+    __include_in_export__ = True
+
+    project = FlexibleForeignKey("sentry.Project")
+    team = FlexibleForeignKey("sentry.Team")
+
+    objects = ProjectTeamManager()
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_projectteam"
+        unique_together = (("project", "team"),)
+
+    __repr__ = sane_repr("project_id", "team_id")
+
+
+post_save.connect(
+    lambda instance, **kwargs: update_code_owners_schema.apply_async(
+        kwargs={
+            "organization": instance.project.organization,
+            "projects": [instance.project],
+        }
+    ),
+    sender=ProjectTeam,
+    weak=False,
+)
+post_delete.connect(
+    lambda instance, **kwargs: update_code_owners_schema.apply_async(
+        kwargs={
+            "organization": instance.project.organization,
+            "projects": [instance.project],
+        }
+    ),
+    sender=ProjectTeam,
+    weak=False,
+)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -1,6 +1,6 @@
 import warnings
 from collections import defaultdict
-from typing import Sequence, Tuple, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Tuple, Union
 
 from django.conf import settings
 from django.db import IntegrityError, connections, models, router, transaction
@@ -28,8 +28,8 @@ class TeamManager(BaseManager):
         self,
         organization: "Organization",
         user: "User",
-        scope=None,
-        with_projects: bool = False
+        scope: Optional[str] = None,
+        with_projects: bool = False,
     ) -> Union[Sequence["Team"], Sequence[Tuple["Team", Sequence["Project"]]]]:
         """
         Returns a list of all teams a user has some level of access to.

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -1,5 +1,6 @@
 import warnings
 from collections import defaultdict
+from typing import Sequence, Tuple, TYPE_CHECKING, Union
 
 from django.conf import settings
 from django.db import IntegrityError, connections, models, router, transaction
@@ -18,9 +19,18 @@ from sentry.db.models.utils import slugify_instance
 from sentry.tasks.code_owners import update_code_owners_schema
 from sentry.utils.retries import TimedRetryPolicy
 
+if TYPE_CHECKING:
+    from sentry.models import Organization, Project, User
+
 
 class TeamManager(BaseManager):
-    def get_for_user(self, organization, user, scope=None, with_projects=False):
+    def get_for_user(
+        self,
+        organization: "Organization",
+        user: "User",
+        scope=None,
+        with_projects: bool = False
+    ) -> Union[Sequence["Team"], Sequence[Tuple["Team", Sequence["Project"]]]]:
         """
         Returns a list of all teams a user has some level of access to.
         """

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -22,7 +22,7 @@ from sentry.utils.http import absolute_uri
 audit_logger = logging.getLogger("sentry.audit.user")
 
 if TYPE_CHECKING:
-    from sentry.models import Organization
+    from sentry.models import Group, Organization, Team
 
 
 class UserManager(BaseManager, DjangoUserManager):
@@ -41,14 +41,15 @@ class UserManager(BaseManager, DjangoUserManager):
             is_active=True,
         ).distinct()
 
-    def get_from_group(self, group):
+    def get_from_group(self, group: "Group") -> QuerySet:
         """Get a queryset of all users in all teams in a given Group's project."""
         return self.filter(
+            sentry_orgmember_set__organization=group.organization,
             sentry_orgmember_set__teams__in=group.project.teams.all(),
             is_active=True,
         )
 
-    def get_from_teams(self, organization_id, teams):
+    def get_from_teams(self, organization_id: int, teams: Sequence["Team"]) -> QuerySet:
         return self.filter(
             sentry_orgmember_set__organization_id=organization_id,
             sentry_orgmember_set__organizationmemberteam__team__in=teams,

--- a/tests/sentry/manager/test_project_manager.py
+++ b/tests/sentry/manager/test_project_manager.py
@@ -1,0 +1,38 @@
+from sentry.models import Project, User
+from sentry.testutils import TestCase
+
+
+class ProjectManagerTest(TestCase):
+    def test_get_for_user(self):
+        user = User.objects.create(username="foo")
+        org = self.create_organization()
+        team = self.create_team(organization=org, name="Test")
+        project = self.create_project(teams=[team], name="foo")
+        project2 = self.create_project(teams=[team], name="baz")
+
+        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=True)
+        assert result == [project2, project]
+
+        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=False)
+        assert result == []
+
+        self.create_member(organization=org, user=user, teams=[team])
+
+        # check again after creating member
+        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=True)
+        assert result == [project2, project]
+
+        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=False)
+        assert result == [project2, project]
+
+        # test with scope user doesn't have
+        result = Project.objects.get_for_user(
+            team=team, user=user, _skip_team_check=False, scope="project:write"
+        )
+        assert result == []
+
+        # check with scope they do have
+        result = Project.objects.get_for_user(
+            team=team, user=user, _skip_team_check=False, scope="project:read"
+        )
+        assert result == [project2, project]

--- a/tests/sentry/manager/test_project_manager.py
+++ b/tests/sentry/manager/test_project_manager.py
@@ -36,3 +36,29 @@ class ProjectManagerTest(TestCase):
             team=team, user=user, _skip_team_check=False, scope="project:read"
         )
         assert result == [project2, project]
+
+    def test_get_by_users_empty(self):
+        assert Project.objects.get_by_users([]) == {}
+        assert Project.objects.get_by_users([self.user]) == {}
+
+    def test_get_by_users(self):
+        organization = self.create_organization()
+
+        user1 = self.create_user("foo@example.com")
+        user2 = self.create_user("foo2@example.com")
+
+        team1 = self.create_team(organization=organization, name="team_1")
+        self.create_member(user=user1, organization=organization, teams=[team1])
+        team2 = self.create_team(organization=organization, name="team_2")
+        self.create_member(user=user2, organization=organization, teams=[team2])
+
+        project1 = self.create_project(teams=[team1], name="foo")
+        project2 = self.create_project(teams=[team1, team2], name="baz")
+        self.create_project(organization=organization, name="no_teams")
+
+        assert Project.objects.get_by_users({user1}) == {user1.id: {project1.id, project2.id}}
+        assert Project.objects.get_by_users({user2}) == {user2.id: {project2.id}}
+        assert Project.objects.get_by_users({user1, user2}) == {
+            user1.id: {project1.id, project2.id},
+            user2.id: {project2.id},
+        }

--- a/tests/sentry/manager/tests.py
+++ b/tests/sentry/manager/tests.py
@@ -1,4 +1,4 @@
-from sentry.models import Group, Project, Team, User
+from sentry.models import Group, Team, User
 from sentry.testutils import TestCase
 
 
@@ -55,39 +55,3 @@ class TeamManagerTest(TestCase):
         project2 = self.create_project(teams=[team], name="bar")
         result = Team.objects.get_for_user(organization=org, user=user, with_projects=True)
         assert result == [(team, [project2, project])]
-
-
-class ProjectManagerTest(TestCase):
-    def test_simple(self):
-        user = User.objects.create(username="foo")
-        org = self.create_organization()
-        team = self.create_team(organization=org, name="Test")
-        project = self.create_project(teams=[team], name="foo")
-        project2 = self.create_project(teams=[team], name="baz")
-
-        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=True)
-        assert result == [project2, project]
-
-        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=False)
-        assert result == []
-
-        self.create_member(organization=org, user=user, teams=[team])
-
-        # check again after creating member
-        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=True)
-        assert result == [project2, project]
-
-        result = Project.objects.get_for_user(team=team, user=user, _skip_team_check=False)
-        assert result == [project2, project]
-
-        # test with scope user doesn't have
-        result = Project.objects.get_for_user(
-            team=team, user=user, _skip_team_check=False, scope="project:write"
-        )
-        assert result == []
-
-        # check with scope they do have
-        result = Project.objects.get_for_user(
-            team=team, user=user, _skip_team_check=False, scope="project:read"
-        )
-        assert result == [project2, project]


### PR DESCRIPTION
This refactor PR tries to move toward two patterns: "one model per file" and "keep business logic in managers". There should be no functionality changes.
