### PR TITLE
dev(feat): Add create-user target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ run-dependent-services \
 drop-db \
 create-db \
 apply-migrations \
+create-user \
 reset-db \
 setup-git \
 node-version-check \


### PR DESCRIPTION
Adds `create-user` as a top-level make target. Right now, this is run as part of
`make bootstrap` and only accessible via `do.sh`.