### PR TITLE
fix(discover): Fixing auto fields

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2807,13 +2807,13 @@ class QueryFields(QueryBase):
                 resolved_columns.append(resolved_column)
 
         # Happens after resolving columns to check if there any aggregates
-        if self.auto_fields and not self.aggregates:
+        if self.auto_fields:
             # Ensure fields we require to build a functioning interface
             # are present.
-            if "id" not in stripped_columns:
+            if not self.aggregates and "id" not in stripped_columns:
                 resolved_columns.append(self.resolve_column("id", alias=True))
-            if "project.id" not in stripped_columns:
-                resolved_columns.append(self.resolve_column("project.id", alias=True))
+            if "id" in stripped_columns and "project.id" not in stripped_columns:
+                resolved_columns.append(self.resolve_column("project.name", alias=True))
 
         return resolved_columns
 


### PR DESCRIPTION
- Didn't fix all the auto field tests
- This fixes
  - test_not_project_in_query_but_in_header
  - test_not_project_in_query_with_all_projects
  - test_raw_data
- This is cause I misunderstood that we were adding project into the
  columns even when aggregates were included
- Also adds project.name instead of project.id