### PR TITLE
feat(insights): Record all instances of `SET_RESOLVED_IN_COMMIT` activity in GroupHistory

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -39,11 +39,7 @@ from sentry.models import (
     remove_group_from_inbox,
 )
 from sentry.models.group import STATUS_UPDATE_CHOICES
-from sentry.models.grouphistory import (
-    activity_type_to_history_status,
-    record_group_history,
-    record_group_history_from_activity_type,
-)
+from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.models.groupinbox import GroupInboxRemoveAction, add_group_to_inbox
 from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
 from sentry.signals import (
@@ -475,9 +471,7 @@ def update_groups(
                         ident=resolution.id if resolution else None,
                         data=activity_data,
                     )
-                    history_status = activity_type_to_history_status(activity_type)
-                    if history_status is not None:
-                        record_group_history(group, history_status, actor=acting_user)
+                    record_group_history_from_activity_type(group, activity_type, actor=acting_user)
 
                     # TODO(dcramer): we need a solution for activity rollups
                     # before sending notifications on bulk changes

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -1,9 +1,14 @@
+from typing import TYPE_CHECKING, Optional, Union
+
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import features
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
+
+if TYPE_CHECKING:
+    from sentry.models import Group, Release, Team, User
 
 
 class GroupHistoryStatus:
@@ -124,7 +129,12 @@ def get_prev_history(group, status):
     return prev_histories.first()
 
 
-def record_group_history_from_activity_type(group, activity_type, actor=None, release=None):
+def record_group_history_from_activity_type(
+    group: "Group",
+    activity_type: int,
+    actor: Optional[Union["User", "Team"]] = None,
+    release: Optional["Release"] = None,
+):
     """
     Writes a `GroupHistory` row for an activity type if there's a relevant `GroupHistoryStatus` that
     maps to it
@@ -134,7 +144,12 @@ def record_group_history_from_activity_type(group, activity_type, actor=None, re
         return record_group_history(group, status, actor, release)
 
 
-def record_group_history(group, status, actor=None, release=None):
+def record_group_history(
+    group: "Group",
+    status: int,
+    actor: Optional[Union["User", "Team"]] = None,
+    release: Optional["Release"] = None,
+):
     if not features.has("organizations:group-history", group.organization):
         return
     prev_history = get_prev_history(group, status)


### PR DESCRIPTION
We missed this in one place. Also simplified some code around this.