### PR TITLE
fix(suspect-spans): Change default sort to total cumulative duration

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -72,7 +72,7 @@ export const SPAN_SORT_OPTIONS: SpanSortOption[] = [
   },
 ];
 
-const DEFAULT_SORT = SpanSortPercentiles.P75_EXCLUSIVE_TIME;
+const DEFAULT_SORT = SpanSortOthers.SUM_EXCLUSIVE_TIME;
 
 function getSuspectSpanSort(sort: string): SpanSortOption {
   const selected = SPAN_SORT_OPTIONS.find(option => option.field === sort);


### PR DESCRIPTION
After some experimentation, the total cumulative duration metric seems to be a
better metric in general for suspect spans. Switching to it as the default
metric to use.