### PR TITLE
feat(workflow): Allow admins to view team stats of all teams

### DIFF
--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import {DateTimeObject} from 'app/components/charts/utils';
 import TeamSelector from 'app/components/forms/teamSelector';
 import * as Layout from 'app/components/layouts/thirds';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {ChangeData} from 'app/components/organizations/timeRangeSelector';
@@ -52,7 +53,7 @@ type Props = {} & RouteComponentProps<{orgId: string}, {}>;
 function TeamInsightsOverview({location, router}: Props) {
   const isSuperuser = isActiveSuperuser();
   const organization = useOrganization();
-  const {teams} = useTeams({provideUserTeams: true});
+  const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
   const theme = useTheme();
 
   const query = location?.query ?? {};
@@ -175,160 +176,163 @@ function TeamInsightsOverview({location, router}: Props) {
       <Header organization={organization} activeTab="team" />
 
       <Body>
-        <Layout.Main fullWidth>
-          <ControlsWrapper>
-            <StyledTeamSelector
-              name="select-team"
-              inFieldLabel={t('Team: ')}
-              value={currentTeam?.slug}
-              onChange={choice => handleChangeTeam(choice.actor.id)}
-              teamFilter={isSuperuser ? undefined : filterTeam => filterTeam.isMember}
-              styles={{
-                singleValue(provided: any) {
-                  const custom = {
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    fontSize: theme.fontSizeMedium,
-                    ':before': {
-                      ...provided[':before'],
-                      color: theme.textColor,
-                      marginRight: space(1.5),
-                      marginLeft: space(0.5),
-                    },
-                  };
-                  return {...provided, ...custom};
-                },
-                input: (provided: any, state: any) => ({
-                  ...provided,
-                  display: 'grid',
-                  gridTemplateColumns: 'max-content 1fr',
-                  alignItems: 'center',
-                  gridGap: space(1),
-                  ':before': {
-                    backgroundColor: state.theme.backgroundSecondary,
-                    height: 24,
-                    width: 38,
-                    borderRadius: 3,
-                    content: '""',
-                    display: 'block',
+        {!initiallyLoaded && <LoadingIndicator />}
+        {initiallyLoaded && (
+          <Layout.Main fullWidth>
+            <ControlsWrapper>
+              <StyledTeamSelector
+                name="select-team"
+                inFieldLabel={t('Team: ')}
+                value={currentTeam?.slug}
+                onChange={choice => handleChangeTeam(choice.actor.id)}
+                teamFilter={isSuperuser ? undefined : filterTeam => filterTeam.isMember}
+                styles={{
+                  singleValue(provided: any) {
+                    const custom = {
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      fontSize: theme.fontSizeMedium,
+                      ':before': {
+                        ...provided[':before'],
+                        color: theme.textColor,
+                        marginRight: space(1.5),
+                        marginLeft: space(0.5),
+                      },
+                    };
+                    return {...provided, ...custom};
                   },
-                }),
-              }}
-            />
-            <StyledPageTimeRangeSelector
-              organization={organization}
-              relative={period ?? ''}
-              start={start ?? null}
-              end={end ?? null}
-              utc={utc ?? null}
-              onUpdate={handleUpdateDatetime}
-              showAbsolute={false}
-              relativeOptions={{
-                '14d': t('Last 2 weeks'),
-                '4w': t('Last 4 weeks'),
-                [INSIGHTS_DEFAULT_STATS_PERIOD]: t('Last 8 weeks'),
-                '12w': t('Last 12 weeks'),
-              }}
-            />
-          </ControlsWrapper>
+                  input: (provided: any, state: any) => ({
+                    ...provided,
+                    display: 'grid',
+                    gridTemplateColumns: 'max-content 1fr',
+                    alignItems: 'center',
+                    gridGap: space(1),
+                    ':before': {
+                      backgroundColor: state.theme.backgroundSecondary,
+                      height: 24,
+                      width: 38,
+                      borderRadius: 3,
+                      content: '""',
+                      display: 'block',
+                    },
+                  }),
+                }}
+              />
+              <StyledPageTimeRangeSelector
+                organization={organization}
+                relative={period ?? ''}
+                start={start ?? null}
+                end={end ?? null}
+                utc={utc ?? null}
+                onUpdate={handleUpdateDatetime}
+                showAbsolute={false}
+                relativeOptions={{
+                  '14d': t('Last 2 weeks'),
+                  '4w': t('Last 4 weeks'),
+                  [INSIGHTS_DEFAULT_STATS_PERIOD]: t('Last 8 weeks'),
+                  '12w': t('Last 12 weeks'),
+                }}
+              />
+            </ControlsWrapper>
 
-          <SectionTitle>{t('Project Health')}</SectionTitle>
-          <DescriptionCard
-            title={t('Crash Free Sessions')}
-            description={t(
-              'The percentage of healthy, errored, and abnormal sessions that didn’t cause a crash.'
-            )}
-          >
-            <TeamStability
-              projects={projects}
-              organization={organization}
-              period={period}
-              start={start}
-              end={end}
-              utc={utc}
-            />
-          </DescriptionCard>
+            <SectionTitle>{t('Project Health')}</SectionTitle>
+            <DescriptionCard
+              title={t('Crash Free Sessions')}
+              description={t(
+                'The percentage of healthy, errored, and abnormal sessions that didn’t cause a crash.'
+              )}
+            >
+              <TeamStability
+                projects={projects}
+                organization={organization}
+                period={period}
+                start={start}
+                end={end}
+                utc={utc}
+              />
+            </DescriptionCard>
 
-          <DescriptionCard
-            title={t('User Misery')}
-            description={t(
-              'The number of unique users that experienced load times 4x the project’s configured threshold.'
-            )}
-          >
-            <TeamMisery
-              organization={organization}
-              projects={projects}
-              period={period}
-              start={start?.toString()}
-              end={end?.toString()}
-              location={location}
-            />
-          </DescriptionCard>
+            <DescriptionCard
+              title={t('User Misery')}
+              description={t(
+                'The number of unique users that experienced load times 4x the project’s configured threshold.'
+              )}
+            >
+              <TeamMisery
+                organization={organization}
+                projects={projects}
+                period={period}
+                start={start?.toString()}
+                end={end?.toString()}
+                location={location}
+              />
+            </DescriptionCard>
 
-          <DescriptionCard
-            title={t('Metric Alerts Triggered')}
-            description={t('Alerts triggered from the Alert Rules your team created.')}
-          >
-            <TeamAlertsTriggered
-              organization={organization}
-              teamSlug={currentTeam!.slug}
-              period={period}
-              start={start?.toString()}
-              end={end?.toString()}
-              location={location}
-            />
-          </DescriptionCard>
+            <DescriptionCard
+              title={t('Metric Alerts Triggered')}
+              description={t('Alerts triggered from the Alert Rules your team created.')}
+            >
+              <TeamAlertsTriggered
+                organization={organization}
+                teamSlug={currentTeam!.slug}
+                period={period}
+                start={start?.toString()}
+                end={end?.toString()}
+                location={location}
+              />
+            </DescriptionCard>
 
-          <SectionTitle>{t('Team Activity')}</SectionTitle>
-          <DescriptionCard
-            title={t('Issues Reviewed')}
-            description={t(
-              'Issues triaged by your team taking an action on them such as resolving, ignoring, marking as reviewed, or deleting.'
-            )}
-          >
-            <TeamIssuesReviewed
-              organization={organization}
-              projects={projects}
-              teamSlug={currentTeam!.slug}
-              period={period}
-              start={start?.toString()}
-              end={end?.toString()}
-              location={location}
-            />
-          </DescriptionCard>
-          <DescriptionCard
-            title={t('Time to Resolution')}
-            description={t(
-              `The mean time it took for issues to be resolved by your team.`
-            )}
-          >
-            <TeamResolutionTime
-              organization={organization}
-              teamSlug={currentTeam!.slug}
-              period={period}
-              start={start?.toString()}
-              end={end?.toString()}
-              location={location}
-            />
-          </DescriptionCard>
-          <DescriptionCard
-            title={t('Number of Releases')}
-            description={t(
-              'A breakdown showing how your team shipped releases over time.'
-            )}
-          >
-            <TeamReleases
-              projects={projects}
-              organization={organization}
-              teamSlug={currentTeam!.slug}
-              period={period}
-              start={start}
-              end={end}
-              utc={utc}
-            />
-          </DescriptionCard>
-        </Layout.Main>
+            <SectionTitle>{t('Team Activity')}</SectionTitle>
+            <DescriptionCard
+              title={t('Issues Reviewed')}
+              description={t(
+                'Issues triaged by your team taking an action on them such as resolving, ignoring, marking as reviewed, or deleting.'
+              )}
+            >
+              <TeamIssuesReviewed
+                organization={organization}
+                projects={projects}
+                teamSlug={currentTeam!.slug}
+                period={period}
+                start={start?.toString()}
+                end={end?.toString()}
+                location={location}
+              />
+            </DescriptionCard>
+            <DescriptionCard
+              title={t('Time to Resolution')}
+              description={t(
+                `The mean time it took for issues to be resolved by your team.`
+              )}
+            >
+              <TeamResolutionTime
+                organization={organization}
+                teamSlug={currentTeam!.slug}
+                period={period}
+                start={start?.toString()}
+                end={end?.toString()}
+                location={location}
+              />
+            </DescriptionCard>
+            <DescriptionCard
+              title={t('Number of Releases')}
+              description={t(
+                'A breakdown showing how your team shipped releases over time.'
+              )}
+            >
+              <TeamReleases
+                projects={projects}
+                organization={organization}
+                teamSlug={currentTeam!.slug}
+                period={period}
+                start={start}
+                end={end}
+                utc={utc}
+              />
+            </DescriptionCard>
+          </Layout.Main>
+        )}
       </Body>
     </Fragment>
   );

--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import {DateTimeObject} from 'app/components/charts/utils';
 import TeamSelector from 'app/components/forms/teamSelector';
 import * as Layout from 'app/components/layouts/thirds';
+import NoProjectMessage from 'app/components/noProjectMessage';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {ChangeData} from 'app/components/organizations/timeRangeSelector';
 import PageTimeRangeSelector from 'app/components/pageTimeRangeSelector';
@@ -162,6 +163,12 @@ function TeamInsightsOverview({location, router}: Props) {
     return {period: INSIGHTS_DEFAULT_STATS_PERIOD};
   }
   const {period, start, end, utc} = dataDatetime();
+
+  if (teams.length === 0) {
+    return (
+      <NoProjectMessage organization={organization} superuserNeedsToBeProjectMember />
+    );
+  }
 
   return (
     <Fragment>


### PR DESCRIPTION
Show all teams to super admins

Switch to the useTeams hook with `provideUserTeams` since it handles this for us. withUserTeams currently doesn't allow for all teams.

fixes the page for users with regular users w/ no teams, they will see the "Join a Team" button.
![image](https://user-images.githubusercontent.com/1400464/139157820-2b9340ef-f46c-4bb9-8e71-9652044707c0.png)
