### PR TITLE
feat: Restrict superuser attributes to permission

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -94,7 +94,7 @@ class UserSerializer(BaseUserSerializer):
         return super().validate(attrs)
 
 
-class SuperuserUserSerializer(BaseUserSerializer):
+class PrivilegedUserSerializer(BaseUserSerializer):
     isActive = serializers.BooleanField(source="is_active")
     isStaff = serializers.BooleanField(source="is_staff")
     isSuperuser = serializers.BooleanField(source="is_superuser")
@@ -140,8 +140,8 @@ class UserDetailsEndpoint(UserEndpoint):
         :auth: required
         """
 
-        if is_active_superuser(request):
-            serializer_cls = SuperuserUserSerializer
+        if is_active_superuser(request) and request.access.has_permission("users.admin"):
+            serializer_cls = PrivilegedUserSerializer
         else:
             serializer_cls = UserSerializer
         serializer = serializer_cls(user, data=request.data, partial=True)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2175,7 +2175,7 @@ INVALID_EMAIL_ADDRESS_PATTERN = re.compile(r"\@qq\.com$", re.I)
 
 # This is customizable for sentry.io, but generally should only be additive
 # (currently the values not used anymore so this is more for documentation purposes)
-SENTRY_USER_PERMISSIONS = ("broadcasts.admin",)
+SENTRY_USER_PERMISSIONS = ("broadcasts.admin", "users.admin")
 
 KAFKA_CLUSTERS = {
     "default": {


### PR DESCRIPTION
Add the 'users.admin' permission and restrict superuser-style mutations on users to superusers which have this permission.
