### PR TITLE
ref(sentry-test/enzyme): Add migration warning message

### DIFF
--- a/tests/js/sentry-test/enzyme.js
+++ b/tests/js/sentry-test/enzyme.js
@@ -5,6 +5,7 @@ import {mount, render, shallow} from 'enzyme'; // eslint-disable-line no-restric
 import {lightTheme} from 'app/utils/theme';
 
 /**
+ * @deprecated
  * As we are migrating our tests to React Testing Library,
  * please avoid using `sentry-test/enzyme` and use `sentry-test/reactTestingLibrary` instead.
  */

--- a/tests/js/sentry-test/enzyme.js
+++ b/tests/js/sentry-test/enzyme.js
@@ -4,6 +4,10 @@ import {mount, render, shallow} from 'enzyme'; // eslint-disable-line no-restric
 
 import {lightTheme} from 'app/utils/theme';
 
+/**
+ * As we are migrating our tests to React Testing Library,
+ * please avoid using `sentry-test/enzyme` and use `sentry-test/reactTestingLibrary` instead.
+ */
 const mountWithTheme = (tree, opts) => {
   const WrappingThemeProvider = props => (
     <CacheProvider value={cache}>

--- a/tests/js/sentry-test/enzyme.js
+++ b/tests/js/sentry-test/enzyme.js
@@ -1,13 +1,13 @@
 import {cache} from '@emotion/css'; // eslint-disable-line emotion/no-vanilla
 import {CacheProvider, ThemeProvider} from '@emotion/react';
-import {mount, render, shallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
+import {mount, shallow as enzymeShallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 
 import {lightTheme} from 'app/utils/theme';
 
 /**
  * @deprecated
  * As we are migrating our tests to React Testing Library,
- * please avoid using `sentry-test/enzyme` and use `sentry-test/reactTestingLibrary` instead.
+ * please avoid using `sentry-test/enzyme/mountWithTheme` and use `sentry-test/reactTestingLibrary/mountWithTheme` instead.
  */
 const mountWithTheme = (tree, opts) => {
   const WrappingThemeProvider = props => (
@@ -19,4 +19,11 @@ const mountWithTheme = (tree, opts) => {
   return mount(tree, {wrappingComponent: WrappingThemeProvider, ...opts});
 };
 
-export {mountWithTheme, render, shallow};
+/**
+ * @deprecated
+ * As we are migrating our tests to React Testing Library,
+ * please avoid using `sentry-test/enzyme/shallow` and use `sentry-test/reactTestingLibrary/mountWithTheme` instead.
+ */
+const shallow = enzymeShallow;
+
+export {mountWithTheme, shallow};


### PR DESCRIPTION
As we are migrating our enzyme tests to the React Testing Library, we would like to warn devs that the use of enzyme `shallow` and `mountWithTheme` is not recommended