### PR TITLE
Add performance spans around `post_process.handle_owner_assignment`

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -82,43 +82,52 @@ def handle_owner_assignment(project, group, event):
     from sentry.models import GroupAssignee, ProjectOwnership
 
     with metrics.timer("post_process.handle_owner_assignment"):
-        owner_key = "owner_exists:1:%s" % group.id
-        owners_exists = cache.get(owner_key)
-        if owners_exists is None:
-            owners_exists = group.groupowner_set.exists()
-            # Cache for an hour if it's assigned. We don't need to move that fast.
-            cache.set(owner_key, owners_exists, 3600 if owners_exists else 60)
+        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.cache_set_owner"):
+            owner_key = "owner_exists:1:%s" % group.id
+            owners_exists = cache.get(owner_key)
+            if owners_exists is None:
+                owners_exists = group.groupowner_set.exists()
+                # Cache for an hour if it's assigned. We don't need to move that fast.
+                cache.set(owner_key, owners_exists, 3600 if owners_exists else 60)
 
-        # Is the issue already assigned to a team or user?
-        assignee_key = "assignee_exists:1:%s" % group.id
-        assignees_exists = cache.get(assignee_key)
-        if assignees_exists is None:
-            assignees_exists = group.assignee_set.exists()
-            # Cache for an hour if it's assigned. We don't need to move that fast.
-            cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
+        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.cache_set_assignee"):
+            # Is the issue already assigned to a team or user?
+            assignee_key = "assignee_exists:1:%s" % group.id
+            assignees_exists = cache.get(assignee_key)
+            if assignees_exists is None:
+                assignees_exists = group.assignee_set.exists()
+                # Cache for an hour if it's assigned. We don't need to move that fast.
+                cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
 
         if owners_exists and assignees_exists:
             return
 
-        auto_assignment, owners, assigned_by_codeowners = ProjectOwnership.get_autoassign_owners(
-            group.project_id, event.data
-        )
+        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.get_autoassign_owners"):
+            (
+                auto_assignment,
+                owners,
+                assigned_by_codeowners,
+            ) = ProjectOwnership.get_autoassign_owners(group.project_id, event.data)
 
-        if auto_assignment and owners and not assignees_exists:
-            assignment = GroupAssignee.objects.assign(group, owners[0])
-            if assignment["new_assignment"] or assignment["updated_assignment"]:
-                analytics.record(
-                    "codeowners.assignment" if assigned_by_codeowners else "issueowners.assignment",
-                    organization_id=project.organization_id,
-                    project_id=project.id,
-                    group_id=group.id,
-                )
+        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.analytics_record"):
+            if auto_assignment and owners and not assignees_exists:
+                assignment = GroupAssignee.objects.assign(group, owners[0])
+                if assignment["new_assignment"] or assignment["updated_assignment"]:
+                    analytics.record(
+                        "codeowners.assignment"
+                        if assigned_by_codeowners
+                        else "issueowners.assignment",
+                        organization_id=project.organization_id,
+                        project_id=project.id,
+                        group_id=group.id,
+                    )
 
-        if owners and not owners_exists:
-            try:
-                handle_group_owners(project, group, owners)
-            except Exception:
-                logger.exception("Failed to store group owners")
+        with sentry_sdk.start_span(op="post_process.handle_owner_assignment.handle_group_owners"):
+            if owners and not owners_exists:
+                try:
+                    handle_group_owners(project, group, owners)
+                except Exception:
+                    logger.exception("Failed to store group owners")
 
 
 def handle_group_owners(project, group, owners):
@@ -133,7 +142,9 @@ def handle_group_owners(project, group, owners):
 
     lock = locks.get(f"groupowner-bulk:{group.id}", duration=10)
     try:
-        with lock.acquire(), metrics.timer("post_process.handle_group_owners"):
+        with metrics.timer("post_process.handle_group_owners"), sentry_sdk.start_span(
+            op="post_process.handle_group_owners"
+        ), lock.acquire():
             current_group_owners = GroupOwner.objects.filter(
                 group=group, type=GroupOwnerType.OWNERSHIP_RULE.value
             )
@@ -173,7 +184,7 @@ def handle_group_owners(project, group, owners):
             if new_group_owners:
                 GroupOwner.objects.bulk_create(new_group_owners)
     except UnableToAcquireLock:
-        pass
+        logger.exception("Failed to acquire lock at post_process.handle_group_owners")
 
 
 def update_existing_attachments(event):


### PR DESCRIPTION
Adding some spans to investigate slowdowns of `tasks.post_process_group.handle_owner_assignment` (up to 30 sec).
Probably related to locking added here https://github.com/getsentry/sentry/pull/29309