### PR TITLE
test(js): Always use our exported act

### DIFF
--- a/tests/js/spec/components/editableText.spec.tsx
+++ b/tests/js/spec/components/editableText.spec.tsx
@@ -1,7 +1,6 @@
-import {act} from 'react-dom/test-utils';
-
 import {createListeners} from 'sentry-test/createListeners';
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import EditableText from 'app/components/editableText';
 

--- a/tests/js/spec/components/modals/sudoModal.spec.jsx
+++ b/tests/js/spec/components/modals/sudoModal.spec.jsx
@@ -1,6 +1,5 @@
-import {act} from 'react-dom/test-utils';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import {Client} from 'app/api';
 import ConfigStore from 'app/stores/configStore';

--- a/tests/js/spec/utils/discover/teamKeyTransactionField.spec.jsx
+++ b/tests/js/spec/utils/discover/teamKeyTransactionField.spec.jsx
@@ -1,6 +1,5 @@
-import {act} from 'react-dom/test-utils';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import * as TeamKeyTransactionManager from 'app/components/performance/teamKeyTransactionsManager';
 import ProjectsStore from 'app/stores/projectsStore';

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -1,10 +1,10 @@
-import {act} from 'react-dom/test-utils';
 import {browserHistory} from 'react-router';
 
 import {createListeners} from 'sentry-test/createListeners';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'app/stores/projectsStore';
 import {DashboardState} from 'app/views/dashboardsV2/types';

--- a/tests/js/spec/views/onboarding/platform.spec.jsx
+++ b/tests/js/spec/views/onboarding/platform.spec.jsx
@@ -1,6 +1,5 @@
-import {act} from 'react-dom/test-utils';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import {createProject} from 'app/actionCreators/projects';
 import TeamStore from 'app/stores/teamStore';

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -1,6 +1,5 @@
-import {act} from 'react-dom/test-utils';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import * as projectsActions from 'app/actionCreators/projects';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -1,7 +1,6 @@
-import {act} from 'react-dom/test-utils';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {mountGlobalModal} from 'sentry-test/modal';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import {Client} from 'app/api';
 import App from 'app/views/app';


### PR DESCRIPTION
Can add some linting rules for this in the future