### PR TITLE
feat(ui): Switch organizationStats to thirds, reorder dropdowns

### DIFF
--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -531,8 +531,8 @@ const commonTheme = {
 
     // On mobile views org stats dropdowns overlap
     orgStats: {
-      dataCategory: 1,
-      timeRange: 2,
+      dataCategory: 2,
+      timeRange: 1,
     },
 
     // On mobile views issue list dropdowns overlap

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import {DateTimeObject} from 'app/components/charts/utils';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import ErrorBoundary from 'app/components/errorBoundary';
+import * as Layout from 'app/components/layouts/thirds';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {ChangeData} from 'app/components/organizations/timeRangeSelector';
 import PageHeading from 'app/components/pageHeading';
@@ -16,7 +17,7 @@ import PageTimeRangeSelector from 'app/components/pageTimeRangeSelector';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
-import {PageContent, PageHeader} from 'app/styles/organization';
+import {PageHeader} from 'app/styles/organization';
 import space from 'app/styles/space';
 import {
   DataCategory,
@@ -229,16 +230,6 @@ export class OrganizationStats extends Component<Props> {
 
     return (
       <Fragment>
-        <StyledPageTimeRangeSelector
-          organization={organization}
-          relative={period ?? ''}
-          start={start ?? null}
-          end={end ?? null}
-          utc={utc ?? null}
-          onUpdate={this.handleUpdateDatetime}
-          relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h'])}
-        />
-
         <DropdownDataCategory
           label={
             <DropdownLabel>
@@ -250,6 +241,7 @@ export class OrganizationStats extends Component<Props> {
           {CHART_OPTIONS_DATACATEGORY.map(option => (
             <DropdownItem
               key={option.value}
+              isActive={option.value === this.dataCategory}
               eventKey={option.value}
               onSelect={(val: string) =>
                 this.setStateOnUrl({dataCategory: val as DataCategory})
@@ -259,6 +251,16 @@ export class OrganizationStats extends Component<Props> {
             </DropdownItem>
           ))}
         </DropdownDataCategory>
+
+        <StyledPageTimeRangeSelector
+          organization={organization}
+          relative={period ?? ''}
+          start={start ?? null}
+          end={end ?? null}
+          utc={utc ?? null}
+          onUpdate={this.handleUpdateDatetime}
+          relativeOptions={omit(DEFAULT_RELATIVE_PERIODS, ['1h'])}
+        />
       </Fragment>
     );
   };
@@ -273,49 +275,50 @@ export class OrganizationStats extends Component<Props> {
           {hasTeamInsights && (
             <HeaderTabs organization={organization} activeTab="stats" />
           )}
+          <Body>
+            <Layout.Main fullWidth>
+              {!hasTeamInsights && (
+                <Fragment>
+                  <PageHeader>
+                    <PageHeading>{t('Organization Usage Stats')}</PageHeading>
+                  </PageHeader>
+                  <p>
+                    {t(
+                      'We collect usage metrics on three types of events: errors, transactions, and attachments. The charts below reflect events that Sentry has received across your entire organization. You can also find them broken down by project in the table.'
+                    )}
+                  </p>
+                </Fragment>
+              )}
 
-          <PageContent>
-            {!hasTeamInsights && (
-              <Fragment>
-                <PageHeader>
-                  <PageHeading>{t('Organization Usage Stats')}</PageHeading>
-                </PageHeader>
-                <p>
-                  {t(
-                    'We collect usage metrics on three types of events: errors, transactions, and attachments. The charts below reflect events that Sentry has received across your entire organization. You can also find them broken down by project in the table.'
-                  )}
-                </p>
-              </Fragment>
-            )}
+              <PageGrid>
+                {this.renderPageControl()}
 
-            <PageGrid>
-              {this.renderPageControl()}
-
-              <ErrorBoundary mini>
-                <UsageStatsOrg
-                  organization={organization}
-                  dataCategory={this.dataCategory}
-                  dataCategoryName={this.dataCategoryName}
-                  dataDatetime={this.dataDatetime}
-                  chartTransform={this.chartTransform}
-                  handleChangeState={this.setStateOnUrl}
-                />
-              </ErrorBoundary>
-              <ErrorBoundary mini>
-                <UsageStatsProjects
-                  organization={organization}
-                  dataCategory={this.dataCategory}
-                  dataCategoryName={this.dataCategoryName}
-                  dataDatetime={this.dataDatetime}
-                  tableSort={this.tableSort}
-                  tableQuery={this.tableQuery}
-                  tableCursor={this.tableCursor}
-                  handleChangeState={this.setStateOnUrl}
-                  getNextLocations={this.getNextLocations}
-                />
-              </ErrorBoundary>
-            </PageGrid>
-          </PageContent>
+                <ErrorBoundary mini>
+                  <UsageStatsOrg
+                    organization={organization}
+                    dataCategory={this.dataCategory}
+                    dataCategoryName={this.dataCategoryName}
+                    dataDatetime={this.dataDatetime}
+                    chartTransform={this.chartTransform}
+                    handleChangeState={this.setStateOnUrl}
+                  />
+                </ErrorBoundary>
+                <ErrorBoundary mini>
+                  <UsageStatsProjects
+                    organization={organization}
+                    dataCategory={this.dataCategory}
+                    dataCategoryName={this.dataCategoryName}
+                    dataDatetime={this.dataDatetime}
+                    tableSort={this.tableSort}
+                    tableQuery={this.tableQuery}
+                    tableCursor={this.tableCursor}
+                    handleChangeState={this.setStateOnUrl}
+                    getNextLocations={this.getNextLocations}
+                  />
+                </ErrorBoundary>
+              </PageGrid>
+            </Layout.Main>
+          </Body>
         </Fragment>
       </SentryDocumentTitle>
     );
@@ -381,5 +384,13 @@ const DropdownLabel = styled('span')`
 
   > span:last-child {
     font-weight: 400;
+  }
+`;
+
+const Body = styled(Layout.Body)`
+  margin-bottom: -20px;
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    display: block;
   }
 `;


### PR DESCRIPTION
Also enables the active state for the data type dropdown items

The dropdowns are now in the same order as team stats

![image](https://user-images.githubusercontent.com/1400464/138183123-373f4738-1e92-4825-a279-4badd00ae937.png)
