### PR TITLE
ref(grouprelease):  Buffer GroupRelease.last_seen update per minute

### DIFF
--- a/src/sentry/models/grouprelease.py
+++ b/src/sentry/models/grouprelease.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 
@@ -65,7 +67,7 @@ class GroupRelease(Model):
         else:
             created = False
 
-        if not created:
+        if not created and instance.last_seen < datetime - timedelta(seconds=60):
             buffer.incr(
                 model=cls,
                 columns={},

--- a/tests/sentry/models/test_grouprelease.py
+++ b/tests/sentry/models/test_grouprelease.py
@@ -36,3 +36,13 @@ class GetOrCreateTest(TestCase):
 
         assert grouprelease.first_seen == datetime
         assert grouprelease.last_seen == datetime_new
+
+        datetime_new2 = datetime_new + timedelta(seconds=1)
+
+        # this should not update immediately as the window is too close
+        grouprelease = GroupRelease.get_or_create(
+            group=group, release=release, environment=env, datetime=datetime_new2
+        )
+
+        assert grouprelease.first_seen == datetime
+        assert grouprelease.last_seen == datetime_new


### PR DESCRIPTION
Reintroduce 1m check for GroupRelease.last_seen updates (https://github.com/getsentry/sentry/pull/29311). Without the 1m
optimization and with only 10s buffers processing schedule we don't benefit
from buffering.
