### PR TITLE
dev: Add pyright as a pre-commit hook [WOR-1318]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,13 @@ repos:
       language: system
       files: requirements-base.txt
       pass_filenames: false
+    - id: pyright
+      name: pyright
+      entry: pyright
+      language: node
+      types: [ python ]
+      pass_filenames: true
+      additional_dependencies: [ "pyright@1.1.178" ]
 
 -   repo: https://github.com/sirosen/check-jsonschema
     rev: 0.3.0

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "prism-sentry": "^1.0.2",
     "process": "^0.11.10",
     "prop-types": "^15.6.0",
+    "pyright": "^1.1.178",
     "qrcode.react": "^1.0.1",
     "query-string": "7.0.1",
     "react": "17.0.2",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": [
+    "src"
+  ],
+
+  "exclude": [
+    ".volta/**"
+  ],
+
+  "typeCheckingMode": "off",
+  "reportMissingImports": "none",
+  "reportUndefinedVariable": "none",
+  "reportUnboundVariable": "error"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12117,6 +12117,11 @@ puppeteer@^10.1.0:
     unbzip2-stream "1.3.3"
     ws "7.4.6"
 
+pyright@^1.1.178:
+  version "1.1.178"
+  resolved "https://registry.yarnpkg.com/pyright/-/pyright-1.1.178.tgz#0c3db46989ae59c01643f5b9778c6b43a56696c7"
+  integrity sha512-OhEoC5HfKZqvY5GVCsHeroYDx85xp4CZwevhNsePxNzZyW+W491K4bfLTvuOBnvcnMWip+aMQ7zzFDkw74Gtkg==
+
 qr.js@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"


### PR DESCRIPTION
Adds Pyright as a pre-commit hook check for potential unbound variables, and all type checks are disabled given that we use mypy for that

Future Preventive measures against https://getsentry.atlassian.net/browse/INC-31
In my particular case, PyCharm linter usually alerts me when there is a potential unbound variable. However, in this case it didn't because the code block was wrapped in a context manager, and so adding Pyright to alert in the future against unbound local variables 

![Screenshot 2021-10-13 at 11 26 04](https://user-images.githubusercontent.com/10855986/137107172-006ee444-88c3-4c33-9202-4485f05549d8.png)
