### PR TITLE
ref(ts): Fix discrepency on ModalActions.openModal

### DIFF
--- a/static/app/actionCreators/modal.tsx
+++ b/static/app/actionCreators/modal.tsx
@@ -23,7 +23,7 @@ export function openModal(
   renderer: (renderProps: ModalRenderProps) => React.ReactNode,
   options?: ModalOptions
 ) {
-  ModalActions.openModal(renderer, options);
+  ModalActions.openModal(renderer, options ?? {});
 }
 
 /**


### PR DESCRIPTION
The listener for ModalActions.openModal actually says that options MUST be passed. Fix this by ensuring we always at least pass an empty object.