### PR TITLE
feat(cmp_alerts): Show change alert status in the metric alert builder chart

### DIFF
--- a/static/app/actionCreators/events.tsx
+++ b/static/app/actionCreators/events.tsx
@@ -22,6 +22,7 @@ type Options = {
   start?: DateString;
   end?: DateString;
   interval?: string;
+  comparisonDelta?: number;
   includePrevious?: boolean;
   limit?: number;
   query?: string;
@@ -45,6 +46,7 @@ type Options = {
  * @param {String[]} options.team List of teams to query for
  * @param {String} options.period Time period to query for, in the format: <integer><units> where units are "d" or "h"
  * @param {String} options.interval Time interval to group results in, in the format: <integer><units> where units are "d", "h", "m", "s"
+ * @param {String} options.comparisonDelta Comparison delta
  * @param {Boolean} options.includePrevious Should request also return reqsults for previous period?
  * @param {Number} options.limit The number of rows to return
  * @param {String} options.query Search query
@@ -60,6 +62,7 @@ export const doEventsRequest = (
     start,
     end,
     interval,
+    comparisonDelta,
     includePrevious,
     query,
     yAxis,
@@ -75,6 +78,7 @@ export const doEventsRequest = (
   const urlQuery = Object.fromEntries(
     Object.entries({
       interval,
+      comparisonDelta,
       project,
       environment,
       team,

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -72,7 +72,7 @@ type DefaultProps = {
    */
   interval: string;
   /**
-   *
+   * Time delta for comparing intervals  alert metrics, value in minutes
    */
   comparisonDelta?: number;
   /**

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -71,6 +71,10 @@ type DefaultProps = {
    */
   interval: string;
   /**
+   *
+   */
+  comparisonDelta?: number;
+  /**
    * number of rows to return
    */
   limit: number;
@@ -198,6 +202,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     start: null,
     end: null,
     interval: '1d',
+    comparisonDelta: undefined,
     limit: 15,
     query: '',
     includePrevious: true,

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -449,7 +449,7 @@ export type ProjectSdkUpdates = {
   suggestions: SDKUpdatesSuggestion[];
 };
 
-export type EventsStatsData = [number, {count: number}[]][];
+export type EventsStatsData = [number, {count: number; comparisonCount?: number}[]][];
 
 // API response format for a single series
 export type EventsStats = {

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -559,7 +559,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   };
 
   handleComparisonTypeChange = (value: AlertRuleComparisonType) => {
-    const comparisonDelta = value === AlertRuleComparisonType.COUNT ? undefined : this.state.comparisonDelta;
+    const comparisonDelta =
+      value === AlertRuleComparisonType.COUNT ? undefined : this.state.comparisonDelta;
     this.setState({comparisonType: value, comparisonDelta});
   };
 
@@ -637,6 +638,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       resolveThreshold,
       thresholdType,
       comparisonDelta,
+      comparisonType,
     };
     const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
 

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -559,7 +559,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
   };
 
   handleComparisonTypeChange = (value: AlertRuleComparisonType) => {
-    this.setState({comparisonType: value});
+    const comparisonDelta = value === AlertRuleComparisonType.COUNT ? undefined : this.state.comparisonDelta;
+    this.setState({comparisonType: value, comparisonDelta});
   };
 
   handleComparisonDeltaChange = (value: number) => {
@@ -635,6 +636,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       environment,
       resolveThreshold,
       thresholdType,
+      comparisonDelta,
     };
     const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
 

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -123,7 +123,10 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       resolveThreshold: rule.resolveThreshold,
       thresholdType: rule.thresholdType,
       comparisonDelta: rule.comparisonDelta,
-      comparisonType: AlertRuleComparisonType.COUNT,
+      comparisonType:
+        rule.comparisonDelta === undefined
+          ? AlertRuleComparisonType.COUNT
+          : AlertRuleComparisonType.CHANGE,
       projects: [this.props.project],
       owner: rule.owner,
     };

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -310,28 +310,21 @@ class TriggersChart extends React.PureComponent<Props, State> {
     const warningTrigger = triggers?.find(trig => trig.label === 'warning');
     const criticalTriggerAlertThreshold =
       typeof criticalTrigger?.alertThreshold === 'number'
-        ? criticalTrigger?.alertThreshold
+        ? criticalTrigger.alertThreshold
         : undefined;
     const warningTriggerAlertThreshold =
       typeof warningTrigger?.alertThreshold === 'number'
-        ? warningTrigger?.alertThreshold
+        ? warningTrigger.alertThreshold
         : undefined;
 
-    if (thresholdType === AlertRuleThresholdType.ABOVE) {
-      if (criticalTriggerAlertThreshold && value >= criticalTriggerAlertThreshold) {
-        return 'critical';
-      } else if (warningTriggerAlertThreshold && value >= warningTriggerAlertThreshold) {
+    if (thresholdType === AlertRuleThresholdType.ABOVE && criticalTriggerAlertThreshold && value >= criticalTriggerAlertThreshold) {
+      return 'critical';
+    } else if (thresholdType === AlertRuleThresholdType.ABOVE && warningTriggerAlertThreshold && value >= warningTriggerAlertThreshold) {
         return 'warning';
-      }
-    } else {
-      if (criticalTriggerAlertThreshold && -1 * value >= criticalTriggerAlertThreshold) {
+    } else if (thresholdType === AlertRuleThresholdType.BELOW && criticalTriggerAlertThreshold && -1 * value >= criticalTriggerAlertThreshold) {
         return 'critical';
-      } else if (
-        warningTriggerAlertThreshold &&
-        -1 * value >= warningTriggerAlertThreshold
-      ) {
+    } else if (thresholdType === AlertRuleThresholdType.BELOW && warningTriggerAlertThreshold && -1 * value >= warningTriggerAlertThreshold) {
         return 'warning';
-      }
     }
 
     return '';

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -319,25 +319,32 @@ class TriggersChart extends React.PureComponent<Props, State> {
         ? warningTrigger.alertThreshold
         : undefined;
 
+    // Need to catch the critical threshold cases before warning threshold cases
     if (
       thresholdType === AlertRuleThresholdType.ABOVE &&
       criticalTriggerAlertThreshold &&
       value >= criticalTriggerAlertThreshold
     ) {
       return 'critical';
-    } else if (
+    }
+    if (
       thresholdType === AlertRuleThresholdType.ABOVE &&
       warningTriggerAlertThreshold &&
       value >= warningTriggerAlertThreshold
     ) {
       return 'warning';
-    } else if (
+    }
+    // When threshold is below(lower than in comparison alerts) the % diff value is negative
+    // It crosses the threshold if its abs value is greater than threshold
+    // -80% change crosses below 60% threshold -1 * (-80) > 60
+    if (
       thresholdType === AlertRuleThresholdType.BELOW &&
       criticalTriggerAlertThreshold &&
       -1 * value >= criticalTriggerAlertThreshold
     ) {
       return 'critical';
-    } else if (
+    }
+    if (
       thresholdType === AlertRuleThresholdType.BELOW &&
       warningTriggerAlertThreshold &&
       -1 * value >= warningTriggerAlertThreshold

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -215,7 +215,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
     return period;
   };
 
-  makeComparisonMarkLines(
+  getComparisonMarkLines(
     timeseriesData: Series[] = [],
     comparisonTimeseriesData: Series[] = []
   ): LineChartSeries[] {
@@ -255,7 +255,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
         });
 
         return changeStatuses.slice(0, -1).map(({name, status}, idx) => ({
-          seriesName: 'Status Area',
+          seriesName: t('status'),
           type: 'line',
           markLine: MarkLine({
             silent: true,
@@ -482,7 +482,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
               {({loading, reloading, timeseriesData, comparisonTimeseriesData}) => {
                 let comparisonMarkLines: LineChartSeries[] = [];
                 if (renderComparisonStats && comparisonTimeseriesData) {
-                  comparisonMarkLines = this.makeComparisonMarkLines(
+                  comparisonMarkLines = this.getComparisonMarkLines(
                     timeseriesData,
                     comparisonTimeseriesData
                   );

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -219,6 +219,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
     timeseriesData: Series[] = [],
     comparisonTimeseriesData: Series[] = []
   ): LineChartSeries[] {
+    const {timeWindow} = this.props;
     const changeStatuses: {name: number | string; status: string}[] = [];
 
     if (
@@ -233,7 +234,8 @@ class TriggersChart extends React.PureComponent<Props, State> {
       if (
         this.props.triggers.some(({alertThreshold}) => typeof alertThreshold === 'number')
       ) {
-        const lastPointLimit = (baseData[changeData.length - 1].name as number) - MINUTE;
+        const lastPointLimit =
+          (baseData[changeData.length - 1].name as number) - timeWindow * MINUTE;
         changeData.forEach(({name, value: comparisonValue}, idx) => {
           const baseValue = baseData[idx].value;
           const comparisonPercentage =
@@ -317,14 +319,30 @@ class TriggersChart extends React.PureComponent<Props, State> {
         ? warningTrigger.alertThreshold
         : undefined;
 
-    if (thresholdType === AlertRuleThresholdType.ABOVE && criticalTriggerAlertThreshold && value >= criticalTriggerAlertThreshold) {
+    if (
+      thresholdType === AlertRuleThresholdType.ABOVE &&
+      criticalTriggerAlertThreshold &&
+      value >= criticalTriggerAlertThreshold
+    ) {
       return 'critical';
-    } else if (thresholdType === AlertRuleThresholdType.ABOVE && warningTriggerAlertThreshold && value >= warningTriggerAlertThreshold) {
-        return 'warning';
-    } else if (thresholdType === AlertRuleThresholdType.BELOW && criticalTriggerAlertThreshold && -1 * value >= criticalTriggerAlertThreshold) {
-        return 'critical';
-    } else if (thresholdType === AlertRuleThresholdType.BELOW && warningTriggerAlertThreshold && -1 * value >= warningTriggerAlertThreshold) {
-        return 'warning';
+    } else if (
+      thresholdType === AlertRuleThresholdType.ABOVE &&
+      warningTriggerAlertThreshold &&
+      value >= warningTriggerAlertThreshold
+    ) {
+      return 'warning';
+    } else if (
+      thresholdType === AlertRuleThresholdType.BELOW &&
+      criticalTriggerAlertThreshold &&
+      -1 * value >= criticalTriggerAlertThreshold
+    ) {
+      return 'critical';
+    } else if (
+      thresholdType === AlertRuleThresholdType.BELOW &&
+      warningTriggerAlertThreshold &&
+      -1 * value >= warningTriggerAlertThreshold
+    ) {
+      return 'warning';
     }
 
     return '';

--- a/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/index.tsx
@@ -52,6 +52,7 @@ type Props = {
   resolveThreshold: IncidentRule['resolveThreshold'];
   thresholdType: IncidentRule['thresholdType'];
   header?: React.ReactNode;
+  comparisonDelta?: number;
 };
 
 const TIME_PERIOD_MAP: Record<TimePeriod, string> = {
@@ -282,7 +283,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {api, organization, projects, timeWindow, query, aggregate, environment} =
+    const {api, organization, projects, timeWindow, query, aggregate, environment, comparisonDelta} =
       this.props;
     const {totalCount} = this.state;
 

--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -309,6 +309,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
       right: 10,
       top: 0,
       selected,
+      data: data.map(d => ({name: d.seriesName})),
     };
 
     const chartOptions = {

--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -21,7 +21,7 @@ import {AlertRuleThresholdType, IncidentRule, Trigger} from '../../types';
 
 type DefaultProps = {
   data: Series[];
-  changeDataSeries: LineChartSeries[];
+  comparisonMarkLines: LineChartSeries[];
 };
 
 type Props = DefaultProps & {
@@ -62,7 +62,7 @@ const COLOR = {
 export default class ThresholdsChart extends PureComponent<Props, State> {
   static defaultProps: DefaultProps = {
     data: [],
-    changeDataSeries: [],
+    comparisonMarkLines: [],
   };
 
   state: State = {
@@ -80,7 +80,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
     if (
       this.props.triggers !== prevProps.triggers ||
       this.props.data !== prevProps.data ||
-      this.props.changeDataSeries !== prevProps.changeDataSeries
+      this.props.comparisonMarkLines !== prevProps.comparisonMarkLines
     ) {
       this.handleUpdateChartAxis();
     }
@@ -289,7 +289,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
   }
 
   render() {
-    const {data, triggers, period, aggregate, changeDataSeries} = this.props;
+    const {data, triggers, period, aggregate, comparisonMarkLines} = this.props;
     const dataWithoutRecentBucket: LineChartSeries[] = data?.map(
       ({data: eventData, ...restOfData}) => ({
         ...restOfData,
@@ -342,7 +342,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
             ])
           ),
         })}
-        series={[...dataWithoutRecentBucket, ...changeDataSeries]}
+        series={[...dataWithoutRecentBucket, ...comparisonMarkLines]}
         onFinished={() => {
           // We want to do this whenever the chart finishes re-rendering so that we can update the dimensions of
           // any graphics related to the triggers (e.g. the threshold areas + boundaries)

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -102,7 +102,7 @@ function createStatusAreaSeries(
   yPosition: number
 ): LineChartSeries {
   return {
-    seriesName: 'Status Area',
+    seriesName: '',
     type: 'line',
     markLine: MarkLine({
       silent: true,


### PR DESCRIPTION
This updates the metric alert builder chart for change alerts. It removes the threshold lines from the chart and adds the status areas based on the change percentage if a change percentage threshold and `changeDelta` period is selected in the alert builder, after picking `Percent Change` for the threshold type.

Example:
![Screen Shot 2021-10-13 at 1 00 36 AM](https://user-images.githubusercontent.com/15015880/137092009-c54ec1bb-55b6-4285-b655-58b2fe8c2e25.png)

Jira: [WOR-1409](https://getsentry.atlassian.net/browse/WOR-1409)
Figma: [Alerts-V3](https://www.figma.com/file/AQwJvc18VjSWWc3ujAWt4O/Alerts-V3?node-id=483%3A21326)
