### PR TITLE
ref(ts): Adjust how Modal{Options,RenderProps} are imported

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import ModalActions from 'app/actions/modalActions';
-import GlobalModal from 'app/components/globalModal';
+import type {ModalTypes} from 'app/components/globalModal';
 import type {DashboardWidgetModalOptions} from 'app/components/modals/addDashboardWidgetModal';
 import type {DashboardWidgetQuerySelectorModalOptions} from 'app/components/modals/dashboardWidgetQuerySelectorModal';
 import {InviteRow} from 'app/components/modals/inviteMembersModal/types';
@@ -11,10 +11,8 @@ import {Group, IssueOwnership, Organization, Project, SentryApp, Team} from 'app
 import {CustomRepoType} from 'app/types/debugFiles';
 import {Event} from 'app/types/event';
 
-type ModalProps = Required<React.ComponentProps<typeof GlobalModal>>;
-
-export type ModalOptions = ModalProps['options'];
-export type ModalRenderProps = Parameters<NonNullable<ModalProps['children']>>[0];
+export type ModalOptions = ModalTypes['options'];
+export type ModalRenderProps = ModalTypes['renderProps'];
 
 /**
  * Show a modal

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -65,6 +65,17 @@ type ModalRenderProps = {
   CloseButton: ReturnType<typeof makeCloseButton>;
 };
 
+/**
+ * Meta-type to make re-exporting these in the action creator easy without
+ * poluting the global API namespace with duplicate type names.
+ *
+ * eg. you won't accidentally import ModalRenderProps from here.
+ */
+export type ModalTypes = {
+  options: ModalOptions;
+  renderProps: ModalRenderProps;
+};
+
 type Props = {
   /**
    * Configuration of the modal


### PR DESCRIPTION
This is helpful for when we change the prop types on the `GlobalModal` when we refactor away the container

See #29135 