### PR TITLE
fix(notifications): backfillMissingProvidersWithFallback

### DIFF
--- a/tests/js/spec/utils/settings/notifications/backfill.spec.tsx
+++ b/tests/js/spec/utils/settings/notifications/backfill.spec.tsx
@@ -1,0 +1,56 @@
+import {backfillMissingProvidersWithFallback} from 'app/views/settings/account/notifications/utils';
+
+describe('backfillMissingProvidersWithFallback', () => {
+  describe('when scopeType is user', () => {
+    it('should add missing provider with the fallback value', () => {
+      expect(
+        backfillMissingProvidersWithFallback({}, ['email'], 'sometimes', 'user')
+      ).toEqual({email: 'sometimes', slack: 'never'});
+    });
+
+    it('should turn on both providers with the fallback value', () => {
+      expect(
+        backfillMissingProvidersWithFallback(
+          {email: 'never', slack: 'never'},
+          ['email', 'slack'],
+          'sometimes',
+          'user'
+        )
+      ).toEqual({email: 'sometimes', slack: 'sometimes'});
+    });
+
+    it('should move the existing setting when providers are swapped', () => {
+      expect(
+        backfillMissingProvidersWithFallback(
+          {email: 'always', slack: 'never'},
+          ['slack'],
+          '',
+          'user'
+        )
+      ).toEqual({email: 'never', slack: 'always'});
+    });
+
+    it('should turn off both providers when providers is empty', () => {
+      expect(
+        backfillMissingProvidersWithFallback(
+          {email: 'always', slack: 'always'},
+          [],
+          '',
+          'user'
+        )
+      ).toEqual({email: 'never', slack: 'never'});
+    });
+  });
+  describe('when scopeType is organization', () => {
+    it('should retain OFF organization scope preference when provider list changes', () => {
+      expect(
+        backfillMissingProvidersWithFallback(
+          {email: 'never', slack: 'never'},
+          ['slack'],
+          'sometimes',
+          'organization'
+        )
+      ).toEqual({email: 'never', slack: 'never'});
+    });
+  });
+});

--- a/tests/js/spec/utils/settings/notifications/testUtils.spec.tsx
+++ b/tests/js/spec/utils/settings/notifications/testUtils.spec.tsx
@@ -1,5 +1,4 @@
 import {
-  backfillMissingProvidersWithFallback,
   decideDefault,
   getUserDefaultValues,
 } from 'app/views/settings/account/notifications/utils';
@@ -31,49 +30,6 @@ describe('Notification Settings Utils', () => {
           email: 'never',
           slack: 'never',
         });
-      });
-    });
-  });
-
-  describe('backfillMissingProvidersWithFallback', () => {
-    describe('when scopeType is user', () => {
-      it('should add missing provider with the fallback value', () => {
-        expect(
-          backfillMissingProvidersWithFallback({}, ['email'], 'sometimes', 'user')
-        ).toEqual({email: 'sometimes', slack: 'never'});
-      });
-
-      it('should turn on both providers with the fallback value', () => {
-        expect(
-          backfillMissingProvidersWithFallback(
-            {email: 'never', slack: 'never'},
-            ['email', 'slack'],
-            'sometimes',
-            'user'
-          )
-        ).toEqual({email: 'sometimes', slack: 'sometimes'});
-      });
-
-      it('should move the existing setting when providers are swapped', () => {
-        expect(
-          backfillMissingProvidersWithFallback(
-            {email: 'always', slack: 'never'},
-            ['slack'],
-            '',
-            'user'
-          )
-        ).toEqual({email: 'never', slack: 'always'});
-      });
-
-      it('should turn off both providers when providers is empty', () => {
-        expect(
-          backfillMissingProvidersWithFallback(
-            {email: 'always', slack: 'always'},
-            [],
-            '',
-            'user'
-          )
-        ).toEqual({email: 'never', slack: 'never'});
       });
     });
   });


### PR DESCRIPTION
When a user updates their "Delivery Method" in fine-tuning settings, if their parent scoped Notification Settings are NEVER, then they should remain NEVER.
![Screen Shot 2021-10-19 at 4 06 45 PM](https://user-images.githubusercontent.com/31750075/138002556-4127b714-af29-43ca-9b11-f06f7ffdad29.png)