### PR TITLE
feat(releases): Set default absolute date to release period

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -139,6 +139,11 @@ type Props = WithRouterProps & {
    * Small info icon with tooltip hint text
    */
   hint?: string;
+
+  /**
+   * Set an optional default value to prefill absolute date with
+   */
+  defaultAbsolute?: {start?: Date; end?: Date};
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -231,17 +236,19 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
   };
 
   handleAbsoluteClick = () => {
-    const {relative, onChange, defaultPeriod} = this.props;
+    const {relative, onChange, defaultPeriod, defaultAbsolute} = this.props;
 
     // Set default range to equivalent of last relative period,
     // or use default stats period
     const newDateTime: ChangeData = {
       relative: null,
-      start: getPeriodAgo(
-        'hours',
-        parsePeriodToHours(relative || defaultPeriod || DEFAULT_STATS_PERIOD)
-      ).toDate(),
-      end: new Date(),
+      start: defaultAbsolute?.start
+        ? defaultAbsolute.start
+        : getPeriodAgo(
+            'hours',
+            parsePeriodToHours(relative || defaultPeriod || DEFAULT_STATS_PERIOD)
+          ).toDate(),
+      end: defaultAbsolute?.end ? defaultAbsolute.end : new Date(),
     };
 
     if (defined(this.props.utc)) {

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -355,6 +355,14 @@ class ReleaseOverview extends AsyncView<Props> {
                               ...DEFAULT_RELATIVE_PERIODS,
                             }}
                             defaultPeriod={RELEASE_PERIOD_KEY}
+                            defaultAbsolute={{
+                              start: moment(releaseBounds.releaseStart)
+                                .subtract(1, 'hour')
+                                .toDate(),
+                              end: releaseBounds.releaseEnd
+                                ? moment(releaseBounds.releaseEnd).add(1, 'hour').toDate()
+                                : undefined,
+                            }}
                           />
 
                           {(hasDiscover || hasPerformance || hasHealthData) && (

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -280,4 +280,23 @@ describe('TimeRangeSelector', function () {
     expect(wrapper.find('SelectorItem[value="absolute"]').prop('selected')).toBe(true);
     expect(wrapper.find('SelectorItem[value="14d"]').prop('selected')).toBe(false);
   });
+
+  it('uses the default absolute date', async function () {
+    wrapper = createWrapper({
+      defaultAbsolute: {
+        start: new Date('2017-10-10T00:00:00.000Z'),
+        end: new Date('2017-10-17T23:59:59.000Z'),
+      },
+    });
+
+    await wrapper.find('HeaderItem').simulate('click');
+    await wrapper.find('SelectorItem[value="absolute"]').simulate('click');
+
+    wrapper.find('SelectorItem[value="absolute"]').simulate('click');
+    expect(onChange).toHaveBeenCalledWith({
+      relative: null,
+      start: new Date('2017-10-10T00:00:00.000Z'),
+      end: new Date('2017-10-17T23:59:59.000Z'),
+    });
+  });
 });


### PR DESCRIPTION
When picking an absolute date, default to the current release period seen in the graph on the release page

https://getsentry.atlassian.net/browse/WOR-1201