### PR TITLE
fix(ui): tidying up issue details actions

### DIFF
--- a/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -81,9 +81,14 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
         onConfirm={onDelete}
         disabled={disabled}
       >
-        <MenuItemActionLink title="">{t('Delete issue')}</MenuItemActionLink>
+        <MenuItemActionLink title={t('Delete issue')}>
+          {t('Delete issue')}
+        </MenuItemActionLink>
       </Confirm>
-      <MenuItemActionLink title="" onAction={openDiscardModal}>
+      <MenuItemActionLink
+        title={t('Delete and discard future events')}
+        onAction={openDiscardModal}
+      >
         {t('Delete and discard future events')}
       </MenuItemActionLink>
     </Fragment>

--- a/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/static/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -1,17 +1,11 @@
 import {Fragment} from 'react';
-import styled from '@emotion/styled';
 
 import {ModalRenderProps, openModal} from 'app/actionCreators/modal';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
-import ActionButton from 'app/components/actions/button';
-import MenuHeader from 'app/components/actions/menuHeader';
 import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import Button from 'app/components/button';
-import ButtonBar from 'app/components/buttonBar';
 import Confirm from 'app/components/confirm';
-import DropdownLink from 'app/components/dropdownLink';
-import {IconChevron, IconDelete} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -79,7 +73,7 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
   }
 
   return (
-    <ButtonBar merged>
+    <Fragment>
       <Confirm
         message={t(
           'Deleting this issue is permanent. Are you sure you wish to continue?'
@@ -87,42 +81,13 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
         onConfirm={onDelete}
         disabled={disabled}
       >
-        <DeleteButton
-          disabled={disabled}
-          label={t('Delete issue')}
-          icon={<IconDelete size="xs" />}
-        />
+        <MenuItemActionLink title="">{t('Delete issue')}</MenuItemActionLink>
       </Confirm>
-      <DropdownLink
-        caret={false}
-        disabled={disabled}
-        customTitle={
-          <ActionButton
-            disabled={disabled}
-            label={t('More delete options')}
-            icon={<IconChevron direction="down" size="xs" />}
-          />
-        }
-      >
-        <MenuHeader>{t('Delete & Discard')}</MenuHeader>
-        <MenuItemActionLink title="" onAction={openDiscardModal}>
-          {t('Delete and discard future events')}
-        </MenuItemActionLink>
-      </DropdownLink>
-    </ButtonBar>
+      <MenuItemActionLink title="" onAction={openDiscardModal}>
+        {t('Delete and discard future events')}
+      </MenuItemActionLink>
+    </Fragment>
   );
 }
-
-const DeleteButton = styled(ActionButton)`
-  ${p =>
-    !p.disabled &&
-    `
-  &:hover {
-    background-color: ${p.theme.button.danger.background};
-    color: ${p.theme.button.danger.color};
-    border-color: ${p.theme.button.danger.border};
-  }
-  `}
-`;
 
 export default DeleteAction;

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -16,8 +16,9 @@ import ActionButton from 'app/components/actions/button';
 import IgnoreActions from 'app/components/actions/ignore';
 import ResolveActions from 'app/components/actions/resolve';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
+import DropdownLink from 'app/components/dropdownLink';
 import Tooltip from 'app/components/tooltip';
-import {IconStar} from 'app/icons';
+import {IconEllipsis, IconStar} from 'app/icons';
 import {IconRefresh} from 'app/icons/iconRefresh';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -260,13 +261,6 @@ class Actions extends React.Component<Props, State> {
         >
           <ReviewAction onUpdate={this.onUpdate} disabled={!group.inbox || disabled} />
         </Tooltip>
-        <DeleteAction
-          disabled={disabled}
-          organization={organization}
-          project={project}
-          onDelete={this.onDelete}
-          onDiscard={this.onDiscard}
-        />
         {orgFeatures.has('shared-issues') && (
           <ShareIssue
             disabled={disabled}
@@ -310,6 +304,22 @@ class Actions extends React.Component<Props, State> {
           group={group}
           onClick={this.handleClick(disabled, this.onToggleSubscribe)}
         />
+
+        <DropdownLink
+          anchorRight
+          caret={false}
+          title={
+            <ActionButton aria-label={t('Show more')} icon={<IconEllipsis size="xs" />} />
+          }
+        >
+          <DeleteAction
+            disabled={disabled}
+            organization={organization}
+            project={project}
+            onDelete={this.onDelete}
+            onDiscard={this.onDiscard}
+          />
+        </DropdownLink>
 
         {displayReprocessEventAction(organization.features, event) && (
           <ReprocessAction

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -14,12 +14,12 @@ import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import ActionButton from 'app/components/actions/button';
 import IgnoreActions from 'app/components/actions/ignore';
+import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import ResolveActions from 'app/components/actions/resolve';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import DropdownLink from 'app/components/dropdownLink';
 import Tooltip from 'app/components/tooltip';
 import {IconEllipsis, IconStar} from 'app/icons';
-import {IconRefresh} from 'app/icons/iconRefresh';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -319,23 +319,20 @@ class Actions extends React.Component<Props, State> {
             onDelete={this.onDelete}
             onDiscard={this.onDiscard}
           />
-        </DropdownLink>
 
-        {displayReprocessEventAction(organization.features, event) && (
-          <ReprocessAction
-            disabled={disabled}
-            icon={<IconRefresh size="xs" />}
-            title={t('Reprocess this issue')}
-            label={t('Reprocess this issue')}
-            onClick={this.handleClick(disabled, this.onReprocessEvent)}
-          />
-        )}
+          {displayReprocessEventAction(organization.features, event) && (
+            <MenuItemActionLink
+              title={t('Reprocess events')}
+              onAction={this.handleClick(disabled, this.onReprocessEvent)}
+            >
+              {t('Reprocess events')}
+            </MenuItemActionLink>
+          )}
+        </DropdownLink>
       </Wrapper>
     );
   }
 }
-
-const ReprocessAction = styled(ActionButton)``;
 
 const BookmarkButton = styled(ActionButton)<{isActive: boolean}>`
   ${p =>

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -323,7 +323,7 @@ class Actions extends React.Component<Props, State> {
           {displayReprocessEventAction(organization.features, event) && (
             <MenuItemActionLink
               title={t('Reprocess events')}
-              onAction={this.handleClick(disabled, this.onReprocessEvent)}
+              onAction={() => this.handleClick(disabled, this.onReprocessEvent)}
             >
               {t('Reprocess events')}
             </MenuItemActionLink>

--- a/tests/js/spec/views/organizationGroupDetails/actions.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/actions.spec.tsx
@@ -106,7 +106,7 @@ describe('GroupActions', function () {
     it('renders ReprocessAction component if org has feature flag reprocessing-v2', function () {
       const wrapper = renderComponent();
 
-      const reprocessActionButton = wrapper.find('ReprocessAction');
+      const reprocessActionButton = wrapper.find('a[aria-label="Reprocess events"]');
       expect(reprocessActionButton).toBeTruthy();
     });
 
@@ -120,7 +120,7 @@ describe('GroupActions', function () {
 
       const wrapper = renderComponent(event);
 
-      const reprocessActionButton = wrapper.find('ReprocessAction');
+      const reprocessActionButton = wrapper.find('a[aria-label="Reprocess events"]');
       expect(reprocessActionButton).toBeTruthy();
 
       reprocessActionButton.simulate('click');


### PR DESCRIPTION
The number of actions in the Issue Details header is overwhelming so this is the first step in prioritizing the most important actions over others. 

Here I’m moving `Delete`, `Discard Future Events`, and `Reprocess Events` into a `...` button — other actions will be moved into it in the future. 

### Before

![CleanShot 2021-10-06 at 15 50 52](https://user-images.githubusercontent.com/1900676/136294946-eccf952e-35a9-409f-97c4-17a80227c56a.png)
 

### After
![CleanShot 2021-10-06 at 15 50 29](https://user-images.githubusercontent.com/1900676/136294955-9c062e19-6eb7-4a37-a171-c7c2c99c4a6a.png)

