### PR TITLE
fix(scim): no-op when member on team doesn't exist

### DIFF
--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -149,7 +149,7 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
             try:
                 omt = OrganizationMemberTeam.objects.get(team=team, organizationmember=member)
             except OrganizationMemberTeam.DoesNotExist:
-                pass
+                return
 
             self.create_audit_entry(
                 request=request,


### PR DESCRIPTION
If a Sentry org admin manually removes a user from a team, there is a chance azure doesn't sync with this change and will try to remove the user from the team. This throws an error because we `pass` instead of `return`.

[The RFC doesn't provide guidance in this case](https://datatracker.ietf.org/doc/html/rfc7644#section-3.5.2.2), but in the opposite one (member is already in team and you try to add), they simply say to let it go as a no-op, so we do the same here.