### PR TITLE
feat(dashboards): updated Open in Discover buttons to react router Link

### DIFF
--- a/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
+++ b/static/app/components/modals/dashboardWidgetQuerySelectorModal.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {browserHistory} from 'react-router';
+import {Link} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -54,17 +54,21 @@ class DashboardWidgetQuerySelectorModal extends React.Component<Props> {
               </SearchLabel>
               <StyledInput value={query.conditions} disabled />
             </Container>
-            <OpenInDiscoverButton
-              priority="primary"
-              icon={<IconChevron size="xs" direction="right" />}
-              onClick={() => {
-                trackAdvancedAnalyticsEvent('dashboards_views.query_selector.selected', {
-                  organization,
-                  widget_type: widget.displayType,
-                });
-                browserHistory.push(discoverLocation);
-              }}
-            />
+            <Link to={discoverLocation}>
+              <OpenInDiscoverButton
+                priority="primary"
+                icon={<IconChevron size="xs" direction="right" />}
+                onClick={() => {
+                  trackAdvancedAnalyticsEvent(
+                    'dashboards_views.query_selector.selected',
+                    {
+                      organization,
+                      widget_type: widget.displayType,
+                    }
+                  );
+                }}
+              />
+            </Link>
           </QueryContainer>
         </React.Fragment>
       );

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -144,7 +144,7 @@ class WidgetCard extends React.Component<Props> {
         }
         if (widget.queries.length === 1) {
           menuOptions.push(
-            <Link to={discoverLocation}>
+            <Link key="open-discover-link" to={discoverLocation}>
               <StyledMenuItem key="open-discover">{t('Open in Discover')}</StyledMenuItem>
             </Link>
           );

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import LazyLoad from 'react-lazyload';
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {Link, withRouter, WithRouterProps} from 'react-router';
 import {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -123,48 +123,48 @@ class WidgetCard extends React.Component<Props> {
       // Open table widget in Discover
 
       if (widget.queries.length) {
-        menuOptions.push(
-          <MenuItem
-            key="open-discover"
-            onClick={event => {
-              event.preventDefault();
-              trackAnalyticsEvent({
-                eventKey: 'dashboards2.tablewidget.open_in_discover',
-                eventName: 'Dashboards2: Table Widget - Open in Discover',
-                organization_id: parseInt(this.props.organization.id, 10),
-              });
-              if (widget.queries.length === 1) {
-                const eventView = eventViewFromWidget(
-                  widget.title,
-                  widget.queries[0],
-                  selection,
-                  widget.displayType
-                );
-                const discoverLocation = eventView.getResultsViewUrlTarget(
-                  organization.slug
-                );
-                if (this.isAllowWidgetsToDiscover()) {
-                  // Pull a max of 3 valid Y-Axis from the widget
-                  const yAxisOptions = eventView
-                    .getYAxisOptions()
-                    .map(({value}) => value);
-                  discoverLocation.query.yAxis = widget.queries[0].fields
-                    .filter(field => yAxisOptions.includes(field))
-                    .slice(0, 3);
-                }
-                browserHistory.push(discoverLocation);
-              } else {
+        trackAnalyticsEvent({
+          eventKey: 'dashboards2.tablewidget.open_in_discover',
+          eventName: 'Dashboards2: Table Widget - Open in Discover',
+          organization_id: parseInt(this.props.organization.id, 10),
+        });
+        const eventView = eventViewFromWidget(
+          widget.title,
+          widget.queries[0],
+          selection,
+          widget.displayType
+        );
+        const discoverLocation = eventView.getResultsViewUrlTarget(organization.slug);
+        if (this.isAllowWidgetsToDiscover()) {
+          // Pull a max of 3 valid Y-Axis from the widget
+          const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
+          discoverLocation.query.yAxis = widget.queries[0].fields
+            .filter(field => yAxisOptions.includes(field))
+            .slice(0, 3);
+        }
+        if (widget.queries.length === 1) {
+          menuOptions.push(
+            <Link to={discoverLocation}>
+              <StyledMenuItem key="open-discover">{t('Open in Discover')}</StyledMenuItem>
+            </Link>
+          );
+        } else {
+          menuOptions.push(
+            <StyledMenuItem
+              key="open-discover"
+              onClick={event => {
+                event.preventDefault();
                 trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
                   organization,
                   widget_type: widget.displayType,
                 });
                 openDashboardWidgetQuerySelectorModal({organization, widget});
-              }
-            }}
-          >
-            {t('Open in Discover')}
-          </MenuItem>
-        );
+              }}
+            >
+              {t('Open in Discover')}
+            </StyledMenuItem>
+          );
+        }
       }
     }
 
@@ -302,4 +302,11 @@ const WidgetHeader = styled('div')`
 
 const ContextWrapper = styled('div')`
   margin-left: ${space(1)};
+`;
+
+const StyledMenuItem = styled(MenuItem)`
+  color: ${p => p.theme.gray500};
+  :hover {
+    color: ${p => p.theme.gray500};
+  }
 `;

--- a/tests/js/spec/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
+++ b/tests/js/spec/components/modals/dashboardWidgetQuerySelectorModal.spec.tsx
@@ -1,5 +1,3 @@
-import {browserHistory} from 'react-router';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
@@ -138,8 +136,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     const wrapper = mountModal({initialData, widget: mockWidget});
     // @ts-expect-error
     await tick();
-    wrapper.find('OpenInDiscoverButton').simulate('click');
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(wrapper.find('QueryContainer').find('Link').props().to).toEqual(
       expect.objectContaining({
         pathname: '/organizations/org-slug/discover/results/',
         query: expect.objectContaining({
@@ -159,8 +156,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     const wrapper = mountModal({initialData, widget: mockWidget});
     // @ts-expect-error
     await tick();
-    wrapper.find('OpenInDiscoverButton').simulate('click');
-    expect(browserHistory.push).toHaveBeenCalledWith({
+    expect(wrapper.find('QueryContainer').find('Link').props().to).toEqual({
       pathname: '/organizations/org-slug/discover/results/',
       query: expect.objectContaining({
         field: ['geo.country_code', 'count()'],

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.jsx
@@ -120,9 +120,8 @@ describe('Dashboards > WidgetCard', function () {
 
     const menuOptions = wrapper.find('ContextMenu').props().children;
     expect(menuOptions.length > 0).toBe(true);
-    expect(menuOptions[0].props.children).toEqual(t('Open in Discover'));
-    menuOptions[0].props.onClick(mockEvent);
-    expect(browserHistory.push).toHaveBeenCalledWith(
+    expect(menuOptions[0].props.children.props.children).toEqual(t('Open in Discover'));
+    expect(menuOptions[0].props.to).toEqual(
       expect.objectContaining({
         pathname: '/organizations/org-slug/discover/results/',
         query: expect.objectContaining({


### PR DESCRIPTION
Updated the `Open in Discover` buttons for Dashboards widgets to React Router Link. This allows the user to control/command click these buttons to open in a new tab.