### PR TITLE
feat(alert-rules): Add validation for schema fields attached to alert rules

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -37,7 +37,8 @@ class RuleNodeField(serializers.Field):
         if node.id in SCHEMA_FORM_ACTIONS:
             if not data.get("hasSchemaFormConfig"):
                 raise ValidationError("Please configure your integration settings below.")
-            return node.self_validate(data)
+            node.self_validate()
+            return data
 
         if not node.form_cls:
             return data

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -35,6 +35,8 @@ class RuleNodeField(serializers.Field):
 
         # Nodes with user-declared fields will manage their own validation
         if node.id in SCHEMA_FORM_ACTIONS:
+            if not data.get("hasSchemaFormConfig"):
+                raise ValidationError("Invalid node. Expected node with a schema-based form.")
             return node.self_validate(data)
 
         if not node.form_cls:

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -36,7 +36,7 @@ class RuleNodeField(serializers.Field):
         # Nodes with user-declared fields will manage their own validation
         if node.id in SCHEMA_FORM_ACTIONS:
             if not data.get("hasSchemaFormConfig"):
-                raise ValidationError("Please configure your integration settings below.")
+                raise ValidationError("Please configure your integration settings.")
             node.self_validate()
             return data
 

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from sentry import features
-from sentry.constants import MIGRATED_CONDITIONS, TICKET_ACTIONS
+from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
 from sentry.models import ActorTuple, Environment, Team, User
 from sentry.rules import rules
 
@@ -32,6 +32,10 @@ class RuleNodeField(serializers.Field):
             raise ValidationError(msg % data["id"])
 
         node = cls(self.context["project"], data)
+
+        # Nodes with user-declared fields will manage their own validation
+        if node.id in SCHEMA_FORM_ACTIONS:
+            return node.self_validate(data)
 
         if not node.form_cls:
             return data

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -36,7 +36,7 @@ class RuleNodeField(serializers.Field):
         # Nodes with user-declared fields will manage their own validation
         if node.id in SCHEMA_FORM_ACTIONS:
             if not data.get("hasSchemaFormConfig"):
-                raise ValidationError("Invalid node. Expected node with a schema-based form.")
+                raise ValidationError("Please configure your integration settings below.")
             return node.self_validate(data)
 
         if not node.form_cls:

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -33,10 +33,6 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
     # Required field for EventAction, value is ignored
     label = ""
 
-    # TODO(Leander): As there is no form_cls (e.g. NotifyEventSentryAppActionForm) the form data will
-    # not be validated on the backend. This is tricky to do since the schema form is dynamic, and will
-    # be implemented on it's own in the future. Frontend validation is still in place in the mean time.
-
     def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
         action_list = []
         for install in SentryAppInstallation.get_installed_for_org(project.organization_id):
@@ -68,8 +64,8 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
 
         return None
 
-    def self_validate(self, data):
-        sentry_app_installation_uuid = data.get("sentryAppInstallationUuid")
+    def self_validate(self):
+        sentry_app_installation_uuid = self.data.get("sentryAppInstallationUuid")
         if not sentry_app_installation_uuid:
             raise ValidationError("Missing attribute 'sentryAppInstallationUuid'")
 
@@ -87,7 +83,7 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
                 f"Alert Rule Actions are not enabled for the {sentry_app.name} integration."
             )
 
-        incoming_settings = data.get("settings")
+        incoming_settings = self.data.get("settings")
         if not incoming_settings:
             raise ValidationError(f"{sentry_app.name} requires settings to configure alert rules.")
 
@@ -117,8 +113,6 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
                 raise ValidationError(
                     f"Unexpected setting '{key}' configured for {sentry_app.name}"
                 )
-
-        return data
 
     def after(self, event: Event, state: str) -> Any:
         sentry_app = self.get_sentry_app(event)

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -20,7 +20,7 @@ def validate_field(value: str, field: Mapping[str, Any], app_name: str):
     # Only validate synchronous select fields
     if field.get("type") == "select" and not field.get("uri"):
         allowed_values = [option[0] for option in field.get("options")]
-        if value not in allowed_values:
+        if value and value not in allowed_values:
             field_label = field.get("label")
             allowed_values_message = ", ".join(allowed_values)
             raise ValidationError(

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -8,8 +8,7 @@ from rest_framework import serializers
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
 from sentry.eventstore.models import Event
-from sentry.models import Project, SentryApp, SentryAppInstallation
-from sentry.models.sentryappcomponent import SentryAppComponent
+from sentry.models import Project, SentryApp, SentryAppComponent, SentryAppInstallation
 from sentry.rules.actions.base import EventAction
 from sentry.tasks.sentry_apps import notify_sentry_app
 
@@ -72,7 +71,7 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
         try:
             sentry_app = SentryApp.objects.get(installations__uuid=sentry_app_installation_uuid)
         except SentryApp.DoesNotExist:
-            raise ValidationError("Could not identify sentry app from the installation uuid.")
+            raise ValidationError("Could not identify integration from the installation uuid.")
 
         try:
             alert_rule_component = SentryAppComponent.objects.get(
@@ -90,7 +89,7 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
         schema = alert_rule_component.schema.get("settings")
         all_fields = {}
         # Ensure required fields are provided and valid
-        for required_field in schema.get("required_fields"):
+        for required_field in schema.get("required_fields", []):
             field_name = required_field.get("name")
             field_value = incoming_settings.get(field_name)
             if not field_value:

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -3,12 +3,29 @@ Used for notifying a *specific* sentry app with a custom webhook payload (i.e. s
 """
 from typing import Any, Mapping, Optional, Sequence
 
+from rest_framework import serializers
+
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
 from sentry.eventstore.models import Event
 from sentry.models import Project, SentryApp, SentryAppInstallation
+from sentry.models.sentryappcomponent import SentryAppComponent
 from sentry.rules.actions.base import EventAction
 from sentry.tasks.sentry_apps import notify_sentry_app
+
+ValidationError = serializers.ValidationError
+
+
+def validate_field(value: str, field: Mapping[str, Any], app_name: str):
+    # Only validate synchronous select fields
+    if field.get("type") == "select" and not field.get("uri"):
+        allowed_values = [option[0] for option in field.get("options")]
+        if value not in allowed_values:
+            field_label = field.get("label")
+            allowed_values_message = ", ".join(allowed_values)
+            raise ValidationError(
+                f"{app_name} received {value} for {field_label} setting.\n Allowed values are {allowed_values_message}'"
+            )
 
 
 class NotifyEventSentryAppAction(EventAction):  # type: ignore
@@ -50,6 +67,57 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
             self.logger.info("rules.fail.no_app", extra=extra)
 
         return None
+
+    def self_validate(self, data):
+        sentry_app_installation_uuid = (
+            data.get("sentryAppInstallationUuid") or "b85e70c6-9c0a-4d4f-a06b-267ad8de97ca"
+        )
+        if not sentry_app_installation_uuid:
+            raise ValidationError("Please configure your integration settings below.")
+
+        try:
+            sentry_app = SentryApp.objects.get(installations__uuid=sentry_app_installation_uuid)
+        except SentryApp.DoesNotExist:
+            raise ValidationError("Could not identify sentry app from the installation uuid.")
+
+        try:
+            alert_rule_component = SentryAppComponent.objects.get(
+                sentry_app_id=sentry_app.id, type="alert-rule-action"
+            )
+        except SentryAppComponent.DoesNotExist:
+            raise ValidationError(
+                f"Alert Rule Actions are not enabled for the {sentry_app.name} integration."
+            )
+
+        incoming_settings = data.get("settings")
+        if not incoming_settings:
+            raise ValidationError(f"{sentry_app.name} requires settings to configure alert rules.")
+
+        schema = alert_rule_component.schema.get("settings")
+        for required_field in schema.get("required_fields"):
+            field_name = required_field.get("name")
+            field_label = required_field.get("label")
+            field_value = incoming_settings.get(field_name)
+            if not field_value:
+                raise ValidationError(
+                    f"{sentry_app.name} is missing required field '{field_label}'"
+                )
+            validate_field(incoming_settings.get(field_name), required_field, sentry_app.name)
+
+        for optional_field in schema.get("optional_fields", []):
+            field_name = optional_field.get("name")
+            field_value = incoming_settings.get(field_name)
+            validate_field(incoming_settings.get(field_name), optional_field, sentry_app.name)
+
+        for key in incoming_settings.keys():
+            if key not in schema.get("required_fields") and key not in schema.get(
+                "optional_fields"
+            ):
+                raise ValidationError(
+                    f"Unexpected setting '{key}' configured for {sentry_app.name}"
+                )
+
+        return data
 
     def after(self, event: Event, state: str) -> Any:
         sentry_app = self.get_sentry_app(event)

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -69,11 +69,9 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
         return None
 
     def self_validate(self, data):
-        sentry_app_installation_uuid = (
-            data.get("sentryAppInstallationUuid") or "b85e70c6-9c0a-4d4f-a06b-267ad8de97ca"
-        )
+        sentry_app_installation_uuid = data.get("sentryAppInstallationUuid")
         if not sentry_app_installation_uuid:
-            raise ValidationError("Please configure your integration settings below.")
+            raise ValidationError("Missing attribute 'sentryAppInstallationUuid'")
 
         try:
             sentry_app = SentryApp.objects.get(installations__uuid=sentry_app_installation_uuid)

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -73,7 +73,6 @@ from sentry.models import (
     Repository,
     RepositoryProjectPathConfig,
     Rule,
-    SentryAppComponent,
     Team,
     User,
     UserEmail,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -73,6 +73,7 @@ from sentry.models import (
     Repository,
     RepositoryProjectPathConfig,
     Rule,
+    SentryAppComponent,
     Team,
     User,
     UserEmail,
@@ -787,7 +788,24 @@ class Factories:
             "settings": {
                 "type": "alert-rule-settings",
                 "uri": "/sentry/alert-rule",
-                "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
+                "required_fields": [
+                    {"type": "text", "name": "title", "label": "Title"},
+                    {"type": "text", "name": "summary", "label": "Summary"},
+                ],
+                "optional_fields": [
+                    {
+                        "type": "select",
+                        "name": "points",
+                        "label": "Points",
+                        "options": [["1", "1"], ["2", "2"], ["3", "3"], ["5", "5"], ["8", "8"]],
+                    },
+                    {
+                        "type": "select",
+                        "name": "assignee",
+                        "label": "Assignee",
+                        "uri": "/sentry/members",
+                    },
+                ],
             },
         }
 

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -798,11 +798,7 @@ class UpdateProjectRuleTest(APITestCase):
         self.create_sentry_app(
             name="Pied Piper",
             organization=project.organization,
-            schema={
-                "elements": [
-                    self.create_alert_rule_action_schema(),
-                ]
-            },
+            schema={"elements": [self.create_alert_rule_action_schema()]},
         )
         install = self.create_sentry_app_installation(
             slug="pied-piper", organization=project.organization

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -811,7 +811,7 @@ class UpdateProjectRuleTest(APITestCase):
         actions = [
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
-                "settings": {"assignee": "Team Rocket", "priority": 27},
+                "settings": {"title": "Team Rocket", "summary": "We're blasting off again."},
                 "sentryAppInstallationUuid": install.uuid,
                 "hasSchemaFormConfig": True,
             },

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -439,7 +439,7 @@ class CreateProjectRuleTest(APITestCase):
         actions = [
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
-                "settings": {"assignee": "Team Rocket", "priority": 27},
+                "settings": {"title": "Team Rocket", "summary": "We're blasting off again."},
                 "sentryAppInstallationUuid": install.uuid,
                 "hasSchemaFormConfig": True,
             },

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -426,11 +426,7 @@ class CreateProjectRuleTest(APITestCase):
         self.create_sentry_app(
             name="Pied Piper",
             organization=project.organization,
-            schema={
-                "elements": [
-                    self.create_alert_rule_action_schema(),
-                ]
-            },
+            schema={"elements": [self.create_alert_rule_action_schema()]},
         )
         install = self.create_sentry_app_installation(
             slug="pied-piper", organization=project.organization

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -162,14 +162,16 @@ class ProjectRuleConfigurationTest(APITestCase):
         assert len(response.data["conditions"]) == 6
         assert len(response.data["filters"]) == 7
 
-    def test_sentry_app_alert_rules(self):
+    @patch("sentry.mediators.sentry_app_components.Preparer.run")
+    def test_sentry_app_alert_rules(self, mock_sentry_app_components_preparer):
         team = self.create_team()
         project1 = self.create_project(teams=[team], name="foo")
         self.create_project(teams=[team], name="baz")
+        settings_schema = self.create_alert_rule_action_schema()
 
         sentry_app = self.create_sentry_app(
             organization=self.organization,
-            schema={"elements": [self.create_alert_rule_action_schema()]},
+            schema={"elements": [settings_schema]},
             is_alertable=True,
         )
         install = self.create_sentry_app_installation(
@@ -185,11 +187,7 @@ class ProjectRuleConfigurationTest(APITestCase):
             "prompt": sentry_app.name,
             "enabled": True,
             "label": "Create Task with App with these ",
-            "formFields": {
-                "type": "alert-rule-settings",
-                "uri": "/sentry/alert-rule",
-                "required_fields": [{"type": "text", "name": "channel", "label": "Channel"}],
-            },
+            "formFields": settings_schema["settings"],
             "sentryAppInstallationUuid": str(install.uuid),
         } in response.data["actions"]
         assert len(response.data["conditions"]) == 6

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -1,29 +1,23 @@
+from unittest.mock import patch
+
+from exam import before
+from rest_framework import serializers
+
 from sentry.rules.actions.notify_event_sentry_app import NotifyEventSentryAppAction
 from sentry.tasks.sentry_apps import notify_sentry_app
 from sentry.testutils.cases import RuleTestCase
 
+ValidationError = serializers.ValidationError
 SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
 
 
 class NotifyEventSentryAppActionTest(RuleTestCase):
     rule_cls = NotifyEventSentryAppAction
-    schema = {
-        "elements": [
-            {
-                "type": "alert-rule-action",
-                "title": "Create Alert Rule UI Example Task",
-                "settings": {
-                    "type": "alert-rule-settings",
-                    "uri": "/test/",
-                    "required_fields": [
-                        {"type": "text", "label": "Title", "name": "title"},
-                        {"type": "textarea", "label": "Description", "name": "description"},
-                    ],
-                },
-            }
-        ]
-    }
-    schema_data = {"title": "foo", "description": "bar"}
+    schema_data = {"title": "Squid Game", "summary": "circle triangle square"}
+
+    @before
+    def create_schema(self):
+        self.schema = {"elements": [self.create_alert_rule_action_schema()]}
 
     def test_applies_correctly_for_sentry_apps(self):
         event = self.get_event()
@@ -54,7 +48,8 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         assert futures[0].kwargs["sentry_app"].id == self.app.id
         assert futures[0].kwargs["schema_defined_settings"] == self.schema_data
 
-    def test_sentry_app_actions(self):
+    @patch("sentry.mediators.sentry_app_components.Preparer.run")
+    def test_sentry_app_actions(self, mock_sentry_app_component_preparer):
         event = self.get_event()
 
         self.project = self.create_project(organization=event.organization)
@@ -70,12 +65,17 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
             slug="test-application", organization=event.organization
         )
 
+        # self.component = self.create_sentry_app_component(
+        #     sentry_app=self.app, schema=self.create_alert_rule_action_schema()
+        # )
+
         rule = self.get_rule(
             data={
                 "sentryAppInstallationUuid": self.install.uuid,
                 "settings": self.schema_data,
             }
         )
+        print(self.schema)
 
         action_list = rule.get_custom_actions(self.project)
         assert len(action_list) == 1
@@ -89,3 +89,82 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         assert action["enabled"]
         assert action["formFields"] == alert_element["settings"]
         assert alert_element["title"] in action["label"]
+
+    def test_self_validate(self):
+        self.organization = self.create_organization()
+        self.app = self.create_sentry_app(
+            organization=self.organization,
+            name="Test Application",
+            is_alertable=True,
+            schema=self.schema,
+        )
+        self.install = self.create_sentry_app_installation(
+            slug="test-application", organization=self.organization
+        )
+
+        # Test no Sentry App Installation uuid
+        rule = self.get_rule(data={"hasSchemaFormConfig": True})
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
+        # Test invalid Sentry App Installation uuid
+        rule = self.get_rule(
+            data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": "not_a_real_uuid"}
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
+        # Test Sentry Apps without alert rules configured in their schema
+        self.create_sentry_app(organization=self.organization, name="No Alert Rule Action")
+        test_install = self.create_sentry_app_installation(
+            organization=self.organization, slug="no-alert-rule-action"
+        )
+        rule = self.get_rule(
+            data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": test_install.uuid}
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
+        # Test without providing settings in rule data
+        rule = self.get_rule(
+            data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": self.install.uuid}
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
+        # Test without providing required field values
+        rule = self.get_rule(
+            data={
+                "hasSchemaFormConfig": True,
+                "sentryAppInstallationUuid": self.install.uuid,
+                "settings": {"title": "Lamy"},
+            }
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
+        # Test with additional fields not on the app's schema
+        rule = self.get_rule(
+            data={
+                "hasSchemaFormConfig": True,
+                "sentryAppInstallationUuid": self.install.uuid,
+                "settings": {"title": "Lamy", "summary": "Safari", "invalidField": "Invalid Value"},
+            }
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
+        # Test with invalid value on Select field
+        rule = self.get_rule(
+            data={
+                "hasSchemaFormConfig": True,
+                "sentryAppInstallationUuid": self.install.uuid,
+                "settings": {
+                    "title": "Lamy",
+                    "summary": "Safari",
+                    "points": "Invalid Select Value",
+                },
+            }
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -75,7 +75,6 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
                 "settings": self.schema_data,
             }
         )
-        print(self.schema)
 
         action_list = rule.get_custom_actions(self.project)
         assert len(action_list) == 1

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -113,6 +113,17 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         with self.assertRaises(ValidationError):
             rule.self_validate()
 
+        # Test deleted Sentry App Installation uuid
+        test_install = self.create_sentry_app_installation(
+            organization=self.organization, slug="test-application"
+        )
+        test_install.delete()
+        rule = self.get_rule(
+            data={"hasSchemaFormConfig": True, "sentryAppInstallationUuid": test_install.uuid}
+        )
+        with self.assertRaises(ValidationError):
+            rule.self_validate()
+
         # Test Sentry Apps without alert rules configured in their schema
         self.create_sentry_app(organization=self.organization, name="No Alert Rule Action")
         test_install = self.create_sentry_app_installation(

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -65,10 +65,6 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
             slug="test-application", organization=event.organization
         )
 
-        # self.component = self.create_sentry_app_component(
-        #     sentry_app=self.app, schema=self.create_alert_rule_action_schema()
-        # )
-
         rule = self.get_rule(
             data={
                 "sentryAppInstallationUuid": self.install.uuid,


### PR DESCRIPTION
See [API-2168](https://getsentry.atlassian.net/browse/API-2168)

This PR adds some validation to the forms coming in to create alert rules with UI components. Since the payload is directly sent to the third party, and we have a schema of what to expect, this will eliminate some obviously malformed request instead of ignoring errors or forcing a network request to identify them. 

**TODO**

- [x] Add tests
- [x] Write PR description
- [x] Take screenshots for proof

**Full API Demo**

Here you can see all the errors that are being tested for being surfaced. These errors would show up as toasts above the alert rule's action nodes, but it would involve bypassing the frontend validation which is a lot of tedious work to image all the errors showing up, so instead I just recorded some Postman proof. Here's an example of the error being surfaced.

<img width="885" alt="image" src="https://user-images.githubusercontent.com/35509934/136852039-155de791-8197-4d55-b78c-0a3121956801.png">

And here are all the possible errors that can be surfaced:

https://user-images.githubusercontent.com/35509934/136851522-07ef849c-7513-4cd4-a243-797960c55e25.mov

