### PR TITLE
ref(ui): Fix issues mobile pii tooltip flake

### DIFF
--- a/static/app/components/events/groupingInfo/groupingConfigSelect.tsx
+++ b/static/app/components/events/groupingInfo/groupingConfigSelect.tsx
@@ -51,7 +51,10 @@ class GroupingConfigSelect extends AsyncComponent<Props, State> {
     return (
       <DropdownAutoComplete onSelect={onSelect} items={options}>
         {({isOpen}) => (
-          <Tooltip title={t('Click here to experiment with other grouping configs')}>
+          <Tooltip
+            title={t('Click here to experiment with other grouping configs')}
+            disableForVisualTest
+          >
             <StyledDropdownButton isOpen={isOpen} size="small">
               <GroupingConfigItem isActive={eventConfigId === configId}>
                 {configId}


### PR DESCRIPTION
### Summary
There is a visual flake in 'acceptance-mobile/issue-details-pii-tooltips.png' which is presumably caused by a tooltip since I haven't seen it elsewhere. Just going to put this up to remove the tooltip check on this (it is a static tooltip anyway) to see if it fixes it.