### PR TITLE
feat(suspect-spans): Allow filters on span ops

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -364,6 +364,29 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             )
 
     @pytest.mark.skip("setting snuba config is too slow")
+    def test_op_filters(self):
+        event = self.create_event()
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={
+                    "project": self.project.id,
+                    "sort": "-count",
+                    "spanOp": "http.server",
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        self.assert_suspect_span(
+            response.data,
+            # when sorting by -count, this should be the last of the 3 results
+            # but the spanOp filter means it should be the only result
+            [self.suspect_span_results("percentiles", event)],
+        )
+
+    @pytest.mark.skip("setting snuba config is too slow")
     def test_pagination_first_page(self):
         self.create_event()
 


### PR DESCRIPTION
This adds support for a filter on the span op to allow for use cases such as
seeing only the db spans in the transactions.