### PR TITLE
ref(js): useTheme for SelectControl

### DIFF
--- a/static/app/components/forms/selectControl.tsx
+++ b/static/app/components/forms/selectControl.tsx
@@ -10,14 +10,13 @@ import ReactSelect, {
 import Async from 'react-select/async';
 import AsyncCreatable from 'react-select/async-creatable';
 import Creatable from 'react-select/creatable';
-import {withTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {IconChevron, IconClose} from 'app/icons';
 import space from 'app/styles/space';
 import {Choices, SelectValue} from 'app/types';
 import convertFromSelect2Choices from 'app/utils/convertFromSelect2Choices';
-import {Theme} from 'app/utils/theme';
 
 function isGroupedOptions<OptionType>(
   maybe:
@@ -90,10 +89,9 @@ export type ControlProps<OptionType = GeneralSelectValue> = Omit<
 };
 
 /**
- * Additional props provided by forwardRef and withTheme()
+ * Additional props provided by forwardRef
  */
 type WrappedControlProps<OptionType> = ControlProps<OptionType> & {
-  theme: Theme;
   /**
    * Ref forwarded into ReactSelect component.
    * The any is inherited from react-select.
@@ -110,7 +108,7 @@ export type GeneralSelectValue = SelectValue<any>;
 function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValue>(
   props: WrappedControlProps<OptionType>
 ) {
-  const {theme} = props;
+  const theme = useTheme();
 
   // TODO(epurkhiser): The loading indicator should probably also be our loading
   // indicator.
@@ -363,8 +361,6 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   );
 }
 
-const SelectControlWithTheme = withTheme(SelectControl);
-
 type PickerProps<OptionType> = ControlProps<OptionType> & {
   /**
    * Enable async option loading.
@@ -407,7 +403,7 @@ const RefForwardedSelectControl = React.forwardRef<
   ReactSelect<GeneralSelectValue>,
   ControlProps<GeneralSelectValue>
 >(function RefForwardedSelectControl(props, ref) {
-  return <SelectControlWithTheme forwardedRef={ref} {...props} />;
+  return <SelectControl forwardedRef={ref as any} {...props} />;
 });
 
 export default RefForwardedSelectControl;


### PR DESCRIPTION
The `ref` became any since withTheme I _think_ was masking it