### PR TITLE
fix(jira): Only use CDN verification if key_id is presented

### DIFF
--- a/src/sentry/integrations/jira/installed.py
+++ b/src/sentry/integrations/jira/installed.py
@@ -9,6 +9,7 @@ from sentry.integrations.atlassian_connect import (
 )
 from sentry.integrations.pipeline import ensure_integration
 from sentry.tasks.integrations import sync_metadata
+from sentry.utils import jwt
 
 from .integration import JiraIntegrationProvider
 
@@ -31,15 +32,17 @@ class JiraInstalledEndpoint(Endpoint):
         if not state:
             return self.respond(status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            decoded_claims = authenticate_asymmetric_jwt(token)
-        except AtlassianConnectValidationError:
-            return self.respond(status=status.HTTP_400_BAD_REQUEST)
+        key_id = jwt.peek_header(token).get("kid")
+        if key_id:
+            try:
+                decoded_claims = authenticate_asymmetric_jwt(token, key_id)
+            except AtlassianConnectValidationError:
+                return self.respond(status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            verify_claims(decoded_claims, request.path, request.GET, method="POST")
-        except AtlassianConnectValidationError:
-            return self.respond(status=status.HTTP_400_BAD_REQUEST)
+            try:
+                verify_claims(decoded_claims, request.path, request.GET, method="POST")
+            except AtlassianConnectValidationError:
+                return self.respond(status=status.HTTP_400_BAD_REQUEST)
 
         data = JiraIntegrationProvider().build_integration(state)
         integration = ensure_integration("jira", data)

--- a/src/sentry/integrations/jira/installed.py
+++ b/src/sentry/integrations/jira/installed.py
@@ -36,10 +36,6 @@ class JiraInstalledEndpoint(Endpoint):
         if key_id:
             try:
                 decoded_claims = authenticate_asymmetric_jwt(token, key_id)
-            except AtlassianConnectValidationError:
-                return self.respond(status=status.HTTP_400_BAD_REQUEST)
-
-            try:
                 verify_claims(decoded_claims, request.path, request.GET, method="POST")
             except AtlassianConnectValidationError:
                 return self.respond(status=status.HTTP_400_BAD_REQUEST)

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -11,11 +11,25 @@ from tests.sentry.utils.test_jwt import RS256_KEY, RS256_PUB_KEY
 
 class JiraInstalledTest(APITestCase):
     external_id = "it2may+cody"
-    jira_signing_algorithm = "RS256"
     kid = "cudi"
+    shared_secret = "garden"
     path = "/extensions/jira/installed/"
 
-    def jwt_token(self):
+    def jwt_token_secret(self):
+        jira_signing_algorithm = "HS256"
+        return jwt.encode(
+            {
+                "iss": self.external_id,
+                "aud": absolute_uri(),
+                "qsh": get_query_hash(self.path, method="POST", query_params={}),
+            },
+            self.shared_secret,
+            algorithm=jira_signing_algorithm,
+            headers={"alg": jira_signing_algorithm},
+        )
+
+    def jwt_token_cdn(self):
+        jira_signing_algorithm = "RS256"
         return jwt.encode(
             {
                 "iss": self.external_id,
@@ -23,12 +37,32 @@ class JiraInstalledTest(APITestCase):
                 "qsh": get_query_hash(self.path, method="POST", query_params={}),
             },
             RS256_KEY,
-            algorithm=self.jira_signing_algorithm,
-            headers={"kid": self.kid, "alg": self.jira_signing_algorithm},
+            algorithm=jira_signing_algorithm,
+            headers={"kid": self.kid, "alg": jira_signing_algorithm},
         )
 
+    def test_with_shared_secret(self):
+        resp = self.client.post(
+            self.path,
+            data={
+                "jira": {
+                    "metadata": {},
+                    "external_id": self.external_id,
+                },
+                "clientKey": "limepie",
+                "oauthClientId": "EFG",
+                "publicKey": "yourCar",
+                "sharedSecret": self.shared_secret,
+                "baseUrl": "https://sentry.io.org.xyz.online.dev.sentry.io",
+            },
+            HTTP_AUTHORIZATION="JWT " + self.jwt_token_secret(),
+        )
+        integration = Integration.objects.get(provider="jira", external_id=self.external_id)
+        assert integration.status == ObjectStatus.VISIBLE
+        assert resp.status_code == 200
+
     @responses.activate
-    def test_simple(self):
+    def test_with_key_id(self):
         responses.add(
             responses.GET,
             f"https://connect-install-keys.atlassian.com/{self.kid}",
@@ -45,10 +79,10 @@ class JiraInstalledTest(APITestCase):
                 "clientKey": "limepie",
                 "oauthClientId": "EFG",
                 "publicKey": "yourCar",
-                "sharedSecret": "garden",
+                "sharedSecret": self.shared_secret,
                 "baseUrl": "https://sentry.io.org.xyz.online.dev.sentry.io",
             },
-            HTTP_AUTHORIZATION="JWT " + self.jwt_token(),
+            HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn(),
         )
         integration = Integration.objects.get(provider="jira", external_id=self.external_id)
         assert integration.status == ObjectStatus.VISIBLE


### PR DESCRIPTION
See [API-2184](https://getsentry.atlassian.net/browse/API-2184)

fixes SENTRY-SJA

This corrects a bug in https://github.com/getsentry/sentry/pull/29465 wherein I assumed that the descriptor updated immediately on Jira's end. The new CDN installs should only be used if the key_id is presented in the token headers.

Updated the tests to also reflect this.