### PR TITLE
fix(workflow): Adjust insights padding, wrap controls on mobile

### DIFF
--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -278,10 +278,13 @@ const StyledLayoutTitle = styled(Layout.Title)`
 
 const ControlsWrapper = styled('div')`
   display: grid;
-  grid-template-columns: 0.5fr 1fr;
   align-items: center;
   gap: ${space(1)};
   margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: 246px 1fr;
+  }
 `;
 
 const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`

--- a/static/app/views/teamInsights/teamStability.tsx
+++ b/static/app/views/teamInsights/teamStability.tsx
@@ -204,6 +204,10 @@ const StyledPanelTable = styled(PanelTable)`
   white-space: nowrap;
   margin-bottom: 0;
   border: 0;
+
+  & > div {
+    padding: ${space(1)} ${space(2)};
+  }
 `;
 
 const RightAligned = styled('span')`


### PR DESCRIPTION
match table padding with the other tables + limit the max width of the team selector.