### PR TITLE
fix(dev): Install Python 3.6.x with --patch on Big Sur

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -35,9 +35,7 @@ Pillow==8.2.0; python_version == '3.6'
 Pillow==8.3.1; python_version > '3.6'
 progressbar2==3.32.0
 python-rapidjson==1.4
-psycopg2-binary==2.8.6; python_version == '3.6'
-# For development only: This version removes needing to setting flags for Apple's M1 chipset
-psycopg2-binary==2.9.1; python_version > '3.6'
+psycopg2-binary==2.8.6
 PyJWT==2.1.0
 python-dateutil==2.8.1
 python-memcached==1.59

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -95,7 +95,7 @@ ${red}${bold}
 ERROR: You're running a virtualenv with Python ${python_version}.
 On Apple M1 machines, we only support >= 3.8.10 < 3.9.
 Either run "rm -rf ${venv_name} && direnv allow" to
-OR set SENTRY_PYTHON_VERSION=${python_version} to an `.env` file to bypass this check."
+OR set SENTRY_PYTHON_VERSION=${python_version} to an .env file to bypass this check."
 EOF
             return 1
         fi
@@ -129,6 +129,12 @@ install-py-dev() {
     # This helps when getsentry calls into this script
     cd "${HERE}/.." || exit
     echo "--> Installing Sentry (for development)"
+    if query-apple-m1; then
+        # This installs pyscopg-binary2 since there's no arm64 wheel
+        # This saves having to install postgresql on the Developer's machine + using flags
+        # https://github.com/psycopg/psycopg2/issues/1286
+        pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
+    fi
     # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
     # Webpacked assets are only necessary for devserver (which does it lazily anyways)
     # and acceptance tests, which webpack automatically if run.
@@ -258,12 +264,6 @@ reset-db() {
 
 prerequisites() {
     brew update -q && brew bundle -q
-    if query-apple-m1; then
-        # psycopg2-binary does not have an arm64 wheel, thus, we need to build it locally
-        # by installing postgresql
-        # See details: https://github.com/psycopg/psycopg2/issues/1286
-        brew install postgresql
-    fi
 }
 
 direnv-help() {

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -94,13 +94,15 @@ install_pyenv() {
       exit 1
     fi
 
-    if query-apple-m1; then
-      pyenv install --skip-existing "${PYENV_VERSION}"
-    elif query-big-sur && [ "${PYENV_VERSION}" = 3.6.10 ]; then
-      # TODO(joshuarli): Can be removed when 3.6 is removed.
-      curl -sSL https://github.com/python/cpython/commit/8ea6353.patch | \
-      cat | \
-      pyenv install --skip-existing --patch "${PYENV_VERSION}"
+    # I'm assuming that SENTRY_PYTHON_VERSION won't be used to specify a 3.6 version to simplify the condition
+    # When a user sets a SENTRY_PYTHON_VERSION they intend to use a non-default version that I assume
+    # is newer, thus, can install with the non-source-patched default pyenv install command
+    if query-big-sur && [[ -z "${SENTRY_PYTHON_VERSION:-}" ]]; then
+      # For Python 3.6.x, we need to patch the source code on Big Sur before building Python
+      # We can remove this once we upgrade to newer versions of Python
+      # cat is used since pyenv would finish to soon when the Python version is already installed
+      curl -sSL https://github.com/python/cpython/commit/8ea6353.patch | cat |
+        pyenv install --skip-existing --patch "${PYENV_VERSION}"
     else
       pyenv install --skip-existing "${PYENV_VERSION}"
     fi


### PR DESCRIPTION
Fixes regression introduced in #29058.

On Big Sur, we cannot install Python 3.6.x without patching the source code first.