### PR TITLE
fix(cmp_alerts): Set type when comparison delta default value when null or undefined

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -124,7 +124,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       thresholdType: rule.thresholdType,
       comparisonDelta: rule.comparisonDelta,
       comparisonType:
-        rule.comparisonDelta === undefined
+        rule.comparisonDelta === undefined || rule.comparisonDelta === null
           ? AlertRuleComparisonType.COUNT
           : AlertRuleComparisonType.CHANGE,
       projects: [this.props.project],


### PR DESCRIPTION
This fixes an error in editing alert rules because `comparisonDelta` value returned for alert rule is `null` when it is not set.