### PR TITLE
fix(slack): Enable channel_id field on the backend

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -53,7 +53,11 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
         self._pending_save = False
 
     def clean(self) -> Mapping[str, Any]:
-        channel_id = self.data.get("inputChannelId") or self.data.get("input_channel_id")
+        channel_id = (
+            self.data.get("inputChannelId")
+            or self.data.get("input_channel_id")
+            or self.data.get("channel_id")
+        )
         if channel_id:
             logger.info(
                 "rule.slack.provide_channel_id",

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -411,6 +411,7 @@ class UpdateProjectRuleTest(APITestCase):
         )
 
         actions[0]["channel"] = "#new_channel_name"
+        actions[0]["channel_id"] = "new_channel_id"
 
         url = reverse(
             "sentry-api-0-project-rule-details",
@@ -435,6 +436,13 @@ class UpdateProjectRuleTest(APITestCase):
             status=200,
             content_type="application/json",
             body=json.dumps(channels),
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://slack.com/api/conversations.info",
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ok": channels["ok"], "channel": channels["channels"][1]}),
         )
 
         response = self.client.put(
@@ -502,13 +510,19 @@ class UpdateProjectRuleTest(APITestCase):
                 {"name": "new_channel_name", "id": "new_channel_id"},
             ],
         }
-
         responses.add(
             method=responses.GET,
-            url="https://slack.com/api/channels.list",
+            url="https://slack.com/api/conversations.list",
             status=200,
             content_type="application/json",
             body=json.dumps(channels),
+        )
+        responses.add(
+            method=responses.GET,
+            url="https://slack.com/api/conversations.info",
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ok": channels["ok"], "channel": channels["channels"][0]}),
         )
 
         response = self.client.put(
@@ -574,7 +588,7 @@ class UpdateProjectRuleTest(APITestCase):
                         "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
                         "workspace": integration.id,
                         "channel": "#team-team-team",
-                        "input_channel_id": "CSVK0921",
+                        "channel_id": "CSVK0921",
                     }
                 ],
                 "conditions": [


### PR DESCRIPTION
See [API-2201](https://getsentry.atlassian.net/browse/API-2201)

Just a missed check on the field coming from the frontend. The frontend form rendered with `channel_id` as the field name, while the backend only read the values from `inputChannelId` or `input_channel_id`. For backwards compatability purposes, those fields will stay there so that existing slack alert rules don't appear empty when being edited.

**before**:

https://user-images.githubusercontent.com/35509934/138523538-c1147346-0282-4d6e-b40e-620d6d06b76c.mov

**after**:

https://user-images.githubusercontent.com/35509934/138523552-bbd10534-41be-4d76-a380-717eb321e090.mov


