### PR TITLE
fix(tests) Add a sleep to /issues test

### DIFF
--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1,3 +1,4 @@
+import time
 from datetime import timedelta
 from urllib.parse import quote
 from uuid import uuid4
@@ -123,6 +124,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.client.get(f"{self.path}?statsPeriod=", format="json")
         assert response.status_code == 200
 
+        time.sleep(1)
         response = self.client.get(f"{self.path}?statsPeriod=48h", format="json")
         assert response.status_code == 400
 


### PR DESCRIPTION
There was a rate limit added to this endpoint recently which started causing
this test to fail. Add a sleep to avoid hitting that.