### PR TITLE
feat(ui): Clamp long lasting releases

### DIFF
--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -167,6 +167,16 @@ export function getReleaseBounds(release?: Release): ReleaseBounds {
     };
   }
 
+  const thousandDaysAfterReleaseStart = moment(releaseStart).add('999', 'days');
+  if (thousandDaysAfterReleaseStart.isBefore(releaseEnd)) {
+    // if the release spans for more than thousand days, we need to clamp it
+    // (otherwise we would hit the backend limit for the amount of data buckets)
+    return {
+      releaseStart,
+      releaseEnd: thousandDaysAfterReleaseStart.utc().format(),
+    };
+  }
+
   return {
     releaseStart,
     releaseEnd,

--- a/tests/js/spec/views/releases/utils/index.spec.tsx
+++ b/tests/js/spec/views/releases/utils/index.spec.tsx
@@ -48,6 +48,21 @@ describe('releases/utils', () => {
         releaseEnd: '2020-03-23T01:03:59Z',
       });
     });
+
+    it('clamps releases lasting longer than 1000 days', () => {
+      expect(
+        getReleaseBounds(
+          // @ts-expect-error
+          TestStubs.Release({
+            dateCreated: '2020-03-23T01:02:30Z',
+            lastEvent: '2023-03-23T01:02:30Z',
+          })
+        )
+      ).toEqual({
+        releaseStart: '2020-03-23T01:02:00Z',
+        releaseEnd: '2022-12-17T01:02:00Z',
+      });
+    });
   });
 
   describe('getReleaseParams', () => {


### PR DESCRIPTION
If the release span is more than 1000 days, it will result in fetching more than 1000 data buckets (the largest time interval possible right now is `1d`) and will hit the backend limit.  We are clamping the release view so that we are always within 1000 days.