### PR TITLE
fix(discover): Fixed text colour for Open in Discover on dark theme

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -305,8 +305,8 @@ const ContextWrapper = styled('div')`
 `;
 
 const StyledMenuItem = styled(MenuItem)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.textColor};
   :hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.textColor};
   }
 `;


### PR DESCRIPTION
Fixes the text colour for the Open in Discover button on dark theme
![image](https://user-images.githubusercontent.com/83961295/138294973-98a607a2-85d1-4a6d-9167-bc221b416ffd.png)
