### PR TITLE
fix(discover): Fixing release stage tests with snql

### DIFF
--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -1646,12 +1646,7 @@ class QueryFilter(QueryFields):
 
         organization_id: int = self.params["organization_id"]
         project_ids: Optional[list[int]] = self.params.get("project_id")
-        environment_ids: Optional[list[int]] = self.params.get("environment_id", [])
-        environments = list(
-            Environment.objects.filter(
-                organization_id=organization_id, id__in=environment_ids
-            ).values_list("name", flat=True)
-        )
+        environments: Optional[list[Environment]] = self.params.get("environment_objects", [])
         qs = (
             Release.objects.filter_by_stage(
                 organization_id,


### PR DESCRIPTION
- This fixes the test_release_stage test when run with snql enabled
- Now that we just store the params throughout the only available ways to check the environments for the query is either `environment` or `environment_id`