### PR TITLE
feat(snql): Add support for array join clause

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -29,6 +29,7 @@ class QueryBuilder(QueryFilter):
         auto_aggregations: bool = False,
         use_aggregate_conditions: bool = False,
         functions_acl: Optional[List[str]] = None,
+        array_join: Optional[str] = None,
         limit: Optional[int] = 50,
         offset: Optional[int] = 0,
         limitby: Optional[Tuple[str, int]] = None,
@@ -52,6 +53,7 @@ class QueryBuilder(QueryFilter):
 
         self.columns = self.resolve_select(selected_columns, equations)
         self.orderby = self.resolve_orderby(orderby)
+        self.array_join = None if array_join is None else self.resolve_column(array_join)
 
     def resolve_limitby(self, limitby: Optional[Tuple[str, int]]) -> Optional[LimitBy]:
         if limitby is None:
@@ -122,6 +124,7 @@ class QueryBuilder(QueryFilter):
             dataset=self.dataset.value,
             match=Entity(self.dataset.value),
             select=self.columns,
+            array_join=self.array_join,
             where=self.where,
             having=self.having,
             groupby=self.groupby,

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -454,3 +454,4 @@ class QueryBuilderTest(TestCase):
             ],
         )
         assert query.array_join == Column("spans.op")
+        query.get_snql_query().validate()

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -434,3 +434,23 @@ class QueryBuilderTest(TestCase):
                 ),
             ],
         )
+
+    def test_array_join_clause(self):
+        query = QueryBuilder(
+            Dataset.Discover,
+            self.params,
+            "",
+            selected_columns=[
+                "spans_op",
+                "count()",
+            ],
+            array_join="spans_op",
+        )
+        self.assertCountEqual(
+            query.columns,
+            [
+                AliasedExpression(Column("spans.op"), "spans_op"),
+                Function("count", [], "count"),
+            ],
+        )
+        assert query.array_join == Column("spans.op")


### PR DESCRIPTION
This adds support for the array join clause in clickhouse through SnQL. The
array join clause is like a database join but instead of joining two tables, the
join is performed on the table with the array.