### PR TITLE
ref(sentry-metrics): Default to using the postgres indexer

### DIFF
--- a/.github/workflows/snuba-integration-test.yml
+++ b/.github/workflows/snuba-integration-test.yml
@@ -21,7 +21,6 @@ jobs:
       MATRIX_INSTANCE_TOTAL: 2
       USE_SNUBA: 1
       MIGRATIONS_TEST_MIGRATE: 1
-      USE_INDEXER: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1381,7 +1381,7 @@ SENTRY_METRICS_PREFIX = "sentry."
 SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefixes.
 
 # Metrics product
-SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.mock.MockIndexer"
+SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.postgres.PGStringIndexer"
 SENTRY_METRICS_INDEXER_OPTIONS = {}
 SENTRY_METRICS_INDEXER_CACHE_TTL = 3600 * 2
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -118,9 +118,6 @@ def pytest_configure(config):
         settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
         settings.SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
 
-    if os.environ.get("USE_INDEXER", False):
-        settings.SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.postgres.PGStringIndexer"
-
     if os.environ.get("DISABLE_TEST_SDK", False):
         settings.SENTRY_SDK_CONFIG = {}
 


### PR DESCRIPTION
Previously we were using the `MockIndexer` as the default, and an env var to let certain tests run with the postgres indexer. There are tests (such as `snuba/test_metrics.py`) where we want to keep using the mock indexer, so I've updated those tests accordingly. 