### PR TITLE
ref(api): Use relative endpoint for ChunkUploadEndpoint if upload-url-prefix is absent

### DIFF
--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -26,11 +26,6 @@ class ChunkUploadTest(APITestCase):
             self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
         )
 
-        endpoint = options.get("system.upload-url-prefix")
-        # We fallback to default system url if config is not set
-        if len(endpoint) == 0:
-            endpoint = options.get("system.url-prefix")
-
         assert response.status_code == 200, response.content
         assert response.data["chunkSize"] == settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE
         assert response.data["chunksPerRequest"] == MAX_CHUNKS_PER_REQUEST
@@ -38,7 +33,7 @@ class ChunkUploadTest(APITestCase):
         assert response.data["maxFileSize"] == options.get("system.maximum-file-size")
         assert response.data["concurrency"] == MAX_CONCURRENCY
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
-        assert response.data["url"] == options.get("system.url-prefix") + self.url
+        assert response.data["url"] == self.url.replace("/api/0", "/")
 
         options.set("system.upload-url-prefix", "test")
         response = self.client.get(


### PR DESCRIPTION
Making this change allows people to use sentry-cli configured URL for chunks upload, instead of relying on fixed URL configured in the on-premise instance.

sentry-cli handles relative URLs nicely already, so there are no changes needed there: https://github.com/getsentry/sentry-cli/blob/master/src/api.rs#L395-L405

It won't break anything sentry-side, as we check for prefix existence and add it if necessary here: https://github.com/getsentry/sentry/blob/master/src/sentry/api/client.py#L39-L42

I was trying to use `reverse()` here to get an endpoint prefix, but I cannot make it work. If anyone has a better idea of how to make `/api/0` prefix generic in this function, I'm all ears.

Fixes https://github.com/getsentry/sentry-cli/issues/839
Closes https://github.com/getsentry/sentry-cli/pull/862