### PR TITLE
fix(ui): changed table heading to "Last 7 days"

### DIFF
--- a/static/app/views/teamInsights/teamMisery.tsx
+++ b/static/app/views/teamInsights/teamMisery.tsx
@@ -82,7 +82,7 @@ function TeamMisery({
           t('Key transaction'),
           t('Project'),
           tct('Last [period]', {period}),
-          t('This Week'),
+          t('Last 7 Days'),
           <RightAligned key="change">{t('Change')}</RightAligned>,
         ]}
         isLoading={isLoading}

--- a/static/app/views/teamInsights/teamReleases.tsx
+++ b/static/app/views/teamInsights/teamReleases.tsx
@@ -249,7 +249,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
             <RightAligned key="last">
               {tct('Last [period] Average', {period})}
             </RightAligned>,
-            <RightAligned key="curr">{t('This Week')}</RightAligned>,
+            <RightAligned key="curr">{t('Last 7 Days')}</RightAligned>,
             <RightAligned key="diff">{t('Difference')}</RightAligned>,
           ]}
         >

--- a/static/app/views/teamInsights/teamStability.tsx
+++ b/static/app/views/teamInsights/teamStability.tsx
@@ -177,7 +177,7 @@ class TeamStability extends AsyncComponent<Props, State> {
         headers={[
           t('Project'),
           <RightAligned key="last">{tct('Last [period]', {period})}</RightAligned>,
-          <RightAligned key="curr">{t('This Week')}</RightAligned>,
+          <RightAligned key="curr">{t('Last 7 Days')}</RightAligned>,
           <RightAligned key="diff">{t('Difference')}</RightAligned>,
         ]}
       >


### PR DESCRIPTION
Copy fix for tables in Reports: `This Week` -> `Last 7 Days`

### Before
![CleanShot 2021-10-18 at 13 12 24](https://user-images.githubusercontent.com/1900676/137800175-efac3a6b-fbb3-4ae7-977b-4f8d42206148.png)
 
### After
![CleanShot 2021-10-18 at 13 12 19](https://user-images.githubusercontent.com/1900676/137800193-b0c5d925-c876-4d8b-b733-d27b27ddbf38.png)
 