### PR TITLE
ref: Hacks out use of session dict generator func

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,5 +1,3 @@
-import time
-import uuid
 from datetime import datetime, timedelta
 
 import pytest
@@ -287,40 +285,6 @@ class BaseIncidentEventStatsTest(BaseIncidentsTest, BaseIncidentsValidation):
         )
 
 
-class BaseCrashRateAlertsTest(SnubaTestCase):
-    def setUp(self):
-        super().setUp()
-        self.session_release = "foo@1.0.0"
-        self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
-
-    def make_session(
-        self,
-        received=None,
-        started=None,
-        status="ok",
-    ):
-        if received is None:
-            received = time.time()
-        if started is None:
-            started = time.time() // 60 * 60
-
-        return {
-            "session_id": str(uuid.uuid4()),
-            "distinct_id": str(uuid.uuid4()),
-            "status": status,
-            "seq": 0,
-            "release": self.session_release,
-            "environment": "prod",
-            "retention_days": 90,
-            "org_id": self.project.organization_id,
-            "project_id": self.project.id,
-            "duration": 60.0,
-            "errors": 0,
-            "started": started,
-            "received": received,
-        }
-
-
 @freeze_time()
 class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
     @fixture
@@ -402,7 +366,11 @@ class GetIncidentEventStatsTest(TestCase, BaseIncidentEventStatsTest):
 
 
 @freeze_time()
-class GetIncidentSessionStatsTest(TestCase, BaseCrashRateAlertsTest, BaseIncidentsValidation):
+class GetIncidentSessionStatsTest(TestCase, SnubaTestCase, BaseIncidentsValidation):
+    def setUp(self):
+        super().setUp()
+        self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
+
     def test_with_sessions(self):
         alert_rule = self.create_alert_rule(
             self.organization,
@@ -419,13 +387,13 @@ class GetIncidentSessionStatsTest(TestCase, BaseCrashRateAlertsTest, BaseInciden
             alert_rule=alert_rule,
         )
         for _ in range(3):
-            self.store_session(self.make_session(status="exited"))
-        self.store_session(self.make_session(status="crashed"))
+            self.store_session(self.build_session(status="exited"))
+        self.store_session(self.build_session(status="crashed"))
 
         self._6_min_ago_dt = datetime.utcnow() - timedelta(minutes=6)
         self._6_min_ago = self._6_min_ago_dt.timestamp()
         self.store_session(
-            self.make_session(status="crashed", received=self._6_min_ago, started=self._6_min_ago)
+            self.build_session(status="crashed", received=self._6_min_ago, started=self._6_min_ago)
         )
         result = get_incident_session_stats(incident, windowed_stats=False)
         self.validate_result(
@@ -451,11 +419,12 @@ class GetIncidentAggregatesTest(TestCase, BaseIncidentAggregatesTest):
         assert get_incident_aggregates(self.project_incident) == {"count": 4, "unique_users": 2}
 
 
-class GetCrashRateIncidentAggregatesTest(TestCase, BaseCrashRateAlertsTest):
+class GetCrashRateIncidentAggregatesTest(TestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
+        self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
         for _ in range(2):
-            self.store_session(self.make_session(status="exited"))
+            self.store_session(self.build_session(status="exited"))
 
     def test_sessions(self):
         incident = self.create_incident(
@@ -498,15 +467,19 @@ class CreateEventStatTest(TestCase, BaseIncidentsTest):
 
 
 @freeze_time()
-class CreateSessionStatTest(TestCase, BaseCrashRateAlertsTest):
+class CreateSessionStatTest(TestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
+
     def test_simple(self):
         for _ in range(2):
-            self.store_session(self.make_session(status="exited"))
-        self.store_session(self.make_session(status="crashed"))
+            self.store_session(self.build_session(status="exited"))
+        self.store_session(self.build_session(status="crashed"))
         self._2_min_ago_dt = datetime.utcnow() - timedelta(minutes=2)
         self._2_min_ago = self._2_min_ago_dt.timestamp()
         self.store_session(
-            self.make_session(status="crashed", received=self._2_min_ago, started=self._2_min_ago)
+            self.build_session(status="crashed", received=self._2_min_ago, started=self._2_min_ago)
         )
 
         alert_rule = self.create_alert_rule(

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -41,76 +41,52 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         session_2 = "5e910c1a-6941-460e-9843-24103fb6a63c"
         session_3 = "a148c0c5-06a2-423b-8901-6b43b812cf82"
         user_1 = "39887d89-13b2-4c84-8c23-5d13d2102666"
-        self.store_session(
-            {
-                "session_id": session_1,
-                "distinct_id": user_1,
-                "status": "exited",
-                "seq": 0,
-                "release": self.session_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
-        )
 
         self.store_session(
-            {
-                "session_id": session_2,
-                "distinct_id": user_1,
-                "status": "ok",
-                "seq": 0,
-                "release": self.session_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": None,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                distinct_id=user_1,
+                session_id=session_1,
+                status="exited",
+                release=self.session_release,
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
         )
-
         self.store_session(
-            {
-                "session_id": session_2,
-                "distinct_id": user_1,
-                "status": "exited",
-                "seq": 1,
-                "release": self.session_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 30.0,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                distinct_id=user_1,
+                session_id=session_2,
+                release=self.session_release,
+                environment="prod",
+                duration=None,
+                started=self.session_started,
+                received=self.received,
+            )
         )
-
         self.store_session(
-            {
-                "session_id": session_3,
-                "distinct_id": user_1,
-                "status": "crashed",
-                "seq": 0,
-                "release": self.session_crashed_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                distinct_id=user_1,
+                session_id=session_2,
+                seq=1,
+                duration=30,
+                status="exited",
+                release=self.session_release,
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
+        )
+        self.store_session(
+            self.build_session(
+                distinct_id=user_1,
+                session_id=session_3,
+                status="crashed",
+                release=self.session_crashed_release,
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
         )
 
     def test_get_oldest_health_data_for_releases(self):
@@ -193,21 +169,12 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         # Add an extra session with a different `distinct_id` so that sorting by users
         # is stable
         self.store_session(
-            {
-                "session_id": "5e910c1a-6941-460e-9843-24103fb6a63c",
-                "distinct_id": "39887d89-13b2-4c84-8c23-5d13d2102665",
-                "status": "ok",
-                "seq": 0,
-                "release": self.session_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": None,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                release=self.session_release,
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
         )
 
         for scope in "sessions", "users":
@@ -228,21 +195,13 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
 
         # add another user to session_release to make sure that they are sorted correctly
         self.store_session(
-            {
-                "session_id": str(uuid.uuid4()),
-                "distinct_id": str(uuid.uuid4()),
-                "status": "exited",
-                "seq": 0,
-                "release": self.session_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                status="exited",
+                release=self.session_release,
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
         )
 
         for scope in "crash_free_sessions", "crash_free_users":
@@ -260,20 +219,13 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         returned on `users` and `crash_free_users` sorts
         """
         self.store_session(
-            {
-                "session_id": "bd1521fc-d27c-11eb-b8bc-0242ac130003",
-                "status": "ok",
-                "seq": 0,
-                "release": "release-with-no-users",
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": None,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                distinct_id=None,
+                release="release-with-no-users",
+                environment="prod",
+                started=self.session_started,
+                received=self.received,
+            )
         )
         data = self.backend.get_project_releases_by_stability(
             [self.project.id], offset=0, limit=100, scope="users", stats_period="24h"
@@ -321,21 +273,13 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
 
     def test_get_release_adoption_lowered(self):
         self.store_session(
-            {
-                "session_id": "4574c381-acc5-4e05-b10b-f16cdc2f385a",
-                "distinct_id": "da50f094-10b4-40fb-89fb-cb3aa9014148",
-                "status": "crashed",
-                "seq": 0,
-                "release": self.session_crashed_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received,
-            }
+            self.build_session(
+                release=self.session_crashed_release,
+                environment="prod",
+                status="crashed",
+                started=self.session_started,
+                received=self.received,
+            )
         )
 
         data = self.backend.get_release_adoption(
@@ -481,39 +425,24 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         """
         # Same release session
         self.store_session(
-            {
-                "session_id": "5e910c1a-6941-460e-9843-24103fb6a63c",
-                "distinct_id": "39887d89-13b2-4c84-8c23-5d13d2102666",
-                "status": "exited",
-                "seq": 1,
-                "release": self.session_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 30.0,
-                "errors": 0,
-                "started": self.session_started - 3600 * 2,
-                "received": self.received - 3600 * 2,
-            }
+            self.build_session(
+                release=self.session_release,
+                environment="prod",
+                status="exited",
+                started=self.session_started - 3600 * 2,
+                received=self.received - 3600 * 2,
+            )
         )
+
         # Different release session
         self.store_session(
-            {
-                "session_id": "a148c0c5-06a2-423b-8901-6b43b812cf82",
-                "distinct_id": "39887d89-13b2-4c84-8c23-5d13d2102666",
-                "status": "crashed",
-                "seq": 0,
-                "release": self.session_crashed_release,
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": self.project.id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started - 3600 * 2,
-                "received": self.received - 3600 * 2,
-            }
+            self.build_session(
+                release=self.session_crashed_release,
+                environment="prod",
+                status="crashed",
+                started=self.session_started - 3600 * 2,
+                received=self.received - 3600 * 2,
+            )
         )
 
         if isinstance(self.backend, MetricsReleaseHealthBackend):
@@ -683,21 +612,13 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         _100h = 100 * 60 * 60  # 100 hours in seconds
         proj_id = self.project.id
         self.store_session(
-            {
-                "session_id": "f6a01ae0-7fa7-44df-afb9-ae32ef1c8102",
-                "distinct_id": "5849e12a-220a-4bda-8c72-4e35391c341f",
-                "status": "crashed",
-                "seq": 0,
-                "release": "foo@3.0.0",
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": proj_id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started - _100h,
-                "received": self.received - 3600 * 2,
-            }
+            self.build_session(
+                release="foo@3.0.0",
+                environment="prod",
+                status="crashed",
+                started=self.session_started - _100h,
+                received=self.received - 3600 * 2,
+            )
         )
 
         data = self.backend.get_changed_project_release_model_adoptions([proj_id])
@@ -708,21 +629,14 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         proj_id = self.project.id
         new_proj_id = proj_id + 1
         self.store_session(
-            {
-                "session_id": "f6a01ae0-7fa7-44df-afb9-ae32ef1c8102",
-                "distinct_id": "5849e12a-220a-4bda-8c72-4e35391c341f",
-                "status": "crashed",
-                "seq": 0,
-                "release": "foo@3.0.0",
-                "environment": "prod",
-                "retention_days": 90,
-                "org_id": self.project.organization_id,
-                "project_id": new_proj_id,
-                "duration": 60.0,
-                "errors": 0,
-                "started": self.session_started,
-                "received": self.received - 3600 * 2,
-            }
+            self.build_session(
+                project_id=new_proj_id,
+                release="foo@3.0.0",
+                environment="prod",
+                status="crashed",
+                started=self.session_started,
+                received=self.received - 3600 * 2,
+            )
         )
 
         data = self.backend.get_changed_project_release_model_adoptions([proj_id, new_proj_id])

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -24,26 +24,6 @@ def make_24h_stats(ts):
     return _make_stats(datetime.utcfromtimestamp(ts).replace(tzinfo=pytz.utc), 3600, 24)
 
 
-def generate_session_default_args(session_dict):
-    session_dict_default = {
-        "session_id": str(uuid.uuid4()),
-        "distinct_id": str(uuid.uuid4()),
-        "status": "ok",
-        "seq": 0,
-        "release": "random@1.0",
-        "environment": "prod",
-        "retention_days": 90,
-        "org_id": 0,
-        "project_id": 0,
-        "duration": 60.0,
-        "errors": 0,
-        "started": time.time() // 60 * 60,
-        "received": time.time(),
-    }
-    session_dict_default.update(session_dict)
-    return session_dict_default
-
-
 class ReleaseHealthMetricsTestCase(SessionMetricsTestCase):
     backend = MetricsReleaseHealthBackend()
 
@@ -167,8 +147,8 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             (datetime.utcnow() - timedelta(days=100)).replace(tzinfo=pytz.utc)
         )
         self.store_session(
-            generate_session_default_args(
-                {
+            self.build_session(
+                **{
                     "started": date_100_days_ago // 60 * 60,
                     "received": date_100_days_ago,
                     "project_id": project2.id,
@@ -194,8 +174,12 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
             organization=self.organization,
         )
         self.store_session(
-            generate_session_default_args(
-                {"project_id": project2.id, "org_id": project2.organization_id, "status": "exited"}
+            self.build_session(
+                **{
+                    "project_id": project2.id,
+                    "org_id": project2.organization_id,
+                    "status": "exited",
+                }
             )
         )
         data = self.backend.check_has_health_data([self.project.id, project2.id])
@@ -1034,8 +1018,8 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
         # Project 1
         for _ in range(0, 2):
             self.store_session(
-                generate_session_default_args(
-                    {
+                self.build_session(
+                    **{
                         "project_id": self.project.id,
                         "org_id": self.project.organization_id,
                         "status": "exited",
@@ -1048,8 +1032,8 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             if idx == 2:
                 status = "crashed"
             self.store_session(
-                generate_session_default_args(
-                    {
+                self.build_session(
+                    **{
                         "project_id": self.project.id,
                         "org_id": self.project.organization_id,
                         "status": status,
@@ -1064,8 +1048,8 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             if i == 1:
                 status = "crashed"
             self.store_session(
-                generate_session_default_args(
-                    {
+                self.build_session(
+                    **{
                         "project_id": self.project2.id,
                         "org_id": self.project2.organization_id,
                         "status": status,
@@ -1079,8 +1063,8 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             if i == 4:
                 status = "crashed"
             self.store_session(
-                generate_session_default_args(
-                    {
+                self.build_session(
+                    **{
                         "project_id": self.project3.id,
                         "org_id": self.project3.organization_id,
                         "status": status,


### PR DESCRIPTION
Removes functions that generate default session
dictionary in tests to use `build.session` defined
on `SnubaTestCase`