### PR TITLE
fix: Trim GNU versioning trailers

### DIFF
--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -5,6 +5,7 @@ from sentry.utils.safe import setdefault_path
 
 _windecl_hash = re.compile(r"^@?(.*?)@[0-9]+$")
 _rust_hash = re.compile(r"::h[a-z0-9]{16}$")
+_gnu_version = re.compile(r"@@?GLIBC_([0-9.]+)$")
 _cpp_trailer_re = re.compile(r"(\bconst\b|&)$")
 _rust_blanket_re = re.compile(r"^([A-Z] as )")
 _lambda_re = re.compile(
@@ -242,6 +243,9 @@ def trim_native_function_name(function, platform, normalize_lambdas=True):
 
     # trim off rust markers
     function = _rust_hash.sub("", function)
+
+    # trim off gnu symbol versioning info
+    function = _gnu_version.sub("", function)
 
     # trim off windows decl markers
     return _windecl_hash.sub("\\1", function)

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -98,6 +98,8 @@ from sentry.stacktraces.functions import (
             "std::__1::unique_ptr<X,std::default_delete<X> >::operator->",
             "std::__1::unique_ptr<T>::operator->",
         ],
+        ["pthread_cond_timedwait@@GLIBC_2.3.2", "pthread_cond_timedwait"],
+        ["glob64@GLIBC_2.2", "glob64"],
     ],
 )
 def test_trim_native_function_name(input, output):


### PR DESCRIPTION
Symbols can be versioned, as is the case for GLIBC.
See https://developers.redhat.com/blog/2019/08/01/how-the-gnu-c-library-handles-backward-compatibility
and https://maskray.me/blog/2020-11-26-all-about-symbol-versioning
for reference.

In theory, all symbols could be versioned, but we only trim GLIBC for now, as to not interfere with MSVC mangling, which
uses @ as special character.