### PR TITLE
feat(u2f): disabled enrolling the same device for u2f

### DIFF
--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -49,7 +49,7 @@ class U2fInterface extends React.Component<Props, State> {
     }
   }
 
-  invokeU2fSetupFlow(promise) {
+  submitU2fResponse(promise) {
     promise
       .then(data => {
         this.setState(
@@ -116,32 +116,13 @@ class U2fInterface extends React.Component<Props, State> {
 
     if (this.props.flowMode === 'sign') {
       promise = u2f.sign(this.props.challengeData.authenticateRequests);
-      this.invokeU2fSetupFlow(promise);
     } else if (this.props.flowMode === 'enroll') {
-      const {registerRequests, authenticateRequests, registeredKeys} =
-        this.props.challengeData;
-      if (registeredKeys.length !== 0) {
-        u2f
-          .register(registerRequests as any, registeredKeys as any)
-          .then(() => {
-            promise = u2f.register(registerRequests, authenticateRequests);
-            this.invokeU2fSetupFlow(promise);
-          })
-          .catch(err => {
-            const failure = 'DUPLICATE_DEVICE';
-            Sentry.captureException(err);
-            this.setState({
-              deviceFailure: failure,
-              hasBeenTapped: false,
-            });
-          });
-      } else {
-        promise = u2f.register(registerRequests, authenticateRequests);
-        this.invokeU2fSetupFlow(promise);
-      }
+      const {registerRequests, registeredKeys} = this.props.challengeData;
+      promise = u2f.register(registerRequests as any, registeredKeys as any);
     } else {
       throw new Error(`Unsupported flow mode '${this.props.flowMode}'`);
     }
+    this.submitU2fResponse(promise);
   }
 
   onTryAgain = () => {

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -123,6 +123,7 @@ class U2fInterface extends React.Component<Props, State> {
         u2f
           .register(registerRequests as any, registeredKeys as any)
           .then(() => {
+            promise = u2f.register(registerRequests, authenticateRequests);
             this.invokeU2fSetupFlow(promise);
           })
           .catch(err => {

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -121,7 +121,7 @@ class U2fInterface extends React.Component<Props, State> {
         this.props.challengeData;
       if (registeredKeys.length !== 0) {
         u2f
-          .register(registerRequests, registeredKeys)
+          .register(registerRequests as any, registeredKeys as any)
           .then(() => {
             this.invokeU2fSetupFlow(promise);
           })
@@ -200,7 +200,7 @@ class U2fInterface extends React.Component<Props, State> {
             {
               UNKNOWN_ERROR: t('There was an unknown problem, please try again'),
               DEVICE_ERROR: t('Your U2F device reported an error.'),
-              DUPLICATE_DEVICE: t('This device is already in use.'),
+              DUPLICATE_DEVICE: t('This device is already registered with Sentry.'),
               UNKNOWN_DEVICE: t('The device you used for sign-in is unknown.'),
               BAD_APPID: tct(
                 '[p1:The Sentry server administrator modified the ' +

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -116,6 +116,7 @@ class U2fInterface extends React.Component<Props, State> {
 
     if (this.props.flowMode === 'sign') {
       promise = u2f.sign(this.props.challengeData.authenticateRequests);
+      this.invokeU2fSetupFlow(promise);
     } else if (this.props.flowMode === 'enroll') {
       const {registerRequests, authenticateRequests, registeredKeys} =
         this.props.challengeData;

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -726,9 +726,10 @@ export type Authenticator = {
   );
 
 export type ChallengeData = {
-  authenticateRequests: u2f.SignRequest;
-  registerRequests: u2f.RegisterRequest;
-  registeredKeys: u2f.RegisteredKey;
+  // will have only authenticateRequest or registerRequest
+  authenticateRequests?: u2f.SignRequest[];
+  registerRequests?: u2f.RegisterRequest[];
+  registeredKeys: u2f.RegisteredKey[];
 };
 
 export type EnrolledAuthenticator = {

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -728,6 +728,7 @@ export type Authenticator = {
 export type ChallengeData = {
   authenticateRequests: u2f.SignRequest;
   registerRequests: u2f.RegisterRequest;
+  registeredKeys: u2f.RegisteredKey;
 };
 
 export type EnrolledAuthenticator = {

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -727,8 +727,8 @@ export type Authenticator = {
 
 export type ChallengeData = {
   // will have only authenticateRequest or registerRequest
-  authenticateRequests?: u2f.SignRequest[];
-  registerRequests?: u2f.RegisterRequest[];
+  authenticateRequests: u2f.SignRequest;
+  registerRequests: u2f.RegisterRequest;
   registeredKeys: u2f.RegisteredKey[];
 };
 


### PR DESCRIPTION
A user will no longer be able to enrol the same u2f device twice. 

u2f.register() with registeredKeys passed in will error if the device is been registered already. If so, we want to display that it has been registered and not allow the user to continue with adding a u2f key.

Solves: https://getsentry.atlassian.net/browse/ER-640
https://getsentry.atlassian.net/browse/ER-642