### PR TITLE
feat(discover): Previous period on charts

### DIFF
--- a/src/sentry/charts/types.py
+++ b/src/sentry/charts/types.py
@@ -15,3 +15,4 @@ class ChartType(Enum):
     SLACK_DISCOVER_TOTAL_DAILY = "slack:discover.totalDaily"
     SLACK_DISCOVER_TOP5_PERIOD = "slack:discover.top5Period"
     SLACK_DISCOVER_TOP5_DAILY = "slack:discover.top5Daily"
+    SLACK_DISCOVER_PREVIOUS_PERIOD = "slack:discover.previousPeriod"

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -37,8 +37,9 @@ def get_double_period(period: str) -> str:
     m = re.match(r"^(\d+)([hdmsw]?)$", period)
     if not m:
         m = re.match(r"^(\d+)([hdmsw]?)$", DEFAULT_PERIOD)
-    value, unit = m.groups()
-    value = int(value)  # type: ignore
+
+    value, unit = m.groups()  # type: ignore
+    value = int(value)
 
     return f"{value * 2}{unit}"
 

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -125,7 +125,7 @@ def unfurl_discover(
             params.pop("topEvents", None)
 
         if "previous" in display_mode:
-            stats_period = params.getlist("statsPeriod")[0] or DEFAULT_PERIOD
+            stats_period = params.getlist("statsPeriod", [DEFAULT_PERIOD])[0]
             parsed_period = parse_stats_period(stats_period)
             if parsed_period <= timedelta(days=MAX_PERIOD_DAYS_INCLUDE_PREVIOUS):
                 stats_period, _, _ = get_double_period(stats_period)

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -26,7 +26,6 @@ display_modes: Mapping[str, ChartType] = {
     "top5": ChartType.SLACK_DISCOVER_TOP5_PERIOD,
     "dailytop5": ChartType.SLACK_DISCOVER_TOP5_DAILY,
     "previous": ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD,
-    # TODO(epurkhiser): Previous period
 }
 
 TOP_N = 5

--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -33,14 +33,14 @@ MAX_PERIOD_DAYS_INCLUDE_PREVIOUS = 45
 DEFAULT_PERIOD = "14d"
 
 
-def get_double_period(period):
+def get_double_period(period: str) -> str:
     m = re.match(r"^(\d+)([hdmsw]?)$", period)
     if not m:
-        return None
+        m = re.match(r"^(\d+)([hdmsw]?)$", DEFAULT_PERIOD)
     value, unit = m.groups()
     value = int(value)  # type: ignore
 
-    return (f"{value * 2}{unit}", None, None)
+    return f"{value * 2}{unit}"
 
 
 def unfurl_discover(
@@ -127,8 +127,8 @@ def unfurl_discover(
         if "previous" in display_mode:
             stats_period = params.getlist("statsPeriod", [DEFAULT_PERIOD])[0]
             parsed_period = parse_stats_period(stats_period)
-            if parsed_period <= timedelta(days=MAX_PERIOD_DAYS_INCLUDE_PREVIOUS):
-                stats_period, _, _ = get_double_period(stats_period)
+            if parsed_period and parsed_period <= timedelta(days=MAX_PERIOD_DAYS_INCLUDE_PREVIOUS):
+                stats_period = get_double_period(stats_period)
                 params.setlist("statsPeriod", [stats_period])
 
         try:

--- a/src/sentry/web/frontend/debug/debug_chart_renderer.py
+++ b/src/sentry/web/frontend/debug/debug_chart_renderer.py
@@ -249,5 +249,11 @@ class DebugChartRendererView(View):
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_PERIOD, discover_empty))
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_top5))
         charts.append(generate_chart(ChartType.SLACK_DISCOVER_TOP5_DAILY, discover_empty))
+        charts.append(
+            generate_chart(ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_total_period)
+        )
+        charts.append(
+            generate_chart(ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD, discover_multi_y_axis)
+        )
 
         return render_to_response("sentry/debug/chart-renderer.html", context={"charts": charts})

--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -320,6 +320,7 @@ discoverCharts.push({
         lineSeries.push(
           LineSeries({
             name: t('previous %s', s.key),
+            stack: 'previous',
             data: previous.map(([_, countsForTimestamp], index) => [
               current[index][0] * 1000,
               countsForTimestamp.reduce((acc, {count}) => acc + count, 0),

--- a/static/app/chartcuterie/types.tsx
+++ b/static/app/chartcuterie/types.tsx
@@ -12,6 +12,7 @@ export enum ChartType {
   SLACK_DISCOVER_TOTAL_DAILY = 'slack:discover.totalDaily',
   SLACK_DISCOVER_TOP5_PERIOD = 'slack:discover.top5Period',
   SLACK_DISCOVER_TOP5_DAILY = 'slack:discover.top5Daily',
+  SLACK_DISCOVER_PREVIOUS_PERIOD = 'slack:discover.previousPeriod',
 }
 
 /**

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -197,3 +197,14 @@ export const getDimensionValue = (dimension?: number | string | null) => {
 
   return dimension;
 };
+
+const RGB_LIGHTEN_VALUE = 30;
+export const lightenHexToRgb = (colors: string[]) =>
+  colors.map(hex => {
+    const rgb = [
+      Math.min(parseInt(hex.slice(1, 3), 16) + RGB_LIGHTEN_VALUE, 255),
+      Math.min(parseInt(hex.slice(3, 5), 16) + RGB_LIGHTEN_VALUE, 255),
+      Math.min(parseInt(hex.slice(5, 7), 16) + RGB_LIGHTEN_VALUE, 255),
+    ];
+    return `rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`;
+  });

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -129,6 +129,42 @@ class UnfurlTest(TestCase):
         assert len(chart_data["stats"]["data"]) == 288
 
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
+    def test_unfurl_discover_previous_period(self, mock_generate_chart):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
+        )
+        self.store_event(
+            data={"fingerprint": ["group2"], "timestamp": min_ago}, project_id=self.project.id
+        )
+
+        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=previous&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project={self.project.id}&query=&sort=-timestamp&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise Exception("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(
+            [
+                "organizations:discover-basic",
+                "organizations:chart-unfurls",
+            ]
+        ):
+            unfurls = link_handlers[link_type].fn(self.request, self.integration, links, self.user)
+
+        assert unfurls[url] == build_discover_attachment(
+            title=args["query"].get("name"), chart_url="chart-url"
+        )
+        assert len(mock_generate_chart.mock_calls) == 1
+        chart_data = mock_generate_chart.call_args[0][1]
+        assert chart_data["seriesName"] == "count()"
+        assert len(chart_data["stats"]["data"]) == 48
+
+    @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
     def test_unfurl_discover_multi_y_axis(self, mock_generate_chart):
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -160,6 +160,7 @@ class UnfurlTest(TestCase):
             title=args["query"].get("name"), chart_url="chart-url"
         )
         assert len(mock_generate_chart.mock_calls) == 1
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["seriesName"] == "count()"
         assert len(chart_data["stats"]["data"]) == 48


### PR DESCRIPTION
Add support for previous period on unfurls.

Screenshots
<img width="500" alt="Screen Shot 2021-10-08 at 12 45 40 PM" src="https://user-images.githubusercontent.com/63818634/136593650-7e9c6afd-d965-4d4c-aa0b-f0bafaecd98f.png">

<img width="636" alt="Screen Shot 2021-10-08 at 12 27 21 PM" src="https://user-images.githubusercontent.com/63818634/136592587-5ab349f7-36f8-4ac4-9960-8b24f9c23275.png">

Chart debug:
![Screen Shot 2021-10-08 at 12 26 38 PM](https://user-images.githubusercontent.com/63818634/136592623-9128472f-16ce-479c-87b1-e16d45342a3a.png)

