### PR TITLE
fix(appstore-connect): Detect and use new iTunes credentials when updating ASC creds [NATIVE-292]

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -563,8 +563,8 @@ class AppStoreConnectStartAuthEndpoint(ProjectEndpoint):  # type: ignore
         password = serializer.validated_data.get("itunesPassword")
         credentials_id = serializer.validated_data.get("id")
 
-        missing_password = not password or password == {"hidden-secret": True}
-        source_credentials_from_project = not user_name or missing_password
+        no_new_password = not password or password == {"hidden-secret": True}
+        source_credentials_from_project = not user_name or no_new_password
 
         if credentials_id is not None and source_credentials_from_project:
             try:
@@ -575,7 +575,7 @@ class AppStoreConnectStartAuthEndpoint(ProjectEndpoint):  # type: ignore
                 return Response("No credentials found.", status=400)
 
             user_name = symbol_source_config.itunesUser if not user_name else user_name
-            password = symbol_source_config.itunesPassword if missing_password else password
+            password = symbol_source_config.itunesPassword if no_new_password else password
 
         if user_name is None:
             return Response("No user name provided.", status=400)

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -563,7 +563,10 @@ class AppStoreConnectStartAuthEndpoint(ProjectEndpoint):  # type: ignore
         password = serializer.validated_data.get("itunesPassword")
         credentials_id = serializer.validated_data.get("id")
 
-        if credentials_id is not None:
+        missing_password = not password or password == {"hidden-secret": True}
+        source_credentials_from_project = not user_name or missing_password
+
+        if credentials_id is not None and source_credentials_from_project:
             try:
                 symbol_source_config = appconnect.AppStoreConnectConfig.from_project_config(
                     project, credentials_id
@@ -571,8 +574,8 @@ class AppStoreConnectStartAuthEndpoint(ProjectEndpoint):  # type: ignore
             except KeyError:
                 return Response("No credentials found.", status=400)
 
-            user_name = symbol_source_config.itunesUser
-            password = symbol_source_config.itunesPassword
+            user_name = symbol_source_config.itunesUser if not user_name else user_name
+            password = symbol_source_config.itunesPassword if missing_password else password
 
         if user_name is None:
             return Response("No user name provided.", status=400)

--- a/src/sentry/utils/appleconnect/itunes_connect.py
+++ b/src/sentry/utils/appleconnect/itunes_connect.py
@@ -284,7 +284,7 @@ class ITunesClient:
             self._session_id = start_login.headers["x-apple-id-session-id"]
             self._scnt = start_login.headers["scnt"]
             self.state = ClientState.AUTH_REQUESTED
-        elif start_login.status_code == http.HTTPStatus.UNAUTHORIZED:
+        elif start_login.status_code in [http.HTTPStatus.UNAUTHORIZED, http.HTTPStatus.FORBIDDEN]:
             raise InvalidUsernamePasswordError
         else:
             raise ITunesError(f"Unexpected status code form sign in: {start_login.status_code}")


### PR DESCRIPTION
This fixes an issue where changes made to iTunes credentials would not be verified against iTunes, yet they would be persisted to the project config.

Also fixes a minor issue where the UI shows a server error instead of an invalid username/password error when the user provides invalid credentials.

The error message for incorrect credentials now looks like the following:
<img width="1056" alt="Screenshot 2021-10-27 at 10 26 03 AM" src="https://user-images.githubusercontent.com/5597345/139085820-594ff516-3c5c-4b32-b454-90de4911efa8.png">

