### PR TITLE
feat(insights): Remove `organizations:group-history` feature flag.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -940,8 +940,6 @@ SENTRY_FEATURES = {
     "organizations:performance-view": True,
     # Enable multi project selection
     "organizations:global-views": False,
-    # Enable writing group history
-    "organizations:group-history": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown
     "organizations:grouping-tree-ui": False,
     # Enable experimental new version of stacktrace component where additional

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -78,7 +78,6 @@ default_manager.add("organizations:event-attachments-viewer", OrganizationFeatur
 default_manager.add("organizations:events", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)
 default_manager.add("organizations:global-views", OrganizationFeature)
-default_manager.add("organizations:group-history", OrganizationFeature)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)

--- a/src/sentry/models/grouphistory.py
+++ b/src/sentry/models/grouphistory.py
@@ -5,7 +5,6 @@ from django.db.models import SET_NULL
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import features
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 
 if TYPE_CHECKING:
@@ -153,8 +152,6 @@ def record_group_history(
     actor: Optional[Union["User", "Team"]] = None,
     release: Optional["Release"] = None,
 ):
-    if not features.has("organizations:group-history", group.organization):
-        return
     prev_history = get_prev_history(group, status)
     return GroupHistory.objects.create(
         organization=group.project.organization,

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -23,14 +23,13 @@ class FindReferencedGroupsTest(TestCase):
         assert len(groups) == 1
         assert group in groups
 
-        with self.feature("organizations:group-history"):
-            pr = PullRequest.objects.create(
-                key="1",
-                repository_id=repo.id,
-                organization_id=group.organization.id,
-                title="very cool PR to fix the thing",
-                message=f"Foo Biz\n\nFixes {group2.qualified_short_id}",
-            )
+        pr = PullRequest.objects.create(
+            key="1",
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            title="very cool PR to fix the thing",
+            message=f"Foo Biz\n\nFixes {group2.qualified_short_id}",
+        )
 
         groups = pr.find_referenced_groups()
         assert len(groups) == 1

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -35,13 +35,6 @@ class ResolveGroupResolutionsTest(TestCase):
 
 
 class ResolvedInCommitTest(TestCase):
-    def setUp(self):
-        self._feature_ctx_manager = self.feature("organizations:group-history")
-        self._feature_ctx_manager.__enter__()
-
-    def tearDown(self):
-        self._feature_ctx_manager.__exit__(None, None, None)
-
     def assertResolvedFromCommit(self, group, commit):
         assert GroupLink.objects.filter(
             group_id=group.id, linked_type=GroupLink.LinkedType.commit, linked_id=commit.id

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1806,10 +1806,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"status": "unresolved", "project": self.project.id}, status="resolved"
-            )
+        response = self.get_valid_response(
+            qs_params={"status": "unresolved", "project": self.project.id}, status="resolved"
+        )
         assert response.data == {"status": "resolved", "statusDetails": {}, "inbox": None}
 
         # the previously resolved entry should not be included
@@ -2308,10 +2307,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": group.id}, status="resolved", statusDetails={"inRelease": "latest"}
-            )
+        response = self.get_valid_response(
+            qs_params={"id": group.id}, status="resolved", statusDetails={"inRelease": "latest"}
+        )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inRelease"] == release.version
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2456,10 +2454,9 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": group.id}, status="resolvedInNextRelease"
-            )
+        response = self.get_valid_response(
+            qs_params={"id": group.id}, status="resolvedInNextRelease"
+        )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inNextRelease"]
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2491,12 +2488,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": group.id},
-                status="resolved",
-                statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
-            )
+        response = self.get_valid_response(
+            qs_params={"id": group.id},
+            status="resolved",
+            statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
+        )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inCommit"]["id"] == commit.key
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2529,12 +2525,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": group.id},
-                status="resolved",
-                statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
-            )
+        response = self.get_valid_response(
+            qs_params={"id": group.id},
+            status="resolved",
+            statusDetails={"inCommit": {"commit": commit.key, "repository": repo.name}},
+        )
         assert response.data["status"] == "resolved"
         assert response.data["statusDetails"]["inCommit"]["id"] == commit.key
         assert response.data["statusDetails"]["actor"]["id"] == str(self.user.id)
@@ -2569,12 +2564,11 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_response(
-                qs_params={"id": group.id},
-                status="resolved",
-                statusDetails={"inCommit": {"commit": "a" * 40, "repository": repo.name}},
-            )
+        response = self.get_response(
+            qs_params={"id": group.id},
+            status="resolved",
+            statusDetails={"inCommit": {"commit": "a" * 40, "repository": repo.name}},
+        )
         assert response.status_code == 400
         assert (
             response.data["statusDetails"]["inCommit"]["commit"][0]
@@ -2591,8 +2585,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+        response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
         assert response.data == {"status": "unresolved", "statusDetails": {}}
 
         group = Group.objects.get(id=group.id)
@@ -2614,8 +2607,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
+        response = self.get_valid_response(qs_params={"id": group.id}, status="unresolved")
         assert response.data == {"status": "unresolved", "statusDetails": {}}
 
         group = Group.objects.get(id=group.id)
@@ -2633,8 +2625,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.IGNORED
         ).exists()
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(qs_params={"id": group.id}, status="ignored")
+        response = self.get_valid_response(qs_params={"id": group.id}, status="ignored")
         # existing snooze objects should be cleaned up
         assert not GroupSnooze.objects.filter(id=snooze.id).exists()
 
@@ -2906,10 +2897,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         user = self.user
 
         self.login_as(user=user)
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": group1.id}, assignedTo=user.username
-            )
+        response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo=user.username)
         assert response.data["assignedTo"]["id"] == str(user.id)
         assert response.data["assignedTo"]["type"] == "user"
         assert GroupAssignee.objects.filter(group=group1, user=user).exists()
@@ -2923,8 +2911,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert GroupSubscription.objects.filter(user=user, group=group1, is_active=True).exists()
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo="")
+        response = self.get_valid_response(qs_params={"id": group1.id}, assignedTo="")
         assert response.data["assignedTo"] is None
 
         assert not GroupAssignee.objects.filter(group=group1, user=user).exists()
@@ -2939,8 +2926,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=member)
 
-        with self.feature("organizations:group-history"):
-            response = self.get_response(qs_params={"id": group.id}, assignedTo=non_member.username)
+        response = self.get_response(qs_params={"id": group.id}, assignedTo=non_member.username)
         assert not GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.ASSIGNED
         ).exists()
@@ -2961,10 +2947,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group, status=GroupHistoryStatus.ASSIGNED
         ).exists()
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": group.id}, assignedTo=f"team:{team.id}"
-            )
+        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo=f"team:{team.id}")
         assert response.data["assignedTo"]["id"] == str(team.id)
         assert response.data["assignedTo"]["type"] == "team"
         assert GroupHistory.objects.filter(group=group, status=GroupHistoryStatus.ASSIGNED).exists()
@@ -2974,8 +2957,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         assert GroupSubscription.objects.filter(group=group, is_active=True).count() == 2
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(qs_params={"id": group.id}, assignedTo="")
+        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo="")
         assert response.data["assignedTo"] is None
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.UNASSIGNED
@@ -3016,10 +2998,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group2 = self.create_group(checksum="b" * 32)
 
         self.login_as(user=self.user)
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(
-                qs_params={"id": [group1.id, group2.id]}, inbox="true"
-            )
+        response = self.get_valid_response(qs_params={"id": [group1.id, group2.id]}, inbox="true")
         assert response.data == {"inbox": True}
         assert GroupInbox.objects.filter(group=group1).exists()
         assert GroupInbox.objects.filter(group=group2).exists()
@@ -3030,8 +3009,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group=group2, status=GroupHistoryStatus.REVIEWED
         ).exists()
 
-        with self.feature("organizations:group-history"):
-            response = self.get_valid_response(qs_params={"id": [group2.id]}, inbox="false")
+        response = self.get_valid_response(qs_params={"id": [group2.id]}, inbox="false")
         assert response.data == {"inbox": False}
         assert GroupInbox.objects.filter(group=group1).exists()
         assert not GroupHistory.objects.filter(
@@ -3054,8 +3032,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
 
-        with self.feature("organizations:group-history"):
-            self.get_valid_response(qs_params={"id": [group2.id]}, status="unresolved")
+        self.get_valid_response(qs_params={"id": [group2.id]}, status="unresolved")
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
         assert not GroupHistory.objects.filter(


### PR DESCRIPTION
We only had this flag in place to prevent writing group history rows while checking that everything
was correct. Just removing now to enable for all orgs.