### PR TITLE
ref(vsts): Shadow deprecate VSTS plugin

### DIFF
--- a/src/sentry/api/endpoints/organization_repositories.py
+++ b/src/sentry/api/endpoints/organization_repositories.py
@@ -1,5 +1,6 @@
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -23,6 +24,9 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
         :auth: required
         """
         queryset = Repository.objects.filter(organization_id=organization.id)
+
+        if not features.has("organizations:integrations-ignore-vsts-deprecation", organization):
+            queryset = queryset.exclude(provider="visualstudio")
 
         status = request.GET.get("status", "active")
         if status == "active":

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -11,6 +11,7 @@ from sentry.utils.http import absolute_uri
 SHADOW_DEPRECATED_PLUGINS = {
     "teamwork": "organizations:integrations-ignore-teamwork-deprecation",
     "clubhouse": "organizations:integrations-ignore-clubhouse-deprecation",
+    "vsts": "organizations:integrations-ignore-vsts-deprecation",
 }
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -994,10 +994,12 @@ SENTRY_FEATURES = {
     "organizations:integrations-stacktrace-link": False,
     # Allow orgs to install a custom source code management integration
     "organizations:integrations-custom-scm": False,
-    # Allow orgs to view the Teamwork plugin
+    # Allow orgs to use the deprecated Teamwork plugin
     "organizations:integrations-ignore-teamwork-deprecation": False,
-    # Allow orgs to view the Clubhouse/Shortcut plugin
+    # Allow orgs to use the deprecated Clubhouse/Shortcut plugin
     "organizations:integrations-ignore-clubhouse-deprecation": False,
+    # Allow orgs to use the deprecated VSTS (Azure DevOps) plugin
+    "organizations:integrations-ignore-vsts-deprecation": False,
     # Allow orgs to debug internal/unpublished sentry apps with logging
     "organizations:sentry-app-debugging": False,
     # Temporary safety measure, turned on for specific orgs only if

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -100,10 +100,10 @@ default_manager.add("organizations:integrations-vsts-limited-scopes", Organizati
 default_manager.add(
     "organizations:integrations-ignore-teamwork-deprecation", OrganizationFeature, True
 )
-
 default_manager.add(
     "organizations:integrations-ignore-clubhouse-deprecation", OrganizationFeature, True
 )
+default_manager.add("organizations:integrations-ignore-vsts-deprecation", OrganizationFeature, True)
 default_manager.add("organizations:invite-members", OrganizationFeature)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -14,6 +14,7 @@ const pathPrefix = '/settings/:orgId/projects/:projectId';
 const SHADOW_DEPRECATED_PLUGINS = {
   teamwork: 'integrations-ignore-teamwork-deprecation',
   clubhouse: 'integrations-ignore-clubhouse-deprecation',
+  vsts: 'integrations-ignore-vsts-deprecation',
 };
 
 const canViewPlugin = (pluginId: string, organization?: Organization) => {

--- a/tests/acceptance/sentry_plugins/test_vsts.py
+++ b/tests/acceptance/sentry_plugins/test_vsts.py
@@ -13,7 +13,8 @@ class VstsTest(AcceptanceTestCase):
         self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/vsts/"
 
     def test_simple(self):
-        self.browser.get(self.path)
-        self.browser.wait_until_not(".loading-indicator")
-        self.browser.snapshot("vsts settings")
-        assert self.browser.element_exists(".ref-plugin-config-vsts")
+        with self.feature("organizations:integrations-ignore-vsts-deprecation"):
+            self.browser.get(self.path)
+            self.browser.wait_until_not(".loading-indicator")
+            self.browser.snapshot("vsts settings")
+            assert self.browser.element_exists(".ref-plugin-config-vsts")


### PR DESCRIPTION
See [API-2136](https://getsentry.atlassian.net/browse/API-2136)

This PR, just like [the one for teamwork](https://github.com/getsentry/sentry/pull/29052) and [clubhouse](https://github.com/getsentry/sentry/pull/29082) removes and hides VSTS from the frontend and API to simulate deleting the plugin's source code. Similar to clubhouse, this plugin is already hidden for users who don't have it installed, so that isn't imaged here.

## With the feature flag:

- The plugin can be used and appears in the sidebar, along with any linked issues. These details also appear in the issue header

<img width="325" alt="sidebar before" src="https://user-images.githubusercontent.com/35509934/136508966-25dadeee-9c4d-46b5-97d5-d097b3eb9473.png">

<img width="703" alt="issue header before" src="https://user-images.githubusercontent.com/35509934/136509163-8a96a784-2344-4d3a-b40c-64208db14024.png">

- It appears, if installed, in the integration directory (as well as the plugin directory)

<img width="1425" alt="integrations directory before" src="https://user-images.githubusercontent.com/35509934/136509095-2478a023-a441-409a-b7ee-a401c37d3bea.png">

- Any repositories associated with the plugin appear in the repository list

<img width="1405" alt="repo list before" src="https://user-images.githubusercontent.com/35509934/136509335-bf4170f0-25d2-42f5-96d7-47bd7f6bbef0.png">


---


## Without the feature flag

 - Sidebar and header don't have VSTS information, azure devops linked/created issues are unaffected

<img width="335" alt="sidebar after" src="https://user-images.githubusercontent.com/35509934/136509382-798193fd-9c9f-4026-bd97-9e16b63c7573.png">

<img width="648" alt="issue header after" src="https://user-images.githubusercontent.com/35509934/136509392-2adf8b62-5c79-451d-b009-689762aa266d.png">

 - VSTS is hidden from the directory (Azure devops integration is unaffected)

<img width="1181" alt="integrations directory after" src="https://user-images.githubusercontent.com/35509934/136509415-34dad169-9e38-4650-9cf9-d46cec447fb4.png">

 - VSTS repos are hidden from the repo list (azure devops repos are unaffected)
 
<img width="1432" alt="repo list after" src="https://user-images.githubusercontent.com/35509934/136509430-75a8565a-736f-4e5b-95c1-9892c1924f8b.png">

