### PR TITLE
feat(ui): Add related issues to crash rate alerts

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -288,7 +288,7 @@ export default class DetailsBody extends React.Component<Props> {
       return this.renderLoading();
     }
 
-    const {query, projects: projectSlugs} = rule;
+    const {query, projects: projectSlugs, dataset} = rule;
 
     const queryWithTypeFilter = `${query} ${extractEventTypeFilterFromRule(rule)}`.trim();
 
@@ -364,15 +364,13 @@ export default class DetailsBody extends React.Component<Props> {
                     projects={projects}
                     interval={this.getInterval()}
                     filter={this.getFilter()}
-                    query={
-                      rule.dataset === Dataset.SESSIONS ? query : queryWithTypeFilter
-                    }
+                    query={dataset === Dataset.SESSIONS ? query : queryWithTypeFilter}
                     orgId={orgId}
                     handleZoom={handleZoom}
                   />
                   <DetailWrapper>
                     <ActivityWrapper>
-                      {rule?.dataset === Dataset.ERRORS && (
+                      {[Dataset.SESSIONS, Dataset.ERRORS].includes(dataset) && (
                         <RelatedIssues
                           organization={organization}
                           rule={rule}
@@ -380,9 +378,16 @@ export default class DetailsBody extends React.Component<Props> {
                             rule.projects.includes(project.slug)
                           )}
                           timePeriod={timePeriod}
+                          query={
+                            dataset === Dataset.ERRORS
+                              ? queryWithTypeFilter
+                              : dataset === Dataset.SESSIONS
+                              ? `${query} error.unhandled:true`
+                              : undefined
+                          }
                         />
                       )}
-                      {rule?.dataset === Dataset.TRANSACTIONS && (
+                      {dataset === Dataset.TRANSACTIONS && (
                         <RelatedTransactions
                           organization={organization}
                           location={location}

--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -11,7 +11,6 @@ import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
-import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/alerts/incidentRules/constants';
 import {IncidentRule} from 'app/views/alerts/incidentRules/types';
 
 import {TimePeriodType} from './constants';
@@ -21,6 +20,7 @@ type Props = {
   rule: IncidentRule;
   projects: Project[];
   timePeriod: TimePeriodType;
+  query?: string;
 };
 
 class RelatedIssues extends Component<Props> {
@@ -37,7 +37,7 @@ class RelatedIssues extends Component<Props> {
   };
 
   render() {
-    const {rule, projects, organization, timePeriod} = this.props;
+    const {rule, projects, organization, timePeriod, query} = this.props;
     const {start, end} = timePeriod;
 
     const path = `/organizations/${organization.slug}/issues/`;
@@ -48,12 +48,7 @@ class RelatedIssues extends Component<Props> {
       limit: 5,
       ...(rule.environment ? {environment: rule.environment} : {}),
       sort: rule.aggregate === 'count_unique(user)' ? 'user' : 'freq',
-      query: [
-        rule.query,
-        rule.eventTypes?.length
-          ? `event.type:[${rule.eventTypes.join(`, `)}]`
-          : DATASET_EVENT_TYPE_FILTERS[rule.dataset],
-      ].join(' '),
+      query,
       project: projects.map(project => project.id),
     };
     const issueSearch = {


### PR DESCRIPTION
Adding the list of unhandled issues to the crash rate alert rule detail page. Unhandled issues are the ones that cause sessions to crash that's why these are the most relevant to show.