### PR TITLE
feat(dev): Use experimental arm64 Snuba image

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1820,7 +1820,14 @@ SENTRY_DEVSERVICES = {
     ),
     "snuba": lambda settings, options: (
         {
-            "image": "getsentry/snuba:nightly",
+            "image": "getsentry/snuba:nightly" if not APPLE_ARM64
+            # We don't yet have a way to produce a Snuba arm64 image as part of our release process, thus, we build it
+            # by hand (docker build . -t armenzg/snuba:4602206-arm64-test) on an Apple arm64 host
+            # This is because the amd64 image does not support pthread robust mutexes affecting uWSGI
+            # For details see: https://github.com/getsentry/snuba/issues/2147
+            # If you need to test against the latest Snuba, you need to start devservices w/o snuba
+            # and start `snuba api`
+            else "armenzg/snuba:4602206-arm64-test",
             "pull": True,
             "ports": {"1218/tcp": 1218},
             "command": ["devserver"],

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1822,7 +1822,7 @@ SENTRY_DEVSERVICES = {
         {
             "image": "getsentry/snuba:nightly" if not APPLE_ARM64
             # We cross-build arm64 images on GH's Apple Intel runners
-            else "ghcr.io/getsentry/snuba-ci:dee35135b6259aea343f0228b15adccb41547d2e:latest",
+            else "ghcr.io/getsentry/snuba-ci:latest",
             "pull": True,
             "ports": {"1218/tcp": 1218},
             "command": ["devserver"],

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1821,12 +1821,8 @@ SENTRY_DEVSERVICES = {
     "snuba": lambda settings, options: (
         {
             "image": "getsentry/snuba:nightly" if not APPLE_ARM64
-            # We don't yet have a way to produce a Snuba arm64 image as part of our release process
-            # The following image was built on an Intel MBP like this:
-            # > docker buildx create --name mybuilder --use
-            # > docker auth
-            # > docker buildx build --platform linux/arm64 -t armenzg/snuba:buildx-latest --push .
-            else "armenzg/snuba:buildx-latest",
+            # We cross-build arm64 images on GH's Apple Intel runners
+            else "ghcr.io/getsentry/snuba-ci:dee35135b6259aea343f0228b15adccb41547d2e:latest",
             "pull": True,
             "ports": {"1218/tcp": 1218},
             "command": ["devserver"],

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1821,13 +1821,12 @@ SENTRY_DEVSERVICES = {
     "snuba": lambda settings, options: (
         {
             "image": "getsentry/snuba:nightly" if not APPLE_ARM64
-            # We don't yet have a way to produce a Snuba arm64 image as part of our release process, thus, we build it
-            # by hand (docker build . -t armenzg/snuba:4602206-arm64-test) on an Apple arm64 host
-            # This is because the amd64 image does not support pthread robust mutexes affecting uWSGI
-            # For details see: https://github.com/getsentry/snuba/issues/2147
-            # If you need to test against the latest Snuba, you need to start devservices w/o snuba
-            # and start `snuba api`
-            else "armenzg/snuba:4602206-arm64-test",
+            # We don't yet have a way to produce a Snuba arm64 image as part of our release process
+            # The following image was built on an Intel MBP like this:
+            # > docker buildx create --name mybuilder --use
+            # > docker auth
+            # > docker buildx build --platform linux/arm64 -t armenzg/snuba:buildx-latest --push .
+            else "armenzg/snuba:buildx-latest",
             "pull": True,
             "ports": {"1218/tcp": 1218},
             "command": ["devserver"],

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1822,7 +1822,7 @@ SENTRY_DEVSERVICES = {
         {
             "image": "getsentry/snuba:nightly" if not APPLE_ARM64
             # We cross-build arm64 images on GH's Apple Intel runners
-            else "ghcr.io/getsentry/snuba-ci:latest",
+            else "ghcr.io/getsentry/snuba-arm64-dev:latest",
             "pull": True,
             "ports": {"1218/tcp": 1218},
             "command": ["devserver"],


### PR DESCRIPTION
Running the Snuba _Intel_ image on an Apple M1 host produces uWSGI errors (see [issue](https://github.com/getsentry/snuba/issues/2147)).

We now produce `linux/arm64` images on GH's CI (see [PR](https://github.com/getsentry/snuba/pull/2165)).