### PR TITLE
ref(release): Use bulk insert for CommitFileChange in set_commits

### DIFF
--- a/src/sentry/db/postgres/helpers.py
+++ b/src/sentry/db/postgres/helpers.py
@@ -1,28 +1,5 @@
 import psycopg2
-from django.db import connections, router
 from django.db.utils import DatabaseError, InterfaceError
-
-
-def bulk_insert_on_conflict_do_nothing(Model, rows):
-    """
-    Bulk insert, ignoring conflicts. Does not trigger pre/post save signals.
-
-    `rows` should be supplied as list of mappings, with collumn names as keys.
-    """
-    if not rows:
-        return
-    cols = rows[0].keys()
-    with connections[router.db_for_write(Model)].cursor() as cursor:
-        cursor.execute(
-            f"""
-            INSERT INTO {Model._meta.db_table}
-                ({','.join(cols)})
-            VALUES
-                {','.join(['(%s, %s, %s, %s)'] * len(rows))}
-            ON CONFLICT DO NOTHING;
-            """,
-            [row[col] for row in rows for col in cols],
-        )
 
 
 def can_reconnect(exc):

--- a/src/sentry/db/postgres/helpers.py
+++ b/src/sentry/db/postgres/helpers.py
@@ -16,7 +16,7 @@ def bulk_insert_on_conflict_do_nothing(Model, rows):
         cursor.execute(
             f"""
             INSERT INTO {Model._meta.db_table}
-                (','.join(cols))
+                ({','.join(cols)})
             VALUES
                 {','.join(['(%s, %s, %s, %s)'] * len(rows))}
             ON CONFLICT DO NOTHING;

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -894,7 +894,7 @@ class Release(Model):
                         patch_set_rows = [
                             {
                                 "organization_id": self.organization.id,
-                                "commit": commit,
+                                "commit_id": commit.id,
                                 "filename": patched_file["path"],
                                 "type": patched_file["type"],
                             }


### PR DESCRIPTION
For large `patch_set`s this can result in a lot of inserts and commits/rollbacks for the savepoints. (e.g. https://sentry.io/organizations/sentry/performance/sentry:55a714cffce145528800d18f8176a237/?project=1&query=transaction.duration%3A%3C15m+transaction%3A%2Afetch_commits%2A+event.type%3Atransaction&statsPeriod=24h&transaction=sentry.tasks.commits.fetch_commits&unselectedSeries=p100%28%29)