### PR TITLE
feat(workflow): Sort all team stats tables by trend

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -20,6 +20,8 @@ import type {Color} from 'app/utils/theme';
 
 import {transactionSummaryRouteWithQuery} from '../../performance/transactionSummary/utils';
 
+import {groupByTrend} from './utils';
+
 type TeamMiseryProps = {
   organization: Organization;
   location: Location;
@@ -31,7 +33,7 @@ type TeamMiseryProps = {
 };
 
 /** The number of elements to display before collapsing */
-const COLLAPSE_COUNT = 8;
+const COLLAPSE_COUNT = 5;
 
 function TeamMisery({
   organization,
@@ -69,10 +71,7 @@ function TeamMisery({
     .filter(x => x.trend !== null)
     .sort((a, b) => Math.abs(b.trend) - Math.abs(a.trend));
 
-  const worseItems = sortedTableData.filter(x => Math.round(x.trend) < 0);
-  const betterItems = sortedTableData.filter(x => Math.round(x.trend) > 0);
-  const zeroItems = sortedTableData.filter(x => Math.round(x.trend) === 0);
-  const groupedData = [...worseItems, ...betterItems, ...zeroItems];
+  const groupedData = groupByTrend(sortedTableData);
 
   return (
     <Fragment>

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -20,6 +20,8 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {Color, Theme} from 'app/utils/theme';
 
+import {groupByTrend} from './utils';
+
 type Props = AsyncComponent['props'] & {
   theme: Theme;
   organization: Organization;
@@ -171,6 +173,12 @@ class TeamReleases extends AsyncComponent<Props, State> {
     const {projects, period, theme} = this.props;
     const {periodReleases} = this.state;
 
+    const sortedProjects = projects
+      .map(project => ({project, trend: this.getTrend(Number(project.id)) ?? 0}))
+      .sort((a, b) => Math.abs(b.trend) - Math.abs(a.trend));
+
+    const groupedProjects = groupByTrend(sortedProjects);
+
     const data = Object.entries(periodReleases?.release_counts ?? {})
       .map(([bucket, count]) => ({
         value: Math.ceil(count),
@@ -215,6 +223,9 @@ class TeamReleases extends AsyncComponent<Props, State> {
                   silent: true,
                   lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
                   data: [{yAxis: totalPeriodAverage} as any],
+                  label: {
+                    show: false,
+                  },
                 }),
               } as any,
             ]}
@@ -253,7 +264,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
             <RightAligned key="diff">{t('Difference')}</RightAligned>,
           ]}
         >
-          {projects.map(project => (
+          {groupedProjects.map(({project}) => (
             <Fragment key={project.id}>
               <ProjectBadgeContainer>
                 <ProjectBadge avatarSize={18} project={project} />

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -17,6 +17,8 @@ import {getCrashFreeRate} from 'app/utils/sessions';
 import {Color} from 'app/utils/theme';
 import {displayCrashFreePercent} from 'app/views/releases/utils';
 
+import {groupByTrend} from './utils';
+
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   projects: Project[];
@@ -171,6 +173,12 @@ class TeamStability extends AsyncComponent<Props, State> {
   renderBody() {
     const {projects, period} = this.props;
 
+    const sortedProjects = projects
+      .map(project => ({project, trend: this.getTrend(Number(project.id)) ?? 0}))
+      .sort((a, b) => Math.abs(b.trend) - Math.abs(a.trend));
+
+    const groupedProjects = groupByTrend(sortedProjects);
+
     return (
       <StyledPanelTable
         isEmpty={projects.length === 0}
@@ -181,7 +189,7 @@ class TeamStability extends AsyncComponent<Props, State> {
           <RightAligned key="diff">{t('Difference')}</RightAligned>,
         ]}
       >
-        {projects.map(project => (
+        {groupedProjects.map(({project}) => (
           <Fragment key={project.id}>
             <ProjectBadgeContainer>
               <ProjectBadge avatarSize={18} project={project} />

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -28,3 +28,13 @@ export function convertDayValueObjectToSeries(
     name: new Date(bucket).getTime(),
   }));
 }
+
+/**
+ * Takes a sorted array of trend items and groups them by worst/better/no chagne
+ */
+export function groupByTrend<T extends {trend: number}>(data: T[]): T[] {
+  const worseItems = data.filter(x => Math.round(x.trend) < 0);
+  const betterItems = data.filter(x => Math.round(x.trend) > 0);
+  const zeroItems = data.filter(x => Math.round(x.trend) === 0);
+  return [...worseItems, ...betterItems, ...zeroItems];
+}

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -105,11 +105,11 @@ describe('TeamMisery', () => {
     expect(periodMisery).toHaveBeenCalledTimes(1);
 
     // Should have 8 items, the rest are collapsed.
-    expect(screen.getAllByText(project.slug)).toHaveLength(8);
+    expect(screen.getAllByText(project.slug)).toHaveLength(5);
 
     expect(screen.getByText('10% better')).toBeInTheDocument();
     expect(screen.getByText('25% worse')).toBeInTheDocument();
-    expect(screen.getAllByText('0% change')).toHaveLength(6);
+    expect(screen.getAllByText('0% change')).toHaveLength(3);
 
     expect(screen.getByText('More')).toBeInTheDocument();
     fireEvent.click(screen.getByText('More'));


### PR DESCRIPTION
- Sort all tables by trend grouped by worse/better
- limits Team User Misery table to 5 instead of 8 rows before "show more"
- hides a label on one of the graphs