### PR TITLE
feat(workflow): Disable mouse pointer on insights bar graph

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -93,6 +93,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
               {
                 seriesName: t('Alerts Triggered'),
                 data: seriesData,
+                silent: true,
               },
             ].reverse()}
           />

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -93,9 +93,10 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
               {
                 seriesName: t('Alerts Triggered'),
                 data: seriesData,
+                // @ts-expect-error silent does not exist in bar series type
                 silent: true,
               },
-            ].reverse()}
+            ]}
           />
         )}
       </ChartWrapper>

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -123,16 +123,21 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
               stacked
               isGroupedByDate
               legend={{right: 0, top: 0}}
-              series={[
-                {
-                  seriesName: t('Reviewed'),
-                  data: convertDaySeriesToWeeks(reviewedSeries),
-                },
-                {
-                  seriesName: t('Not Reviewed'),
-                  data: convertDaySeriesToWeeks(notReviewedSeries),
-                },
-              ]}
+              series={
+                [
+                  {
+                    seriesName: t('Reviewed'),
+                    data: convertDaySeriesToWeeks(reviewedSeries),
+                    silent: true,
+                  },
+                  {
+                    seriesName: t('Not Reviewed'),
+                    data: convertDaySeriesToWeeks(notReviewedSeries),
+                    silent: true,
+                  },
+                  // silent is not incldued in the type for BarSeries
+                ] as any[]
+              }
             />
           )}
         </IssuesChartWrapper>

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -123,21 +123,19 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
               stacked
               isGroupedByDate
               legend={{right: 0, top: 0}}
-              series={
-                [
-                  {
-                    seriesName: t('Reviewed'),
-                    data: convertDaySeriesToWeeks(reviewedSeries),
-                    silent: true,
-                  },
-                  {
-                    seriesName: t('Not Reviewed'),
-                    data: convertDaySeriesToWeeks(notReviewedSeries),
-                    silent: true,
-                  },
+              series={[
+                {
+                  seriesName: t('Reviewed'),
+                  data: convertDaySeriesToWeeks(reviewedSeries),
+                  silent: true,
                   // silent is not incldued in the type for BarSeries
-                ] as any[]
-              }
+                } as any,
+                {
+                  seriesName: t('Not Reviewed'),
+                  data: convertDaySeriesToWeeks(notReviewedSeries),
+                  silent: true,
+                },
+              ]}
             />
           )}
         </IssuesChartWrapper>

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -93,15 +93,14 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
           xAxis={{
             type: 'time',
           }}
-          series={
-            [
-              {
-                seriesName: t('Time to Resolution'),
-                data: seriesData,
-                silent: true,
-              },
-            ] as any
-          }
+          series={[
+            {
+              seriesName: t('Time to Resolution'),
+              data: seriesData,
+              // @ts-expect-error silent not included in bar series
+              silent: true,
+            },
+          ]}
         />
       </ChartWrapper>
     );

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -93,12 +93,15 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
           xAxis={{
             type: 'time',
           }}
-          series={[
-            {
-              seriesName: t('Time to Resolution'),
-              data: seriesData,
-            },
-          ].reverse()}
+          series={
+            [
+              {
+                seriesName: t('Time to Resolution'),
+                data: seriesData,
+                silent: true,
+              },
+            ] as any
+          }
         />
       </ChartWrapper>
     );


### PR DESCRIPTION
bar charts for some reason are missing the `silent: boolean` type but it will likely get added with echarts v5