### PR TITLE
ref(processing): Add separate task and queue for transactions save_event

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -617,6 +617,7 @@ CELERY_QUEUES = [
         routing_key="events.reprocessing.symbolicate_event_low_priority",
     ),
     Queue("events.save_event", routing_key="events.save_event"),
+    Queue("events.save_event_transaction", routing_key="events.save_event_transaction"),
     Queue("events.symbolicate_event", routing_key="events.symbolicate_event"),
     Queue(
         "events.symbolicate_event_low_priority", routing_key="events.symbolicate_event_low_priority"

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -31,7 +31,7 @@ from sentry.ingest.userreport import Conflict, save_userreport
 from sentry.killswitches import killswitch_matches_context
 from sentry.models import Project
 from sentry.signals import event_accepted
-from sentry.tasks.store import preprocess_event
+from sentry.tasks.store import preprocess_event, save_event_transaction
 from sentry.utils import json, metrics
 from sentry.utils.batching_kafka_consumer import AbstractBatchWorker
 from sentry.utils.cache import cache_key_for_event
@@ -279,17 +279,28 @@ def _load_event(
                     cache_key, attachments=attachment_objects, timeout=CACHE_TIMEOUT
                 )
 
-        # Preprocess this event, which spawns either process_event or
-        # save_event. Pass data explicitly to avoid fetching it again from the
-        # cache.
-        with sentry_sdk.start_span(op="ingest_consumer.process_event.preprocess_event"):
-            preprocess_event(
+        if data.get("type") == "transaction":
+            # No need for preprocess/process for transactions thus submit
+            # directly transaction specific save_event task.
+            save_event_transaction.delay(
                 cache_key=cache_key,
-                data=data,
+                data=None,
                 start_time=start_time,
                 event_id=event_id,
-                project=project,
+                project_id=project_id,
             )
+        else:
+            # Preprocess this event, which spawns either process_event or
+            # save_event. Pass data explicitly to avoid fetching it again from the
+            # cache.
+            with sentry_sdk.start_span(op="ingest_consumer.process_event.preprocess_event"):
+                preprocess_event(
+                    cache_key=cache_key,
+                    data=data,
+                    start_time=start_time,
+                    event_id=event_id,
+                    project=project,
+                )
 
         # remember for an 1 hour that we saved this event (deduplication protection)
         cache.set(deduplication_key, "", CACHE_TIMEOUT)

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -22,7 +22,7 @@ import sentry_sdk
 from django.conf import settings
 from django.core.cache import cache
 
-from sentry import eventstore, features
+from sentry import eventstore, features, options
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.event_manager import save_attachment
 from sentry.eventstore.processing import event_processing_store
@@ -279,7 +279,8 @@ def _load_event(
                     cache_key, attachments=attachment_objects, timeout=CACHE_TIMEOUT
                 )
 
-        if data.get("type") == "transaction":
+        save_event_transaction_rate = options.get("store.save-transactions-ingest-consumer-rate")
+        if data.get("type") == "transaction" and random.random() < save_event_transaction_rate:
             # No need for preprocess/process for transactions thus submit
             # directly transaction specific save_event task.
             save_event_transaction.delay(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -376,3 +376,7 @@ register("subscriptions-query.sample-rate", default=0.01)
 register("symbolicate-event.low-priority.metrics.submission-rate", default=0.0)
 
 register("performance.suspect-spans-ingestion-projects", default={})
+
+# Sampling rate for controlled rollout of a change where ignest-consumer spawns
+# special save_event task for transactions avoiding the preprocess.
+register("store.save-transactions-ingest-consumer-rate", default=0.0)

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -761,3 +761,20 @@ def save_event(
     **kwargs: Any,
 ) -> None:
     _do_save_event(cache_key, data, start_time, event_id, project_id, **kwargs)
+
+
+@instrumented_task(  # type: ignore
+    name="sentry.tasks.store.save_event_transaction",
+    queue="events.save_event_transaction",
+    time_limit=65,
+    soft_time_limit=60,
+)
+def save_event_transaction(
+    cache_key: Optional[str] = None,
+    data: Optional[Event] = None,
+    start_time: Optional[int] = None,
+    event_id: Optional[str] = None,
+    project_id: Optional[int] = None,
+    **kwargs: Any,
+) -> None:
+    _do_save_event(cache_key, data, start_time, event_id, project_id, **kwargs)

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -92,6 +92,7 @@ def test_transactions_spawn_save_event(
     save_event_transaction,
     save_event_transaction_rate,
 ):
+    project_id = default_project.id
     now = datetime.datetime.now()
     event = {
         "type": "transaction",
@@ -111,7 +112,6 @@ def test_transactions_spawn_save_event(
     }
     payload = get_normalized_event(event, default_project)
     event_id = payload["event_id"]
-    project_id = default_project.id
     start_time = time.time() - 3600
 
     # Use the old way through preprocess_event
@@ -141,7 +141,6 @@ def test_transactions_spawn_save_event(
     save_event_transaction_rate(1.0)
     payload = get_normalized_event(event, default_project)
     event_id = payload["event_id"]
-    project_id = default_project.id
     start_time = time.time() - 3600
     process_event(
         {
@@ -160,7 +159,7 @@ def test_transactions_spawn_save_event(
         data=None,
         start_time=start_time,
         event_id=event_id,
-        project_id=2,
+        project_id=project_id,
     )
 
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -1,8 +1,11 @@
+import datetime
 import time
 import uuid
+from unittest.mock import Mock
 
 import pytest
 
+from sentry import options
 from sentry.event_manager import EventManager
 from sentry.ingest.ingest_consumer import (
     process_attachment_chunk,
@@ -18,6 +21,13 @@ def get_normalized_event(data, project):
     mgr = EventManager(data, project=project)
     mgr.normalize()
     return dict(mgr.get_data())
+
+
+@pytest.fixture
+def save_event_transaction(monkeypatch):
+    mock = Mock()
+    monkeypatch.setattr("sentry.ingest.ingest_consumer.save_event_transaction", mock)
+    return mock
 
 
 @pytest.fixture
@@ -58,6 +68,79 @@ def test_deduplication_works(default_project, task_runner, preprocess_event):
         "project": default_project,
         "start_time": start_time,
     }
+
+
+@pytest.mark.django_db
+def test_transactions_spawn_save_event(
+    default_project, task_runner, preprocess_event, save_event_transaction
+):
+    now = datetime.datetime.now()
+    event = {
+        "type": "transaction",
+        "timestamp": now.isoformat(),
+        "start_timestamp": now.isoformat(),
+        "spans": [],
+        "contexts": {
+            "trace": {
+                "parent_span_id": "8988cec7cc0779c1",
+                "type": "trace",
+                "op": "foobar",
+                "trace_id": "a7d67cf796774551a95be6543cacd459",
+                "span_id": "babaae0d4b7512d9",
+                "status": "ok",
+            }
+        },
+    }
+    payload = get_normalized_event(event, default_project)
+    event_id = payload["event_id"]
+    project_id = default_project.id
+    start_time = time.time() - 3600
+    process_event(
+        {
+            "payload": json.dumps(payload),
+            "start_time": start_time,
+            "event_id": event_id,
+            "project_id": project_id,
+            "remote_addr": "127.0.0.1",
+        },
+        projects={default_project.id: default_project},
+    )
+    (kwargs,) = preprocess_event
+    assert kwargs == {
+        "cache_key": f"e:{event_id}:{project_id}",
+        "data": payload,
+        "event_id": event_id,
+        "project": default_project,
+        "start_time": start_time,
+    }
+    preprocess_event.clear()
+
+    # TODO(michal): After we are fully on save_event_transaction remove the
+    # option and keep only this part of test
+    options.set("store.save-transactions-ingest-consumer-rate", 1.0)
+    payload = get_normalized_event(event, default_project)
+    event_id = payload["event_id"]
+    project_id = default_project.id
+    start_time = time.time() - 3600
+    process_event(
+        {
+            "payload": json.dumps(payload),
+            "start_time": start_time,
+            "event_id": event_id,
+            "project_id": project_id,
+            "remote_addr": "127.0.0.1",
+        },
+        projects={default_project.id: default_project},
+    )
+    assert not len(preprocess_event)
+    assert save_event_transaction.delay.call_args[0] == ()
+    assert save_event_transaction.delay.call_args[1] == dict(
+        cache_key=f"e:{event_id}:{project_id}",
+        data=None,
+        start_time=start_time,
+        event_id=event_id,
+        project_id=2,
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Using separate queue and workers for `save_event` of transaction events should result in slower backlog buildup in cases like contention on project counter.