### PR TITLE
ref(plugins): Remove deprecation date for PagerDuty

### DIFF
--- a/src/sentry_plugins/pagerduty/plugin.py
+++ b/src/sentry_plugins/pagerduty/plugin.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.plugins.bases.notify import NotifyPlugin
 from sentry.utils.http import absolute_uri
@@ -31,9 +29,6 @@ class PagerDutyPlugin(CorePluginMixin, NotifyPlugin):
             IntegrationFeatures.ALERT_RULE,
         ),
     ]
-    deprecation_date = datetime(2021, 9, 20)
-    alternative = "pagerduty"
-    alt_is_sentry_app = False
 
     def error_message_from_json(self, data):
         message = data.get("message", "unknown error")


### PR DESCRIPTION
Remove the deprecation warning for the PagerDuty plugin as we've gotten some pushback from customers about removing this right now - it will still be removed, but at a later date. 