### PR TITLE
feat(discover): Disable other y axis options when in a display mode that doesnt support multi y axis

### DIFF
--- a/static/app/components/charts/optionCheckboxSelector.tsx
+++ b/static/app/components/charts/optionCheckboxSelector.tsx
@@ -74,17 +74,17 @@ class OptionCheckboxSelector extends Component<Props, State> {
     return [...selected, value];
   }
 
-  shouldBeDisabled(value: string) {
+  shouldBeDisabled({value, disabled}: SelectValue<string>) {
     const {selected} = this.props;
     // Y-Axis is capped at 3 fields
-    return selected.length > 2 && !selected.includes(value);
+    return disabled || (selected.length > 2 && !selected.includes(value));
   }
 
-  handleCheckboxClick(event: MouseEvent, value: string) {
+  handleCheckboxClick(event: MouseEvent, opt: SelectValue<string>) {
     const {onChange} = this.props;
     event.stopPropagation();
-    if (!this.shouldBeDisabled(value)) {
-      onChange(this.selectCheckbox(value));
+    if (!this.shouldBeDisabled(opt)) {
+      onChange(this.selectCheckbox(opt.value));
     }
   }
 
@@ -119,7 +119,7 @@ class OptionCheckboxSelector extends Component<Props, State> {
                   blendCorner
                 >
                   {options.map(opt => {
-                    const disabled = this.shouldBeDisabled(opt.value);
+                    const disabled = this.shouldBeDisabled(opt);
                     return (
                       <StyledDropdownItem
                         key={opt.value}
@@ -140,7 +140,8 @@ class OptionCheckboxSelector extends Component<Props, State> {
                           title={
                             disabled
                               ? t(
-                                  'Only a maximum of 3 fields can be displayed on the Y-Axis at a time'
+                                  opt.tooltip ??
+                                    'Only a maximum of 3 fields can be displayed on the Y-Axis at a time'
                                 )
                               : undefined
                           }
@@ -149,7 +150,7 @@ class OptionCheckboxSelector extends Component<Props, State> {
                             className={opt.value}
                             isChecked={selected.includes(opt.value)}
                             isDisabled={disabled}
-                            onClick={event => this.handleCheckboxClick(event, opt.value)}
+                            onClick={event => this.handleCheckboxClick(event, opt)}
                           />
                         </Tooltip>
                       </StyledDropdownItem>

--- a/static/app/components/charts/optionCheckboxSelector.tsx
+++ b/static/app/components/charts/optionCheckboxSelector.tsx
@@ -20,7 +20,7 @@ const defaultProps = {
 };
 
 type Props = {
-  options: SelectValue<string>[];
+  options: (SelectValue<string> & {checkboxHidden?: boolean})[];
   selected: string[];
   onChange: (value: string[]) => void;
   title: string;
@@ -136,23 +136,25 @@ class OptionCheckboxSelector extends Component<Props, State> {
                           maxLength={60}
                           expandDirection="left"
                         />
-                        <Tooltip
-                          title={
-                            disabled
-                              ? t(
-                                  opt.tooltip ??
-                                    'Only a maximum of 3 fields can be displayed on the Y-Axis at a time'
-                                )
-                              : undefined
-                          }
-                        >
-                          <CheckboxFancy
-                            className={opt.value}
-                            isChecked={selected.includes(opt.value)}
-                            isDisabled={disabled}
-                            onClick={event => this.handleCheckboxClick(event, opt)}
-                          />
-                        </Tooltip>
+                        {!opt.checkboxHidden && (
+                          <Tooltip
+                            title={
+                              disabled
+                                ? t(
+                                    opt.tooltip ??
+                                      'Only a maximum of 3 fields can be displayed on the Y-Axis at a time'
+                                  )
+                                : undefined
+                            }
+                          >
+                            <CheckboxFancy
+                              className={opt.value}
+                              isChecked={selected.includes(opt.value)}
+                              isDisabled={disabled}
+                              onClick={event => this.handleCheckboxClick(event, opt)}
+                            />
+                          </Tooltip>
+                        )}
                       </StyledDropdownItem>
                     );
                   })}

--- a/static/app/utils/discover/types.tsx
+++ b/static/app/utils/discover/types.tsx
@@ -44,3 +44,9 @@ export const CHART_AXIS_OPTIONS = [
   {label: 'count()', value: 'count()'},
   {label: 'count_unique(user)', value: 'count_unique(user)'},
 ];
+
+export const MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES = [
+  DisplayModes.DEFAULT,
+  DisplayModes.DAILY,
+  DisplayModes.PREVIOUS,
+];

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -31,7 +31,10 @@ import {defined, generateQueryWithTag} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import {generateAggregateFields} from 'app/utils/discover/fields';
-import {DisplayModes} from 'app/utils/discover/types';
+import {
+  DisplayModes,
+  MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
+} from 'app/utils/discover/types';
 import localStorage from 'app/utils/localStorage';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
 import withApi from 'app/utils/withApi';
@@ -309,11 +312,9 @@ class Results extends React.Component<Props, State> {
 
   handleYAxisChange = (value: string[]) => {
     const {router, location} = this.props;
-    const isDisplayMultiYAxisSupported = [
-      DisplayModes.DEFAULT,
-      DisplayModes.DAILY,
-      DisplayModes.PREVIOUS,
-    ].includes(location.query.display as DisplayModes);
+    const isDisplayMultiYAxisSupported = MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES.includes(
+      location.query.display as DisplayModes
+    );
 
     const newQuery = {
       ...location.query,

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -222,21 +222,19 @@ class ResultsChartContainer extends Component<ContainerProps> {
 
     const yAxisValue = hasConnectDiscoverAndDashboards ? yAxis : [eventView.getYAxis()];
     let yAxisOptions = eventView.getYAxisOptions();
-    // Disable multi y axis options when in an unsupported Display Mode
+    // Hide multi y axis checkbox when in an unsupported Display Mode
     if (
       !MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES.includes(
         eventView.getDisplayMode() as DisplayModes
       )
     ) {
       yAxisOptions = yAxisOptions.map(option => {
-        if (option.value !== yAxisValue[0]) {
-          return {
-            ...option,
-            disabled: true,
-            tooltip: t('Multiple Y-Axis cannot be plotted on this Display mode.'),
-          };
-        }
-        return option;
+        return {
+          ...option,
+          disabled: true,
+          tooltip: t('Multiple Y-Axis cannot be plotted on this Display mode.'),
+          checkboxHidden: true,
+        };
       });
     }
 

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -15,7 +15,11 @@ import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
-import {DisplayModes, TOP_N} from 'app/utils/discover/types';
+import {
+  DisplayModes,
+  MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
+  TOP_N,
+} from 'app/utils/discover/types';
 import getDynamicText from 'app/utils/getDynamicText';
 import {decodeScalar} from 'app/utils/queryString';
 import withApi from 'app/utils/withApi';
@@ -217,6 +221,24 @@ class ResultsChartContainer extends Component<ContainerProps> {
       });
 
     const yAxisValue = hasConnectDiscoverAndDashboards ? yAxis : [eventView.getYAxis()];
+    let yAxisOptions = eventView.getYAxisOptions();
+    // Disable multi y axis options when in an unsupported Display Mode
+    if (
+      !MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES.includes(
+        eventView.getDisplayMode() as DisplayModes
+      )
+    ) {
+      yAxisOptions = yAxisOptions.map(option => {
+        if (option.value !== yAxisValue[0]) {
+          return {
+            ...option,
+            disabled: true,
+            tooltip: t('Multiple Y-Axis cannot be plotted on this Display mode.'),
+          };
+        }
+        return option;
+      });
+    }
 
     return (
       <StyledPanel>
@@ -235,7 +257,7 @@ class ResultsChartContainer extends Component<ContainerProps> {
           organization={organization}
           total={total}
           yAxisValue={yAxisValue}
-          yAxisOptions={eventView.getYAxisOptions()}
+          yAxisOptions={yAxisOptions}
           onAxisChange={onAxisChange}
           displayOptions={displayOptions}
           displayMode={eventView.getDisplayMode()}

--- a/tests/js/spec/views/eventsV2/resultsChart.spec.tsx
+++ b/tests/js/spec/views/eventsV2/resultsChart.spec.tsx
@@ -82,4 +82,30 @@ describe('EventsV2 > ResultsChart', function () {
       t('No Y-Axis selected.')
     );
   });
+
+  it('disables other y-axis options when not in default, daily, or previous period display mode', async function () {
+    eventView.display = DisplayModes.WORLDMAP;
+    const wrapper = mountWithTheme(
+      <ResultsChart
+        // @ts-expect-error
+        router={TestStubs.router()}
+        organization={organization}
+        eventView={eventView}
+        // @ts-expect-error
+        location={location}
+        onAxisChange={() => undefined}
+        onDisplayChange={() => undefined}
+        total={1}
+        confirmedQuery
+        yAxis={['count()']}
+      />,
+      initialData.routerContext
+    );
+    const yAxisOptions = wrapper.find('ChartFooter').props().yAxisOptions;
+    yAxisOptions.forEach(({value, disabled}) => {
+      if (value !== 'count()') {
+        expect(disabled).toBe(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
When in a Display Mode that doesn't support multi y axis selection (like World Map and Top Period), hide the checkbox for Y-Axis options:
![image](https://user-images.githubusercontent.com/83961295/138356967-38d65fd3-4daf-48b4-91bc-da6ab1f18c2e.png)

Display modes that support multi y will still have checkboxes:
![image](https://user-images.githubusercontent.com/83961295/138357014-46950860-98c8-4c7c-985a-7e0e6e35622e.png)

