### PR TITLE
fix(code-mapping): Allow for periods in branch names

### DIFF
--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -18,6 +18,9 @@ def gen_path_regex_field():
     )
 
 
+BRANCH_NAME_ERROR_MESSAGE = "Branch name may only have letters, numbers, underscores, forward slashes, dashes and periods. Branch name may not start or end with a forward slash."
+
+
 class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     repository_id = serializers.IntegerField(required=True)
     project_id = serializers.IntegerField(required=True)
@@ -26,11 +29,7 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     default_branch = serializers.RegexField(
         r"^(^(?![\/]))([\w\.\/-]+)(?<![\/])$",
         required=True,
-        error_messages={
-            "invalid": _(
-                "Branch name may only have letters, numbers, underscores, forward slashes, dashes and periods. Branch name may not start or end with a forward slash."
-            )
-        },
+        error_messages={"invalid": _(BRANCH_NAME_ERROR_MESSAGE)},
     )
 
     class Meta:

--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -24,11 +24,11 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     stack_root = gen_path_regex_field()
     source_root = gen_path_regex_field()
     default_branch = serializers.RegexField(
-        r"^(^(?![\/]))([\w\/-]+)(?<![\/])$",
+        r"^(^(?![\/]))([\w\.\/-]+)(?<![\/])$",
         required=True,
         error_messages={
             "invalid": _(
-                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
+                "Branch name may only have letters, numbers, underscores, forward slashes, dashes and periods. Branch name may not start or end with a forward slash."
             )
         },
     )

--- a/src/sentry/api/endpoints/organization_code_mappings.py
+++ b/src/sentry/api/endpoints/organization_code_mappings.py
@@ -18,7 +18,7 @@ def gen_path_regex_field():
     )
 
 
-BRANCH_NAME_ERROR_MESSAGE = "Branch name may only have letters, numbers, underscores, forward slashes, dashes and periods. Branch name may not start or end with a forward slash."
+BRANCH_NAME_ERROR_MESSAGE = "Branch name may only have letters, numbers, underscores, forward slashes, dashes, and periods. Branch name may not start or end with a forward slash."
 
 
 class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):

--- a/tests/sentry/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mappings.py
@@ -298,6 +298,10 @@ class OrganizationCodeMappingsTest(APITestCase):
         response = self.make_post({"defaultBranch": "prod/deploy-branch"})
         assert response.status_code == 201, response.content
 
+    def test_period_in_branch(self):
+        response = self.make_post({"defaultBranch": "release-2.0.0"})
+        assert response.status_code == 201, response.content
+
     def test_leading_forward_slash_in_branch_conflict(self):
         response = self.make_post({"defaultBranch": "/prod/deploy-branch"})
         assert response.status_code == 400

--- a/tests/sentry/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mappings.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from sentry.api.endpoints.organization_code_mappings import BRANCH_NAME_ERROR_MESSAGE
 from sentry.models import Integration, Repository, RepositoryProjectPathConfig
 from sentry.testutils import APITestCase
 
@@ -288,11 +289,7 @@ class OrganizationCodeMappingsTest(APITestCase):
     def test_quote_in_branch(self):
         response = self.make_post({"defaultBranch": "f'f"})
         assert response.status_code == 400
-        assert response.data == {
-            "defaultBranch": [
-                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
-            ],
-        }
+        assert response.data == {"defaultBranch": [BRANCH_NAME_ERROR_MESSAGE]}
 
     def test_forward_slash_in_branch(self):
         response = self.make_post({"defaultBranch": "prod/deploy-branch"})
@@ -305,17 +302,9 @@ class OrganizationCodeMappingsTest(APITestCase):
     def test_leading_forward_slash_in_branch_conflict(self):
         response = self.make_post({"defaultBranch": "/prod/deploy-branch"})
         assert response.status_code == 400
-        assert response.data == {
-            "defaultBranch": [
-                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
-            ],
-        }
+        assert response.data == {"defaultBranch": [BRANCH_NAME_ERROR_MESSAGE]}
 
     def test_ending_forward_slash_in_branch_conflict(self):
         response = self.make_post({"defaultBranch": "prod/deploy-branch/"})
         assert response.status_code == 400
-        assert response.data == {
-            "defaultBranch": [
-                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
-            ],
-        }
+        assert response.data == {"defaultBranch": [BRANCH_NAME_ERROR_MESSAGE]}


### PR DESCRIPTION
See [ISSUE-1280](https://getsentry.atlassian.net/browse/ISSUE-1280)

This PR allows for periods in the branch names for stack trace linking. The functionality and links themselves still work just fine. The error message has been updated along with another test.

---

**Before**

<img width="624" alt="image" src="https://user-images.githubusercontent.com/35509934/137795420-70dfec4c-0d0e-4dce-bf6f-f8ecf5e6518b.png">


**After**

The field no longer throws any errors for periods:

<img width="636" alt="image" src="https://user-images.githubusercontent.com/35509934/137795006-df2d75fe-68ed-475d-8955-cd6e8336bfb0.png">

Stacktrace linking still works:

<img width="495" alt="image" src="https://user-images.githubusercontent.com/35509934/137795130-78d48173-9d8f-4d0e-9535-101f19058293.png">

<img width="789" alt="image" src="https://user-images.githubusercontent.com/35509934/137795206-e04a6560-78ff-452a-91e7-77c2ee5f91df.png">

New error message:
<img width="624" alt="image" src="https://user-images.githubusercontent.com/35509934/137796142-275f1bb7-b2bd-4206-b2b6-9eb09fae8585.png">
