### PR TITLE
ref(teams): Alert team filter now uses team slug instead of team name

### DIFF
--- a/static/app/views/alerts/rules/teamFilter.tsx
+++ b/static/app/views/alerts/rules/teamFilter.tsx
@@ -71,11 +71,11 @@ function TeamFilter({
       filtered: false,
     },
   ];
-  const teamItems = teams.map(({id, name}) => ({
-    label: name,
+  const teamItems = teams.map(({id, slug}) => ({
+    label: slug,
     value: id,
     filtered: teamFilterSearch
-      ? !name.toLowerCase().includes(teamFilterSearch.toLowerCase())
+      ? !slug.toLowerCase().includes(teamFilterSearch.toLowerCase())
       : false,
     checked: selectedTeams.has(id),
   }));
@@ -85,7 +85,7 @@ function TeamFilter({
       header={
         <StyledInput
           autoFocus
-          placeholder={t('Filter by team name')}
+          placeholder={t('Filter by team slug')}
           onClick={event => {
             event.stopPropagation();
           }}


### PR DESCRIPTION
Use/filter by slug here:

![image](https://user-images.githubusercontent.com/9372512/137195939-b73a87b9-a039-4127-8ff7-107f7abc112c.png)

