### PR TITLE
feat(workflow): Adding 'this week' totals, dynamic average, and merging into one query

### DIFF
--- a/src/sentry/api/endpoints/team_release_count.py
+++ b/src/sentry/api/endpoints/team_release_count.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 
 from django.db.models import Count
@@ -24,35 +25,38 @@ class TeamReleaseCountEndpoint(TeamEndpoint, EnvironmentMixin):
         per_project_average_releases = (
             Release.objects.filter(
                 id__in=ReleaseProject.objects.filter(project__in=project_list).values("release_id"),
-                date_added__gte=now() - timedelta(days=84),
-                date_added__lte=now(),
-            )
-            .values("projects")
-            .annotate(count=Count("id"))
-        )
-        # TODO: Also need "this week" count for each project. Should i just bucket by week and average in python?
-        project_avgs = {}
-        for row in per_project_average_releases:
-            project_avgs[row["projects"]] = row["count"] / 12
-
-        bucketed_total_releases = (
-            Release.objects.filter(
-                id__in=ReleaseProject.objects.filter(project__in=project_list).values("release_id"),
                 date_added__gte=start,
                 date_added__lte=end,
             )
             .annotate(bucket=TruncDay("date_added"))
             .order_by("bucket")
-            .values("bucket")
+            .values("projects", "bucket")
             .annotate(count=Count("id"))
         )
 
-        current_day, agg_project_counts = start, {}
+        agg_project_counts = {}
+        project_avgs = defaultdict(int)
+        this_week_start = now() - timedelta(days=7)
+        this_week_totals = {}
+        for row in per_project_average_releases:
+            project_avgs[row["projects"]] += row["count"]
+            agg_project_counts[str(row["bucket"].date())] = row["count"]
+            this_week_totals.setdefault(row["projects"], 0)  # zero-fill for each project
+            if row["bucket"] >= this_week_start:
+                this_week_totals[row["projects"]] += row["count"]
+
+        for row in project_avgs:
+            project_avgs[row] = (project_avgs[row] / (end - start).days) * 7
+
+        current_day = start
         while current_day < end:
-            agg_project_counts[str(current_day)] = 0
+            agg_project_counts.setdefault(str(current_day), 0)
             current_day += timedelta(days=1)
 
-        for bucket in bucketed_total_releases:
-            agg_project_counts[str(bucket["bucket"].date())] = bucket["count"]
-
-        return Response({"release_counts": agg_project_counts, "project_avgs": project_avgs})
+        return Response(
+            {
+                "release_counts": agg_project_counts,
+                "project_avgs": project_avgs,
+                "last_week_totals": this_week_totals,
+            }
+        )

--- a/src/sentry/api/endpoints/team_release_count.py
+++ b/src/sentry/api/endpoints/team_release_count.py
@@ -22,7 +22,7 @@ class TeamReleaseCountEndpoint(TeamEndpoint, EnvironmentMixin):
         end = end.date() + timedelta(days=1)
         start = start.date() + timedelta(days=1)
 
-        per_project_average_releases = (
+        per_project_daily_release_counts = (
             Release.objects.filter(
                 id__in=ReleaseProject.objects.filter(project__in=project_list).values("release_id"),
                 date_added__gte=start,
@@ -36,12 +36,11 @@ class TeamReleaseCountEndpoint(TeamEndpoint, EnvironmentMixin):
 
         agg_project_counts = {}
         project_avgs = defaultdict(int)
+        this_week_totals = defaultdict(int)
         this_week_start = now() - timedelta(days=7)
-        this_week_totals = {}
-        for row in per_project_average_releases:
+        for row in per_project_daily_release_counts:
             project_avgs[row["projects"]] += row["count"]
             agg_project_counts[str(row["bucket"].date())] = row["count"]
-            this_week_totals.setdefault(row["projects"], 0)  # zero-fill for each project
             if row["bucket"] >= this_week_start:
                 this_week_totals[row["projects"]] += row["count"]
 

--- a/tests/sentry/api/endpoints/test_team_release_count.py
+++ b/tests/sentry/api/endpoints/test_team_release_count.py
@@ -53,8 +53,7 @@ class TeamReleaseCountTest(APITestCase):
         assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90
         assert len(response.data["project_avgs"]) == 2
-        assert len(response.data["last_week_totals"]) == 2
-        assert response.data["last_week_totals"][project1.id] == 0
+        assert len(response.data["last_week_totals"]) == 1
         assert response.data["last_week_totals"][project3.id] == 2
 
         assert response.data["release_counts"][str(before_now(days=0).date())] == 0
@@ -120,7 +119,7 @@ class TeamReleaseCountTest(APITestCase):
         assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90
         assert len(response.data["project_avgs"]) == 2
-        assert len(response.data["last_week_totals"]) == 2
+        assert len(response.data["last_week_totals"]) == 1
 
         assert response.data["release_counts"][str(before_now(days=0).date())] == 0
         assert response.data["release_counts"][str(before_now(days=5).date())] == 2

--- a/tests/sentry/api/endpoints/test_team_release_count.py
+++ b/tests/sentry/api/endpoints/test_team_release_count.py
@@ -50,14 +50,27 @@ class TeamReleaseCountTest(APITestCase):
         release5.add_project(project3)
         response = self.get_valid_response(org.slug, team1.slug)
 
-        assert len(response.data) == 2
+        assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90
         assert len(response.data["project_avgs"]) == 2
+        assert len(response.data["last_week_totals"]) == 2
+        assert response.data["last_week_totals"][project1.id] == 0
+        assert response.data["last_week_totals"][project3.id] == 2
 
         assert response.data["release_counts"][str(before_now(days=0).date())] == 0
         assert response.data["release_counts"][str(before_now(days=5).date())] == 2
         assert response.data["release_counts"][str(before_now(days=10).date())] == 1
         assert response.data["release_counts"][str(before_now(days=15).date())] == 1
+
+        release4.add_project(project1)  # up the last week total for project1 by 1
+
+        response = self.get_valid_response(org.slug, team1.slug)
+        assert len(response.data) == 3
+        assert len(response.data["release_counts"]) == 90
+        assert len(response.data["project_avgs"]) == 2
+        assert len(response.data["last_week_totals"]) == 2
+        assert response.data["last_week_totals"][project1.id] == 1
+        assert response.data["last_week_totals"][project3.id] == 2
 
     def test_multi_project_release(self):
         user = self.create_user(is_staff=False, is_superuser=False)
@@ -104,9 +117,10 @@ class TeamReleaseCountTest(APITestCase):
         release5.add_project(project3)
         response = self.get_valid_response(org.slug, team1.slug)
 
-        assert len(response.data) == 2
+        assert len(response.data) == 3
         assert len(response.data["release_counts"]) == 90
         assert len(response.data["project_avgs"]) == 2
+        assert len(response.data["last_week_totals"]) == 2
 
         assert response.data["release_counts"][str(before_now(days=0).date())] == 0
         assert response.data["release_counts"][str(before_now(days=5).date())] == 2


### PR DESCRIPTION
This PR changes the fixed 12 week average to be the average over the selected time period instead. It also now returns the count of releases in the last week for each project, and in making these changes, I was able to merge these two queries into one.