### PR TITLE
ref(Slack): Allow users to enter a channel ID for alert rules on the front end

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -28,6 +28,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
         ]:
             return int(action.target_identifier)
 
+        # if an input_channel_id is provided, we flip these to display properly
         return (
             action.target_display if action.target_display is not None else action.target_identifier
         )
@@ -45,6 +46,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
                 AlertRuleTriggerAction.TargetType(obj.target_type)
             ],
             "targetIdentifier": self.get_identifier_from_action(obj),
+            "inputChannelId": obj.target_identifier,
             "integrationId": obj.integration_id,
             "sentryAppId": obj.sentry_app_id,
             "dateCreated": obj.date_added,

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -146,9 +146,6 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
 
 
 class SlackNotifyServiceAction(IntegrationEventAction):  # type: ignore
-
-    from django.utils.safestring import mark_safe
-
     form_cls = SlackNotifyServiceForm
     label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
     prompt = "Send a Slack notification"

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -31,7 +31,7 @@ logger = logging.getLogger("sentry.rules")
 class SlackNotifyServiceForm(forms.Form):  # type: ignore
     workspace = forms.ChoiceField(choices=(), widget=forms.Select())
     channel = forms.CharField(widget=forms.TextInput())
-    channel_id = forms.HiddenInput()
+    channel_id = forms.CharField(required=False, widget=forms.TextInput())
     tags = forms.CharField(required=False, widget=forms.TextInput())
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -146,8 +146,11 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
 
 
 class SlackNotifyServiceAction(IntegrationEventAction):  # type: ignore
+
+    from django.utils.safestring import mark_safe
+
     form_cls = SlackNotifyServiceForm
-    label = "Send a notification to the {workspace} Slack workspace to {channel} and show tags {tags} in notification"
+    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
     prompt = "Send a Slack notification"
     provider = "slack"
     integration_key = "workspace"
@@ -160,6 +163,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):  # type: ignore
                 "choices": [(i.id, i.name) for i in self.get_integrations()],
             },
             "channel": {"type": "string", "placeholder": "i.e #critical"},
+            "channel_id": {"type": "string", "placeholder": "i.e. CA2FRA079 or UA1J9RTE1"},
             "tags": {"type": "string", "placeholder": "i.e environment,user,my_tag"},
         }
 
@@ -209,6 +213,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):  # type: ignore
         return self.label.format(
             workspace=self.get_integration_name(),
             channel=self.get_option("channel"),
+            channel_id=self.get_option("channel_id"),
             tags="[{}]".format(", ".join(tags)),
         )
 

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
@@ -1,20 +1,10 @@
 import {t} from 'app/locale';
-import {Organization, Project} from 'app/types';
-import {
-  Action,
-  ActionType,
-  MetricActionTemplate,
-  TargetType,
-} from 'app/views/alerts/incidentRules/types';
+import {Action, ActionType, TargetType} from 'app/views/alerts/incidentRules/types';
 import Input from 'app/views/settings/components/forms/controls/input';
 
 type Props = {
   action: Action;
-  availableAction?: MetricActionTemplate;
   disabled: boolean;
-  loading: boolean;
-  organization: Organization;
-  project?: Project;
   onChange: (value: string) => void;
 };
 

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
@@ -1,6 +1,4 @@
-import * as React from 'react';
-import {Fragment} from 'react';
-
+import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {
   Action,
@@ -20,9 +18,7 @@ type Props = {
   onChange: (value: string) => void;
 };
 
-export default function ActionSpecificTargetSelector(props: Props) {
-  const {action, disabled, onChange} = props;
-
+function ActionSpecificTargetSelector({action, disabled, onChange}: Props) {
   const handleChangeSpecificTargetIdentifier = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -30,7 +26,7 @@ export default function ActionSpecificTargetSelector(props: Props) {
   };
 
   if (action.targetType !== TargetType.SPECIFIC || action.type !== ActionType.SLACK) {
-    return <Fragment />;
+    return null;
   }
   return (
     <Input
@@ -40,7 +36,9 @@ export default function ActionSpecificTargetSelector(props: Props) {
       key="inputChannelId"
       value={action.inputChannelId || ''}
       onChange={handleChangeSpecificTargetIdentifier}
-      placeholder="optional: channel ID or user ID"
+      placeholder={t('optional: channel ID or user ID')}
     />
   );
 }
+
+export default ActionSpecificTargetSelector;

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import {Fragment} from 'react';
+
+import SelectControl from 'app/components/forms/selectControl';
+import TeamSelector from 'app/components/forms/teamSelector';
+import SelectMembers from 'app/components/selectMembers';
+import {Organization, Project, SelectValue} from 'app/types';
+import {
+  Action,
+  ActionType,
+  MetricActionTemplate,
+  TargetType,
+} from 'app/views/alerts/incidentRules/types';
+import Input from 'app/views/settings/components/forms/controls/input';
+
+type Props = {
+  action: Action;
+  availableAction?: MetricActionTemplate;
+  disabled: boolean;
+  loading: boolean;
+  organization: Organization;
+  project?: Project;
+  onChange: (value: string) => void;
+};
+
+export default function ActionSpecificTargetSelector(props: Props) {
+  const {action, availableAction, disabled, loading, onChange, organization, project} =
+    props;
+
+  const handleChangeTargetIdentifier = (value: SelectValue<string>) => {
+    onChange(value.value);
+  };
+
+  const handleChangeSpecificTargetIdentifier = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    onChange(e.target.value);
+  };
+
+  switch (action.targetType) {
+    case TargetType.TEAM:
+    case TargetType.USER:
+      const isTeam = action.targetType === TargetType.TEAM;
+
+      return isTeam ? (
+        <TeamSelector
+          disabled={disabled}
+          key="team"
+          project={project}
+          value={action.targetIdentifier}
+          onChange={handleChangeTargetIdentifier}
+          useId
+        />
+      ) : (
+        <SelectMembers
+          disabled={disabled}
+          key="member"
+          project={project}
+          organization={organization}
+          value={action.targetIdentifier}
+          onChange={handleChangeTargetIdentifier}
+        />
+      );
+
+    case TargetType.SPECIFIC:
+      return availableAction?.options ? (
+        <SelectControl
+          isDisabled={disabled || loading}
+          value={action.targetIdentifier}
+          options={availableAction.options}
+          onChange={handleChangeTargetIdentifier}
+        />
+      ) : action.type === ActionType.SLACK ? (
+        <Fragment>
+          <Input
+            type="text"
+            autoComplete="off"
+            disabled={disabled}
+            key="inputChannelId"
+            value={action.inputChannelId || ''}
+            onChange={handleChangeSpecificTargetIdentifier}
+            placeholder="optional: channel ID or user ID"
+          />
+        </Fragment>
+      ) : (
+        <Fragment />
+      );
+
+    default:
+      return null;
+  }
+}

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import {Fragment} from 'react';
 
-import SelectControl from 'app/components/forms/selectControl';
-import TeamSelector from 'app/components/forms/teamSelector';
-import SelectMembers from 'app/components/selectMembers';
-import {Organization, Project, SelectValue} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {
   Action,
   ActionType,
@@ -24,12 +21,7 @@ type Props = {
 };
 
 export default function ActionSpecificTargetSelector(props: Props) {
-  const {action, availableAction, disabled, loading, onChange, organization, project} =
-    props;
-
-  const handleChangeTargetIdentifier = (value: SelectValue<string>) => {
-    onChange(value.value);
-  };
+  const {action, disabled, onChange} = props;
 
   const handleChangeSpecificTargetIdentifier = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -37,56 +29,18 @@ export default function ActionSpecificTargetSelector(props: Props) {
     onChange(e.target.value);
   };
 
-  switch (action.targetType) {
-    case TargetType.TEAM:
-    case TargetType.USER:
-      const isTeam = action.targetType === TargetType.TEAM;
-
-      return isTeam ? (
-        <TeamSelector
-          disabled={disabled}
-          key="team"
-          project={project}
-          value={action.targetIdentifier}
-          onChange={handleChangeTargetIdentifier}
-          useId
-        />
-      ) : (
-        <SelectMembers
-          disabled={disabled}
-          key="member"
-          project={project}
-          organization={organization}
-          value={action.targetIdentifier}
-          onChange={handleChangeTargetIdentifier}
-        />
-      );
-
-    case TargetType.SPECIFIC:
-      return availableAction?.options ? (
-        <SelectControl
-          isDisabled={disabled || loading}
-          value={action.targetIdentifier}
-          options={availableAction.options}
-          onChange={handleChangeTargetIdentifier}
-        />
-      ) : action.type === ActionType.SLACK ? (
-        <Fragment>
-          <Input
-            type="text"
-            autoComplete="off"
-            disabled={disabled}
-            key="inputChannelId"
-            value={action.inputChannelId || ''}
-            onChange={handleChangeSpecificTargetIdentifier}
-            placeholder="optional: channel ID or user ID"
-          />
-        </Fragment>
-      ) : (
-        <Fragment />
-      );
-
-    default:
-      return null;
+  if (action.targetType !== TargetType.SPECIFIC || action.type !== ActionType.SLACK) {
+    return <Fragment />;
   }
+  return (
+    <Input
+      type="text"
+      autoComplete="off"
+      disabled={disabled}
+      key="inputChannelId"
+      value={action.inputChannelId || ''}
+      onChange={handleChangeSpecificTargetIdentifier}
+      placeholder="optional: channel ID or user ID"
+    />
+  );
 }

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -119,7 +119,12 @@ const getFullActionTitle = ({
  * Lists saved actions as well as control to add a new action
  */
 class ActionsPanel extends PureComponent<Props> {
-  handleChangeKey(triggerIndex: number, index: number, key: string, value: string) {
+  handleChangeKey(
+    triggerIndex: number,
+    index: number,
+    key: 'targetIdentifier' | 'inputChannelId',
+    value: string
+  ) {
     const {triggers, onChange} = this.props;
     const {actions} = triggers[triggerIndex];
     const newAction = {

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -331,17 +331,13 @@ class ActionsPanel extends PureComponent<Props> {
                     />
                     <ActionSpecificTargetSelector
                       action={action}
-                      availableAction={availableAction}
                       disabled={disabled}
-                      loading={loading}
                       onChange={this.handleChangeKey.bind(
                         this,
                         triggerIndex,
                         actionIdx,
                         'inputChannelId'
                       )}
-                      organization={organization}
-                      project={project}
                     />
                   </PanelItemSelects>
                   <DeleteActionButton

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -60,6 +60,7 @@ const getCleanAction = (actionConfig, dateCreated?: string): Action => {
         ? actionConfig.allowedTargetTypes[0]
         : null,
     targetIdentifier: actionConfig.sentryAppId || '',
+    inputChannelId: null,
     integrationId: actionConfig.integrationId,
     sentryAppId: actionConfig.sentryAppId,
     options: actionConfig.options || null,

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -16,6 +16,7 @@ import {uniqueId} from 'app/utils/guid';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
 import withOrganization from 'app/utils/withOrganization';
+import ActionSpecificTargetSelector from 'app/views/alerts/incidentRules/triggers/actionsPanel/actionSpecificTargetSelector';
 import ActionTargetSelector from 'app/views/alerts/incidentRules/triggers/actionsPanel/actionTargetSelector';
 import DeleteActionButton from 'app/views/alerts/incidentRules/triggers/actionsPanel/deleteActionButton';
 import {
@@ -123,6 +124,21 @@ class ActionsPanel extends PureComponent<Props> {
     const newAction = {
       ...actions[index],
       targetIdentifier: value,
+    };
+
+    onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
+  }
+
+  handleChangeSpecificTargetIdentifier(
+    triggerIndex: number,
+    index: number,
+    value: string
+  ) {
+    const {triggers, onChange} = this.props;
+    const {actions} = triggers[triggerIndex];
+    const newAction = {
+      ...actions[index],
+      inputChannelId: value,
     };
 
     onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
@@ -314,6 +330,19 @@ class ActionsPanel extends PureComponent<Props> {
                       disabled={disabled}
                       loading={loading}
                       onChange={this.handleChangeTargetIdentifier.bind(
+                        this,
+                        triggerIndex,
+                        actionIdx
+                      )}
+                      organization={organization}
+                      project={project}
+                    />
+                    <ActionSpecificTargetSelector
+                      action={action}
+                      availableAction={availableAction}
+                      disabled={disabled}
+                      loading={loading}
+                      onChange={this.handleChangeSpecificTargetIdentifier.bind(
                         this,
                         triggerIndex,
                         actionIdx

--- a/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/actionsPanel/index.tsx
@@ -119,27 +119,12 @@ const getFullActionTitle = ({
  * Lists saved actions as well as control to add a new action
  */
 class ActionsPanel extends PureComponent<Props> {
-  handleChangeTargetIdentifier(triggerIndex: number, index: number, value: string) {
+  handleChangeKey(triggerIndex: number, index: number, key: string, value: string) {
     const {triggers, onChange} = this.props;
     const {actions} = triggers[triggerIndex];
     const newAction = {
       ...actions[index],
-      targetIdentifier: value,
-    };
-
-    onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
-  }
-
-  handleChangeSpecificTargetIdentifier(
-    triggerIndex: number,
-    index: number,
-    value: string
-  ) {
-    const {triggers, onChange} = this.props;
-    const {actions} = triggers[triggerIndex];
-    const newAction = {
-      ...actions[index],
-      inputChannelId: value,
+      [key]: value,
     };
 
     onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
@@ -330,10 +315,11 @@ class ActionsPanel extends PureComponent<Props> {
                       availableAction={availableAction}
                       disabled={disabled}
                       loading={loading}
-                      onChange={this.handleChangeTargetIdentifier.bind(
+                      onChange={this.handleChangeKey.bind(
                         this,
                         triggerIndex,
-                        actionIdx
+                        actionIdx,
+                        'targetIdentifier'
                       )}
                       organization={organization}
                       project={project}
@@ -343,10 +329,11 @@ class ActionsPanel extends PureComponent<Props> {
                       availableAction={availableAction}
                       disabled={disabled}
                       loading={loading}
-                      onChange={this.handleChangeSpecificTargetIdentifier.bind(
+                      onChange={this.handleChangeKey.bind(
                         this,
                         triggerIndex,
-                        actionIdx
+                        actionIdx,
+                        'inputChannelId'
                       )}
                       organization={organization}
                       project={project}

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -239,7 +239,7 @@ type UnsavedAction = {
    */
   targetIdentifier: string | null;
   /**
-   * An optional Slack channel or user ID the user can input to avoid rate limiting issues.
+   * An optional Slack channel or user id the user can input to avoid rate limiting issues.
    */
   inputChannelId: string | null;
   /**

--- a/static/app/views/alerts/incidentRules/types.tsx
+++ b/static/app/views/alerts/incidentRules/types.tsx
@@ -238,7 +238,10 @@ type UnsavedAction = {
    * user_id, team_id, SentryApp id, etc
    */
   targetIdentifier: string | null;
-
+  /**
+   * An optional Slack channel or user ID the user can input to avoid rate limiting issues.
+   */
+  inputChannelId: string | null;
   /**
    * The id of the integration, can be null (e.g. email) or undefined (server errors when posting w/ null value)
    */

--- a/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
+++ b/static/app/views/alerts/issueRuleEditor/ruleNode.tsx
@@ -276,6 +276,22 @@ class RuleNode extends React.Component<Props> {
         </MarginlessAlert>
       );
     }
+    if (data.id === 'sentry.integrations.slack.notify_action.SlackNotifyServiceAction') {
+      return (
+        <MarginlessAlert type="warning">
+          {tct(
+            'Having rate limiting problems? Enter a channel or user ID. Read more [rateLimiting].',
+            {
+              rateLimiting: (
+                <ExternalLink href="https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error">
+                  {t('here')}
+                </ExternalLink>
+              ),
+            }
+          )}
+        </MarginlessAlert>
+      );
+    }
     /**
      * Would prefer to check if data is of `IssueAlertRuleAction` type, however we can't do typechecking at runtime as
      * user defined types are erased through transpilation.

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -312,6 +312,7 @@ class CreateProjectRuleTest(APITestCase):
                     "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
                     "workspace": str(integration.id),
                     "channel": "#team-team-team",
+                    "channel_id": "",
                     "tags": "",
                 }
             ],

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -50,25 +50,35 @@ class SlackNotifyActionTest(RuleTestCase):
 
     def test_render_label(self):
         rule = self.get_rule(
-            data={"workspace": self.integration.id, "channel": "#my-channel", "tags": "one, two"}
+            data={
+                "workspace": self.integration.id,
+                "channel": "#my-channel",
+                "channel_id": "",
+                "tags": "one, two",
+            }
         )
 
         assert (
             rule.render_label()
-            == "Send a notification to the Awesome Team Slack workspace to #my-channel and show tags [one, two] in notification"
+            == "Send a notification to the Awesome Team Slack workspace to #my-channel (optionally, an ID: ) and show tags [one, two] in notification"
         )
 
     def test_render_label_without_integration(self):
         self.integration.delete()
 
         rule = self.get_rule(
-            data={"workspace": self.integration.id, "channel": "#my-channel", "tags": ""}
+            data={
+                "workspace": self.integration.id,
+                "channel": "#my-channel",
+                "channel_id": "",
+                "tags": "",
+            }
         )
 
         label = rule.render_label()
         assert (
             label
-            == "Send a notification to the [removed] Slack workspace to #my-channel and show tags [] in notification"
+            == "Send a notification to the [removed] Slack workspace to #my-channel (optionally, an ID: ) and show tags [] in notification"
         )
 
     @responses.activate


### PR DESCRIPTION
This is essentially the UI version of the API approach implemented here: https://github.com/getsentry/sentry/pull/24314 which allows a user to enter in their Slack channel ID in the event that they have too many channels and cannot save a rule due to them being rate limited. If they provide the channel ID, it will bypass the Slack channel lookup (it validates the entered name and ID are correct). 