### PR TITLE
ref(ci): Move "change type" to new repo

### DIFF
--- a/.github/workflows/meta-deploys-detect-change-type.yml
+++ b/.github/workflows/meta-deploys-detect-change-type.yml
@@ -14,20 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check for file changes
-        uses: getsentry/paths-filter@master
-        id: changes
-        with:
-          list-files: shell
-          token: ${{ github.token }}
-          filters: .github/file-filters.yml
-
-      - name: Create GitHub job
-        uses: actions/github-script@v5
-        with:
-          script: |
-            require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/deploy`).updateChangeType({
-              github,
-              context,
-              fileChanges: ${{ toJson(steps.changes.outputs) }}
-            });
+      - uses: getsentry/actions/sentry-what-changed@main

--- a/.github/workflows/meta-deploys-detect-change-type.yml
+++ b/.github/workflows/meta-deploys-detect-change-type.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   files-changed:


### PR DESCRIPTION
Try moving the what changed workflow into a [new repo (getsentry/actions)](https://github.com/getsentry/actions) so that it can be re-used on getsentry