### PR TITLE
fix(discover): Add support for auto_fields to snql

### DIFF
--- a/src/sentry/search/events/base.py
+++ b/src/sentry/search/events/base.py
@@ -13,10 +13,15 @@ from sentry.utils.snuba import Dataset, resolve_column
 
 class QueryBase:
     def __init__(
-        self, dataset: Dataset, params: ParamsType, functions_acl: Optional[List[str]] = None
+        self,
+        dataset: Dataset,
+        params: ParamsType,
+        auto_fields: bool = False,
+        functions_acl: Optional[List[str]] = None,
     ):
         self.dataset = dataset
         self.params = params
+        self.auto_fields = auto_fields
         self.functions_acl = set() if functions_acl is None else functions_acl
 
         # Function is a subclass of CurriedFunction

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -30,9 +30,8 @@ class QueryBuilder(QueryFilter):
         offset: Optional[int] = 0,
         limitby: Optional[Tuple[str, int]] = None,
     ):
-        super().__init__(dataset, params, functions_acl)
+        super().__init__(dataset, params, auto_fields, functions_acl)
 
-        self.auto_fields = auto_fields
         # TODO: implement this in `resolve_select`
         self.auto_aggregations = auto_aggregations
 

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -22,6 +22,7 @@ class QueryBuilder(QueryFilter):
         query: Optional[str] = None,
         selected_columns: Optional[List[str]] = None,
         orderby: Optional[List[str]] = None,
+        auto_fields: bool = False,
         auto_aggregations: bool = False,
         use_aggregate_conditions: bool = False,
         functions_acl: Optional[List[str]] = None,
@@ -31,6 +32,7 @@ class QueryBuilder(QueryFilter):
     ):
         super().__init__(dataset, params, functions_acl)
 
+        self.auto_fields = auto_fields
         # TODO: implement this in `resolve_select`
         self.auto_aggregations = auto_aggregations
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2167,9 +2167,13 @@ class QueryFields(QueryBase):
     """Field logic for a snql query"""
 
     def __init__(
-        self, dataset: Dataset, params: ParamsType, functions_acl: Optional[List[str]] = None
+        self,
+        dataset: Dataset,
+        params: ParamsType,
+        auto_fields: bool = False,
+        functions_acl: Optional[List[str]] = None,
     ):
-        super().__init__(dataset, params, functions_acl)
+        super().__init__(dataset, params, auto_fields, functions_acl)
 
         self.function_alias_map: Dict[str, FunctionDetails] = {}
         self.field_alias_converter: Mapping[str, Callable[[str], SelectType]] = {

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2675,6 +2675,15 @@ class QueryFields(QueryBase):
             if resolved_column not in self.columns:
                 resolved_columns.append(resolved_column)
 
+        # Happens after resolving columns to check if there any aggregates
+        if self.auto_fields and not self.aggregates:
+            # Ensure fields we require to build a functioning interface
+            # are present.
+            if "id" not in stripped_columns:
+                resolved_columns.append(self.resolve_column("id", alias=True))
+            if "project.id" not in stripped_columns:
+                resolved_columns.append(self.resolve_column("project.id", alias=True))
+
         return resolved_columns
 
     def resolve_column(self, field: str, alias: bool = False) -> SelectType:

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -1038,9 +1038,13 @@ class QueryFilter(QueryFields):
     """Filter logic for a snql query"""
 
     def __init__(
-        self, dataset: Dataset, params: ParamsType, functions_acl: Optional[List[str]] = None
+        self,
+        dataset: Dataset,
+        params: ParamsType,
+        auto_fields: bool = False,
+        functions_acl: Optional[List[str]] = None,
     ):
-        super().__init__(dataset, params, functions_acl)
+        super().__init__(dataset, params, auto_fields, functions_acl)
 
         self.search_filter_converter: Mapping[
             str, Callable[[SearchFilter], Optional[WhereType]]

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -241,6 +241,7 @@ def query(
             query=query,
             selected_columns=selected_columns,
             orderby=orderby,
+            auto_fields=auto_fields,
             auto_aggregations=auto_aggregations,
             use_aggregate_conditions=use_aggregate_conditions,
             functions_acl=functions_acl,


### PR DESCRIPTION
- This adds auto_fields support, which is usually used for the id field
  in the discover table when theer's no aggregates involved
- Mayyyy have messed up the parent branch name here, sorry