### PR TITLE
fix(snql): Orderby duplicate column should work

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2727,7 +2727,7 @@ class QueryFields(QueryBase):
             for selected_column in self.columns:
                 if isinstance(selected_column, Column) and selected_column == resolved_orderby:
                     validated.append(OrderBy(selected_column, direction))
-                    continue
+                    break
 
                 elif (
                     isinstance(selected_column, AliasedExpression)
@@ -2736,13 +2736,13 @@ class QueryFields(QueryBase):
                     # We cannot directly order by an `AliasedExpression`.
                     # Instead, we order by the column inside.
                     validated.append(OrderBy(selected_column.exp, direction))
-                    continue
+                    break
 
                 elif (
                     isinstance(selected_column, Function) and selected_column.alias == bare_orderby
                 ):
                     validated.append(OrderBy(selected_column, direction))
-                    continue
+                    break
 
         if len(validated) == len(orderby_columns):
             return validated

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -85,6 +85,18 @@ class QueryBuilderTest(TestCase):
         )
         query.get_snql_query().validate()
 
+    def test_orderby_duplicate_columns(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            selected_columns=["user.email", "user.email"],
+            orderby=["user.email"],
+        )
+        self.assertCountEqual(
+            query.orderby,
+            [OrderBy(Column("email"), Direction.ASC)],
+        )
+
     def test_simple_limitby(self):
         query = QueryBuilder(
             dataset=Dataset.Discover,


### PR DESCRIPTION
When the column to orderby is present more than once in the select, it should
not error.