### PR TITLE
digests: Add logging to see how often we're missing records from digests

### DIFF
--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -234,7 +234,17 @@ class RedisBackend(Backend):
             # If the record value is `None`, this means the record data was
             # missing (it was presumably evicted by Redis) so we don't need to
             # return it here.
-            yield [record for record in records if record.value is not None]
+            filtered_records = [record for record in records if record.value is not None]
+            if len(records) != len(filtered_records):
+                logger.info(
+                    "Filtered out missing records",
+                    extra={
+                        "key": key,
+                        "record_count": len(records),
+                        "filtered_record_count": len(filtered_records),
+                    },
+                )
+            yield filtered_records
 
             script(
                 connection,

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -236,8 +236,8 @@ class RedisBackend(Backend):
             # return it here.
             filtered_records = [record for record in records if record.value is not None]
             if len(records) != len(filtered_records):
-                logger.info(
-                    "Filtered out missing records",
+                logger.warning(
+                    "Filtered out missing records when fetching digest",
                     extra={
                         "key": key,
                         "record_count": len(records),


### PR DESCRIPTION
A bit of a pain that we don't have project id in here. One option could be to return these as logs,
but I don't really want to change the function signature.