### PR TITLE
ref(tests): Use correct assertions in RTL

### DIFF
--- a/tests/js/spec/components/avatar/avatarList.spec.tsx
+++ b/tests/js/spec/components/avatar/avatarList.spec.tsx
@@ -17,9 +17,9 @@ describe('AvatarList', () => {
     ];
 
     const {container} = renderComponent(users);
-    expect(screen.getByText('A')).toBeTruthy();
-    expect(screen.getByText('B')).toBeTruthy();
-    expect(screen.queryByTestId('avatarList-collapsedusers')).toBeNull();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.queryByTestId('avatarList-collapsedusers')).not.toBeInTheDocument();
 
     expect(container).toSnapshot();
   });
@@ -35,13 +35,13 @@ describe('AvatarList', () => {
     ];
 
     const {container} = renderComponent(users);
-    expect(screen.queryAllByText(users[0].name.charAt(0))).toBeTruthy();
-    expect(screen.queryAllByText(users[1].name.charAt(0))).toBeTruthy();
-    expect(screen.queryAllByText(users[2].name.charAt(0))).toBeTruthy();
-    expect(screen.queryAllByText(users[3].name.charAt(0))).toBeTruthy();
-    expect(screen.queryAllByText(users[4].name.charAt(0))).toBeTruthy();
-    expect(screen.queryByText(users[5].name.charAt(0))).toBeNull();
-    expect(screen.getByTestId('avatarList-collapsedusers')).toBeTruthy();
+    expect(screen.queryByText(users[0].name.charAt(0))).toBeInTheDocument();
+    expect(screen.queryByText(users[1].name.charAt(0))).toBeInTheDocument();
+    expect(screen.queryByText(users[2].name.charAt(0))).toBeInTheDocument();
+    expect(screen.queryByText(users[3].name.charAt(0))).toBeInTheDocument();
+    expect(screen.queryByText(users[4].name.charAt(0))).toBeInTheDocument();
+    expect(screen.queryByText(users[5].name.charAt(0))).not.toBeInTheDocument();
+    expect(screen.getByTestId('avatarList-collapsedusers')).toBeInTheDocument();
     expect(container).toSnapshot();
   });
 });

--- a/tests/js/spec/components/banner.spec.tsx
+++ b/tests/js/spec/components/banner.spec.tsx
@@ -9,12 +9,12 @@ describe('Banner', function () {
 
     fireEvent.click(screen.getByLabelText('Close'));
 
-    expect(screen.queryByText('test')).toBeNull();
+    expect(screen.queryByText('test')).not.toBeInTheDocument();
     expect(localStorage.getItem('test-banner-dismissed')).toBe('true');
   });
 
   it('is not dismissable', function () {
     mountWithTheme(<Banner isDismissable={false} />);
-    expect(screen.queryByLabelText('Close')).toBeNull();
+    expect(screen.queryByLabelText('Close')).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/components/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/breadcrumbs.spec.jsx
@@ -38,7 +38,7 @@ describe('Breadcrumbs', () => {
   it('returns null when 0 crumbs', () => {
     const empty = mountWithTheme(<Breadcrumbs crumbs={[]} />);
 
-    expect(empty.container.firstChild).toBeNull();
+    expect(empty.container).toBeEmptyDOMElement();
   });
 
   it('renders crumbs with icon', () => {

--- a/tests/js/spec/components/checkboxFancy.spec.tsx
+++ b/tests/js/spec/components/checkboxFancy.spec.tsx
@@ -10,22 +10,22 @@ describe('CheckboxFancy', function () {
 
   it('isChecked', function () {
     mountWithTheme(<CheckboxFancy isChecked />);
-    expect(screen.getByRole('checkbox', {checked: true})).toBeTruthy();
+    expect(screen.getByRole('checkbox', {checked: true})).toBeInTheDocument();
     expect(screen.getByTestId('icon-check-mark')).toBeInTheDocument();
-    expect(screen.queryByTestId('icon-subtract')).toBeNull();
+    expect(screen.queryByTestId('icon-subtract')).not.toBeInTheDocument();
   });
 
   it('isIndeterminate', function () {
     mountWithTheme(<CheckboxFancy isIndeterminate />);
-    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-checked', 'mixed');
-    expect(screen.queryByTestId('icon-check-mark')).toBeNull();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
     expect(screen.getByTestId('icon-subtract')).toBeInTheDocument();
   });
 
   it('isDisabled', function () {
     mountWithTheme(<CheckboxFancy isDisabled />);
     expect(screen.getByRole('checkbox')).toHaveAttribute('aria-disabled', 'true');
-    expect(screen.queryByTestId('icon-check-mark')).toBeNull();
-    expect(screen.queryByTestId('icon-subtract')).toBeNull();
+    expect(screen.queryByTestId('icon-check-mark')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('icon-subtract')).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/components/errorRobot.spec.jsx
+++ b/tests/js/spec/components/errorRobot.spec.jsx
@@ -36,7 +36,7 @@ describe('ErrorRobot', function () {
     it('Renders a button for creating an event', function () {
       createWrapper();
       const button = screen.getByRole('button', {name: 'Create a sample event'});
-      expect(button).not.toBeDisabled();
+      expect(button).toBeEnabled();
       expect(getIssues).toHaveBeenCalled();
     });
 
@@ -66,7 +66,7 @@ describe('ErrorRobot', function () {
 
     it('does not display install instructions', function () {
       createWrapper();
-      expect(screen.queryByText('Installation Instructions')).toBeNull();
+      expect(screen.queryByText('Installation Instructions')).not.toBeInTheDocument();
     });
   });
 });

--- a/tests/js/spec/components/eventOrGroupHeader.spec.tsx
+++ b/tests/js/spec/components/eventOrGroupHeader.spec.tsx
@@ -97,7 +97,7 @@ describe('EventOrGroupHeader', function () {
         {context: routerContext}
       );
 
-      expect(screen.getByText('metadata value')).toBeTruthy();
+      expect(screen.getByText('metadata value')).toBeInTheDocument();
     });
 
     it('renders location', async function () {

--- a/tests/js/spec/components/events/eventTagsAndScreenshot.spec.tsx
+++ b/tests/js/spec/components/events/eventTagsAndScreenshot.spec.tsx
@@ -158,33 +158,31 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeFalsy();
+      expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeTruthy();
+      expect(screen.queryByText('Tags')).toBeInTheDocument();
       const contextItems = screen.queryAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
       // Context Item 1
       const contextItem1 = within(contextItems[0]);
-      expect(contextItem1.getByRole('heading').textContent).toEqual(user.email);
-      expect(contextItem1.getByTestId('context-sub-title').textContent).toEqual(
+      expect(contextItem1.getByRole('heading')).toHaveTextContent(user.email);
+      expect(contextItem1.getByTestId('context-sub-title')).toHaveTextContent(
         `ID:${user.id}`
       );
 
       // Context Item 2
       const contextItem2 = within(contextItems[1]);
-      expect(contextItem2.getByRole('heading').textContent).toEqual(contexts.os.name);
-      expect(contextItem2.getByTestId('context-sub-title').textContent).toEqual(
+      expect(contextItem2.getByRole('heading')).toHaveTextContent(contexts.os.name);
+      expect(contextItem2.getByTestId('context-sub-title')).toHaveTextContent(
         `Version:${contexts.os.version}`
       );
 
       // Context Item 3
       const contextItem3 = within(contextItems[2]);
-      expect(contextItem3.getByRole('heading').textContent).toEqual(
-        contexts.device.model
-      );
-      expect(contextItem3.getByTestId('context-sub-title').textContent).toEqual(
+      expect(contextItem3.getByRole('heading')).toHaveTextContent(contexts.device.model);
+      expect(contextItem3.getByTestId('context-sub-title')).toHaveTextContent(
         `Model:${contexts.device.model_id}`
       );
 
@@ -210,10 +208,10 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeFalsy();
+      expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeTruthy();
+      expect(screen.queryByText('Tags')).toBeInTheDocument();
 
       expect(container).toSnapshot();
     });
@@ -233,10 +231,10 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeFalsy();
+      expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeTruthy();
+      expect(screen.queryByText('Tags')).toBeInTheDocument();
 
       expect(container).toSnapshot();
     });
@@ -257,11 +255,11 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeFalsy();
+      expect(screen.queryByText('Tags')).not.toBeInTheDocument();
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeTruthy();
-      expect(screen.getByText('View screenshot')).toBeTruthy();
+      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
@@ -286,15 +284,15 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeTruthy();
-      expect(screen.getByText('View screenshot')).toBeTruthy();
+      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeTruthy();
+      expect(screen.queryByText('Tags')).toBeInTheDocument();
       const contextItems = screen.queryAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
@@ -319,21 +317,21 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeTruthy();
-      expect(screen.getByText('View screenshot')).toBeTruthy();
+      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeTruthy();
+      expect(screen.queryByText('Tags')).toBeInTheDocument();
       const contextItems = screen.queryAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
       // Tags
       const tagsContainer = within(screen.getByTestId('event-tags'));
-      expect(tagsContainer.queryAllByRole('listitem')).toHaveLength(0);
+      expect(tagsContainer.queryByRole('listitem')).not.toBeInTheDocument();
 
       expect(container).toSnapshot();
     });
@@ -352,17 +350,17 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeTruthy();
-      expect(screen.getByText('View screenshot')).toBeTruthy();
+      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
         `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeTruthy();
-      const contextItems = screen.queryAllByTestId('context-item');
-      expect(contextItems).toHaveLength(0);
+      expect(screen.queryByText('Tags')).toBeInTheDocument();
+      const contextItems = screen.queryByTestId('context-item');
+      expect(contextItems).not.toBeInTheDocument();
 
       // Tags
       const tagsContainer = within(screen.getByTestId('event-tags'));

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -82,9 +82,9 @@ describe('Breadcrumbs', () => {
 
       fireEvent.change(searchInput, {target: {value: 'up'}});
 
-      expect(screen.queryByText('Sorry, no breadcrumbs match your search query')).toBe(
-        null
-      );
+      expect(
+        screen.queryByText('Sorry, no breadcrumbs match your search query')
+      ).not.toBeInTheDocument();
 
       expect(await findAllByTextContent(component, 'sup')).toHaveLength(3);
     });
@@ -133,7 +133,7 @@ describe('Breadcrumbs', () => {
 
       fireEvent.change(searchInput, {target: {value: 'sup'}});
 
-      expect(screen.queryAllByTestId('crumb')).toHaveLength(0);
+      expect(screen.queryByTestId('crumb')).not.toBeInTheDocument();
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });
@@ -156,7 +156,7 @@ describe('Breadcrumbs', () => {
       mountWithTheme(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
-      expect(screen.queryAllByTestId('crumb')).toHaveLength(1);
+      expect(screen.queryByTestId('crumb')).toBeInTheDocument();
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });

--- a/tests/js/spec/components/events/interfaces/frame/line.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/frame/line.spec.tsx
@@ -106,7 +106,7 @@ describe('Frame - Line', function () {
         <Line data={data} registers={{}} components={[]} event={event} isExpanded />
       );
 
-      expect(screen.queryByText('registers')).toBeFalsy();
+      expect(screen.queryByText('registers')).not.toBeInTheDocument();
     });
 
     it('should render context vars', () => {

--- a/tests/js/spec/components/events/interfaces/stacktrace.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/stacktrace.spec.tsx
@@ -109,15 +109,15 @@ describe('StackTrace', function () {
     const frames = screen.getByTestId('frames');
     expect(frames.children).toHaveLength(5);
 
-    const expandedToggleButtons = screen.queryByTestId('toggle-button-expanded');
+    const expandedToggleButtons = screen.getByTestId('toggle-button-expanded');
 
     // only one frame is expanded by default
     expect(expandedToggleButtons).toBeInTheDocument();
     expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(4);
 
     // collapse the expanded frame (by default)
-    fireEvent.mouseDown(expandedToggleButtons?.[0]);
-    fireEvent.click(expandedToggleButtons?.[0]);
+    fireEvent.mouseDown(expandedToggleButtons);
+    fireEvent.click(expandedToggleButtons);
 
     // all frames are now collapsed
     expect(screen.queryByTestId('toggle-button-expanded')).not.toBeInTheDocument();

--- a/tests/js/spec/components/events/interfaces/stacktrace.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/stacktrace.spec.tsx
@@ -32,13 +32,13 @@ describe('StackTrace', function () {
 
     // stack trace content
     const stackTraceContent = screen.getByTestId('stack-trace-content');
-    expect(stackTraceContent).toBeTruthy();
+    expect(stackTraceContent).toBeInTheDocument();
 
     // stack trace content has to have a platform icon and a frame list
     expect(stackTraceContent.children).toHaveLength(2);
 
     // platform icon
-    expect(screen.getByTestId('platform-icon-python')).toBeTruthy();
+    expect(screen.getByTestId('platform-icon-python')).toBeInTheDocument();
 
     // frame list
     const frames = screen.getByTestId('frames');
@@ -53,20 +53,20 @@ describe('StackTrace', function () {
     // frame - filename
     const frameFilenames = screen.queryAllByTestId('filename');
     expect(frameFilenames).toHaveLength(5);
-    expect(frameFilenames[0].textContent).toEqual('raven/scripts/runner.py');
-    expect(frameFilenames[1].textContent).toEqual('raven/scripts/runner.py');
-    expect(frameFilenames[2].textContent).toEqual('raven/base.py');
-    expect(frameFilenames[3].textContent).toEqual('raven/base.py');
-    expect(frameFilenames[4].textContent).toEqual('raven/base.py');
+    expect(frameFilenames[0]).toHaveTextContent('raven/scripts/runner.py');
+    expect(frameFilenames[1]).toHaveTextContent('raven/scripts/runner.py');
+    expect(frameFilenames[2]).toHaveTextContent('raven/base.py');
+    expect(frameFilenames[3]).toHaveTextContent('raven/base.py');
+    expect(frameFilenames[4]).toHaveTextContent('raven/base.py');
 
     // frame - function
     const frameFunction = screen.queryAllByTestId('function');
     expect(frameFunction).toHaveLength(5);
-    expect(frameFunction[0].textContent).toEqual('main');
-    expect(frameFunction[1].textContent).toEqual('send_test_message');
-    expect(frameFunction[2].textContent).toEqual('captureMessage');
-    expect(frameFunction[3].textContent).toEqual('capture');
-    expect(frameFunction[4].textContent).toEqual('build_msg');
+    expect(frameFunction[0]).toHaveTextContent('main');
+    expect(frameFunction[1]).toHaveTextContent('send_test_message');
+    expect(frameFunction[2]).toHaveTextContent('captureMessage');
+    expect(frameFunction[3]).toHaveTextContent('capture');
+    expect(frameFunction[4]).toHaveTextContent('build_msg');
   });
 
   it('collapse/expand frames by clicking anywhere in the frame element', function () {
@@ -76,7 +76,7 @@ describe('StackTrace', function () {
     expect(frames.children).toHaveLength(5);
 
     // only one frame is expanded by default
-    expect(screen.queryAllByTestId('toggle-button-expanded')).toHaveLength(1);
+    expect(screen.queryByTestId('toggle-button-expanded')).toBeInTheDocument();
     expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(4);
 
     // clickable list item element
@@ -87,7 +87,7 @@ describe('StackTrace', function () {
     fireEvent.click(frameTitles[0]);
 
     // all frames are now collapsed
-    expect(screen.queryAllByTestId('toggle-button-expanded')).toHaveLength(0);
+    expect(screen.queryByTestId('toggle-button-expanded')).not.toBeInTheDocument();
     expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(5);
 
     // expand penultimate and last frame
@@ -109,18 +109,18 @@ describe('StackTrace', function () {
     const frames = screen.getByTestId('frames');
     expect(frames.children).toHaveLength(5);
 
-    const expandedToggleButtons = screen.queryAllByTestId('toggle-button-expanded');
+    const expandedToggleButtons = screen.queryByTestId('toggle-button-expanded');
 
     // only one frame is expanded by default
-    expect(expandedToggleButtons).toHaveLength(1);
+    expect(expandedToggleButtons).toBeInTheDocument();
     expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(4);
 
     // collapse the expanded frame (by default)
-    fireEvent.mouseDown(expandedToggleButtons[0]);
-    fireEvent.click(expandedToggleButtons[0]);
+    fireEvent.mouseDown(expandedToggleButtons?.[0]);
+    fireEvent.click(expandedToggleButtons?.[0]);
 
     // all frames are now collapsed
-    expect(screen.queryAllByTestId('toggle-button-expanded')).toHaveLength(0);
+    expect(screen.queryByTestId('toggle-button-expanded')).not.toBeInTheDocument();
     expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(5);
 
     const collapsedToggleButtons = screen.queryAllByTestId('toggle-button-collapsed');
@@ -170,12 +170,10 @@ describe('StackTrace', function () {
       // frame list - in app only
       expect(frameTitles).toHaveLength(2);
 
-      expect(frameTitles[0].textContent).toEqual(
+      expect(frameTitles[0]).toHaveTextContent(
         'Crashed in non-app: raven/scripts/runner.py in main at line 112'
       );
-      expect(frameTitles[1].textContent).toEqual(
-        'raven/base.py in build_msg at line 303'
-      );
+      expect(frameTitles[1]).toHaveTextContent('raven/base.py in build_msg at line 303');
     });
 
     it('displays called from only', function () {
@@ -203,10 +201,10 @@ describe('StackTrace', function () {
       // frame list - in app only
       expect(frameTitles).toHaveLength(2);
 
-      expect(frameTitles[0].textContent).toEqual(
+      expect(frameTitles[0]).toHaveTextContent(
         'raven/scripts/runner.py in main at line 112'
       );
-      expect(frameTitles[1].textContent).toEqual(
+      expect(frameTitles[1]).toHaveTextContent(
         'Called from: raven/scripts/runner.py in send_test_message at line 77'
       );
     });
@@ -236,11 +234,11 @@ describe('StackTrace', function () {
       // frame list - in app only
       expect(frameTitles).toHaveLength(3);
 
-      expect(frameTitles[0].textContent).toEqual(
+      expect(frameTitles[0]).toHaveTextContent(
         'Crashed in non-app: raven/scripts/runner.py in main at line 112'
       );
-      expect(frameTitles[1].textContent).toEqual('raven/base.py in capture at line 459');
-      expect(frameTitles[2].textContent).toEqual(
+      expect(frameTitles[1]).toHaveTextContent('raven/base.py in capture at line 459');
+      expect(frameTitles[2]).toHaveTextContent(
         'Called from: raven/base.py in build_msg at line 303'
       );
     });

--- a/tests/js/spec/components/forms/teamSelector.spec.jsx
+++ b/tests/js/spec/components/forms/teamSelector.spec.jsx
@@ -53,9 +53,9 @@ describe('Team Selector', function () {
     createWrapper();
     openSelectMenu();
 
-    expect(screen.getByText('#team1')).toBeTruthy();
-    expect(screen.getByText('#team2')).toBeTruthy();
-    expect(screen.getByText('#team3')).toBeTruthy();
+    expect(screen.getByText('#team1')).toBeInTheDocument();
+    expect(screen.getByText('#team2')).toBeInTheDocument();
+    expect(screen.getByText('#team3')).toBeInTheDocument();
   });
 
   it('selects an option', function () {
@@ -73,18 +73,18 @@ describe('Team Selector', function () {
     createWrapper({teamFilter});
     openSelectMenu();
 
-    expect(screen.getByText('#team1')).toBeTruthy();
+    expect(screen.getByText('#team1')).toBeInTheDocument();
 
     // These options should be filtered out
-    expect(screen.queryByText('#team2')).toBeFalsy();
-    expect(screen.queryByText('#team3')).toBeFalsy();
+    expect(screen.queryByText('#team2')).not.toBeInTheDocument();
+    expect(screen.queryByText('#team3')).not.toBeInTheDocument();
   });
 
   it('respects the project filter', async function () {
     createWrapper({project});
     openSelectMenu();
 
-    expect(screen.getByText('#team1')).toBeTruthy();
+    expect(screen.getByText('#team1')).toBeInTheDocument();
 
     // team2 and team3 should have add to project buttons
     expect(screen.getAllByRole('button').length).toBe(2);
@@ -95,10 +95,10 @@ describe('Team Selector', function () {
     createWrapper({teamFilter, project});
     openSelectMenu();
 
-    expect(screen.getByText('#team1')).toBeTruthy();
+    expect(screen.getByText('#team1')).toBeInTheDocument();
 
     // team3 should be filtered out
-    expect(screen.queryByText('#team3')).toBeFalsy();
+    expect(screen.queryByText('#team3')).not.toBeInTheDocument();
 
     // team2 should have add to project buttons
     expect(screen.getAllByRole('button').length).toBe(1);
@@ -108,7 +108,7 @@ describe('Team Selector', function () {
     createWrapper({project});
     openSelectMenu();
 
-    expect(screen.getByText('#team1')).toBeTruthy();
+    expect(screen.getByText('#team1')).toBeInTheDocument();
 
     // team2 and team3 should have add to project buttons
     const addToProjectButtons = screen.getAllByRole('button');

--- a/tests/js/spec/components/indicators.spec.jsx
+++ b/tests/js/spec/components/indicators.spec.jsx
@@ -74,7 +74,7 @@ describe('Indicators', function () {
     addMessage('Loading', '', {duration: null});
     act(jest.runAllTimers);
     expect(wrapper.container).toHaveTextContent('Loading');
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
   });
 
   it('has a loading indicator when type is "loading"', function () {
@@ -94,7 +94,7 @@ describe('Indicators', function () {
     clearIndicators();
     act(jest.runAllTimers);
     expect(wrapper.container).toHaveTextContent('');
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
   });
 
   it('adds and replaces toast by calling action creators', function () {
@@ -106,7 +106,7 @@ describe('Indicators', function () {
     addMessage('success', 'success', {duration: null});
     act(jest.runAllTimers);
     expect(wrapper.container).toHaveTextContent('success');
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
   });
 
   it('adds and replaces toasts by calling action creators helpers', async function () {
@@ -146,7 +146,7 @@ describe('Indicators', function () {
     clearIndicators();
     act(jest.runAllTimers);
     expect(wrapper.container).toHaveTextContent('');
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
   });
 
   it('dismisses on click', function () {
@@ -157,7 +157,7 @@ describe('Indicators', function () {
     fireEvent.click(screen.getByTestId('toast'));
     act(jest.runAllTimers);
     expect(wrapper.container).toHaveTextContent('');
-    expect(screen.queryByTestId('toast')).toBeNull();
+    expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
   });
 
   it('hides after 10s', function () {
@@ -171,6 +171,6 @@ describe('Indicators', function () {
 
     act(() => jest.advanceTimersByTime(2));
     expect(wrapper.container).toHaveTextContent('');
-    expect(screen.queryByTestId('toast')).toBeNull();
+    expect(screen.queryByTestId('toast')).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/components/loading/loadingContainer.spec.jsx
+++ b/tests/js/spec/components/loading/loadingContainer.spec.jsx
@@ -15,7 +15,7 @@ describe('LoadingContainer', () => {
 
   it('handles normal state', () => {
     renderComponent();
-    expect(screen.getByText('hello!')).toBeTruthy();
+    expect(screen.getByText('hello!')).toBeInTheDocument();
     expect(() => screen.getByTestId('loading-indicator')).toThrow();
   });
 
@@ -23,21 +23,21 @@ describe('LoadingContainer', () => {
     const {rerender} = renderComponent({
       isLoading: true,
     });
-    expect(screen.getByText('hello!')).toBeTruthy();
-    expect(screen.getByTestId('loading-indicator')).toBeTruthy();
+    expect(screen.getByText('hello!')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     rerender(<LoadingContainer isLoading />);
-    expect(screen.queryByText('hello!')).toBeNull();
-    expect(screen.getByTestId('loading-indicator')).toBeTruthy();
+    expect(screen.queryByText('hello!')).not.toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 
   it('handles reloading state', () => {
     const {rerender} = renderComponent({
       isReloading: true,
     });
-    expect(screen.getByText('hello!')).toBeTruthy();
-    expect(screen.getByTestId('loading-indicator')).toBeTruthy();
+    expect(screen.getByText('hello!')).toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     rerender(<LoadingContainer isReloading />);
-    expect(screen.queryByText('hello!')).toBeNull();
-    expect(screen.getByTestId('loading-indicator')).toBeTruthy();
+    expect(screen.queryByText('hello!')).not.toBeInTheDocument();
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/components/queryCount.spec.tsx
+++ b/tests/js/spec/components/queryCount.spec.tsx
@@ -14,7 +14,7 @@ describe('QueryCount', function () {
 
   it('does not render if count is 0', function () {
     const {container} = mountWithTheme(<QueryCount count={0} />);
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('can render when count is 0 when `hideIfEmpty` is false', function () {

--- a/tests/js/spec/components/similarScoreCard.spec.tsx
+++ b/tests/js/spec/components/similarScoreCard.spec.tsx
@@ -9,7 +9,7 @@ describe('SimilarScoreCard', function () {
 
   it('renders', function () {
     const {container} = mountWithTheme(<SimilarScoreCard />);
-    expect(container.firstChild).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('renders with score list', function () {

--- a/tests/js/spec/utils/withTags.spec.jsx
+++ b/tests/js/spec/utils/withTags.spec.jsx
@@ -41,6 +41,6 @@ describe('withTags HoC', function () {
     expect(renderedTag).toBeInTheDocument();
 
     // excludes issue tags by default
-    expect(screen.queryByText(/is\s/)).toBeNull();
+    expect(screen.queryByText(/is\s/)).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -118,11 +118,11 @@ describe('groupDetails', () => {
     ProjectsStore.reset();
     createWrapper();
 
-    expect(screen.queryByText(group.title)).toBeNull();
+    expect(screen.queryByText(group.title)).not.toBeInTheDocument();
 
     ProjectsStore.loadInitialData(organization.projects);
 
-    expect(await screen.findByText(group.title, {exact: false})).toBeTruthy();
+    expect(await screen.findByText(group.title, {exact: false})).toBeInTheDocument();
   });
 
   it('renders error when issue is not found', async function () {
@@ -137,10 +137,10 @@ describe('groupDetails', () => {
 
     createWrapper();
 
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(
       await screen.findByText('The issue you were looking for was not found.')
-    ).toBeTruthy();
+    ).toBeInTheDocument();
   });
 
   it('renders MissingProjectMembership when trying to access issue in project the user does not belong to', async function () {
@@ -155,12 +155,12 @@ describe('groupDetails', () => {
 
     createWrapper();
 
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     expect(
       await screen.findByText(
         "You'll need to join a team with access before you can view this data."
       )
-    ).toBeTruthy();
+    ).toBeInTheDocument();
   });
 
   it('fetches issue details for a given environment', async function () {
@@ -168,9 +168,9 @@ describe('groupDetails', () => {
       selection: {environments: ['staging']},
     });
 
-    expect(screen.queryByTestId('loading-indicator')).toBeNull();
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
 
-    expect(await screen.findByText('environment: staging')).toBeTruthy();
+    expect(await screen.findByText('environment: staging')).toBeInTheDocument();
   });
 
   /**
@@ -182,7 +182,7 @@ describe('groupDetails', () => {
       body: {...group, id: 'new-id'},
     });
     createWrapper();
-    expect(screen.queryByText('Group Details Mock')).toBeNull();
+    expect(screen.queryByText('Group Details Mock')).not.toBeInTheDocument();
     await waitFor(() => {
       expect(browserHistory.push).toHaveBeenCalledTimes(1);
       expect(browserHistory.push).toHaveBeenCalledWith(
@@ -197,7 +197,7 @@ describe('groupDetails', () => {
       statusCode: 404,
     });
     createWrapper();
-    expect(await screen.findByText('eventError')).toBeTruthy();
+    expect(await screen.findByText('eventError')).toBeInTheDocument();
   });
 
   it('renders for review reason', async function () {
@@ -217,7 +217,7 @@ describe('groupDetails', () => {
 
     ProjectsStore.loadInitialData(organization.projects);
 
-    expect(await screen.findByText('New Issue')).toBeTruthy();
+    expect(await screen.findByText('New Issue')).toBeInTheDocument();
   });
 
   it('renders alert for sample event', async function () {
@@ -226,7 +226,7 @@ describe('groupDetails', () => {
     ProjectsStore.loadInitialData([aProject]);
     createWrapper();
 
-    expect(await screen.findByText(SAMPLE_EVENT_ALERT_TEXT)).toBeTruthy();
+    expect(await screen.findByText(SAMPLE_EVENT_ALERT_TEXT)).toBeInTheDocument();
   });
   it('does not render alert for non sample events', async function () {
     const aProject = TestStubs.Project({firstEvent: false});
@@ -234,6 +234,6 @@ describe('groupDetails', () => {
     ProjectsStore.loadInitialData([aProject]);
     createWrapper();
 
-    expect(await screen.queryByText(SAMPLE_EVENT_ALERT_TEXT)).toBeNull();
+    expect(await screen.queryByText(SAMPLE_EVENT_ALERT_TEXT)).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/organizationStats/teamInsights/index.spec.tsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/index.spec.tsx
@@ -20,7 +20,7 @@ describe('TeamInsightsContainer', () => {
       {context}
     );
 
-    expect(screen.queryByText('test')).toBeNull();
+    expect(screen.queryByText('test')).not.toBeInTheDocument();
   });
   it('allows access for orgs with flag', () => {
     ProjectsStore.loadInitialData([
@@ -38,7 +38,7 @@ describe('TeamInsightsContainer', () => {
       {context}
     );
 
-    expect(screen.getByText('test')).toBeTruthy();
+    expect(screen.getByText('test')).toBeInTheDocument();
   });
   it('shows message for users with no teams', () => {
     ProjectsStore.loadInitialData([]);
@@ -50,6 +50,6 @@ describe('TeamInsightsContainer', () => {
 
     expect(
       screen.getByText('You need at least one project to use this view')
-    ).toBeTruthy();
+    ).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -132,6 +132,6 @@ describe('TeamMisery', () => {
       expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
     });
 
-    expect(screen.getByText('There are no items to display')).toBeTruthy();
+    expect(screen.getByText('There are no items to display')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
@@ -18,7 +18,7 @@ describe('TeamStability', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByTestId('loading-placeholder')).toBeNull();
+      expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
     });
 
     expect(screen.getByText('project-slug')).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe('TeamStability', () => {
     );
 
     await waitFor(() => {
-      expect(screen.queryByTestId('loading-placeholder')).toBeNull();
+      expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
     });
 
     expect(screen.getAllByText('\u2014')).toHaveLength(3);
@@ -49,6 +49,6 @@ describe('TeamStability', () => {
       <TeamStability projects={[]} organization={TestStubs.Organization()} period="7d" />
     );
 
-    expect(screen.getByText('There are no items to display')).toBeTruthy();
+    expect(screen.getByText('There are no items to display')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
+++ b/tests/js/spec/views/performance/transactionDetails/index.spec.jsx
@@ -27,7 +27,7 @@ describe('EventDetails', () => {
       />,
       {context: routerContext}
     );
-    expect(screen.queryByText(alertText)).toBeTruthy();
+    expect(screen.queryByText(alertText)).toBeInTheDocument();
   });
 
   it('does not reender alert if already received transaction', () => {
@@ -48,6 +48,6 @@ describe('EventDetails', () => {
       />,
       {context: routerContext}
     );
-    expect(screen.queryByText(alertText)).toBeNull();
+    expect(screen.queryByText(alertText)).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/projectDetail/index.spec.tsx
+++ b/tests/js/spec/views/projectDetail/index.spec.tsx
@@ -67,7 +67,7 @@ describe('ProjectDetail', function () {
           'Event Processing for this project is currently degraded. Events may appear with larger delays than usual or get dropped.',
           {exact: false}
         )
-      ).toBe(null);
+      ).not.toBeInTheDocument();
     });
 
     it('renders alert', async function () {

--- a/tests/js/spec/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/tests/js/spec/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -35,10 +35,10 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
       {context: routerContext}
     );
 
-    expect(screen.getByLabelText('Chart Title').textContent).toBe(
+    expect(screen.getByLabelText('Chart Title')).toHaveTextContent(
       'Crash Free Session Rate'
     );
-    expect(screen.getByLabelText('Chart Value').textContent).toContain('95.006% 4.51%');
+    expect(screen.getByLabelText('Chart Value')).toHaveTextContent(/95\.006% 4\.51%/);
 
     expect(screen.getAllByRole('radio').length).toBe(3);
 
@@ -91,8 +91,10 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
       />
     );
 
-    expect(screen.getByLabelText('Chart Title').textContent).toBe('Crash Free User Rate');
-    expect(screen.getByLabelText('Chart Value').textContent).toContain('75% 24.908%');
+    expect(screen.getByLabelText('Chart Title')).toHaveTextContent(
+      'Crash Free User Rate'
+    );
+    expect(screen.getByLabelText('Chart Value')).toHaveTextContent(/75% 24\.908%/);
   });
 
   it('can expand row to show more charts', () => {

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -70,7 +70,7 @@ describe('SettingsSearch', function () {
     mountWithTheme(<SettingsSearch params={{orgId: 'org-slug'}} />);
 
     fireEvent.keyDown(document, {code: 'Slash', key: '/', keyCode: 191});
-    expect(document.activeElement).toEqual(screen.getByPlaceholderText('Search'));
+    expect(screen.getByPlaceholderText('Search')).toHaveFocus();
   });
 
   it('can search', async function () {

--- a/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
+++ b/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
@@ -212,8 +212,7 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no error rules to display')
       ).not.toBeInTheDocument();
-      const errorRules = screen.queryByText('Errors only');
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       expect(screen.getByText('Add error rule')).toBeInTheDocument();
 
@@ -355,8 +354,7 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no error rules to display')
       ).not.toBeInTheDocument();
-      const errorRules = screen.queryByText('Errors only');
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
       expect(
@@ -383,7 +381,7 @@ describe('Filters and Sampling', function () {
       // Release field is not empty
       const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
       expect(releaseFieldValues).toBeInTheDocument();
-      expect(releaseFieldValues?.[0]).toHaveTextContent('1*');
+      expect(releaseFieldValues).toHaveTextContent('1*');
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -425,12 +423,12 @@ describe('Filters and Sampling', function () {
       // Autocomplete suggests options
       const autocompleteOptions = within(
         modal.getByTestId('autocomplete-release')
-      ).queryByTestId('option');
+      ).getByTestId('option');
       expect(autocompleteOptions).toBeInTheDocument();
-      expect(autocompleteOptions?.[0]).toHaveTextContent('[I3].[0-9]');
+      expect(autocompleteOptions).toHaveTextContent('[I3].[0-9]');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions?.[0]);
+      fireEvent.click(autocompleteOptions);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -453,9 +451,8 @@ describe('Filters and Sampling', function () {
       await waitForElementToBeRemoved(() => screen.getByText('Edit Error Sampling Rule'));
 
       // Error rules panel is updated
-      expect(errorRules).toBeInTheDocument();
-
       expect(screen.getByText('Errors only')).toBeInTheDocument();
+
       expect(screen.queryAllByText('Release')).toHaveLength(2);
 
       // Old values
@@ -569,8 +566,7 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no error rules to display')
       ).not.toBeInTheDocument();
-      const errorRules = screen.queryByText('Errors only');
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
       expect(
@@ -598,7 +594,7 @@ describe('Filters and Sampling', function () {
       // Release field is not empty
       const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
       expect(releaseFieldValues).toBeInTheDocument();
-      expect(releaseFieldValues?.[0]).toHaveTextContent('1.2.3');
+      expect(releaseFieldValues).toHaveTextContent('1.2.3');
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -640,12 +636,12 @@ describe('Filters and Sampling', function () {
       // Autocomplete suggests options
       const autocompleteOptions = within(
         modal.getByTestId('autocomplete-release')
-      ).queryByTestId('option');
+      ).getByTestId('option');
       expect(autocompleteOptions).toBeInTheDocument();
-      expect(autocompleteOptions?.[0]).toHaveTextContent('[0-9]');
+      expect(autocompleteOptions).toHaveTextContent('[0-9]');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions?.[0]);
+      fireEvent.click(autocompleteOptions);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -670,7 +666,7 @@ describe('Filters and Sampling', function () {
       );
 
       // Error rules panel is updated
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       expect(screen.getByText('Transaction traces')).toBeInTheDocument();
       expect(screen.queryAllByText('Release')).toHaveLength(2);
@@ -786,8 +782,7 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no error rules to display')
       ).not.toBeInTheDocument();
-      const errorRules = screen.queryByText('Errors only');
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
       expect(
@@ -856,12 +851,12 @@ describe('Filters and Sampling', function () {
       // Autocomplete suggests options
       const autocompleteOptions = within(
         modal.getByTestId('autocomplete-release')
-      ).queryByTestId('option');
+      ).getByTestId('option');
       expect(autocompleteOptions).toBeInTheDocument();
-      expect(autocompleteOptions?.[0]).toHaveTextContent('[0-9]');
+      expect(autocompleteOptions).toHaveTextContent('[0-9]');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions?.[0]);
+      fireEvent.click(autocompleteOptions);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -886,7 +881,7 @@ describe('Filters and Sampling', function () {
       );
 
       // Error rules panel is updated
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       expect(screen.getByText('Individual transactions')).toBeInTheDocument();
       expect(screen.queryAllByText('Release')).toHaveLength(2);
@@ -982,8 +977,7 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no error rules to display')
       ).not.toBeInTheDocument();
-      const errorRules = screen.queryByText('Errors only');
-      expect(errorRules).toBeInTheDocument();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
       expect(
@@ -1150,12 +1144,12 @@ describe('Filters and Sampling', function () {
       });
 
       // Autocomplete suggests options
-      const autocompleteOptions = within(releaseField).queryByTestId('option');
+      const autocompleteOptions = within(releaseField).getByTestId('option');
       expect(autocompleteOptions).toBeInTheDocument();
-      expect(autocompleteOptions?.[0]).toHaveTextContent('1.2.3');
+      expect(autocompleteOptions).toHaveTextContent('1.2.3');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions?.[0]);
+      fireEvent.click(autocompleteOptions);
 
       // Button is still disabled
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -1179,8 +1173,7 @@ describe('Filters and Sampling', function () {
 
       // Error rules panel is updated
       expect(queryByText('There are no error rules to display')).not.toBeInTheDocument();
-      const errorRules = queryByText('Errors only');
-      expect(errorRules).toBeInTheDocument();
+      expect(getByText('Errors only')).toBeInTheDocument();
       expect(getByText('Release')).toBeInTheDocument();
       expect(getByText('1.2.3')).toBeInTheDocument();
       expect(getByText('20%')).toBeInTheDocument();
@@ -1358,12 +1351,12 @@ describe('Filters and Sampling', function () {
         // Autocomplete suggests options
         const autocompleteOptions = within(
           modal.getByTestId('autocomplete-release')
-        ).queryByTestId('option');
+        ).getByTestId('option');
         expect(autocompleteOptions).toBeInTheDocument();
-        expect(autocompleteOptions?.[0]).toHaveTextContent('1.2.3');
+        expect(autocompleteOptions).toHaveTextContent('1.2.3');
 
         // Click on the suggested option
-        fireEvent.click(autocompleteOptions?.[0]);
+        fireEvent.click(autocompleteOptions);
 
         // Button is still disabled
         const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -1478,12 +1471,12 @@ describe('Filters and Sampling', function () {
           // Autocomplete suggests options
           const autocompleteOptions = within(
             modal.getByTestId('autocomplete-release')
-          ).queryByTestId('option');
+          ).getByTestId('option');
           expect(autocompleteOptions).toBeInTheDocument();
-          expect(autocompleteOptions?.[0]).toHaveTextContent('1.2.3');
+          expect(autocompleteOptions).toHaveTextContent('1.2.3');
 
           // Click on the suggested option
-          fireEvent.click(autocompleteOptions?.[0]);
+          fireEvent.click(autocompleteOptions);
 
           // Button is still disabled
           const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
@@ -1595,7 +1588,7 @@ describe('Filters and Sampling', function () {
           for (const legacyBrowser of legacyBrowsers) {
             const {icon, title} = LEGACY_BROWSER_LIST[legacyBrowser];
             expect(modal.getByText(title)).toBeInTheDocument();
-            expect(modal.queryByTestId(`icon-${icon}`)).toBeInTheDocument();
+            expect(modal.queryAllByTestId(`icon-${icon}`)[0]).toBeInTheDocument();
           }
 
           expect(modal.queryAllByTestId('icon-internet-explorer')).toHaveLength(4);

--- a/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
+++ b/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
@@ -73,7 +73,7 @@ describe('Filters and Sampling', function () {
       const {container} = component;
 
       // Title
-      expect(screen.getByText('Filters & Sampling')).toBeTruthy();
+      expect(screen.getByText('Filters & Sampling')).toBeInTheDocument();
 
       // Error rules container
       expect(
@@ -89,18 +89,20 @@ describe('Filters and Sampling', function () {
         })
       ).toHaveAttribute('href', DYNAMIC_SAMPLING_DOC_LINK);
 
-      expect(screen.getByText('There are no error rules to display')).toBeTruthy();
-      expect(screen.getByText('Add error rule')).toBeTruthy();
+      expect(screen.getByText('There are no error rules to display')).toBeInTheDocument();
+      expect(screen.getByText('Add error rule')).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
       expect(
         screen.getByText(
           'Rules for traces should precede rules for individual transactions.'
         )
-      ).toBeTruthy();
+      ).toBeInTheDocument();
 
-      expect(screen.getByText('There are no transaction rules to display')).toBeTruthy();
-      expect(screen.getByText('Add transaction rule')).toBeTruthy();
+      expect(
+        screen.getByText('There are no transaction rules to display')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Add transaction rule')).toBeInTheDocument();
 
       const readDocsButtonLinks = screen.queryAllByRole('button', {
         name: 'Read the docs',
@@ -191,7 +193,7 @@ describe('Filters and Sampling', function () {
       const {container} = component;
 
       // Title
-      expect(screen.getByText('Filters & Sampling')).toBeTruthy();
+      expect(screen.getByText('Filters & Sampling')).toBeInTheDocument();
 
       // Error rules container
       expect(
@@ -207,27 +209,31 @@ describe('Filters and Sampling', function () {
         })
       ).toHaveAttribute('href', DYNAMIC_SAMPLING_DOC_LINK);
 
-      expect(screen.queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = screen.queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no error rules to display')
+      ).not.toBeInTheDocument();
+      const errorRules = screen.queryByText('Errors only');
+      expect(errorRules).toBeInTheDocument();
 
-      expect(screen.getByText('Add error rule')).toBeTruthy();
+      expect(screen.getByText('Add error rule')).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
       expect(
         screen.getByText(
           'Rules for traces should precede rules for individual transactions.'
         )
-      ).toBeTruthy();
+      ).toBeInTheDocument();
 
-      expect(screen.queryByText('There are no transaction rules to display')).toBeFalsy();
-      const transactionTraceRules = screen.queryAllByText('Transaction traces');
-      expect(transactionTraceRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no transaction rules to display')
+      ).not.toBeInTheDocument();
+      const transactionTraceRules = screen.queryByText('Transaction traces');
+      expect(transactionTraceRules).toBeInTheDocument();
 
-      const individualTransactionRules = screen.queryAllByText('Individual transactions');
-      expect(individualTransactionRules).toHaveLength(1);
+      const individualTransactionRules = screen.queryByText('Individual transactions');
+      expect(individualTransactionRules).toBeInTheDocument();
 
-      expect(screen.getByText('Add transaction rule')).toBeTruthy();
+      expect(screen.getByText('Add transaction rule')).toBeInTheDocument();
 
       const readDocsButtonLinks = screen.queryAllByRole('button', {
         name: 'Read the docs',
@@ -346,14 +352,18 @@ describe('Filters and Sampling', function () {
       renderComponent();
 
       // Error rules container
-      expect(screen.queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = screen.queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no error rules to display')
+      ).not.toBeInTheDocument();
+      const errorRules = screen.queryByText('Errors only');
+      expect(errorRules).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
-      expect(screen.queryByText('There are no transaction rules to display')).toBeFalsy();
-      const transactionTraceRules = screen.queryAllByText('Transaction traces');
-      expect(transactionTraceRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no transaction rules to display')
+      ).not.toBeInTheDocument();
+      const transactionTraceRules = screen.queryByText('Transaction traces');
+      expect(transactionTraceRules).toBeInTheDocument();
 
       const editRuleButtons = screen.queryAllByLabelText('Edit Rule');
       expect(editRuleButtons).toHaveLength(2);
@@ -362,27 +372,27 @@ describe('Filters and Sampling', function () {
       const modal = await renderModal(editRuleButtons[0]);
 
       // Modal content
-      expect(modal.getByText('Edit Error Sampling Rule')).toBeTruthy();
-      expect(modal.queryByText('Tracing')).toBeFalsy();
+      expect(modal.getByText('Edit Error Sampling Rule')).toBeInTheDocument();
+      expect(modal.queryByText('Tracing')).not.toBeInTheDocument();
 
       // Release Field
       await modal.findByTestId('autocomplete-release');
       const releaseField = modal.getByTestId('autocomplete-release');
-      expect(releaseField).toBeTruthy();
+      expect(releaseField).toBeInTheDocument();
 
       // Release field is not empty
-      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
-      expect(releaseFieldValues).toHaveLength(1);
-      expect(releaseFieldValues[0].textContent).toEqual('1*');
+      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      expect(releaseFieldValues).toBeInTheDocument();
+      expect(releaseFieldValues?.[0]).toHaveTextContent('1*');
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-      expect(saveRuleButton).toBeTruthy();
+      expect(saveRuleButton).toBeInTheDocument();
       expect(saveRuleButton).toBeEnabled();
 
       // Sample rate field
       const sampleRateField = modal.getByPlaceholderText('\u0025');
-      expect(sampleRateField).toBeTruthy();
+      expect(sampleRateField).toBeInTheDocument();
 
       // Sample rate is not empty
       expect(sampleRateField).toHaveValue(10);
@@ -397,8 +407,8 @@ describe('Filters and Sampling', function () {
       // Release field is now empty
       const newReleaseFieldValues = within(
         modal.getByTestId('autocomplete-release')
-      ).queryAllByTestId('multivalue');
-      expect(newReleaseFieldValues).toHaveLength(0);
+      ).queryByTestId('multivalue');
+      expect(newReleaseFieldValues).not.toBeInTheDocument();
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
 
@@ -415,12 +425,12 @@ describe('Filters and Sampling', function () {
       // Autocomplete suggests options
       const autocompleteOptions = within(
         modal.getByTestId('autocomplete-release')
-      ).queryAllByTestId('option');
-      expect(autocompleteOptions).toHaveLength(1);
-      expect(autocompleteOptions[0].textContent).toEqual('[I3].[0-9]');
+      ).queryByTestId('option');
+      expect(autocompleteOptions).toBeInTheDocument();
+      expect(autocompleteOptions?.[0]).toHaveTextContent('[I3].[0-9]');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions[0]);
+      fireEvent.click(autocompleteOptions?.[0]);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -443,18 +453,18 @@ describe('Filters and Sampling', function () {
       await waitForElementToBeRemoved(() => screen.getByText('Edit Error Sampling Rule'));
 
       // Error rules panel is updated
-      expect(errorRules).toHaveLength(1);
+      expect(errorRules).toBeInTheDocument();
 
-      expect(screen.getByText('Errors only')).toBeTruthy();
+      expect(screen.getByText('Errors only')).toBeInTheDocument();
       expect(screen.queryAllByText('Release')).toHaveLength(2);
 
       // Old values
-      expect(screen.queryByText('1*')).toBeFalsy();
-      expect(screen.queryByText('10%')).toBeFalsy();
+      expect(screen.queryByText('1*')).not.toBeInTheDocument();
+      expect(screen.queryByText('10%')).not.toBeInTheDocument();
 
       // New values
-      expect(screen.getByText('[I3].[0-9]')).toBeTruthy();
-      expect(screen.getByText('50%')).toBeTruthy();
+      expect(screen.getByText('[I3].[0-9]')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
     });
 
     it('transaction trace rule', async function () {
@@ -556,14 +566,18 @@ describe('Filters and Sampling', function () {
       renderComponent();
 
       // Error rules container
-      expect(screen.queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = screen.queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no error rules to display')
+      ).not.toBeInTheDocument();
+      const errorRules = screen.queryByText('Errors only');
+      expect(errorRules).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
-      expect(screen.queryByText('There are no transaction rules to display')).toBeFalsy();
-      const transactionTraceRules = screen.queryAllByText('Transaction traces');
-      expect(transactionTraceRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no transaction rules to display')
+      ).not.toBeInTheDocument();
+      const transactionTraceRules = screen.queryByText('Transaction traces');
+      expect(transactionTraceRules).toBeInTheDocument();
 
       const editRuleButtons = screen.queryAllByLabelText('Edit Rule');
       expect(editRuleButtons).toHaveLength(2);
@@ -572,28 +586,28 @@ describe('Filters and Sampling', function () {
       const modal = await renderModal(editRuleButtons[1]);
 
       // Modal content
-      expect(modal.getByText('Edit Transaction Sampling Rule')).toBeTruthy();
-      expect(modal.queryByText('Tracing')).toBeTruthy();
+      expect(modal.getByText('Edit Transaction Sampling Rule')).toBeInTheDocument();
+      expect(modal.queryByText('Tracing')).toBeInTheDocument();
       expect(modal.getByRole('checkbox')).toBeChecked();
 
       // Release Field
       await modal.findByTestId('autocomplete-release');
       const releaseField = modal.getByTestId('autocomplete-release');
-      expect(releaseField).toBeTruthy();
+      expect(releaseField).toBeInTheDocument();
 
       // Release field is not empty
-      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
-      expect(releaseFieldValues).toHaveLength(1);
-      expect(releaseFieldValues[0].textContent).toEqual('1.2.3');
+      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      expect(releaseFieldValues).toBeInTheDocument();
+      expect(releaseFieldValues?.[0]).toHaveTextContent('1.2.3');
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-      expect(saveRuleButton).toBeTruthy();
+      expect(saveRuleButton).toBeInTheDocument();
       expect(saveRuleButton).toBeEnabled();
 
       // Sample rate field
       const sampleRateField = modal.getByPlaceholderText('\u0025');
-      expect(sampleRateField).toBeTruthy();
+      expect(sampleRateField).toBeInTheDocument();
 
       // Sample rate is not empty
       expect(sampleRateField).toHaveValue(20);
@@ -608,8 +622,8 @@ describe('Filters and Sampling', function () {
       // Release field is now empty
       const newReleaseFieldValues = within(
         modal.getByTestId('autocomplete-release')
-      ).queryAllByTestId('multivalue');
-      expect(newReleaseFieldValues).toHaveLength(0);
+      ).queryByTestId('multivalue');
+      expect(newReleaseFieldValues).not.toBeInTheDocument();
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
 
@@ -626,12 +640,12 @@ describe('Filters and Sampling', function () {
       // Autocomplete suggests options
       const autocompleteOptions = within(
         modal.getByTestId('autocomplete-release')
-      ).queryAllByTestId('option');
-      expect(autocompleteOptions).toHaveLength(1);
-      expect(autocompleteOptions[0].textContent).toEqual('[0-9]');
+      ).queryByTestId('option');
+      expect(autocompleteOptions).toBeInTheDocument();
+      expect(autocompleteOptions?.[0]).toHaveTextContent('[0-9]');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions[0]);
+      fireEvent.click(autocompleteOptions?.[0]);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -656,18 +670,18 @@ describe('Filters and Sampling', function () {
       );
 
       // Error rules panel is updated
-      expect(errorRules).toHaveLength(1);
+      expect(errorRules).toBeInTheDocument();
 
-      expect(screen.getByText('Transaction traces')).toBeTruthy();
+      expect(screen.getByText('Transaction traces')).toBeInTheDocument();
       expect(screen.queryAllByText('Release')).toHaveLength(2);
 
       // Old values
-      expect(screen.queryByText('1.2.3')).toBeFalsy();
-      expect(screen.queryByText('20%')).toBeFalsy();
+      expect(screen.queryByText('1.2.3')).not.toBeInTheDocument();
+      expect(screen.queryByText('20%')).not.toBeInTheDocument();
 
       // New values
-      expect(screen.getByText('[0-9]')).toBeTruthy();
-      expect(screen.getByText('60%')).toBeTruthy();
+      expect(screen.getByText('[0-9]')).toBeInTheDocument();
+      expect(screen.getByText('60%')).toBeInTheDocument();
     });
 
     it('individual transaction rule', async function () {
@@ -769,14 +783,18 @@ describe('Filters and Sampling', function () {
       renderComponent();
 
       // Error rules container
-      expect(screen.queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = screen.queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no error rules to display')
+      ).not.toBeInTheDocument();
+      const errorRules = screen.queryByText('Errors only');
+      expect(errorRules).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
-      expect(screen.queryByText('There are no transaction rules to display')).toBeFalsy();
-      const transactionTraceRules = screen.queryAllByText('Individual transactions');
-      expect(transactionTraceRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no transaction rules to display')
+      ).not.toBeInTheDocument();
+      const transactionTraceRules = screen.queryByText('Individual transactions');
+      expect(transactionTraceRules).toBeInTheDocument();
 
       const editRuleButtons = screen.queryAllByLabelText('Edit Rule');
       expect(editRuleButtons).toHaveLength(2);
@@ -785,27 +803,27 @@ describe('Filters and Sampling', function () {
       const modal = await renderModal(editRuleButtons[1]);
 
       // Modal content
-      expect(modal.getByText('Edit Transaction Sampling Rule')).toBeTruthy();
-      expect(modal.queryByText('Tracing')).toBeTruthy();
+      expect(modal.getByText('Edit Transaction Sampling Rule')).toBeInTheDocument();
+      expect(modal.queryByText('Tracing')).toBeInTheDocument();
       expect(modal.getByRole('checkbox')).not.toBeChecked();
 
       // Release Field
       await modal.findByTestId('autocomplete-release');
       const releaseField = modal.getByTestId('autocomplete-release');
-      expect(releaseField).toBeTruthy();
+      expect(releaseField).toBeInTheDocument();
 
       // Release field is not empty
-      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
-      expect(releaseFieldValues).toHaveLength(1);
+      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      expect(releaseFieldValues).toBeInTheDocument();
 
       // Button is enabled - meaning the form is valid
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-      expect(saveRuleButton).toBeTruthy();
+      expect(saveRuleButton).toBeInTheDocument();
       expect(saveRuleButton).toBeEnabled();
 
       // Sample rate field
       const sampleRateField = modal.getByPlaceholderText('\u0025');
-      expect(sampleRateField).toBeTruthy();
+      expect(sampleRateField).toBeInTheDocument();
 
       // Sample rate is not empty
       expect(sampleRateField).toHaveValue(20);
@@ -820,8 +838,8 @@ describe('Filters and Sampling', function () {
       // Release field is now empty
       const newReleaseFieldValues = within(
         modal.getByTestId('autocomplete-release')
-      ).queryAllByTestId('multivalue');
-      expect(newReleaseFieldValues).toHaveLength(0);
+      ).queryByTestId('multivalue');
+      expect(newReleaseFieldValues).not.toBeInTheDocument();
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
 
@@ -838,12 +856,12 @@ describe('Filters and Sampling', function () {
       // Autocomplete suggests options
       const autocompleteOptions = within(
         modal.getByTestId('autocomplete-release')
-      ).queryAllByTestId('option');
-      expect(autocompleteOptions).toHaveLength(1);
-      expect(autocompleteOptions[0].textContent).toEqual('[0-9]');
+      ).queryByTestId('option');
+      expect(autocompleteOptions).toBeInTheDocument();
+      expect(autocompleteOptions?.[0]).toHaveTextContent('[0-9]');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions[0]);
+      fireEvent.click(autocompleteOptions?.[0]);
 
       expect(modal.getByRole('button', {name: 'Save Rule'})).toBeEnabled();
 
@@ -868,18 +886,18 @@ describe('Filters and Sampling', function () {
       );
 
       // Error rules panel is updated
-      expect(errorRules).toHaveLength(1);
+      expect(errorRules).toBeInTheDocument();
 
-      expect(screen.getByText('Individual transactions')).toBeTruthy();
+      expect(screen.getByText('Individual transactions')).toBeInTheDocument();
       expect(screen.queryAllByText('Release')).toHaveLength(2);
 
       // Old values
-      expect(screen.queryByText('1.2.3')).toBeFalsy();
-      expect(screen.queryByText('20%')).toBeFalsy();
+      expect(screen.queryByText('1.2.3')).not.toBeInTheDocument();
+      expect(screen.queryByText('20%')).not.toBeInTheDocument();
 
       // New values
-      expect(screen.getByText('[0-9]')).toBeTruthy();
-      expect(screen.getByText('60%')).toBeTruthy();
+      expect(screen.getByText('[0-9]')).toBeInTheDocument();
+      expect(screen.getByText('60%')).toBeInTheDocument();
     });
   });
 
@@ -961,14 +979,18 @@ describe('Filters and Sampling', function () {
       renderComponent();
 
       // Error rules container
-      expect(screen.queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = screen.queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no error rules to display')
+      ).not.toBeInTheDocument();
+      const errorRules = screen.queryByText('Errors only');
+      expect(errorRules).toBeInTheDocument();
 
       // Transaction traces and individual transactions rules container
-      expect(screen.queryByText('There are no transaction rules to display')).toBeFalsy();
-      const transactionTraceRules = screen.queryAllByText('Transaction traces');
-      expect(transactionTraceRules).toHaveLength(1);
+      expect(
+        screen.queryByText('There are no transaction rules to display')
+      ).not.toBeInTheDocument();
+      const transactionTraceRules = screen.queryByText('Transaction traces');
+      expect(transactionTraceRules).toBeInTheDocument();
 
       const deleteRuleButtons = screen.queryAllByLabelText('Delete Rule');
       expect(deleteRuleButtons).toHaveLength(2);
@@ -978,12 +1000,12 @@ describe('Filters and Sampling', function () {
 
       expect(
         modal.getByText('Are you sure you wish to delete this dynamic sampling rule?')
-      ).toBeTruthy();
+      ).toBeInTheDocument();
 
       const modalActionButtons = modal.queryAllByRole('button');
       expect(modalActionButtons).toHaveLength(2);
-      expect(modalActionButtons[0].textContent).toEqual('Cancel');
-      expect(modalActionButtons[1].textContent).toEqual('Confirm');
+      expect(modalActionButtons[0]).toHaveTextContent('Cancel');
+      expect(modalActionButtons[1]).toHaveTextContent('Confirm');
 
       // Confirm deletion
       fireEvent.click(modalActionButtons[1]);
@@ -994,10 +1016,12 @@ describe('Filters and Sampling', function () {
       );
 
       // Error rules panel is updated
-      expect(screen.queryByText('There are no error rules to display')).toBeTruthy();
+      expect(
+        screen.queryByText('There are no error rules to display')
+      ).toBeInTheDocument();
 
       // There is still one transaction rule
-      expect(transactionTraceRules).toHaveLength(1);
+      expect(transactionTraceRules).toBeInTheDocument();
     });
   });
 
@@ -1009,16 +1033,16 @@ describe('Filters and Sampling', function () {
       const modal = await renderModal(screen.getByText('Add error rule'), true);
 
       // Modal content
-      expect(modal.getByText('Add Error Sampling Rule')).toBeTruthy();
-      expect(modal.queryByText('Tracing')).toBeFalsy();
-      expect(modal.getByText('Conditions')).toBeTruthy();
-      expect(modal.getByText('Add Condition')).toBeTruthy();
-      expect(modal.getByText('Apply sampling rate to all errors')).toBeTruthy();
-      expect(modal.getByText('Sampling Rate \u0025')).toBeTruthy();
+      expect(modal.getByText('Add Error Sampling Rule')).toBeInTheDocument();
+      expect(modal.queryByText('Tracing')).not.toBeInTheDocument();
+      expect(modal.getByText('Conditions')).toBeInTheDocument();
+      expect(modal.getByText('Add Condition')).toBeInTheDocument();
+      expect(modal.getByText('Apply sampling rate to all errors')).toBeInTheDocument();
+      expect(modal.getByText('Sampling Rate \u0025')).toBeInTheDocument();
       expect(modal.getByPlaceholderText('\u0025')).toHaveValue(null);
-      expect(modal.getByRole('button', {name: 'Cancel'})).toBeTruthy();
+      expect(modal.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-      expect(saveRuleButton).toBeTruthy();
+      expect(saveRuleButton).toBeInTheDocument();
       expect(saveRuleButton).toBeDisabled();
 
       // Close Modal
@@ -1044,7 +1068,7 @@ describe('Filters and Sampling', function () {
       expect(conditionOptions).toHaveLength(commonConditionCategories.length);
 
       for (const conditionOptionIndex in conditionOptions) {
-        expect(conditionOptions[conditionOptionIndex].textContent).toEqual(
+        expect(conditionOptions[conditionOptionIndex]).toHaveTextContent(
           commonConditionCategories[conditionOptionIndex]
         );
       }
@@ -1093,7 +1117,7 @@ describe('Filters and Sampling', function () {
       });
 
       const component = renderComponent();
-      const {getByText, queryByText, queryAllByText} = component;
+      const {getByText, queryByText} = component;
 
       // Open Modal
       const modal = await renderModal(getByText('Add error rule'));
@@ -1114,11 +1138,11 @@ describe('Filters and Sampling', function () {
       // Release Field
       await modal.findByTestId('autocomplete-release');
       const releaseField = modal.getByTestId('autocomplete-release');
-      expect(releaseField).toBeTruthy();
+      expect(releaseField).toBeInTheDocument();
 
       // Release field is empty
-      const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
-      expect(releaseFieldValues).toHaveLength(0);
+      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      expect(releaseFieldValues).not.toBeInTheDocument();
 
       // Type into realease field
       fireEvent.change(within(releaseField).getByLabelText('Search or add a release'), {
@@ -1126,21 +1150,21 @@ describe('Filters and Sampling', function () {
       });
 
       // Autocomplete suggests options
-      const autocompleteOptions = within(releaseField).queryAllByTestId('option');
-      expect(autocompleteOptions).toHaveLength(1);
-      expect(autocompleteOptions[0].textContent).toEqual('1.2.3');
+      const autocompleteOptions = within(releaseField).queryByTestId('option');
+      expect(autocompleteOptions).toBeInTheDocument();
+      expect(autocompleteOptions?.[0]).toHaveTextContent('1.2.3');
 
       // Click on the suggested option
-      fireEvent.click(autocompleteOptions[0]);
+      fireEvent.click(autocompleteOptions?.[0]);
 
       // Button is still disabled
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-      expect(saveRuleButton).toBeTruthy();
+      expect(saveRuleButton).toBeInTheDocument();
       expect(saveRuleButton).toBeDisabled();
 
       // Fill sample rate field
       const sampleRateField = modal.getByPlaceholderText('\u0025');
-      expect(sampleRateField).toBeTruthy();
+      expect(sampleRateField).toBeInTheDocument();
       fireEvent.change(sampleRateField, {target: {value: 20}});
 
       // Save button is now enabled
@@ -1154,12 +1178,12 @@ describe('Filters and Sampling', function () {
       await waitForElementToBeRemoved(() => getByText('Add Error Sampling Rule'));
 
       // Error rules panel is updated
-      expect(queryByText('There are no error rules to display')).toBeFalsy();
-      const errorRules = queryAllByText('Errors only');
-      expect(errorRules).toHaveLength(1);
-      expect(getByText('Release')).toBeTruthy();
-      expect(getByText('1.2.3')).toBeTruthy();
-      expect(getByText('20%')).toBeTruthy();
+      expect(queryByText('There are no error rules to display')).not.toBeInTheDocument();
+      const errorRules = queryByText('Errors only');
+      expect(errorRules).toBeInTheDocument();
+      expect(getByText('Release')).toBeInTheDocument();
+      expect(getByText('1.2.3')).toBeInTheDocument();
+      expect(getByText('20%')).toBeInTheDocument();
     });
   });
 
@@ -1179,8 +1203,8 @@ describe('Filters and Sampling', function () {
       const modal = await renderModal(screen.getByText('Add transaction rule'), true);
 
       // Modal content
-      expect(modal.getByText('Add Transaction Sampling Rule')).toBeTruthy();
-      expect(modal.getByText('Tracing')).toBeTruthy();
+      expect(modal.getByText('Add Transaction Sampling Rule')).toBeInTheDocument();
+      expect(modal.getByText('Tracing')).toBeInTheDocument();
       expect(modal.getByRole('checkbox')).toBeChecked();
       expect(
         await findByTextContent(
@@ -1193,14 +1217,16 @@ describe('Filters and Sampling', function () {
           name: 'Learn more about tracing',
         })
       ).toHaveAttribute('href', DYNAMIC_SAMPLING_DOC_LINK);
-      expect(modal.getByText('Conditions')).toBeTruthy();
-      expect(modal.getByText('Add Condition')).toBeTruthy();
-      expect(modal.getByText('Apply sampling rate to all transactions')).toBeTruthy();
-      expect(modal.getByText('Sampling Rate \u0025')).toBeTruthy();
+      expect(modal.getByText('Conditions')).toBeInTheDocument();
+      expect(modal.getByText('Add Condition')).toBeInTheDocument();
+      expect(
+        modal.getByText('Apply sampling rate to all transactions')
+      ).toBeInTheDocument();
+      expect(modal.getByText('Sampling Rate \u0025')).toBeInTheDocument();
       expect(modal.getByPlaceholderText('\u0025')).toHaveValue(null);
-      expect(modal.getByRole('button', {name: 'Cancel'})).toBeTruthy();
+      expect(modal.getByRole('button', {name: 'Cancel'})).toBeInTheDocument();
       const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-      expect(saveRuleButton).toBeTruthy();
+      expect(saveRuleButton).toBeInTheDocument();
       expect(saveRuleButton).toBeDisabled();
 
       // Close Modal
@@ -1229,7 +1255,7 @@ describe('Filters and Sampling', function () {
       expect(conditionTracingOptions).toHaveLength(conditionTracingCategories.length);
 
       for (const conditionTracingOptionIndex in conditionTracingOptions) {
-        expect(conditionTracingOptions[conditionTracingOptionIndex].textContent).toEqual(
+        expect(conditionTracingOptions[conditionTracingOptionIndex]).toHaveTextContent(
           conditionTracingCategories[conditionTracingOptionIndex]
         );
       }
@@ -1245,7 +1271,7 @@ describe('Filters and Sampling', function () {
       expect(conditionOptions).toHaveLength(commonConditionCategories.length);
 
       for (const conditionOptionIndex in conditionOptions) {
-        expect(conditionOptions[conditionOptionIndex].textContent).toEqual(
+        expect(conditionOptions[conditionOptionIndex]).toHaveTextContent(
           commonConditionCategories[conditionOptionIndex]
         );
       }
@@ -1318,11 +1344,11 @@ describe('Filters and Sampling', function () {
         // Release Field
         await modal.findByTestId('autocomplete-release');
         const releaseField = modal.getByTestId('autocomplete-release');
-        expect(releaseField).toBeTruthy();
+        expect(releaseField).toBeInTheDocument();
 
         // Release field is empty
-        const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
-        expect(releaseFieldValues).toHaveLength(0);
+        const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+        expect(releaseFieldValues).not.toBeInTheDocument();
 
         // Type into realease field
         fireEvent.change(within(releaseField).getByLabelText('Search or add a release'), {
@@ -1332,21 +1358,21 @@ describe('Filters and Sampling', function () {
         // Autocomplete suggests options
         const autocompleteOptions = within(
           modal.getByTestId('autocomplete-release')
-        ).queryAllByTestId('option');
-        expect(autocompleteOptions).toHaveLength(1);
-        expect(autocompleteOptions[0].textContent).toEqual('1.2.3');
+        ).queryByTestId('option');
+        expect(autocompleteOptions).toBeInTheDocument();
+        expect(autocompleteOptions?.[0]).toHaveTextContent('1.2.3');
 
         // Click on the suggested option
-        fireEvent.click(autocompleteOptions[0]);
+        fireEvent.click(autocompleteOptions?.[0]);
 
         // Button is still disabled
         const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-        expect(saveRuleButton).toBeTruthy();
+        expect(saveRuleButton).toBeInTheDocument();
         expect(saveRuleButton).toBeDisabled();
 
         // Fill sample rate field
         const sampleRateField = modal.getByPlaceholderText('\u0025');
-        expect(sampleRateField).toBeTruthy();
+        expect(sampleRateField).toBeInTheDocument();
         fireEvent.change(sampleRateField, {target: {value: 20}});
 
         // Save button is now enabled
@@ -1364,12 +1390,12 @@ describe('Filters and Sampling', function () {
         // Transaction rules panel is updated
         expect(
           screen.queryByText('There are no transaction rules to display')
-        ).toBeFalsy();
-        const transactionTraceRules = screen.queryAllByText('Transaction traces');
-        expect(transactionTraceRules).toHaveLength(1);
-        expect(screen.getByText('Release')).toBeTruthy();
-        expect(screen.getByText('1.2.3')).toBeTruthy();
-        expect(screen.getByText('20%')).toBeTruthy();
+        ).not.toBeInTheDocument();
+        const transactionTraceRules = screen.queryByText('Transaction traces');
+        expect(transactionTraceRules).toBeInTheDocument();
+        expect(screen.getByText('Release')).toBeInTheDocument();
+        expect(screen.getByText('1.2.3')).toBeInTheDocument();
+        expect(screen.getByText('20%')).toBeInTheDocument();
       });
 
       describe('individual transaction', function () {
@@ -1435,11 +1461,11 @@ describe('Filters and Sampling', function () {
           // Release Field
           await modal.findByTestId('autocomplete-release');
           const releaseField = modal.getByTestId('autocomplete-release');
-          expect(releaseField).toBeTruthy();
+          expect(releaseField).toBeInTheDocument();
 
           // Release field is empty
-          const releaseFieldValues = within(releaseField).queryAllByTestId('multivalue');
-          expect(releaseFieldValues).toHaveLength(0);
+          const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+          expect(releaseFieldValues).not.toBeInTheDocument();
 
           // Type into realease field
           fireEvent.change(
@@ -1452,21 +1478,21 @@ describe('Filters and Sampling', function () {
           // Autocomplete suggests options
           const autocompleteOptions = within(
             modal.getByTestId('autocomplete-release')
-          ).queryAllByTestId('option');
-          expect(autocompleteOptions).toHaveLength(1);
-          expect(autocompleteOptions[0].textContent).toEqual('1.2.3');
+          ).queryByTestId('option');
+          expect(autocompleteOptions).toBeInTheDocument();
+          expect(autocompleteOptions?.[0]).toHaveTextContent('1.2.3');
 
           // Click on the suggested option
-          fireEvent.click(autocompleteOptions[0]);
+          fireEvent.click(autocompleteOptions?.[0]);
 
           // Button is still disabled
           const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-          expect(saveRuleButton).toBeTruthy();
+          expect(saveRuleButton).toBeInTheDocument();
           expect(saveRuleButton).toBeDisabled();
 
           // Fill sample rate field
           const sampleRateField = modal.getByPlaceholderText('\u0025');
-          expect(sampleRateField).toBeTruthy();
+          expect(sampleRateField).toBeInTheDocument();
           fireEvent.change(sampleRateField, {target: {value: 20}});
 
           // Save button is now enabled
@@ -1484,14 +1510,14 @@ describe('Filters and Sampling', function () {
           // Transaction rules panel is updated
           expect(
             screen.queryByText('There are no transaction rules to display')
-          ).toBeFalsy();
-          const individualTransactionRules = screen.queryAllByText(
+          ).not.toBeInTheDocument();
+          const individualTransactionRules = screen.queryByText(
             'Individual transactions'
           );
-          expect(individualTransactionRules).toHaveLength(1);
-          expect(screen.getByText('Release')).toBeTruthy();
-          expect(screen.getByText('1.2.3')).toBeTruthy();
-          expect(screen.getByText('20%')).toBeTruthy();
+          expect(individualTransactionRules).toBeInTheDocument();
+          expect(screen.getByText('Release')).toBeInTheDocument();
+          expect(screen.getByText('1.2.3')).toBeInTheDocument();
+          expect(screen.getByText('20%')).toBeInTheDocument();
         });
 
         it('legacy browser', async function () {
@@ -1563,19 +1589,19 @@ describe('Filters and Sampling', function () {
           fireEvent.click(conditionOptions[6]);
 
           // Legacy Browsers
-          expect(modal.getByText('All browsers')).toBeTruthy();
+          expect(modal.getByText('All browsers')).toBeInTheDocument();
 
           const legacyBrowsers = Object.keys(LEGACY_BROWSER_LIST);
           for (const legacyBrowser of legacyBrowsers) {
             const {icon, title} = LEGACY_BROWSER_LIST[legacyBrowser];
-            expect(modal.getByText(title)).toBeTruthy();
-            expect(modal.queryAllByTestId(`icon-${icon}`)).toBeTruthy();
+            expect(modal.getByText(title)).toBeInTheDocument();
+            expect(modal.queryByTestId(`icon-${icon}`)).toBeInTheDocument();
           }
 
           expect(modal.queryAllByTestId('icon-internet-explorer')).toHaveLength(4);
           expect(modal.queryAllByTestId('icon-opera')).toHaveLength(2);
-          expect(modal.queryAllByTestId('icon-safari')).toHaveLength(1);
-          expect(modal.queryAllByTestId('icon-android')).toHaveLength(1);
+          expect(modal.queryByTestId('icon-safari')).toBeInTheDocument();
+          expect(modal.queryByTestId('icon-android')).toBeInTheDocument();
 
           const switchButtons = modal.queryAllByTestId('switch');
           expect(switchButtons).toHaveLength(legacyBrowsers.length + 1);
@@ -1595,12 +1621,12 @@ describe('Filters and Sampling', function () {
 
           // Button is still disabled
           const saveRuleButton = modal.getByRole('button', {name: 'Save Rule'});
-          expect(saveRuleButton).toBeTruthy();
+          expect(saveRuleButton).toBeInTheDocument();
           expect(saveRuleButton).toBeDisabled();
 
           // Fill sample rate field
           const sampleRateField = modal.getByPlaceholderText('\u0025');
-          expect(sampleRateField).toBeTruthy();
+          expect(sampleRateField).toBeInTheDocument();
           fireEvent.change(sampleRateField, {target: {value: 20}});
 
           // Save button is now enabled
@@ -1618,17 +1644,17 @@ describe('Filters and Sampling', function () {
           // Transaction rules panel is updated
           expect(
             screen.queryByText('There are no transaction rules to display')
-          ).toBeFalsy();
-          const individualTransactionRules = screen.queryAllByText(
+          ).not.toBeInTheDocument();
+          const individualTransactionRules = screen.queryByText(
             'Individual transactions'
           );
-          expect(individualTransactionRules).toHaveLength(1);
-          expect(screen.getByText('Legacy Browser')).toBeTruthy();
+          expect(individualTransactionRules).toBeInTheDocument();
+          expect(screen.getByText('Legacy Browser')).toBeInTheDocument();
           for (const legacyBrowser of legacyBrowsers) {
             const {title} = LEGACY_BROWSER_LIST[legacyBrowser];
-            expect(screen.getByText(title)).toBeTruthy();
+            expect(screen.getByText(title)).toBeInTheDocument();
           }
-          expect(screen.getByText('20%')).toBeTruthy();
+          expect(screen.getByText('20%')).toBeInTheDocument();
         });
       });
     });


### PR DESCRIPTION
The advantages of using these recommended assertions are:
- better error messages
- overall semantics, consistency, and uniformity

In a follow-up PR, I'll put an eslint rule (https://github.com/testing-library/eslint-plugin-jest-dom) in place to ensure that we keep this up in the future.

Relates to https://github.com/getsentry/sentry/pull/29312 and https://github.com/getsentry/sentry/pull/29517