### PR TITLE
fix(repositories-settings): Disable UI components in case of no permission - [ISSUE-1329]

### DIFF
--- a/static/app/views/settings/projectDebugFiles/externalSources/builtInRepositories.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/builtInRepositories.tsx
@@ -1,9 +1,12 @@
+import styled from '@emotion/styled';
+
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import ProjectActions from 'app/actions/projectActions';
 import {Client} from 'app/api';
+import Access from 'app/components/acl/access';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
-import {Choices, Organization, Project} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {BuiltinSymbolSource} from 'app/types/debugFiles';
 import SelectField from 'app/views/settings/components/forms/selectField';
 
@@ -22,6 +25,12 @@ function BuiltInRepositories({
   builtinSymbolSources,
   projSlug,
 }: Props) {
+  // If the project details object has an unknown built-in source, this will be filtered here.
+  // This prevents the UI from showing the wrong feedback message when updating the field
+  const validBuiltInSymbolSources = builtinSymbolSources.filter(builtinSymbolSource =>
+    builtinSymbolSourceOptions.find(({sentry_key}) => sentry_key === builtinSymbolSource)
+  );
+
   function getRequestMessages(builtinSymbolSourcesQuantity: number) {
     if (builtinSymbolSourcesQuantity === 0) {
       return {
@@ -29,7 +38,7 @@ function BuiltInRepositories({
       };
     }
 
-    if (builtinSymbolSourcesQuantity > builtinSymbolSources.length) {
+    if (builtinSymbolSourcesQuantity > validBuiltInSymbolSources.length) {
       return {
         successMessage: t('Successfully added built-in repository'),
         errorMessage: t('An error occurred while adding new built-in repository'),
@@ -67,27 +76,37 @@ function BuiltInRepositories({
     <Panel>
       <PanelHeader>{t('Built-in Repositories')}</PanelHeader>
       <PanelBody>
-        <SelectField
-          name="builtinSymbolSources"
-          label={t('Built-in Repositories')}
-          help={t(
-            'Configures which built-in repositories Sentry should use to resolve debug files.'
+        <Access access={['project:write']}>
+          {({hasAccess}) => (
+            <StyledSelectField
+              disabled={!hasAccess}
+              name="builtinSymbolSources"
+              label={t('Built-in Repositories')}
+              help={t(
+                'Configures which built-in repositories Sentry should use to resolve debug files.'
+              )}
+              placeholder={t('Select built-in repository')}
+              value={validBuiltInSymbolSources}
+              onChange={handleChange}
+              options={builtinSymbolSourceOptions
+                .filter(source => !source.hidden)
+                .map(source => ({
+                  value: source.sentry_key,
+                  label: source.name,
+                }))}
+              getValue={value => (value === null ? [] : value)}
+              flexibleControlStateSize
+              multiple
+            />
           )}
-          placeholder={t('Select built-in repository')}
-          value={builtinSymbolSources}
-          onChange={handleChange}
-          choices={
-            builtinSymbolSourceOptions
-              ?.filter(source => !source.hidden)
-              .map(source => [source.sentry_key, t(source.name)]) as Choices
-          }
-          getValue={value => (value === null ? [] : value)}
-          flexibleControlStateSize
-          multiple
-        />
+        </Access>
       </PanelBody>
     </Panel>
   );
 }
 
 export default BuiltInRepositories;
+
+const StyledSelectField = styled(SelectField)`
+  ${p => p.disabled && `cursor: not-allowed`}
+`;

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/actions.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/actions.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import Access from 'app/components/acl/access';
 import ActionButton from 'app/components/actions/button';
 import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import Button from 'app/components/button';
@@ -8,6 +9,7 @@ import ButtonBar from 'app/components/buttonBar';
 import ConfirmDelete from 'app/components/confirmDelete';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownLink from 'app/components/dropdownLink';
+import Tooltip from 'app/components/tooltip';
 import {IconEllipsis} from 'app/icons/iconEllipsis';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -91,26 +93,70 @@ function Actions({
           {t('Details')}
         </StyledDropdownButton>
       )}
-      <StyledButton onClick={onEdit} size="small">
-        {t('Configure')}
-      </StyledButton>
-      {renderConfirmDelete(<StyledButton size="small">{t('Delete')}</StyledButton>)}
-      <DropDownWrapper>
-        <DropdownLink
-          caret={false}
-          customTitle={
-            <StyledActionButton label={t('Actions')} icon={<IconEllipsis />} />
-          }
-          anchorRight
-        >
-          <MenuItemActionLink title={t('Configure')} onClick={onEdit}>
-            {t('Configure')}
-          </MenuItemActionLink>
-          {renderConfirmDelete(
-            <MenuItemActionLink title={t('Delete')}>{t('Delete')}</MenuItemActionLink>
-          )}
-        </DropdownLink>
-      </DropDownWrapper>
+      <Access access={['project:write']}>
+        {({hasAccess}) => (
+          <Fragment>
+            <ButtonTooltip
+              title={t(
+                'You do not have permission to edit custom repository configurations.'
+              )}
+              disabled={hasAccess}
+            >
+              <ActionBtn
+                disabled={!hasAccess || isDetailsDisabled}
+                onClick={onEdit}
+                size="small"
+              >
+                {t('Configure')}
+              </ActionBtn>
+            </ButtonTooltip>
+
+            {!hasAccess || isDetailsDisabled ? (
+              <ButtonTooltip
+                title={t(
+                  'You do not have permission to delete custom repository configurations.'
+                )}
+                disabled={hasAccess}
+              >
+                <ActionBtn size="small" disabled>
+                  {t('Delete')}
+                </ActionBtn>
+              </ButtonTooltip>
+            ) : (
+              renderConfirmDelete(<ActionBtn size="small">{t('Delete')}</ActionBtn>)
+            )}
+            <DropDownWrapper>
+              <DropdownLink
+                caret={false}
+                customTitle={
+                  <StyledActionButton
+                    label={t('Actions')}
+                    disabled={!hasAccess || isDetailsDisabled}
+                    title={
+                      !hasAccess
+                        ? t(
+                            'You do not have permission to edit and delete custom repository configurations.'
+                          )
+                        : undefined
+                    }
+                    icon={<IconEllipsis />}
+                  />
+                }
+                anchorRight
+              >
+                <MenuItemActionLink title={t('Configure')} onClick={onEdit}>
+                  {t('Configure')}
+                </MenuItemActionLink>
+                {renderConfirmDelete(
+                  <MenuItemActionLink title={t('Delete')}>
+                    {t('Delete')}
+                  </MenuItemActionLink>
+                )}
+              </DropdownLink>
+            </DropDownWrapper>
+          </Fragment>
+        )}
+      </Access>
     </StyledButtonBar>
   );
 }
@@ -138,7 +184,14 @@ const StyledButtonBar = styled(ButtonBar)`
   }
 `;
 
-const StyledButton = styled(Button)`
+const ButtonTooltip = styled(Tooltip)`
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    display: none;
+  }
+`;
+
+const ActionBtn = styled(Button)`
+  width: 100%;
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     display: none;
   }

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/index.tsx
@@ -7,6 +7,7 @@ import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {openDebugFileSourceModal} from 'app/actionCreators/modal';
 import ProjectActions from 'app/actions/projectActions';
 import {Client} from 'app/api';
+import Access from 'app/components/acl/access';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -229,9 +230,22 @@ function CustomRepositories({
           })}
         >
           {({isOpen}) => (
-            <DropdownButton isOpen={isOpen} size="small">
-              {t('Add Repository')}
-            </DropdownButton>
+            <Access access={['project:write']}>
+              {({hasAccess}) => (
+                <DropdownButton
+                  isOpen={isOpen}
+                  title={
+                    !hasAccess
+                      ? t('You do not have permission to add custom repositories.')
+                      : undefined
+                  }
+                  disabled={!hasAccess}
+                  size="small"
+                >
+                  {t('Add Repository')}
+                </DropdownButton>
+              )}
+            </Access>
           )}
         </DropdownAutoComplete>
       </PanelHeader>


### PR DESCRIPTION
If the user has no "project edit" permission, a couple of buttons in the UI have to be disabled and provide a message to the user saying that he has no permission.

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/139079202-9684c5d3-c315-4e31-9da8-d08980b584c9.png)

![image](https://user-images.githubusercontent.com/29228205/139079251-e260bbf4-d163-4388-8d3e-eb8739f44a08.png)

![image](https://user-images.githubusercontent.com/29228205/139079352-41e6e7c6-5f99-4172-b25b-390e36174551.png)

![image](https://user-images.githubusercontent.com/29228205/139088823-1b5997bd-21d2-4957-8816-3f7ffdabe11f.png)

ps: 

- backend team will update the validation endpoint   `/projects/${orgSlug}/${project.slug}/appstoreconnect/validate/${appStoreConnectSymbolSourceId}/` so we the UI will be able to expose all non-sensitive app store connect data to all users independently of the user role. When this happens the "placeholder" component won't load forever 

- Since the refresh credentials (App store connect) code will be soon removed, I did not touch it in this PR 

- In this part of the UI  I am facing the same issue that this PR tries to solve https://github.com/getsentry/sentry/pull/29413