### PR TITLE
ref(tests) Move tests for withTags() HOC off of enzyme

### DIFF
--- a/tests/js/spec/utils/withTags.spec.jsx
+++ b/tests/js/spec/utils/withTags.spec.jsx
@@ -1,4 +1,4 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {act, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import TagStore from 'app/stores/tagStore';
 import withTags from 'app/utils/withTags';
@@ -9,23 +9,38 @@ describe('withTags HoC', function () {
   });
 
   it('works', async function () {
-    const MyComponent = () => null;
+    const MyComponent = ({other, tags}) => {
+      return (
+        <div>
+          <span>{other}</span>
+          {tags &&
+            Object.entries(tags).map(([key, tag]) => (
+              <em key={key}>
+                {tag.key} : {tag.name}
+              </em>
+            ))}
+        </div>
+      );
+    };
+
     const Container = withTags(MyComponent);
-    const wrapper = mountWithTheme(<Container other="value" />);
+    mountWithTheme(<Container other="value" />);
 
     // Should forward props.
-    expect(wrapper.find('MyComponent').prop('other')).toEqual('value');
+    expect(screen.getByText('value')).toBeInTheDocument();
 
-    TagStore.onLoadTagsSuccess([{name: 'Mechanism', key: 'mechanism', count: 1}]);
-    await wrapper.update();
+    act(() => {
+      TagStore.onLoadTagsSuccess([{name: 'Mechanism', key: 'mechanism', count: 1}]);
+    });
 
     // Should forward prop
-    expect(wrapper.find('MyComponent').prop('other')).toEqual('value');
+    expect(screen.getByText('value')).toBeInTheDocument();
 
-    const tagsProp = wrapper.find('MyComponent').prop('tags');
     // includes custom tags
-    expect(tagsProp.mechanism).toBeTruthy();
+    const renderedTag = screen.getByText('mechanism : Mechanism');
+    expect(renderedTag).toBeInTheDocument();
+
     // excludes issue tags by default
-    expect(tagsProp.is).toBeUndefined();
+    expect(screen.queryByText(/is\s/)).toBeNull();
   });
 });


### PR DESCRIPTION
Use React-Testing-Library instead of enzyme. Creating a simple stub component to render out the HOC data seems to be a reasonable way to ensure the interface between the HOC and wrapped components is documented and tested.