### PR TITLE
feat(workflow) rate limit ProjectKeyStats endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -7,10 +7,12 @@ from sentry import tsdb
 from sentry.api.base import StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.models import ProjectKey
 
 
 class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
+    @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, project, key_id):
         try:
             key = ProjectKey.objects.get(

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -4,13 +4,12 @@ from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.api.helpers.group_index import rate_limit_endpoint
+from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.models import Environment
 
 
 class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
-
     @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, project):
         """

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -4,13 +4,11 @@ from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.models import Environment
 
 
 class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
-    @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, project):
         """
         Retrieve Event Counts for a Project

--- a/src/sentry/api/endpoints/project_stats.py
+++ b/src/sentry/api/endpoints/project_stats.py
@@ -5,10 +5,13 @@ from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
+from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.models import Environment
 
 
 class ProjectStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
+
+    @rate_limit_endpoint(limit=20, window=1)
     def get(self, request, project):
         """
         Retrieve Event Counts for a Project


### PR DESCRIPTION
This endpoint is being abused by an organization every minute causing snuba to rate limit it and taking up valuable resources. This fairly liberal rate limit should significantly cut down those requests and prevent abuse in the future 

There was a rate limit [added yesterday](https://github.com/getsentry/sentry/pull/29160) to a different endpoint, but it was in fact the wrong one