### PR TITLE
ref(search): Enable search without waiting for search groups to load

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -471,13 +471,10 @@ class SmartSearchBar extends React.Component<Props, State> {
 
     callIfFunction(onKeyDown, evt);
 
-    if (!this.state.searchGroups.length) {
-      return;
-    }
-
+    const hasSearchGroups = this.state.searchGroups.length > 0;
     const isSelectingDropdownItems = this.state.activeSearchItem !== -1;
 
-    if (key === 'ArrowDown' || key === 'ArrowUp') {
+    if ((key === 'ArrowDown' || key === 'ArrowUp') && hasSearchGroups) {
       evt.preventDefault();
 
       const {flatSearchItems, activeSearchItem} = this.state;
@@ -529,7 +526,11 @@ class SmartSearchBar extends React.Component<Props, State> {
       this.setState({searchGroups, activeSearchItem: nextActiveSearchItem});
     }
 
-    if ((key === 'Tab' || key === 'Enter') && isSelectingDropdownItems) {
+    if (
+      (key === 'Tab' || key === 'Enter') &&
+      isSelectingDropdownItems &&
+      hasSearchGroups
+    ) {
       evt.preventDefault();
 
       const {activeSearchItem, searchGroups} = this.state;
@@ -622,7 +623,6 @@ class SmartSearchBar extends React.Component<Props, State> {
    */
   get hasValidSearch() {
     const {parsedQuery} = this.state;
-
     // If we fail to parse be optimistic that it's valid
     if (parsedQuery === null) {
       return true;

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -623,6 +623,7 @@ class SmartSearchBar extends React.Component<Props, State> {
    */
   get hasValidSearch() {
     const {parsedQuery} = this.state;
+
     // If we fail to parse be optimistic that it's valid
     if (parsedQuery === null) {
       return true;


### PR DESCRIPTION
Previously, when waiting for tags to load you wouldn't be able to execute a search. This is not that great as some tags take a very long time to load values.

![image](https://user-images.githubusercontent.com/9372512/137401012-e459edcd-1b7e-4d2e-97ac-a442d8a28bc7.png)

Disabling this behavior so that you are free to make a search even in loading state.
