### PR TITLE
feat: Restrict hard deletions on users to permission

### DIFF
--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -9,7 +9,7 @@ from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import AdminBroadcastSerializer, BroadcastSerializer, serialize
 from sentry.api.validators import AdminBroadcastValidator, BroadcastValidator
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import has_superuser_permission
 from sentry.models import Broadcast, BroadcastSeen
 
 logger = logging.getLogger("sentry")
@@ -19,7 +19,7 @@ class BroadcastDetailsEndpoint(Endpoint):
     permission_classes = (IsAuthenticated,)
 
     def _get_broadcast(self, request, broadcast_id):
-        if is_active_superuser(request) and request.access.has_permission("broadcasts.admin"):
+        if has_superuser_permission(request, "broadcasts.admin"):
             queryset = Broadcast.objects.all()
         else:
             queryset = Broadcast.objects.filter(
@@ -31,12 +31,12 @@ class BroadcastDetailsEndpoint(Endpoint):
             raise ResourceDoesNotExist
 
     def _get_validator(self, request):
-        if is_active_superuser(request):
+        if has_superuser_permission(request, "broadcasts.admin"):
             return AdminBroadcastValidator
         return BroadcastValidator
 
     def _get_serializer(self, request):
-        if is_active_superuser(request):
+        if has_superuser_permission(request, "broadcasts.admin"):
             return AdminBroadcastSerializer
         return BroadcastSerializer
 

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -15,7 +15,7 @@ from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.api.serializers.rest_framework import ListField
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import has_superuser_permission
 from sentry.constants import LANGUAGES
 from sentry.models import Organization, OrganizationMember, OrganizationStatus, User, UserOption
 
@@ -140,7 +140,7 @@ class UserDetailsEndpoint(UserEndpoint):
         :auth: required
         """
 
-        if is_active_superuser(request) and request.access.has_permission("users.admin"):
+        if has_superuser_permission(request, "users.admin"):
             serializer_cls = PrivilegedUserSerializer
         else:
             serializer_cls = UserSerializer
@@ -233,9 +233,9 @@ class UserDetailsEndpoint(UserEndpoint):
         hard_delete = serializer.validated_data.get("hardDelete", False)
 
         # Only active superusers can hard delete accounts
-        if hard_delete and not is_active_superuser(request):
+        if hard_delete and not has_superuser_permission(request, "users.admin"):
             return Response(
-                {"detail": "Only superusers may hard delete a user account"},
+                {"detail": "Missing required permission to hard delete account."},
                 status=status.HTTP_403_FORBIDDEN,
             )
 

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -58,6 +58,10 @@ def is_active_superuser(request):
     return su.is_active
 
 
+def has_superuser_permission(request, permission):
+    return is_active_superuser(request) and request.access.has_permission(permission)
+
+
 class Superuser:
     allowed_ips = [ipaddress.ip_network(str(v), strict=False) for v in ALLOWED_IPS]
 


### PR DESCRIPTION
This also adjusts several code paths to use the new `has_superuser_permission` helper, and in doing so more correctly locks down certain code paths to admins only (vs superusers only).

Fixes #29609 