### PR TITLE
fix(ui) Improve Darkmode for ownership assignments

### DIFF
--- a/static/app/views/settings/project/projectOwnership/ruleBuilder.tsx
+++ b/static/app/views/settings/project/projectOwnership/ruleBuilder.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import Button from 'app/components/button';
 import SelectField from 'app/components/forms/selectField';
+import Tag from 'app/components/tag';
 import TextOverflow from 'app/components/textOverflow';
 import {IconAdd, IconChevron} from 'app/icons';
 import {t} from 'app/locale';
@@ -127,7 +128,7 @@ class RuleBuilder extends React.Component<Props, State> {
                 >
                   <StyledIconAdd isCircled />
                   <StyledTextOverflow>{v}</StyledTextOverflow>
-                  <TypeHint>[PATH]</TypeHint>
+                  <Tag>{t('Path')}</Tag>
                 </RuleCandidate>
               ))}
             {urls &&
@@ -138,7 +139,7 @@ class RuleBuilder extends React.Component<Props, State> {
                 >
                   <StyledIconAdd isCircled />
                   <StyledTextOverflow>{v}</StyledTextOverflow>
-                  <TypeHint>[URL]</TypeHint>
+                  <Tag>{t('URL')}</Tag>
                 </RuleCandidate>
               ))}
           </Candidates>
@@ -198,10 +199,6 @@ const Candidates = styled('div')`
   margin-bottom: 10px;
 `;
 
-const TypeHint = styled('div')`
-  color: ${p => p.theme.border};
-`;
-
 const StyledTextOverflow = styled(TextOverflow)`
   flex: 1;
 `;
@@ -209,9 +206,10 @@ const StyledTextOverflow = styled(TextOverflow)`
 const RuleCandidate = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   border: 1px solid ${p => p.theme.border};
-  background-color: #f8fafd;
-  padding-left: 5px;
-  margin-bottom: 3px;
+  border-radius: ${p => p.theme.borderRadius};
+  background-color: ${p => p.theme.background};
+  padding: ${space(0.25)} ${space(0.5)};
+  margin-bottom: ${space(0.5)};
   cursor: pointer;
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
Also replace square bracket text with Tag component, and improve spacing and borders.

Fixes #28993

![Screen Shot 2021-10-07 at 5 33 00 PM](https://user-images.githubusercontent.com/24086/136466383-dc84f9e6-bc82-411c-944c-ff3728fa1f00.png)
![Screen Shot 2021-10-07 at 5 33 18 PM](https://user-images.githubusercontent.com/24086/136466385-b7e4a57d-de94-4f64-b49e-18277950229a.png)
