### PR TITLE
ref(minichart): Add extra empty space on the top - [INGEST-495]

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -234,7 +234,7 @@ function MiniBarChart({
   };
 
   return (
-    <BarChart series={chartSeries} height={height} {...chartOptions} {...barChartProps}  />
+    <BarChart series={chartSeries} height={height} {...chartOptions} {...barChartProps} />
   );
 }
 

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -191,7 +191,7 @@ function MiniBarChart({
           return 10;
         }
         // Adds extra spacing at the top of the chart canvas, ensuring the series doesn't hit the ceiling, leaving more empty space.
-        // When the user hovers over an empty space, a tooltip with information from all series is displayed.
+        // When the user hovers over an empty space, a tooltip with all series information is displayed.
         return (value.max * (height + 10)) / height;
       },
       splitLine: {

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -234,7 +234,7 @@ function MiniBarChart({
   };
 
   return (
-    <BarChart series={chartSeries} {...chartOptions} {...barChartProps} height={height} />
+    <BarChart series={chartSeries} height={height} {...chartOptions} {...barChartProps}  />
   );
 }
 

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -22,7 +22,11 @@ type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 type BarChartProps = React.ComponentProps<typeof BarChart>;
 
-type Props = Omit<ChartProps, 'css' | 'colors' | 'series'> & {
+type Props = Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> & {
+  /**
+   * Chart height
+   */
+  height: number;
   /**
    * Show max/min values on yAxis
    */
@@ -83,6 +87,7 @@ function MiniBarChart({
   colors,
   stacked = false,
   labelYAxisExtents = false,
+  height,
   ...props
 }: Props) {
   const {ref: _ref, ...barChartProps} = props;
@@ -179,10 +184,15 @@ function MiniBarChart({
         : undefined,
     },
     yAxis: {
-      max(value) {
+      max(value: {min: number; max: number}) {
         // This keeps small datasets from looking 'scary'
         // by having full bars for < 10 values.
-        return Math.max(10, value.max);
+        if (value.max < 10) {
+          return 10;
+        }
+        // Adds extra spacing at the top of the chart canvas, ensuring the series doesn't hit the ceiling, leaving more empty space.
+        // When the user hovers over an empty space, a tooltip with information from all series is displayed.
+        return (value.max * (height + 10)) / height;
       },
       splitLine: {
         show: false,
@@ -223,7 +233,9 @@ function MiniBarChart({
     },
   };
 
-  return <BarChart series={chartSeries} {...chartOptions} {...barChartProps} />;
+  return (
+    <BarChart series={chartSeries} {...chartOptions} {...barChartProps} height={height} />
+  );
 }
 
 export default MiniBarChart;


### PR DESCRIPTION
Adds extra spacing at the top of the chart canvas, ensuring the series doesn't hit the ceiling, leaving more empty space. When the user hovers over empty space, a tooltip with information from all series is displayed.

**Before:**
![image](https://user-images.githubusercontent.com/29228205/137360437-f1f879d1-6686-46ed-b40f-af9e1c9f1f16.png)

**After:**
![Screenshot 2021-10-14 at 18 29 49](https://user-images.githubusercontent.com/29228205/137359907-55710a17-08b8-490b-88e5-22837c5ae98e.png)

