### PR TITLE
ref(symbolicator): Stagger metrics reporting

### DIFF
--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -76,10 +76,7 @@ def update_lpq_eligibility(project_id: int, cutoff: int) -> None:
     should consider when calculating a project's eligibility. In other words, only data recorded
     before `cutoff` should be considered.
     """
-    try:
-        _update_lpq_eligibility(project_id, cutoff)
-    finally:
-        _record_metrics()
+    _update_lpq_eligibility(project_id, cutoff)
 
 
 def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:


### PR DESCRIPTION
Cuts down on the frequency of LPQ metrics reporting as requested in https://github.com/getsentry/sentry/pull/29229/files#r731107657.

This means that changes to LPQ candidacy in both the manual kill switches and the automatically generated list will potentially take up to 10 seconds to be reflected in metrics.