### PR TITLE
build(ci): Remove `if: always()` conditions from workflows

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -78,7 +78,6 @@ jobs:
           css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
 
       - name: Save snapshots
-        if: always()
         uses: getsentry/action-visual-snapshot@v2
         with:
           save-only: true
@@ -189,7 +188,6 @@ jobs:
           tar xf dist.tar.gz
 
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
-        if: always()
         run: |
           mkdir -p ${{ steps.setup.outputs.acceptance-dir }}
           mkdir -p ${{ steps.setup.outputs.acceptance-dir }}-mobile
@@ -200,7 +198,6 @@ jobs:
           USE_SNUBA: 1
 
       - name: Save snapshots
-        if: always()
         uses: getsentry/action-visual-snapshot@v2
         with:
           save-only: true
@@ -261,7 +258,6 @@ jobs:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
 
       - name: Save snapshots
-        if: always()
         uses: getsentry/action-visual-snapshot@v2
         with:
           save-only: true

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -47,6 +47,7 @@ jobs:
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: Install dependencies
+        id: dependencies
         if: steps.changes.outputs.frontend == 'true'
         run: yarn install --frozen-lockfile
 
@@ -102,7 +103,7 @@ jobs:
           github-token: ${{ steps.token.outputs.token }}
 
       - name: tsc
-        if: always() && steps.changes.outputs.frontend == 'true'
+        if: steps.dependencies.outcome == 'success' && steps.changes.outputs.frontend == 'true'
         run: |
           yarn tsc -p config/tsconfig.build.json
 


### PR DESCRIPTION
I do not remember why this was added, but removing these because it is adding noise to our workflow annotations when a previous step fails. If our setup steps fails, these steps will always fail as well, so there is not point in attempting to run them.