### PR TITLE
fix(snql): Array join is not an aggregate

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2627,9 +2627,7 @@ class QueryFields(QueryBase):
                 SnQLFunction(
                     "array_join",
                     required_args=[StringArrayColumn("column")],
-                    snql_aggregate=lambda args, alias: Function(
-                        "arrayJoin", [args["column"]], alias
-                    ),
+                    snql_column=lambda args, alias: Function("arrayJoin", [args["column"]], alias),
                     default_result_type="string",
                     private=True,
                 ),

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -333,6 +333,23 @@ class QueryBuilderTest(TestCase):
             ],
         )
 
+    def test_array_join(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "",
+            selected_columns=["array_join(measurements_key)", "count()"],
+            functions_acl=["array_join"],
+        )
+        array_join_column = Function(
+            "arrayJoin",
+            [Column("measurements.key")],
+            "array_join_measurements_key",
+        )
+        self.assertCountEqual(query.columns, [array_join_column, Function("count", [], "count")])
+        # make sure the the array join columns are present in gropuby
+        self.assertCountEqual(query.groupby, [array_join_column])
+
     def test_retention(self):
         with self.options({"system.event-retention-days": 10}):
             with self.assertRaises(QueryOutsideRetentionError):


### PR DESCRIPTION
The arrayJoin function does not produce an aggregate result and should be added
to the group by when there is an aggregate present.