### PR TITLE
fix(ui): made alert wizard chart consistent with Discover

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -3,8 +3,8 @@ import color from 'color';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 
+import AreaChart, {AreaChartSeries} from 'app/components/charts/areaChart';
 import Graphic from 'app/components/charts/components/graphic';
-import LineChart, {LineChartSeries} from 'app/components/charts/lineChart';
 import space from 'app/styles/space';
 import {GlobalSelection} from 'app/types';
 import {ReactEchartsRef, Series} from 'app/types/echarts';
@@ -21,7 +21,7 @@ import {AlertRuleThresholdType, IncidentRule, Trigger} from '../../types';
 
 type DefaultProps = {
   data: Series[];
-  comparisonMarkLines: LineChartSeries[];
+  comparisonMarkLines: AreaChartSeries[];
 };
 
 type Props = DefaultProps & {
@@ -290,7 +290,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
 
   render() {
     const {data, triggers, period, aggregate, comparisonMarkLines} = this.props;
-    const dataWithoutRecentBucket: LineChartSeries[] = data?.map(
+    const dataWithoutRecentBucket: AreaChartSeries[] = data?.map(
       ({data: eventData, ...restOfData}) => ({
         ...restOfData,
         data: eventData.slice(0, -1),
@@ -327,7 +327,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
       },
     };
     return (
-      <LineChart
+      <AreaChart
         isGroupedByDate
         showTimeInTooltip
         period={period}

--- a/tests/js/spec/views/alerts/incidentRules/triggersChart.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/triggersChart.spec.jsx
@@ -2,10 +2,10 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {Client} from 'app/api';
-import LineChart from 'app/components/charts/lineChart';
+import AreaChart from 'app/components/charts/areaChart';
 import TriggersChart from 'app/views/alerts/incidentRules/triggers/chart';
 
-jest.mock('app/components/charts/lineChart');
+jest.mock('app/components/charts/areaChart');
 
 describe('Incident Rules Create', () => {
   let eventStatsMock;
@@ -14,7 +14,7 @@ describe('Incident Rules Create', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    LineChart.default = jest.fn(() => null);
+    AreaChart.default = jest.fn(() => null);
     api = new Client();
     eventStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
@@ -73,7 +73,7 @@ describe('Incident Rules Create', () => {
       })
     );
 
-    expect(LineChart).toHaveBeenCalledWith(
+    expect(AreaChart).toHaveBeenCalledWith(
       expect.objectContaining({
         series: [{data: expect.objectContaining({length: 1}), seriesName: 'count()'}],
       }),
@@ -137,15 +137,15 @@ describe('Incident Rules Create', () => {
     );
 
     // "series" accessed directly to assist with jest diff
-    expect(LineChart.mock.calls[0][0].series).toEqual([
+    expect(AreaChart.mock.calls[0][0].series).toEqual([
       {data: expect.anything(), seriesName: 'count()'},
       {data: expect.anything(), seriesName: 'Minimum'},
       {data: expect.anything(), seriesName: 'Average'},
       {data: expect.anything(), seriesName: 'Maximum'},
     ]);
-    expect(LineChart.mock.calls[0][0].series[0].data).toHaveLength(1199);
-    expect(LineChart.mock.calls[0][0].series[1].data).toHaveLength(239);
-    expect(LineChart.mock.calls[0][0].series[2].data).toHaveLength(239);
-    expect(LineChart.mock.calls[0][0].series[3].data).toHaveLength(239);
+    expect(AreaChart.mock.calls[0][0].series[0].data).toHaveLength(1199);
+    expect(AreaChart.mock.calls[0][0].series[1].data).toHaveLength(239);
+    expect(AreaChart.mock.calls[0][0].series[2].data).toHaveLength(239);
+    expect(AreaChart.mock.calls[0][0].series[3].data).toHaveLength(239);
   });
 });


### PR DESCRIPTION
Making the Alert Wizard chart more consistent with the way we present charts in Discover — with an area chart. Also just looks way better.

#### Before

![CleanShot 2021-10-18 at 16 17 57](https://user-images.githubusercontent.com/1900676/137819155-3bf6479e-8046-4b7f-9d70-55e19c5fb438.png)

#### After
![CleanShot 2021-10-18 at 16 15 57](https://user-images.githubusercontent.com/1900676/137819166-2646e956-d349-4a6d-8680-d4a1c75ecc6e.png)


