### PR TITLE
fix(teams): useTeams now correctly sets initiallyLoaded

### DIFF
--- a/tests/js/spec/utils/useTeams.spec.tsx
+++ b/tests/js/spec/utils/useTeams.spec.tsx
@@ -94,6 +94,8 @@ describe('useTeams', function () {
       initialProps: {slugs: ['foo']},
     });
 
+    expect(result.current.initiallyLoaded).toBe(false);
+
     await act(async () => {
       // @ts-expect-error
       await tick();
@@ -104,5 +106,17 @@ describe('useTeams', function () {
     const {teams} = result.current;
     expect(teams.length).toBe(1);
     expect(teams).toEqual(expect.arrayContaining([teamFoo]));
+  });
+
+  it('only loads slugs when needed', async function () {
+    act(() => void TeamStore.loadInitialData(mockTeams));
+
+    const {result} = renderHook(props => useTeams(props), {
+      initialProps: {slugs: [mockTeams[0].slug]},
+    });
+
+    const {teams, initiallyLoaded} = result.current;
+    expect(initiallyLoaded).toBe(true);
+    expect(teams).toEqual(expect.arrayContaining(mockTeams));
   });
 });


### PR DESCRIPTION
Before if we detected that we didn't need to load any `slugs` in `useTeams` we would not trigger an api request, but I also forgot to set `initiallyLoaded` to true.

Decided to make it a little more clear when we load teams and added a test to catch this case.