### PR TITLE
chore(tests): Temporarily increase timeouts for acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -146,7 +146,7 @@ jobs:
   acceptance:
     name: acceptance
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.8.12]


### PR DESCRIPTION
We're getting timeouts due to slow image pulls, temporarily increasing this timeout so we can still merge