### PR TITLE
feat(workflow): Align xAxis dates on team stats bar graphs

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -9,7 +9,11 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 
-import {convertDaySeriesToWeeks, convertDayValueObjectToSeries} from './utils';
+import {
+  barAxisLabel,
+  convertDaySeriesToWeeks,
+  convertDayValueObjectToSeries,
+} from './utils';
 
 type AlertsTriggered = Record<string, number>;
 
@@ -86,9 +90,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
             period="7d"
             legend={{right: 0, top: 0}}
             yAxis={{minInterval: 1}}
-            xAxis={{
-              type: 'time',
-            }}
+            xAxis={barAxisLabel(seriesData.length)}
             series={[
               {
                 seriesName: t('Alerts Triggered'),

--- a/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesReviewed.tsx
@@ -14,7 +14,11 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {formatPercentage} from 'app/utils/formatters';
 
-import {convertDaySeriesToWeeks, convertDayValueObjectToSeries} from './utils';
+import {
+  barAxisLabel,
+  convertDaySeriesToWeeks,
+  convertDayValueObjectToSeries,
+} from './utils';
 
 type IssuesBreakdown = Record<string, Record<string, {reviewed: number; total: number}>>;
 
@@ -110,8 +114,12 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
       }
     }
 
-    const reviewedSeries = convertDayValueObjectToSeries(allReviewedByDay);
-    const notReviewedSeries = convertDayValueObjectToSeries(allNotReviewedByDay);
+    const reviewedSeries = convertDaySeriesToWeeks(
+      convertDayValueObjectToSeries(allReviewedByDay)
+    );
+    const notReviewedSeries = convertDaySeriesToWeeks(
+      convertDayValueObjectToSeries(allNotReviewedByDay)
+    );
 
     return (
       <Fragment>
@@ -122,17 +130,20 @@ class TeamIssuesReviewed extends AsyncComponent<Props, State> {
               style={{height: 200}}
               stacked
               isGroupedByDate
+              useShortDate
               legend={{right: 0, top: 0}}
+              xAxis={barAxisLabel(reviewedSeries.length)}
+              yAxis={{minInterval: 1}}
               series={[
                 {
                   seriesName: t('Reviewed'),
-                  data: convertDaySeriesToWeeks(reviewedSeries),
+                  data: reviewedSeries,
                   silent: true,
                   // silent is not incldued in the type for BarSeries
                 } as any,
                 {
                   seriesName: t('Not Reviewed'),
-                  data: convertDaySeriesToWeeks(notReviewedSeries),
+                  data: notReviewedSeries,
                   silent: true,
                 },
               ]}

--- a/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamResolutionTime.tsx
@@ -10,7 +10,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {getDuration} from 'app/utils/formatters';
 
-import {convertDaySeriesToWeeks} from './utils';
+import {barAxisLabel, convertDaySeriesToWeeks} from './utils';
 
 type TimeToResolution = Record<string, {count: number; avg: number}>;
 
@@ -90,9 +90,7 @@ class TeamResolutionTime extends AsyncComponent<Props, State> {
             },
           }}
           legend={{right: 0, top: 0}}
-          xAxis={{
-            type: 'time',
-          }}
+          xAxis={barAxisLabel(seriesData.length)}
           series={[
             {
               seriesName: t('Time to Resolution'),

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -42,7 +42,7 @@ export const barAxisLabel = (
       showMaxLabel: true,
       showMinLabel: true,
       formatter: (date: number) => {
-        return moment(new Date(date)).format('MMM Do');
+        return moment(new Date(date)).format('MMM D');
       },
     },
   };

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -1,5 +1,7 @@
 import chunk from 'lodash/chunk';
+import moment from 'moment';
 
+import BaseChart from 'app/components/charts/baseChart';
 import {SeriesDataUnit} from 'app/types/echarts';
 
 /**
@@ -28,3 +30,20 @@ export function convertDayValueObjectToSeries(
     name: new Date(bucket).getTime(),
   }));
 }
+
+export const barAxisLabel = (
+  dataEntries: number
+): React.ComponentProps<typeof BaseChart>['xAxis'] => {
+  return {
+    splitNumber: dataEntries,
+    type: 'category',
+    min: 0,
+    axisLabel: {
+      showMaxLabel: true,
+      showMinLabel: true,
+      formatter: (date: number) => {
+        return moment(new Date(date)).format('MMM Do');
+      },
+    },
+  };
+};


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/1400464/138365756-3ab661cc-ab0d-47dd-880a-5b12482aeb5f.png)


after
![image](https://user-images.githubusercontent.com/1400464/138365705-c8a214cf-f6f4-4db9-9b1f-42408a3455cb.png)
