### PR TITLE
fix(tests): Do not rate limit test_stats_period

### DIFF
--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -106,7 +106,9 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert links["previous"]["results"] == "true"
         assert links["next"]["results"] == "false"
 
-    def test_stats_period(self):
+    @patch("sentry.api.helpers.group_index.ratelimiter.is_limited")
+    def test_stats_period(self, mock_rate_limiter):
+        mock_rate_limiter.return_value = False  # Never rate limit
         # TODO(dcramer): this test really only checks if validation happens
         # on statsPeriod
         self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))


### PR DESCRIPTION
There was a rate limit added to this endpoint recently which started causing
this test to fail. Mock rate limiter to prevent this.