### PR TITLE
feat(suspect-spans): Show arrow next to sorting key

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
@@ -1,8 +1,10 @@
 import {ReactNode} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {SectionHeading as _SectionHeading} from 'app/components/charts/styles';
 import {Panel} from 'app/components/panels';
+import {IconArrow} from 'app/icons';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -44,13 +46,23 @@ type HeaderItemProps = {
   label: string;
   value: ReactNode;
   align: 'left' | 'right';
+  isSortKey?: boolean;
 };
 
 export function HeaderItem(props: HeaderItemProps) {
-  const {label, value, align} = props;
+  const {label, value, align, isSortKey} = props;
+  const theme = useTheme();
 
   return (
     <HeaderItemContainer align={align}>
+      {isSortKey && (
+        <IconArrow
+          data-test-id="span-sort-arrow"
+          size="xs"
+          color={theme.subText as any}
+          direction="down"
+        />
+      )}
       <SectionHeading>{label}</SectionHeading>
       <SectionValue>{value}</SectionValue>
     </HeaderItemContainer>
@@ -66,7 +78,7 @@ export const HeaderItemContainer = styled('div')<{align: 'left' | 'right'}>`
 `;
 
 const SectionHeading = styled(_SectionHeading)`
-  margin: 0;
+  margin: 0px 0px 0px ${space(0.5)};
 `;
 
 const SectionValue = styled('h1')`

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -108,6 +108,8 @@ export default function SuspectSpanEntry(props: Props) {
     spans: example.spans,
   }));
 
+  const sort = getSuspectSpanSortFromEventView(eventView);
+
   return (
     <div data-test-id="suspect-card">
       <UpperPanel>
@@ -116,15 +118,8 @@ export default function SuspectSpanEntry(props: Props) {
           value={<SpanLabel span={suspectSpan} />}
           align="left"
         />
-        <PercentileDuration
-          sort={getSuspectSpanSortFromEventView(eventView)}
-          suspectSpan={suspectSpan}
-        />
-        <SpanCount
-          sort={getSuspectSpanSortFromEventView(eventView)}
-          suspectSpan={suspectSpan}
-          totalCount={totalCount}
-        />
+        <PercentileDuration sort={sort} suspectSpan={suspectSpan} />
+        <SpanCount sort={sort} suspectSpan={suspectSpan} totalCount={totalCount} />
         <HeaderItem
           label={t('Total Cumulative Duration')}
           value={
@@ -134,6 +129,7 @@ export default function SuspectSpanEntry(props: Props) {
             />
           }
           align="right"
+          isSortKey={sort.field === SpanSortOthers.SUM_EXCLUSIVE_TIME}
         />
       </UpperPanel>
       <LowerPanel data-test-id="suspect-card-lower">
@@ -180,6 +176,7 @@ function PercentileDuration(props: HeaderItemProps) {
       label={PERCENTILE_LABELS[sortKey]}
       value={<PerformanceDuration abbreviation milliseconds={suspectSpan[sortKey]} />}
       align="right"
+      isSortKey={sort.field === sortKey}
     />
   );
 }
@@ -193,6 +190,7 @@ function SpanCount(props: HeaderItemProps & {totalCount?: number}) {
         label={t('Occurrences')}
         value={String(suspectSpan.count)}
         align="right"
+        isSortKey
       />
     );
   }

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -236,6 +236,10 @@ describe('Performance > Transaction Spans', function () {
         expect(
           await within(card).findByText('Total Cumulative Duration')
         ).toBeInTheDocument();
+
+        const arrow = await within(card).findByTestId('span-sort-arrow');
+        expect(arrow).toBeInTheDocument();
+        expect(await within(arrow.closest('div')!).findByText(label)).toBeInTheDocument();
       }
     });
   });
@@ -261,6 +265,12 @@ describe('Performance > Transaction Spans', function () {
       expect(await within(card).findByText('Occurrences')).toBeInTheDocument();
       expect(
         await within(card).findByText('Total Cumulative Duration')
+      ).toBeInTheDocument();
+
+      const arrow = await within(card).findByTestId('span-sort-arrow');
+      expect(arrow).toBeInTheDocument();
+      expect(
+        await within(arrow.closest('div')!).findByText('Occurrences')
       ).toBeInTheDocument();
     }
   });


### PR DESCRIPTION
The sort order on the spans tab is not obvious. This adds an arrow next to the
value that is sorted upon to make it clearer.