### PR TITLE
ref(js): Properly type hooks in HookStore

### DIFF
--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -4,10 +4,7 @@ import Reflux from 'reflux';
 import {HookName, Hooks} from 'app/types/hooks';
 
 type HookStoreInterface = {
-  // XXX(epurkhiser): We could type this as {[H in HookName]?:
-  // Array<Hooks[H]>}, however this causes typescript to produce a complex
-  // union that it complains is 'too complex'
-  hooks: any;
+  hooks: {[H in HookName]?: Array<Hooks[H]>};
 
   add<H extends HookName>(hookName: H, callback: Hooks[H]): void;
   remove<H extends HookName>(hookName: H, callback: Hooks[H]): void;


### PR DESCRIPTION
Newer typescript handles this just fine