### PR TITLE
fix(snql): Auto fields for project

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2852,6 +2852,7 @@ class QueryFields(QueryBase):
             # are present.
             if not self.aggregates and "id" not in stripped_columns:
                 resolved_columns.append(self.resolve_column("id", alias=True))
+                stripped_columns.append("id")
             if "id" in stripped_columns and "project.id" not in stripped_columns:
                 resolved_columns.append(self.resolve_column("project.name", alias=True))
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -4513,6 +4513,20 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert meta["percentile_measurements_frames_slow_rate_0_5"] == "percentage"
         assert meta["percentile_measurements_stall_percentage_0_5"] == "percentage"
 
+    def test_project_auto_fields(self):
+        project = self.create_project()
+        self.store_event(
+            data={"event_id": "a" * 32, "environment": "staging", "timestamp": self.min_ago},
+            project_id=project.id,
+        )
+
+        query = {"field": ["environment"]}
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        assert response.data["data"][0]["environment"] == "staging"
+        assert response.data["data"][0]["project.name"] == project.slug
+
 
 class OrganizationEventsV2EndpointTestWithSnql(OrganizationEventsV2EndpointTest):
     def setUp(self):


### PR DESCRIPTION
The id column inserted by the auto fields should be considered when determining
if the project auto field will be necessary. This is necessary for features like
the event links in discover which requires a project id.