### PR TITLE
fix(discover): Support percentiles without an arg

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2248,14 +2248,18 @@ def normalize_percentile_alias(args: Mapping[str, str]) -> str:
     # function signature. This function only accepts percentile
     # aliases.
     aggregate_alias = args["aggregate_alias"]
-    match = re.match(r"(p\d{2,3})_(\w+)", aggregate_alias)
+    match = re.match(r"(p\d{2,3})_?(\w+)?", aggregate_alias)
 
     if not match:
         raise InvalidFunctionArgument("Aggregate alias must be a percentile function.")
 
     # Translating an arg of the pattern `measurements_lcp`
     # to `measurements.lcp`.
-    aggregate_arg = ".".join(match.group(2).split("_"))
+    if match.group(2):
+        aggregate_arg = ".".join(match.group(2).split("_"))
+    # We default percentiles without an arg to duration
+    else:
+        aggregate_arg = "transaction.duration"
 
     return f"{match.group(1)}({aggregate_arg})"
 


### PR DESCRIPTION
- This allows the use of an percentile without any args (eg. p75) in
  compare_numeric_aggregates
- This is tested via `test_compare_numeric_aggregate` with snql enable