### PR TITLE
ref(js): useLegacyStore for GlobalModal

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/index.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {DebugImageDetails} from 'sentry/components/events/interfaces/debugMeta/debugImageDetails';
@@ -26,16 +26,18 @@ describe('Debug Meta - Image Details', function () {
   it('Candidates correctly sorted', function () {
     renderGlobalModal();
 
-    openModal(modalProps => (
-      <DebugImageDetails
-        {...modalProps}
-        organization={organization}
-        image={eventEntryDebugMeta.data.images[0]}
-        projSlug={project.slug}
-        event={event}
-        onReprocessEvent={jest.fn()}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <DebugImageDetails
+          {...modalProps}
+          organization={organization}
+          image={eventEntryDebugMeta.data.images[0]}
+          projSlug={project.slug}
+          event={event}
+          onReprocessEvent={jest.fn()}
+        />
+      ))
+    );
 
     // Check status order.
     // The UI shall sort the candidates by status. However, this sorting is not alphabetical but in the following order:

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   renderGlobalModal,
   screen,
   userEvent,
@@ -43,17 +44,19 @@ describe('StacktraceLinkModal', () => {
 
   it('links to source code with one GitHub integration', () => {
     renderGlobalModal();
-    openModal(modalProps => (
-      <StacktraceLinkModal
-        {...modalProps}
-        filename={filename}
-        closeModal={closeModal}
-        integrations={[integration]}
-        organization={org}
-        project={project}
-        onSubmit={onSubmit}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <StacktraceLinkModal
+          {...modalProps}
+          filename={filename}
+          closeModal={closeModal}
+          integrations={[integration]}
+          organization={org}
+          project={project}
+          onSubmit={onSubmit}
+        />
+      ))
+    );
 
     expect(screen.getByText('Tell us where your source code is')).toBeInTheDocument();
 
@@ -73,17 +76,19 @@ describe('StacktraceLinkModal', () => {
     });
 
     renderGlobalModal();
-    openModal(modalProps => (
-      <StacktraceLinkModal
-        {...modalProps}
-        filename={filename}
-        closeModal={closeModal}
-        integrations={[integration]}
-        organization={org}
-        project={project}
-        onSubmit={onSubmit}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <StacktraceLinkModal
+          {...modalProps}
+          filename={filename}
+          closeModal={closeModal}
+          integrations={[integration]}
+          organization={org}
+          project={project}
+          onSubmit={onSubmit}
+        />
+      ))
+    );
 
     userEvent.type(
       screen.getByRole('textbox', {name: 'Copy the URL and paste it below'}),
@@ -105,17 +110,19 @@ describe('StacktraceLinkModal', () => {
     });
 
     renderGlobalModal({context: TestStubs.routerContext()});
-    openModal(modalProps => (
-      <StacktraceLinkModal
-        {...modalProps}
-        filename={filename}
-        closeModal={closeModal}
-        integrations={[integration]}
-        organization={org}
-        project={project}
-        onSubmit={onSubmit}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <StacktraceLinkModal
+          {...modalProps}
+          filename={filename}
+          closeModal={closeModal}
+          integrations={[integration]}
+          organization={org}
+          project={project}
+          onSubmit={onSubmit}
+        />
+      ))
+    );
 
     userEvent.type(
       screen.getByRole('textbox', {name: 'Copy the URL and paste it below'}),

--- a/static/app/components/featureFeedback/feedbackModal.spec.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.spec.tsx
@@ -9,6 +9,7 @@ import * as Sentry from '@sentry/react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
+  act,
   renderGlobalModal,
   screen,
   userEvent,
@@ -52,11 +53,13 @@ describe('FeatureFeedback', function () {
 
       renderGlobalModal();
 
-      openModal(modalProps => (
-        <ComponentProviders>
-          <FeedbackModal {...modalProps} featureName="test" />
-        </ComponentProviders>
-      ));
+      act(() =>
+        openModal(modalProps => (
+          <ComponentProviders>
+            <FeedbackModal {...modalProps} featureName="test" />
+          </ComponentProviders>
+        ))
+      );
 
       // Form fields
       expect(screen.getByText('Select type of feedback')).toBeInTheDocument();
@@ -109,15 +112,17 @@ describe('FeatureFeedback', function () {
     it('renders provided feedbackTypes', function () {
       renderGlobalModal();
 
-      openModal(modalProps => (
-        <ComponentProviders>
-          <FeedbackModal
-            {...modalProps}
-            featureName="test"
-            feedbackTypes={['Custom feedback type A', 'Custom feedback type B']}
-          />
-        </ComponentProviders>
-      ));
+      act(() =>
+        openModal(modalProps => (
+          <ComponentProviders>
+            <FeedbackModal
+              {...modalProps}
+              featureName="test"
+              feedbackTypes={['Custom feedback type A', 'Custom feedback type B']}
+            />
+          </ComponentProviders>
+        ))
+      );
 
       userEvent.click(screen.getByText('Select type of feedback'));
 
@@ -132,15 +137,17 @@ describe('FeatureFeedback', function () {
     it('renders an arbitrary secondary action', function () {
       renderGlobalModal();
 
-      openModal(modalProps => (
-        <ComponentProviders>
-          <FeedbackModal
-            {...modalProps}
-            featureName="test"
-            secondaryAction={<a href="#">Test Secondary Action Link</a>}
-          />
-        </ComponentProviders>
-      ));
+      act(() =>
+        openModal(modalProps => (
+          <ComponentProviders>
+            <FeedbackModal
+              {...modalProps}
+              featureName="test"
+              secondaryAction={<a href="#">Test Secondary Action Link</a>}
+            />
+          </ComponentProviders>
+        ))
+      );
 
       userEvent.click(screen.getByText('Select type of feedback'));
 
@@ -161,55 +168,57 @@ describe('FeatureFeedback', function () {
 
       renderGlobalModal();
 
-      openModal(modalProps => (
-        <ComponentProviders>
-          <FeedbackModal
-            {...modalProps}
-            featureName="test"
-            initialData={{step: 0, name: null, surname: null}}
-          >
-            {({Header, Body, Footer, state, onFieldChange}) => {
-              if (state.step === 0) {
+      act(() =>
+        openModal(modalProps => (
+          <ComponentProviders>
+            <FeedbackModal
+              {...modalProps}
+              featureName="test"
+              initialData={{step: 0, name: null, surname: null}}
+            >
+              {({Header, Body, Footer, state, onFieldChange}) => {
+                if (state.step === 0) {
+                  return (
+                    <Fragment>
+                      <Header>First Step</Header>
+                      <Body>
+                        <TextField
+                          label="Name"
+                          value={state.name}
+                          name="name"
+                          onChange={value => onFieldChange('name', value)}
+                        />
+                      </Body>
+                      <Footer onNext={() => onFieldChange('step', 1)} />
+                    </Fragment>
+                  );
+                }
+
                 return (
                   <Fragment>
-                    <Header>First Step</Header>
+                    <Header>Last Step</Header>
                     <Body>
                       <TextField
-                        label="Name"
-                        value={state.name}
-                        name="name"
-                        onChange={value => onFieldChange('name', value)}
+                        label="Surname"
+                        value={state.surname}
+                        name="surname"
+                        onChange={value => onFieldChange('surname', value)}
                       />
                     </Body>
-                    <Footer onNext={() => onFieldChange('step', 1)} />
+                    <Footer
+                      onBack={() => onFieldChange('step', 0)}
+                      primaryDisabledReason={
+                        !state.surname ? 'Please answer at least one question' : undefined
+                      }
+                      submitEventData={{message: 'Feedback: test'}}
+                    />
                   </Fragment>
                 );
-              }
-
-              return (
-                <Fragment>
-                  <Header>Last Step</Header>
-                  <Body>
-                    <TextField
-                      label="Surname"
-                      value={state.surname}
-                      name="surname"
-                      onChange={value => onFieldChange('surname', value)}
-                    />
-                  </Body>
-                  <Footer
-                    onBack={() => onFieldChange('step', 0)}
-                    primaryDisabledReason={
-                      !state.surname ? 'Please answer at least one question' : undefined
-                    }
-                    submitEventData={{message: 'Feedback: test'}}
-                  />
-                </Fragment>
-              );
-            }}
-          </FeedbackModal>
-        </ComponentProviders>
-      ));
+              }}
+            </FeedbackModal>
+          </ComponentProviders>
+        ))
+      );
 
       // Does not render the default form
       expect(screen.queryByText('Select type of feedback')).not.toBeInTheDocument();

--- a/static/app/components/globalModal/index.spec.jsx
+++ b/static/app/components/globalModal/index.spec.jsx
@@ -1,4 +1,5 @@
 import {
+  act,
   render,
   renderGlobalModal,
   screen,
@@ -17,11 +18,11 @@ describe('GlobalModal', function () {
   it('uses actionCreators to open and close Modal', async function () {
     renderGlobalModal();
 
-    openModal(() => <div data-test-id="modal-test">Hi</div>);
+    act(() => openModal(() => <div data-test-id="modal-test">Hi</div>));
 
     expect(screen.getByTestId('modal-test')).toBeInTheDocument();
 
-    closeModal();
+    act(() => closeModal());
 
     await waitForElementToBeRemoved(screen.queryByTestId('modal-test'));
     expect(screen.queryByTestId('modal-test')).not.toBeInTheDocument();
@@ -31,13 +32,15 @@ describe('GlobalModal', function () {
     renderGlobalModal();
     const closeSpy = jest.fn();
 
-    openModal(
-      ({Header}) => (
-        <div id="modal-test">
-          <Header closeButton>Header</Header>Hi
-        </div>
-      ),
-      {onClose: closeSpy}
+    act(() =>
+      openModal(
+        ({Header}) => (
+          <div id="modal-test">
+            <Header closeButton>Header</Header>Hi
+          </div>
+        ),
+        {onClose: closeSpy}
+      )
     );
 
     userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
@@ -49,9 +52,11 @@ describe('GlobalModal', function () {
     renderGlobalModal();
     const closeSpy = jest.fn();
 
-    openModal(({closeModal: cm}) => <button onClick={cm}>Yo</button>, {
-      onClose: closeSpy,
-    });
+    act(() =>
+      openModal(({closeModal: cm}) => <button onClick={cm}>Yo</button>, {
+        onClose: closeSpy,
+      })
+    );
 
     userEvent.click(screen.getByRole('button', {name: 'Yo'}));
 
@@ -62,13 +67,15 @@ describe('GlobalModal', function () {
     renderGlobalModal();
     render(<div data-test-id="outside-test">Hello</div>);
 
-    openModal(
-      ({Header}) => (
-        <div data-test-id="modal-test">
-          <Header closeButton>Header</Header>Hi
-        </div>
-      ),
-      {allowClickClose: false}
+    act(() =>
+      openModal(
+        ({Header}) => (
+          <div data-test-id="modal-test">
+            <Header closeButton>Header</Header>Hi
+          </div>
+        ),
+        {allowClickClose: false}
+      )
     );
 
     expect(screen.getByTestId('modal-test')).toBeInTheDocument();

--- a/static/app/components/group/sentryAppExternalIssueActions.spec.jsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.spec.jsx
@@ -75,7 +75,7 @@ describe('SentryAppExternalIssueActions', () => {
     }
   });
 
-  it('links to an existing Issue', () => {
+  it('links to an existing Issue', async () => {
     const request = MockApiClient.addMockResponse({
       url: submitUrl,
       method: 'POST',
@@ -88,7 +88,7 @@ describe('SentryAppExternalIssueActions', () => {
         sentryAppComponent={component}
       />
     );
-    renderGlobalModal();
+    const {waitForModalToHide} = renderGlobalModal();
 
     // Open The Modal
     userEvent.click(
@@ -100,6 +100,8 @@ describe('SentryAppExternalIssueActions', () => {
 
     userEvent.type(screen.getByRole('textbox', {name: 'Issue'}), '99');
     userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitForModalToHide();
 
     expect(request).toHaveBeenCalledWith(
       submitUrl,
@@ -113,7 +115,7 @@ describe('SentryAppExternalIssueActions', () => {
     );
   });
 
-  it('creates a new Issue', () => {
+  it('creates a new Issue', async () => {
     const request = MockApiClient.addMockResponse({
       url: submitUrl,
       method: 'POST',
@@ -126,7 +128,7 @@ describe('SentryAppExternalIssueActions', () => {
         sentryAppComponent={component}
       />
     );
-    renderGlobalModal();
+    const {waitForModalToHide} = renderGlobalModal();
 
     // Open The Modal
     userEvent.click(
@@ -140,6 +142,8 @@ describe('SentryAppExternalIssueActions', () => {
     userEvent.type(screen.getByRole('textbox', {name: 'Description'}), 'bar');
 
     userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitForModalToHide();
 
     expect(request).toHaveBeenCalledWith(
       submitUrl,

--- a/static/app/components/modals/demoEndModal.spec.tsx
+++ b/static/app/components/modals/demoEndModal.spec.tsx
@@ -1,4 +1,4 @@
-import {renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import DemoEndModal from 'sentry/components/modals/demoEndModal';
@@ -11,18 +11,20 @@ describe('DemoEndModal', function () {
 
     renderGlobalModal();
 
-    openModal(
-      modalProps => (
-        <DemoEndModal {...modalProps} orgSlug={organization.slug} tour="issues" />
-      ),
-      {onClose: closeModal}
+    act(() =>
+      openModal(
+        modalProps => (
+          <DemoEndModal {...modalProps} orgSlug={organization.slug} tour="issues" />
+        ),
+        {onClose: closeModal}
+      )
     );
 
     userEvent.click(screen.getByRole('button', {name: 'Close Modal'}));
     expect(closeModal).toHaveBeenCalled();
   });
 
-  it('restarts tour on button click', function () {
+  it('restarts tour on button click', async function () {
     const finishMock = MockApiClient.addMockResponse({
       method: 'PUT',
       url: '/assistant/',
@@ -34,13 +36,17 @@ describe('DemoEndModal', function () {
       url: '/assistant/',
     });
 
-    renderGlobalModal();
+    const {waitForModalToHide} = renderGlobalModal();
 
-    openModal(modalProps => (
-      <DemoEndModal {...modalProps} orgSlug={organization.slug} tour="issues" />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <DemoEndModal {...modalProps} orgSlug={organization.slug} tour="issues" />
+      ))
+    );
 
     userEvent.click(screen.getByRole('button', {name: 'Restart Tour'}));
+    await waitForModalToHide();
+
     expect(finishMock).toHaveBeenCalledWith(
       '/assistant/',
       expect.objectContaining({
@@ -56,9 +62,11 @@ describe('DemoEndModal', function () {
   it('opens sign up page on button click', function () {
     renderGlobalModal();
 
-    openModal(modalProps => (
-      <DemoEndModal {...modalProps} orgSlug={organization.slug} tour="issues" />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <DemoEndModal {...modalProps} orgSlug={organization.slug} tour="issues" />
+      ))
+    );
 
     const signUpButton = screen.getByRole('button', {name: 'Sign up for Sentry'});
     expect(signUpButton).toBeInTheDocument();

--- a/static/app/components/modals/redirectToProject.spec.tsx
+++ b/static/app/components/modals/redirectToProject.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {renderGlobalModal} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {RedirectToProjectModal} from 'sentry/components/modals/redirectToProject';
@@ -26,16 +26,18 @@ describe('RedirectToProjectModal', function () {
 
     renderGlobalModal();
 
-    openModal(modalProps => (
-      <RedirectToProjectModal
-        {...modalProps}
-        routes={router.routes}
-        router={router}
-        location={router.location}
-        slug="new-slug"
-        params={{orgId: 'org-slug', projectId: 'project-slug'}}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <RedirectToProjectModal
+          {...modalProps}
+          routes={router.routes}
+          router={router}
+          location={router.location}
+          slug="new-slug"
+          params={{orgId: 'org-slug', projectId: 'project-slug'}}
+        />
+      ))
+    );
 
     jest.advanceTimersByTime(4900);
     expect(window.location.assign).not.toHaveBeenCalled();

--- a/static/app/components/modals/suggestProjectModal.spec.tsx
+++ b/static/app/components/modals/suggestProjectModal.spec.tsx
@@ -1,4 +1,4 @@
-import {renderGlobalModal} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import SuggestProjectModal from 'sentry/components/modals/suggestProjectModal';
@@ -7,13 +7,15 @@ describe('SuggestProjectModal', function () {
   it('renders', function () {
     const {container} = renderGlobalModal();
 
-    openModal(modalProps => (
-      <SuggestProjectModal
-        {...modalProps}
-        organization={TestStubs.Organization()}
-        matchedUserAgentString="okhttp/"
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <SuggestProjectModal
+          {...modalProps}
+          organization={TestStubs.Organization()}
+          matchedUserAgentString="okhttp/"
+        />
+      ))
+    );
 
     expect(container).toSnapshot();
   });

--- a/static/app/views/organizationGroupDetails/actions/shareModal.spec.tsx
+++ b/static/app/views/organizationGroupDetails/actions/shareModal.spec.tsx
@@ -1,4 +1,4 @@
-import {renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {act, renderGlobalModal, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import GroupStore from 'sentry/stores/groupStore';
@@ -31,15 +31,17 @@ describe('shareModal', () => {
     });
     renderGlobalModal();
 
-    openModal(modalProps => (
-      <ShareIssueModal
-        {...modalProps}
-        groupId={group.id}
-        organization={organization}
-        projectSlug={project.slug}
-        onToggle={onToggle}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <ShareIssueModal
+          {...modalProps}
+          groupId={group.id}
+          organization={organization}
+          projectSlug={project.slug}
+          onToggle={onToggle}
+        />
+      ))
+    );
 
     expect(screen.getByText('Share Issue')).toBeInTheDocument();
     expect(await screen.findByRole('button', {name: 'Copy Link'})).toBeInTheDocument();
@@ -58,15 +60,17 @@ describe('shareModal', () => {
     });
     renderGlobalModal();
 
-    openModal(modalProps => (
-      <ShareIssueModal
-        {...modalProps}
-        groupId={group.id}
-        organization={organization}
-        projectSlug={project.slug}
-        onToggle={onToggle}
-      />
-    ));
+    act(() =>
+      openModal(modalProps => (
+        <ShareIssueModal
+          {...modalProps}
+          groupId={group.id}
+          organization={organization}
+          projectSlug={project.slug}
+          onToggle={onToggle}
+        />
+      ))
+    );
 
     userEvent.click(screen.getByLabelText('Unshare'));
 

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -99,7 +99,7 @@ describe('IntegrationCodeMappings', function () {
       }),
     });
     render(<IntegrationCodeMappings organization={org} integration={integration} />);
-    renderGlobalModal();
+    const {waitForModalToHide} = renderGlobalModal();
 
     userEvent.click(screen.getByRole('button', {name: 'Add Code Mapping'}));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -112,6 +112,8 @@ describe('IntegrationCodeMappings', function () {
     userEvent.clear(screen.getByRole('textbox', {name: 'Branch'}));
     userEvent.type(screen.getByRole('textbox', {name: 'Branch'}), defaultBranch);
     userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitForModalToHide();
 
     expect(createMock).toHaveBeenCalledWith(
       url,
@@ -128,7 +130,7 @@ describe('IntegrationCodeMappings', function () {
     );
   });
 
-  it('edit existing config', () => {
+  it('edit existing config', async () => {
     const stackRoot = 'new/root';
     const sourceRoot = 'source/root';
     const defaultBranch = 'master';
@@ -146,12 +148,14 @@ describe('IntegrationCodeMappings', function () {
       }),
     });
     render(<IntegrationCodeMappings organization={org} integration={integration} />);
-    renderGlobalModal();
+    const {waitForModalToHide} = renderGlobalModal();
 
     userEvent.click(screen.getAllByRole('button', {name: 'edit'})[0]);
     userEvent.clear(screen.getByRole('textbox', {name: 'Stack Trace Root'}));
     userEvent.type(screen.getByRole('textbox', {name: 'Stack Trace Root'}), stackRoot);
     userEvent.click(screen.getByRole('button', {name: 'Save Changes'}));
+
+    await waitForModalToHide();
 
     expect(editMock).toHaveBeenCalledWith(
       url,

--- a/static/app/views/settings/account/accountClose.spec.jsx
+++ b/static/app/views/settings/account/accountClose.spec.jsx
@@ -39,7 +39,7 @@ describe('AccountClose', function () {
     });
   });
 
-  it('lists all orgs user is an owner of', function () {
+  it('lists all orgs user is an owner of', async function () {
     render(<AccountClose />);
     renderGlobalModal();
 
@@ -60,13 +60,16 @@ describe('AccountClose', function () {
     // Delete
     userEvent.click(screen.getByRole('button', {name: 'Close Account'}));
 
-    // First button is cancel, target Button at index 2
     expect(
       screen.getByText(
         'This is permanent and cannot be undone, are you really sure you want to do this?'
       )
     ).toBeInTheDocument();
     userEvent.click(screen.getByText('Confirm'));
+
+    await screen.findByText(
+      'Your account has been deactivated and scheduled for removal.'
+    );
 
     expect(deleteMock).toHaveBeenCalledWith(
       '/users/me/',

--- a/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -126,7 +126,7 @@ describe('Organization Developer Settings', function () {
       expect(publishButton).toHaveAttribute('aria-disabled', 'false');
       userEvent.click(publishButton);
 
-      renderGlobalModal();
+      const {waitForModalToHide} = renderGlobalModal();
       const dialog = await screen.findByRole('dialog');
       expect(dialog).toBeInTheDocument();
       const questionnaire = [
@@ -157,6 +157,8 @@ describe('Organization Developer Settings', function () {
       expect(requestPublishButton).toHaveAttribute('aria-disabled', 'false');
 
       userEvent.click(requestPublishButton);
+
+      await waitForModalToHide();
 
       expect(mock).toHaveBeenCalledWith(
         `/sentry-apps/${sentryApp.slug}/publish-request/`,

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -112,7 +112,17 @@ function render(ui: React.ReactElement, options?: Options) {
 const fireEvent = rtl.fireEvent;
 
 function renderGlobalModal(options?: Options) {
-  return render(<GlobalModal />, options);
+  const result = render(<GlobalModal />, options);
+
+  /**
+   * Helper that waits for the modal to be removed from the DOM. You may need to
+   * wait for the modal to be removed to avoid any act warnings.
+   */
+  function waitForModalToHide() {
+    return rtl.waitForElementToBeRemoved(() => rtl.screen.getByRole('dialog'));
+  }
+
+  return {...result, waitForModalToHide};
 }
 
 /**


### PR DESCRIPTION
Removes the container and replaces it with useLegacyStore

* Updates a number of test to use `waitForModalToHide` to correctly handle state updates.
* Adds `act()` wrappers to `openModal` since this also now triggers state update from outside of typical user interactions.