### PR TITLE
fix(alerts): Align alert details icon, disable translation

### DIFF
--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -61,7 +61,10 @@ class RelatedIssues extends Component<Props> {
         <ControlsWrapper>
           <StyledSectionHeading>
             {t('Related Issues')}
-            <Tooltip title={t('Top issues containing events matching the metric.')}>
+            <Tooltip
+              title={t('Top issues containing events matching the metric.')}
+              skipWrapper
+            >
               <IconInfo size="xs" color="gray200" />
             </Tooltip>
           </StyledSectionHeading>

--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -113,10 +113,10 @@ export function isIssueAlert(
 export const DATA_SOURCE_LABELS = {
   [Dataset.ERRORS]: t('Errors'),
   [Dataset.TRANSACTIONS]: t('Transactions'),
-  [Datasource.ERROR_DEFAULT]: t('event.type:error OR event.type:default'),
-  [Datasource.ERROR]: t('event.type:error'),
-  [Datasource.DEFAULT]: t('event.type:default'),
-  [Datasource.TRANSACTION]: t('event.type:transaction'),
+  [Datasource.ERROR_DEFAULT]: 'event.type:error OR event.type:default',
+  [Datasource.ERROR]: 'event.type:error',
+  [Datasource.DEFAULT]: 'event.type:default',
+  [Datasource.TRANSACTION]: 'event.type:transaction',
 };
 
 // Maps a datasource to the relevant dataset and event_types for the backend to use


### PR DESCRIPTION
icon is not aligned because of tooltip wrapper span
![image](https://user-images.githubusercontent.com/1400464/138800601-11479ce4-03bb-42cc-a075-4a7f8c6bcc79.png)

removes translation from text that shouldn't be translated.