### PR TITLE
fix(discover): Disable y axis equations when in world map view

### DIFF
--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -17,6 +17,7 @@ import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
+import {isEquation} from 'app/utils/discover/fields';
 import {
   DisplayModes,
   MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
@@ -250,6 +251,10 @@ class ResultsChartContainer extends Component<ContainerProps> {
           checkboxHidden: true,
         };
       });
+    }
+    // Equations on World Map isn't supported
+    if (eventView.getDisplayMode() === DisplayModes.WORLDMAP) {
+      yAxisOptions = yAxisOptions.filter(({value}) => !isEquation(value));
     }
 
     return (

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -252,7 +252,8 @@ class ResultsChartContainer extends Component<ContainerProps> {
         };
       });
     }
-    // Equations on World Map isn't supported
+    // Equations on World Map isn't supported on the events-geo endpoint
+    // Disabling equations as an option to prevent erroring out
     if (eventView.getDisplayMode() === DisplayModes.WORLDMAP) {
       yAxisOptions = yAxisOptions.filter(({value}) => !isEquation(value));
     }

--- a/tests/js/spec/views/eventsV2/resultsChart.spec.tsx
+++ b/tests/js/spec/views/eventsV2/resultsChart.spec.tsx
@@ -113,4 +113,33 @@ describe('EventsV2 > ResultsChart', function () {
       }
     });
   });
+
+  it('disables equation y-axis options when in World Map display mode', async function () {
+    eventView.display = DisplayModes.WORLDMAP;
+    eventView.fields = [
+      {field: 'count()'},
+      {field: 'count_unique(user)'},
+      {field: 'equation|count() + 2'},
+    ];
+    const wrapper = mountWithTheme(
+      <ResultsChart
+        // @ts-expect-error
+        router={TestStubs.router()}
+        organization={organization}
+        eventView={eventView}
+        // @ts-expect-error
+        location={location}
+        onAxisChange={() => undefined}
+        onDisplayChange={() => undefined}
+        total={1}
+        confirmedQuery
+        yAxis={['count()']}
+      />,
+      initialData.routerContext
+    );
+    const yAxisOptions = wrapper.find('ChartFooter').props().yAxisOptions;
+    expect(yAxisOptions.length).toEqual(2);
+    expect(yAxisOptions[0].value).toEqual('count()');
+    expect(yAxisOptions[1].value).toEqual('count_unique(user)');
+  });
 });


### PR DESCRIPTION
World Map display mode uses the `events-geo` endpoint which currently does not support equations.
Disabling equations from the y-axis dropdown selection when the user is in World Map display mode.