### PR TITLE
ref: Use lstrip instead of replace in ChunkUploadEndpoint

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -20,7 +20,7 @@ MAX_REQUEST_SIZE = 32 * 1024 * 1024
 MAX_CONCURRENCY = settings.DEBUG and 1 or 8
 HASH_ALGORITHM = "sha1"
 SENTRYCLI_SEMVER_RE = re.compile(r"^sentry-cli\/(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+).*$")
-
+API_PREFIX = "/api/0"
 CHUNK_UPLOAD_ACCEPT = (
     "debug_files",  # DIF assemble
     "release_files",  # Release files assemble
@@ -65,8 +65,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         if len(endpoint) == 0:
             # And we support relative url uploads, return a relative, versionless endpoint (with `/api/0` stripped)
             if supports_relative_url:
-                prefix = "/api/0"
-                url = relative_url.replace(prefix, "/")
+                url = relative_url.lstrip(API_PREFIX)
             # Otherwise, if we do not support them, return an absolute, versioned endpoint with a default, system-wide prefix
             else:
                 endpoint = options.get("system.url-prefix")

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from sentry import options
 from sentry.api.endpoints.chunk import (
+    API_PREFIX,
     HASH_ALGORITHM,
     MAX_CHUNKS_PER_REQUEST,
     MAX_CONCURRENCY,
@@ -57,7 +58,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/1.70.1",
             format="json",
         )
-        assert response.data["url"] == self.url.replace("/api/0", "/")
+        assert response.data["url"] == self.url.lstrip(API_PREFIX)
 
         response = self.client.get(
             self.url,
@@ -65,7 +66,7 @@ class ChunkUploadTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/2.77.4",
             format="json",
         )
-        assert response.data["url"] == self.url.replace("/api/0", "/")
+        assert response.data["url"] == self.url.lstrip(API_PREFIX)
 
         # < 1.70.1
         response = self.client.get(


### PR DESCRIPTION
A small refactor to make it more obvious what we want to achieve and less error-prone in tests.