### PR TITLE
feat(metric-alerts): Create/update Alert Rule UI Components

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -109,9 +109,9 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
                 context = {"uuid": client.uuid}
                 return Response(context, status=202)
 
-            updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
+            trigger_alert_rule_action_creators(kwargs.get("actions"))
 
-            trigger_alert_rule_action_creators(kwargs.get("actions"), rule, request)
+            updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 
             RuleActivity.objects.create(
                 rule=updated_rule, user=request.user, type=RuleActivityType.UPDATED.value

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,7 +1,6 @@
 from typing import Mapping, Sequence
 
 from rest_framework import serializers, status
-from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
@@ -25,8 +24,6 @@ from sentry.web.decorators import transaction_start
 
 def trigger_alert_rule_action_creators(
     actions: Sequence[Mapping[str, str]],
-    rule: Rule,
-    request: Request,
 ) -> None:
     for action in actions:
         # Only call creator for Sentry Apps with UI Components for alert rules.
@@ -37,9 +34,6 @@ def trigger_alert_rule_action_creators(
         result = alert_rule_actions.AlertRuleActionCreator.run(
             install=install,
             fields=action.get("settings"),
-            uri=action.get("uri"),
-            rule=rule,
-            request=request,
         )
         # Bubble up errors from Sentry App to the UI
         if not result["success"]:
@@ -128,12 +122,11 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 tasks.find_channel_id_for_rule.apply_async(kwargs=kwargs)
                 return Response(uuid_context, status=202)
 
+            trigger_alert_rule_action_creators(kwargs.get("actions"))
             rule = project_rules.Creator.run(request=request, **kwargs)
             RuleActivity.objects.create(
                 rule=rule, user=request.user, type=RuleActivityType.CREATED.value
             )
-
-            trigger_alert_rule_action_creators(kwargs.get("actions"), rule, request)
 
             self.create_audit_entry(
                 request=request,

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -36,7 +36,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         from sentry.incidents.endpoints.serializers import action_target_type_to_string
 
-        return {
+        result = {
             "id": str(obj.id),
             "alertRuleTriggerId": str(obj.alert_rule_trigger_id),
             "type": AlertRuleTriggerAction.get_registered_type(
@@ -52,3 +52,8 @@ class AlertRuleTriggerActionSerializer(Serializer):
             "dateCreated": obj.date_added,
             "desc": self.human_desc(obj),
         }
+
+        if obj.sentry_app_id and obj.sentry_app_config:
+            result["settings"] = obj.sentry_app_config
+
+        return result

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -53,6 +53,7 @@ class AlertRuleTriggerActionSerializer(Serializer):
             "desc": self.human_desc(obj),
         }
 
+        # Check if action is a Sentry App that has Alert Rule UI Component settings
         if obj.sentry_app_id and obj.sentry_app_config:
             result["settings"] = obj.sentry_app_config
 

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -89,7 +89,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
     target_type = serializers.CharField()
     sentry_app_config = serializers.JSONField(required=False)
     sentry_app_installation_uuid = serializers.CharField(required=False)
-    sentry_app_uri = serializers.CharField(required=False)
 
     class Meta:
         model = AlertRuleTriggerAction
@@ -102,7 +101,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
             "sentry_app",
             "sentry_app_config",
             "sentry_app_installation_uuid",
-            "sentry_app_uri",
         ]
         extra_kwargs = {
             "target_identifier": {"required": True},
@@ -111,7 +109,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
             "sentry_app": {"required": False, "allow_null": True},
             "sentry_app_config": {"required": False, "allow_null": True},
             "sentry_app_installation_uuid": {"required": False, "allow_null": True},
-            "sentry_app_uri": {"required": False, "allow_null": True},
         }
 
     def validate_type(self, type):
@@ -187,10 +184,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                     raise serializers.ValidationError(
                         {"sentry_app": "Missing paramater: sentry_app_installation_uuid"}
                     )
-                if not attrs.get("sentry_app_uri"):
-                    raise serializers.ValidationError(
-                        {"sentry_app": "Missing paramater: sentry_app_uri"}
-                    )
 
                 try:
                     install = SentryAppInstallation.objects.get(
@@ -204,7 +197,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 result = alert_rule_actions.AlertRuleActionCreator.run(
                     install=install,
                     fields=attrs.get("sentry_app_config"),
-                    uri=attrs.get("sentry_app_uri"),
                 )
 
                 if not result["success"]:
@@ -213,7 +205,6 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                     )
 
                 del attrs["sentry_app_installation_uuid"]
-                del attrs["sentry_app_uri"]
 
         attrs["use_async_lookup"] = self.context.get("use_async_lookup")
         attrs["input_channel_id"] = self.context.get("input_channel_id")

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -37,10 +37,8 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
 )
 from sentry.integrations.slack.utils import validate_channel_id
-from sentry.models import ActorTuple
-from sentry.models.organizationmember import OrganizationMember
-from sentry.models.team import Team
-from sentry.models.user import User
+from sentry.mediators import alert_rule_actions
+from sentry.models import ActorTuple, OrganizationMember, SentryAppInstallation, Team, User
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
@@ -89,15 +87,31 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
     id = serializers.IntegerField(required=False)
     type = serializers.CharField()
     target_type = serializers.CharField()
+    sentry_app_config = serializers.JSONField(required=False)
+    sentry_app_installation_uuid = serializers.CharField(required=False)
+    sentry_app_uri = serializers.CharField(required=False)
 
     class Meta:
         model = AlertRuleTriggerAction
-        fields = ["id", "type", "target_type", "target_identifier", "integration", "sentry_app"]
+        fields = [
+            "id",
+            "type",
+            "target_type",
+            "target_identifier",
+            "integration",
+            "sentry_app",
+            "sentry_app_config",
+            "sentry_app_installation_uuid",
+            "sentry_app_uri",
+        ]
         extra_kwargs = {
             "target_identifier": {"required": True},
             "target_display": {"required": False},
             "integration": {"required": False, "allow_null": True},
             "sentry_app": {"required": False, "allow_null": True},
+            "sentry_app_config": {"required": False, "allow_null": True},
+            "sentry_app_installation_uuid": {"required": False, "allow_null": True},
+            "sentry_app_uri": {"required": False, "allow_null": True},
         }
 
     def validate_type(self, type):
@@ -168,6 +182,39 @@ class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
                 raise serializers.ValidationError(
                     {"sentry_app": "SentryApp must be provided for sentry_app"}
                 )
+            if attrs.get("sentry_app_config"):
+                if attrs.get("sentry_app_installation_uuid") is None:
+                    raise serializers.ValidationError(
+                        {"sentry_app": "Missing paramater: sentry_app_installation_uuid"}
+                    )
+                if not attrs.get("sentry_app_uri"):
+                    raise serializers.ValidationError(
+                        {"sentry_app": "Missing paramater: sentry_app_uri"}
+                    )
+
+                try:
+                    install = SentryAppInstallation.objects.get(
+                        uuid=attrs.get("sentry_app_installation_uuid")
+                    )
+                except SentryAppInstallation.DoesNotExist:
+                    raise serializers.ValidationError(
+                        {"sentry_app": "The installation does not exist."}
+                    )
+                # Check response from creator and bubble up errors from providers as a ValidationError
+                result = alert_rule_actions.AlertRuleActionCreator.run(
+                    install=install,
+                    fields=attrs.get("sentry_app_config"),
+                    uri=attrs.get("sentry_app_uri"),
+                )
+
+                if not result["success"]:
+                    raise serializers.ValidationError(
+                        {"sentry_app": f'{install.sentry_app.name}: {result["message"]}'}
+                    )
+
+                del attrs["sentry_app_installation_uuid"]
+                del attrs["sentry_app_uri"]
+
         attrs["use_async_lookup"] = self.context.get("use_async_lookup")
         attrs["input_channel_id"] = self.context.get("input_channel_id")
         should_validate_channel_id = self.context.get("validate_channel_id", True)
@@ -273,7 +320,6 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
                     instance=action_instance,
                     data=action_data,
                 )
-
                 if action_serializer.is_valid():
                     try:
                         action_serializer.save()

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1200,6 +1200,7 @@ def create_alert_rule_trigger_action(
     sentry_app=None,
     use_async_lookup=False,
     input_channel_id=None,
+    sentry_app_config=None,
 ):
     """
     Creates an AlertRuleTriggerAction
@@ -1240,6 +1241,7 @@ def create_alert_rule_trigger_action(
         target_display=target_display,
         integration=integration,
         sentry_app=sentry_app,
+        sentry_app_config=sentry_app_config,
     )
 
 
@@ -1252,6 +1254,7 @@ def update_alert_rule_trigger_action(
     sentry_app=None,
     use_async_lookup=False,
     input_channel_id=None,
+    sentry_app_config=None,
 ):
     """
     Updates values on an AlertRuleTriggerAction
@@ -1274,6 +1277,8 @@ def update_alert_rule_trigger_action(
         updated_fields["integration"] = integration
     if sentry_app is not None:
         updated_fields["sentry_app"] = sentry_app
+    if sentry_app_config is not None:
+        updated_fields["sentry_app_config"] = sentry_app_config
     if target_identifier is not None:
         type = updated_fields.get("type", trigger_action.type)
 
@@ -1560,4 +1565,8 @@ def rewrite_trigger_action_fields(action_data):
     elif "sentryAppId" in action_data:
         action_data["sentry_app"] = action_data.pop("sentryAppId")
 
+    if "settings" in action_data:
+        action_data["sentry_app_config"] = action_data.pop("settings")
+    if "uri" in action_data:
+        action_data["sentry_app_uri"] = action_data.pop("uri")
     return action_data

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1567,6 +1567,4 @@ def rewrite_trigger_action_fields(action_data):
 
     if "settings" in action_data:
         action_data["sentry_app_config"] = action_data.pop("settings")
-    if "uri" in action_data:
-        action_data["sentry_app_uri"] = action_data.pop("uri")
     return action_data

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -6,7 +6,7 @@ class AlertRuleActionCreator(Mediator):
     install = Param("sentry.models.SentryAppInstallation")
     fields = Param(object)
     uri = Param((str,))
-    rule = Param("sentry.models.Rule")
+    rule = Param("sentry.models.Rule", required=False, default=None)
 
     def call(self):
         self._make_external_request()
@@ -14,7 +14,9 @@ class AlertRuleActionCreator(Mediator):
         return self.response
 
     def _save_alert_rule_action(self):
-        self.rule.save()
+        # Save Issue Alert Rules
+        if self.rule is not None:
+            self.rule.save()
 
     def _make_external_request(self):
         self.response = external_requests.AlertRuleActionRequester.run(

--- a/src/sentry/mediators/alert_rule_actions/creator.py
+++ b/src/sentry/mediators/alert_rule_actions/creator.py
@@ -1,3 +1,4 @@
+from sentry.coreapi import APIError
 from sentry.mediators import Mediator, Param, external_requests
 from sentry.models import SentryAppComponent
 from sentry.utils.cache import memoize
@@ -16,9 +17,13 @@ class AlertRuleActionCreator(Mediator):
         component = SentryAppComponent.objects.get(
             type="alert-rule-action", sentry_app=self.sentry_app
         )
-        return component.schema.get("uri")
+        settings = component.schema.get("settings", {})
+        return settings.get("uri")
 
-    def _make_external_request(self, uri):
+    def _make_external_request(self, uri=None):
+        if uri is None:
+            raise APIError("Sentry App request url not found")
+
         self.response = external_requests.AlertRuleActionRequester.run(
             install=self.install,
             uri=uri,

--- a/src/sentry/mediators/external_requests/alert_rule_action_requester.py
+++ b/src/sentry/mediators/external_requests/alert_rule_action_requester.py
@@ -42,7 +42,7 @@ class AlertRuleActionRequester(Mediator):
                 data=self.body,
             )
             body = safe_urlread(req)
-            response = json.loads(body)
+            response = {"success": True, "message": "", "body": json.loads(body)}
         except Exception as e:
             logger.info(
                 "alert_rule_action.error",
@@ -53,7 +53,8 @@ class AlertRuleActionRequester(Mediator):
                     "error_message": str(e),
                 },
             )
-            response = {}
+            # Bubble up error message from Sentry App to the UI for the user.
+            response = {"success": False, "message": str(e.response.text), "body": {}}
 
         return response
 

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -320,12 +320,11 @@ export class SentryAppExternalForm extends Component<Props, State> {
   };
 
   handleAlertRuleSubmit = (formData, onSubmitSuccess) => {
-    const {config, sentryAppInstallationUuid} = this.props;
+    const {sentryAppInstallationUuid} = this.props;
     if (this.model.validateForm()) {
       onSubmitSuccess({
         // The form data must be nested in 'settings' to ensure they don't overlap with any other field names.
         settings: formData,
-        uri: config.uri,
         sentryAppInstallationUuid,
         // Used on the backend to explicitly associate with a different rule than those without a custom form.
         hasSchemaFormConfig: true,

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -795,7 +795,15 @@ class UpdateProjectRuleTest(APITestCase):
 
         rule = Rule.objects.create(project=project, label="my super cool rule")
 
-        self.create_sentry_app(name="Pied Piper", organization=project.organization)
+        self.create_sentry_app(
+            name="Pied Piper",
+            organization=project.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
         install = self.create_sentry_app_installation(
             slug="pied-piper", organization=project.organization
         )
@@ -804,7 +812,6 @@ class UpdateProjectRuleTest(APITestCase):
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
                 "settings": {"assignee": "Team Rocket", "priority": 27},
-                "uri": "/sentry/alerts/",
                 "sentryAppInstallationUuid": install.uuid,
                 "hasSchemaFormConfig": True,
             },
@@ -841,16 +848,12 @@ class UpdateProjectRuleTest(APITestCase):
         kwargs = {
             "install": install,
             "fields": actions[0].get("settings"),
-            "uri": actions[0].get("uri"),
-            "rule": rule,
         }
 
         call_kwargs = mock_alert_rule_action_creator.call_args[1]
 
         assert call_kwargs["install"].id == kwargs["install"].id
         assert call_kwargs["fields"] == kwargs["fields"]
-        assert call_kwargs["uri"] == kwargs["uri"]
-        assert call_kwargs["rule"].id == kwargs["rule"].id
 
         assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.UPDATED.value).exists()
 

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -423,7 +423,15 @@ class CreateProjectRuleTest(APITestCase):
 
         project = self.create_project()
 
-        self.create_sentry_app(name="Pied Piper", organization=project.organization)
+        self.create_sentry_app(
+            name="Pied Piper",
+            organization=project.organization,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
+        )
         install = self.create_sentry_app_installation(
             slug="pied-piper", organization=project.organization
         )
@@ -432,7 +440,6 @@ class CreateProjectRuleTest(APITestCase):
             {
                 "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
                 "settings": {"assignee": "Team Rocket", "priority": 27},
-                "uri": "/sentry/alerts/",
                 "sentryAppInstallationUuid": install.uuid,
                 "hasSchemaFormConfig": True,
             },
@@ -467,13 +474,9 @@ class CreateProjectRuleTest(APITestCase):
         kwargs = {
             "install": install,
             "fields": actions[0].get("settings"),
-            "uri": actions[0].get("uri"),
-            "rule": rule,
         }
 
         call_kwargs = mock_alert_rule_action_creator.call_args[1]
 
         assert call_kwargs["install"].id == kwargs["install"].id
         assert call_kwargs["fields"] == kwargs["fields"]
-        assert call_kwargs["uri"] == kwargs["uri"]
-        assert call_kwargs["rule"].id == kwargs["rule"].id

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -662,6 +662,21 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             "trigger": self.trigger,
         }
 
+    @fixture
+    def sentry_app(self):
+        return self.create_sentry_app(
+            organization=self.organization,
+            published=True,
+            verify_install=False,
+            name="Super Awesome App",
+        )
+
+    @fixture
+    def sentry_app_installation(self):
+        return self.create_sentry_app_installation(
+            slug=self.sentry_app.slug, organization=self.organization, user=self.user
+        )
+
     def run_fail_validation_test(self, params, errors):
         base_params = self.valid_params.copy()
         base_params.update(params)
@@ -887,3 +902,126 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             AlertRuleTriggerAction.objects.filter(integration=integration)
         )
         assert len(alert_rule_trigger_actions) == 0
+
+    def test_sentry_app_action_missing_params(self):
+
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.SENTRY_APP
+                ).slug,
+                "target_type": action_target_type_to_string[
+                    AlertRuleTriggerAction.TargetType.SENTRY_APP
+                ],
+                "target_identifier": "123",
+                "sentry_app": self.sentry_app.id,
+                "sentry_app_config": {"tag": "asdfasdfads"},
+            },
+            {"sentryApp": ["Missing paramater: sentry_app_installation_uuid"]},
+        )
+
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.SENTRY_APP
+                ).slug,
+                "target_type": action_target_type_to_string[
+                    AlertRuleTriggerAction.TargetType.SENTRY_APP
+                ],
+                "target_identifier": "1",
+                "sentry_app": self.sentry_app.id,
+                "sentry_app_config": {"tag": "asdfasdfads"},
+                "sentry_app_installation_uuid": self.sentry_app_installation.uuid,
+            },
+            {"sentryApp": ["Missing paramater: sentry_app_uri"]},
+        )
+
+    @responses.activate
+    def test_sentry_app_action_creator_fails(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/alert-rule",
+            status=400,
+            body="Invalid tag.",
+        )
+        self.run_fail_validation_test(
+            {
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.SENTRY_APP
+                ).slug,
+                "target_type": action_target_type_to_string[
+                    AlertRuleTriggerAction.TargetType.SENTRY_APP
+                ],
+                "target_identifier": "1",
+                "sentry_app": self.sentry_app.id,
+                "sentry_app_config": {"tag": "asdfasdfads"},
+                "sentry_app_installation_uuid": self.sentry_app_installation.uuid,
+                "sentry_app_uri": "/alert-rule",
+            },
+            {"sentryApp": ["Super Awesome App: Invalid tag."]},
+        )
+
+    @responses.activate
+    def test_create_and_update_sentry_app_action_success(self):
+        responses.add(
+            method=responses.POST,
+            url="https://example.com/alert-rule",
+            status=200,
+            json={},
+        )
+
+        serializer = AlertRuleTriggerActionSerializer(
+            context=self.context,
+            data={
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.SENTRY_APP
+                ).slug,
+                "target_type": action_target_type_to_string[
+                    AlertRuleTriggerAction.TargetType.SENTRY_APP
+                ],
+                "target_identifier": "1",
+                "sentry_app": self.sentry_app.id,
+                "sentry_app_config": {"tag": "task"},
+                "sentry_app_installation_uuid": self.sentry_app_installation.uuid,
+                "sentry_app_uri": "/alert-rule",
+            },
+        )
+        assert serializer.is_valid()
+
+        # Create action
+        serializer.save()
+
+        # # Make sure the action was created.
+        alert_rule_trigger_actions = list(
+            AlertRuleTriggerAction.objects.filter(sentry_app=self.sentry_app)
+        )
+        assert len(alert_rule_trigger_actions) == 1
+
+        # Update action
+        serializer = AlertRuleTriggerActionSerializer(
+            context=self.context,
+            data={
+                "type": AlertRuleTriggerAction.get_registered_type(
+                    AlertRuleTriggerAction.Type.SENTRY_APP
+                ).slug,
+                "target_type": action_target_type_to_string[
+                    AlertRuleTriggerAction.TargetType.SENTRY_APP
+                ],
+                "target_identifier": "1",
+                "sentry_app": self.sentry_app.id,
+                "sentry_app_config": {"tag": "epic"},
+                "sentry_app_installation_uuid": self.sentry_app_installation.uuid,
+                "sentry_app_uri": "/alert-rule",
+            },
+            instance=alert_rule_trigger_actions[0],
+        )
+
+        assert serializer.is_valid()
+
+        # Update action
+        serializer.save()
+
+        alert_rule_trigger_action = AlertRuleTriggerAction.objects.get(sentry_app=self.sentry_app)
+
+        # Make sure the changes got applied
+        assert alert_rule_trigger_action.sentry_app_config == {"tag": "epic"}

--- a/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
+++ b/tests/sentry/mediators/external_requests/test_alert_rule_action_requester.py
@@ -16,7 +16,13 @@ class TestAlertRuleActionRequester(TestCase):
         self.group = self.create_group(project=self.project)
 
         self.sentry_app = self.create_sentry_app(
-            name="foo", organization=self.org, webhook_url="https://example.com", scopes=()
+            name="foo",
+            organization=self.org,
+            schema={
+                "elements": [
+                    self.create_alert_rule_action_schema(),
+                ]
+            },
         )
 
         self.install = self.create_sentry_app_installation(
@@ -29,17 +35,17 @@ class TestAlertRuleActionRequester(TestCase):
 
         responses.add(
             method=responses.POST,
-            url="https://example.com/alert-rule",
+            url="https://example.com/sentry/alert-rule",
             status=200,
-            content_type="application/json",
+            json={},
         )
 
         result = AlertRuleActionRequester.run(
             install=self.install,
-            uri="/alert-rule",
+            uri="/sentry/alert-rule",
             fields=fields,
         )
-        assert not result
+        assert result["success"]
 
         request = responses.calls[0].request
         assert request.headers["Sentry-App-Signature"]


### PR DESCRIPTION
## Objective:
Metric Alert POST/ or PUT/ request body should accept the settings from the sentry app alert rules. It forwards the data to the Sentry App using the AlertRuleAction Creator and saves the data in Sentry.

We also bubble up the error response text from the Sentry App to the UI. This happens for both Metric and Issue Alerts.

## Test Plan:
Added tests for the AlertRuleTriggerAction serializer