### PR TITLE
ref(grouprelease): Buffer updates to GroupRelease.last_seen

### DIFF
--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -62,7 +62,6 @@ class GroupRelease(Model):
                     ),
                     False,
                 )
-            cache.set(cache_key, instance, 3600)
         else:
             created = False
 
@@ -74,5 +73,6 @@ class GroupRelease(Model):
                 extra={"last_seen": datetime},
             )
             instance.last_seen = datetime
-            cache.set(cache_key, instance, 3600)
+
+        cache.set(cache_key, instance, 3600)
         return instance

--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -1,8 +1,7 @@
-from datetime import timedelta
-
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 
+from sentry import buffer
 from sentry.db.models import BoundedBigIntegerField, BoundedPositiveIntegerField, Model, sane_repr
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
@@ -67,13 +66,13 @@ class GroupRelease(Model):
         else:
             created = False
 
-        # TODO(dcramer): this would be good to buffer, but until then we minimize
-        # updates to once a minute, and allow Postgres to optimistically skip
-        # it even if we can't
-        if not created and instance.last_seen < datetime - timedelta(seconds=60):
-            cls.objects.filter(
-                id=instance.id, last_seen__lt=datetime - timedelta(seconds=60)
-            ).update(last_seen=datetime)
+        if not created:
+            buffer.incr(
+                model=cls,
+                columns={},
+                filters={"id": instance.id},
+                extra={"last_seen": datetime},
+            )
             instance.last_seen = datetime
             cache.set(cache_key, instance, 3600)
         return instance

--- a/tests/sentry/models/test_grouprelease.py
+++ b/tests/sentry/models/test_grouprelease.py
@@ -36,13 +36,3 @@ class GetOrCreateTest(TestCase):
 
         assert grouprelease.first_seen == datetime
         assert grouprelease.last_seen == datetime_new
-
-        datetime_new2 = datetime_new + timedelta(seconds=1)
-
-        # this should not update immediately as the window is too close
-        grouprelease = GroupRelease.get_or_create(
-            group=group, release=release, environment=env, datetime=datetime_new2
-        )
-
-        assert grouprelease.first_seen == datetime
-        assert grouprelease.last_seen == datetime_new


### PR DESCRIPTION
Due to high concurrency of `save_event` workers the 1m check is not working as
expected especially during spikes and we consistently do high number of
mutations on GroupRelease.last_seen. Buffering the updates will hopefully
reduce the number of updates and prevent spikes in locks as well.