### PR TITLE
feat(ui): Adjust getSessionsInterval thresholds

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -16,6 +16,7 @@ export const THIRTY_DAYS = 43200;
 export const TWO_WEEKS = 20160;
 export const ONE_WEEK = 10080;
 export const TWENTY_FOUR_HOURS = 1440;
+export const SIX_HOURS = 360;
 export const ONE_HOUR = 60;
 
 /**
@@ -115,7 +116,7 @@ export function getInterval(datetimeObj: DateTimeObject, fidelity: Fidelity = 'm
 
 /**
  * Duplicate of getInterval, except that we do not support <1h granularity
- * Used by SessionsV2 and OrgStatsV2 API
+ * Used by OrgStatsV2 API
  */
 export function getSeriesApiInterval(datetimeObj: DateTimeObject) {
   const diffInMinutes = getDiffInMinutes(datetimeObj);

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -5,8 +5,9 @@ import moment from 'moment';
 import {
   DateTimeObject,
   getDiffInMinutes,
-  ONE_WEEK,
-  TWO_WEEKS,
+  SIX_HOURS,
+  SIXTY_DAYS,
+  THIRTY_DAYS,
 } from 'app/components/charts/utils';
 import {SessionApiResponse, SessionField, SessionStatus} from 'app/types';
 import {SeriesDataUnit} from 'app/types/echarts';
@@ -259,15 +260,20 @@ export function getSessionsInterval(
     highFidelity = false;
   }
 
-  if (diffInMinutes > TWO_WEEKS) {
+  if (diffInMinutes >= SIXTY_DAYS) {
     return '1d';
   }
-  if (diffInMinutes > ONE_WEEK) {
-    return '6h';
+
+  if (diffInMinutes >= THIRTY_DAYS) {
+    return '4h';
+  }
+
+  if (diffInMinutes >= SIX_HOURS) {
+    return '1h';
   }
 
   // limit on backend for sub-hour session resolution is set to six hours
-  if (highFidelity && diffInMinutes < 360) {
+  if (highFidelity) {
     if (diffInMinutes <= 30) {
       return '1m';
     }

--- a/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
+++ b/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
@@ -5,7 +5,6 @@ import omit from 'lodash/omit';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
-import {getSeriesApiInterval} from 'app/components/charts/utils';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {t} from 'app/locale';
 import {
@@ -18,7 +17,12 @@ import {
 import {Series} from 'app/types/echarts';
 import {percent} from 'app/utils';
 import {getPeriod} from 'app/utils/getPeriod';
-import {getCount, getCountSeries, initSessionsChart} from 'app/utils/sessions';
+import {
+  getCount,
+  getCountSeries,
+  getSessionsInterval,
+  initSessionsChart,
+} from 'app/utils/sessions';
 import {Theme} from 'app/utils/theme';
 import {getCrashFreePercent} from 'app/views/releases/utils';
 
@@ -133,13 +137,15 @@ class ProjectSessionsChartRequest extends React.Component<Props, State> {
   }
 
   queryParams({shouldFetchWithPrevious = false}) {
-    const {selection, query} = this.props;
+    const {selection, query, organization} = this.props;
     const {datetime, projects, environments: environment} = selection;
 
     const baseParams = {
       field: 'sum(session)',
       groupBy: 'session.status',
-      interval: getSeriesApiInterval(datetime),
+      interval: getSessionsInterval(datetime, {
+        highFidelity: organization.features.includes('minute-resolution-sessions'),
+      }),
       project: projects[0],
       environment,
       query,

--- a/tests/js/spec/utils/sessions.spec.tsx
+++ b/tests/js/spec/utils/sessions.spec.tsx
@@ -174,20 +174,20 @@ describe('utils/sessions', () => {
 
   describe('getSessionsInterval', () => {
     describe('with high fidelity', () => {
-      it('greater than 14 days', () => {
-        expect(getSessionsInterval({period: '15d'}, {highFidelity: true})).toBe('1d');
+      it('>= 60 days', () => {
+        expect(getSessionsInterval({period: '60d'}, {highFidelity: true})).toBe('1d');
       });
 
-      it('greater than 7 days', () => {
-        expect(getSessionsInterval({period: '8d'}, {highFidelity: true})).toBe('6h');
+      it('>= 30 days', () => {
+        expect(getSessionsInterval({period: '30d'}, {highFidelity: true})).toBe('4h');
       });
 
-      it('30 minutes or less', () => {
-        expect(getSessionsInterval({period: '28m'}, {highFidelity: true})).toBe('1m');
+      it('14 days', () => {
+        expect(getSessionsInterval({period: '14d'}, {highFidelity: true})).toBe('1h');
       });
 
-      it('between one week and six hours', () => {
-        expect(getSessionsInterval({period: '1d'}, {highFidelity: true})).toBe('1h');
+      it('>= 6 hours', () => {
+        expect(getSessionsInterval({period: '6h'}, {highFidelity: true})).toBe('1h');
       });
 
       it('between 6 hours and 30 minutes', () => {
@@ -209,26 +209,26 @@ describe('utils/sessions', () => {
     });
 
     describe('with low fidelity', () => {
-      it('greater than 14 days', () => {
-        expect(getSessionsInterval({period: '15d'})).toBe('1d');
+      it('>= 60 days', () => {
+        expect(getSessionsInterval({period: '60d'})).toBe('1d');
         expect(
           getSessionsInterval(
-            {start: '2021-07-19T15:14:23Z', end: '2021-08-03T15:13:32Z'},
+            {start: '2021-07-19T15:14:23Z', end: '2021-10-19T15:14:23Z'},
             {highFidelity: true}
           )
         ).toBe('1d');
       });
 
-      it('greater than 7 days', () => {
-        expect(getSessionsInterval({period: '8d'})).toBe('6h');
+      it('>= 30 days', () => {
+        expect(getSessionsInterval({period: '30d'})).toBe('4h');
       });
 
-      it('30 minutes or less', () => {
-        expect(getSessionsInterval({period: '28m'})).toBe('1h');
+      it('14 days', () => {
+        expect(getSessionsInterval({period: '14d'})).toBe('1h');
       });
 
-      it('between one week and six hours', () => {
-        expect(getSessionsInterval({period: '1d'})).toBe('1h');
+      it('>= 6 hours', () => {
+        expect(getSessionsInterval({period: '6h'})).toBe('1h');
       });
 
       it('between 6 hours and 30 minutes', () => {


### PR DESCRIPTION
Adjusting interval thresholds to better mimic what we use elsewhere in the app.
This also allowed us to replace one usage of getSeriesApiInterval.