### PR TITLE
chore: Update selenium to 4.0.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -94,7 +94,7 @@ phabricator==0.7.0
 
 # test dependencies, but unable to move to requirements-test until
 # sentry.utils.pytest and sentry.testutils are moved to tests/
-selenium==3.141.0
+selenium==4.0.0
 sqlparse==0.2.4
 
 # this is already a transitive dependency via structlog, and we started

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -103,7 +103,7 @@ sudo-askpass() {
 }
 
 upgrade-pip() {
-    pip install --upgrade "pip==21.1.2" "wheel==0.36.2"
+    pip install --upgrade "pip==21.3.1" "wheel==0.36.2"
 }
 
 install-py-dev() {


### PR DESCRIPTION
Unable to run pytest locally since `selenium` v3 contains SyntaxErrors that python 3.8 doesn't like.