### PR TITLE
feat(perf): Add trends widgets for landing page v3

### DIFF
--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -7,6 +7,7 @@ import GenericDiscoverQuery, {
 import withApi from 'app/utils/withApi';
 import {
   TrendChangeType,
+  TrendFunctionField,
   TrendsData,
   TrendsDataEvents,
   TrendsQuery,
@@ -20,12 +21,13 @@ import {
 
 export type TrendsRequest = {
   trendChangeType?: TrendChangeType;
+  trendFunctionField?: TrendFunctionField;
   eventView: Partial<TrendView>;
 };
 
 type RequestProps = DiscoverQueryProps & TrendsRequest;
 
-type ChildrenProps = Omit<GenericChildrenProps<TrendsData>, 'tableData'> & {
+export type ChildrenProps = Omit<GenericChildrenProps<TrendsData>, 'tableData'> & {
   trendsData: TrendsData | null;
 };
 
@@ -44,13 +46,13 @@ type EventProps = RequestProps & {
 export function getTrendsRequestPayload(props: RequestProps) {
   const {eventView} = props;
   const apiPayload: TrendsQuery = eventView?.getEventsAPIPayload(props.location);
-  const trendFunction = getCurrentTrendFunction(props.location);
+  const trendFunction = getCurrentTrendFunction(props.location, props.trendFunctionField);
   const trendParameter = getCurrentTrendParameter(props.location);
   apiPayload.trendFunction = generateTrendFunctionAsString(
     trendFunction.field,
     trendParameter.column
   );
-  apiPayload.trendType = eventView?.trendType;
+  apiPayload.trendType = eventView?.trendType || props.trendChangeType;
   apiPayload.interval = eventView?.interval;
   apiPayload.middle = eventView?.middle;
   return apiPayload;
@@ -59,9 +61,9 @@ export function getTrendsRequestPayload(props: RequestProps) {
 function TrendsDiscoverQuery(props: Props) {
   return (
     <GenericDiscoverQuery<TrendsData, TrendsRequest>
+      {...props}
       route="events-trends-stats"
       getRequestPayload={getTrendsRequestPayload}
-      {...props}
     >
       {({tableData, ...rest}) => {
         return props.children({trendsData: tableData, ...rest});
@@ -73,9 +75,9 @@ function TrendsDiscoverQuery(props: Props) {
 function EventsDiscoverQuery(props: EventProps) {
   return (
     <GenericDiscoverQuery<TrendsDataEvents, TrendsRequest>
+      {...props}
       route="events-trends"
       getRequestPayload={getTrendsRequestPayload}
-      {...props}
     >
       {({tableData, ...rest}) => {
         return props.children({trendsData: tableData, ...rest});

--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -27,12 +27,15 @@ export type TrendsRequest = {
 
 type RequestProps = DiscoverQueryProps & TrendsRequest;
 
-export type ChildrenProps = Omit<GenericChildrenProps<TrendsData>, 'tableData'> & {
+export type TrendDiscoveryChildrenProps = Omit<
+  GenericChildrenProps<TrendsData>,
+  'tableData'
+> & {
   trendsData: TrendsData | null;
 };
 
 type Props = RequestProps & {
-  children: (props: ChildrenProps) => React.ReactNode;
+  children: (props: TrendDiscoveryChildrenProps) => React.ReactNode;
 };
 
 type EventChildrenProps = Omit<GenericChildrenProps<TrendsDataEvents>, 'tableData'> & {

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -1,3 +1,4 @@
+import {ReactText} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
@@ -59,6 +60,25 @@ export const LANDING_DISPLAYS = [
     badge: 'new' as const,
   },
 ];
+
+export function excludeTransaction(
+  transaction: string | ReactText,
+  props: {eventView: EventView; location: Location}
+) {
+  const {eventView, location} = props;
+
+  const searchConditions = new MutableSearch(eventView.query);
+  searchConditions.addFilterValues('!transaction', [`${transaction}`]);
+
+  browserHistory.push({
+    pathname: location.pathname,
+    query: {
+      ...location.query,
+      cursor: undefined,
+      query: searchConditions.formatString(),
+    },
+  });
+}
 
 export function getCurrentLandingDisplay(
   location: Location,

--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -24,9 +24,10 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
       <DoubleChartRow
         {...props}
         allowedCharts={[
-          PerformanceWidgetSetting.TPM_AREA,
           PerformanceWidgetSetting.MOST_RELATED_ERRORS,
           PerformanceWidgetSetting.MOST_RELATED_ISSUES,
+          PerformanceWidgetSetting.MOST_IMPROVED,
+          PerformanceWidgetSetting.MOST_REGRESSED,
         ]}
       />
       <Table {...props} setError={usePageError().setPageError} />

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -68,7 +68,7 @@ function _DataDisplay<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> &
     WidgetDataProps<T> & {nextWidgetData: T; totalHeight: number}
 ) {
-  const {Visualizations, chartHeight, totalHeight, containerType} = props;
+  const {Visualizations, chartHeight, totalHeight, containerType, EmptyComponent} = props;
 
   const Container = getPerformanceWidgetContainer({
     containerType,
@@ -111,7 +111,14 @@ function _DataDisplay<T extends WidgetDataConstraint>(
             />
           </ContentContainer>
         ))}
-        emptyComponent={<Placeholder height={`${totalHeight - paddingOffset}px`} />}
+        loadingComponent={<Placeholder height={`${totalHeight - paddingOffset}px`} />}
+        emptyComponent={
+          EmptyComponent ? (
+            <EmptyComponent />
+          ) : (
+            <Placeholder height={`${totalHeight - paddingOffset}px`} />
+          )
+        }
       />
     </Container>
   );

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -53,10 +53,8 @@ export const RightAlignedCell = styled('div')`
 `;
 
 const ListItemContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 24px auto 150px 30px;
-  grid-template-rows: repeat(2, auto);
-  grid-column-gap: ${space(1)};
+  display: flex;
+
   border-top: 1px solid ${p => p.theme.border};
   padding: ${space(1)} ${space(2)};
 `;

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -12,6 +12,7 @@ import {GenericPerformanceWidgetDataType} from '../types';
 import {PerformanceWidgetSetting, WIDGET_DEFINITIONS} from '../widgetDefinitions';
 import {LineChartListWidget} from '../widgets/lineChartListWidget';
 import {SingleFieldAreaWidget} from '../widgets/singleFieldAreaWidget';
+import {TrendsWidget} from '../widgets/trendsWidget';
 
 import {ChartRowProps} from './widgetChartRow';
 
@@ -89,7 +90,7 @@ const _WidgetContainer = (props: Props) => {
 
   switch (widgetProps.dataType) {
     case GenericPerformanceWidgetDataType.trends:
-      throw new Error('Trends not currently supported.');
+      return <TrendsWidget {...props} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.area:
       return <SingleFieldAreaWidget {...props} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.line_list:

--- a/static/app/views/performance/landing/widgets/transforms/transformTrendsDiscover.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformTrendsDiscover.tsx
@@ -1,0 +1,21 @@
+import {ChildrenProps} from 'app/utils/performance/trends/trendsDiscoverQuery';
+import {normalizeTrends} from 'app/views/performance/trends/utils';
+
+export function transformTrendsDiscover(_: any, props: ChildrenProps) {
+  const {trendsData} = props;
+  const events = trendsData
+    ? normalizeTrends((trendsData && trendsData.events && trendsData.events.data) || [])
+    : [];
+  return {
+    ...props,
+    data: trendsData,
+    hasData: !!trendsData?.events?.data.length,
+    loading: props.isLoading,
+    isLoading: props.isLoading,
+    isErrored: !!props.error,
+    errored: props.error,
+    statsData: trendsData ? trendsData.stats : {},
+    transactionsList: events && events.slice ? events.slice(0, 3) : [],
+    events,
+  };
+}

--- a/static/app/views/performance/landing/widgets/transforms/transformTrendsDiscover.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformTrendsDiscover.tsx
@@ -1,7 +1,7 @@
-import {ChildrenProps} from 'app/utils/performance/trends/trendsDiscoverQuery';
+import {TrendDiscoveryChildrenProps} from 'app/utils/performance/trends/trendsDiscoverQuery';
 import {normalizeTrends} from 'app/views/performance/trends/utils';
 
-export function transformTrendsDiscover(_: any, props: ChildrenProps) {
+export function transformTrendsDiscover(_: any, props: TrendDiscoveryChildrenProps) {
   const {trendsData} = props;
   const events = trendsData
     ? normalizeTrends((trendsData && trendsData.events && trendsData.events.data) || [])

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -110,6 +110,8 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
 
   // Components
   HeaderActions?: HeaderActions<T>;
+  EmptyComponent?: FunctionComponent<{height?: number}>;
+
   Queries: Queries<T>;
   Visualizations: Visualizations<T>;
 };

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -1,0 +1,197 @@
+import {Fragment, FunctionComponent, useMemo, useState} from 'react';
+import {withRouter} from 'react-router';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+import omit from 'lodash/omit';
+
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import Link from 'app/components/links/link';
+import Truncate from 'app/components/truncate';
+import {IconClose} from 'app/icons';
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import TrendsDiscoverQuery from 'app/utils/performance/trends/trendsDiscoverQuery';
+import {MutableSearch} from 'app/utils/tokenizeSearch';
+import withProjects from 'app/utils/withProjects';
+import {CompareDurations} from 'app/views/performance/trends/changedTransactions';
+import {trendsTargetRoute} from 'app/views/performance/utils';
+
+import {Chart} from '../../../trends/chart';
+import {TrendChangeType, TrendFunctionField} from '../../../trends/types';
+import {excludeTransaction} from '../../utils';
+import {GenericPerformanceWidget} from '../components/performanceWidget';
+import SelectableList, {RightAlignedCell} from '../components/selectableList';
+import {transformTrendsDiscover} from '../transforms/transformTrendsDiscover';
+import {WidgetDataResult} from '../types';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
+
+type Props = {
+  title: string;
+  titleTooltip: string;
+  fields: string[];
+  chartColor?: string;
+
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+  chartSetting: PerformanceWidgetSetting;
+
+  ContainerActions: FunctionComponent<{isLoading: boolean}>;
+};
+
+type TrendsWidgetDataType = {
+  chart: WidgetDataResult & ReturnType<typeof transformTrendsDiscover>;
+};
+
+const fields = [{field: 'transaction'}, {field: 'project'}];
+
+export function TrendsWidget(props: Props) {
+  const {eventView: _eventView, ContainerActions} = props;
+  const trendChangeType =
+    props.chartSetting === PerformanceWidgetSetting.MOST_IMPROVED
+      ? TrendChangeType.IMPROVED
+      : TrendChangeType.REGRESSION;
+  const trendFunctionField = TrendFunctionField.AVG; // Average is the easiest chart to understand.
+
+  const [selectedListIndex, setSelectListIndex] = useState<number>(0);
+
+  const eventView = _eventView.clone();
+  eventView.fields = fields;
+  eventView.sorts = [
+    {
+      kind: trendChangeType === TrendChangeType.IMPROVED ? 'asc' : 'desc',
+      field: 'trend_percentage()',
+    },
+  ];
+  const rest = {eventView, ...omit(props, 'eventView')};
+  eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
+  eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
+  eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
+  eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
+
+  const Queries = useMemo(() => {
+    return {
+      chart: {
+        fields: ['transaction', 'project'],
+        component: provided => (
+          <TrendsDiscoverQuery
+            {...provided}
+            eventView={eventView}
+            location={props.location}
+            trendChangeType={trendChangeType}
+            trendFunctionField={trendFunctionField}
+            limit={3}
+          />
+        ),
+        transform: transformTrendsDiscover,
+      },
+    };
+  }, [_eventView, trendChangeType]);
+
+  return (
+    <GenericPerformanceWidget<TrendsWidgetDataType>
+      {...rest}
+      subtitle={<Subtitle>{t('Trending Transactions')}</Subtitle>}
+      HeaderActions={provided => <ContainerActions {...provided.widgetData.chart} />}
+      Queries={Queries}
+      Visualizations={[
+        {
+          component: provided => (
+            <TrendsChart
+              {...provided}
+              {...rest}
+              isLoading={provided.widgetData.chart.isLoading}
+              statsData={provided.widgetData.chart.statsData}
+              query={eventView.query}
+              project={eventView.project}
+              environment={eventView.environment}
+              start={eventView.start}
+              end={eventView.end}
+              statsPeriod={eventView.statsPeriod}
+              transaction={provided.widgetData.chart.transactionsList[selectedListIndex]}
+              trendChangeType={trendChangeType}
+              trendFunctionField={trendFunctionField}
+              disableXAxis
+              disableLegend
+            />
+          ),
+          bottomPadding: false,
+          height: 160,
+        },
+        {
+          component: provided => (
+            <SelectableList
+              selectedIndex={selectedListIndex}
+              setSelectedIndex={setSelectListIndex}
+              items={provided.widgetData.chart.transactionsList.map(listItem => () => {
+                const initialConditions = new MutableSearch([]);
+                initialConditions.addFilterValues('transaction', [listItem.transaction]);
+
+                const trendsTarget = trendsTargetRoute({
+                  organization: props.organization,
+                  location: props.location,
+                  initialConditions,
+                  additionalQuery: {
+                    trendFunction: trendFunctionField,
+                  },
+                });
+                return (
+                  <Fragment>
+                    <GrowLink to={trendsTarget}>
+                      <Truncate value={listItem.transaction} maxLength={40} />
+                    </GrowLink>
+                    <RightAlignedCell>
+                      <CompareDurations transaction={listItem} />
+                    </RightAlignedCell>
+                    <CloseContainer>
+                      <StyledIconClose
+                        onClick={() => {
+                          excludeTransaction(listItem.transaction, props);
+                          setSelectListIndex(0);
+                        }}
+                      />
+                    </CloseContainer>
+                  </Fragment>
+                );
+              })}
+            />
+          ),
+          height: 200,
+          noPadding: true,
+        },
+      ]}
+      EmptyComponent={() => (
+        <StyledEmptyStateWarning small>{t('No results')}</StyledEmptyStateWarning>
+      )}
+    />
+  );
+}
+
+const TrendsChart = withRouter(withProjects(Chart));
+const Subtitle = styled('span')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+const CloseContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+const GrowLink = styled(Link)`
+  flex-grow: 1;
+`;
+
+const StyledIconClose = styled(IconClose)`
+  cursor: pointer;
+  color: ${p => p.theme.gray200};
+
+  &:hover {
+    color: ${p => p.theme.gray300};
+  }
+`;
+
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  min-height: 300px;
+  justify-content: center;
+`;

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -2,7 +2,6 @@ import {Fragment, FunctionComponent, useMemo, useState} from 'react';
 import {withRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import omit from 'lodash/omit';
 
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Link from 'app/components/links/link';
@@ -64,7 +63,7 @@ export function TrendsWidget(props: Props) {
       field: 'trend_percentage()',
     },
   ];
-  const rest = {eventView, ...omit(props, 'eventView')};
+  const rest = {...props, eventView};
   eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
   eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
   eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);

--- a/static/app/views/performance/trends/changedTransactions.tsx
+++ b/static/app/views/performance/trends/changedTransactions.tsx
@@ -486,7 +486,11 @@ function TrendsListItem(props: TrendsListItemProps) {
   );
 }
 
-const CompareDurations = ({transaction}: TrendsListItemProps) => {
+export const CompareDurations = ({
+  transaction,
+}: {
+  transaction: TrendsListItemProps['transaction'];
+}) => {
   const {fromSeconds, toSeconds, showDigits} = transformDeltaSpread(
     transaction.aggregate_range_1,
     transaction.aggregate_range_2

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -135,8 +135,12 @@ export function resetCursors() {
   return cursors;
 }
 
-export function getCurrentTrendFunction(location: Location): TrendFunction {
-  const trendFunctionField = decodeScalar(location?.query?.trendFunction);
+export function getCurrentTrendFunction(
+  location: Location,
+  _trendFunctionField?: TrendFunctionField
+): TrendFunction {
+  const trendFunctionField =
+    _trendFunctionField ?? decodeScalar(location?.query?.trendFunction);
   const trendFunction = TRENDS_FUNCTIONS.find(({field}) => field === trendFunctionField);
   return trendFunction || TRENDS_FUNCTIONS[0];
 }

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -1,10 +1,12 @@
+import {browserHistory} from 'react-router';
 import {Location, LocationDescriptor, Query} from 'history';
 
 import Duration from 'app/components/duration';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {backend, frontend, mobile} from 'app/data/platformCategories';
-import {GlobalSelection, OrganizationSummary, Project} from 'app/types';
+import {GlobalSelection, Organization, OrganizationSummary, Project} from 'app/types';
 import {defined} from 'app/utils';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {statsPeriodToDays} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
 import {TRACING_FIELDS} from 'app/utils/discover/fields';
@@ -12,6 +14,8 @@ import {getDuration} from 'app/utils/formatters';
 import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'app/utils/queryString';
 import {MutableSearch} from 'app/utils/tokenizeSearch';
+
+import {DEFAULT_MAX_DURATION} from './trends/utils';
 
 /**
  * Performance type can used to determine a default view or which specific field should be used by default on pages
@@ -115,6 +119,67 @@ export function getPerformanceTrendsUrl(organization: OrganizationSummary): stri
 
 export function getTransactionSearchQuery(location: Location, query: string = '') {
   return decodeScalar(location.query.query, query).trim();
+}
+
+export function handleTrendsClick({
+  location,
+  organization,
+}: {
+  location: Location;
+  organization: Organization;
+}) {
+  trackAnalyticsEvent({
+    eventKey: 'performance_views.change_view',
+    eventName: 'Performance Views: Change View',
+    organization_id: parseInt(organization.id, 10),
+    view_name: 'TRENDS',
+  });
+
+  const target = trendsTargetRoute({location, organization});
+
+  browserHistory.push(target);
+}
+
+export function trendsTargetRoute({
+  location,
+  organization,
+  initialConditions,
+  additionalQuery,
+}: {
+  location: Location;
+  organization: Organization;
+  initialConditions?: MutableSearch;
+  additionalQuery?: {[x: string]: string};
+}) {
+  const newQuery = {
+    ...location.query,
+    ...additionalQuery,
+  };
+
+  const query = decodeScalar(location.query.query, '');
+  const conditions = new MutableSearch(query);
+
+  const modifiedConditions = initialConditions ?? new MutableSearch([]);
+
+  if (conditions.hasFilter('tpm()')) {
+    modifiedConditions.setFilterValues('tpm()', conditions.getFilterValues('tpm()'));
+  } else {
+    modifiedConditions.setFilterValues('tpm()', ['>0.01']);
+  }
+  if (conditions.hasFilter('transaction.duration')) {
+    modifiedConditions.setFilterValues(
+      'transaction.duration',
+      conditions.getFilterValues('transaction.duration')
+    );
+  } else {
+    modifiedConditions.setFilterValues('transaction.duration', [
+      '>0',
+      `<${DEFAULT_MAX_DURATION}`,
+    ]);
+  }
+  newQuery.query = modifiedConditions.formatString();
+
+  return {pathname: getPerformanceTrendsUrl(organization), query: {...newQuery}};
 }
 
 export function removeTracingKeysFromSearch(

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -157,8 +157,8 @@ describe('Performance > Landing > Index', function () {
 
     expect(wrapper.find('Table').exists()).toBe(true);
 
-    expect(eventStatsMock).toHaveBeenCalledTimes(4); // Currently defaulting to 4 event stat charts on all transactions view + 1 event chart.
-    expect(eventsV2Mock).toHaveBeenCalledTimes(1);
+    expect(eventStatsMock).toHaveBeenCalledTimes(3); // Currently defaulting to 4 event stat charts on all transactions view + 1 event chart.
+    expect(eventsV2Mock).toHaveBeenCalledTimes(2);
 
     const titles = wrapper.find('div[data-test-id="performance-widget-title"]');
     expect(titles).toHaveLength(5);
@@ -166,7 +166,7 @@ describe('Performance > Landing > Index', function () {
     expect(titles.at(0).text()).toEqual('User Misery');
     expect(titles.at(1).text()).toEqual('Transactions Per Minute');
     expect(titles.at(2).text()).toEqual('Failure Rate');
-    expect(titles.at(3).text()).toEqual('Transactions Per Minute');
-    expect(titles.at(4).text()).toEqual('Most Related Errors');
+    expect(titles.at(3).text()).toEqual('Most Related Errors');
+    expect(titles.at(4).text()).toEqual('Most Related Issues');
   });
 });

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -25,6 +25,7 @@ const WrappedComponent = ({data, ...rest}) => {
 describe('Performance > Widgets > WidgetContainer', function () {
   let eventStatsMock;
   let eventsV2Mock;
+  let eventsTrendsStats;
   beforeEach(function () {
     eventStatsMock = MockApiClient.addMockResponse({
       method: 'GET',
@@ -34,6 +35,11 @@ describe('Performance > Widgets > WidgetContainer', function () {
     eventsV2Mock = MockApiClient.addMockResponse({
       method: 'GET',
       url: `/organizations/org-slug/eventsv2/`,
+      body: [],
+    });
+    eventsTrendsStats = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/events-trends-stats/',
       body: [],
     });
   });
@@ -203,6 +209,84 @@ describe('Performance > Widgets > WidgetContainer', function () {
           query: 'event.type:error !tags[transaction]:""',
           sort: '-count()',
           statsPeriod: '14d',
+        }),
+      })
+    );
+  });
+
+  it('Most improved trends widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.MOST_IMPROVED}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'Most Improved'
+    );
+    expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+    expect(eventsTrendsStats).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: [],
+          field: ['transaction', 'project'],
+          interval: undefined,
+          middle: undefined,
+          per_page: 3,
+          project: [],
+          query:
+            'tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
+          sort: 'trend_percentage()',
+          statsPeriod: '14d',
+          trendFunction: 'avg(transaction.duration)',
+          trendType: 'improved',
+        }),
+      })
+    );
+  });
+
+  it('Most regressed trends widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.MOST_REGRESSED}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'Most Regressed'
+    );
+    expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+    expect(eventsTrendsStats).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: [],
+          field: ['transaction', 'project'],
+          interval: undefined,
+          middle: undefined,
+          per_page: 3,
+          project: [],
+          query:
+            'tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
+          sort: '-trend_percentage()',
+          statsPeriod: '14d',
+          trendFunction: 'avg(transaction.duration)',
+          trendType: 'regression',
         }),
       })
     );


### PR DESCRIPTION
### Summary
This adds trends widgets in the new generic performance widget format. Clicking on the transaction will bring you to the trends page scope to that transaction, which should help discovery of trends as a feature. Made some modifications to the trends chart and query to support alternate use, and moved a few shared functions.

Other:
- Did some light fixes for multi-breakpoints, will need to do more still since it's not great between wide screen and phone size.