### PR TITLE
fix(integrations): Populate fields with default value to avoid empty labels submitting

### DIFF
--- a/static/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/static/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -160,7 +160,7 @@ export default class AbstractExternalIssueForm<
     const modifiedLabel = (
       <React.Fragment>
         <QuestionTooltip
-          title={tct('This is your current default [label].', {
+          title={tct('This is your current [label].', {
             label: field.label,
           })}
           size="xs"


### PR DESCRIPTION
This PR will prevent the submitting external issue forms with empty labels for async field. The problem would arise since typing into any of these inputs sends a third party request which will return the results based on what the user typed. Since we have a default reporter for the user, it would often start with the a choice (`[value, label]`) on load. When the user types into the field, if the result doesn't include the default value, when we overwrite the choices we lose the `label` associated with it, and the field appears empty. This PR will retain the current value even when the user types into the field.

**With the default option pre-loaded**

<img width="595" alt="image" src="https://user-images.githubusercontent.com/35509934/137773707-114716b2-fe05-4646-afb7-0212fe06cad4.png">

<img width="595" alt="image" src="https://user-images.githubusercontent.com/35509934/137773787-15c13a81-ab36-4ec2-8747-87ab8cce1bae.png">

<img width="636" alt="image" src="https://user-images.githubusercontent.com/35509934/137775690-015d17bc-5701-44be-b998-5a73507685f4.png">

**After selecting a new option**

<img width="589" alt="Screen Shot 2021-10-18 at 9 46 58 AM" src="https://user-images.githubusercontent.com/35509934/137774055-94d35175-8c7d-44ca-b47d-da78bc971be7.png">

<img width="589" alt="image" src="https://user-images.githubusercontent.com/35509934/137773969-2d63d788-f979-481a-94ee-8cb300e2ae1b.png">

