### PR TITLE
fix(ui): Release comparison performance view for smaller screens

### DIFF
--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -355,6 +355,8 @@ const StyledPanelTable = styled(PanelTable)<{disableTopBorder: boolean}>`
 
 const StyledPanelItem = styled(PanelItem)`
   display: block;
+  white-space: nowrap;
+  width: 100%;
 `;
 
 const SubTitle = styled('div')`


### PR DESCRIPTION
Fix the performance sections on the release details page for smaller screen resolutions.

FIXES [WOR-1424](https://getsentry.atlassian.net/browse/WOR-1424)

cc @robinrendle 

# Before
<img width="483" alt="Screen Shot 2021-10-06 at 1 16 18 PM" src="https://user-images.githubusercontent.com/20312973/136639195-659f4348-9cad-4f6b-a5f8-2336727c05b1.png">

# After
This will scroll now
<img width="362" alt="Screen Shot 2021-10-08 at 5 12 33 PM" src="https://user-images.githubusercontent.com/20312973/136639203-5fe53d84-4153-447b-83b9-d6b63d0e636f.png">

