### PR TITLE
feat(symbolicator): Record metrics for projects being assigned and unassigned to the LPQ

### DIFF
--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -114,7 +114,7 @@ def _report_change(project_id, change: Literal["added", "removed"], reason: Opti
 
 
 def _record_metrics() -> None:
-    project_count = list(realtime_metrics.get_lpq_projects())
+    project_count = sum(1 for _p in realtime_metrics.get_lpq_projects())
     metrics.gauge(
         "tasks.store.symbolicate_event.low_priority.projects.auto",
         project_count,

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -57,7 +57,7 @@ def _scan_for_suspect_projects() -> None:
     realtime_metrics.remove_projects_from_lpq(expired_projects)
 
     for project_id in expired_projects:
-        _log_change(project_id=project_id, change="removed", reason="no metrics")
+        _report_change(project_id=project_id, change="removed", reason="no metrics")
 
 
 @instrumented_task(  # type: ignore
@@ -90,14 +90,14 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
     if is_eligible:
         was_added = realtime_metrics.add_project_to_lpq(project_id)
         if was_added:
-            _log_change(project_id=project_id, change="added", reason="eligible")
+            _report_change(project_id=project_id, change="added", reason="eligible")
     else:
         was_removed = realtime_metrics.remove_projects_from_lpq({project_id})
         if was_removed:
-            _log_change(project_id=project_id, change="removed", reason="ineligible")
+            _report_change(project_id=project_id, change="removed", reason="ineligible")
 
 
-def _log_change(project_id, change: Literal["added", "removed"], reason: Optional[str]) -> None:
+def _report_change(project_id, change: Literal["added", "removed"], reason: Optional[str]) -> None:
     if not reason:
         reason = "unknown"
 

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -34,8 +34,10 @@ logger = logging.getLogger(__name__)
 )
 def scan_for_suspect_projects() -> None:
     """Scans and updates the list of projects assigned to the low priority queue."""
-    _scan_for_suspect_projects()
-    _record_metrics()
+    try:
+        _scan_for_suspect_projects()
+    finally:
+        _record_metrics()
 
 
 def _scan_for_suspect_projects() -> None:
@@ -75,8 +77,10 @@ def update_lpq_eligibility(project_id: int, cutoff: int) -> None:
     should consider when calculating a project's eligibility. In other words, only data recorded
     before `cutoff` should be considered.
     """
-    _update_lpq_eligibility(project_id, cutoff)
-    _record_metrics()
+    try:
+        _update_lpq_eligibility(project_id, cutoff)
+    finally:
+        _record_metrics()
 
 
 def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -53,7 +53,7 @@ def _scan_for_suspect_projects() -> None:
         # TODO: add metrics!
         logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
 
-    project_count = len(list(realtime_metrics.projects()))
+    project_count = len(list(realtime_metrics.get_lpq_projects()))
     metrics.gauge(
         "tasks.store.symbolicate_event.low_priority.projects",
         project_count,
@@ -91,7 +91,7 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
         was_added = realtime_metrics.add_project_to_lpq(project_id)
         if was_added:
             logger.warning("Moved project to symbolicator's low priority queue: %s", project_id)
-            project_count = len(list(realtime_metrics.projects()))
+            project_count = len(list(realtime_metrics.get_lpq_projects()))
             metrics.gauge(
                 "tasks.store.symbolicate_event.low_priority.projects",
                 project_count,
@@ -101,7 +101,7 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
         was_removed = realtime_metrics.remove_projects_from_lpq({project_id})
         if was_removed:
             logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
-            project_count = len(list(realtime_metrics.projects()))
+            project_count = len(list(realtime_metrics.get_lpq_projects()))
             metrics.gauge(
                 "tasks.store.symbolicate_event.low_priority.projects",
                 project_count,

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -101,7 +101,9 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
             _report_change(project_id=project_id, change="removed", reason="ineligible")
 
 
-def _report_change(project_id, change: Literal["added", "removed"], reason: Optional[str]) -> None:
+def _report_change(
+    project_id: int, change: Literal["added", "removed"], reason: Optional[str]
+) -> None:
     if not reason:
         reason = "unknown"
 

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -12,6 +12,7 @@ import logging
 import time
 from typing import Iterable
 
+import sentry_sdk
 from typing_extensions import Literal
 
 from sentry import options
@@ -20,7 +21,6 @@ from sentry.processing import realtime_metrics
 from sentry.processing.realtime_metrics.base import BucketedCount, DurationHistogram
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
-from sentry.utils.sdk import capture_message, push_scope
 
 logger = logging.getLogger(__name__)
 
@@ -109,11 +109,11 @@ def _report_change(project_id: int, change: Literal["added", "removed"], reason:
     else:
         message = "Removed project from symbolicator's low priority queue"
 
-    with push_scope() as scope:
+    with sentry_sdk.push_scope() as scope:
         scope.set_level("warning")
         scope.set_tag("project", project_id)
         scope.set_tag("reason", reason)
-        capture_message(message)
+        sentry_sdk.capture_message(message)
 
 
 def _record_metrics() -> None:

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -120,10 +120,17 @@ def _record_metrics() -> None:
         project_count,
     )
 
+    # The manual kill switch is a list of configurations where each config item corresponds to one
+    # project affected by the switch. The general idea is to grab the raw option, validate its
+    # contents, and then assume that the length of the validated list corresponds to the number of
+    # projects in that switch.
+
     always_included_raw = options.get(
         "store.symbolicate-event-lpq-always",
     )
-    always_included = normalize_value("store.symbolicate-event-lpq-always", always_included_raw)
+    always_included = len(
+        normalize_value("store.symbolicate-event-lpq-always", always_included_raw)
+    )
     metrics.gauge(
         "tasks.store.symbolicate_event.low_priority.projects.manual.always",
         always_included,
@@ -132,7 +139,7 @@ def _record_metrics() -> None:
     never_included_raw = options.get(
         "store.symbolicate-event-lpq-never",
     )
-    never_included = normalize_value("store.symbolicate-event-lpq-never", never_included_raw)
+    never_included = len(normalize_value("store.symbolicate-event-lpq-never", never_included_raw))
     metrics.gauge(
         "tasks.store.symbolicate_event.low_priority.projects.manual.never",
         never_included,

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -53,7 +53,7 @@ def _scan_for_suspect_projects() -> None:
         # TODO: add metrics!
         logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
 
-    project_count = len(realtime_metrics.projects())
+    project_count = len(list(realtime_metrics.projects()))
     metrics.gauge(
         "tasks.store.symbolicate_event.low_priority.projects",
         project_count,
@@ -91,7 +91,7 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
         was_added = realtime_metrics.add_project_to_lpq(project_id)
         if was_added:
             logger.warning("Moved project to symbolicator's low priority queue: %s", project_id)
-            project_count = len(realtime_metrics.projects())
+            project_count = len(list(realtime_metrics.projects()))
             metrics.gauge(
                 "tasks.store.symbolicate_event.low_priority.projects",
                 project_count,
@@ -101,7 +101,7 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
         was_removed = realtime_metrics.remove_projects_from_lpq({project_id})
         if was_removed:
             logger.warning("Moved project out of symbolicator's low priority queue: %s", project_id)
-            project_count = len(realtime_metrics.projects())
+            project_count = len(list(realtime_metrics.projects()))
             metrics.gauge(
                 "tasks.store.symbolicate_event.low_priority.projects",
                 project_count,


### PR DESCRIPTION
Adds two major changes:
1. Reports project-related metrics that might be of interest to the LPQ, as requested by ops:
   - the number of projects selected for the LPQ
   - the number of projects manually forced into the LPQ via the killswitch
   - the number of projects manually excluded from the LPQ via the killswitch
2. Sends more detailed warnings to sentry when a project is moved in/out of the LPQ
   - adds project id
   - includes reason for change

2's implementation is heavily inspired by existing code in `getsentry`. 1 is a best attempt given the tools known to me. 

One drawback to 1's implementation is that it can take up to 10 seconds for a change to the manual kill switch to be reflected in our metrics. However, this seems preferable to the alternative of reporting whenever an event is processed, as there is no guarantee that events will always be hitting sentry. Reporting in both places is an option though.