### PR TITLE
fix: Detect sentry-cli version for relative endpoint use in ChunkUploadEndpoint

### DIFF
--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -17,6 +17,10 @@ from sentry.testutils import APITestCase
 
 
 class ChunkUploadTest(APITestCase):
+    @pytest.fixture(autouse=True)
+    def _restore_upload_url_options(self):
+        options.delete("system.upload-url-prefix")
+
     def setUp(self):
         self.organization = self.create_organization(owner=self.user)
         self.token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
@@ -208,7 +212,3 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
-
-    @pytest.fixture(autouse=True)
-    def _restore_upload_url_options(self):
-        options.delete("system.upload-url-prefix")

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -1,5 +1,6 @@
 from hashlib import sha1
 
+import pytest
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
@@ -33,13 +34,60 @@ class ChunkUploadTest(APITestCase):
         assert response.data["maxFileSize"] == options.get("system.maximum-file-size")
         assert response.data["concurrency"] == MAX_CONCURRENCY
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
-        assert response.data["url"] == self.url.replace("/api/0", "/")
+        assert response.data["url"] == options.get("system.url-prefix") + self.url
 
         options.set("system.upload-url-prefix", "test")
         response = self.client.get(
             self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
         )
 
+        assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
+
+    def test_relative_url_support(self):
+        # Starting `sentry-cli@1.70.1` we added a support for relative chunk-uploads urls
+
+        # >= 1.70.1
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_USER_AGENT="sentry-cli/1.70.1",
+            format="json",
+        )
+        assert response.data["url"] == self.url.replace("/api/0", "/")
+
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_USER_AGENT="sentry-cli/2.77.4",
+            format="json",
+        )
+        assert response.data["url"] == self.url.replace("/api/0", "/")
+
+        # < 1.70.1
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_USER_AGENT="sentry-cli/1.70.0",
+            format="json",
+        )
+        assert response.data["url"] == options.get("system.url-prefix") + self.url
+
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_USER_AGENT="sentry-cli/0.69.3",
+            format="json",
+        )
+        assert response.data["url"] == options.get("system.url-prefix") + self.url
+
+        # user overriden upload url prefix has priority, even when calling from sentry-cli that supports relative urls
+        options.set("system.upload-url-prefix", "test")
+        response = self.client.get(
+            self.url,
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_USER_AGENT="sentry-cli/1.70.1",
+            format="json",
+        )
         assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
 
     def test_large_uploads(self):
@@ -160,3 +208,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+
+    @pytest.fixture(autouse=True)
+    def _restore_upload_url_options(self):
+        options.delete("system.upload-url-prefix")


### PR DESCRIPTION
Prior to sentry-cli `1.70.1` we issued a warning about usage of relative URLs for chunked uploads. Because we changed it in the Sentry itself, it was issued for every user of sentry-cli, that do not override their on-premise `system.upload-url-prefix` config. We did remove this warning in `1.70.1`, and it's only the log message, however, we do count it as a regression and would rather patch it here as well.

Note: There is no generic semver parser available in our codebase, and there is no need to pull additional package to do this here.

ref: https://github.com/getsentry/sentry-cli/pull/1054#pullrequestreview-784595616
ref: https://github.com/getsentry/sentry/pull/29347