### PR TITLE
fix(ui): tidied up descriptions for Reports

### DIFF
--- a/static/app/views/teamInsights/descriptionCard.tsx
+++ b/static/app/views/teamInsights/descriptionCard.tsx
@@ -53,6 +53,7 @@ const Title = styled('div')`
 
 const Description = styled('div')`
   color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 const RightPanel = styled('div')`

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -256,7 +256,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('User Misery')}
               description={t(
-                'This shows the number of unique users that experienced load times 4x the project’s configured threshold.'
+                'The number of unique users that experienced load times 4x the project’s configured threshold.'
               )}
             >
               <TeamMisery
@@ -303,7 +303,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('Time to Resolution')}
               description={t(
-                `This shows the mean time it took for issues to be resolved by your team.`
+                `The mean time it took for issues to be resolved by your team.`
               )}
             >
               <TeamResolutionTime

--- a/static/app/views/teamInsights/overview.tsx
+++ b/static/app/views/teamInsights/overview.tsx
@@ -240,7 +240,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('Crash Free Sessions')}
               description={t(
-                'The percentage of healthy, errored, and abnormal sessions that did not cause a crash.'
+                'The percentage of healthy, errored, and abnormal sessions that didn’t cause a crash.'
               )}
             >
               <TeamStability
@@ -256,7 +256,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('User Misery')}
               description={t(
-                'User Misery shows the number of unique users that experienced load times 4x the project’s configured threshold.'
+                'This shows the number of unique users that experienced load times 4x the project’s configured threshold.'
               )}
             >
               <TeamMisery
@@ -271,9 +271,7 @@ function TeamInsightsOverview({
 
             <DescriptionCard
               title={t('Metric Alerts Triggered')}
-              description={t(
-                'These are the alerts triggered from the Alert Rules your team created.'
-              )}
+              description={t('Alerts triggered from the Alert Rules your team created.')}
             >
               <TeamAlertsTriggered
                 organization={organization}
@@ -289,7 +287,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('Issues Reviewed')}
               description={t(
-                'Issues that were triaged by your team taking an action on them such as resolving, ignoring, marking as reviewed, or deleting.'
+                'Issues triaged by your team taking an action on them such as resolving, ignoring, marking as reviewed, or deleting.'
               )}
             >
               <TeamIssuesReviewed
@@ -305,8 +303,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('Time to Resolution')}
               description={t(
-                `This shows the mean time it took for issues to be resolved by your team.
-                 If issues took a long time to resolve, this could be a problem that your team needs to fix.`
+                `This shows the mean time it took for issues to be resolved by your team.`
               )}
             >
               <TeamResolutionTime
@@ -321,7 +318,7 @@ function TeamInsightsOverview({
             <DescriptionCard
               title={t('Number of Releases')}
               description={t(
-                'A breakdown showing how your team shipped releases over time. This is a signal that team velocity is high or low.'
+                'A breakdown showing how your team shipped releases over time.'
               )}
             >
               <TeamReleases


### PR DESCRIPTION
- Tidied up description of Report charts
- Made font-size smaller 

---

### Before

![CleanShot 2021-10-18 at 12 08 52](https://user-images.githubusercontent.com/1900676/137799302-822a8ea9-f26f-4d5a-af3f-7c5f921746e5.png)

### After
![CleanShot 2021-10-18 at 12 59 43](https://user-images.githubusercontent.com/1900676/137799388-cc42e260-83d9-4c36-8f80-5ecd830a37db.png)

