### PR TITLE
fix(cmp_alerts): Allow comparison event frequency percent alerts to set a value > 100

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -74,6 +74,7 @@ class EventFrequencyForm(forms.Form):
             msg = forms.ValidationError("comparisonInterval is required when comparing by percent")
             self.add_error("comparisonInterval", msg)
             return
+        return cleaned_data
 
 
 class BaseEventFrequencyCondition(EventCondition):
@@ -217,7 +218,17 @@ class EventFrequencyPercentForm(EventFrequencyForm):
             )
         ]
     )
-    value = forms.FloatField(widget=forms.TextInput(), min_value=0, max_value=100)
+    value = forms.FloatField(widget=forms.TextInput(), min_value=0)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data["comparisonType"] == COMPARISON_TYPE_COUNT and cleaned_data["value"] > 100:
+            self.add_error(
+                "value", forms.ValidationError("Ensure this value is less than or equal to 100")
+            )
+            return
+
+        return cleaned_data
 
 
 class EventFrequencyPercentCondition(BaseEventFrequencyCondition):


### PR DESCRIPTION
Event frequency percent alerts are capped at a value between 0-100%, which makes sense for that kind
of alert. When we change these to be comparison alerts this doesn't make sense though, since we're
just taking into account relative change. This pr changes the validation to be conditional.