### PR TITLE
fix(suspect): Increase examples to 5 per suspect

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -282,7 +282,7 @@ def query_example_transactions(
     query: Optional[str],
     order_column: str,
     suspects: List[SuspectSpan],
-    per_suspect: int = 3,
+    per_suspect: int = 5,
 ) -> Dict[Tuple[str, str], List[str]]:
     # there aren't any suspects, early return to save an empty query
     if not suspects:

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -459,8 +459,6 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
 
     @pytest.mark.skip("setting snuba config is too slow")
     def test_span_group_prefixed_with_zeros(self):
-        self.update_snuba_config_ensure({"write_span_columns_projects": f"[{self.project.id}]"})
-
         trace_context = {
             "op": "http.server",
             "hash": "00" + "ab" * 7,


### PR DESCRIPTION
Showing only 3 examples per suspect is too little, bumping this up to 5.