### PR TITLE
feat(ui): Add absolute numbers to release adoption charts

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -105,7 +105,11 @@ type Props = {
         utc: boolean,
         showTimeInTooltip: boolean
       ) => string;
-      valueFormatter?: (value: number, label?: string) => string | number;
+      valueFormatter?: (
+        value: number,
+        label?: string,
+        seriesParams?: EChartOption.Tooltip.Format
+      ) => string | number;
       nameFormatter?: (name: string) => string;
       /**
        * Array containing seriesNames that need to be indented

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -191,7 +191,7 @@ function getFormatter({
           const formattedLabel = nameFormatter(
             truncationFormatter(s.seriesName ?? '', truncate)
           );
-          const value = valueFormatter(getSeriesValue(s, 1), s.seriesName);
+          const value = valueFormatter(getSeriesValue(s, 1), s.seriesName, s);
 
           const className = indentLabels.includes(formattedLabel)
             ? 'tooltip-label tooltip-label-indent'

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -24,6 +24,14 @@ export function getCount(groups: SessionApiResponse['groups'] = [], field: Sessi
   return groups.reduce((acc, group) => acc + group.totals[field], 0);
 }
 
+export function getCountAtIndex(
+  groups: SessionApiResponse['groups'] = [],
+  field: SessionField,
+  index: number
+) {
+  return groups.reduce((acc, group) => acc + group.series[field][index], 0);
+}
+
 export function getCrashFreeRate(
   groups: SessionApiResponse['groups'] = [],
   field: SessionField

--- a/tests/js/spec/utils/sessions.spec.tsx
+++ b/tests/js/spec/utils/sessions.spec.tsx
@@ -2,6 +2,7 @@ import {SessionField, SessionStatus} from 'app/types';
 import {
   filterSessionsInTimeWindow,
   getCount,
+  getCountAtIndex,
   getCrashFreeRate,
   getSessionsInterval,
   getSessionStatusRate,
@@ -145,6 +146,16 @@ describe('utils/sessions', () => {
     });
     it('returns users count', () => {
       expect(getCount(groups, SessionField.USERS)).toBe(720);
+    });
+  });
+
+  describe('getCountAtIndex', () => {
+    const groups = [sessionsApiResponse.groups[1], sessionsApiResponse.groups[2]];
+    it('returns sessions count', () => {
+      expect(getCountAtIndex(groups, SessionField.SESSIONS, 1)).toBe(35);
+    });
+    it('returns users count', () => {
+      expect(getCountAtIndex(groups, SessionField.USERS, 1)).toBe(16);
     });
   });
 


### PR DESCRIPTION
This PR adds absolute numbers to the existing percentages on release adoption charts.

![image](https://user-images.githubusercontent.com/9060071/138096570-7631474d-6c1e-4a2e-92cf-3b740e737815.png)



