### PR TITLE
Temporarily disable pyright pre-commit checks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,13 +57,15 @@ repos:
       language: system
       files: requirements-base.txt
       pass_filenames: false
-    - id: pyright
-      name: pyright
-      entry: pyright
-      language: node
-      types: [ python ]
-      pass_filenames: true
-      additional_dependencies: [ "pyright@1.1.178" ]
+# Temporarily disable pyright checking until we clean up unbound variable errors across
+# the codebase
+#    - id: pyright
+#      name: pyright
+#      entry: pyright
+#      language: node
+#      types: [ python ]
+#      pass_filenames: true
+#      additional_dependencies: [ "pyright@1.1.178" ]
 
 -   repo: https://github.com/sirosen/check-jsonschema
     rev: 0.3.0


### PR DESCRIPTION
This is causing some unexpected extra work for teams, since any file they touch is analyzed and old
code is showing unbound exceptions. We'll discuss the best way to handle this in backend tsc.