### PR TITLE
build(ci): Fix `check migration` job

### DIFF
--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -28,20 +28,22 @@ jobs:
         # TODO(joshuarli): Add 3.8.12.
         python-version: [3.6.13]
     needs: [should-check]
-    if: needs.should-check.outputs.changed == 'true'
 
     steps:
       - name: Checkout sentry
         uses: actions/checkout@v2
+        if: needs.should-check.outputs.changed == 'true'
 
       - name: Setup sentry env (python ${{ matrix.python-version }})
         uses: ./.github/actions/setup-sentry
+        if: needs.should-check.outputs.changed == 'true'
         id: setup
         with:
           python-version: ${{ matrix.python-version }}
           pip-cache-version: ${{ secrets.PIP_CACHE_VERSION }}
 
       - name: Migration & lockfile checks
+        if: needs.should-check.outputs.changed == 'true'
         env:
           SENTRY_LOG_LEVEL: ERROR
           PGPASSWORD: postgres


### PR DESCRIPTION
Previously we were skipping the job if relevant files were not changed. On GitHub we have to specify the exact job name for the "required" checks. However, when the job has a matrix, it will append the matrix value to the job name. And if you skip a job, the matrix application is skipped, so it will never add the matrix value to the job name. Thus, we could not make this job required as it would never satisfy the checks if the job were skipped.

As a hack, we have to skip each individual step in the job.