### PR TITLE
fix(dashboards): Fix inconsistent widget query legends

### DIFF
--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
 
 import {doEventsRequest} from 'app/actionCreators/events';
@@ -339,10 +340,13 @@ class WidgetQueries extends React.Component<Props, State> {
             transformResult(widget.queries[i], rawResults)
           );
 
+          const rawResultsClone = cloneDeep(prevState.rawResults ?? []);
+          rawResultsClone[i] = rawResults;
+
           return {
             ...prevState,
             timeseriesResults,
-            rawResults: (prevState.rawResults ?? []).concat(rawResults),
+            rawResults: rawResultsClone,
           };
         });
       } catch (err) {


### PR DESCRIPTION
It seems because of the async nature of
the promises being resolved for widget
queries, simply concating raw results
doesn't work because the order isn't
ensured. Instead, we want to use the index
as a key here so that we can always
ensure the raw results are in the same
order as the widgetQueries.

Example of weird labels (Note how Releases and the NEW series have switched):
![Screen Shot 2021-10-22 at 9 03 24 AM](https://user-images.githubusercontent.com/63818634/138458145-b647b49e-aa49-4f49-b449-893f2c99c315.png)



![Screen Shot 2021-10-22 at 9 02 07 AM](https://user-images.githubusercontent.com/63818634/138458053-a0e00b28-b5ba-4b8d-8e84-b3e4c52599ed.png)


