### PR TITLE
feat(workflow): Switch number of releases average to a markline

### DIFF
--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -321,7 +321,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('Number of Releases')}
               description={t(
-                'Projects that had the largest difference of releases deployed compared to the 12 week average.'
+                'A breakdown showing how your team shipped releases over time. This is a signal that team velocity is high or low.'
               )}
             >
               <TeamReleases

--- a/static/app/views/teamInsights/teamReleases.tsx
+++ b/static/app/views/teamInsights/teamReleases.tsx
@@ -178,10 +178,6 @@ class TeamReleases extends AsyncComponent<Props, State> {
       }))
       .sort((a, b) => a.name - b.name);
 
-    const projectAvgData = Object.values(periodReleases?.project_avgs ?? {}).reduce(
-      (total, currentData) => total + currentData,
-      0
-    );
     // Convert from days to 7 day groups
     const seriesData = chunk(data, 7).map(week => {
       return {
@@ -190,8 +186,12 @@ class TeamReleases extends AsyncComponent<Props, State> {
       };
     });
 
+    const projectAvgSum = Object.values(periodReleases?.project_avgs ?? {}).reduce(
+      (total, currentData) => total + currentData,
+      0
+    );
     const totalPeriodAverage = Math.ceil(
-      projectAvgData / Object.keys(periodReleases?.project_avgs ?? {}).length
+      projectAvgSum / Object.keys(periodReleases?.project_avgs ?? {}).length
     );
 
     return (

--- a/static/app/views/teamInsights/teamReleases.tsx
+++ b/static/app/views/teamInsights/teamReleases.tsx
@@ -1,11 +1,14 @@
-import {Fragment} from 'react';
+import {ComponentType, Fragment} from 'react';
+import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import chunk from 'lodash/chunk';
 import isEqual from 'lodash/isEqual';
 import round from 'lodash/round';
+import moment from 'moment';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import BarChart from 'app/components/charts/barChart';
+import MarkLine from 'app/components/charts/components/markLine';
 import {DateTimeObject} from 'app/components/charts/utils';
 import IdBadge from 'app/components/idBadge';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
@@ -15,9 +18,10 @@ import {IconArrow} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
-import {Color} from 'app/utils/theme';
+import {Color, Theme} from 'app/utils/theme';
 
 type Props = AsyncComponent['props'] & {
+  theme: Theme;
   organization: Organization;
   teamSlug: string;
   projects: Project[];
@@ -164,7 +168,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {projects, period} = this.props;
+    const {projects, period, theme} = this.props;
     const {periodReleases} = this.state;
 
     const data = Object.entries(periodReleases?.release_counts ?? {})
@@ -186,17 +190,14 @@ class TeamReleases extends AsyncComponent<Props, State> {
       };
     });
 
-    const prevSeriesData = chunk(data, 7).map(week => {
-      return {
-        name: week[0].name,
-        value: Math.ceil(projectAvgData / projects.length),
-      };
-    });
+    const totalPeriodAverage = Math.ceil(
+      projectAvgData / Object.keys(periodReleases?.project_avgs ?? {}).length
+    );
 
     return (
       <div>
         <ChartWrapper>
-          <StyledBarChart
+          <BarChart
             style={{height: 190}}
             isGroupedByDate
             useShortDate
@@ -209,15 +210,37 @@ class TeamReleases extends AsyncComponent<Props, State> {
             series={[
               {
                 seriesName: t('This Period'),
+                silent: true,
                 data: seriesData,
-              },
+                markLine: MarkLine({
+                  silent: true,
+                  lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
+                  data: [{yAxis: totalPeriodAverage} as any],
+                }),
+              } as any,
             ]}
-            previousPeriod={[
-              {
-                seriesName: t(`Last ${period} Average`),
-                data: prevSeriesData ?? [],
+            tooltip={{
+              formatter: seriesParams => {
+                // `seriesParams` can be an array or an object :/
+                const [series] = Array.isArray(seriesParams)
+                  ? seriesParams
+                  : [seriesParams];
+
+                const dateFormat = 'MMM D';
+                const startDate = moment(series.axisValue).format(dateFormat);
+                const endDate = moment(series.axisValue)
+                  .add(7, 'days')
+                  .format(dateFormat);
+                return [
+                  '<div class="tooltip-series">',
+                  `<div><span class="tooltip-label">${series.marker} <strong>${series.seriesName}</strong></span> ${series.data[1]}</div>`,
+                  `<div><span class="tooltip-label"><strong>Last ${period} Average</strong></span> ${totalPeriodAverage}</div>`,
+                  '</div>',
+                  `<div class="tooltip-date">${startDate} - ${endDate}</div>`,
+                  '<div class="tooltip-arrow"></div>',
+                ].join('');
               },
-            ]}
+            }}
           />
         </ChartWrapper>
         <StyledPanelTable
@@ -248,14 +271,12 @@ class TeamReleases extends AsyncComponent<Props, State> {
   }
 }
 
-export default TeamReleases;
+export default withTheme(TeamReleases as ComponentType<Props>);
 
 const ChartWrapper = styled('div')`
-  padding: ${space(2)};
+  padding: ${space(2)} ${space(2)} 0 ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
 `;
-
-const StyledBarChart = styled(BarChart)<{previousPeriod: any[]}>``;
 
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: 1fr 0.2fr 0.2fr 0.2fr;

--- a/static/app/views/teamInsights/teamReleases.tsx
+++ b/static/app/views/teamInsights/teamReleases.tsx
@@ -186,13 +186,12 @@ class TeamReleases extends AsyncComponent<Props, State> {
       };
     });
 
-    const projectAvgSum = Object.values(periodReleases?.project_avgs ?? {}).reduce(
+    const averageValues = Object.values(periodReleases?.project_avgs ?? {});
+    const projectAvgSum = averageValues.reduce(
       (total, currentData) => total + currentData,
       0
     );
-    const totalPeriodAverage = Math.ceil(
-      projectAvgSum / Object.keys(periodReleases?.project_avgs ?? {}).length
-    );
+    const totalPeriodAverage = Math.ceil(projectAvgSum / averageValues.length);
 
     return (
       <div>


### PR DESCRIPTION
- Markline extends to the ends of the graph and padding adjustment
- Fixes a bug where the number of projects (in a team) is more than the number of averages returned. This made the average wrong.

before
![image](https://user-images.githubusercontent.com/1400464/137558360-58b90594-0057-4522-bbe3-426b765faa6d.png)


after
![image](https://user-images.githubusercontent.com/1400464/137558276-6498dd8b-17e7-4fd5-be45-0ffb5e91920a.png)
