### PR TITLE
test: remove mock compat

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -96,9 +96,6 @@ phabricator==0.7.0
 # sentry.utils.pytest and sentry.testutils are moved to tests/
 selenium==3.141.0
 sqlparse==0.2.4
-# We're still using mock in Python 3.6 because it contains a fix to Python issue37972.
-# We should be able to fully swap it out for stdlib once we're on 3.8.
-mock==4.0.3
 
 # this is already a transitive dependency via structlog, and we started
 # implicitly relying on it because of that. Can probably be removed with 3.8

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -29,6 +29,8 @@ import os.path
 import time
 from contextlib import contextmanager
 from datetime import datetime
+from unittest import mock
+from unittest.mock import patch
 from urllib.parse import urlencode
 from uuid import uuid4
 
@@ -84,8 +86,6 @@ from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils import json
 from sentry.utils.auth import SSO_SESSION_KEY
-from sentry.utils.compat import mock
-from sentry.utils.compat.mock import patch
 from sentry.utils.pytest.selenium import Browser
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snuba import _snuba_pool

--- a/src/sentry/testutils/helpers/features.py
+++ b/src/sentry/testutils/helpers/features.py
@@ -3,10 +3,10 @@ __all__ = ["Feature", "with_feature"]
 import logging
 from collections.abc import Mapping
 from contextlib import contextmanager
+from unittest.mock import patch
 
 import sentry.features
 from sentry.features.exceptions import FeatureNotRegistered
-from sentry.utils.compat.mock import patch
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/testutils/helpers/options.py
+++ b/src/sentry/testutils/helpers/options.py
@@ -1,10 +1,9 @@
 __all__ = ["override_options"]
 
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from django.test.utils import override_settings
-
-from sentry.utils.compat.mock import patch
 
 
 @contextmanager

--- a/src/sentry/testutils/helpers/task_runner.py
+++ b/src/sentry/testutils/helpers/task_runner.py
@@ -1,11 +1,10 @@
 __all__ = ["TaskRunner"]
 
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from celery import current_app
 from django.conf import settings
-
-from sentry.utils.compat.mock import patch
 
 
 @contextmanager

--- a/src/sentry/utils/compat/mock.py
+++ b/src/sentry/utils/compat/mock.py
@@ -1,4 +1,0 @@
-from mock import *  # NOQA
-
-# We're still using mock in Python 3.6 because it contains a fix to Python issue37972.
-# We should be able to fully swap it out for stdlib once we're on 3.8.

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -1,10 +1,10 @@
 import os
 from hashlib import md5
+from unittest import mock
 
 from django.conf import settings
 from sentry_sdk import Hub
 
-from sentry.utils.compat import mock
 from sentry.utils.warnings import UnsupportedBackend
 
 TEST_ROOT = os.path.normpath(

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -1,6 +1,7 @@
+from unittest.mock import patch
+
 from sentry.models import Project
 from sentry.testutils import AcceptanceTestCase
-from sentry.utils.compat.mock import patch
 
 
 class CreateProjectTest(AcceptanceTestCase):

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 from tests.acceptance.page_objects.issue_details import IssueDetailsPage
 

--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from selenium.common.exceptions import TimeoutException
 
 from sentry.models import Project
 from sentry.testutils import AcceptanceTestCase
-from sentry.utils.compat import mock
 from sentry.utils.retries import TimedRetryPolicy
 
 

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import timedelta
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
@@ -9,7 +10,6 @@ from selenium.webdriver.common.keys import Keys
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 FEATURE_NAMES = [

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 import pytz
@@ -6,7 +7,6 @@ from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from tests.acceptance.page_objects.issue_details import IssueDetailsPage
 from tests.acceptance.page_objects.issue_list import IssueListPage
 

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytz
 from django.utils import timezone
@@ -7,7 +8,6 @@ from sentry.models import AssistantActivity, GroupInboxReason
 from sentry.models.groupinbox import add_group_to_inbox
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from tests.acceptance.page_objects.issue_list import IssueListPage
 
 event_time = before_now(days=3).replace(tzinfo=pytz.utc)

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -1,7 +1,8 @@
+from unittest.mock import Mock, patch
+
 from django.utils import timezone
 
 from sentry.testutils import AcceptanceTestCase
-from sentry.utils.compat.mock import Mock, patch
 
 
 class OrganizationRateLimitsTest(AcceptanceTestCase):

--- a/tests/acceptance/test_performance_landing.py
+++ b/tests/acceptance/test_performance_landing.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 import pytz
 from django.db.models import F
 
 from sentry.models import Project
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 from .page_objects.base import BasePage

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 import pytz
 from django.db.models import F
 
 from sentry.models import Project
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 from .page_objects.base import BasePage

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytz
@@ -5,7 +6,6 @@ import pytz
 from sentry.models import AssistantActivity
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 from .page_objects.transaction_summary import TransactionSummaryPage

--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -1,11 +1,11 @@
 from datetime import timedelta
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytz
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 FEATURE_NAMES = ["organizations:performance-view"]

--- a/tests/acceptance/test_performance_trends.py
+++ b/tests/acceptance/test_performance_trends.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytz
@@ -6,7 +7,6 @@ from django.db.models import F
 from sentry.models import Project
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 from .page_objects.base import BasePage

--- a/tests/acceptance/test_performance_vital_detail.py
+++ b/tests/acceptance/test_performance_vital_detail.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytz
@@ -6,7 +7,6 @@ from django.db.models import F
 from sentry.models import Project
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 from .page_objects.base import BasePage

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -1,10 +1,10 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytz
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 current_time = datetime.utcnow().replace(tzinfo=pytz.utc)

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -1,11 +1,11 @@
 import copy
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, timestamp_format
-from sentry.utils.compat.mock import patch
 from tests.acceptance.test_organization_events_v2 import generate_transaction
 
 FEATURE_NAMES = ["organizations:performance-view"]

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 from django.conf import settings
 
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 from sentry.utils.settings import ConfigurationError, import_string, validate_settings
 
 DEPENDENCY_TEST_DATA = {

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -2,6 +2,7 @@ import os.path
 import zipfile
 from base64 import b64encode
 from io import BytesIO
+from unittest.mock import patch
 
 import responses
 from django.utils.encoding import force_bytes
@@ -11,7 +12,6 @@ from sentry.models.releasefile import update_artifact_index
 from sentry.testutils import RelayStoreHelper, SnubaTestCase, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 BASE64_SOURCEMAP = "data:application/json;base64," + (
     b64encode(

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import pytest
 import sentry_sdk
@@ -7,7 +8,6 @@ from sentry_sdk import Hub, push_scope
 
 from sentry import eventstore
 from sentry.testutils import assert_mock_called_once_with_partial
-from sentry.utils.compat import mock
 from sentry.utils.pytest.relay import adjust_settings_for_relay_tests
 from sentry.utils.sdk import bind_organization_context, configure_sdk
 

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -1,11 +1,11 @@
 from datetime import datetime
+from unittest.mock import patch
 
 import pytest
 import pytz
 
 from sentry.analytics import Attribute, Event, Map
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class ExampleEvent(Event):

--- a/tests/sentry/api/bases/test_endpoint.py
+++ b/tests/sentry/api/bases/test_endpoint.py
@@ -1,8 +1,9 @@
+from unittest.mock import Mock
+
 from django.http import QueryDict
 
 from sentry.api.base import Endpoint
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock
 
 
 class EndpointTest(TestCase):

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 
 from django.db.models import F
 from django.test import RequestFactory
@@ -14,7 +15,6 @@ from sentry.auth.access import NoAccess, from_request
 from sentry.auth.authenticators import TotpInterface
 from sentry.models import ApiKey, Organization, OrganizationMember
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class MockSuperUser:

--- a/tests/sentry/api/bases/test_sentryapps.py
+++ b/tests/sentry/api/bases/test_sentryapps.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.http import Http404
 
 from sentry.api.bases.sentryapps import (
@@ -9,7 +11,6 @@ from sentry.api.bases.sentryapps import (
 )
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import Mock
-from sentry.utils.compat.mock import patch
 
 
 class SentryAppPermissionTest(TestCase):

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class AuthLoginEndpointTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -1,4 +1,5 @@
 from hashlib import sha1
+from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.urls import reverse
@@ -14,7 +15,6 @@ from sentry.tasks.assemble import (
     set_assemble_status,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class DifAssembleEndpoint(APITestCase):

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -1,5 +1,7 @@
 from base64 import b64encode
 from datetime import timedelta
+from unittest import mock
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -23,8 +25,6 @@ from sentry.models import (
 )
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.utils.compat import mock
-from sentry.utils.compat.mock import patch
 
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -1,4 +1,5 @@
 import copy
+from unittest import mock
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models import Activity, ExternalIssue, GroupLink, Integration
@@ -6,7 +7,6 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 import responses
 from exam import fixture
 
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class GroupNotesDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -1,5 +1,6 @@
+from unittest.mock import patch
+
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class InternalBeaconTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_code_mapping_codeowners.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mapping_codeowners.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.models import Integration, Repository
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 GITHUB_CODEOWNER = {
     "filepath": "CODEOWNERS",

--- a/tests/sentry/api/endpoints/test_organization_has_mobile_app_events.py
+++ b/tests/sentry/api/endpoints/test_organization_has_mobile_app_events.py
@@ -1,5 +1,6 @@
+from unittest import mock
+
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 from sentry.utils.samples import create_sample_event
 
 

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -1,6 +1,7 @@
+from unittest.mock import patch
+
 from sentry.models import Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationIntegrationReposTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -1,8 +1,9 @@
+from unittest.mock import MagicMock, patch
+
 from sentry.integrations.aws_lambda.integration import AwsLambdaIntegration
 from sentry.models import Integration, ProjectKey
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.faux import Mock
-from sentry.utils.compat.mock import MagicMock, patch
 
 cloudformation_arn = (
     "arn:aws:cloudformation:us-east-2:599817902985:stack/"

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from exam import fixture
 
 from sentry.models import (
@@ -10,7 +12,6 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat.mock import patch
 
 
 class InviteRequestBase(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from django.core import mail
 from exam import fixture
 
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember, OrganizationOption
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationJoinRequestTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 from django.db.models import F
 from django.urls import reverse
@@ -14,7 +16,6 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.utils.compat import map
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationMemberTestBase(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 from django.urls import reverse
 
@@ -12,7 +14,6 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase, TestCase
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationMemberSerializerTest(TestCase):

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -1,4 +1,5 @@
 from hashlib import sha1
+from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 from django.urls import reverse
@@ -6,7 +7,6 @@ from django.urls import reverse
 from sentry.models import ApiToken, FileBlob, FileBlobOwner
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationReleaseAssembleTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 from django.urls import reverse
@@ -20,7 +21,6 @@ from sentry.models import (
     Repository,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class ReleaseDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1,5 +1,6 @@
 from base64 import b64encode
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 from django.urls import reverse
@@ -43,7 +44,6 @@ from sentry.testutils import (
     SnubaTestCase,
     TestCase,
 )
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationReleaseListTest(APITestCase, SnubaTestCase):

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.constants import ObjectStatus
@@ -5,7 +7,6 @@ from sentry.integrations.example import ExampleRepositoryProvider
 from sentry.models import Integration, OrganizationIntegration, Repository
 from sentry.plugins.providers.dummy.repository import DummyRepositoryProvider
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationRepositoriesListTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 from django.utils import timezone
 
@@ -5,7 +7,6 @@ from sentry.constants import ObjectStatus
 from sentry.models import Commit, Integration, OrganizationOption, Repository, ScheduledDeletion
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import with_feature
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationRepositoryDeleteTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_request_project_creation.py
+++ b/tests/sentry/api/endpoints/test_organization_request_project_creation.py
@@ -1,5 +1,6 @@
+from unittest import mock
+
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.sdk_updates import SdkIndexState
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class OrganizationSdkUpdates(APITestCase, SnubaTestCase):

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 import responses
 from django.urls import reverse
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class SentryAppInstallationDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1,4 +1,5 @@
 from time import time
+from unittest import mock, zip
 
 import pytest
 
@@ -31,7 +32,6 @@ from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, faux
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
-from sentry.utils.compat import mock, zip
 
 
 def _dyn_sampling_data():

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1,5 +1,5 @@
 from time import time
-from unittest import mock, zip
+from unittest import mock
 
 import pytest
 

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from sentry.models import AuditLogEntry, ProjectOption
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 class ProjectPluginDetailsTestBase(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase
 from sentry.utils.compat import filter
-from sentry.utils.compat.mock import patch
 
 
 class ProjectPluginsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_task_details.py
@@ -1,9 +1,9 @@
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.urls import reverse
 
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class ProjectRuleTaskDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -1,6 +1,7 @@
+from unittest.mock import Mock, patch
+
 from sentry.rules.registry import RuleRegistry
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import Mock, patch
 
 EMAIL_ACTION = "sentry.mail.actions.NotifyEmailAction"
 APP_ACTION = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -1,9 +1,9 @@
 from typing import Any, Mapping
+from unittest import mock
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models import Integration, OrganizationIntegration
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 def serialized_provider() -> Mapping[str, Any]:

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry import tagstore
 from sentry.tagstore import TagKeyStatus
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class ProjectTagKeyDetailsTest(APITestCase, SnubaTestCase):

--- a/tests/sentry/api/endpoints/test_project_transaction_threshold_override.py
+++ b/tests/sentry/api/endpoints/test_project_transaction_threshold_override.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.models.transaction_threshold import (
@@ -6,7 +8,6 @@ from sentry.models.transaction_threshold import (
 )
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
-from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 
 

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -1,7 +1,8 @@
+from unittest.mock import call, patch
+
 from sentry.constants import SentryAppInstallationStatus
 from sentry.coreapi import APIError
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import call, patch
 
 
 class SentryAppComponentsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
@@ -5,7 +7,6 @@ from sentry.models import OrganizationMember, SentryApp
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class SentryAppDetailsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 class SentryAppPublishRequestTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import patch
 
 from django.urls import reverse
 
@@ -15,7 +16,6 @@ from sentry.models.sentryapp import MASKED_VALUE
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature, with_feature
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class SentryAppsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 from django.conf import settings
 from django.core import mail
@@ -8,7 +9,6 @@ from django.utils import timezone
 from sentry.auth.authenticators import RecoveryCodeInterface, SmsInterface, TotpInterface
 from sentry.models import Authenticator, Organization, User
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 def get_auth(user: "User") -> Authenticator:

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 from urllib.parse import parse_qsl
 
 from django.conf import settings
@@ -15,7 +16,6 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 from tests.sentry.api.endpoints.test_user_authenticator_details import assert_security_email_sent
 
 

--- a/tests/sentry/api/endpoints/test_user_emails_confirm.py
+++ b/tests/sentry/api/endpoints/test_user_emails_confirm.py
@@ -1,6 +1,7 @@
+from unittest import mock
+
 from sentry.models import UserEmail
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 class UserEmailsConfirmTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_user_password.py
+++ b/tests/sentry/api/endpoints/test_user_password.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 from sentry.auth.password_validation import MinimumLengthValidator
 from sentry.models import User
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 class UserPasswordTest(APITestCase):

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock, patch
+
 from django.http import QueryDict
 
 from sentry.api.helpers.group_index import (
@@ -9,7 +11,6 @@ from sentry.api.helpers.group_index import (
 from sentry.api.issue_search import parse_search_query
 from sentry.models import GroupInbox, GroupInboxReason, GroupStatus, add_group_to_inbox
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock, patch
 from sentry.utils.hashlib import md5_text
 
 

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -1,4 +1,6 @@
 from datetime import timedelta
+from unittest import mock
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -18,8 +20,6 @@ from sentry.models import (
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.compat import mock
-from sentry.utils.compat.mock import patch
 
 
 class GroupSerializerTest(TestCase):

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.conf import settings
 
 from sentry import features
@@ -5,7 +7,6 @@ from sentry.api.serializers import DetailedOrganizationSerializer, serialize
 from sentry.auth import access
 from sentry.features.base import OrganizationFeature
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class OrganizationSerializerTest(TestCase):

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -1,5 +1,6 @@
 import datetime
 from datetime import timedelta
+from unittest import mock
 
 from django.db.models import F
 from django.utils import timezone
@@ -24,7 +25,6 @@ from sentry.models import (
 )
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 
 

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 from rest_framework.exceptions import ErrorDetail
@@ -22,7 +23,6 @@ from sentry.models import (
 )
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 
 class ReleaseSerializerTest(TestCase, SnubaTestCase):

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from django.http import HttpRequest
 
 from sentry.api.invite_helper import ApiInviteHelper
 from sentry.models import AuthProvider, OrganizationMember
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class ApiInviteHelperTest(TestCase):

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -1,9 +1,9 @@
 import zlib
+from unittest import mock
 
 import pytest
 
 from sentry.cache.redis import RbCache, RedisClusterCache
-from sentry.utils.compat import mock
 from sentry.utils.imports import import_string
 
 KEY_FMT = "c:1:%s"

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import pytest
 import responses
 
 from sentry.auth.providers.github.client import GitHubClient
 from sentry.auth.providers.github.constants import API_DOMAIN
-from sentry.utils.compat import mock
 
 
 @pytest.fixture

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -1,5 +1,6 @@
 import types
 from datetime import datetime
+from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -9,7 +10,6 @@ from sentry.auth.helper import AuthHelper
 from sentry.auth.providers.saml2.provider import Attributes, SAML2ACSView, SAML2Provider
 from sentry.models import AuthProvider
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 dummy_provider_config = {
     "attribute_mapping": {

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -1,9 +1,10 @@
+from unittest.mock import Mock
+
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.auth import access
 from sentry.models import AuthIdentity, AuthProvider, ObjectStatus, Organization
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock
 
 
 class FromUserTest(TestCase):

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import urlencode
 
 from django.contrib import messages
@@ -22,7 +23,6 @@ from sentry.models import (
 )
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat import mock
 from sentry.utils.redis import clusters
 
 

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
@@ -22,7 +23,6 @@ from sentry.middleware.superuser import SuperuserMiddleware
 from sentry.models import User
 from sentry.testutils import TestCase
 from sentry.utils.auth import mark_sso_complete
-from sentry.utils.compat.mock import Mock, patch
 
 UNSET = object()
 

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -1,11 +1,11 @@
 from datetime import timedelta
+from unittest import mock
 
 from django.utils import timezone
 
 from sentry.buffer.base import Buffer
 from sentry.models import Group, Organization, Project, Release, ReleaseProject, Team
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class BufferTest(TestCase):

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -1,5 +1,6 @@
 import pickle
 from datetime import datetime
+from unittest import mock
 
 from django.utils import timezone
 from django.utils.encoding import force_text
@@ -7,7 +8,6 @@ from django.utils.encoding import force_text
 from sentry.buffer.redis import RedisBuffer
 from sentry.models import Group, Project
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class RedisBufferTest(TestCase):
@@ -104,7 +104,7 @@ class RedisBufferTest(TestCase):
         assert pickle.loads(f) == {"pk": 1, "datetime": now}
         assert pickle.loads(result.pop("e+datetime")) == now
         assert pickle.loads(result.pop("e+foo")) == "bar"
-        assert result == {"i+times_seen": b"1", "m": b"mock.mock.Mock"}
+        assert result == {"i+times_seen": b"1", "m": b"unittest.mock.Mock"}
 
         pending = client.zrange("b:p", 0, -1)
         assert pending == [b"foo"]
@@ -116,7 +116,7 @@ class RedisBufferTest(TestCase):
         assert pickle.loads(f) == {"pk": 1, "datetime": now}
         assert pickle.loads(result.pop("e+datetime")) == now
         assert pickle.loads(result.pop("e+foo")) == "baz"
-        assert result == {"i+times_seen": b"2", "m": b"mock.mock.Mock"}
+        assert result == {"i+times_seen": b"2", "m": b"unittest.mock.Mock"}
 
         pending = client.zrange("b:p", 0, -1)
         assert pending == [b"foo"]
@@ -176,30 +176,29 @@ class RedisBufferTest(TestCase):
             {
                 "f": '{"pk": ["i","1"]}',
                 "i+times_seen": "1",
-                "m": "sentry.utils.compat.mock.Mock",
+                "m": "unittest.mock.Mock",
                 "s": "1",
             },
         )
         self.buf.process("foo")
         process.assert_called_once_with(mock.Mock, {"times_seen": 1}, {"pk": 1}, {}, True)
 
-    """
-    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
-    def test_incr_uses_signal_only(self):
-        now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
-        client = self.buf.cluster.get_routing_client()
-        model = mock.Mock()
-        model.__name__ = "Mock"
-        columns = {"times_seen": 1}
-        filters = {"pk": 1, "datetime": now}
-        self.buf.incr(model, columns, filters, extra={"foo": "bar", "datetime": now}, signal_only=True)
-        result = client.hgetall("foo")
-        assert result == {
-            "e+foo": '["s","bar"]',
-            "e+datetime": '["d","1493791566.000000"]',
-            "f": '{"pk":["i","1"],"datetime":["d","1493791566.000000"]}',
-            "i+times_seen": "1",
-            "m": "mock.mock.Mock",
-            "s": "1"
-        }
-    """
+
+#    @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
+#    def test_incr_uses_signal_only(self):
+#        now = datetime(2017, 5, 3, 6, 6, 6, tzinfo=timezone.utc)
+#        client = self.buf.cluster.get_routing_client()
+#        model = mock.Mock()
+#        model.__name__ = "Mock"
+#        columns = {"times_seen": 1}
+#        filters = {"pk": 1, "datetime": now}
+#        self.buf.incr(model, columns, filters, extra={"foo": "bar", "datetime": now}, signal_only=True)
+#        result = client.hgetall("foo")
+#        assert result == {
+#            "e+foo": '["s","bar"]',
+#            "e+datetime": '["d","1493791566.000000"]',
+#            "f": '{"pk":["i","1"],"datetime":["d","1493791566.000000"]}',
+#            "i+times_seen": "1",
+#            "m": "mock.mock.Mock",
+#            "s": "1"
+#        }

--- a/tests/sentry/charts/test_chartcuterie.py
+++ b/tests/sentry/charts/test_chartcuterie.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 import responses
 from django.urls.base import reverse
@@ -6,7 +8,6 @@ from sentry.charts import generate_chart, is_enabled
 from sentry.charts.types import ChartType
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 from freezegun import freeze_time
 
 from sentry.data_export.base import ExportQueryType, ExportStatus
 from sentry.data_export.models import ExportedData
 from sentry.search.utils import parse_datetime_string
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 from sentry.utils.snuba import MAX_FIELDS
 
 

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -1,5 +1,6 @@
 import tempfile
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core import mail
 from django.urls import reverse
@@ -10,7 +11,6 @@ from sentry.data_export.models import ExportedData
 from sentry.models import File
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.db import IntegrityError
 
 from sentry.data_export.base import ExportQueryType
@@ -8,7 +10,6 @@ from sentry.models import File
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import (
     DatasetSelectionError,

--- a/tests/sentry/db/test_mixin.py
+++ b/tests/sentry/db/test_mixin.py
@@ -1,6 +1,7 @@
+from unittest.mock import patch
+
 from sentry.models import OrganizationOption, Repository
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class RenamePendingDeleteTest(TestCase):

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from uuid import uuid4
 
 from sentry import nodestore
@@ -16,7 +17,6 @@ from sentry.models import (
 from sentry.tasks.deletion import delete_groups
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class DeleteGroupTest(TestCase, SnubaTestCase):

--- a/tests/sentry/deletions/test_repository.py
+++ b/tests/sentry/deletions/test_repository.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 
 from sentry.constants import ObjectStatus
@@ -5,7 +7,6 @@ from sentry.exceptions import PluginError
 from sentry.models import Commit, Repository, ScheduledDeletion
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TransactionTestCase
-from sentry.utils.compat.mock import patch
 
 
 class DeleteRepositoryTest(TransactionTestCase):

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import pytest
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.interfaces.stacktrace import get_context, is_url
-from sentry.utils.compat import mock
 
 
 def test_is_url():

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta
 from time import time
+from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -42,7 +43,6 @@ from sentry.models import (
 from sentry.spans.grouping.utils import hash_values
 from sentry.testutils import TestCase, assert_mock_called_once_with_partial
 from sentry.utils.cache import cache_key_for_event
-from sentry.utils.compat import mock
 from sentry.utils.outcomes import Outcome
 
 

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from sentry.eventstore.base import Filter
 from sentry.eventstore.snuba.backend import SnubaEventStorage
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 
 

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -1,4 +1,5 @@
 import logging
+from unittest import mock
 
 import pytest
 
@@ -7,7 +8,6 @@ from sentry.eventstore.base import EventStorage
 from sentry.eventstore.models import Event
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 
 

--- a/tests/sentry/eventstream/kafka/test_state.py
+++ b/tests/sentry/eventstream/kafka/test_state.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from sentry.eventstream.kafka.state import (
@@ -8,7 +10,6 @@ from sentry.eventstream.kafka.state import (
     SynchronizedPartitionState,
     SynchronizedPartitionStateManager,
 )
-from sentry.utils.compat import mock
 
 
 def test_transitions():

--- a/tests/sentry/features/test_helpers.py
+++ b/tests/sentry/features/test_helpers.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from django.http import HttpRequest
 from rest_framework.response import Response
@@ -7,7 +8,6 @@ from sentry import features
 from sentry.features import OrganizationFeature
 from sentry.features.helpers import any_organization_has_feature, requires_feature
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestFeatureHelpers(TestCase):

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -1,4 +1,5 @@
 from typing import Any, Mapping, Optional, Union
+from unittest import mock
 
 from django.conf import settings
 
@@ -6,7 +7,6 @@ from sentry import features
 from sentry.features import Feature
 from sentry.models import User
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class MockBatchHandler(features.BatchFeatureHandler):

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import responses
 from exam import fixture
 from requests.exceptions import SSLError
@@ -7,7 +9,6 @@ from sentry.identity.oauth2 import OAuth2CallbackView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock
 
 
 class OAuth2CallbackViewTest(TestCase):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest import mock
 
 import pytz
 from exam import fixture
@@ -6,7 +7,6 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
 from sentry.testutils import APITestCase
-from sentry.utils.compat import mock
 
 
 class BaseIncidentDetailsTest:

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from exam import fixture
 
 from sentry.api.serializers import serialize
@@ -11,7 +13,6 @@ from sentry.incidents.models import (
 )
 from sentry.models import Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class AlertRuleDetailsBase:

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytz
 import requests
 from exam import fixture
@@ -10,7 +12,6 @@ from sentry.snuba.models import QueryDatasets
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from tests.sentry.api.serializers.test_alert_rule import BaseAlertRuleSerializerTest
 
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from exam import fixture
 from rest_framework import serializers
@@ -22,7 +24,6 @@ from sentry.models import ACTOR_TYPES, Environment, Integration
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class TestAlertRuleSerializer(TestCase):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1,6 +1,7 @@
 import time
 import uuid
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 import pytz
@@ -86,7 +87,6 @@ from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEven
 from sentry.testutils import BaseIncidentsTest, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 
 

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import timedelta
+from unittest.mock import Mock, patch
 
 from django.core.cache import cache
 from django.db import IntegrityError, transaction
@@ -23,7 +24,6 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock, patch
 
 
 class FetchForOrganizationTest(TestCase):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 from random import randint
+from unittest.mock import Mock, call, patch
 from uuid import uuid4
 
 import pytz
@@ -42,7 +43,6 @@ from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils import json
 from sentry.utils.compat import map
-from sentry.utils.compat.mock import Mock, call, patch
 from sentry.utils.dates import to_timestamp
 
 EMPTY = object()

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
 
 from django.urls import reverse
 from django.utils import timezone
@@ -29,7 +30,6 @@ from sentry.incidents.tasks import (
     send_subscriber_notifications,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock, patch
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -1,10 +1,11 @@
+from unittest.mock import MagicMock, patch
+
 import boto3
 
 from sentry.integrations.aws_lambda.client import gen_aws_client
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import Mock
 from sentry.utils import json
-from sentry.utils.compat.mock import MagicMock, patch
 
 
 class AwsLambdaClientTest(TestCase):

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -1,3 +1,4 @@
+from unittest.mock import ANY, MagicMock, patch
 from urllib.parse import urlencode
 
 from botocore.exceptions import ClientError
@@ -11,7 +12,6 @@ from sentry.pipeline import PipelineView
 from sentry.testutils import IntegrationTestCase
 from sentry.testutils.helpers.faux import Mock
 from sentry.utils.compat import map
-from sentry.utils.compat.mock import ANY, MagicMock, patch
 
 arn = (
     "arn:aws:cloudformation:us-east-2:599817902985:stack/"

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 from django.core.cache import cache
 from django.test import override_settings
 
@@ -17,7 +19,6 @@ from sentry.integrations.aws_lambda.utils import (
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import Mock
-from sentry.utils.compat.mock import MagicMock, patch
 
 
 class ParseArnTest(TestCase):

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Integration, Repository
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class GitHubAppsClientTest(TestCase):

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from urllib.parse import urlencode, urlparse
 
 import responses
@@ -10,7 +11,6 @@ from sentry.models import Integration, OrganizationIntegration, Project, Reposit
 from sentry.plugins.base import plugins
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils import IntegrationTestCase
-from sentry.utils.compat.mock import MagicMock
 from tests.sentry.plugins.testutils import register_mock_plugins, unregister_mock_plugins
 
 

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.test import RequestFactory
 from exam import fixture
@@ -7,7 +9,6 @@ from sentry.models import ExternalIssue, Integration
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class GitHubIssueBasicTest(TestCase):

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 import pytest
 import responses
@@ -10,7 +11,6 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import PluginTestCase
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 from .testutils import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
 

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.utils import timezone
@@ -6,7 +7,6 @@ from django.utils import timezone
 from sentry import options
 from sentry.models import Commit, CommitAuthor, GroupLink, Integration, PullRequest, Repository
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 from .testutils import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import responses
@@ -11,7 +12,6 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.testutils import IntegrationTestCase
-from sentry.utils.compat.mock import patch
 
 
 class GitHubEnterpriseIntegrationTest(IntegrationTestCase):

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.test import RequestFactory
 from exam import fixture
@@ -6,7 +8,6 @@ from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIn
 from sentry.models import ExternalIssue, Integration
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class GitHubEnterpriseIssueBasicTest(TestCase):

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -1,11 +1,11 @@
 from datetime import datetime
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.utils import timezone
 
 from sentry.models import Commit, CommitAuthor, Integration, PullRequest, Repository
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 from .testutils import (
     PULL_REQUEST_CLOSED_EVENT_EXAMPLE,

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import responses
@@ -12,7 +13,6 @@ from sentry.models import (
     Repository,
 )
 from sentry.testutils import IntegrationTestCase
-from sentry.utils.compat.mock import Mock, patch
 
 
 class GitlabIntegrationTest(IntegrationTestCase):

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 import responses
 
 from sentry.integrations.jira.client import JiraCloud
 from sentry.models import Integration
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 
 class StubJiraCloud(JiraCloud):

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -1,4 +1,5 @@
 import copy
+from unittest import mock
 
 import pytest
 import responses
@@ -18,7 +19,6 @@ from sentry.testutils import APITestCase, IntegrationTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat import mock
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign
 from tests.fixtures.integrations import StubService

--- a/tests/sentry/integrations/jira/test_issue_hook.py
+++ b/tests/sentry/integrations/jira/test_issue_hook.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from django.utils import timezone
 from jwt import ExpiredSignatureError
@@ -6,7 +7,6 @@ from jwt import ExpiredSignatureError
 from sentry.integrations.atlassian_connect import AtlassianConnectValidationError
 from sentry.models import ExternalIssue, Group, GroupLink, Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 
 UNABLE_TO_VERIFY_INSTALLATION = b"Unable to verify installation"

--- a/tests/sentry/integrations/jira/test_ui_hook.py
+++ b/tests/sentry/integrations/jira/test_ui_hook.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from jwt import ExpiredSignatureError
 
 from sentry.integrations.atlassian_connect import AtlassianConnectValidationError
 from sentry.models import Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 
 UNABLE_TO_VERIFY_INSTALLATION = b"Unable to verify installation"

--- a/tests/sentry/integrations/jira/test_uninstalled.py
+++ b/tests/sentry/integrations/jira/test_uninstalled.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
+
 from sentry.constants import ObjectStatus
 from sentry.models import Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 
 class JiraUninstalledTest(APITestCase):

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -5,7 +7,6 @@ from django.urls import reverse
 from sentry.integrations.issues import IssueSyncMixin
 from sentry.models import Integration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 from tests.fixtures.integrations.mock_service import StubService
 
 

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import jwt
 import responses
 from requests.exceptions import ConnectionError
@@ -5,7 +7,6 @@ from requests.exceptions import ConnectionError
 from sentry.integrations.jira_server.integration import JiraServerIntegration
 from sentry.models import OrganizationIntegration
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 
 from . import EXAMPLE_PAYLOAD, get_integration, link_group
 

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import patch
 
 import responses
 from django.http import HttpResponse
@@ -21,7 +22,6 @@ from sentry.models import (
 from sentry.testutils import APITestCase
 from sentry.testutils.asserts import assert_mock_called_once_with_partial
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class BaseEventTest(APITestCase):

--- a/tests/sentry/integrations/msteams/test_client.py
+++ b/tests/sentry/integrations/msteams/test_client.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import responses
@@ -5,7 +6,6 @@ import responses
 from sentry.integrations.msteams.client import MsTeamsClient
 from sentry.models import Integration
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class MsTeamsClientTest(TestCase):

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import responses
@@ -5,7 +6,6 @@ import responses
 from sentry.integrations.msteams import MsTeamsIntegrationProvider
 from sentry.models import Integration, OrganizationIntegration
 from sentry.testutils import IntegrationTestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.signing import sign
 
 team_id = "19:8d46058cda57449380517cc374727f2a@thread.tacv2"

--- a/tests/sentry/integrations/msteams/test_link_identity.py
+++ b/tests/sentry/integrations/msteams/test_link_identity.py
@@ -1,4 +1,5 @@
 import time
+from unittest.mock import patch
 
 import responses
 
@@ -12,7 +13,6 @@ from sentry.models import (
 )
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class MsTeamsIntegrationLinkIdentityTest(TestCase):

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from unittest import mock
 from urllib.parse import urlencode
 
 import responses
@@ -6,7 +7,6 @@ import responses
 from sentry.models import Identity, IdentityProvider, Integration
 from sentry.testutils import APITestCase
 from sentry.utils import jwt
-from sentry.utils.compat import mock
 
 from .test_helpers import (
     DECODED_TOKEN,

--- a/tests/sentry/integrations/pagerduty/test_client.py
+++ b/tests/sentry/integrations/pagerduty/test_client.py
@@ -1,11 +1,11 @@
 import copy
+from unittest.mock import patch
 
 from sentry.api.serializers import ExternalEventSerializer, serialize
 from sentry.models import Integration, PagerDutyService
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 # external_id is the account name in pagerduty
 EXTERNAL_ID = "example-pagerduty"

--- a/tests/sentry/integrations/slack/endpoints/test_action.py
+++ b/tests/sentry/integrations/slack/endpoints/test_action.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import parse_qs
 
 import responses
@@ -24,7 +25,6 @@ from sentry.models import (
 )
 from sentry.testutils import APITestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from tests.sentry.integrations.slack import add_identity, install_slack
 
 

--- a/tests/sentry/integrations/slack/endpoints/test_event.py
+++ b/tests/sentry/integrations/slack/endpoints/test_event.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qsl
 
 import responses
@@ -7,7 +8,6 @@ from sentry.integrations.slack.unfurl import Handler, LinkType, make_type_coerce
 from sentry.models import Identity, IdentityProvider, IdentityStatus
 from sentry.testutils import APITestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import Mock, patch
 from tests.sentry.integrations.slack import get_response_text, install_slack
 
 UNSET = object()

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import parse_qs
 
 import responses
@@ -5,7 +6,6 @@ import responses
 from sentry.models import Activity, Identity, IdentityProvider, IdentityStatus, Integration
 from sentry.notifications.notifications.activity import AssignedActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_deploy.py
+++ b/tests/sentry/integrations/slack/notifications/test_deploy.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 from django.utils import timezone
 
 from sentry.models import Activity, Deploy, Release
 from sentry.notifications.notifications.activity import ReleaseActivityNotification
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -1,3 +1,5 @@
+from unittest import mock
+from unittest.mock import patch
 from urllib.parse import parse_qs
 
 import responses
@@ -27,8 +29,6 @@ from sentry.plugins.base import Notification
 from sentry.tasks.digests import deliver_digest
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
-from sentry.utils.compat import mock
-from sentry.utils.compat.mock import patch
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import NewProcessingIssuesActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import NoteActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import RegressionActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedInReleaseActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import UnassignedActivityNotification
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 from . import SlackActivityNotificationTest, get_attachment, send_notification
 

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import urlencode
 
 from sentry import options
@@ -9,7 +10,6 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_options
 from sentry.utils import json
 from sentry.utils.cache import memoize
-from sentry.utils.compat import mock
 
 
 class SlackRequestTest(TestCase):

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from uuid import uuid4
 
 import responses
@@ -14,7 +15,6 @@ from sentry.models import Rule
 from sentry.receivers.rules import DEFAULT_RULE_LABEL
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from tests.sentry.integrations.slack import install_slack
 
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.http.request import QueryDict
 from django.test import RequestFactory
@@ -11,7 +13,6 @@ from sentry.integrations.slack.message_builder.issues import build_group_attachm
 from sentry.integrations.slack.unfurl import LinkType, UnfurlableUrl, link_handlers, match_link
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from tests.sentry.integrations.slack import install_slack
 
 

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -1,4 +1,5 @@
 from time import time
+from unittest import mock
 
 import responses
 
@@ -7,7 +8,6 @@ from sentry.identity.oauth2 import OAuth2Provider
 from sentry.integrations.client import ApiClient, OAuth2RefreshMixin
 from sentry.models import Identity, IdentityProvider
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class ApiClientTest(TestCase):

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry.integrations.example import AliasedIntegrationProvider, ExampleIntegrationProvider
 from sentry.integrations.gitlab.integration import GitlabIntegrationProvider
 from sentry.models import (
@@ -10,7 +12,6 @@ from sentry.models import (
 from sentry.plugins.base import plugins
 from sentry.plugins.bases.issue2 import IssuePlugin2
 from sentry.testutils import IntegrationTestCase
-from sentry.utils.compat.mock import patch
 
 
 class ExamplePlugin(IssuePlugin2):

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from unittest import mock
 
 from django.urls import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
@@ -9,7 +10,6 @@ from sentry.models.grouplink import GroupLink
 from sentry.models.integration import Integration
 from sentry.models.rule import Rule
 from sentry.testutils import RuleTestCase
-from sentry.utils.compat import mock
 from tests.fixtures.integrations.jira import MockJira
 
 RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -15,7 +16,6 @@ from sentry.models import (
 from sentry.plugins.base import plugins
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
 from sentry.testutils.helpers import with_feature
-from sentry.utils.compat.mock import Mock, patch
 from tests.sentry.plugins.testutils import (
     VstsPlugin,
     register_mock_plugins,

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -1,4 +1,5 @@
 from time import time
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qs
 
 import responses
@@ -8,7 +9,6 @@ from sentry.identity.vsts.provider import VSTSIdentityProvider, VSTSOAuth2Callba
 from sentry.integrations.vsts.integration import AccountConfigView, AccountForm
 from sentry.models import Identity, IdentityProvider
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock, patch
 from sentry.utils.http import absolute_uri
 
 

--- a/tests/sentry/integrations/vsts/test_webhooks.py
+++ b/tests/sentry/integrations/vsts/test_webhooks.py
@@ -1,4 +1,5 @@
 from time import time
+from unittest.mock import patch
 
 import responses
 
@@ -14,7 +15,6 @@ from sentry.models import (
     Integration,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 
 from .testutils import (

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 from django.urls import reverse
@@ -8,7 +9,6 @@ from sentry.integrations.vsts_extension import (
     VstsExtensionIntegrationProvider,
 )
 from sentry.models import Integration
-from sentry.utils.compat.mock import patch
 from tests.sentry.integrations.vsts.test_integration import FULL_SCOPES
 from tests.sentry.integrations.vsts.testutils import VstsIntegrationTestCase
 

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -4,6 +4,7 @@ import unittest
 import zipfile
 from copy import deepcopy
 from io import BytesIO
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 import responses
@@ -35,7 +36,6 @@ from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, update_artifact_i
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
-from sentry.utils.compat.mock import ANY, MagicMock, call, patch
 from sentry.utils.strings import truncatechars
 
 base64_sourcemap = "data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiZ2VuZXJhdGVkLmpzIiwic291cmNlcyI6WyIvdGVzdC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiO0FBQUEiLCJzb3VyY2VzQ29udGVudCI6WyJjb25zb2xlLmxvZyhcImhlbGxvLCBXb3JsZCFcIikiXX0="

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.conf import settings
 
 from sentry.loader.browsersdkversion import (
@@ -6,7 +8,6 @@ from sentry.loader.browsersdkversion import (
     get_highest_selected_browser_sdk_version,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 MOCK_VERSIONS = [
     "4.0.0-rc.1",

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -1,9 +1,9 @@
 import logging
+from unittest import mock
 
 import pytest
 
 from sentry.logging.handlers import StructLogHandler
-from sentry.utils.compat import mock
 
 
 @pytest.fixture

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,5 +1,6 @@
 from collections import Counter
 from datetime import datetime
+from unittest import mock
 
 import pytz
 from django.contrib.auth.models import AnonymousUser
@@ -44,7 +45,6 @@ from sentry.rules.processor import RuleFuture
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.compat import mock
 from sentry.utils.email import MessageBuilder, get_email_addresses
 from sentry_plugins.opsgenie.plugin import OpsGeniePlugin
 from tests.sentry.mail import make_event_data, send_notification

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -1,6 +1,7 @@
+from unittest.mock import call, patch
+
 from sentry.mediators.sentry_app_components import Preparer
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import call, patch
 
 
 class TestPreparerIssueLink(TestCase):

--- a/tests/sentry/mediators/sentry_app_installation_tokens/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installation_tokens/test_creator.py
@@ -1,10 +1,10 @@
 from datetime import date
+from unittest.mock import patch
 
 from sentry.mediators.sentry_app_installation_tokens import Creator
 from sentry.mediators.sentry_app_installations import Creator as SentryAppInstallationCreator
 from sentry.models import AuditLogEntry, SentryAppInstallation, SentryAppInstallationToken
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestCreatorBase(TestCase):

--- a/tests/sentry/mediators/sentry_app_installation_tokens/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installation_tokens/test_destroyer.py
@@ -1,7 +1,8 @@
+from unittest.mock import patch
+
 from sentry.mediators.sentry_app_installation_tokens import Destroyer
 from sentry.models import ApiToken, AuditLogEntry, SentryAppInstallation, SentryAppInstallationToken
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestDestroyer(TestCase):

--- a/tests/sentry/mediators/sentry_app_installations/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_creator.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 
 from sentry.constants import SentryAppInstallationStatus
@@ -10,7 +12,6 @@ from sentry.models import (
     ServiceHookProject,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestCreator(TestCase):

--- a/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_destroyer.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.db import connection
 from requests.exceptions import RequestException
@@ -13,7 +15,6 @@ from sentry.models import (
     ServiceHook,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestDestroyer(TestCase):

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -1,11 +1,11 @@
 from collections import namedtuple
+from unittest.mock import patch
 
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.sentry_app_installations import InstallationNotifier
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import faux
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
 

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.db import IntegrityError
 
 from sentry.mediators.sentry_apps import Creator
@@ -11,7 +13,6 @@ from sentry.models import (
     User,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestCreator(TestCase):

--- a/tests/sentry/mediators/sentry_apps/test_destroyer.py
+++ b/tests/sentry/mediators/sentry_apps/test_destroyer.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.db import connection
 
@@ -11,7 +13,6 @@ from sentry.models import (
     User,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestDestroyer(TestCase):

--- a/tests/sentry/mediators/sentry_apps/test_internal_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_internal_creator.py
@@ -1,8 +1,9 @@
+from unittest.mock import MagicMock, patch
+
 from sentry.mediators.sentry_apps import InternalCreator
 from sentry.models import AuditLogEntryEvent, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import faux
-from sentry.utils.compat.mock import MagicMock, patch
 
 
 class TestInternalCreator(TestCase):

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -1,11 +1,11 @@
 import logging
 import types
+from unittest.mock import PropertyMock, patch
 
 from sentry.mediators import Mediator, Param
 from sentry.models import User
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import faux
-from sentry.utils.compat.mock import PropertyMock, patch
 
 
 class Double:

--- a/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
+++ b/tests/sentry/mediators/token_exchange/test_grant_exchanger.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import ApiApplication, ApiGrant, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestGrantExchanger(TestCase):

--- a/tests/sentry/mediators/token_exchange/test_refresher.py
+++ b/tests/sentry/mediators/token_exchange/test_refresher.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import GrantExchanger, Refresher
 from sentry.models import ApiApplication, ApiToken, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestRefresher(TestCase):

--- a/tests/sentry/mediators/token_exchange/test_validator.py
+++ b/tests/sentry/mediators/token_exchange/test_validator.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import Validator
 from sentry.models import SentryApp
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class TestValidator(TestCase):

--- a/tests/sentry/metrics/test_datadog.py
+++ b/tests/sentry/metrics/test_datadog.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from datadog.util.hostname import get_hostname
 
 from sentry.metrics.datadog import DatadogMetricsBackend
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class DatadogMetricsBackendTest(TestCase):

--- a/tests/sentry/metrics/test_statsd.py
+++ b/tests/sentry/metrics/test_statsd.py
@@ -1,6 +1,7 @@
+from unittest.mock import patch
+
 from sentry.metrics.statsd import StatsdMetricsBackend
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class StatsdMetricsBackendTest(TestCase):

--- a/tests/sentry/middleware/test_health.py
+++ b/tests/sentry/middleware/test_health.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.test import RequestFactory
 from exam import fixture
 
@@ -5,7 +7,6 @@ from sentry.middleware.health import HealthCheck
 from sentry.status_checks import Problem
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class HealthCheckTest(TestCase):

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 from django.test import RequestFactory
 from exam import fixture
 
 from sentry.middleware.stats import RequestTimingMiddleware, add_request_metric_tags
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import Mock
-from sentry.utils.compat.mock import patch
 
 
 class RequestTimingMiddlewareTest(TestCase):

--- a/tests/sentry/models/test_groupassignee.py
+++ b/tests/sentry/models/test_groupassignee.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from sentry.integrations.example.integration import ExampleIntegration
@@ -11,7 +13,6 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class GroupAssigneeTestCase(TestCase):

--- a/tests/sentry/models/test_groupinbox.py
+++ b/tests/sentry/models/test_groupinbox.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry.models import (
     Activity,
     GroupInbox,
@@ -7,7 +9,6 @@ from sentry.models import (
     remove_group_from_inbox,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class GroupInboxTestCase(TestCase):

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -1,5 +1,6 @@
 import itertools
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -8,7 +9,6 @@ from sentry import tsdb
 from sentry.models import Group, GroupSnooze
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class GroupSnoozeTest(TestCase, SnubaTestCase):

--- a/tests/sentry/models/test_monitor.py
+++ b/tests/sentry/models/test_monitor.py
@@ -1,10 +1,10 @@
 from datetime import datetime
+from unittest.mock import patch
 
 from django.utils import timezone
 
 from sentry.models import Monitor, MonitorFailure, MonitorType, ScheduleType
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class MonitorTestCase(TestCase):

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -1,4 +1,5 @@
 import copy
+from unittest import mock
 from uuid import uuid4
 
 from django.core import mail
@@ -33,7 +34,6 @@ from sentry.models import (
     User,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class OrganizationTest(TestCase):

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core import mail
 from django.utils import timezone
@@ -6,7 +7,6 @@ from django.utils import timezone
 from sentry.auth import manager
 from sentry.models import INVITE_DAYS_VALID, InviteStatus, OrganizationMember
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationMemberTest(TestCase):

--- a/tests/sentry/models/test_recentsearch.py
+++ b/tests/sentry/models/test_recentsearch.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 
 from sentry.models.recentsearch import RecentSearch, remove_excess_recent_searches
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.hashlib import md5_text
 
 

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.utils import timezone
 from freezegun import freeze_time
@@ -32,7 +34,6 @@ from sentry.models import (
 )
 from sentry.search.events.filter import parse_semver
 from sentry.testutils import SetRefsTestCase, TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.strings import truncatechars
 
 

--- a/tests/sentry/net/test_socket.py
+++ b/tests/sentry/net/test_socket.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.core.exceptions import SuspiciousOperation
 from django.test import override_settings
@@ -10,7 +12,6 @@ from sentry.net.socket import (
 )
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_blacklist
-from sentry.utils.compat.mock import patch
 
 
 class SocketTest(TestCase):

--- a/tests/sentry/nodestore/bigtable/backend/tests.py
+++ b/tests/sentry/nodestore/bigtable/backend/tests.py
@@ -1,12 +1,12 @@
 import os
 from contextlib import contextmanager
+from unittest import mock
 
 import pytest
 from google.oauth2.credentials import Credentials
 from google.rpc.status_pb2 import Status
 
 from sentry.nodestore.bigtable.backend import BigtableKVStorage, BigtableNodeStorage
-from sentry.utils.compat import mock
 
 
 class MockedBigtableKVStorage(BigtableKVStorage):

--- a/tests/sentry/nodestore/django/backend/tests.py
+++ b/tests/sentry/nodestore/django/backend/tests.py
@@ -1,5 +1,6 @@
 import pickle
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -7,7 +8,6 @@ from django.utils import timezone
 from sentry.nodestore.base import json_dumps
 from sentry.nodestore.django.backend import DjangoNodeStorage
 from sentry.nodestore.django.models import Node
-from sentry.utils.compat import mock
 from sentry.utils.strings import compress
 
 

--- a/tests/sentry/notifications/test_digests.py
+++ b/tests/sentry/notifications/test_digests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 
 import sentry
@@ -8,7 +10,6 @@ from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 USER_COUNT = 2
 

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
 from exam import around, fixture
@@ -15,7 +17,6 @@ from sentry.options.manager import (
 )
 from sentry.options.store import OptionsStore
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.types import Int, String
 
 

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from uuid import uuid1
 
 import pytest
@@ -8,7 +9,6 @@ from exam import before, fixture
 from sentry.models import Option
 from sentry.options.store import OptionsStore
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class OptionsStoreTest(TestCase):

--- a/tests/sentry/plugins/bases/issue/tests.py
+++ b/tests/sentry/plugins/bases/issue/tests.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 from sentry.models import User
 from sentry.plugins.bases import IssueTrackingPlugin
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 from social_auth.models import UserSocialAuth
 
 

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 from sentry.models import GroupMeta, User
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat import mock
 from social_auth.models import UserSocialAuth
 
 

--- a/tests/sentry/plugins/helpers/tests.py
+++ b/tests/sentry/plugins/helpers/tests.py
@@ -1,6 +1,7 @@
+from unittest import mock
+
 from sentry.plugins.helpers import get_option, set_option, unset_option
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class SentryPluginTest(TestCase):

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -1,4 +1,5 @@
 import time
+from unittest import mock
 
 from exam import fixture, patcher
 
@@ -6,7 +7,7 @@ from sentry.constants import DataCategory
 from sentry.quotas.base import QuotaConfig, QuotaScope
 from sentry.quotas.redis import RedisQuota, is_rate_limited
 from sentry.testutils import TestCase
-from sentry.utils.compat import map, mock
+from sentry.utils.compat import map
 from sentry.utils.redis import clusters
 
 

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -1,4 +1,5 @@
 from hashlib import sha1
+from unittest.mock import patch
 from uuid import uuid4
 
 from sentry.models import (
@@ -22,7 +23,6 @@ from sentry.models import (
     add_group_to_inbox,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class ResolveGroupResolutionsTest(TestCase):

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from sentry.constants import SentryAppInstallationStatus
 from sentry.models import Commit, GroupAssignee, GroupLink, Release, Repository
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.faux import faux
-from sentry.utils.compat.mock import patch
 
 
 # This testcase needs to be an APITestCase because all of the logic to resolve

--- a/tests/sentry/receivers/test_signals.py
+++ b/tests/sentry/receivers/test_signals.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from django.utils import timezone
 
 from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
 from sentry.signals import inbox_in, inbox_out, issue_mark_reviewed, issue_unignored
 from sentry.testutils import SnubaTestCase, TestCase
-from sentry.utils.compat.mock import patch
 
 
 class SignalsTest(TestCase, SnubaTestCase):

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 from exam import fixture
 
 from sentry.models import OrganizationMember, Project
 from sentry.signals import event_processed, transaction_processed
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 
 class RecordFirstTransactionTest(TestCase):

--- a/tests/sentry/rules/actions/test_notify_event.py
+++ b/tests/sentry/rules/actions/test_notify_event.py
@@ -1,7 +1,8 @@
+from unittest.mock import MagicMock
+
 from sentry.rules.actions.notify_event import NotifyEventAction
 from sentry.rules.actions.services import LegacyPluginService
 from sentry.testutils.cases import RuleTestCase
-from sentry.utils.compat.mock import MagicMock
 
 
 class NotifyEventActionTest(RuleTestCase):

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -1,9 +1,10 @@
+from unittest.mock import MagicMock, patch
+
 from django.utils import timezone
 
 from sentry.rules.actions.notify_event_service import NotifyEventServiceAction
 from sentry.tasks.sentry_apps import notify_sentry_app
 from sentry.testutils.cases import RuleTestCase
-from sentry.utils.compat.mock import MagicMock, patch
 
 
 class NotifyEventServiceActionTest(RuleTestCase):

--- a/tests/sentry/rules/filters/test_age_comparison.py
+++ b/tests/sentry/rules/filters/test_age_comparison.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytz
 from django.utils import timezone
 
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.testutils.cases import RuleTestCase
-from sentry.utils.compat import mock
 
 
 class AgeComparisonFilterTest(RuleTestCase):

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from unittest import mock
+from unittest.mock import patch
 
 from django.core.cache import cache
 from django.db import DEFAULT_DB_ALIAS, connections
@@ -12,7 +13,6 @@ from sentry.rules import init_registry
 from sentry.rules.filters.base import EventFilter
 from sentry.rules.processor import RuleProcessor
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 EMAIL_ACTION_DATA = {
     "id": "sentry.mail.actions.NotifyEmailAction",

--- a/tests/sentry/runner/commands/test_killswitches.py
+++ b/tests/sentry/runner/commands/test_killswitches.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 from sentry.killswitches import KillswitchInfo
 from sentry.runner.commands.killswitches import killswitches
 from sentry.testutils import CliTestCase
-from sentry.utils.compat import mock
 
 OPTION = "store.load-shed-group-creation-projects"
 

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
 from django.utils import timezone
@@ -23,7 +24,6 @@ from sentry.search.utils import (
     tokenize_query,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 def test_get_numeric_field_value():

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -27,7 +28,6 @@ from sentry.search.events.constants import (
 from sentry.snuba import discover
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import Dataset, get_array_column_alias
 

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -1,6 +1,7 @@
 import unittest
 from copy import deepcopy
 from datetime import timedelta
+from unittest import mock
 
 import pytz
 from dateutil.parser import parse as parse_date
@@ -18,7 +19,6 @@ from sentry.snuba.query_subscription_consumer import (
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import TestCase
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 
 class BaseQuerySubscriptionTest:

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -1,4 +1,5 @@
 import abc
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -18,7 +19,6 @@ from sentry.snuba.tasks import (
 )
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import Mock, patch
 from sentry.utils.snuba import _snuba_pool
 
 

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import ANY, Mock, patch
 
 from django.utils import timezone
 
@@ -23,7 +24,6 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.utils.cache import cache
-from sentry.utils.compat.mock import ANY, Mock, patch
 
 
 class EventMatcher:

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -1,6 +1,7 @@
+from unittest import mock
+
 from sentry.tasks.process_buffer import process_incr, process_pending
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 
 
 class ProcessIncrTest(TestCase):

--- a/tests/sentry/tasks/test_activity.py
+++ b/tests/sentry/tasks/test_activity.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from sentry.models import Activity
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.testutils import PluginTestCase
 from sentry.types.activity import ActivityType
-from sentry.utils.compat import mock
 
 
 class BasicPreprocessorPlugin(NotificationPlugin):

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -1,6 +1,7 @@
 import io
 import os
 from hashlib import sha1
+from unittest.mock import patch
 
 from django.core.files.base import ContentFile
 
@@ -16,7 +17,6 @@ from sentry.tasks.assemble import (
     get_assemble_status,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class BaseAssembleTest(TestCase):

--- a/tests/sentry/tasks/test_auto_resolve_issues.py
+++ b/tests/sentry/tasks/test_auto_resolve_issues.py
@@ -1,12 +1,12 @@
 from datetime import timedelta
 from time import time
+from unittest.mock import patch
 
 from django.utils import timezone
 
 from sentry.models import Group, GroupStatus
 from sentry.tasks.auto_resolve_issues import schedule_auto_resolution
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class ScheduleAutoResolutionTest(TestCase):

--- a/tests/sentry/tasks/test_beacon.py
+++ b/tests/sentry/tasks/test_beacon.py
@@ -1,4 +1,5 @@
 import platform
+from unittest.mock import patch
 from uuid import uuid4
 
 import responses
@@ -9,7 +10,6 @@ from sentry.models import Broadcast
 from sentry.tasks.beacon import BEACON_URL, send_beacon, send_beacon_metric
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class SendBeaconTest(TestCase):

--- a/tests/sentry/tasks/test_check_auth.py
+++ b/tests/sentry/tasks/test_check_auth.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -7,7 +8,6 @@ from sentry.auth.providers.dummy import DummyProvider
 from sentry.models import AuthIdentity, AuthProvider, OrganizationMember
 from sentry.tasks.check_auth import AUTH_CHECK_INTERVAL, check_auth, check_auth_identity
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class CheckAuthTest(TestCase):

--- a/tests/sentry/tasks/test_clear_expired_snoozes.py
+++ b/tests/sentry/tasks/test_clear_expired_snoozes.py
@@ -1,11 +1,11 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 
 from sentry.models import Group, GroupSnooze, GroupStatus
 from sentry.tasks.clear_expired_snoozes import clear_expired_snoozes
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class ClearExpiredSnoozesTest(TestCase):

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 
 from sentry.app import locks
@@ -13,7 +15,6 @@ from sentry.models import (
 )
 from sentry.tasks.commits import fetch_commits, handle_invalid_identity
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from social_auth.models import UserSocialAuth
 
 

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core import mail
 
 import sentry
@@ -7,7 +9,6 @@ from sentry.models.rule import Rule
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 
 class DeliverDigestTest(TestCase):

--- a/tests/sentry/tasks/test_enqueue_scheduled_jobs.py
+++ b/tests/sentry/tasks/test_enqueue_scheduled_jobs.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -8,7 +9,6 @@ from sentry.models import ScheduledJob
 from sentry.models.scheduledjob import schedule_jobs
 from sentry.tasks.scheduler import enqueue_scheduled_jobs
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class EnqueueScheduledJobsTest(TestCase):

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.utils import timezone
 
 from sentry.models import GroupRelease, Repository
@@ -6,7 +8,6 @@ from sentry.tasks.groupowner import PREFERRED_GROUP_OWNER_AGE, process_suspect_c
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.committers import get_frame_paths, get_serialized_event_file_committers
-from sentry.utils.compat.mock import patch
 
 
 class TestGroupOwners(TestCase):

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Generator
+from unittest import mock
 
 import pytest
 from freezegun import freeze_time
@@ -19,7 +20,6 @@ from sentry.tasks.low_priority_symbolication import (
     excessive_event_rate,
 )
 from sentry.testutils.helpers.task_runner import TaskRunner
-from sentry.utils.compat import mock
 from sentry.utils.services import LazyServiceWrapper
 
 if TYPE_CHECKING:

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry import eventstore, eventstream
 from sentry.models import Group, GroupEnvironment, GroupMeta, GroupRedirect, UserReport
 from sentry.similarity import _make_index_backend
@@ -5,7 +7,6 @@ from sentry.tasks.merge import merge_groups
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import redis
-from sentry.utils.compat.mock import patch
 
 # Use the default redis client as a cluster client in the similarity index
 index = _make_index_backend(redis.clusters.get("default").get_local_client(0))

--- a/tests/sentry/tasks/test_options.py
+++ b/tests/sentry/tasks/test_options.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from sentry.models import Option
 from sentry.options import default_manager, default_store
 from sentry.tasks.options import sync_options
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class SyncOptionsTest(TestCase):

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 import pytest
 
 from sentry.models import ProjectKey, ProjectOption
 from sentry.relay.projectconfig_cache.redis import RedisProjectConfigCache
 from sentry.relay.projectconfig_debounce_cache.redis import RedisProjectConfigDebounceCache
 from sentry.tasks.relay import schedule_update_config_cache
-from sentry.utils.compat.mock import patch
 
 
 def _cache_keys_for_project(project):

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -1,6 +1,7 @@
 import copy
 import functools
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
 import pytz
@@ -37,7 +38,7 @@ from sentry.tasks.reports import (
 from sentry.testutils.cases import OutcomesSnubaTest, SnubaTestCase, TestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format
-from sentry.utils.compat import map, mock
+from sentry.utils.compat import map
 from sentry.utils.dates import floor_to_utc_day, to_datetime, to_timestamp
 from sentry.utils.outcomes import Outcome
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from unittest.mock import patch
 
 import pytest
 from celery import Task
@@ -25,7 +26,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.testutils.helpers.faux import faux
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 
 from sentry.tasks.servicehooks import get_payload_v0, process_service_hook
@@ -5,7 +7,6 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.faux import faux
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class DictContaining:

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -1,4 +1,5 @@
 from time import time
+from unittest import mock
 
 import pytest
 from django.test.utils import override_settings
@@ -12,7 +13,6 @@ from sentry.tasks.store import (
     save_event,
     time_synthetic_monitoring_event,
 )
-from sentry.utils.compat import mock
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
 

--- a/tests/sentry/tasks/test_symbolication.py
+++ b/tests/sentry/tasks/test_symbolication.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from sentry.plugins.base.v2 import Plugin2
@@ -9,7 +11,6 @@ from sentry.tasks.symbolication import (
 )
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.helpers.task_runner import TaskRunner
-from sentry.utils.compat import mock
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
 

--- a/tests/sentry/templatetags/test_sentry_plugins.py
+++ b/tests/sentry/templatetags/test_sentry_plugins.py
@@ -1,8 +1,9 @@
+from unittest.mock import MagicMock
+
 from django.template import engines
 
 from sentry.plugins.base.v2 import Plugin2
 from sentry.testutils import PluginTestCase
-from sentry.utils.compat.mock import MagicMock
 
 
 class SamplePlugin(Plugin2):

--- a/tests/sentry/test_constants.py
+++ b/tests/sentry/test_constants.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from sentry.constants import (
     INTEGRATION_ID_TO_PLATFORM_DATA,
     get_integration_id_for_event,
     get_integration_id_for_marketing_slug,
 )
-from sentry.utils.compat.mock import patch
 
 mock_integration_ids = {
     "java": {},

--- a/tests/sentry/test_http.py
+++ b/tests/sentry/test_http.py
@@ -1,5 +1,6 @@
 import platform
 import tempfile
+from unittest.mock import patch
 
 import pytest
 import responses
@@ -8,7 +9,6 @@ from urllib3.util.connection import HAS_IPV6
 
 from sentry import http
 from sentry.testutils.helpers import override_blacklist
-from sentry.utils.compat.mock import patch
 
 
 @responses.activate

--- a/tests/sentry/testutils/helpers/test_faux.py
+++ b/tests/sentry/testutils/helpers/test_faux.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from sentry.testutils.helpers.faux import faux
-from sentry.utils.compat.mock import patch
 
 
 def fakefunc(*args, **kwargs):

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -1,11 +1,10 @@
 import itertools
 from datetime import datetime, timedelta
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytz
 
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, BaseTSDB
-from sentry.utils.compat import mock
 from sentry.utils.dates import to_timestamp
 
 

--- a/tests/sentry/utils/email/test_message_builder.py
+++ b/tests/sentry/utils/email/test_message_builder.py
@@ -1,11 +1,11 @@
 import functools
+from unittest.mock import patch
 
 from django.core import mail
 
 from sentry import options
 from sentry.models import GroupEmailThread, User, UserEmail, UserOption
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.email import MessageBuilder
 from sentry.utils.email.faker import create_fake_email
 

--- a/tests/sentry/utils/email/test_send_mail.py
+++ b/tests/sentry/utils/email/test_send_mail.py
@@ -1,5 +1,6 @@
+from unittest.mock import patch
+
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.email import send_mail
 
 

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from django.http import HttpRequest
 from exam import fixture
@@ -6,7 +7,6 @@ from exam import fixture
 from sentry import options
 from sentry.models import Project
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 from sentry.utils.http import (
     absolute_uri,
     get_origins,

--- a/tests/sentry/utils/locking/test_lock.py
+++ b/tests/sentry/utils/locking/test_lock.py
@@ -1,9 +1,9 @@
 import unittest
+from unittest import mock
 from unittest.mock import call, patch
 
 import pytest
 
-from sentry.utils.compat import mock
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.locking.backends import LockBackend
 from sentry.utils.locking.lock import Lock

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import timedelta
+from unittest.mock import Mock
 from uuid import uuid4
 
 from django.utils import timezone
@@ -17,7 +18,6 @@ from sentry.utils.committers import (
     score_path_match_length,
     tokenize_path,
 )
-from sentry.utils.compat.mock import Mock
 
 # TODO(lb): Tests are still needed for _get_committers and _get_event_file_commiters
 

--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -3,10 +3,10 @@ from concurrent.futures import CancelledError, Future
 from contextlib import contextmanager
 from queue import Full
 from threading import Event
+from unittest import mock
 
 import pytest
 
-from sentry.utils.compat import mock
 from sentry.utils.concurrent import (
     FutureSet,
     SynchronousExecutor,

--- a/tests/sentry/utils/test_cursors.py
+++ b/tests/sentry/utils/test_cursors.py
@@ -1,6 +1,6 @@
 import math
+from unittest.mock import Mock
 
-from sentry.utils.compat.mock import Mock
 from sentry.utils.cursors import Cursor, build_cursor
 
 

--- a/tests/sentry/utils/test_metrics.py
+++ b/tests/sentry/utils/test_metrics.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 import pytest
 
 from sentry.utils import metrics
-from sentry.utils.compat import mock
 
 
 def test_timer_success():

--- a/tests/sentry/utils/test_redis.py
+++ b/tests/sentry/utils/test_redis.py
@@ -1,12 +1,11 @@
 import functools
 import logging
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 from django.utils.functional import SimpleLazyObject
 
 from sentry.exceptions import InvalidConfiguration
-from sentry.utils.compat import mock
 from sentry.utils.redis import (
     ClusterManager,
     _RedisCluster,

--- a/tests/sentry/utils/test_request_cache.py
+++ b/tests/sentry/utils/test_request_cache.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.core.handlers.wsgi import WSGIHandler
 from django.core.signals import request_finished
 from django.http import HttpRequest
@@ -5,7 +7,6 @@ from django.utils import timezone
 
 from sentry import app
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.request_cache import clear_cache, request_cache
 
 

--- a/tests/sentry/utils/test_retries.py
+++ b/tests/sentry/utils/test_retries.py
@@ -1,8 +1,7 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 
-from sentry.utils.compat import mock
 from sentry.utils.retries import ConditionalRetryPolicy, RetryException, TimedRetryPolicy
 
 

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -1,12 +1,12 @@
 import unittest
 from collections import OrderedDict
 from functools import partial
+from unittest.mock import Mock, patch
 
 import pytest
 
 from sentry.testutils import TestCase
 from sentry.utils.canonical import CanonicalKeyDict
-from sentry.utils.compat.mock import Mock, patch
 from sentry.utils.safe import (
     get_path,
     safe_execute,

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
 import pytz
@@ -7,7 +8,6 @@ from django.utils import timezone
 
 from sentry.models import GroupRelease, Project, Release
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 from sentry.utils.snuba import (
     Dataset,
     SnubaQueryParams,

--- a/tests/sentry/utils/test_urllib3_timeout.py
+++ b/tests/sentry/utils/test_urllib3_timeout.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 import pytest
 from urllib3 import HTTPConnectionPool
 from urllib3.exceptions import HTTPError, ReadTimeoutError
 
-from sentry.utils.compat import mock
 from sentry.utils.snuba import RetrySkipTimeout
 
 

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -1,9 +1,10 @@
+from unittest import mock
+
 from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 
 class CrossDomainXmlTest(TestCase):

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import urlencode
 
 import pytest
@@ -12,7 +13,6 @@ from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import OrganizationMember, User
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 
 # TODO(dcramer): need tests for SSO behavior and single org behavior

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.urls import reverse
@@ -8,7 +9,6 @@ from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Login, OAuth2Prov
 from sentry.models import AuthProvider
 from sentry.testutils import AuthProviderTestCase
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 
 class DummyOAuth2Login(OAuth2Login):

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from urllib.parse import urlencode
 
 from django.test import override_settings
@@ -16,7 +17,6 @@ from sentry.models import (
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import with_feature
 from sentry.utils import json
-from sentry.utils.compat import mock
 
 
 # TODO(dcramer): this is an integration test and repeats tests from

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -1,4 +1,5 @@
 import base64
+from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
@@ -12,7 +13,7 @@ from sentry.auth.providers.saml2.provider import HAS_SAML2, Attributes, SAML2Pro
 from sentry.models import AuditLogEntry, AuditLogEntryEvent, AuthProvider, Organization
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat import map, mock
+from sentry.utils.compat import map
 
 dummy_provider_config = {
     "idp": {

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from django.conf import settings
 from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 
 
 class JavaScriptSdkLoaderTest(TestCase):

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -1,7 +1,8 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.testutils import TestCase
-from sentry.utils.compat import mock
 from sentry.utils.email import group_id_to_email
 
 body_plain = "foo bar"

--- a/tests/sentry/web/frontend/test_msteams_extension.py
+++ b/tests/sentry/web/frontend/test_msteams_extension.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from django.core.signing import SignatureExpired
 
 from sentry.models import OrganizationMember
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import patch
 from sentry.utils.signing import sign
 from sentry.web.frontend.msteams_extension_configuration import MsTeamsExtensionConfigurationView
 

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.db import models
 from django.urls import reverse
@@ -14,7 +16,6 @@ from sentry.models import (
     SentryAppInstallationForProvider,
 )
 from sentry.testutils import AuthProviderTestCase, PermissionTestCase
-from sentry.utils.compat.mock import patch
 
 
 class OrganizationAuthSettingsPermissionTest(PermissionTestCase):

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -1,5 +1,6 @@
 import hmac
 from hashlib import sha256
+from unittest.mock import patch
 
 from django.urls import reverse
 from exam import fixture
@@ -7,7 +8,6 @@ from exam import fixture
 from sentry.models import ProjectOption
 from sentry.testutils import TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 
 
 class ReleaseWebhookTestBase(TestCase):

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -1,9 +1,10 @@
+from unittest.mock import patch
+
 from botocore.client import ClientError
 from exam import fixture
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry_plugins.amazon_sqs.plugin import AmazonSQSPlugin
 
 

--- a/tests/sentry_plugins/github/test_provider.py
+++ b/tests/sentry_plugins/github/test_provider.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
+
 import responses
 from exam import fixture
 
 from sentry.models import Integration, OrganizationIntegration, Repository
 from sentry.testutils import PluginTestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import patch
 from sentry_plugins.github.client import GitHubAppsClient, GitHubClient
 from sentry_plugins.github.plugin import GitHubAppsRepositoryProvider, GitHubRepositoryProvider
 from sentry_plugins.github.testutils import (

--- a/tests/sentry_plugins/heroku/test_plugin.py
+++ b/tests/sentry_plugins/heroku/test_plugin.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import Mock, patch
 
 from django.utils import timezone
 
@@ -15,7 +16,6 @@ from sentry.models import (
     User,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock, patch
 from sentry_plugins.heroku.plugin import HerokuReleaseHook
 
 

--- a/tests/sentry_plugins/test_client.py
+++ b/tests/sentry_plugins/test_client.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 import responses
 
@@ -8,7 +10,6 @@ from sentry.shared_integrations.exceptions import (
     UnsupportedResponseType,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat.mock import Mock
 from sentry_plugins.client import ApiClient, AuthApiClient
 
 

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.models import Environment, GroupInboxReason, Release
 from sentry.models.groupinbox import add_group_to_inbox, remove_group_from_inbox
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -1,8 +1,9 @@
+from unittest.mock import patch
+
 from django.urls import NoReverseMatch, reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 
 
 class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import mock
 from uuid import uuid4
 
 from django.urls import reverse
@@ -8,7 +9,6 @@ from rest_framework.exceptions import ParseError
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,10 +1,11 @@
+from unittest import mock
+
 from django.urls import reverse
 from pytz import utc
 from rest_framework.exceptions import ParseError
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import timedelta
+from unittest import mock, zip
 from uuid import uuid4
 
 import dateutil.parser as parse_date
@@ -12,7 +13,6 @@ from sentry.models.transaction_threshold import ProjectTransactionThreshold, Tra
 from sentry.snuba.discover import OTHER_KEY
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock, zip
 from sentry.utils.samples import load_data
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import timedelta
-from unittest import mock, zip
+from unittest import mock
 from uuid import uuid4
 
 import dateutil.parser as parse_date

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1,4 +1,5 @@
 from base64 import b64encode
+from unittest import mock, zip
 
 import pytest
 from django.urls import reverse
@@ -28,7 +29,6 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat import mock, zip
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import QueryExecutionError, QueryIllegalTypeOfArgument, RateLimitExceeded
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1,5 +1,5 @@
 from base64 import b64encode
-from unittest import mock, zip
+from unittest import mock
 
 import pytest
 from django.urls import reverse

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from dateutil.parser import parse as parse_datetime
@@ -48,7 +49,6 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat.mock import Mock, patch
 
 
 class GroupListTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 
 
 class OrganizationTagsTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1,5 +1,6 @@
 import time
 from datetime import timedelta
+from unittest.mock import Mock, patch
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -33,7 +34,6 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils import json
-from sentry.utils.compat.mock import Mock, patch
 
 
 class GroupListTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -1,5 +1,7 @@
 import time
 from datetime import timedelta
+from unittest import mock
+from unittest.mock import patch
 
 import pytz
 from django.utils import timezone
@@ -27,8 +29,6 @@ from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.cache import cache
-from sentry.utils.compat import mock
-from sentry.utils.compat.mock import patch
 from sentry.utils.hashlib import hash_values
 
 

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -1,13 +1,13 @@
 import logging
 import time
 from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
 
 from sentry.event_manager import EventManager
 from sentry.eventstream.kafka import KafkaEventStream
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.utils import json, snuba
-from sentry.utils.compat.mock import Mock, patch
 from sentry.utils.samples import load_data
 
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 from hashlib import md5
+from unittest import mock
 
 import pytest
 import pytz
@@ -27,7 +28,6 @@ from sentry.search.snuba.backend import (
 from sentry.search.snuba.executors import InvalidQueryForExecutor
 from sentry.testutils import SnubaTestCase, TestCase, xfail_if_not_postgres
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import mock
 from sentry.utils.snuba import SENTRY_SNUBA_MAP, Dataset, SnubaError
 
 

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -2,6 +2,7 @@ import time
 from copy import deepcopy
 from datetime import timedelta
 from unittest import mock
+from unittest.mock import Mock, call
 from uuid import uuid4
 
 import pytz
@@ -20,7 +21,6 @@ from sentry.snuba.query_subscription_consumer import (
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.utils import json
-from sentry.utils.compat.mock import Mock, call
 
 
 class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -5,6 +5,7 @@ import logging
 import uuid
 from collections import OrderedDict
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 from django.utils import timezone
@@ -27,7 +28,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import redis
 from sentry.utils.compat import map
-from sentry.utils.compat.mock import patch
 from sentry.utils.dates import to_timestamp
 
 # Use the default redis client as a cluster client in the similarity index

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytz
 
@@ -7,7 +8,6 @@ from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.tsdb.base import TSDBModel
 from sentry.tsdb.snuba import SnubaTSDB
-from sentry.utils.compat.mock import patch
 from sentry.utils.dates import to_timestamp
 
 

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -1,5 +1,6 @@
 import zipfile
 from io import BytesIO
+from unittest.mock import patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -10,7 +11,6 @@ from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models import EventAttachment, File
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
-from sentry.utils.compat.mock import patch
 from tests.symbolicator import get_fixture_path, insta_snapshot_stacktrace_data
 
 # IMPORTANT:

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -1,6 +1,7 @@
 import re
 import zipfile
 from io import BytesIO
+from unittest.mock import patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -10,7 +11,6 @@ from sentry import eventstore
 from sentry.models import File, ProjectDebugFile
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat.mock import patch
 from tests.symbolicator import get_fixture_path, insta_snapshot_stacktrace_data
 
 # IMPORTANT:

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -1,5 +1,6 @@
 import zipfile
 from io import BytesIO
+from unittest.mock import patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -8,7 +9,6 @@ from django.urls import reverse
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models import EventAttachment, File
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
-from sentry.utils.compat.mock import patch
 from tests.symbolicator import get_fixture_path
 
 # IMPORTANT:


### PR DESCRIPTION
Back in Python 3.6, we couldn't remove the mock backport due to Python issue37972. Now, we can swap it out for the stdlib. 