### PR TITLE
fix(ui): Disable scroll hijack with cursor over zoomable charts

### DIFF
--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -282,7 +282,7 @@ class ChartZoom extends React.Component<Props> {
       utc,
       start,
       end,
-      dataZoom: DataZoomInside({xAxisIndex, zoomLock: true}),
+      dataZoom: DataZoomInside({xAxisIndex}),
       showTimeInTooltip: true,
       toolBox: ToolBox(
         {},

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -282,7 +282,7 @@ class ChartZoom extends React.Component<Props> {
       utc,
       start,
       end,
-      dataZoom: DataZoomInside({xAxisIndex}),
+      dataZoom: DataZoomInside({xAxisIndex, zoomLock: true}),
       showTimeInTooltip: true,
       toolBox: ToolBox(
         {},

--- a/static/app/components/charts/components/dataZoomInside.tsx
+++ b/static/app/components/charts/components/dataZoomInside.tsx
@@ -4,9 +4,9 @@ import {EChartOption} from 'echarts';
 
 const DEFAULT = {
   type: 'inside',
-  /** Mouse wheel can not trigger zoom. */
+  // Mouse wheel can not trigger zoom
   zoomOnMouseWheel: false,
-  /** The translation (by mouse drag or touch drag) is avialable but zoom is not */
+  // The translation (by mouse drag or touch drag) is avialable but zoom is not
   zoomLock: true,
   throttle: 50,
 };

--- a/static/app/components/charts/components/dataZoomInside.tsx
+++ b/static/app/components/charts/components/dataZoomInside.tsx
@@ -4,7 +4,10 @@ import {EChartOption} from 'echarts';
 
 const DEFAULT = {
   type: 'inside',
-  zoomOnMouseWheel: 'shift',
+  /** Mouse wheel can not trigger zoom. */
+  zoomOnMouseWheel: false,
+  /** The translation (by mouse drag or touch drag) is avialable but zoom is not */
+  zoomLock: true,
   throttle: 50,
 };
 


### PR DESCRIPTION
@Jesse-Box reported an issue with having your cursor over a chart hijacking the ability to scroll the entire document. eg. on the project details page. This setting should disable that feature of the zoom charts https://echarts.apache.org/en/option.html#dataZoom-inside.zoomLock

I don't think we use scroll to zoom anywhere??