### PR TITLE
feat(cmp_alerts): Show thresholds for change alerts in the alert details sidebar

### DIFF
--- a/static/app/icons/iconRectangle.tsx
+++ b/static/app/icons/iconRectangle.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import SvgIcon from './svgIcon';
+
+type Props = React.ComponentProps<typeof SvgIcon>;
+
+const IconRectangle = React.forwardRef(function IconRectangle(
+  props: Props,
+  ref: React.Ref<SVGSVGElement>
+) {
+  return (
+    <SvgIcon {...props} ref={ref}>
+      <rect
+        x="6.38721"
+        y="0.341797"
+        width="9.03286"
+        height="9.03286"
+        rx="1.5"
+        transform="rotate(45 6.38721 0.341797)"
+      />
+    </SvgIcon>
+  );
+});
+
+IconRectangle.displayName = 'IconRectangle';
+
+export {IconRectangle};

--- a/static/app/icons/index.tsx
+++ b/static/app/icons/index.tsx
@@ -69,6 +69,7 @@ export {IconPrint} from './iconPrint';
 export {IconProject} from './iconProject';
 export {IconProjects} from './iconProjects';
 export {IconQuestion} from './iconQuestion';
+export {IconRectangle} from './iconRectangle';
 export {IconRefresh} from './iconRefresh';
 export {IconReleases} from './iconReleases';
 export {IconReturn} from './iconReturn';

--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -578,10 +578,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     this.setState({comparisonType: value, comparisonDelta, timeWindow});
   };
 
-  handleComparisonDeltaChange = (value: number) => {
-    this.setState({comparisonDelta: value});
-  };
-
   handleDeleteRule = async () => {
     const {params} = this.props;
     const {orgId, projectId, ruleId} = params;

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -21,7 +21,7 @@ import {parseSearch} from 'app/components/searchSyntax/parser';
 import HighlightQuery from 'app/components/searchSyntax/renderer';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
-import {IconCheckmark, IconFire, IconInfo, IconWarning} from 'app/icons';
+import {IconInfo, IconRectangle} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -135,28 +135,40 @@ export default class DetailsBody extends React.Component<Props> {
     }
 
     const status =
+      trigger.label === 'critical'
+        ? t('Critical')
+        : trigger.label === 'warning'
+        ? t('Warning')
+        : t('Resolved');
+    const statusIcon =
       trigger.label === 'critical' ? (
-        <StatusWrapper>
-          <IconFire color="red300" size="sm" /> Critical
-        </StatusWrapper>
+        <StyledIconRectangle color="red300" size="sm" />
       ) : trigger.label === 'warning' ? (
-        <StatusWrapper>
-          <IconWarning color="yellow300" size="sm" /> Warning
-        </StatusWrapper>
+        <StyledIconRectangle color="yellow300" size="sm" />
       ) : (
-        <StatusWrapper>
-          <IconCheckmark color="green300" size="sm" isCircled /> Resolved
-        </StatusWrapper>
+        <StyledIconRectangle color="green300" size="sm" />
       );
 
     const thresholdTypeText =
       rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('above') : t('below');
 
+    const thresholdText = tct('If  [condition] in [timeWindow]', {
+      condition: `${thresholdTypeText} ${trigger.alertThreshold}`,
+      timeWindow: this.getTimeWindow(),
+    });
+
     return (
-      <TriggerCondition>
-        {status}
-        <TriggerText>{`${thresholdTypeText} ${trigger.alertThreshold}`}</TriggerText>
-      </TriggerCondition>
+      <TriggerConditionContainer>
+        {statusIcon}
+        <TriggerCondition>
+          {status}
+          <TriggerText>{thresholdText}</TriggerText>
+          {trigger.actions.map(
+            action =>
+              action.desc && <TriggerText key={action.id}>{action.desc}</TriggerText>
+          )}
+        </TriggerCondition>
+      </TriggerConditionContainer>
     );
   }
 
@@ -191,7 +203,7 @@ export default class DetailsBody extends React.Component<Props> {
         </SidebarGroup>
 
         <SidebarGroup>
-          <Heading>{t('Conditions')}</Heading>
+          <Heading>{t('Thresholds and Actions')}</Heading>
           {criticalTrigger && this.renderTrigger(criticalTrigger)}
           {warningTrigger && this.renderTrigger(warningTrigger)}
         </SidebarGroup>
@@ -443,14 +455,6 @@ const DetailWrapper = styled('div')`
   }
 `;
 
-const StatusWrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  svg {
-    margin-right: ${space(0.5)};
-  }
-`;
-
 const HeaderContainer = styled('div')`
   height: 60px;
   display: flex;
@@ -548,16 +552,25 @@ const Filters = styled('span')`
   font-family: ${p => p.theme.text.familyMono};
 `;
 
+const TriggerConditionContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
 const TriggerCondition = styled('div')`
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  margin-left: ${space(0.75)};
 `;
 
 const TriggerText = styled('div')`
-  margin-left: ${space(0.5)};
-  white-space: nowrap;
+  color: ${p => p.theme.subText};
 `;
 
 const CreatedBy = styled('div')`
   ${overflowEllipsis}
+`;
+
+const StyledIconRectangle = styled(IconRectangle)`
+  margin-top: ${space(0.75)};
 `;

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -498,14 +498,14 @@ class MetricChart extends React.PureComponent<Props, State> {
     }
 
     let maxThresholdValue = 0;
-    if (warningTrigger?.alertThreshold) {
+    if (!rule.comparisonDelta && warningTrigger?.alertThreshold) {
       const {alertThreshold} = warningTrigger;
       const warningThresholdLine = createThresholdSeries(theme.yellow300, alertThreshold);
       series.push(warningThresholdLine);
       maxThresholdValue = Math.max(maxThresholdValue, alertThreshold);
     }
 
-    if (criticalTrigger?.alertThreshold) {
+    if (!rule.comparisonDelta && criticalTrigger?.alertThreshold) {
       const {alertThreshold} = criticalTrigger;
       const criticalThresholdLine = createThresholdSeries(theme.red300, alertThreshold);
       series.push(criticalThresholdLine);


### PR DESCRIPTION
This updates the alert details page sidebar for the change alerts. If it's a change alert we show comparison scheme in writing and a more descriptive threshold description for other alerts. Also added actions for critical and warning thresholds based on the new design. Also removed the threshold lines for change alerts.

Old (same for change/non-change alerts):
![Screen Shot 2021-10-20 at 11 13 36 PM](https://user-images.githubusercontent.com/15015880/138221623-3d91f2e8-a1eb-43db-bb9b-211a647a95cd.png)

New (non-change alert):
![Screen Shot 2021-10-20 at 11 15 53 PM](https://user-images.githubusercontent.com/15015880/138221856-f1307eb3-9725-4a3b-a067-b0a06c3fcaba.png)

New (change alert):
![Screen Shot 2021-10-20 at 11 12 22 PM](https://user-images.githubusercontent.com/15015880/138221679-1cd1dcb9-3f66-4ef0-9bf4-830aad176704.png)

Jira: [WOR-1450](https://getsentry.atlassian.net/browse/WOR-1450)

 