### PR TITLE
Fix(digests): Fix error with empty digests

### DIFF
--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -113,7 +113,7 @@ class Pipeline:
         self.operations: MutableSequence[Callable[..., Any]] = []
         self.logs: MutableSequence[str] = []
 
-    def __call__(self, sequence: Sequence[Any]) -> Any:
+    def __call__(self, sequence: Sequence[Any]) -> Tuple[Any, Sequence[str]]:
         # Explicitly typing to satisfy mypy.
         func: Callable[[Any, Callable[[Any], Any]], Any] = lambda x, operation: operation(x)
         return reduce(func, self.operations, sequence), self.logs
@@ -228,10 +228,10 @@ def build_digest(
     project: "Project",
     records: Sequence[Record],
     state: Optional[Mapping[str, Any]] = None,
-) -> Optional[Any]:
+) -> Tuple[Optional[Any], Sequence[str]]:
     records = list(records)
     if not records:
-        return None
+        return None, []
 
     # XXX: This is a hack to allow generating a mock digest without actually
     # doing any real IO!

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -337,3 +337,6 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
             self.user5.id: set(events),
         }
         self.assert_get_personalized_digests(self.project, digest, self.user_ids, expected_result)
+
+    def test_empty_records(self):
+        assert build_digest(self.project, []) == (None, [])

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -41,3 +41,7 @@ class DeliverDigestTest(TestCase):
 
     def test_member_key(self):
         self.run_test(f"mail:p:{self.project.id}:Member:{self.user.id}")
+
+    def test_no_records(self):
+        # This shouldn't error if no records are present
+        deliver_digest(f"mail:p:{self.project.id}:IssueOwners:")


### PR DESCRIPTION
We changed the return type of `build_digest`, but mypy missed this due to the return typing being
`Any`. Luckily this only caused us to throw errors on empty digests which couldn't send, and didn't
block any actual emails from going out.

Fixes SENTRY-SJD