### PR TITLE
feat(perf): Add histogram widget for perf landing

### DIFF
--- a/static/app/utils/performance/histogram/histogramQuery.tsx
+++ b/static/app/utils/performance/histogram/histogramQuery.tsx
@@ -22,12 +22,15 @@ type HistogramProps = {
 
 type RequestProps = DiscoverQueryProps & HistogramProps;
 
-type ChildrenProps = Omit<GenericChildrenProps<HistogramProps>, 'tableData'> & {
+export type HistogramQueryChildrenProps = Omit<
+  GenericChildrenProps<HistogramProps>,
+  'tableData'
+> & {
   histograms: Histograms | null;
 };
 
 type Props = RequestProps & {
-  children: (props: ChildrenProps) => React.ReactNode;
+  children: (props: HistogramQueryChildrenProps) => React.ReactNode;
 };
 
 function getHistogramRequestPayload(props: RequestProps) {

--- a/static/app/views/performance/landing/chart/histogramChart.tsx
+++ b/static/app/views/performance/landing/chart/histogramChart.tsx
@@ -18,6 +18,7 @@ import {Series} from 'app/types/echarts';
 import EventView from 'app/utils/discover/eventView';
 import getDynamicText from 'app/utils/getDynamicText';
 import HistogramQuery from 'app/utils/performance/histogram/histogramQuery';
+import {HistogramData} from 'app/utils/performance/histogram/types';
 import {computeBuckets, formatHistogramData} from 'app/utils/performance/histogram/utils';
 
 import {DoubleHeaderContainer} from '../../styles';
@@ -52,18 +53,8 @@ export function HistogramChart(props: Props) {
     backupField,
     usingBackupAxis,
   } = props;
-  const theme = useTheme();
 
   const _backupField = backupField ? [backupField] : [];
-
-  const xAxis = {
-    type: 'category' as const,
-    truncate: true,
-    boundaryGap: false,
-    axisTick: {
-      alignWithLabel: true,
-    },
-  };
 
   return (
     <div>
@@ -85,11 +76,11 @@ export function HistogramChart(props: Props) {
       >
         {results => {
           const _field = usingBackupAxis ? getFieldOrBackup(field, backupField) : field;
-          const loading = results.isLoading;
-          const errored = results.error !== null;
+          const isLoading = results.isLoading;
+          const isErrored = results.error !== null;
           const chartData = results.histograms?.[_field];
 
-          if (errored) {
+          if (isErrored) {
             return (
               <ErrorPanel height="250px">
                 <IconWarning color="gray300" size="lg" />
@@ -101,68 +92,124 @@ export function HistogramChart(props: Props) {
             return null;
           }
 
-          const series = {
-            seriesName: t('Count'),
-            data: formatHistogramData(chartData, {type: 'duration'}),
-          };
-          const allSeries: Series[] = [];
-
-          if (!loading && !errored) {
-            allSeries.push(series);
-          }
-
-          const yAxis = {
-            type: 'value' as const,
-            axisLabel: {
-              color: theme.chartLabel,
-            },
-          };
-
           return (
-            <Fragment>
-              <BarChartZoom
-                minZoomWidth={10 ** -PRECISION * NUM_BUCKETS}
-                location={location}
-                paramStart={`${_field}:>=`}
-                paramEnd={`${_field}:<=`}
-                xAxisIndex={[0]}
-                buckets={computeBuckets(chartData)}
-                onHistoryPush={onFilterChange}
-              >
-                {zoomRenderProps => {
-                  return (
-                    <BarChartContainer>
-                      <MaskContainer>
-                        <TransparentLoadingMask visible={loading} />
-                        {getDynamicText({
-                          value: (
-                            <BarChart
-                              height={250}
-                              series={allSeries}
-                              xAxis={xAxis}
-                              yAxis={yAxis}
-                              grid={{
-                                left: space(3),
-                                right: space(3),
-                                top: space(3),
-                                bottom: loading ? space(4) : space(1.5),
-                              }}
-                              stacked
-                              {...zoomRenderProps}
-                            />
-                          ),
-                          fixed: <Placeholder height="250px" testId="skeleton-ui" />,
-                        })}
-                      </MaskContainer>
-                    </BarChartContainer>
-                  );
-                }}
-              </BarChartZoom>
-            </Fragment>
+            <Chart
+              isLoading={isLoading}
+              isErrored={isErrored}
+              chartData={chartData}
+              location={location}
+              onFilterChange={onFilterChange}
+              field={_field}
+            />
           );
         }}
       </HistogramQuery>
     </div>
+  );
+}
+
+type ChartProps = {
+  chartData?: HistogramData;
+  isLoading: boolean;
+  isErrored: boolean;
+  location: Location;
+  onFilterChange: Props['onFilterChange'];
+  field: string;
+  height?: number;
+  grid?: BarChart['props']['grid'];
+  disableXAxis?: boolean;
+  colors?: string[];
+};
+
+export function Chart(props: ChartProps) {
+  const {
+    isLoading,
+    isErrored,
+    chartData,
+    location,
+    field,
+    onFilterChange,
+    height,
+    grid,
+    disableXAxis,
+    colors,
+  } = props;
+  if (!chartData) {
+    return null;
+  }
+  const theme = useTheme();
+
+  const series = {
+    seriesName: t('Count'),
+    data: formatHistogramData(chartData, {type: 'duration'}),
+  };
+
+  const xAxis = {
+    type: 'category' as const,
+    truncate: true,
+    boundaryGap: false,
+    axisTick: {
+      alignWithLabel: true,
+    },
+  };
+
+  const allSeries: Series[] = [];
+
+  if (!isLoading && !isErrored) {
+    allSeries.push(series);
+  }
+
+  const yAxis = {
+    type: 'value' as const,
+    axisLabel: {
+      color: theme.chartLabel,
+    },
+  };
+
+  return (
+    <Fragment>
+      <BarChartZoom
+        minZoomWidth={10 ** -PRECISION * NUM_BUCKETS}
+        location={location}
+        paramStart={`${field}:>=`}
+        paramEnd={`${field}:<=`}
+        xAxisIndex={[0]}
+        buckets={computeBuckets(chartData)}
+        onHistoryPush={onFilterChange}
+      >
+        {zoomRenderProps => {
+          return (
+            <BarChartContainer>
+              <MaskContainer>
+                <TransparentLoadingMask visible={isLoading} />
+                {getDynamicText({
+                  value: (
+                    <BarChart
+                      height={height ?? 250}
+                      series={allSeries}
+                      xAxis={disableXAxis ? {show: false} : xAxis}
+                      yAxis={yAxis}
+                      colors={colors}
+                      grid={
+                        grid ?? {
+                          left: space(3),
+                          right: space(3),
+                          top: space(3),
+                          bottom: isLoading ? space(4) : space(1.5),
+                        }
+                      }
+                      stacked
+                      {...zoomRenderProps}
+                    />
+                  ),
+                  fixed: <Placeholder height="250px" testId="skeleton-ui" />,
+                })}
+              </MaskContainer>
+            </BarChartContainer>
+          );
+        }}
+      </BarChartZoom>
+    </Fragment>
   );
 }
 

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -2,12 +2,24 @@ import {usePageError} from 'app/utils/performance/contexts/pageError';
 
 import Table from '../../table';
 import {FRONTEND_PAGELOAD_COLUMN_TITLES} from '../data';
+import {TripleChartRow} from '../widgets/components/widgetChartRow';
+import {PerformanceWidgetSetting} from '../widgets/widgetDefinitions';
 
 import {BasePerformanceViewProps} from './types';
 
 export function FrontendPageloadView(props: BasePerformanceViewProps) {
   return (
     <div data-test-id="frontend-pageload-view">
+      <TripleChartRow
+        {...props}
+        allowedCharts={[
+          PerformanceWidgetSetting.P75_LCP_AREA,
+          PerformanceWidgetSetting.LCP_HISTOGRAM,
+          PerformanceWidgetSetting.FCP_HISTOGRAM,
+          PerformanceWidgetSetting.USER_MISERY_AREA,
+          PerformanceWidgetSetting.TPM_AREA,
+        ]}
+      />
       <Table
         {...props}
         columnTitles={FRONTEND_PAGELOAD_COLUMN_TITLES}

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -10,6 +10,7 @@ import ContextMenu from 'app/views/dashboardsV2/contextMenu';
 
 import {GenericPerformanceWidgetDataType} from '../types';
 import {PerformanceWidgetSetting, WIDGET_DEFINITIONS} from '../widgetDefinitions';
+import {HistogramWidget} from '../widgets/histogramWidget';
 import {LineChartListWidget} from '../widgets/lineChartListWidget';
 import {SingleFieldAreaWidget} from '../widgets/singleFieldAreaWidget';
 
@@ -94,6 +95,8 @@ const _WidgetContainer = (props: Props) => {
       return <SingleFieldAreaWidget {...props} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.line_list:
       return <LineChartListWidget {...props} {...widgetProps} />;
+    case GenericPerformanceWidgetDataType.histogram:
+      return <HistogramWidget {...props} {...widgetProps} />;
     default:
       throw new Error(`Widget type "${widgetProps.dataType}" has no implementation.`);
   }

--- a/static/app/views/performance/landing/widgets/transforms/transformHistogramQuery.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformHistogramQuery.tsx
@@ -1,0 +1,12 @@
+import {HistogramQueryChildrenProps} from 'app/utils/performance/histogram/histogramQuery';
+
+export function transformHistogramQuery(_: any, results: HistogramQueryChildrenProps) {
+  const {histograms} = results;
+  return {
+    ...results,
+    data: histograms,
+    isLoading: results.isLoading,
+    isErrored: results.error !== null,
+    hasData: !!Object.values(histograms || {}).length,
+  };
+}

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -24,6 +24,7 @@ export enum PerformanceWidgetSetting {
   P50_DURATION_AREA = 'p50_duration_area',
   P95_DURATION_AREA = 'p95_duration_area',
   P99_DURATION_AREA = 'p99_duration_area',
+  P75_LCP_AREA = 'p75_lcp_area',
   TPM_AREA = 'tpm_area',
   FAILURE_RATE_AREA = 'failure_rate_area',
   USER_MISERY_AREA = 'user_misery_area',
@@ -109,6 +110,13 @@ export const WIDGET_DEFINITIONS: ({
     fields: ['p99(transaction.duration)'], // TODO(k-fish): Check
     dataType: GenericPerformanceWidgetDataType.area,
     chartColor: WIDGET_PALETTE[3],
+  },
+  [PerformanceWidgetSetting.P75_LCP_AREA]: {
+    title: t('p75 LCP'),
+    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
+    fields: ['p75(measurements.lcp)'],
+    dataType: GenericPerformanceWidgetDataType.area,
+    chartColor: WIDGET_PALETTE[1],
   },
   [PerformanceWidgetSetting.FAILURE_RATE_AREA]: {
     title: t('Failure Rate'),

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -1,0 +1,89 @@
+import {Fragment, FunctionComponent, useMemo} from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import _EventsRequest from 'app/components/charts/eventsRequest';
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import HistogramQuery from 'app/utils/performance/histogram/histogramQuery';
+import {Chart as HistogramChart} from 'app/views/performance/landing/chart/histogramChart';
+
+import {GenericPerformanceWidget} from '../components/performanceWidget';
+import {transformHistogramQuery} from '../transforms/transformHistogramQuery';
+import {WidgetDataResult} from '../types';
+
+type Props = {
+  title: string;
+  titleTooltip: string;
+  fields: string[];
+  chartColor?: string;
+
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+
+  ContainerActions: FunctionComponent<{isLoading: boolean}>;
+};
+
+type AreaDataType = {
+  chart: WidgetDataResult & ReturnType<typeof transformHistogramQuery>;
+};
+
+export function HistogramWidget(props: Props) {
+  const {ContainerActions, location} = props;
+  const globalSelection = props.eventView.getGlobalSelection();
+
+  const Queries = useMemo(() => {
+    return {
+      chart: {
+        fields: props.fields,
+        component: provided => (
+          <HistogramQuery {...provided} numBuckets={20} dataFilter="exclude_outliers" />
+        ),
+        transform: transformHistogramQuery,
+      },
+    };
+  }, [props.eventView, props.fields, props.organization.slug]);
+
+  const onFilterChange = () => {};
+
+  return (
+    <GenericPerformanceWidget<AreaDataType>
+      {...props}
+      subtitle={
+        <Subtitle>{t('Compared to last %s ', globalSelection.datetime.period)}</Subtitle>
+      }
+      HeaderActions={provided => (
+        <Fragment>
+          <ContainerActions {...provided.widgetData.chart} />
+        </Fragment>
+      )}
+      Queries={Queries}
+      Visualizations={[
+        {
+          component: provided => (
+            <HistogramChart
+              {...provided}
+              colors={props.chartColor ? [props.chartColor] : undefined}
+              height={100}
+              location={location}
+              isLoading={false}
+              isErrored={false}
+              onFilterChange={onFilterChange}
+              field={props.fields[0]}
+              chartData={provided.widgetData.chart?.data?.[props.fields[0]]}
+              disableXAxis
+            />
+          ),
+          height: 160,
+        },
+      ]}
+    />
+  );
+}
+
+const Subtitle = styled('span')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -104,6 +104,13 @@ describe('Performance > Landing > Index', function () {
     );
 
     expect(wrapper.find('Table')).toHaveLength(1);
+
+    const titles = wrapper.find('div[data-test-id="performance-widget-title"]');
+    expect(titles).toHaveLength(3);
+
+    expect(titles.at(0).text()).toEqual('p75 LCP');
+    expect(titles.at(1).text()).toEqual('LCP Distribution');
+    expect(titles.at(2).text()).toEqual('FCP Distribution');
   });
 
   it('renders frontend other view', async function () {

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -157,7 +157,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       'LCP Distribution'
     );
 
-    // Add histogram mock
+    // TODO(k-fish): Add histogram mock
   });
 
   it('FCP Histogram Widget', async function () {
@@ -177,7 +177,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       'FCP Distribution'
     );
 
-    // Add histogram mock
+    // TODO(k-fish): Add histogram mock
   });
 
   it('Most errors widget', async function () {

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -140,6 +140,46 @@ describe('Performance > Widgets > WidgetContainer', function () {
     );
   });
 
+  it('LCP Histogram Widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.LCP_HISTOGRAM}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'LCP Distribution'
+    );
+
+    // Add histogram mock
+  });
+
+  it('FCP Histogram Widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.FCP_HISTOGRAM}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'FCP Distribution'
+    );
+
+    // Add histogram mock
+  });
+
   it('Most errors widget', async function () {
     const data = initializeData();
 


### PR DESCRIPTION
### Summary
This adds the histogram widget to performance landing. It splits up the existing histogram chart for the landing page into the query portion and chart portion, and exports the chart with some extra options for the widget.

Other:
- Added the minichart row for the frontend pageload view.