### PR TITLE
ref(tests): Replace waitFor with find in RTL

### DIFF
--- a/tests/js/spec/components/breadcrumbs.spec.jsx
+++ b/tests/js/spec/components/breadcrumbs.spec.jsx
@@ -1,9 +1,4 @@
-import {
-  fireEvent,
-  mountWithTheme,
-  screen,
-  waitFor,
-} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import Breadcrumbs from 'app/components/breadcrumbs';
 
@@ -84,11 +79,10 @@ describe('Breadcrumbs', () => {
     );
     fireEvent.mouseOver(screen.getByText('dropdown crumb'));
 
-    await waitFor(() => {
-      expect(screen.getByText('item3')).toBeInTheDocument();
-    });
+    const item3 = await screen.findByText('item3');
+    expect(item3).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('item3'));
+    fireEvent.click(item3);
     expect(onSelect).toHaveBeenCalledWith(
       expect.objectContaining({label: 'item3'}),
       expect.anything(),

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -166,9 +166,8 @@ describe('ProjectAlertsCreate', function () {
     it('loads default values', async function () {
       createWrapper();
 
-      await waitFor(() => {
-        expect(screen.getByDisplayValue('__all_environments__')).toBeInTheDocument();
-      });
+      const allEnvironments = await screen.findByDisplayValue('__all_environments__');
+      expect(allEnvironments).toBeInTheDocument();
       expect(screen.getByDisplayValue('all')).toBeInTheDocument();
       expect(screen.getByDisplayValue('30')).toBeInTheDocument();
     });

--- a/tests/js/spec/views/app.spec.jsx
+++ b/tests/js/spec/views/app.spec.jsx
@@ -1,4 +1,4 @@
-import {mountWithTheme, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'app/stores/configStore';
 import App from 'app/views/app';
@@ -48,10 +48,10 @@ describe('App', function () {
       </App>
     );
 
-    await waitFor(() => {
-      const node = screen.getByText('Yes, I would like to receive updates via email');
-      return expect(node).toBeInTheDocument();
-    });
+    const node = await screen.findByText(
+      'Yes, I would like to receive updates via email'
+    );
+    expect(node).toBeInTheDocument();
 
     user.flags.newsletter_consent_prompt = false;
   });
@@ -67,11 +67,9 @@ describe('App', function () {
       </App>
     );
 
-    await waitFor(() => {
-      const node = screen.getByText(
-        'Complete setup by filling out the required configuration.'
-      );
-      return expect(node).toBeInTheDocument();
-    });
+    const node = await screen.findByText(
+      'Complete setup by filling out the required configuration.'
+    );
+    expect(node).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/app.spec.jsx
+++ b/tests/js/spec/views/app.spec.jsx
@@ -48,10 +48,10 @@ describe('App', function () {
       </App>
     );
 
-    const node = await screen.findByText(
+    const updatesViaEmail = await screen.findByText(
       'Yes, I would like to receive updates via email'
     );
-    expect(node).toBeInTheDocument();
+    expect(updatesViaEmail).toBeInTheDocument();
 
     user.flags.newsletter_consent_prompt = false;
   });
@@ -67,9 +67,9 @@ describe('App', function () {
       </App>
     );
 
-    const node = await screen.findByText(
+    const completeSetup = await screen.findByText(
       'Complete setup by filling out the required configuration.'
     );
-    expect(node).toBeInTheDocument();
+    expect(completeSetup).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
There's a recommendation to use find* to query for something that may not be available right away.

Those two are basically equivalent (find* queries even use waitFor under the hood), but the find* is simpler and the error message we get will be better.