### PR TITLE
fix(suspect-spans): No aggregate conditions in examples query

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -288,8 +288,6 @@ def query_example_transactions(
         ],
         query=query,
         orderby=get_function_alias(order_column),
-        auto_aggregations=True,
-        use_aggregate_conditions=True,
         # we want only `per_suspect` examples for each suspect
         limit=len(suspects) * per_suspect,
         functions_acl=["array_join", "sumArray", "percentileArray", "maxArray"],


### PR DESCRIPTION
Carrying over the aggregate conditions from the suspect query into the examples
query results in some weird behaviour. For example the `count():>1` condition
will filter out all examples where the span only occurs once.