### PR TITLE
ref(ui): Refactor sessions existence checks

### DIFF
--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -25,9 +25,11 @@ import {
   ReleaseProject,
   ReleaseWithHealth,
   SessionApiResponse,
+  SessionField,
 } from 'app/types';
 import {formatVersion} from 'app/utils/formatters';
 import routeTitleGen from 'app/utils/routeTitle';
+import {getCount} from 'app/utils/sessions';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 import AsyncView from 'app/views/asyncView';
@@ -216,7 +218,7 @@ class ReleasesDetail extends AsyncView<Props, State> {
               defaultStatsPeriod,
               getHealthData,
               isHealthLoading,
-              hasHealthData: !!sessions?.groups[0].totals['sum(session)'],
+              hasHealthData: getCount(sessions?.groups, SessionField.SESSIONS) > 0,
               releaseBounds,
             }}
           >


### PR DESCRIPTION
`project` now has a top-level property `hasSessions`, we do not need to fetch sessions on frontend to get this info anymore.