### PR TITLE
fix(ui): all project position

### DIFF
--- a/static/app/components/organizations/multipleProjectSelector.tsx
+++ b/static/app/components/organizations/multipleProjectSelector.tsx
@@ -359,7 +359,7 @@ const SelectorFooterControls = ({
     : t('Select My Projects');
 
   return (
-    <FooterContainer>
+    <FooterContainer style={{justifyContent: message ? 'space-between' : 'flex-end'}}>
       {message && <FooterMessage>{message}</FooterMessage>}
       <FooterActions>
         {!disableMultipleProjectSelection && (
@@ -405,7 +405,6 @@ export default withRouter(MultipleProjectSelector);
 
 const FooterContainer = styled('div')`
   display: flex;
-  justify-content: space-between;
 `;
 
 const FooterActions = styled('div')`


### PR DESCRIPTION
`Select All Projects` button accidentally got moved left in a recent PR:
![Screen Shot 2021-10-26 at 1 34 37 PM](https://user-images.githubusercontent.com/8533851/138956830-853efe82-57ff-4934-93f3-58331b938d19.png)

This moves it back:

![Screen Shot 2021-10-26 at 1 34 15 PM](https://user-images.githubusercontent.com/8533851/138956925-57cf6a7a-7d02-4c25-a5e7-c4bc47671692.png)

