### PR TITLE
ref(notifications): make class methods for building slack payload

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -2,11 +2,7 @@ from typing import Any, Dict, List, Mapping, Union
 
 from sentry.integrations.slack.message_builder import SlackBody
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
-from sentry.integrations.slack.message_builder.issues import (
-    SlackIssuesMessageBuilder,
-    build_attachment_title,
-    get_title_link,
-)
+from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.models import Team, User
 from sentry.notifications.notifications.activity.new_processing_issues import (
     NewProcessingIssuesActivityNotification,
@@ -79,10 +75,11 @@ class SlackNotificationsMessageBuilder(SlackMessageBuilder):
             )
 
         return self._build(
-            title=build_attachment_title(group),
-            title_link=get_title_link(group, None, False, True, self.notification),
+            title=self.notification.build_attachment_title(),
+            title_link=self.notification.get_title_link(),
             text=self.notification.get_message_description(),
-            footer=build_notification_footer(self.notification, self.recipient),
+            footer=self.notification.build_notification_footer(self.recipient),
+            actions=self.notification.get_actions(),
             color="info",
         )
 

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, MutableMapping, Optional, Tuple, Union
 
 from sentry.utils.http import absolute_uri
 
@@ -60,3 +60,24 @@ class BaseNotification:
 
     def get_unsubscribe_key(self) -> Optional[Tuple[str, int, Optional[str]]]:
         return None
+
+    # TODO: move to different classes
+    def build_attachment_title(self) -> str:
+        from sentry.integrations.slack.message_builder.issues import build_attachment_title
+
+        return build_attachment_title(self.group)
+
+    def get_title_link(self) -> str:
+        from sentry.integrations.slack.message_builder.issues import get_title_link
+
+        return get_title_link(self.group, None, False, True, self)
+
+    def build_notification_footer(self, recipient: Union["Team", "User"]) -> str:
+        from sentry.integrations.slack.message_builder.notifications import (
+            build_notification_footer,
+        )
+
+        return build_notification_footer(self, recipient)
+
+    def get_actions(self) -> List[Dict[str, str]]:
+        return []


### PR DESCRIPTION
This PR starts moving certain methods related to building the payload of notifications to the base class. The purpose of this is to make it easier to extend notifications to new cases, including ones that exist in getsentry. This is just a draft to show how this might be done.