### PR TITLE
fix(ui): Un-disable buttons for hover event propagation

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -238,7 +238,7 @@ const StyledButton = styled(
       }
 
       if (!href) {
-        return <button ref={ref} disabled={disabled} {...props} />;
+        return <button ref={ref} {...props} />;
       }
 
       if (external && href) {

--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -238,7 +238,7 @@ const StyledButton = styled(
       }
 
       if (!href) {
-        return <button ref={ref} {...props} />;
+        return <button ref={ref} disabled={disabled} {...props} />;
       }
 
       if (external && href) {
@@ -265,6 +265,7 @@ const StyledButton = styled(
   ${getColors};
   ${getBoxShadow(false)};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
+  pointer-events: ${p => (p.disabled ? 'none' : 'auto')};
   opacity: ${p => (p.busy || p.disabled) && '0.65'};
 
   &:active {


### PR DESCRIPTION
~~This removes the disabled prop from the button, because it breaks the tooltip hover. With the prop, when you hover off the button quickly the tooltip doesn't disappear, you have to linger on the button. We disable the click actions higher in the component chain so this shouldn't break anything.~~ Tooltip on disabled buttons doesn't get removed when cursor moved off too quickly. This adds `pointer-events: none` to the button when it is disabled to fix this issue. cursor no changing to `'not-allowed'` still persist and will need us to remove `disabled` prop from the `<button>` element. See the clips for the issue.

Old tooltip:

https://user-images.githubusercontent.com/15015880/137949692-3a2595a6-8452-41ca-8c32-6ac893c6fd16.mov


New tooltip:

https://user-images.githubusercontent.com/15015880/140588305-f937e931-0d62-4829-85b6-80656b4c4f95.mov


Reported in Jira: [ISSUE-1309](https://getsentry.atlassian.net/browse/ISSUE-1309)


