### PR TITLE
fix(ui): Dropdown menu arrow border

### DIFF
--- a/static/app/styles/global.tsx
+++ b/static/app/styles/global.tsx
@@ -189,10 +189,17 @@ const styles = (theme: Theme, isDark: boolean) => css`
           color: ${theme.textColor};
           background-color: ${theme.background} !important;
           border: 1px solid ${theme.border};
-          &:after,
           &:before {
-            border-top-color: ${theme.border} !important;
-            border-bottom-color: ${theme.border} !important;
+            border-bottom-color: ${theme.border};
+          }
+          &:after {
+            border-bottom-color: ${theme.background};
+          }
+          &.inverted:before {
+            border-top-color: ${theme.border};
+          }
+          &.inverted:after {
+            border-top-color: ${theme.background};
           }
         }
         .context-summary .context-item.darwin .context-item-icon,


### PR DESCRIPTION
Make the dropdown menu arrow look more like the hovercard arrow in dark mode.

Before:
<img width="176" alt="Screen Shot 2021-10-18 at 7 19 12 PM" src="https://user-images.githubusercontent.com/44172267/137832877-6f1b7370-c0f8-4766-959c-d4ee45e8d7ec.png">

After:
<img width="214" alt="Screen Shot 2021-10-18 at 7 19 29 PM" src="https://user-images.githubusercontent.com/44172267/137832907-30507b68-f23c-461e-9df2-4ad7814f0241.png">

In light mode it looks the same as it is today.