### PR TITLE
feat(suspect-span): Show frequency as percentage

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -12,6 +12,7 @@ import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {ColumnType, fieldAlignment} from 'app/utils/discover/fields';
+import {formatPercentage} from 'app/utils/formatters';
 import {SuspectSpan} from 'app/utils/performance/suspectSpans/types';
 
 import {PerformanceDuration} from '../../utils';
@@ -79,10 +80,18 @@ type Props = {
     hash?: string
   ) => LocationDescriptor;
   eventView: EventView;
+  totalCount: number | undefined;
 };
 
 export default function SuspectSpanEntry(props: Props) {
-  const {location, organization, suspectSpan, generateTransactionLink, eventView} = props;
+  const {
+    location,
+    organization,
+    suspectSpan,
+    generateTransactionLink,
+    eventView,
+    totalCount,
+  } = props;
 
   const examples = suspectSpan.examples.map(example => ({
     id: example.id,
@@ -112,7 +121,11 @@ export default function SuspectSpanEntry(props: Props) {
         />
         <HeaderItem
           label="Frequency"
-          value={String(suspectSpan.frequency)}
+          value={
+            defined(totalCount)
+              ? formatPercentage(suspectSpan.frequency / totalCount)
+              : '\u2014'
+          }
           align="right"
         />
         <HeaderItem

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -150,6 +150,11 @@ describe('Performance > Transaction Spans', function () {
     });
     // @ts-expect-error
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: 100,
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-spans-performance/',
       body: spans.map(makeSuspectSpan),
     });


### PR DESCRIPTION
This changes the frequency from a count to a relative percentage to give a sense
of the proportion of transactions that contains a specific span.