### PR TITLE
fix(ui): Storybook - Dark mode colors

### DIFF
--- a/.storybook/previewGlobalStyles.tsx
+++ b/.storybook/previewGlobalStyles.tsx
@@ -9,7 +9,7 @@ const styles = (theme: Theme) => css`
     font-family: ${theme.text.family};
     font-feature-settings: 'liga';
     font-size: ${theme.fontSizeLarge};
-    color: ${theme.gray500};
+    color: ${theme.textColor};
   }
   div,
   p,
@@ -17,31 +17,32 @@ const styles = (theme: Theme) => css`
   button {
     font-family: ${theme.text.family};
     font-size: 1rem;
-    color: ${theme.gray500};
+    color: ${theme.textColor};
   }
 
   /** Content wraps */
   #docs-root {
     display: flex;
     justify-content: center;
-    background: ${theme.white};
+    background: ${theme.background};
   }
   .sbdocs.sbdocs-wrapper {
     padding: calc(${space(4)} * 3) calc(${space(4)} * 2);
     justify-content: flex-start;
+    background: ${theme.background};
   }
   .sbdocs.sbdocs-content {
     position: relative;
     max-width: 48em;
   }
   .sidebar-container {
-    border-right: solid 1px ${theme.gray100};
+    border-right: solid 1px ${theme.innerBorder};
   }
 
   /** Dividers */
   .sbdocs.sbdocs-hr {
     margin: calc(${space(4)} * 2) 0;
-    border-top: solid 1px ${theme.gray100};
+    border-top: solid 1px ${theme.border};
   }
 
   /** Images */
@@ -51,19 +52,19 @@ const styles = (theme: Theme) => css`
   }
   .sbdocs.sbdocs-img.with-border {
     border-radius: ${theme.borderRadius};
-    border: solid 1px ${theme.gray100};
+    border: solid 1px ${theme.border};
   }
 
   /** Body text */
   .sbdocs.sbdocs-p {
     font-family: ${theme.text.family};
     font-size: 1rem;
-    color: ${theme.gray500};
+    color: ${theme.textColor};
     margin: ${space(2)} 0;
   }
   .sbdocs.small {
     font-size: 0.875rem;
-    color: ${theme.gray300};
+    color: ${theme.subText};
   }
 
   /** Links */
@@ -79,7 +80,7 @@ const styles = (theme: Theme) => css`
     text-decoration-color: ${theme.blue200};
   }
   .sbdocs.sbdocs-a.gray-link {
-    color: ${theme.gray300};
+    color: ${theme.subText};
     text-decoration: none;
   }
   .sbdocs.sbdocs-a.gray-link:hover {
@@ -95,9 +96,9 @@ const styles = (theme: Theme) => css`
     font-family: ${theme.text.familyMono};
     font-size: 1rem;
     padding: 0.125rem 0.25rem;
-    color: ${theme.gray500};
+    color: ${theme.textColor};
     background: ${theme.bodyBackground};
-    border: solid 1px ${theme.gray100};
+    border: solid 1px ${theme.innerBorder};
   }
 
   /** Lists */
@@ -110,7 +111,7 @@ const styles = (theme: Theme) => css`
   .sbdocs.sbdocs-li:last-child {
     font-family: ${theme.text.family};
     font-size: 1rem;
-    color: ${theme.gray500};
+    color: ${theme.textColor};
     margin: ${space(1)} 0;
   }
   ul > .sbdocs.sbdocs-li ul > .sbdocs.sbdocs-li {
@@ -127,7 +128,7 @@ const styles = (theme: Theme) => css`
   .sbdocs.sbdocs-h4 {
     font-family: ${theme.text.family};
     font-weight: 600;
-    color: ${theme.gray500};
+    color: ${theme.textColor};
     border-bottom: none;
   }
   .sbdocs.sbdocs-h1 {

--- a/docs-ui/components/code.tsx
+++ b/docs-ui/components/code.tsx
@@ -60,7 +60,7 @@ const Code = ({children, className, label}: Props) => {
   return (
     <Wrap className={className}>
       <LabelWrap>
-        <IconCode theme={theme} color="gray300" />
+        <IconCode theme={theme} color="subText" />
         {label && <Label>{label.replaceAll('_', ' ')}</Label>}
       </LabelWrap>
       <HighlightedCode className={className} ref={codeRef}>
@@ -84,8 +84,12 @@ const Wrap = styled('pre')`
     margin-top: ${space(4)};
     margin-bottom: ${space(2)};
     background: ${p => p.theme.bodyBackground};
-    border: solid 1px ${p => p.theme.gray100};
+    border: solid 1px ${p => p.theme.border};
     overflow: visible;
+    text-shadow: none;
+  }
+  & code {
+    text-shadow: none;
   }
 `;
 
@@ -97,15 +101,15 @@ const LabelWrap = styled('div')`
   left: calc(${space(2)} - ${space(1)});
   transform: translateY(-50%);
   padding: ${space(0.25)} ${space(1)};
-  background: ${p => p.theme.white};
-  border: solid 1px ${p => p.theme.gray100};
+  background: ${p => p.theme.bodyBackground};
+  border: solid 1px ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
 `;
 
 const Label = styled('p')`
   font-size: 0.875rem;
   font-weight: 600;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   text-transform: uppercase;
   margin-bottom: 0;
   margin-left: ${space(1)};
@@ -131,9 +135,9 @@ const CopyButton = styled('button')`
 
   font-size: 0.875rem;
   font-weight: 600;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 
   &:hover:not(:disabled) {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.textColor};
   }
 `;

--- a/docs-ui/components/colorChip.tsx
+++ b/docs-ui/components/colorChip.tsx
@@ -75,7 +75,7 @@ const Wrapper = styled('span')<WrapperProps>`
   display: flex;
   align-items: center;
   border-radius: ${p => p.theme.borderRadius};
-  ${p => !p.noText && `border: solid 1px ${p.theme.gray100};`}
+  ${p => !p.noText && `border: solid 1px ${p.theme.border};`}
   ${p =>
     p.size === 'lg'
       ? `
@@ -102,7 +102,7 @@ const ColorSwatch = styled('span')<ColorSwatchProps>`
   display: inline;
   border-radius: ${p => p.theme.borderRadius};
   background-color: ${p => p.background};
-  ${p => p.border && `border: solid 1px ${p.theme.gray100};`}
+  ${p => p.border && `border: solid 1px ${p.theme.border};`}
   ${p =>
     p.size === 'lg'
       ? `

--- a/docs-ui/components/doDont.tsx
+++ b/docs-ui/components/doDont.tsx
@@ -68,7 +68,7 @@ const ImgWrap = styled('div')`
   position: relative;
   width: 100%;
   padding-top: 50%;
-  border: solid 1px ${p => p.theme.gray100};
+  border: solid 1px ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
 `;
@@ -113,5 +113,5 @@ const Label = styled('p')`
 `;
 const Text = styled('p')`
   margin-bottom: 0;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/docs-ui/components/docsLinks.tsx
+++ b/docs-ui/components/docsLinks.tsx
@@ -49,7 +49,7 @@ const DocsLink = ({img, title, desc, kind, story}: LinkProps) => (
     <TitleWrap>
       <Title>{title}</Title>
       <IconWrap>
-        <IconArrow color="gray500" direction="right" size="sm" />
+        <IconArrow color="textColor" direction="right" size="sm" />
       </IconWrap>
     </TitleWrap>
     {desc && <Desc>{desc}</Desc>}
@@ -89,13 +89,13 @@ const ImgWrap = styled('div')`
   position: relative;
   width: 100%;
   padding-top: 50%;
-  border: solid 1px ${p => p.theme.gray100};
+  border: solid 1px ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   overflow: hidden;
   transition: 0.2s ease-out;
 
   ${/* sc-selector */ LinkWrap}:hover & {
-    border: solid 1px ${p => p.theme.gray200};
+    border: solid 1px ${p => p.theme.border};
   }
 `;
 
@@ -134,5 +134,5 @@ const IconWrap = styled('div')`
 const Desc = styled('p')`
   margin-top: ${space(0.5)};
   font-size: 0.875rem;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
 `;

--- a/docs-ui/components/sample.tsx
+++ b/docs-ui/components/sample.tsx
@@ -4,7 +4,7 @@ import space from 'app/styles/space';
 
 const Sample = styled('div')`
   border-radius: ${p => p.theme.borderRadius};
-  border: dashed 1px ${p => p.theme.gray200};
+  border: dashed 1px ${p => p.theme.border};
   padding: ${space(1)} ${space(2)};
   margin: ${space(2)} 0;
 

--- a/docs-ui/components/table.tsx
+++ b/docs-ui/components/table.tsx
@@ -12,7 +12,7 @@ const TableOuter = styled('div')`
   width: 100%;
   margin: ${space(2)} 0;
   overflow: hidden;
-  border: solid 1px ${p => p.theme.gray100};
+  border: solid 1px ${p => p.theme.border};
   border-radius: 4px;
 `;
 
@@ -29,12 +29,12 @@ export const Table = ({children}) => (
 
 export const TableHead = styled('thead')`
   background: ${p => p.theme.bodyBackground};
-  border-bottom: solid 1px ${p => p.theme.gray100};
+  border-bottom: solid 1px ${p => p.theme.border};
 `;
 
 export const TableHeadCell = styled('th')<TableCellProps>`
   font-size: 0.875em;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   padding: ${space(1)} 0;
   text-transform: uppercase;
 
@@ -57,7 +57,7 @@ export const TableBody = styled('tbody')``;
 
 export const TableRow = styled('tr')`
   &:not(:last-child) {
-    border-bottom: solid 1px ${p => p.theme.gray100};
+    border-bottom: solid 1px ${p => p.theme.innerBorder};
   }
 `;
 

--- a/docs-ui/components/tableOfContents.tsx
+++ b/docs-ui/components/tableOfContents.tsx
@@ -19,7 +19,7 @@ const Content = styled('div')`
 
   & > .toc-wrapper > .toc-list {
     padding-left: 0;
-    border-left: solid 2px ${p => p.theme.gray100};
+    border-left: solid 2px ${p => p.theme.border};
   }
   & .toc-list-item {
     position: relative;
@@ -33,7 +33,7 @@ const Content = styled('div')`
     top: 0;
     left: 0;
     transform: translateX(calc(-2px - ${space(2)}));
-    border-left: solid 2px ${p => p.theme.gray500};
+    border-left: solid 2px ${p => p.theme.textColor};
     opacity: 0;
     transition: opacity 0.2s;
   }
@@ -41,18 +41,18 @@ const Content = styled('div')`
     opacity: 1;
   }
   & .toc-list-item > a {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
   & .toc-list-item.is-active-li > a {
     font-weight: 600;
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.textColor};
   }
 `;
 
 const Heading = styled('p')`
   font-weight: 600;
   font-size: 0.875em;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.textColor};
   text-transform: uppercase;
   margin-bottom: ${space(1)};
 `;


### PR DESCRIPTION
In Storybook, switch from coded color names (e.g. `gray500`) to aliases (e.g. `textColor`) for better dark mode display.

Before:
<img width="1137" alt="Screen Shot 2021-10-14 at 12 46 21 PM" src="https://user-images.githubusercontent.com/44172267/137385370-4e113951-81bf-4a2d-8a0b-830af01833a7.png">

After:
<img width="1051" alt="Screen Shot 2021-10-14 at 12 30 57 PM" src="https://user-images.githubusercontent.com/44172267/137384713-3826599a-065d-4482-be0a-53f743ecc87b.png">

One side effect of this move is that light mode will look different, due to discrepancies in color mapping. These discrepancies will be fixed as we update our color system in `theme.tsx`.

<img width="1018" alt="Screen Shot 2021-10-14 at 12 44 46 PM" src="https://user-images.githubusercontent.com/44172267/137385174-5e939755-118c-4a67-8b63-6762965d693e.png">

