### PR TITLE
fix(insights): Fix bug when resolution row has no prev row data

### DIFF
--- a/src/sentry/api/endpoints/team_time_to_resolution.py
+++ b/src/sentry/api/endpoints/team_time_to_resolution.py
@@ -35,7 +35,10 @@ class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
         sums = defaultdict(lambda: {"sum": timedelta(), "count": 0})
         for gh in history_list:
             key = str(gh["bucket"].date())
-            sums[key]["sum"] += gh["ttr"]
+            if gh["ttr"] is not None:
+                # If a `GroupHistory` row has no `prev_history_date` then this will end up being
+                # None. Isn't a problem long term, but for older data we will be missing this value.
+                sums[key]["sum"] += gh["ttr"]
             sums[key]["count"] += 1
 
         avgs = {}

--- a/tests/sentry/api/endpoints/test_team_time_to_resolution.py
+++ b/tests/sentry/api/endpoints/test_team_time_to_resolution.py
@@ -103,6 +103,16 @@ class TeamTimeToResolutionTest(APITestCase):
             prev_history=gh2,
             prev_history_date=gh2.date_added,
         )
+        # Make sure that if we have a `GroupHistory` row with no prev history then we don't crash.
+        GroupHistory.objects.create(
+            organization=self.organization,
+            group=group2,
+            project=project2,
+            actor=self.user.actor,
+            status=GroupHistoryStatus.DELETED,
+            prev_history=None,
+            prev_history_date=None,
+        )
 
         response = self.get_success_response(self.team.organization.slug, self.team.slug)
         assert len(response.data) == 90


### PR DESCRIPTION
Going forward `Resolved` history rows shouldn't have a null `prev_history_date`, but for Groups that
were created before we started writing this table it will be null. So we just need to handle this in
the api.