### PR TITLE
fix(relay): Set time limit for update_config_cache task

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -11,7 +11,13 @@ from sentry.utils.sdk import set_current_event_project
 logger = logging.getLogger(__name__)
 
 
-@instrumented_task(name="sentry.tasks.relay.update_config_cache", queue="relay_config")
+@instrumented_task(
+    name="sentry.tasks.relay.update_config_cache",
+    queue="relay_config",
+    time_limit=120,
+    soft_time_limit=110,
+    acks_late=True,
+)
 def update_config_cache(generate, organization_id=None, project_id=None, update_reason=None):
     """
     Update the Redis cache for the Relay projectconfig. This task is invoked


### PR DESCRIPTION
Some "sentry.tasks.relay.update_config_cache" tasks sometimes take 20+ minutes, which most likely 

Also: add `acks_late` to make this (_mostly_ idempotent) task a bit more robust.