### PR TITLE
fix(gitlab): Change instructions to uncheck expire tokens

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -253,6 +253,7 @@ class InstallationGuideView(PipelineView):
                 "setup_values": [
                     {"label": "Name", "value": "Sentry"},
                     {"label": "Redirect URI", "value": absolute_uri("/extensions/gitlab/setup/")},
+                    {"label": "Expire access tokens", "value": "Unchecked"},
                     {"label": "Scopes", "value": "api"},
                 ],
             },


### PR DESCRIPTION
Previously, Gitlab tokens did not expire.

Now, by default, they do expire in 2 hours: https://gitlab.com/gitlab-com/www-gitlab-com/-/merge_requests/89791/diffs

We don't correctly support expiring Gitlab tokens right now.

So changing the instructions for Gitlab until we fix this (there is a ticket in the backlog) cause it's causing broken installations right now: https://github.com/getsentry/sentry/issues/29010.

## Before
![Screen Shot 2021-10-26 at 10 13 40 AM](https://user-images.githubusercontent.com/1417849/138928140-50787a6f-6d80-4224-992f-80bda343d15a.png)

## After
![Screen Shot 2021-10-26 at 10 12 25 AM](https://user-images.githubusercontent.com/1417849/138927997-acf88cbf-8829-4307-be8a-637603296348.png)

## How did I test this change
1. Created a new application with "Expire access tokens" checked
2. Made sure my local Sentry could communicate with it by fetching repositories
3. Waited for 2 hours
4. Tried to fetch repositories again but got a 401 from Gitlab
5. Created a new application with "Expire access tokens" unchecked
6. Repeated steps 2 & 3
7. Tried to fetch repositories again and was successful