### PR TITLE
feat(workflow): Adding some group history entries across app

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -51,6 +51,7 @@ from sentry.models import (
     remove_group_from_inbox,
 )
 from sentry.models.group import STATUS_UPDATE_CHOICES, looks_like_short_id
+from sentry.models.grouphistory import activity_type_to_history_status, record_group_history
 from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, add_group_to_inbox
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
 from sentry.signals import (
@@ -1020,6 +1021,10 @@ def update_groups(
                     user=acting_user,
                     data=activity_data,
                 )
+                history_status = activity_type_to_history_status(activity_type)
+                if history_status:
+                    record_group_history(group, history_status, acting_user.actor)
+
                 # TODO(dcramer): we need a solution for activity rollups
                 # before sending notifications on bulk changes
                 if not is_bulk:

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -51,7 +51,11 @@ from sentry.models import (
     remove_group_from_inbox,
 )
 from sentry.models.group import STATUS_UPDATE_CHOICES, looks_like_short_id
-from sentry.models.grouphistory import activity_type_to_history_status, record_group_history
+from sentry.models.grouphistory import (
+    activity_type_to_history_status,
+    record_group_history,
+    record_group_history_from_activity_type,
+)
 from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, add_group_to_inbox
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
 from sentry.signals import (
@@ -1022,9 +1026,7 @@ def update_groups(
                     user=acting_user,
                     data=activity_data,
                 )
-                history_status = activity_type_to_history_status(activity_type)
-                if history_status is not None:
-                    record_group_history(group, history_status, actor=acting_user)
+                record_group_history_from_activity_type(group, activity_type, actor=acting_user)
 
                 # TODO(dcramer): we need a solution for activity rollups
                 # before sending notifications on bulk changes

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -938,6 +938,8 @@ SENTRY_FEATURES = {
     "organizations:performance-view": True,
     # Enable multi project selection
     "organizations:global-views": False,
+    # Enable writing group history
+    "organizations:group-history": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown
     "organizations:grouping-tree-ui": False,
     # Enable experimental new version of stacktrace component where additional

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -65,6 +65,7 @@ from sentry.models import (
     UserReport,
     get_crashreport_key,
 )
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.plugins.base import plugins
 from sentry.reprocessing2 import (
     delete_old_primary_hash,
@@ -1318,6 +1319,8 @@ def _handle_regression(group, event, release):
         Activity.objects.create_group_activity(
             group, ActivityType.SET_REGRESSION, data={"version": release.version if release else ""}
         )
+        record_group_history(group, GroupHistoryStatus.REGRESSED, actor=None, release=release)
+
         kick_off_status_syncs.apply_async(
             kwargs={"project_id": group.project_id, "group_id": group.id}
         )

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -78,6 +78,7 @@ default_manager.add("organizations:event-attachments-viewer", OrganizationFeatur
 default_manager.add("organizations:events", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)
 default_manager.add("organizations:global-views", OrganizationFeature)
+default_manager.add("organizations:group-history", OrganizationFeature)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -29,6 +29,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.eventstore.models import Event
+from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.types.activity import ActivityType
 from sentry.utils.http import absolute_uri
 from sentry.utils.numbers import base32_decode, base32_encode
@@ -315,6 +316,7 @@ class GroupManager(BaseManager):
         if updated_count:
             for group in groups:
                 Activity.objects.create_group_activity(group, activity_type)
+                record_group_history_from_activity_type(group, activity_type)
 
     def from_share_id(self, share_id: str) -> "Group":
         if not share_id or len(share_id) != 32:

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -68,7 +68,7 @@ class GroupAssigneeManager(BaseManager):
                     "assigneeType": assignee_type,
                 },
             )
-            record_group_history(group, GroupHistoryStatus.ASSIGNED, acting_user.actor)
+            record_group_history(group, GroupHistoryStatus.ASSIGNED, actor=acting_user)
 
             metrics.incr("group.assignee.change", instance="assigned", skip_internal=True)
             # sync Sentry assignee to external issues
@@ -91,7 +91,7 @@ class GroupAssigneeManager(BaseManager):
             activity = Activity.objects.create(
                 project=group.project, group=group, type=Activity.UNASSIGNED, user=acting_user
             )
-            record_group_history(group, GroupHistoryStatus.UNASSIGNED, acting_user.actor)
+            record_group_history(group, GroupHistoryStatus.UNASSIGNED, actor=acting_user)
 
             activity.send_notification()
             metrics.incr("group.assignee.change", instance="deassigned", skip_internal=True)

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -100,7 +100,7 @@ def record_group_history_from_activity_type(group, activity_type, actor=None, re
     maps to it
     """
     status = activity_type_to_history_status(activity_type)
-    if status:
+    if status is not None:
         return record_group_history(group, status, actor, release)
 
 

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -106,7 +106,7 @@ def record_group_history_from_activity_type(group, activity_type, actor=None, re
 
 def record_group_history(group, status, actor=None, release=None):
     prev_history = get_prev_history(group)
-    if not features.has("organizations:group-history"):
+    if not features.has("organizations:group-history", group.organization):
         return
     return GroupHistory.objects.create(
         organization=group.project.organization,

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -103,7 +103,7 @@ def remove_group_from_inbox(group, action=None, user=None, referrer=None):
                 type=Activity.MARK_REVIEWED,
                 user=user,
             )
-            record_group_history(group, GroupHistoryStatus.REVIEWED.value, user.actor)
+            record_group_history(group, GroupHistoryStatus.REVIEWED, actor=user)
 
         if action:
             inbox_out.send_robust(

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, JSONField, Model
 from sentry.models import Activity
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import inbox_in, inbox_out
 
 INBOX_REASON_DETAILS = {
@@ -102,6 +103,7 @@ def remove_group_from_inbox(group, action=None, user=None, referrer=None):
                 type=Activity.MARK_REVIEWED,
                 user=user,
             )
+            record_group_history(group, GroupHistoryStatus.REVIEWED.value, user.actor)
 
         if action:
             inbox_out.send_robust(

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -1030,7 +1030,7 @@ class Release(Model):
                 group = Group.objects.get(id=group_id)
                 group.update(status=GroupStatus.RESOLVED)
                 remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED, user=actor)
-                record_group_history(group, GroupHistoryStatus.RESOLVED, actor.actor)
+                record_group_history(group, GroupHistoryStatus.RESOLVED, actor=actor)
 
                 metrics.incr("group.resolved", instance="in_commit", skip_internal=True)
 

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -34,6 +34,7 @@ from sentry.models import (
     GroupInboxRemoveAction,
     remove_group_from_inbox,
 )
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import issue_resolved
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -1029,6 +1030,8 @@ class Release(Model):
                 group = Group.objects.get(id=group_id)
                 group.update(status=GroupStatus.RESOLVED)
                 remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED, user=actor)
+                record_group_history(group, GroupHistoryStatus.RESOLVED, actor.actor)
+
                 metrics.incr("group.resolved", instance="in_commit", skip_internal=True)
 
             issue_resolved.send_robust(

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -18,7 +18,11 @@ from sentry.models import (
     UserOption,
     remove_group_from_inbox,
 )
-from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
+from sentry.models.grouphistory import (
+    GroupHistoryStatus,
+    record_group_history,
+    record_group_history_from_activity_type,
+)
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_resolved
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
@@ -46,6 +50,9 @@ def remove_resolved_link(link):
                 group_id=link.group_id,
                 type=Activity.SET_UNRESOLVED,
                 ident=link.group_id,
+            )
+            record_group_history_from_activity_type(
+                Group.objects.get(id=link.group_id), Activity.SET_UNRESOLVED
             )
 
 

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -18,6 +18,7 @@ from sentry.models import (
     UserOption,
     remove_group_from_inbox,
 )
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_resolved
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
@@ -190,6 +191,10 @@ def resolved_in_pull_request(instance, created, **kwargs):
                         user=user_list[0],
                         data={"pull_request": instance.id},
                     )
+                    record_group_history(
+                        group, GroupHistoryStatus.RESOLVED_IN_PULL_REQUEST, user_list[0].actor
+                    )
+
                     GroupAssignee.objects.assign(
                         group=group, assigned_to=user_list[0], acting_user=user_list[0]
                     )

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -192,7 +192,7 @@ def resolved_in_pull_request(instance, created, **kwargs):
                         data={"pull_request": instance.id},
                     )
                     record_group_history(
-                        group, GroupHistoryStatus.RESOLVED_IN_PULL_REQUEST, user_list[0].actor
+                        group, GroupHistoryStatus.RESOLVED_IN_PULL_REQUEST, actor=user_list[0]
                     )
 
                     GroupAssignee.objects.assign(

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -13,6 +13,7 @@ from sentry.models import (
     ProjectOption,
     remove_group_from_inbox,
 )
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.integrations import kick_off_status_syncs
 
@@ -78,6 +79,7 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
             Activity.objects.create(
                 group=group, project=project, type=Activity.SET_RESOLVED_BY_AGE, data={"age": age}
             )
+            record_group_history(group, GroupHistoryStatus.AUTO_RESOLVED)
 
             kick_off_status_syncs.apply_async(
                 kwargs={"project_id": group.project_id, "group_id": group.id}

--- a/src/sentry/tasks/clear_expired_resolutions.py
+++ b/src/sentry/tasks/clear_expired_resolutions.py
@@ -46,4 +46,5 @@ def clear_expired_resolutions(release_id):
         except IndexError:
             continue
 
+        # TODO: Do we need to write a `GroupHistory` row here?
         activity.update(data={"version": release.version})

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -5,6 +5,7 @@ import sentry_sdk
 from sentry import analytics, features
 from sentry.app import locks
 from sentry.exceptions import PluginError
+from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -436,6 +437,8 @@ def process_snoozes(group):
             "user_window": snooze.user_window,
         }
         add_group_to_inbox(group, GroupInboxReason.UNIGNORED, snooze_details)
+        record_group_history(group, GroupHistoryStatus.UNIGNORED)
+
         snooze.delete()
         group.update(status=GroupStatus.UNRESOLVED)
         issue_unignored.send_robust(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -5,7 +5,6 @@ import sentry_sdk
 from sentry import analytics, features
 from sentry.app import locks
 from sentry.exceptions import PluginError
-from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -415,6 +414,7 @@ def process_snoozes(group):
     otherwise return False.
     """
     from sentry.models import GroupInboxReason, GroupSnooze, GroupStatus, add_group_to_inbox
+    from sentry.models.grouphistory import GroupHistoryStatus, record_group_history
 
     key = GroupSnooze.get_cache_key(group.id)
     snooze = cache.get(key)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1806,9 +1806,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(
-            qs_params={"status": "unresolved", "project": self.project.id}, status="resolved"
-        )
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"status": "unresolved", "project": self.project.id}, status="resolved"
+            )
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
 
         # the previously resolved entry should not be included
@@ -2307,9 +2308,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
-            qs_params={"id": group.id}, status="resolved", statusDetails={"inRelease": "latest"}
-        )
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": group.id}, status="resolved", statusDetails={"inRelease": "latest"}
+            )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inRelease"] == release.version
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2454,9 +2456,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
-            qs_params={"id": group.id}, status="resolvedInNextRelease"
-        )
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": group.id}, status="resolvedInNextRelease"
+            )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inNextRelease"]
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2488,11 +2491,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
-            qs_params={"id": group.id},
-            status="resolved",
-            statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
-        )
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": group.id},
+                status="resolved",
+                statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
+            )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inCommit"]["id"] == commit.key
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2525,11 +2529,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(
-            qs_params={"id": group.id},
-            status="resolved",
-            statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
-        )
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": group.id},
+                status="resolved",
+                statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
+            )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inCommit"]["id"] == commit.key
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2564,11 +2569,12 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_response(
-            qs_params={"id": group.id},
-            status="resolved",
-            statusDetails={"inCommit": {"commit": "a" * 40, "repository": repo.name}},
-        )
+        with self.feature("organizations:group-history"):
+            response = self.get_response(
+                qs_params={"id": group.id},
+                status="resolved",
+                statusDetails={"inCommit": {"commit": "a" * 40, "repository": repo.name}},
+            )
         assert response.status_code == 400
         assert (
             response.data["statusDetails"]["inCommit"]["commit"][0]
@@ -2585,7 +2591,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
         assert response.data == {"status": "unresolved", "statusDetails": {}}
 
         group = Group.objects.get(id=group.id)
@@ -2607,7 +2614,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
         assert response.data == {"status": "unresolved", "statusDetails": {}}
 
         group = Group.objects.get(id=group.id)
@@ -2625,7 +2633,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.IGNORED
         ).exists()
-        response = self.get_valid_response(qs_params={"id": group.id}, status="ignored")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(qs_params={"id": group.id}, status="ignored")
         # existing snooze objects should be cleaned up
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
@@ -2897,7 +2906,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         user = self.user
 
         self.login_as(user=user)
-        response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo=user.username)
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": group1.id}, assignedTo=user.username
+            )
         assert response.data["assignedTo"]["id"] == str(user.id)
         assert response.data["assignedTo"]["type"] == "user"
         assert GroupAssignee.objects.filter(group=group1, user=user).exists()
@@ -2911,7 +2923,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert GroupSubscription.objects.filter(user=user, group=group1, is_active=True).exists()
 
-        response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo="")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo="")
         assert response.data["assignedTo"] is None
 
         assert not GroupAssignee.objects.filter(group=group1, user=user).exists()
@@ -2926,7 +2939,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=member)
 
-        response = self.get_response(qs_params={"id": group.id}, assignedTo=non_member.username)
+        with self.feature("organizations:group-history"):
+            response = self.get_response(qs_params={"id": group.id}, assignedTo=non_member.username)
         assert not GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.ASSIGNED
         ).exists()
@@ -2947,7 +2961,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group, status=GroupHistoryStatus.ASSIGNED
         ).exists()
 
-        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo=f"team:{team.id}")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": group.id}, assignedTo=f"team:{team.id}"
+            )
         assert response.data["assignedTo"]["id"] == str(team.id)
         assert response.data["assignedTo"]["type"] == "team"
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ASSIGNED).exists()
@@ -2957,7 +2974,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert GroupSubscription.objects.filter(group=group, is_active=True).count() == 2
 
-        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo="")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(qs_params={"id": group.id}, assignedTo="")
         assert response.data["assignedTo"] is None
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.UNASSIGNED
@@ -2998,7 +3016,10 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group2 = self.create_group(checksum="b" * 32)
 
         self.login_as(user=self.user)
-        response = self.get_valid_response(qs_params={"id": [group1.id, group2.id]}, inbox="true")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(
+                qs_params={"id": [group1.id, group2.id]}, inbox="true"
+            )
         assert response.data == {"inbox": True}
         assert GroupInbox.objects.filter(group=group1).exists()
         assert GroupInbox.objects.filter(group=group2).exists()
@@ -3009,7 +3030,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group2, status=GroupHistoryStatus.REVIEWED
         ).exists()
 
-        response = self.get_valid_response(qs_params={"id": [group2.id]}, inbox="false")
+        with self.feature("organizations:group-history"):
+            response = self.get_valid_response(qs_params={"id": [group2.id]}, inbox="false")
         assert response.data == {"inbox": False}
         assert GroupInbox.objects.filter(group=group1).exists()
         assert not GroupHistory.objects.filter(
@@ -3032,7 +3054,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
 
-        response = self.get_valid_response(qs_params={"id": [group2.id]}, status="unresolved")
+        with self.feature("organizations:group-history"):
+            self.get_valid_response(qs_params={"id": [group2.id]}, status="unresolved")
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
         assert not GroupHistory.objects.filter(


### PR DESCRIPTION
To support the recently added endpoints for team insights (time to resolution and issues reviewed), the GroupHistory model needs to be appropriately populated. This PR aims to do that.

While adding these status', I also realized we may need to distinguish between resolution as an action, and resolution as a status. For example:
The issues reviewed API counts marking as resolved (immediately), and marking as resolved in [release/commit] as actions, so I create GroupHistory entries to properly track those when they happen. However, when the release/commit causes the group to be resolved, I am also creating another RESOLVED entry and this would currently get counted as 2 actions on the same group.

I haven't thought of a way to solve this without losing granularity for something else without having two status' such as `SET_RESOLVED` and `RESOLVED`. In this case, the reviewed issues API would only count `SET_RESOLVED` (and other actions), where as the time to resolution API would only count `RESOLVED` entries. The caveat here is that someone clicking "Resolve" in the UI would have to make two entries..
