### PR TITLE
fix(ui): GridEditable on resize cleanup

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -218,17 +218,16 @@ class GridEditable<
   onResizeMouseUp = (e: MouseEvent) => {
     const metadata = this.resizeMetadata;
     const onResizeColumn = this.props.grid.onResizeColumn;
-    if (!metadata || !onResizeColumn) {
-      return;
+
+    if (metadata && onResizeColumn) {
+      const {columnOrder} = this.props;
+      const widthChange = e.clientX - metadata.cursorX;
+
+      onResizeColumn(metadata.columnIndex, {
+        ...columnOrder[metadata.columnIndex],
+        width: metadata.columnWidth + widthChange,
+      });
     }
-
-    const {columnOrder} = this.props;
-    const widthChange = e.clientX - metadata.cursorX;
-
-    onResizeColumn(metadata.columnIndex, {
-      ...columnOrder[metadata.columnIndex],
-      width: metadata.columnWidth + widthChange,
-    });
 
     this.resizeMetadata = undefined;
     this.clearWindowLifecycleEvents();


### PR DESCRIPTION
Previously, the mouse up handler was not cleaning up correctly if no onResizeColumn
handler was specified causing the resize to never stop. This ensures that the
cleanup is properly executed after mouse up and stops the resize.