### PR TITLE
ref(releasehealth): Implement get_project_sessions_count on metrics backend [INGEST-249]

### DIFF
--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -12,7 +12,6 @@ ReleaseName = str
 EnvironmentName = str
 DateString = str
 
-
 #: The functions supported by `run_sessions_query`
 SessionsQueryFunction = Literal[
     "sum(session)",
@@ -66,7 +65,6 @@ FormattedIsoTime = str
 
 ProjectRelease = Tuple[ProjectId, ReleaseName]
 ProjectOrRelease = TypeVar("ProjectOrRelease", ProjectId, ProjectRelease)
-
 
 # taken from sentry.snuba.sessions.STATS_PERIODS
 StatsPeriod = Literal[
@@ -168,6 +166,7 @@ class ReleaseHealthBackend(Service):  # type: ignore
         "get_changed_project_release_model_adoptions",
         "get_oldest_health_data_for_releases",
         "get_project_releases_count",
+        "get_project_sessions_count",
     )
 
     def get_current_and_previous_crash_free_rates(
@@ -347,5 +346,19 @@ class ReleaseHealthBackend(Service):  # type: ignore
     ) -> int:
         """
         Fetches the total count of releases/project combinations
+        """
+        raise NotImplementedError()
+
+    def get_project_sessions_count(
+        self,
+        project_id: ProjectId,
+        rollup: int,  # rollup in seconds
+        start: datetime,
+        end: datetime,
+        environment_id: Optional[int] = None,
+    ) -> int:
+        """
+        Returns the number of sessions in the specified period (optionally
+        filtered by environment)
         """
         raise NotImplementedError()

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -7,6 +7,7 @@ from snuba_sdk import Column, Condition, Entity, Function, Op, Query
 from snuba_sdk.expressions import Granularity
 from snuba_sdk.query import SelectableExpression
 
+from sentry.models import Environment
 from sentry.models.project import Project
 from sentry.release_health.base import (
     CrashFreeBreakdown,
@@ -88,6 +89,21 @@ def filter_releases_by_project_release(
         Op.IN,
         get_tag_values_list(org_id, [x for _, x in project_releases]),
     )
+
+
+def _model_environment_ids_to_environment_names(
+    metric_ids: Sequence[int],
+) -> Mapping[int, Optional[str]]:
+    """
+    Maps Environment Model ids to the environment name
+    Note: this does a Db lookup
+    """
+    empty_string_to_none: Callable[[Any], Optional[Any]] = lambda v: None if v == "" else v
+    id_to_name: Mapping[int, Optional[str]] = {
+        k: empty_string_to_none(v)
+        for k, v in Environment.objects.filter(id__in=metric_ids).values_list("id", "name")
+    }
+    return defaultdict(lambda: None, id_to_name)
 
 
 class MetricsReleaseHealthBackend(ReleaseHealthBackend):
@@ -1263,12 +1279,70 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             select=query_columns,
             where=where,
             having=having,
-            granularity=granularity,
+            granularity=Granularity(granularity),
         )
 
-        rows = raw_snql_query(
-            query, referrer="release_health.metrics.sessions.get_project_releases_count"
-        )["data"]
+        rows = raw_snql_query(query, referrer="release_health.metrics.get_project_releases_count")[
+            "data"
+        ]
 
         ret_val: int = rows[0]["count"] if rows else 0
+        return ret_val
+
+    def get_project_sessions_count(
+        self,
+        project_id: ProjectId,
+        rollup: int,  # rollup in seconds
+        start: datetime,
+        end: datetime,
+        environment_id: Optional[int] = None,
+    ) -> int:
+
+        org_id = self._get_org_id([project_id])
+        columns = [Column("value")]
+
+        try:
+            status_key = tag_key(org_id, "session.status")
+            status_init = tag_value(org_id, "init")
+        except MetricIndexNotFound:
+            return 0
+
+        where_clause = [
+            Condition(Column("org_id"), Op.EQ, org_id),
+            Condition(Column("project_id"), Op.EQ, project_id),
+            Condition(Column("metric_id"), Op.EQ, metric_id(org_id, "session")),
+            Condition(Column("timestamp"), Op.GTE, start),
+            Condition(Column("timestamp"), Op.LT, end),
+            Condition(Column(status_key), Op.EQ, status_init),
+        ]
+
+        if environment_id is not None:
+            # convert the PosgreSQL environmentID into the clickhouse string index
+            # for the environment name
+            env_names = _model_environment_ids_to_environment_names([environment_id])
+            env_name = env_names[environment_id]
+            if env_name is None:
+                return 0  # could not find the requested environment
+
+            try:
+                snuba_env_id = tag_value(org_id, env_name)
+                env_id = tag_key(org_id, "environment")
+            except MetricIndexNotFound:
+                return 0
+
+            where_clause.append(Condition(Column(env_id), Op.EQ, snuba_env_id))
+
+        query = Query(
+            dataset=Dataset.Metrics.value,
+            match=Entity("metrics_counters"),
+            select=columns,
+            where=where_clause,
+            granularity=Granularity(rollup),
+        )
+
+        rows = raw_snql_query(query, referrer="release_health.metrics.get_project_sessions_count")[
+            "data"
+        ]
+
+        ret_val: int = rows[0]["value"] if rows else 0
         return ret_val

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -92,7 +92,7 @@ def filter_releases_by_project_release(
 
 
 def _model_environment_ids_to_environment_names(
-    metric_ids: Sequence[int],
+    environment_ids: Sequence[int],
 ) -> Mapping[int, Optional[str]]:
     """
     Maps Environment Model ids to the environment name
@@ -101,7 +101,7 @@ def _model_environment_ids_to_environment_names(
     empty_string_to_none: Callable[[Any], Optional[Any]] = lambda v: None if v == "" else v
     id_to_name: Mapping[int, Optional[str]] = {
         k: empty_string_to_none(v)
-        for k, v in Environment.objects.filter(id__in=metric_ids).values_list("id", "name")
+        for k, v in Environment.objects.filter(id__in=environment_ids).values_list("id", "name")
     }
     return defaultdict(lambda: None, id_to_name)
 
@@ -1143,7 +1143,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         query = Query(
             dataset=Dataset.Metrics.value,
-            match=Entity("metrics_counters"),
+            match=Entity(EntityKey.MetricsCounters.value),
             select=query_cols,
             where=where_clause,
             groupby=group_by,
@@ -1199,7 +1199,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         query = Query(
             dataset=Dataset.Metrics.value,
-            match=Entity("metrics_counters"),
+            match=Entity(EntityKey.MetricsCounters.value),
             select=query_cols,
             where=where_clause,
             groupby=group_by,
@@ -1263,9 +1263,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         # Filter out releases with zero users when sorting by either `users` or `crash_free_users`
         if scope in ["users", "crash_free_users"]:
             having.append(Condition(Column("value"), Op.GT, 0))
-            match = Entity("metrics_sets")
+            match = Entity(EntityKey.MetricsSets.value)
         else:
-            match = Entity("metrics_counters")
+            match = Entity(EntityKey.MetricsCounters.value)
 
         query_columns = [
             Function(
@@ -1334,7 +1334,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         query = Query(
             dataset=Dataset.Metrics.value,
-            match=Entity("metrics_counters"),
+            match=Entity(EntityKey.MetricsCounters.value),
             select=columns,
             where=where_clause,
             granularity=Granularity(rollup),

--- a/src/sentry/release_health/sessions.py
+++ b/src/sentry/release_health/sessions.py
@@ -27,6 +27,7 @@ from sentry.snuba.sessions import (
     _get_crash_free_breakdown,
     _get_oldest_health_data_for_releases,
     _get_project_releases_count,
+    _get_project_sessions_count,
     _get_release_adoption,
     _get_release_health_data_overview,
     _get_release_sessions_time_bounds,
@@ -161,4 +162,24 @@ class SessionsReleaseHealthBackend(ReleaseHealthBackend):
     ) -> int:
         return _get_project_releases_count(  # type: ignore
             organization_id, project_ids, scope, stats_period, environments
+        )
+
+    def get_project_sessions_count(
+        self,
+        project_id: ProjectId,
+        rollup: int,  # rollup in seconds
+        start: datetime,
+        end: datetime,
+        environment_id: Optional[int] = None,
+    ) -> int:
+        """
+        Returns the number of sessions in the specified period (optionally
+        filtered by environment)
+        """
+        return _get_project_sessions_count(  # type: ignore
+            project_id,
+            rollup,
+            start,
+            end,
+            environment_id,
         )

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1003,3 +1003,161 @@ class CheckReleasesHaveHealthDataTestMetrics(
     """Repeat tests with metrics backend"""
 
     pass
+
+
+class CheckNumberOfSessions(TestCase, SnubaTestCase):
+    backend = SessionsReleaseHealthBackend()
+
+    def setUp(self):
+        super().setUp()
+        self.dev_env = self.create_environment(name="development", project=self.project)
+        self.prod_env = self.create_environment(name="production", project=self.project)
+        self.another_project = self.create_project()
+
+        self.now_dt = datetime.utcnow()
+        self._5_min_ago_dt = self.now_dt - timedelta(minutes=5)
+        self._30_min_ago_dt = self.now_dt - timedelta(minutes=30)
+        self._1_h_ago_dt = self.now_dt - timedelta(hours=1)
+        self._2_h_ago_dt = self.now_dt - timedelta(hours=2)
+
+        self.now = self.now_dt.timestamp()
+        self._5_min_ago = self._5_min_ago_dt.timestamp()
+        self._30_min_ago = self._30_min_ago_dt.timestamp()
+        self._1_h_ago = self._1_h_ago_dt.timestamp()
+        self._2_h_ago = self._2_h_ago_dt.timestamp()
+
+    def make_session(
+        self,
+        environment,
+        received=None,
+        started=None,
+        status="ok",
+        release="foo@1.0.0",
+        project=None,
+    ):
+        if received is None:
+            received = time.time()
+        if started is None:
+            started = received
+        if project is None:
+            project = self.project
+
+        return {
+            "session_id": str(uuid.uuid4()),
+            "distinct_id": str(uuid.uuid4()),
+            "status": status,
+            "seq": 0,
+            "release": release,
+            "environment": environment,
+            "retention_days": 90,
+            "org_id": self.project.organization_id,
+            "project_id": project.id,
+            "duration": 60.0,
+            "errors": 0,
+            "started": started,
+            "received": received,
+        }
+
+    def test_no_sessions(self):
+        """
+        Tests that when there are no sessions the function behaves and returns 0
+        """
+        actual = self.backend.get_project_sessions_count(
+            project_id=self.project.id,
+            environment_id=None,
+            rollup=60,
+            start=self._30_min_ago_dt,
+            end=self.now_dt,
+        )
+        assert 0 == actual
+
+    def test_sessions_in_environment(self):
+        """
+        Tests that it correctly picks up the sessions for the selected environment
+        in the selected time, not counting other environments and other times
+
+        """
+
+        dev = self.dev_env.name
+        prod = self.prod_env.name
+
+        self.bulk_store_sessions(
+            [
+                self.make_session(environment=dev, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._2_h_ago),
+            ]
+        )
+
+        actual = self.backend.get_project_sessions_count(
+            project_id=self.project.id,
+            environment_id=self.prod_env.id,
+            rollup=60,
+            start=self._1_h_ago_dt,
+            end=self.now_dt,
+        )
+
+        assert actual == 2
+
+    def test_sessions_in_all_environments(self):
+        """
+        When the environment is not specified sessions from all environments are counted
+        """
+        dev = self.dev_env.name
+        prod = self.prod_env.name
+
+        self.bulk_store_sessions(
+            [
+                self.make_session(environment=dev, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._2_h_ago),
+                self.make_session(environment=dev, received=self._2_h_ago),
+            ]
+        )
+
+        actual = self.backend.get_project_sessions_count(
+            project_id=self.project.id,
+            environment_id=None,
+            rollup=60,
+            start=self._1_h_ago_dt,
+            end=self.now_dt,
+        )
+
+        assert actual == 3
+
+    def test_sessions_from_multiple_projects(self):
+        """
+        Only sessions from the specified project are considered
+        """
+        dev = self.dev_env.name
+        prod = self.prod_env.name
+
+        self.bulk_store_sessions(
+            [
+                self.make_session(environment=dev, received=self._5_min_ago),
+                self.make_session(environment=prod, received=self._5_min_ago),
+                self.make_session(
+                    environment=prod, received=self._5_min_ago, project=self.another_project
+                ),
+            ]
+        )
+
+        actual = self.backend.get_project_sessions_count(
+            project_id=self.project.id,
+            environment_id=None,
+            rollup=60,
+            start=self._1_h_ago_dt,
+            end=self.now_dt,
+        )
+
+        assert actual == 2
+
+
+class CheckNumberOfSessionsMetrics(ReleaseHealthMetricsTestCase, CheckNumberOfSessions):
+    """
+    Repeat CheckNumberOfSessions tests with the release backend
+    """
+
+    pass


### PR DESCRIPTION
Like in #28598, port get_project_sessions_count from sentry.snuba.sessions to metrics.

INGEST-249