### PR TITLE
ref(tests): Remove query* for anything except checking for non-existe…

### DIFF
--- a/tests/js/spec/components/avatar/avatarList.spec.tsx
+++ b/tests/js/spec/components/avatar/avatarList.spec.tsx
@@ -35,11 +35,11 @@ describe('AvatarList', () => {
     ];
 
     const {container} = renderComponent(users);
-    expect(screen.queryByText(users[0].name.charAt(0))).toBeInTheDocument();
-    expect(screen.queryByText(users[1].name.charAt(0))).toBeInTheDocument();
-    expect(screen.queryByText(users[2].name.charAt(0))).toBeInTheDocument();
-    expect(screen.queryByText(users[3].name.charAt(0))).toBeInTheDocument();
-    expect(screen.queryByText(users[4].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[0].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[1].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[2].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[3].name.charAt(0))).toBeInTheDocument();
+    expect(screen.getByText(users[4].name.charAt(0))).toBeInTheDocument();
     expect(screen.queryByText(users[5].name.charAt(0))).not.toBeInTheDocument();
     expect(screen.getByTestId('avatarList-collapsedusers')).toBeInTheDocument();
     expect(container).toSnapshot();

--- a/tests/js/spec/components/events/eventTagsAndScreenshot.spec.tsx
+++ b/tests/js/spec/components/events/eventTagsAndScreenshot.spec.tsx
@@ -161,8 +161,8 @@ describe('EventTagsAndScreenshot ', function () {
       expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeInTheDocument();
-      const contextItems = screen.queryAllByTestId('context-item');
+      expect(screen.getByText('Tags')).toBeInTheDocument();
+      const contextItems = screen.getAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
       // Context Item 1
@@ -188,7 +188,7 @@ describe('EventTagsAndScreenshot ', function () {
 
       // Tags
       const tagsContainer = within(screen.getByTestId('event-tags'));
-      expect(tagsContainer.queryAllByRole('listitem')).toHaveLength(tags.length);
+      expect(tagsContainer.getAllByRole('listitem')).toHaveLength(tags.length);
 
       expect(container).toSnapshot();
     });
@@ -211,7 +211,7 @@ describe('EventTagsAndScreenshot ', function () {
       expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeInTheDocument();
+      expect(screen.getByText('Tags')).toBeInTheDocument();
 
       expect(container).toSnapshot();
     });
@@ -234,7 +234,7 @@ describe('EventTagsAndScreenshot ', function () {
       expect(screen.queryByText('Screenshot')).not.toBeInTheDocument();
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeInTheDocument();
+      expect(screen.getByText('Tags')).toBeInTheDocument();
 
       expect(container).toSnapshot();
     });
@@ -258,7 +258,7 @@ describe('EventTagsAndScreenshot ', function () {
       expect(screen.queryByText('Tags')).not.toBeInTheDocument();
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('Screenshot')).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
@@ -284,7 +284,7 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('Screenshot')).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
@@ -292,13 +292,13 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeInTheDocument();
-      const contextItems = screen.queryAllByTestId('context-item');
+      expect(screen.getByText('Tags')).toBeInTheDocument();
+      const contextItems = screen.getAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
       // Tags
       const tagsContainer = within(screen.getByTestId('event-tags'));
-      expect(tagsContainer.queryAllByRole('listitem')).toHaveLength(tags.length);
+      expect(tagsContainer.getAllByRole('listitem')).toHaveLength(tags.length);
 
       expect(container).toSnapshot();
     });
@@ -317,7 +317,7 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('Screenshot')).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
@@ -325,8 +325,8 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeInTheDocument();
-      const contextItems = screen.queryAllByTestId('context-item');
+      expect(screen.getByText('Tags')).toBeInTheDocument();
+      const contextItems = screen.getAllByTestId('context-item');
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
       // Tags
@@ -350,7 +350,7 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Screenshot Container
-      expect(screen.queryByText('Screenshot')).toBeInTheDocument();
+      expect(screen.getByText('Screenshot')).toBeInTheDocument();
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByRole('img')).toHaveAttribute(
         'src',
@@ -358,13 +358,13 @@ describe('EventTagsAndScreenshot ', function () {
       );
 
       // Tags Container
-      expect(screen.queryByText('Tags')).toBeInTheDocument();
+      expect(screen.getByText('Tags')).toBeInTheDocument();
       const contextItems = screen.queryByTestId('context-item');
       expect(contextItems).not.toBeInTheDocument();
 
       // Tags
       const tagsContainer = within(screen.getByTestId('event-tags'));
-      expect(tagsContainer.queryAllByRole('listitem')).toHaveLength(tags.length);
+      expect(tagsContainer.getAllByRole('listitem')).toHaveLength(tags.length);
 
       expect(container).toSnapshot();
     });

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -119,7 +119,7 @@ describe('Breadcrumbs', () => {
       mountWithTheme(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
-      expect(screen.queryAllByTestId('crumb')).toHaveLength(4);
+      expect(screen.getAllByTestId('crumb')).toHaveLength(4);
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });
@@ -156,7 +156,7 @@ describe('Breadcrumbs', () => {
       mountWithTheme(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
-      expect(screen.queryByTestId('crumb')).toBeInTheDocument();
+      expect(screen.getByTestId('crumb')).toBeInTheDocument();
 
       expect(screen.getByTestId('last-crumb')).toBeInTheDocument();
     });

--- a/tests/js/spec/components/events/interfaces/frame/line.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/frame/line.spec.tsx
@@ -67,7 +67,7 @@ describe('Frame - Line', function () {
           isExpanded
         />
       );
-      expect(screen.queryByRole('list')).toSnapshot();
+      expect(screen.getByRole('list')).toSnapshot();
     });
 
     it('should render register values', () => {

--- a/tests/js/spec/components/events/interfaces/stacktrace.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/stacktrace.spec.tsx
@@ -51,7 +51,7 @@ describe('StackTrace', function () {
     renderedComponent({});
 
     // frame - filename
-    const frameFilenames = screen.queryAllByTestId('filename');
+    const frameFilenames = screen.getAllByTestId('filename');
     expect(frameFilenames).toHaveLength(5);
     expect(frameFilenames[0]).toHaveTextContent('raven/scripts/runner.py');
     expect(frameFilenames[1]).toHaveTextContent('raven/scripts/runner.py');
@@ -60,7 +60,7 @@ describe('StackTrace', function () {
     expect(frameFilenames[4]).toHaveTextContent('raven/base.py');
 
     // frame - function
-    const frameFunction = screen.queryAllByTestId('function');
+    const frameFunction = screen.getAllByTestId('function');
     expect(frameFunction).toHaveLength(5);
     expect(frameFunction[0]).toHaveTextContent('main');
     expect(frameFunction[1]).toHaveTextContent('send_test_message');
@@ -76,11 +76,11 @@ describe('StackTrace', function () {
     expect(frames.children).toHaveLength(5);
 
     // only one frame is expanded by default
-    expect(screen.queryByTestId('toggle-button-expanded')).toBeInTheDocument();
-    expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(4);
+    expect(screen.getByTestId('toggle-button-expanded')).toBeInTheDocument();
+    expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(4);
 
     // clickable list item element
-    const frameTitles = screen.queryAllByTestId('title');
+    const frameTitles = screen.getAllByTestId('title');
 
     // collapse the expanded frame (by default)
     fireEvent.mouseDown(frameTitles[0]);
@@ -88,7 +88,7 @@ describe('StackTrace', function () {
 
     // all frames are now collapsed
     expect(screen.queryByTestId('toggle-button-expanded')).not.toBeInTheDocument();
-    expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(5);
+    expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(5);
 
     // expand penultimate and last frame
     fireEvent.mouseDown(frameTitles[frameTitles.length - 2]);
@@ -98,8 +98,8 @@ describe('StackTrace', function () {
     fireEvent.click(frameTitles[frameTitles.length - 1]);
 
     // two frames are now collapsed
-    expect(screen.queryAllByTestId('toggle-button-expanded')).toHaveLength(2);
-    expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(3);
+    expect(screen.getAllByTestId('toggle-button-expanded')).toHaveLength(2);
+    expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(3);
   });
 
   it('collapse/expand frames by clicking on the toggle button', function () {
@@ -113,7 +113,7 @@ describe('StackTrace', function () {
 
     // only one frame is expanded by default
     expect(expandedToggleButtons).toBeInTheDocument();
-    expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(4);
+    expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(4);
 
     // collapse the expanded frame (by default)
     fireEvent.mouseDown(expandedToggleButtons);
@@ -121,9 +121,9 @@ describe('StackTrace', function () {
 
     // all frames are now collapsed
     expect(screen.queryByTestId('toggle-button-expanded')).not.toBeInTheDocument();
-    expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(5);
+    expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(5);
 
-    const collapsedToggleButtons = screen.queryAllByTestId('toggle-button-collapsed');
+    const collapsedToggleButtons = screen.getAllByTestId('toggle-button-collapsed');
 
     // expand penultimate and last frame
     fireEvent.mouseDown(collapsedToggleButtons[collapsedToggleButtons.length - 2]);
@@ -133,8 +133,8 @@ describe('StackTrace', function () {
     fireEvent.click(collapsedToggleButtons[collapsedToggleButtons.length - 1]);
 
     // two frames are now collapsed
-    expect(screen.queryAllByTestId('toggle-button-expanded')).toHaveLength(2);
-    expect(screen.queryAllByTestId('toggle-button-collapsed')).toHaveLength(3);
+    expect(screen.getAllByTestId('toggle-button-expanded')).toHaveLength(2);
+    expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(3);
   });
 
   it('if all in_app equals false, all the frames are showing by default', function () {
@@ -165,7 +165,7 @@ describe('StackTrace', function () {
       });
 
       // clickable list item element
-      const frameTitles = screen.queryAllByTestId('title');
+      const frameTitles = screen.getAllByTestId('title');
 
       // frame list - in app only
       expect(frameTitles).toHaveLength(2);
@@ -196,7 +196,7 @@ describe('StackTrace', function () {
       });
 
       // clickable list item element
-      const frameTitles = screen.queryAllByTestId('title');
+      const frameTitles = screen.getAllByTestId('title');
 
       // frame list - in app only
       expect(frameTitles).toHaveLength(2);
@@ -229,7 +229,7 @@ describe('StackTrace', function () {
       });
 
       // clickable list item element
-      const frameTitles = screen.queryAllByTestId('title');
+      const frameTitles = screen.getAllByTestId('title');
 
       // frame list - in app only
       expect(frameTitles).toHaveLength(3);

--- a/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
+++ b/tests/js/spec/views/settings/projectFiltersAndSampling.spec.tsx
@@ -104,7 +104,7 @@ describe('Filters and Sampling', function () {
       ).toBeInTheDocument();
       expect(screen.getByText('Add transaction rule')).toBeInTheDocument();
 
-      const readDocsButtonLinks = screen.queryAllByRole('button', {
+      const readDocsButtonLinks = screen.getAllByRole('button', {
         name: 'Read the docs',
       });
       expect(readDocsButtonLinks).toHaveLength(2);
@@ -113,9 +113,9 @@ describe('Filters and Sampling', function () {
         expect(readDocsButtonLink).toHaveAttribute('href', DYNAMIC_SAMPLING_DOC_LINK);
       }
 
-      expect(screen.queryAllByText('Type')).toHaveLength(2);
-      expect(screen.queryAllByText('Conditions')).toHaveLength(2);
-      expect(screen.queryAllByText('Rate')).toHaveLength(2);
+      expect(screen.getAllByText('Type')).toHaveLength(2);
+      expect(screen.getAllByText('Conditions')).toHaveLength(2);
+      expect(screen.getAllByText('Rate')).toHaveLength(2);
 
       expect(container).toSnapshot();
     });
@@ -226,15 +226,15 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no transaction rules to display')
       ).not.toBeInTheDocument();
-      const transactionTraceRules = screen.queryByText('Transaction traces');
+      const transactionTraceRules = screen.getByText('Transaction traces');
       expect(transactionTraceRules).toBeInTheDocument();
 
-      const individualTransactionRules = screen.queryByText('Individual transactions');
+      const individualTransactionRules = screen.getByText('Individual transactions');
       expect(individualTransactionRules).toBeInTheDocument();
 
       expect(screen.getByText('Add transaction rule')).toBeInTheDocument();
 
-      const readDocsButtonLinks = screen.queryAllByRole('button', {
+      const readDocsButtonLinks = screen.getAllByRole('button', {
         name: 'Read the docs',
       });
       expect(readDocsButtonLinks).toHaveLength(2);
@@ -243,9 +243,9 @@ describe('Filters and Sampling', function () {
         expect(readDocsButtonLink).toHaveAttribute('href', DYNAMIC_SAMPLING_DOC_LINK);
       }
 
-      expect(screen.queryAllByText('Type')).toHaveLength(2);
-      expect(screen.queryAllByText('Conditions')).toHaveLength(2);
-      expect(screen.queryAllByText('Rate')).toHaveLength(2);
+      expect(screen.getAllByText('Type')).toHaveLength(2);
+      expect(screen.getAllByText('Conditions')).toHaveLength(2);
+      expect(screen.getAllByText('Rate')).toHaveLength(2);
 
       expect(container).toSnapshot();
     });
@@ -360,10 +360,10 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no transaction rules to display')
       ).not.toBeInTheDocument();
-      const transactionTraceRules = screen.queryByText('Transaction traces');
+      const transactionTraceRules = screen.getByText('Transaction traces');
       expect(transactionTraceRules).toBeInTheDocument();
 
-      const editRuleButtons = screen.queryAllByLabelText('Edit Rule');
+      const editRuleButtons = screen.getAllByLabelText('Edit Rule');
       expect(editRuleButtons).toHaveLength(2);
 
       // Open rule modal - edit error rule
@@ -379,7 +379,7 @@ describe('Filters and Sampling', function () {
       expect(releaseField).toBeInTheDocument();
 
       // Release field is not empty
-      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      const releaseFieldValues = within(releaseField).getByTestId('multivalue');
       expect(releaseFieldValues).toBeInTheDocument();
       expect(releaseFieldValues).toHaveTextContent('1*');
 
@@ -453,7 +453,7 @@ describe('Filters and Sampling', function () {
       // Error rules panel is updated
       expect(screen.getByText('Errors only')).toBeInTheDocument();
 
-      expect(screen.queryAllByText('Release')).toHaveLength(2);
+      expect(screen.getAllByText('Release')).toHaveLength(2);
 
       // Old values
       expect(screen.queryByText('1*')).not.toBeInTheDocument();
@@ -572,10 +572,10 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no transaction rules to display')
       ).not.toBeInTheDocument();
-      const transactionTraceRules = screen.queryByText('Transaction traces');
+      const transactionTraceRules = screen.getByText('Transaction traces');
       expect(transactionTraceRules).toBeInTheDocument();
 
-      const editRuleButtons = screen.queryAllByLabelText('Edit Rule');
+      const editRuleButtons = screen.getAllByLabelText('Edit Rule');
       expect(editRuleButtons).toHaveLength(2);
 
       // Open rule modal - edit transaction rule
@@ -583,7 +583,7 @@ describe('Filters and Sampling', function () {
 
       // Modal content
       expect(modal.getByText('Edit Transaction Sampling Rule')).toBeInTheDocument();
-      expect(modal.queryByText('Tracing')).toBeInTheDocument();
+      expect(modal.getByText('Tracing')).toBeInTheDocument();
       expect(modal.getByRole('checkbox')).toBeChecked();
 
       // Release Field
@@ -592,7 +592,7 @@ describe('Filters and Sampling', function () {
       expect(releaseField).toBeInTheDocument();
 
       // Release field is not empty
-      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      const releaseFieldValues = within(releaseField).getByTestId('multivalue');
       expect(releaseFieldValues).toBeInTheDocument();
       expect(releaseFieldValues).toHaveTextContent('1.2.3');
 
@@ -669,7 +669,7 @@ describe('Filters and Sampling', function () {
       expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       expect(screen.getByText('Transaction traces')).toBeInTheDocument();
-      expect(screen.queryAllByText('Release')).toHaveLength(2);
+      expect(screen.getAllByText('Release')).toHaveLength(2);
 
       // Old values
       expect(screen.queryByText('1.2.3')).not.toBeInTheDocument();
@@ -788,10 +788,10 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no transaction rules to display')
       ).not.toBeInTheDocument();
-      const transactionTraceRules = screen.queryByText('Individual transactions');
+      const transactionTraceRules = screen.getByText('Individual transactions');
       expect(transactionTraceRules).toBeInTheDocument();
 
-      const editRuleButtons = screen.queryAllByLabelText('Edit Rule');
+      const editRuleButtons = screen.getAllByLabelText('Edit Rule');
       expect(editRuleButtons).toHaveLength(2);
 
       // Open rule modal - edit transaction rule
@@ -799,7 +799,7 @@ describe('Filters and Sampling', function () {
 
       // Modal content
       expect(modal.getByText('Edit Transaction Sampling Rule')).toBeInTheDocument();
-      expect(modal.queryByText('Tracing')).toBeInTheDocument();
+      expect(modal.getByText('Tracing')).toBeInTheDocument();
       expect(modal.getByRole('checkbox')).not.toBeChecked();
 
       // Release Field
@@ -808,7 +808,7 @@ describe('Filters and Sampling', function () {
       expect(releaseField).toBeInTheDocument();
 
       // Release field is not empty
-      const releaseFieldValues = within(releaseField).queryByTestId('multivalue');
+      const releaseFieldValues = within(releaseField).getByTestId('multivalue');
       expect(releaseFieldValues).toBeInTheDocument();
 
       // Button is enabled - meaning the form is valid
@@ -884,7 +884,7 @@ describe('Filters and Sampling', function () {
       expect(screen.getByText('Errors only')).toBeInTheDocument();
 
       expect(screen.getByText('Individual transactions')).toBeInTheDocument();
-      expect(screen.queryAllByText('Release')).toHaveLength(2);
+      expect(screen.getAllByText('Release')).toHaveLength(2);
 
       // Old values
       expect(screen.queryByText('1.2.3')).not.toBeInTheDocument();
@@ -983,10 +983,10 @@ describe('Filters and Sampling', function () {
       expect(
         screen.queryByText('There are no transaction rules to display')
       ).not.toBeInTheDocument();
-      const transactionTraceRules = screen.queryByText('Transaction traces');
+      const transactionTraceRules = screen.getByText('Transaction traces');
       expect(transactionTraceRules).toBeInTheDocument();
 
-      const deleteRuleButtons = screen.queryAllByLabelText('Delete Rule');
+      const deleteRuleButtons = screen.getAllByLabelText('Delete Rule');
       expect(deleteRuleButtons).toHaveLength(2);
 
       // Open deletion confirmation modal - delete error rule
@@ -996,7 +996,7 @@ describe('Filters and Sampling', function () {
         modal.getByText('Are you sure you wish to delete this dynamic sampling rule?')
       ).toBeInTheDocument();
 
-      const modalActionButtons = modal.queryAllByRole('button');
+      const modalActionButtons = modal.getAllByRole('button');
       expect(modalActionButtons).toHaveLength(2);
       expect(modalActionButtons[0]).toHaveTextContent('Cancel');
       expect(modalActionButtons[1]).toHaveTextContent('Confirm');
@@ -1010,9 +1010,7 @@ describe('Filters and Sampling', function () {
       );
 
       // Error rules panel is updated
-      expect(
-        screen.queryByText('There are no error rules to display')
-      ).toBeInTheDocument();
+      expect(screen.getByText('There are no error rules to display')).toBeInTheDocument();
 
       // There is still one transaction rule
       expect(transactionTraceRules).toBeInTheDocument();
@@ -1058,7 +1056,7 @@ describe('Filters and Sampling', function () {
       expect(autoCompleteList).toBeInTheDocument();
 
       // Condition Options
-      const conditionOptions = modal.queryAllByRole('presentation');
+      const conditionOptions = modal.getAllByRole('presentation');
       expect(conditionOptions).toHaveLength(commonConditionCategories.length);
 
       for (const conditionOptionIndex in conditionOptions) {
@@ -1124,7 +1122,7 @@ describe('Filters and Sampling', function () {
       expect(autoCompleteList).toBeInTheDocument();
 
       // Condition Options
-      const conditionOptions = modal.queryAllByRole('presentation');
+      const conditionOptions = modal.getAllByRole('presentation');
 
       // Click on the first condition option
       fireEvent.click(conditionOptions[0]);
@@ -1244,7 +1242,7 @@ describe('Filters and Sampling', function () {
       expect(autoCompleteList).toBeInTheDocument();
 
       // Trancing Condition Options
-      const conditionTracingOptions = modal.queryAllByRole('presentation');
+      const conditionTracingOptions = modal.getAllByRole('presentation');
       expect(conditionTracingOptions).toHaveLength(conditionTracingCategories.length);
 
       for (const conditionTracingOptionIndex in conditionTracingOptions) {
@@ -1260,7 +1258,7 @@ describe('Filters and Sampling', function () {
       fireEvent.click(modal.getByText('Add Condition'));
 
       // No Tracing Condition Options
-      const conditionOptions = modal.queryAllByRole('presentation');
+      const conditionOptions = modal.getAllByRole('presentation');
       expect(conditionOptions).toHaveLength(commonConditionCategories.length);
 
       for (const conditionOptionIndex in conditionOptions) {
@@ -1329,7 +1327,7 @@ describe('Filters and Sampling', function () {
         expect(autoCompleteList).toBeInTheDocument();
 
         // Condition Options
-        const conditionOptions = modal.queryAllByRole('presentation');
+        const conditionOptions = modal.getAllByRole('presentation');
 
         // Click on the first condition option
         fireEvent.click(conditionOptions[0]);
@@ -1384,7 +1382,7 @@ describe('Filters and Sampling', function () {
         expect(
           screen.queryByText('There are no transaction rules to display')
         ).not.toBeInTheDocument();
-        const transactionTraceRules = screen.queryByText('Transaction traces');
+        const transactionTraceRules = screen.getByText('Transaction traces');
         expect(transactionTraceRules).toBeInTheDocument();
         expect(screen.getByText('Release')).toBeInTheDocument();
         expect(screen.getByText('1.2.3')).toBeInTheDocument();
@@ -1446,7 +1444,7 @@ describe('Filters and Sampling', function () {
           expect(autoCompleteList).toBeInTheDocument();
 
           // Condition Options
-          const conditionOptions = modal.queryAllByRole('presentation');
+          const conditionOptions = modal.getAllByRole('presentation');
 
           // Click on the first condition option
           fireEvent.click(conditionOptions[0]);
@@ -1504,9 +1502,7 @@ describe('Filters and Sampling', function () {
           expect(
             screen.queryByText('There are no transaction rules to display')
           ).not.toBeInTheDocument();
-          const individualTransactionRules = screen.queryByText(
-            'Individual transactions'
-          );
+          const individualTransactionRules = screen.getByText('Individual transactions');
           expect(individualTransactionRules).toBeInTheDocument();
           expect(screen.getByText('Release')).toBeInTheDocument();
           expect(screen.getByText('1.2.3')).toBeInTheDocument();
@@ -1576,7 +1572,7 @@ describe('Filters and Sampling', function () {
           expect(autoCompleteList).toBeInTheDocument();
 
           // Condition Options
-          const conditionOptions = modal.queryAllByRole('presentation');
+          const conditionOptions = modal.getAllByRole('presentation');
 
           // Click on the seventh condition option
           fireEvent.click(conditionOptions[6]);
@@ -1588,15 +1584,15 @@ describe('Filters and Sampling', function () {
           for (const legacyBrowser of legacyBrowsers) {
             const {icon, title} = LEGACY_BROWSER_LIST[legacyBrowser];
             expect(modal.getByText(title)).toBeInTheDocument();
-            expect(modal.queryAllByTestId(`icon-${icon}`)[0]).toBeInTheDocument();
+            expect(modal.getAllByTestId(`icon-${icon}`)[0]).toBeInTheDocument();
           }
 
-          expect(modal.queryAllByTestId('icon-internet-explorer')).toHaveLength(4);
-          expect(modal.queryAllByTestId('icon-opera')).toHaveLength(2);
-          expect(modal.queryByTestId('icon-safari')).toBeInTheDocument();
-          expect(modal.queryByTestId('icon-android')).toBeInTheDocument();
+          expect(modal.getAllByTestId('icon-internet-explorer')).toHaveLength(4);
+          expect(modal.getAllByTestId('icon-opera')).toHaveLength(2);
+          expect(modal.getByTestId('icon-safari')).toBeInTheDocument();
+          expect(modal.getByTestId('icon-android')).toBeInTheDocument();
 
-          const switchButtons = modal.queryAllByTestId('switch');
+          const switchButtons = modal.getAllByTestId('switch');
           expect(switchButtons).toHaveLength(legacyBrowsers.length + 1);
 
           // All browsers are unchecked
@@ -1638,9 +1634,7 @@ describe('Filters and Sampling', function () {
           expect(
             screen.queryByText('There are no transaction rules to display')
           ).not.toBeInTheDocument();
-          const individualTransactionRules = screen.queryByText(
-            'Individual transactions'
-          );
+          const individualTransactionRules = screen.getByText('Individual transactions');
           expect(individualTransactionRules).toBeInTheDocument();
           expect(screen.getByText('Legacy Browser')).toBeInTheDocument();
           for (const legacyBrowser of legacyBrowsers) {


### PR DESCRIPTION
…nce in RTL

The `query*` variants should be used only for asserting that an element cannot found.

The `get*` and `find*` variants will throw a more helpful error message if no element is found.

This is a follow-up to: https://github.com/getsentry/sentry/pull/29312 and https://github.com/getsentry/sentry/pull/29508