### PR TITLE
fix(dev): ClickHouse dev container on arm64 has errors

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1802,12 +1802,11 @@ SENTRY_DEVSERVICES = {
     ),
     "clickhouse": lambda settings, options: (
         {
+            "image": "yandex/clickhouse-server:20.3.9.70" if not APPLE_ARM64
             # altinity provides clickhouse support to other companies
             # Official support: https://github.com/ClickHouse/ClickHouse/issues/22222
             # This image is build with this script https://gist.github.com/filimonov/5f9732909ff66d5d0a65b8283382590d
-            "image": "yandex/clickhouse-server:20.3.9.70"
-            if not APPLE_ARM64
-            else "altinity/clickhouse-server:20.10.1.4844-testing-arm",
+            else "altinity/clickhouse-server:21.6.1.6734-testing-arm",
             "pull": True,
             "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
             "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],


### PR DESCRIPTION
In #29081, we changed the arm ClickHouse container at the last moment without realizing that the older
version has this `libunwind: Unsupported .eh_frame_hdr version` [issue][issue].

We upgrade to a newer version that does not have profiling enabled.

[issue]: https://github.com/ClickHouse/ClickHouse/issues/15638