### PR TITLE
fix(owners): Fix bug in `path` matching for project owners

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -120,13 +120,13 @@ class Matcher(namedtuple("Matcher", "type pattern")):
 
     def test_frames(self, data, keys):
         for frame in _iter_frames(data):
-            value = next((frame.get(key) for key in keys if frame.get(key)), None)
+            for key in keys:
+                value = frame.get(key)
+                if not value:
+                    continue
 
-            if not value:
-                continue
-
-            if glob_match(value, self.pattern, ignorecase=True, path_normalize=True):
-                return True
+                if glob_match(value, self.pattern, ignorecase=True, path_normalize=True):
+                    return True
 
         return False
 

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -230,6 +230,19 @@ class ProjectOwnershipTestCase(TestCase):
             self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
         ) == (True, [self.user, self.team], False)
 
+    def test_abs_path_when_filename_present(self):
+        frame = {
+            "filename": "computer.cpp",
+            "abs_path": "C:\\My\\Path\\computer.cpp",
+        }
+        rule = Rule(Matcher("path", "*My\\Path*"), [Owner("team", self.team.slug)])
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema([rule]), fallthrough=True
+        )
+        assert ProjectOwnership.get_owners(
+            self.project.id, {"stacktrace": {"frames": [frame]}}
+        ) == ([ActorTuple(self.team.id, Team)], [rule])
+
 
 class ResolveActorsTestCase(TestCase):
     def test_no_actors(self):

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -127,6 +127,25 @@ def test_matcher_test_exception():
     assert not Matcher("path", "*.py").test({})
 
 
+def test_matcher_file_abs_path_same_frame():
+    data = {
+        "exception": {
+            "values": [
+                {
+                    "stacktrace": {
+                        "frames": [
+                            {"filename": "foo/file.py", "abs_path": "/usr/local/src/other/app.py"},
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+    assert Matcher("path", "/usr/local/src/*/app.py").test(data)
+    assert Matcher("path", "*local/src/*").test(data)
+
+
 def test_matcher_test_stacktrace():
     data = {
         "stacktrace": {


### PR DESCRIPTION
When we match on path we currently try to access `filename` from the frame, and if not present we
use `abs_path`. This means that for any frames that have both `filename` and `abs_path` it's not
possible to match on a segment of the path.

This pr changes the behaviour of `path` to check both `filename` and `abs_path`. If we want to be
more conservative with this matching change we could add a new `abs_path` matching option, but I
feel like that would be adding more bloat to understanding this feature.