### PR TITLE
fix(ui): Revert change to disabled button tooltip

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -129,7 +129,7 @@ class BaseButton extends React.Component<ButtonProps, {}> {
     // Doing this instead of using `Tooltip`'s `disabled` prop so that we can minimize snapshot nesting
     if (title) {
       return (
-        <Tooltip skipWrapper {...tooltipProps} title={title}>
+        <Tooltip skipWrapper={!disabled} {...tooltipProps} title={title}>
           {button}
         </Tooltip>
       );


### PR DESCRIPTION
Unrevert the revert in #29085 It was not the issue.

I'm not sure what is wrong with that particular disabled button tooltip, but it doesn't like hiding.