### PR TITLE
fix(vercel): Get Token

### DIFF
--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -44,7 +44,7 @@ class ProjectIndexEndpoint(Endpoint):
                 queryset = queryset.none()
         elif not (is_active_superuser(request) and request.GET.get("show") == "all"):
             if request.user.is_sentry_app:
-                queryset = SentryAppInstallationToken.get_projects(request.auth)
+                queryset = SentryAppInstallationToken.objects.get_projects(request.auth)
                 if isinstance(queryset, EmptyQuerySet):
                     raise AuthenticationFailed("Token not found")
             else:

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -37,7 +37,7 @@ class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
 
         components = []
 
-        for install in SentryAppInstallation.get_installed_for_org(organization.id):
+        for install in SentryAppInstallation.objects.get_installed_for_organization(organization.id):
             _components = SentryAppComponent.objects.filter(sentry_app_id=install.sentry_app_id)
 
             if "filter" in request.GET:

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -37,7 +37,9 @@ class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
 
         components = []
 
-        for install in SentryAppInstallation.objects.get_installed_for_organization(organization.id):
+        for install in SentryAppInstallation.objects.get_installed_for_organization(
+            organization.id
+        ):
             _components = SentryAppComponent.objects.filter(sentry_app_id=install.sentry_app_id)
 
             if "filter" in request.GET:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -462,7 +462,7 @@ class GroupSerializerBase(Serializer):
             and getattr(request.user, "is_sentry_app", False)
             and isinstance(request.auth, ApiToken)
         ):
-            is_valid_sentryapp = SentryAppInstallationToken.has_organization_access(
+            is_valid_sentryapp = SentryAppInstallationToken.objects.has_organization_access(
                 request.auth, obj.organization
             )
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_available_action_index.py
@@ -89,7 +89,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpoint(OrganizationEndpoint):
             elif registered_type.type == AlertRuleTriggerAction.Type.SENTRY_APP:
                 actions += [
                     build_action_response(registered_type, sentry_app_installation=install)
-                    for install in SentryAppInstallation.get_installed_for_org(
+                    for install in SentryAppInstallation.objects.get_installed_for_organization(
                         organization.id
                     ).filter(
                         sentry_app__is_alertable=True,

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -20,7 +20,7 @@ from sentry.models import (
     Project,
     ProjectKey,
     SentryAppInstallation,
-    SentryAppInstallationForProvider,
+    SentryAppInstallationToken,
     User,
 )
 from sentry.pipeline import NestedPipelineView
@@ -229,7 +229,7 @@ class VercelIntegration(IntegrationInstallation):
             is_next_js = vercel_project.get("framework") == "nextjs"
             dsn_env_name = "NEXT_PUBLIC_SENTRY_DSN" if is_next_js else "SENTRY_DSN"
 
-            sentry_auth_token = SentryAppInstallationForProvider.objects.get_token(
+            sentry_auth_token = SentryAppInstallationToken.objects.get_token(
                 sentry_project.organization.id,
                 "vercel",
             )

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -229,7 +229,7 @@ class VercelIntegration(IntegrationInstallation):
             is_next_js = vercel_project.get("framework") == "nextjs"
             dsn_env_name = "NEXT_PUBLIC_SENTRY_DSN" if is_next_js else "SENTRY_DSN"
 
-            sentry_auth_token = SentryAppInstallationForProvider.get_token(
+            sentry_auth_token = SentryAppInstallationForProvider.objects.get_token(
                 sentry_project.organization.id,
                 "vercel",
             )

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -20,6 +20,7 @@ from sentry.models import (
     Project,
     ProjectKey,
     SentryAppInstallation,
+    SentryAppInstallationForProvider,
     SentryAppInstallationToken,
     User,
 )

--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -110,6 +110,8 @@ from .sentryapp import *  # NOQA
 from .sentryappavatar import *  # NOQA
 from .sentryappcomponent import *  # NOQA
 from .sentryappinstallation import *  # NOQA
+from .sentryappinstallationforprovider import *  # NOQA
+from .sentryappinstallationtoken import *  # NOQA
 from .servicehook import *  # NOQA
 from .team import *  # NOQA
 from .teamavatar import *  # NOQA

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -70,7 +70,7 @@ class AuthProvider(Model):
         from sentry.models import SentryAppInstallationForProvider
 
         if self.flags.scim_enabled:
-            return SentryAppInstallationForProvider.get_token(
+            return SentryAppInstallationForProvider.objects.get_token(
                 self.organization, f"{self.provider}_scim"
             )
         else:

--- a/src/sentry/models/authprovider.py
+++ b/src/sentry/models/authprovider.py
@@ -67,10 +67,10 @@ class AuthProvider(Model):
         return self.get_provider().name
 
     def get_scim_token(self):
-        from sentry.models import SentryAppInstallationForProvider
+        from sentry.models import SentryAppInstallationToken
 
         if self.flags.scim_enabled:
-            return SentryAppInstallationForProvider.objects.get_token(
+            return SentryAppInstallationToken.objects.get_token(
                 self.organization, f"{self.provider}_scim"
             )
         else:

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -6,9 +6,9 @@ from django.utils import timezone
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.db.models import (
-    BaseManager,
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
+    ParanoidManager,
     ParanoidModel,
 )
 
@@ -17,7 +17,7 @@ def default_uuid():
     return str(uuid.uuid4())
 
 
-class SentryAppInstallationForProviderManager(BaseManager):
+class SentryAppInstallationForProviderManager(ParanoidManager):
     def get_installed_for_organization(self, organization_id: int) -> QuerySet:
         return self.filter(
             organization_id=organization_id,

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -5,7 +5,12 @@ from django.db.models import QuerySet
 from django.utils import timezone
 
 from sentry.constants import SentryAppInstallationStatus
-from sentry.db.models import BaseManager, BoundedPositiveIntegerField, FlexibleForeignKey, ParanoidModel
+from sentry.db.models import (
+    BaseManager,
+    BoundedPositiveIntegerField,
+    FlexibleForeignKey,
+    ParanoidModel,
+)
 
 
 def default_uuid():

--- a/src/sentry/models/sentryappinstallationforprovider.py
+++ b/src/sentry/models/sentryappinstallationforprovider.py
@@ -1,24 +1,7 @@
 from django.db import models
 
-from sentry.db.models import BaseManager, FlexibleForeignKey
+from sentry.db.models import FlexibleForeignKey
 from sentry.models import DefaultFieldsModel
-from sentry.models.sentryappinstallationtoken import SentryAppInstallationToken
-
-
-class SentryAppInstallationForProviderManager(BaseManager):
-    def get_token(self, organization_id: int, provider: str) -> str:
-        installation_for_provider = self.select_related(
-            "sentry_app_installation"
-        ).get(organization_id=organization_id, provider=provider)
-        sentry_app_installation = installation_for_provider.sentry_app_installation
-
-        # find a token associated with the installation so we can use it for authentication
-        sentry_app_installation_token = (
-            SentryAppInstallationToken.objects.select_related("api_token")
-                .filter(sentry_app_installation=sentry_app_installation)
-                .first()
-        )
-        return sentry_app_installation_token.api_token.token
 
 
 class SentryAppInstallationForProvider(DefaultFieldsModel):
@@ -28,8 +11,6 @@ class SentryAppInstallationForProvider(DefaultFieldsModel):
     sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")
     organization = FlexibleForeignKey("sentry.Organization")
     provider = models.CharField(max_length=64)
-
-    objects = SentryAppInstallationForProviderManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/sentryappinstallationforprovider.py
+++ b/src/sentry/models/sentryappinstallationforprovider.py
@@ -1,0 +1,33 @@
+from django.db import models
+
+from sentry.db.models import FlexibleForeignKey
+from sentry.models import DefaultFieldsModel
+
+
+class SentryAppInstallationForProvider(DefaultFieldsModel):
+    """Connects a sentry app installation to an organization and a provider."""
+    __include_in_export__ = False
+
+    sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")
+    organization = FlexibleForeignKey("sentry.Organization")
+    provider = models.CharField(max_length=64)
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_sentryappinstallationforprovider"
+        unique_together = (("provider", "organization"),)
+
+    @classmethod
+    def get_token(cls, organization_id, provider):
+        installation_for_provider = SentryAppInstallationForProvider.objects.select_related(
+            "sentry_app_installation"
+        ).get(organization_id=organization_id, provider=provider)
+        sentry_app_installation = installation_for_provider.sentry_app_installation
+
+        # find a token associated with the installation so we can use it for authentication
+        sentry_app_installation_token = (
+            SentryAppInstallationToken.objects.select_related("api_token")
+            .filter(sentry_app_installation=sentry_app_installation)
+            .first()
+        )
+        return sentry_app_installation_token.api_token.token

--- a/src/sentry/models/sentryappinstallationforprovider.py
+++ b/src/sentry/models/sentryappinstallationforprovider.py
@@ -6,6 +6,7 @@ from sentry.models import DefaultFieldsModel
 
 class SentryAppInstallationForProvider(DefaultFieldsModel):
     """Connects a sentry app installation to an organization and a provider."""
+
     __include_in_export__ = False
 
     sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")

--- a/src/sentry/models/sentryappinstallationtoken.py
+++ b/src/sentry/models/sentryappinstallationtoken.py
@@ -1,0 +1,38 @@
+from sentry.db.models import FlexibleForeignKey, Model
+from sentry.models import Project
+
+
+class SentryAppInstallationToken(Model):
+    __include_in_export__ = False
+
+    api_token = FlexibleForeignKey("sentry.ApiToken")
+    sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_sentryappinstallationtoken"
+        unique_together = (("sentry_app_installation", "api_token"),)
+
+    @classmethod
+    def has_organization_access(cls, token, organization):
+        try:
+            install_token = cls.objects.select_related("sentry_app_installation").get(
+                api_token=token
+            )
+        except cls.DoesNotExist:
+            return False
+
+        return install_token.sentry_app_installation.organization_id == organization.id
+
+    @classmethod
+    def get_projects(cls, token):
+        try:
+            install_token = cls.objects.select_related("sentry_app_installation").get(
+                api_token=token
+            )
+        except cls.DoesNotExist:
+            return Project.objects.none()
+
+        return Project.objects.filter(
+            organization_id=install_token.sentry_app_installation.organization_id
+        )

--- a/src/sentry/models/sentryappinstallationtoken.py
+++ b/src/sentry/models/sentryappinstallationtoken.py
@@ -1,5 +1,39 @@
-from sentry.db.models import FlexibleForeignKey, Model
-from sentry.models import Project
+from typing import TYPE_CHECKING, Optional
+
+from django.db.models import QuerySet
+from sentry.db.models import BaseManager, FlexibleForeignKey, Model
+
+if TYPE_CHECKING:
+    from sentry.models import Organization
+
+
+class SentryAppInstallationTokenManager(BaseManager):
+    def _get_token(self, token: str) -> Optional["SentryAppInstallationToken"]:
+        try:
+            return self.select_related("sentry_app_installation").get(
+                api_token=token
+            )
+        except SentryAppInstallationToken.DoesNotExist:
+            pass
+        return None
+
+    def get_projects(self, token: str) -> QuerySet:
+        from sentry.models import Project
+
+        install_token = self._get_token(token)
+        if not install_token:
+            return Project.objects.none()
+
+        return Project.objects.filter(
+            organization_id=install_token.sentry_app_installation.organization_id
+        )
+
+    def has_organization_access(self, token: str, organization: "Organization") -> bool:
+        install_token = self._get_token(token)
+        if not install_token:
+            return False
+
+        return install_token.sentry_app_installation.organization_id == organization.id
 
 
 class SentryAppInstallationToken(Model):
@@ -8,31 +42,9 @@ class SentryAppInstallationToken(Model):
     api_token = FlexibleForeignKey("sentry.ApiToken")
     sentry_app_installation = FlexibleForeignKey("sentry.SentryAppInstallation")
 
+    objects = SentryAppInstallationTokenManager()
+
     class Meta:
         app_label = "sentry"
         db_table = "sentry_sentryappinstallationtoken"
         unique_together = (("sentry_app_installation", "api_token"),)
-
-    @classmethod
-    def has_organization_access(cls, token, organization):
-        try:
-            install_token = cls.objects.select_related("sentry_app_installation").get(
-                api_token=token
-            )
-        except cls.DoesNotExist:
-            return False
-
-        return install_token.sentry_app_installation.organization_id == organization.id
-
-    @classmethod
-    def get_projects(cls, token):
-        try:
-            install_token = cls.objects.select_related("sentry_app_installation").get(
-                api_token=token
-            )
-        except cls.DoesNotExist:
-            return Project.objects.none()
-
-        return Project.objects.filter(
-            organization_id=install_token.sentry_app_installation.organization_id
-        )

--- a/src/sentry/models/sentryappinstallationtoken.py
+++ b/src/sentry/models/sentryappinstallationtoken.py
@@ -4,11 +4,22 @@ from django.db.models import QuerySet
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model
 
 if TYPE_CHECKING:
-    from sentry.models import Organization
+    from sentry.models import ApiToken, Organization
 
 
 class SentryAppInstallationTokenManager(BaseManager):
-    def _get_token(self, token: str) -> Optional["SentryAppInstallationToken"]:
+    def get_token(self, organization_id: int, provider: str) -> Optional[str]:
+        """Find a token associated with the installation so we can use it for authentication."""
+        sentry_app_installation_tokens = self.select_related("api_token").filter(
+            sentry_app_installation__sentryappinstallationforprovider__organization_id=organization_id,
+            sentry_app_installation__sentryappinstallationforprovider__provider=provider,
+        )
+        if not sentry_app_installation_tokens:
+            return None
+
+        return sentry_app_installation_tokens[0].api_token.token
+
+    def _get_token(self, token: "ApiToken") -> Optional["SentryAppInstallationToken"]:
         try:
             return self.select_related("sentry_app_installation").get(
                 api_token=token
@@ -17,7 +28,7 @@ class SentryAppInstallationTokenManager(BaseManager):
             pass
         return None
 
-    def get_projects(self, token: str) -> QuerySet:
+    def get_projects(self, token: "ApiToken") -> QuerySet:
         from sentry.models import Project
 
         install_token = self._get_token(token)
@@ -28,7 +39,7 @@ class SentryAppInstallationTokenManager(BaseManager):
             organization_id=install_token.sentry_app_installation.organization_id
         )
 
-    def has_organization_access(self, token: str, organization: "Organization") -> bool:
+    def has_organization_access(self, token: "ApiToken", organization: "Organization") -> bool:
         install_token = self._get_token(token)
         if not install_token:
             return False

--- a/src/sentry/models/sentryappinstallationtoken.py
+++ b/src/sentry/models/sentryappinstallationtoken.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Optional
 
 from django.db.models import QuerySet
+
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model
 
 if TYPE_CHECKING:
@@ -21,9 +22,7 @@ class SentryAppInstallationTokenManager(BaseManager):
 
     def _get_token(self, token: "ApiToken") -> Optional["SentryAppInstallationToken"]:
         try:
-            return self.select_related("sentry_app_installation").get(
-                api_token=token
-            )
+            return self.select_related("sentry_app_installation").get(api_token=token)
         except SentryAppInstallationToken.DoesNotExist:
             pass
         return None

--- a/src/sentry/models/sentryappinstallationtoken.py
+++ b/src/sentry/models/sentryappinstallationtoken.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from django.db.models import QuerySet
 
@@ -9,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class SentryAppInstallationTokenManager(BaseManager):
-    def get_token(self, organization_id: int, provider: str) -> Optional[str]:
+    def get_token(self, organization_id: int, provider: str) -> str | None:
         """Find a token associated with the installation so we can use it for authentication."""
         sentry_app_installation_tokens = self.select_related("api_token").filter(
             sentry_app_installation__sentryappinstallationforprovider__organization_id=organization_id,
@@ -20,14 +22,14 @@ class SentryAppInstallationTokenManager(BaseManager):
 
         return sentry_app_installation_tokens[0].api_token.token
 
-    def _get_token(self, token: "ApiToken") -> Optional["SentryAppInstallationToken"]:
+    def _get_token(self, token: ApiToken) -> SentryAppInstallationToken | None:
         try:
             return self.select_related("sentry_app_installation").get(api_token=token)
         except SentryAppInstallationToken.DoesNotExist:
             pass
         return None
 
-    def get_projects(self, token: "ApiToken") -> QuerySet:
+    def get_projects(self, token: ApiToken) -> QuerySet:
         from sentry.models import Project
 
         install_token = self._get_token(token)
@@ -38,7 +40,7 @@ class SentryAppInstallationTokenManager(BaseManager):
             organization_id=install_token.sentry_app_installation.organization_id
         )
 
-    def has_organization_access(self, token: "ApiToken", organization: "Organization") -> bool:
+    def has_organization_access(self, token: ApiToken, organization: Organization) -> bool:
         install_token = self._get_token(token)
         if not install_token:
             return False

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -52,7 +52,7 @@ def send_workflow_webhooks(organization, issue, user, event, data=None):
 
 
 def installations_to_notify(organization, event):
-    installations = SentryAppInstallation.get_installed_for_org(organization.id).select_related(
+    installations = SentryAppInstallation.objects.get_installed_for_organization(organization.id).select_related(
         "sentry_app"
     )
 

--- a/src/sentry/receivers/sentry_apps.py
+++ b/src/sentry/receivers/sentry_apps.py
@@ -52,8 +52,8 @@ def send_workflow_webhooks(organization, issue, user, event, data=None):
 
 
 def installations_to_notify(organization, event):
-    installations = SentryAppInstallation.objects.get_installed_for_organization(organization.id).select_related(
-        "sentry_app"
-    )
+    installations = SentryAppInstallation.objects.get_installed_for_organization(
+        organization.id
+    ).select_related("sentry_app")
 
     return [i for i in installations if event in i.sentry_app.events]

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -35,7 +35,9 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
 
     def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
         action_list = []
-        for install in SentryAppInstallation.objects.get_installed_for_organization(project.organization_id):
+        for install in SentryAppInstallation.objects.get_installed_for_organization(
+            project.organization_id
+        ):
             component = install.prepare_sentry_app_components("alert-rule-action", project)
             if component:
                 kwargs = {

--- a/src/sentry/rules/actions/notify_event_sentry_app.py
+++ b/src/sentry/rules/actions/notify_event_sentry_app.py
@@ -35,7 +35,7 @@ class NotifyEventSentryAppAction(EventAction):  # type: ignore
 
     def get_custom_actions(self, project: Project) -> Sequence[Mapping[str, Any]]:
         action_list = []
-        for install in SentryAppInstallation.get_installed_for_org(project.organization_id):
+        for install in SentryAppInstallation.objects.get_installed_for_organization(project.organization_id):
             component = install.prepare_sentry_app_components("alert-rule-action", project)
             if component:
                 kwargs = {

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -198,7 +198,7 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     installations = filter(
         lambda i: event in i.sentry_app.events,
-        SentryAppInstallation.get_installed_for_org(org.id).select_related("sentry_app"),
+        SentryAppInstallation.objects.get_installed_for_organization(org.id).select_related("sentry_app"),
     )
 
     for installation in installations:

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -198,7 +198,9 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     installations = filter(
         lambda i: event in i.sentry_app.events,
-        SentryAppInstallation.objects.get_installed_for_organization(org.id).select_related("sentry_app"),
+        SentryAppInstallation.objects.get_installed_for_organization(org.id).select_related(
+            "sentry_app"
+        ),
     )
 
     for installation in installations:

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -136,7 +136,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         enabled_dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id)).get_dsn(
             public=True
         )
-        sentry_auth_token = SentryAppInstallationForProvider.get_token(org.id, "vercel")
+        sentry_auth_token = SentryAppInstallationForProvider.objects.get_token(org.id, "vercel")
 
         env_var_map = {
             "SENTRY_ORG": {"type": "encrypted", "value": org.slug},
@@ -228,7 +228,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         enabled_dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id)).get_dsn(
             public=True
         )
-        sentry_auth_token = SentryAppInstallationForProvider.get_token(org.id, "vercel")
+        sentry_auth_token = SentryAppInstallationForProvider.objects.get_token(org.id, "vercel")
 
         env_var_map = {
             "SENTRY_ORG": {"type": "encrypted", "value": org.slug},

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -14,6 +14,7 @@ from sentry.models import (
     ScheduledDeletion,
     SentryAppInstallation,
     SentryAppInstallationForProvider,
+    SentryAppInstallationToken,
 )
 from sentry.testutils import IntegrationTestCase
 from sentry.utils import json
@@ -136,7 +137,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         enabled_dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id)).get_dsn(
             public=True
         )
-        sentry_auth_token = SentryAppInstallationForProvider.objects.get_token(org.id, "vercel")
+        sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
 
         env_var_map = {
             "SENTRY_ORG": {"type": "encrypted", "value": org.slug},
@@ -228,7 +229,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         enabled_dsn = ProjectKey.get_default(project=Project.objects.get(id=project_id)).get_dsn(
             public=True
         )
-        sentry_auth_token = SentryAppInstallationForProvider.objects.get_token(org.id, "vercel")
+        sentry_auth_token = SentryAppInstallationToken.objects.get_token(org.id, "vercel")
 
         env_var_map = {
             "SENTRY_ORG": {"type": "encrypted", "value": org.slug},

--- a/tests/sentry/models/test_sentryappinstallationtoken.py
+++ b/tests/sentry/models/test_sentryappinstallationtoken.py
@@ -1,0 +1,39 @@
+from sentry.models import ApiApplication, ApiToken, SentryApp, SentryAppInstallation, SentryAppInstallationForProvider, \
+    SentryAppInstallationToken
+from sentry.testutils import TestCase
+
+
+class SentryAppInstallationTokenTest(TestCase):
+    def setUp(self):
+        self.application = ApiApplication.objects.create(owner=self.user)
+        self.provider = "provider"
+
+        self.sentry_app = SentryApp.objects.create(
+            application=self.application,
+            name="NullDB",
+            proxy_user=self.proxy,
+            owner=self.org,
+            scope_list=("project:read",),
+            webhook_url="http://example.com",
+        )
+
+        self.install = SentryAppInstallation(sentry_app=self.sentry_app, organization=self.organization)
+        self.installation_for_provider = SentryAppInstallationForProvider.objects.create(
+            organization=self.organization,
+            provider=self.provider,
+            sentry_app_installation=self.install,
+        )
+
+    def test_get_token_empty(self):
+        assert not SentryAppInstallationToken.objects.get_token(self.organization.id, self.provider)
+
+    def test_get_token_invalid(self):
+        assert not SentryAppInstallationToken.objects.get_token(self.organization.id, "")
+
+    def test_get_token(self):
+        api_token = ApiToken.objects.create(
+            user=self.user, scope_list=(), refresh_token=None, expires_at=None
+        )
+        token = SentryAppInstallationToken.objects.get_token(self.organization.id, self.provider)
+        assert token.token == api_token.token
+

--- a/tests/sentry/models/test_sentryappinstallationtoken.py
+++ b/tests/sentry/models/test_sentryappinstallationtoken.py
@@ -1,7 +1,6 @@
 from sentry.models import (
     ApiApplication,
     ApiToken,
-    SentryApp,
     SentryAppInstallation,
     SentryAppInstallationForProvider,
     SentryAppInstallationToken,
@@ -14,19 +13,22 @@ class SentryAppInstallationTokenTest(TestCase):
         self.application = ApiApplication.objects.create(owner=self.user)
         self.provider = "provider"
 
-        self.sentry_app = SentryApp.objects.create(
-            application=self.application,
-            name="NullDB",
-            proxy_user=self.proxy,
-            owner=self.org,
-            scope_list=("project:read",),
-            webhook_url="http://example.com",
+        sentry_app = self.create_internal_integration(
+            webhook_url=None,
+            name="Vercel Internal Integration",
+            organization=self.organization,
         )
 
-        self.install = SentryAppInstallation(
-            sentry_app=self.sentry_app, organization=self.organization
+        self.api_token = ApiToken.objects.create(
+            user=self.user, scope_list=(), refresh_token=None, expires_at=None
         )
-        self.installation_for_provider = SentryAppInstallationForProvider.objects.create(
+
+        self.install = SentryAppInstallation.objects.create(
+            sentry_app=sentry_app,
+            organization=self.organization,
+        )
+
+        SentryAppInstallationForProvider.objects.create(
             organization=self.organization,
             provider=self.provider,
             sentry_app_installation=self.install,
@@ -39,8 +41,8 @@ class SentryAppInstallationTokenTest(TestCase):
         assert not SentryAppInstallationToken.objects.get_token(self.organization.id, "")
 
     def test_get_token(self):
-        api_token = ApiToken.objects.create(
-            user=self.user, scope_list=(), refresh_token=None, expires_at=None
+        SentryAppInstallationToken.objects.create(
+            api_token=self.api_token, sentry_app_installation=self.install
         )
         token = SentryAppInstallationToken.objects.get_token(self.organization.id, self.provider)
-        assert token.token == api_token.token
+        assert token == self.api_token.token

--- a/tests/sentry/models/test_sentryappinstallationtoken.py
+++ b/tests/sentry/models/test_sentryappinstallationtoken.py
@@ -1,5 +1,11 @@
-from sentry.models import ApiApplication, ApiToken, SentryApp, SentryAppInstallation, SentryAppInstallationForProvider, \
-    SentryAppInstallationToken
+from sentry.models import (
+    ApiApplication,
+    ApiToken,
+    SentryApp,
+    SentryAppInstallation,
+    SentryAppInstallationForProvider,
+    SentryAppInstallationToken,
+)
 from sentry.testutils import TestCase
 
 
@@ -17,7 +23,9 @@ class SentryAppInstallationTokenTest(TestCase):
             webhook_url="http://example.com",
         )
 
-        self.install = SentryAppInstallation(sentry_app=self.sentry_app, organization=self.organization)
+        self.install = SentryAppInstallation(
+            sentry_app=self.sentry_app, organization=self.organization
+        )
         self.installation_for_provider = SentryAppInstallationForProvider.objects.create(
             organization=self.organization,
             provider=self.provider,
@@ -36,4 +44,3 @@ class SentryAppInstallationTokenTest(TestCase):
         )
         token = SentryAppInstallationToken.objects.get_token(self.organization.id, self.provider)
         assert token.token == api_token.token
-


### PR DESCRIPTION
I saw the `'NoneType' object has no attribute 'api_token'` on Sentry and refactored the function to use Django query syntax to avoid the `AttributeError`. 

While I was here I moved some method from the Model class to the Managers.


Fixes [SENTRY-SGB](https://sentry.io/organizations/sentry/issues/2736608173).