### PR TITLE
feat(workflow): Add team label to team insights dropdown

### DIFF
--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -239,9 +239,9 @@ function TeamSelector(props: Props) {
       onInputChange={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}
       isOptionDisabled={option => !!option.disabled}
       styles={{
-        ...(styles ?? {}),
         ...(includeUnassigned ? unassignedSelectStyles : {}),
         ...placeholderSelectStyles,
+        ...(styles ?? {}),
       }}
       isLoading={fetching}
       {...extraProps}

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
 import pick from 'lodash/pick';
@@ -59,6 +60,7 @@ function TeamInsightsOverview({
   location,
   router,
 }: Props) {
+  const theme = useTheme();
   const query = location?.query ?? {};
   const localStorageKey = `teamInsightsSelectedTeamId:${organization.slug}`;
 
@@ -176,12 +178,30 @@ function TeamInsightsOverview({
         {!loadingTeams && (
           <Layout.Main fullWidth>
             <ControlsWrapper>
-              <TeamSelector
+              <StyledTeamSelector
                 name="select-team"
+                inFieldLabel={t('Team: ')}
                 value={currentTeam?.slug}
                 isLoading={loadingTeams}
                 onChange={choice => handleChangeTeam(choice.actor.id)}
                 teamFilter={filterTeam => filterTeam.isMember}
+                styles={{
+                  singleValue(provided: any) {
+                    const custom = {
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      fontSize: theme.fontSizeMedium,
+                      ':before': {
+                        ...provided[':before'],
+                        color: theme.textColor,
+                        marginRight: space(1.5),
+                        marginLeft: space(0.5),
+                      },
+                    };
+                    return {...provided, ...custom};
+                  },
+                }}
               />
               <StyledPageTimeRangeSelector
                 organization={organization}
@@ -323,8 +343,18 @@ const ControlsWrapper = styled('div')`
   }
 `;
 
+const StyledTeamSelector = styled(TeamSelector)`
+  & > div {
+    box-shadow: ${p => p.theme.dropShadowLight};
+  }
+`;
+
 const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`
-  flex-grow: 1;
+  height: 40px;
+
+  div {
+    min-height: unset;
+  }
 `;
 
 const SectionTitle = styled(Layout.Title)`

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -201,6 +201,21 @@ function TeamInsightsOverview({
                     };
                     return {...provided, ...custom};
                   },
+                  input: (provided: any, state: any) => ({
+                    ...provided,
+                    display: 'grid',
+                    gridTemplateColumns: 'max-content 1fr',
+                    alignItems: 'center',
+                    gridGap: space(1),
+                    ':before': {
+                      backgroundColor: state.theme.backgroundSecondary,
+                      height: 24,
+                      width: 38,
+                      borderRadius: 3,
+                      content: '""',
+                      display: 'block',
+                    },
+                  }),
                 }}
               />
               <StyledPageTimeRangeSelector

--- a/static/app/views/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/teamInsights/teamIssuesReviewed.tsx
@@ -182,6 +182,7 @@ const StyledPanelTable = styled(PanelTable)`
   white-space: nowrap;
   margin-bottom: 0;
   border: 0;
+  box-shadow: unset;
 
   & > div {
     padding: ${space(1)} ${space(2)};

--- a/static/app/views/teamInsights/teamMisery.tsx
+++ b/static/app/views/teamInsights/teamMisery.tsx
@@ -254,7 +254,7 @@ const StyledPanelTable = styled(PanelTable)<{isEmpty: boolean}>`
   white-space: nowrap;
   margin-bottom: 0;
   border: 0;
-  box-shadow: none;
+  box-shadow: unset;
 
   & > div {
     padding: ${space(1)} ${space(2)};

--- a/static/app/views/teamInsights/teamStability.tsx
+++ b/static/app/views/teamInsights/teamStability.tsx
@@ -204,6 +204,7 @@ const StyledPanelTable = styled(PanelTable)`
   white-space: nowrap;
   margin-bottom: 0;
   border: 0;
+  box-shadow: unset;
 
   & > div {
     padding: ${space(1)} ${space(2)};


### PR DESCRIPTION
- Adds a label to the team picker dropdown and makes the two dropdowns match visually
- unset some box shadows in the panel tables that shows up when there is only 1 or 2 items.

![image](https://user-images.githubusercontent.com/1400464/136868045-7b840605-6ca6-448c-9e33-b11869774dcf.png)
