### PR TITLE
ref(input): Add step for input

### DIFF
--- a/static/app/components/forms/inputField.tsx
+++ b/static/app/components/forms/inputField.tsx
@@ -11,6 +11,7 @@ type InputFieldProps = FormField['props'] & {
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
   autoComplete?: string;
   min?: number;
+  step?: number;
 };
 
 class InputField<
@@ -36,6 +37,7 @@ class InputField<
         onKeyPress={this.props.onKeyPress}
         onKeyDown={this.props.onKeyDown}
         min={this.props.min}
+        step={this.props.step}
       />
     );
   }


### PR DESCRIPTION
@getsentry/core-ui Might be better to refactor this to

```
type InputFieldProps = {
  // our custom props 
} & FormField['props']
  & JSX.IntrinsicElements['input'];
```