### PR TITLE
fix(releasehealth): Improve reliability of snuba integration tests for sessions release health  

### DIFF
--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -1275,7 +1275,7 @@ class CheckNumberOfSessions(TestCase, SnubaTestCase):
         self.another_project = self.create_project()
         self.third_project = self.create_project()
 
-        self.now_dt = datetime.utcnow()
+        self.now_dt = datetime(2000, 3, 20, 17, 40, 0)
         self._5_min_ago_dt = self.now_dt - timedelta(minutes=5)
         self._30_min_ago_dt = self.now_dt - timedelta(minutes=30)
         self._1_h_ago_dt = self.now_dt - timedelta(hours=1)


### PR DESCRIPTION
This PR makes CheckNumberOfSession tests use a fix date.
The tests were using the current time which was causing inconsistent results depnending on the exact time at which they were run.