### PR TITLE
ref(sentry-metrics): Add basic caching layer to indexer

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1377,6 +1377,7 @@ SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefix
 # Metrics product
 SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.mock.MockIndexer"
 SENTRY_METRICS_INDEXER_OPTIONS = {}
+SENTRY_METRICS_INDEXER_CACHE_TTL = 3600 * 24
 
 # Release Health
 SENTRY_RELEASE_HEALTH = "sentry.release_health.sessions.SessionsReleaseHealthBackend"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1377,7 +1377,7 @@ SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefix
 # Metrics product
 SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.mock.MockIndexer"
 SENTRY_METRICS_INDEXER_OPTIONS = {}
-SENTRY_METRICS_INDEXER_CACHE_TTL = 3600 * 24
+SENTRY_METRICS_INDEXER_CACHE_TTL = 3600 * 2
 
 # Release Health
 SENTRY_RELEASE_HEALTH = "sentry.release_health.sessions.SessionsReleaseHealthBackend"

--- a/src/sentry/sentry_metrics/indexer/models.py
+++ b/src/sentry/sentry_metrics/indexer/models.py
@@ -14,9 +14,7 @@ class MetricsKeyIndexer(Model):  # type: ignore
     string = models.CharField(max_length=200)
     date_added = models.DateTimeField(default=timezone.now)
 
-    objects = BaseManager(
-        cache_fields=("pk", "string"), cache_ttl=settings.SENTRY_METRICS_INDEXER_CACHE_TTL
-    )
+    objects = BaseManager(cache_fields=("pk", "string"), cache_ttl=settings.SENTRY_METRICS_INDEXER_CACHE_TTL)  # type: ignore
 
     class Meta:
         db_table = "sentry_metricskeyindexer"

--- a/src/sentry/sentry_metrics/indexer/models.py
+++ b/src/sentry/sentry_metrics/indexer/models.py
@@ -1,9 +1,11 @@
 from typing import Any
 
+from django.conf import settings
 from django.db import connections, models, router
 from django.utils import timezone
 
 from sentry.db.models import Model
+from sentry.db.models.manager.base import BaseManager
 
 
 class MetricsKeyIndexer(Model):  # type: ignore
@@ -11,6 +13,10 @@ class MetricsKeyIndexer(Model):  # type: ignore
 
     string = models.CharField(max_length=200)
     date_added = models.DateTimeField(default=timezone.now)
+
+    objects = BaseManager(
+        cache_fields=("pk", "string"), cache_ttl=settings.SENTRY_METRICS_INDEXER_CACHE_TTL
+    )
 
     class Meta:
         db_table = "sentry_metricskeyindexer"

--- a/src/sentry/sentry_metrics/indexer/postgres.py
+++ b/src/sentry/sentry_metrics/indexer/postgres.py
@@ -62,7 +62,7 @@ class PGStringIndexer(Service):  # type: ignore
         Returns None if the entry cannot be found.
         """
         try:
-            id = MetricsKeyIndexer.objects.get_from_cache(string=string).id
+            id: int = MetricsKeyIndexer.objects.get_from_cache(string=string).id
         except MetricsKeyIndexer.DoesNotExist:
             return None
 
@@ -74,7 +74,7 @@ class PGStringIndexer(Service):  # type: ignore
         Returns None if the entry cannot be found.
         """
         try:
-            string = MetricsKeyIndexer.objects.get_from_cache(pk=id).string
+            string: str = MetricsKeyIndexer.objects.get_from_cache(pk=id).string
         except MetricsKeyIndexer.DoesNotExist:
             return None
 

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -1,5 +1,3 @@
-from django.core.cache import cache
-
 from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
 from sentry.sentry_metrics.indexer.postgres import PGStringIndexer
 from sentry.testutils.cases import TestCase
@@ -9,9 +7,6 @@ class PostgresIndexerTest(TestCase):
     def setUp(self) -> None:
         self.indexer = PGStringIndexer()
 
-    def _get_cache_key(self, instance):
-        return PGStringIndexer()._build_indexer_cache_key(instance)
-
     def test_indexer(self):
         results = PGStringIndexer().bulk_record(strings=["hello", "hey", "hi"])
         assert list(results.values()) == [1, 2, 3]
@@ -20,10 +15,6 @@ class PostgresIndexerTest(TestCase):
         obj = MetricsKeyIndexer.objects.get(string="hello")
         assert PGStringIndexer().resolve("hello") == obj.id
         assert PGStringIndexer().reverse_resolve(obj.id) == obj.string
-
-        # test both relationships (str -> int and int -> str) were cached
-        assert cache.get(self._get_cache_key("hello")) == obj.id
-        assert cache.get(self._get_cache_key(obj.id)) == "hello"
 
         # test record on a string that already exists
         PGStringIndexer().record("hello")

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -1,3 +1,5 @@
+from django.core.cache import cache
+
 from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
 from sentry.sentry_metrics.indexer.postgres import PGStringIndexer
 from sentry.testutils.cases import TestCase
@@ -6,6 +8,9 @@ from sentry.testutils.cases import TestCase
 class PostgresIndexerTest(TestCase):
     def setUp(self) -> None:
         self.indexer = PGStringIndexer()
+
+    def _get_cache_key(self, instance):
+        return PGStringIndexer()._build_indexer_cache_key(instance)
 
     def test_indexer(self):
         results = PGStringIndexer().bulk_record(strings=["hello", "hey", "hi"])
@@ -16,6 +21,14 @@ class PostgresIndexerTest(TestCase):
         assert PGStringIndexer().resolve("hello") == obj.id
         assert PGStringIndexer().reverse_resolve(obj.id) == obj.string
 
+        # test both relationships (str -> int and int -> str) were cached
+        assert cache.get(self._get_cache_key("hello")) == obj.id
+        assert cache.get(self._get_cache_key(obj.id)) == "hello"
+
         # test record on a string that already exists
         PGStringIndexer().record("hello")
         assert PGStringIndexer().resolve("hello") == obj.id
+
+        # test invalid values
+        assert PGStringIndexer().resolve("beep") is None
+        assert PGStringIndexer().reverse_resolve(1234) is None


### PR DESCRIPTION
**context**
More information about what the metrics indexer is used for can be found in https://github.com/getsentry/sentry/pull/28914 (and the PRs linked from that PR). 

**This PR**
This adds a basic caching layer to the indexer. Since we'll want to use the indexer to look up both `string` -> `id` and `id` -> `string`, we'll cache both of those relationships. 

To keep things simpler, this uses the default caching on django models. In the future we will probably have to handle the caching manually