### PR TITLE
fix(alerts): Fix logic that creates snapshots for crash rate alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1,8 +1,9 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from itertools import chain
-from typing import Optional
+from typing import Callable, Dict, Optional, Union
 
+import pytz
 from django.db import transaction
 from django.db.models.signals import post_save
 from django.utils import timezone
@@ -61,6 +62,12 @@ NOT_SET = object()
 
 CRITICAL_TRIGGER_LABEL = "critical"
 WARNING_TRIGGER_LABEL = "warning"
+
+# types
+ENTITY_STATS_SNAPSHOT_FUNC = Callable[[Incident, bool], TimeSeriesSnapshot]
+INCIDENT_ENTITY_STATS_FUNC = Callable[
+    [Incident, Optional[datetime], Optional[datetime], bool], SnubaTSResult
+]
 
 
 class AlreadyDeletedError(Exception):
@@ -326,29 +333,76 @@ def create_incident_snapshot(incident, windowed_stats=False):
             total_events=0,
         )
 
-    event_stats_snapshot = create_event_stat_snapshot(incident, windowed_stats=windowed_stats)
-    aggregates = get_incident_aggregates(incident)
+    dataset: QueryDatasets = QueryDatasets(incident.alert_rule.snuba_query.dataset)
+    if dataset == QueryDatasets.SESSIONS:
+        entity_stats_snapshot = create_session_stat_snapshot(
+            incident, windowed_stats=windowed_stats
+        )
+    else:
+        entity_stats_snapshot = create_event_stat_snapshot(incident, windowed_stats=windowed_stats)
+
+    aggregates = get_incident_aggregates(incident, dataset=dataset)
     return IncidentSnapshot.objects.create(
         incident=incident,
-        event_stats_snapshot=event_stats_snapshot,
+        event_stats_snapshot=entity_stats_snapshot,
         unique_users=aggregates["unique_users"],
         total_events=aggregates["count"],
     )
 
 
-def create_event_stat_snapshot(incident, windowed_stats=False):
+def _entity_stats_snapshot_func_factory(
+    dataset: QueryDatasets, entity_stats_func: INCIDENT_ENTITY_STATS_FUNC
+) -> ENTITY_STATS_SNAPSHOT_FUNC:
+    time_col: str = "bucketed_started" if dataset == QueryDatasets.SESSIONS else "time"
+
+    if dataset == QueryDatasets.SESSIONS:
+
+        def convert_to_unix(time):
+            return to_timestamp(
+                datetime.strptime(time, "%Y-%m-%dT%H:%M:%S+00:00").astimezone(pytz.utc)
+            )
+
+    else:
+
+        def convert_to_unix(time):
+            return time
+
+    def create_entity_stat_snapshot(
+        incident: Incident, windowed_stats: bool = False
+    ) -> TimeSeriesSnapshot:
+        entity_stats: SnubaTSResult = entity_stats_func(incident, None, None, windowed_stats)
+        start, end = calculate_incident_time_range(incident, windowed_stats=windowed_stats)
+        return TimeSeriesSnapshot.objects.create(
+            start=start,
+            end=end,
+            values=[
+                [convert_to_unix(row[time_col]), row["count"]] for row in entity_stats.data["data"]
+            ],
+            period=entity_stats.rollup,
+        )
+
+    return create_entity_stat_snapshot
+
+
+def create_event_stat_snapshot(
+    incident: Incident, windowed_stats: bool = False
+) -> TimeSeriesSnapshot:
     """
     Creates an event stats snapshot for an incident in a given period of time.
     """
+    return _entity_stats_snapshot_func_factory(QueryDatasets.EVENTS, get_incident_event_stats)(
+        incident, windowed_stats
+    )
 
-    event_stats = get_incident_event_stats(incident, windowed_stats=windowed_stats)
-    start, end = calculate_incident_time_range(incident, windowed_stats=windowed_stats)
 
-    return TimeSeriesSnapshot.objects.create(
-        start=start,
-        end=end,
-        values=[[row["time"], row["count"]] for row in event_stats.data["data"]],
-        period=event_stats.rollup,
+def create_session_stat_snapshot(
+    incident: Incident, windowed_stats: bool = False
+) -> TimeSeriesSnapshot:
+    """
+    Creates an event stats snapshot for an incident in a given period of time.
+    """
+    return _entity_stats_snapshot_func_factory(QueryDatasets.SESSIONS, get_incident_session_stats)(
+        incident, windowed_stats
     )
 
 
@@ -430,82 +484,127 @@ def calculate_incident_prewindow(start, end, incident=None):
     return prewindow
 
 
-def get_incident_event_stats(incident, start=None, end=None, windowed_stats=False):
+def _incident_entity_stats_func_factory(dataset: QueryDatasets):
+    """
+    Function factory that returns a function responsible for returning incident entity specific
+    stats
+    """
+    time_col: str = "bucketed_started" if dataset == QueryDatasets.SESSIONS else "time"
+
+    def get_incident_entity_stats(
+        incident: Incident,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        windowed_stats=False,
+    ) -> SnubaTSResult:
+        query_params = build_incident_query_params(
+            incident, start=start, end=end, windowed_stats=windowed_stats
+        )
+        time_window = incident.alert_rule.snuba_query.time_window
+        aggregations = query_params.pop("aggregations")[0]
+        snuba_params = [
+            SnubaQueryParams(
+                aggregations=[(aggregations[0], aggregations[1], "count")],
+                orderby=time_col,
+                groupby=[time_col],
+                rollup=time_window,
+                limit=10000,
+                **query_params,
+            )
+        ]
+
+        # We make extra queries to fetch these buckets
+        def build_extra_query_params(bucket_start):
+            extra_bucket_query_params = build_incident_query_params(
+                incident, start=bucket_start, end=bucket_start + timedelta(seconds=time_window)
+            )
+            aggregations = extra_bucket_query_params.pop("aggregations")[0]
+            return SnubaQueryParams(
+                aggregations=[(aggregations[0], aggregations[1], "count")],
+                limit=1,
+                **extra_bucket_query_params,
+            )
+
+        # We want to include the specific buckets for the incident start and closed times,
+        # so that there's no need to interpolate to show them on the frontend. If they're
+        # cleanly divisible by the `time_window` then there's no need to fetch, since
+        # they'll be included in the standard results anyway.
+        start_query_params = None
+        extra_buckets = []
+        retention = quotas.get_event_retention(organization=incident.organization) or 90
+        if (
+            incident.date_started
+            > datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention)
+            and int(to_timestamp(incident.date_started)) % time_window
+        ):
+            start_query_params = build_extra_query_params(incident.date_started)
+            snuba_params.append(start_query_params)
+            extra_buckets.append(incident.date_started)
+
+        if incident.date_closed:
+            date_closed = incident.date_closed.replace(second=0, microsecond=0)
+            if int(to_timestamp(date_closed)) % time_window:
+                snuba_params.append(build_extra_query_params(date_closed))
+                extra_buckets.append(date_closed)
+
+        results = bulk_raw_query(snuba_params, referrer="incidents.get_incident_event_stats")
+        # Once we receive the results, if we requested extra buckets we now need to label
+        # them with timestamp data, since the query we ran only returns the count.
+        for extra_start, result in zip(extra_buckets, results[1:]):
+            result["data"][0][time_col] = int(to_timestamp(extra_start))
+        merged_data = list(chain(*(r["data"] for r in results)))
+        merged_data.sort(key=lambda row: row[time_col])
+        results[0]["data"] = merged_data
+        # When an incident has just been created it's possible for the actual incident start
+        # date to be greater than the latest bucket for the query. Get the actual end date
+        # here.
+        end_date = snuba_params[0].end
+        if start_query_params:
+            end_date = max(end_date, start_query_params.end)
+
+        return SnubaTSResult(results[0], snuba_params[0].start, end_date, snuba_params[0].rollup)
+
+    return get_incident_entity_stats
+
+
+def get_incident_event_stats(
+    incident: Incident,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    windowed_stats: bool = False,
+) -> SnubaTSResult:
     """
     Gets event stats for an incident. If start/end are provided, uses that time
     period, otherwise uses the incident start/current_end.
     """
-    query_params = build_incident_query_params(
-        incident, start=start, end=end, windowed_stats=windowed_stats
+    return _incident_entity_stats_func_factory(QueryDatasets.EVENTS)(
+        incident, start, end, windowed_stats
     )
-    time_window = incident.alert_rule.snuba_query.time_window
-    aggregations = query_params.pop("aggregations")[0]
-    snuba_params = [
-        SnubaQueryParams(
-            aggregations=[(aggregations[0], aggregations[1], "count")],
-            orderby="time",
-            groupby=["time"],
-            rollup=time_window,
-            limit=10000,
-            **query_params,
-        )
-    ]
 
-    # We make extra queries to fetch these buckets
-    def build_extra_query_params(bucket_start):
-        extra_bucket_query_params = build_incident_query_params(
-            incident, start=bucket_start, end=bucket_start + timedelta(seconds=time_window)
-        )
-        aggregations = extra_bucket_query_params.pop("aggregations")[0]
-        return SnubaQueryParams(
-            aggregations=[(aggregations[0], aggregations[1], "count")],
-            limit=1,
-            **extra_bucket_query_params,
-        )
 
-    # We want to include the specific buckets for the incident start and closed times,
-    # so that there's no need to interpolate to show them on the frontend. If they're
-    # cleanly divisible by the `time_window` then there's no need to fetch, since
-    # they'll be included in the standard results anyway.
-    start_query_params = None
-    extra_buckets = []
-    retention = quotas.get_event_retention(organization=incident.organization) or 90
-    if (
-        incident.date_started
-        > datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(days=retention)
-        and int(to_timestamp(incident.date_started)) % time_window
-    ):
-        start_query_params = build_extra_query_params(incident.date_started)
-        snuba_params.append(start_query_params)
-        extra_buckets.append(incident.date_started)
-
-    if incident.date_closed:
-        date_closed = incident.date_closed.replace(second=0, microsecond=0)
-        if int(to_timestamp(date_closed)) % time_window:
-            snuba_params.append(build_extra_query_params(date_closed))
-            extra_buckets.append(date_closed)
-
-    results = bulk_raw_query(snuba_params, referrer="incidents.get_incident_event_stats")
-    # Once we receive the results, if we requested extra buckets we now need to label
-    # them with timestamp data, since the query we ran only returns the count.
-    for extra_start, result in zip(extra_buckets, results[1:]):
-        result["data"][0]["time"] = int(to_timestamp(extra_start))
-    merged_data = list(chain(*(r["data"] for r in results)))
-    merged_data.sort(key=lambda row: row["time"])
-    results[0]["data"] = merged_data
-    # When an incident has just been created it's possible for the actual incident start
-    # date to be greater than the latest bucket for the query. Get the actual end date
-    # here.
-    end_date = snuba_params[0].end
-    if start_query_params:
-        end_date = max(end_date, start_query_params.end)
-
-    return SnubaTSResult(results[0], snuba_params[0].start, end_date, snuba_params[0].rollup)
+def get_incident_session_stats(
+    incident: Incident,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    windowed_stats=False,
+) -> SnubaTSResult:
+    """
+    Gets session stats for an incident. If start/end are provided, uses that time
+    period, otherwise uses the incident start/current_end.
+    """
+    return _incident_entity_stats_func_factory(QueryDatasets.SESSIONS)(
+        incident, start, end, windowed_stats
+    )
 
 
 def get_incident_aggregates(
-    incident, start=None, end=None, windowed_stats=False, use_alert_aggregate=False
-):
+    incident: Incident,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+    windowed_stats: bool = False,
+    use_alert_aggregate: bool = False,
+    dataset: QueryDatasets = QueryDatasets.EVENTS,
+) -> Dict[str, Union[float, int]]:
     """
     Calculates aggregate stats across the life of an incident, or the provided range.
     If `use_alert_aggregate` is True, calculates just the aggregate that the alert is
@@ -516,10 +615,14 @@ def get_incident_aggregates(
     """
     query_params = build_incident_query_params(incident, start, end, windowed_stats)
     if not use_alert_aggregate:
-        query_params["aggregations"] = [
-            ("count()", "", "count"),
-            ("uniq", "tags[sentry:user]", "unique_users"),
-        ]
+        if dataset == QueryDatasets.SESSIONS:
+            query_params["aggregations"][0][2] = "count"
+            query_params["aggregations"][1] = ("identity", "users", "unique_users")
+        else:
+            query_params["aggregations"] = [
+                ("count()", "", "count"),
+                ("uniq", "tags[sentry:user]", "unique_users"),
+            ]
     else:
         query_params["aggregations"][0][2] = "count"
     snuba_params_list = [SnubaQueryParams(limit=10000, **query_params)]

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -423,7 +423,7 @@ class GetIncidentSessionStatsTest(TestCase, BaseCrashRateAlertsTest, BaseInciden
         self.store_session(self.make_session(status="crashed"))
 
         result = get_incident_session_stats(incident, windowed_stats=False)
-        self.validate_result(incident, result, [0.25], start=None, end=None, windowed_stats=False)
+        self.validate_result(incident, result, [75.0], start=None, end=None, windowed_stats=False)
 
 
 class BaseIncidentAggregatesTest(BaseIncidentsTest):
@@ -452,7 +452,7 @@ class GetCrashRateIncidentAggregatesTest(TestCase, BaseCrashRateAlertsTest):
 
     def test_sessions(self):
         incident = self.create_incident(
-            date_started=self.now_dt - timedelta(minutes=120), query="", projects=[self.project]
+            date_started=self.now - timedelta(minutes=120), query="", projects=[self.project]
         )
         alert_rule = self.create_alert_rule(
             self.organization,
@@ -520,13 +520,13 @@ class CreateSessionStatTest(TestCase, BaseCrashRateAlertsTest):
         snapshot = create_session_stat_snapshot(incident, windowed_stats=False)
         assert snapshot.start == incident.date_started - timedelta(minutes=1)
         assert snapshot.end == incident.current_end_date + timedelta(minutes=1)
-        assert [row[1] for row in snapshot.values] == [1.0, 0.3333333333333333]
+        assert [row[1] for row in snapshot.values] == [0.0, 66.667]
 
         snapshot = create_session_stat_snapshot(incident, windowed_stats=True)
         expected_start, expected_end = calculate_incident_time_range(incident, windowed_stats=True)
         assert snapshot.start == expected_start
         assert snapshot.end == expected_end
-        assert [row[1] for row in snapshot.values] == [1.0, 0.3333333333333333]
+        assert [row[1] for row in snapshot.values] == [0.0, 66.667]
 
 
 @freeze_time()

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,3 +1,5 @@
+import time
+import uuid
 from datetime import datetime, timedelta
 
 import pytest
@@ -33,6 +35,7 @@ from sentry.incidents.logic import (
     create_incident,
     create_incident_activity,
     create_incident_snapshot,
+    create_session_stat_snapshot,
     deduplicate_trigger_actions,
     delete_alert_rule,
     delete_alert_rule_trigger,
@@ -44,6 +47,7 @@ from sentry.incidents.logic import (
     get_excluded_projects_for_alert_rule,
     get_incident_aggregates,
     get_incident_event_stats,
+    get_incident_session_stats,
     get_incident_stats,
     get_incident_subscribers,
     get_triggers_for_alert_rule,
@@ -79,7 +83,7 @@ from sentry.models import ActorTuple, PagerDutyService
 from sentry.models.integration import Integration
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
-from sentry.testutils import BaseIncidentsTest, TestCase
+from sentry.testutils import BaseIncidentsTest, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
 from sentry.utils.compat.mock import patch
@@ -234,29 +238,7 @@ class UpdateIncidentStatus(TestCase):
         )
 
 
-class BaseIncidentEventStatsTest(BaseIncidentsTest):
-    @fixture
-    def project_incident(self):
-        self.create_event(self.now - timedelta(minutes=2))
-        self.create_event(self.now - timedelta(minutes=2))
-        self.create_event(self.now - timedelta(minutes=1))
-        return self.create_incident(
-            date_started=self.now - timedelta(minutes=5), query="", projects=[self.project]
-        )
-
-    @fixture
-    def group_incident(self):
-        fingerprint = "group-1"
-        event = self.create_event(self.now - timedelta(minutes=2), fingerprint=fingerprint)
-        self.create_event(self.now - timedelta(minutes=2), fingerprint="other-group")
-        self.create_event(self.now - timedelta(minutes=1), fingerprint=fingerprint)
-        return self.create_incident(
-            date_started=self.now - timedelta(minutes=5),
-            query="",
-            projects=[],
-            groups=[event.group],
-        )
-
+class BaseIncidentsValidation:
     def validate_result(self, incident, result, expected_results, start, end, windowed_stats):
         # Duration of 300s, but no alert rule
         time_window = incident.alert_rule.snuba_query.time_window if incident.alert_rule else 60
@@ -279,6 +261,64 @@ class BaseIncidentEventStatsTest(BaseIncidentsTest):
         assert result.start == expected_start
         assert result.end == expected_end
         assert [r["count"] for r in result.data["data"]] == expected_results
+
+
+class BaseIncidentEventStatsTest(BaseIncidentsTest, BaseIncidentsValidation):
+    @fixture
+    def project_incident(self):
+        self.create_event(self.now - timedelta(minutes=2))
+        self.create_event(self.now - timedelta(minutes=2))
+        self.create_event(self.now - timedelta(minutes=1))
+        return self.create_incident(
+            date_started=self.now - timedelta(minutes=5), query="", projects=[self.project]
+        )
+
+    @fixture
+    def group_incident(self):
+        fingerprint = "group-1"
+        event = self.create_event(self.now - timedelta(minutes=2), fingerprint=fingerprint)
+        self.create_event(self.now - timedelta(minutes=2), fingerprint="other-group")
+        self.create_event(self.now - timedelta(minutes=1), fingerprint=fingerprint)
+        return self.create_incident(
+            date_started=self.now - timedelta(minutes=5),
+            query="",
+            projects=[],
+            groups=[event.group],
+        )
+
+
+class BaseCrashRateAlertsTest(SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.session_release = "foo@1.0.0"
+        self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
+
+    def make_session(
+        self,
+        received=None,
+        started=None,
+        status="ok",
+    ):
+        if received is None:
+            received = time.time()
+        if started is None:
+            started = time.time() // 60 * 60
+
+        return {
+            "session_id": str(uuid.uuid4()),
+            "distinct_id": str(uuid.uuid4()),
+            "status": status,
+            "seq": 0,
+            "release": self.session_release,
+            "environment": "prod",
+            "retention_days": 90,
+            "org_id": self.project.organization_id,
+            "project_id": self.project.id,
+            "duration": 60.0,
+            "errors": 0,
+            "started": started,
+            "received": received,
+        }
 
 
 @freeze_time()
@@ -361,6 +401,31 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
         self.run_test(incident, [2, 1])
 
 
+@freeze_time()
+class GetIncidentSessionStatsTest(TestCase, BaseCrashRateAlertsTest, BaseIncidentsValidation):
+    def test_with_sessions(self):
+        alert_rule = self.create_alert_rule(
+            self.organization,
+            [self.project],
+            query="",
+            time_window=1,
+            dataset=QueryDatasets.SESSIONS,
+            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+        )
+        incident = self.create_incident(
+            date_started=self.now - timedelta(minutes=120),
+            query="",
+            projects=[self.project],
+            alert_rule=alert_rule,
+        )
+        for _ in range(3):
+            self.store_session(self.make_session(status="exited"))
+        self.store_session(self.make_session(status="crashed"))
+
+        result = get_incident_session_stats(incident, windowed_stats=False)
+        self.validate_result(incident, result, [0.25], start=None, end=None, windowed_stats=False)
+
+
 class BaseIncidentAggregatesTest(BaseIncidentsTest):
     @property
     def project_incident(self):
@@ -377,6 +442,31 @@ class BaseIncidentAggregatesTest(BaseIncidentsTest):
 class GetIncidentAggregatesTest(TestCase, BaseIncidentAggregatesTest):
     def test_projects(self):
         assert get_incident_aggregates(self.project_incident) == {"count": 4, "unique_users": 2}
+
+
+class GetCrashRateIncidentAggregatesTest(TestCase, BaseCrashRateAlertsTest):
+    def setUp(self):
+        super().setUp()
+        for _ in range(2):
+            self.store_session(self.make_session(status="exited"))
+
+    def test_sessions(self):
+        incident = self.create_incident(
+            date_started=self.now_dt - timedelta(minutes=120), query="", projects=[self.project]
+        )
+        alert_rule = self.create_alert_rule(
+            self.organization,
+            [self.project],
+            query="",
+            time_window=1,
+            dataset=QueryDatasets.SESSIONS,
+            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+        )
+        incident.update(alert_rule=alert_rule)
+        assert get_incident_aggregates(incident, dataset=QueryDatasets.SESSIONS) == {
+            "count": 0.0,
+            "unique_users": 2,
+        }
 
 
 @freeze_time()
@@ -398,6 +488,45 @@ class CreateEventStatTest(TestCase, BaseIncidentsTest):
         assert snapshot.start == expected_start
         assert snapshot.end == expected_end
         assert [row[1] for row in snapshot.values] == [2, 1]
+
+
+@freeze_time()
+class CreateSessionStatTest(TestCase, BaseCrashRateAlertsTest):
+    def test_simple(self):
+        for _ in range(2):
+            self.store_session(self.make_session(status="exited"))
+        self.store_session(self.make_session(status="crashed"))
+        self._2_min_ago_dt = datetime.utcnow() - timedelta(minutes=2)
+        self._2_min_ago = self._2_min_ago_dt.timestamp()
+        self.store_session(
+            self.make_session(status="crashed", received=self._2_min_ago, started=self._2_min_ago)
+        )
+
+        alert_rule = self.create_alert_rule(
+            self.organization,
+            [self.project],
+            query="",
+            time_window=1,
+            dataset=QueryDatasets.SESSIONS,
+            aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+        )
+        incident = self.create_incident(
+            date_started=self.now - timedelta(minutes=5),
+            query="",
+            projects=[self.project],
+            alert_rule=alert_rule,
+        )
+
+        snapshot = create_session_stat_snapshot(incident, windowed_stats=False)
+        assert snapshot.start == incident.date_started - timedelta(minutes=1)
+        assert snapshot.end == incident.current_end_date + timedelta(minutes=1)
+        assert [row[1] for row in snapshot.values] == [1.0, 0.3333333333333333]
+
+        snapshot = create_session_stat_snapshot(incident, windowed_stats=True)
+        expected_start, expected_end = calculate_incident_time_range(incident, windowed_stats=True)
+        assert snapshot.start == expected_start
+        assert snapshot.end == expected_end
+        assert [row[1] for row in snapshot.values] == [1.0, 0.3333333333333333]
 
 
 @freeze_time()
@@ -1509,7 +1638,7 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
             )
 
     def test_pagerduty(self):
-        SERVICES = [
+        services = [
             {
                 "type": "service",
                 "integration_key": "PND4F9",
@@ -1521,12 +1650,12 @@ class CreateAlertRuleTriggerActionTest(BaseAlertRuleTriggerActionTest, TestCase)
             provider="pagerduty",
             name="Example PagerDuty",
             external_id="example-pagerduty",
-            metadata={"services": SERVICES},
+            metadata={"services": services},
         )
         integration.add_organization(self.organization, self.user)
         service = PagerDutyService.objects.create(
-            service_name=SERVICES[0]["service_name"],
-            integration_key=SERVICES[0]["integration_key"],
+            service_name=services[0]["service_name"],
+            integration_key=services[0]["integration_key"],
             organization_integration=integration.organizationintegration_set.first(),
         )
         type = AlertRuleTriggerAction.Type.PAGERDUTY
@@ -1715,7 +1844,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             )
 
     def test_pagerduty(self):
-        SERVICES = [
+        services = [
             {
                 "type": "service",
                 "integration_key": "PND4F9",
@@ -1727,12 +1856,12 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest, TestCase):
             provider="pagerduty",
             name="Example PagerDuty",
             external_id="example-pagerduty",
-            metadata={"services": SERVICES},
+            metadata={"services": services},
         )
         integration.add_organization(self.organization, self.user)
         service = PagerDutyService.objects.create(
-            service_name=SERVICES[0]["service_name"],
-            integration_key=SERVICES[0]["integration_key"],
+            service_name=services[0]["service_name"],
+            integration_key=services[0]["integration_key"],
             organization_integration=integration.organizationintegration_set.first(),
         )
         type = AlertRuleTriggerAction.Type.PAGERDUTY


### PR DESCRIPTION
Modifies incident snapshot logic to accommodate Crash Rate alerts

Fixes SNUBA-2G8

Follow up: 
Once https://github.com/getsentry/sentry/pull/29061 is merged, Investigate removing 
- https://github.com/getsentry/sentry/blob/cc5ccedb1e73aec4f735f11b0f076e0210bf8ab7/src/sentry/incidents/logic.py#L530  
- https://github.com/getsentry/sentry/blob/ce898db90cf0a79ef3ec9991683bccdfaf8c693b/src/sentry/incidents/endpoints/organization_incident_stats.py#L8