### PR TITLE
feat(dev): Upgrade zookeeper/kafka dev containers for Intel hosts

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1762,24 +1762,17 @@ SENTRY_DEVSERVICES = {
     ),
     "zookeeper": lambda settings, options: (
         {
-            # On Apple arm64, we upgrade to version 6.x allows zookeeper to run properly on Apple's arm64
+            # On Apple arm64, we upgrade to version 6.x to allow zookeeper to run properly on Apple's arm64
             # See details https://github.com/confluentinc/kafka-images/issues/80#issuecomment-855511438
-            # I'm selectively upgrading the version on Apple's arm64 since there was a bug that only affects
-            # Intel machines. For more details see: https://github.com/getsentry/sentry/pull/28672
-            "image": "confluentinc/cp-zookeeper:6.2.0"
-            if APPLE_ARM64
-            else "confluentinc/cp-zookeeper:5.1.2",
+            "image": "confluentinc/cp-zookeeper:6.2.0",
             "environment": {"ZOOKEEPER_CLIENT_PORT": "2181"},
-            "volumes": {"zookeeper": {"bind": "/var/lib/zookeeper"}},
+            "volumes": {"zookeeper_6": {"bind": "/var/lib/zookeeper/data"}},
             "only_if": "kafka" in settings.SENTRY_EVENTSTREAM or settings.SENTRY_USE_RELAY,
         }
     ),
     "kafka": lambda settings, options: (
         {
-            # On Apple arm64, we upgrade to version 6.x to match zookeeper's version (I believe they both release together)
-            "image": "confluentinc/cp-kafka:6.2.0"
-            if APPLE_ARM64
-            else "confluentinc/cp-kafka:5.1.2",
+            "image": "confluentinc/cp-kafka:6.2.0",
             "ports": {"9092/tcp": 9092},
             "environment": {
                 "KAFKA_ZOOKEEPER_CONNECT": "{containers[zookeeper][name]}:2181",
@@ -1794,7 +1787,7 @@ SENTRY_DEVSERVICES = {
                 "KAFKA_MESSAGE_MAX_BYTES": "50000000",
                 "KAFKA_MAX_REQUEST_SIZE": "50000000",
             },
-            "volumes": {"kafka": {"bind": "/var/lib/kafka"}},
+            "volumes": {"kafka_6": {"bind": "/var/lib/kafka/data"}},
             "only_if": "kafka" in settings.SENTRY_EVENTSTREAM
             or settings.SENTRY_USE_RELAY
             or settings.SENTRY_DEV_PROCESS_SUBSCRIPTIONS,


### PR DESCRIPTION
In #28574, we upgraded the versions of zookeeper/kafka to 6.x only for Apple
arm64 hosts.

When trying to use such version on Intel, it would fail because version 6.x
requires specifying the path to `data` *absolutely* (see [docs][docs]), otherwise, you would get this
error:

> Command [/usr/local/bin/dub path /var/lib/kafka/data writable] FAILED !

If you don't rename the key of the moount bind, users with an existing set-up would not get
the absolue path properly configured, thus, they would still face the issue (see [comment][comment]).
In other words, people starting from scratch would have no issues.

At the time, we decided to back things out and investigate later.

This change reunites Intel and arm64 hosts.

[docs]: https://docs.confluent.io/platform/current/installation/docker/operations/external-volumes.html#data-volumes-for-kafka-and-zk
[comment]: https://github.com/getsentry/sentry/pull/28574#issuecomment-922087892