### PR TITLE
chore(dx): Add bin path for black in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,5 +68,6 @@
   "python.linting.flake8Path": "${workspaceFolder}/.venv/bin/flake8",
   "python.linting.pycodestylePath": "${workspaceFolder}/.venv/bin/pep8",
   "python.testing.pytestPath": "${workspaceFolder}/.venv/bin/pytest",
+  "python.formatting.blackPath": "${workspaceFolder}/.venv/bin/black",
   "python.formatting.provider": "black"
 }


### PR DESCRIPTION
We have paths for everything else? "black" was using the bin i had installed globally which was old.