### PR TITLE
fix(alert rules): Ensure Slack channel name is entered

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -66,6 +66,13 @@ class SlackNotifyServiceForm(forms.Form):  # type: ignore
                     "channel_id": self.data.get("channel_id"),
                 },
             )
+            if not self.data.get("channel"):
+                raise forms.ValidationError(
+                    _(
+                        "Slack channel name is a required field.",
+                    ),
+                    code="invalid",
+                )
             # default to "#" if they have the channel name without the prefix
             channel_prefix = self.data["channel"][0] if self.data["channel"][0] == "@" else "#"
 


### PR DESCRIPTION
For a Slack alert rule action, the channel name is required and the channel ID is optional - ensure the required fields are filled out when attempting to save an alert rule.

Fixes [SENTRY-SHF](https://sentry.io/organizations/sentry/issues/2742993898/?project=1)