### PR TITLE
fix(notification platform): Send issue owner team Slack notifications

### DIFF
--- a/src/sentry/digests/__init__.py
+++ b/src/sentry/digests/__init__.py
@@ -1,11 +1,14 @@
 from collections import namedtuple
 from datetime import datetime
-from typing import Any, Mapping, Optional
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence
 
 from django.conf import settings
 
 from sentry.utils.dates import to_datetime
 from sentry.utils.services import LazyServiceWrapper
+
+if TYPE_CHECKING:
+    from sentry.models import Rule, Group
 
 from .backends.base import Backend  # NOQA
 from .backends.dummy import DummyBackend  # NOQA
@@ -26,7 +29,7 @@ ScheduleEntry = namedtuple("ScheduleEntry", "key timestamp")
 
 OPTIONS = frozenset(("increment_delay", "maximum_delay", "minimum_delay"))
 
-Digest = Mapping[str, Mapping[str, Any]]
+Digest = Mapping["Rule", Mapping["Group", Sequence[Record]]]
 
 
 def get_option_key(plugin: str, option: str) -> str:

--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -22,11 +22,12 @@ def get_digest_metadata(
 
         for group, records in groups.items():
             for record in records:
-                if start is None or record.datetime < start:
-                    start = record.datetime
+                if record.datetime:
+                    if start is None or record.datetime < start:
+                        start = record.datetime
 
-                if end is None or record.datetime > end:
-                    end = record.datetime
+                    if end is None or record.datetime > end:
+                        end = record.datetime
 
     return start, end, counts
 

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -1,6 +1,7 @@
 from sentry.mail import mail_adapter
 from sentry.mail.forms.notify_email import NotifyEmailForm
 from sentry.notifications.types import ACTION_CHOICES, ActionTargetType
+from sentry.notifications.utils.participants import determine_eligible_recipients
 from sentry.rules.actions.base import EventAction
 from sentry.utils import metrics
 
@@ -20,8 +21,9 @@ class NotifyEmailAction(EventAction):
         group = event.group
 
         target_type = ActionTargetType(self.data["targetType"])
+        target_identifier = self.data.get("targetIdentifier", None)
 
-        if not mail_adapter.should_notify(target_type, group=group):
+        if not determine_eligible_recipients(group.project, target_type, target_identifier, event):
             extra["group_id"] = group.id
             self.logger.info("rule.fail.should_notify", extra=extra)
             return
@@ -29,7 +31,7 @@ class NotifyEmailAction(EventAction):
         metrics.incr("notifications.sent", instance=self.metrics_slug, skip_internal=False)
         yield self.future(
             lambda event, futures: mail_adapter.rule_notify(
-                event, futures, target_type, self.data.get("targetIdentifier", None)
+                event, futures, target_type, target_identifier
             )
         )
 

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -96,19 +96,6 @@ class MailAdapter:
         users = self.get_sendable_user_objects(project)
         return [user.id for user in users]
 
-    def should_notify(self, target_type, group):
-        metrics.incr("mail_adapter.should_notify")
-        # only notify if we have users to notify. We always want to notify if targeting
-        # a member directly.
-        return (
-            target_type
-            in [
-                ActionTargetType.MEMBER,
-                ActionTargetType.TEAM,
-            ]
-            or self.get_sendable_user_objects(group.project)
-        )
-
     @staticmethod
     def notify(notification, target_type, target_identifier=None, **kwargs):
         AlertRuleNotification(notification, target_type, target_identifier).send()

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -45,7 +45,7 @@ class DigestNotification(ProjectNotification):
             project=self.project,
             target_type=self.target_type,
             target_identifier=self.target_identifier,
-            event=group.get_latest_event() or None,
+            event=group.get_latest_event(),
         )
 
     def get_filename(self) -> str:

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -106,6 +106,8 @@ class DigestNotification(ProjectNotification):
         return extra_context
 
     def send(self) -> None:
+        from sentry.models import User
+
         if not self.should_email():
             return
 
@@ -114,7 +116,12 @@ class DigestNotification(ProjectNotification):
             return
 
         # Get every user ID for every provider as a set.
-        user_ids = {user.id for users in participants_by_provider.values() for user in users}
+        user_ids = {
+            participant.id
+            for participants in participants_by_provider.values()
+            for participant in participants
+            if isinstance(participant, User)
+        }
 
         logger.info(
             "mail.adapter.notify_digest",

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -40,10 +40,12 @@ class DigestNotification(ProjectNotification):
         self.target_identifier = target_identifier
 
     def get_participants(self) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+        group = [list(value.keys())[0] for key, value in self.digest.items()][0]
         return get_send_to(
             project=self.project,
             target_type=self.target_type,
             target_identifier=self.target_identifier,
+            event=group.get_latest_event() or None,
         )
 
     def get_filename(self) -> str:

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -40,12 +40,12 @@ class DigestNotification(ProjectNotification):
         self.target_identifier = target_identifier
 
     def get_participants(self) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
-        group = [key for value in self.digest.values() for key in value.keys()][0]
+        event = [v for value in self.digest.values() for v in value.values()][0][0].value.event
         return get_send_to(
             project=self.project,
             target_type=self.target_type,
             target_identifier=self.target_identifier,
-            event=group.get_latest_event(),
+            event=event,
         )
 
     def get_filename(self) -> str:

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -40,7 +40,7 @@ class DigestNotification(ProjectNotification):
         self.target_identifier = target_identifier
 
     def get_participants(self) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
-        group = [list(value.keys())[0] for key, value in self.digest.items()][0]
+        group = [key for value in self.digest.values() for key in value.keys()][0]
         return get_send_to(
             project=self.project,
             target_type=self.target_type,

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -286,8 +286,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
         with self.tasks():
             deliver_digest(key)
 
-        assert digests.call_count == 0
-
         # check that only one was sent out - more would mean each user is being notified
         # rather than the team
         assert len(responses.calls) == 1
@@ -595,8 +593,6 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
 
         with self.tasks():
             deliver_digest(key)
-
-        assert digests.call_count == 0
 
         attachment, text = get_attachment()
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -645,32 +645,6 @@ class MailAdapterRuleNotifyTest(BaseMailAdapterTest):
         assert digests.add.call_count == 1
 
 
-class MailAdapterShouldNotifyTest(BaseMailAdapterTest):
-    def test_should_notify(self):
-        assert self.adapter.should_notify(ActionTargetType.ISSUE_OWNERS, self.group)
-        assert self.adapter.should_notify(ActionTargetType.MEMBER, self.group)
-
-    def test_should_not_notify_no_users(self):
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user=self.user,
-            project=self.project,
-        )
-        assert not self.adapter.should_notify(ActionTargetType.ISSUE_OWNERS, self.group)
-
-    def test_should_always_notify_target_member(self):
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ISSUE_ALERTS,
-            NotificationSettingOptionValues.NEVER,
-            user=self.user,
-            project=self.project,
-        )
-        assert self.adapter.should_notify(ActionTargetType.MEMBER, self.group)
-
-
 class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest):
     def test_assignment(self):
         NotificationSetting.objects.update_settings(


### PR DESCRIPTION
If a team has Slack notifications enabled and an alert rule has a rule to notify issue owners and the owner resolves to said team AND the notification gets digested AND the team's users' issue alert notification settings were turned off, the alert wouldn't fire. This PR passes the event to `get_send_to` because without it, it'd never return the team as the recipient.

See https://github.com/getsentry/sentry/pull/28617 for initial implementation.