### PR TITLE
style(webpack): Don't use flag style comments for blocks

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -28,9 +28,7 @@ interface Configuration extends webpack.Configuration {
 
 const {env} = process;
 
-/**
- * Environment configuration
- */
+// Environment configuration
 const IS_PRODUCTION = env.NODE_ENV === 'production';
 const IS_TEST = env.NODE_ENV === 'test' || !!env.TEST_SUITE;
 const IS_STORYBOOK = env.STORYBOOK_BUILD === '1';
@@ -52,10 +50,9 @@ const IS_UI_DEV_ONLY = !!env.SENTRY_UI_DEV_ONLY;
 const DEV_MODE = !(IS_PRODUCTION || IS_CI);
 const WEBPACK_MODE: Configuration['mode'] = IS_PRODUCTION ? 'production' : 'development';
 
-/**
- * Environment variables that are used by other tooling and should
- * not be user configurable.
- */
+// Environment variables that are used by other tooling and should
+// not be user configurable.
+//
 // Ports used by webpack dev server to proxy to backend and webpack
 const SENTRY_BACKEND_PORT = env.SENTRY_BACKEND_PORT;
 const SENTRY_WEBPACK_PROXY_HOST = env.SENTRY_WEBPACK_PROXY_HOST;
@@ -67,14 +64,12 @@ const FORCE_WEBPACK_DEV_SERVER = !!env.FORCE_WEBPACK_DEV_SERVER;
 const HAS_WEBPACK_DEV_SERVER_CONFIG =
   !!SENTRY_BACKEND_PORT && !!SENTRY_WEBPACK_PROXY_PORT;
 
-/**
- * User/tooling configurable environment variables
- */
+// User/tooling configurable environment variables
 const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
 const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
 
-// Deploy previews are built using zeit. We can check if we're in zeit's
+// Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.
 const DEPLOY_PREVIEW_CONFIG = IS_DEPLOY_PREVIEW && {
   branch: env.NOW_GITHUB_COMMIT_REF,
@@ -100,9 +95,7 @@ const sentryDjangoAppPath = path.join(__dirname, 'src/sentry/static/sentry');
 const distPath = env.SENTRY_STATIC_DIST_PATH || path.join(sentryDjangoAppPath, 'dist');
 const staticPrefix = path.join(__dirname, 'static');
 
-/**
- * Locale file extraction build step
- */
+// Locale file extraction build step
 if (env.SENTRY_EXTRACT_TRANSLATIONS === '1') {
   babelConfig.plugins?.push([
     'module:babel-gettext-extractor',
@@ -121,21 +114,19 @@ if (env.SENTRY_EXTRACT_TRANSLATIONS === '1') {
   ]);
 }
 
-/**
- * Locale compilation and optimizations.
- *
- * Locales are code-split from the app and vendor chunk into separate chunks
- * that will be loaded by layout.html depending on the users configured locale.
- *
- * Code splitting happens using the splitChunks plugin, configured under the
- * `optimization` key of the webpack module. We create chunk (cache) groups for
- * each of our supported locales and extract the PO files and moment.js locale
- * files into each chunk.
- *
- * A plugin is used to remove the locale chunks from the app entry's chunk
- * dependency list, so that our compiled bundle does not expect that *all*
- * locale chunks must be loaded
- */
+// Locale compilation and optimizations.
+//
+// Locales are code-split from the app and vendor chunk into separate chunks
+// that will be loaded by layout.html depending on the users configured locale.
+//
+// Code splitting happens using the splitChunks plugin, configured under the
+// `optimization` key of the webpack module. We create chunk (cache) groups for
+// each of our supported locales and extract the PO files and moment.js locale
+// files into each chunk.
+//
+// A plugin is used to remove the locale chunks from the app entry's chunk
+// dependency list, so that our compiled bundle does not expect that *all*
+// locale chunks must be loaded
 const localeCatalogPath = path.join(
   __dirname,
   'src',


### PR DESCRIPTION
Flag style comments assign documentation to the function / variable declaration immediately below them. In these cases, the documentation was not specific to the declaration below the, but the block below them.

It's all just semantics