### PR TITLE
ref(js): Remove unused withProjects on incidentRules/triggers

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/index.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/index.tsx
@@ -4,7 +4,6 @@ import {Panel, PanelBody} from 'app/components/panels';
 import {Organization, Project} from 'app/types';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
-import withProjects from 'app/utils/withProjects';
 import ActionsPanel from 'app/views/alerts/incidentRules/triggers/actionsPanel';
 import TriggerForm from 'app/views/alerts/incidentRules/triggers/form';
 
@@ -145,4 +144,4 @@ class Triggers extends Component<Props> {
   }
 }
 
-export default withProjects(Triggers);
+export default Triggers;


### PR DESCRIPTION
`Projects` is already being passed down in the usage of this component.

Also worth noting, withProjects is actually typed wrong in such a way that it implies you can override projects via props, but you actually cannot. I'll fix that in a followup PR