### PR TITLE
build(ci): *TEMP* increase GHA timeouts to 90 minutes

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -17,7 +17,7 @@ jobs:
   frontend:
     name: frontend tests
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 90
     strategy:
       matrix:
         # XXX: When updating this, make sure you also update CI_NODE_TOTAL.
@@ -89,7 +89,7 @@ jobs:
   webpack:
     name: create frontend bundle
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     outputs:
       dist-path: ${{ steps.config.outputs.dist-path }}
 
@@ -146,7 +146,7 @@ jobs:
   acceptance:
     name: acceptance
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]
@@ -209,7 +209,7 @@ jobs:
   chartcuterie:
     name: chartcuterie integration
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     name: backend lint
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: backend test
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: backend typing
     runs-on: ubuntu-20.04
-    timeout-minutes: 12
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -10,7 +10,7 @@ jobs:
   bootstrap-script:
     name: bootstrap
     runs-on: macos-11.0
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Run bootstrap scripts
         run: |

--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -5,7 +5,7 @@ jobs:
   should-check:
     name: did files change
     runs-on: ubuntu-20.04
-    timeout-minutes: 3
+    timeout-minutes: 90
     # Map a step output to a job output
     outputs:
       changed: ${{ steps.changes.outputs.migration_lockfile }}

--- a/.github/workflows/command-line-test.yml
+++ b/.github/workflows/command-line-test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     name: cli test
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -16,7 +16,7 @@ jobs:
   dev-environment:
     name: dev docs set up
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 90
     strategy:
       matrix:
         # Using Ubuntu 18 until I figure out this error:
@@ -83,7 +83,7 @@ jobs:
 
   bootstrap-script:
     runs-on: macos-11
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: on
       # Make the environment more similar to what Mac defaults to

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -5,7 +5,7 @@ jobs:
   did-migration-change:
     name: check if any migration changes
     runs-on: ubuntu-20.04
-    timeout-minutes: 3
+    timeout-minutes: 90
     # Map a step output to a job output
     outputs:
       added: ${{ steps.changes.outputs.migrations_added }}
@@ -24,7 +24,7 @@ jobs:
   modified-migration:
     name: check if modified migration
     runs-on: ubuntu-20.04
-    timeout-minutes: 4
+    timeout-minutes: 90
     needs: did-migration-change
     if: ${{ needs.did-migration-change.outputs.modified == 'true' }}
 
@@ -38,7 +38,7 @@ jobs:
   sql:
     name: Generate SQL
     runs-on: ubuntu-20.04
-    timeout-minutes: 8
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/plugins-test.yml
+++ b/.github/workflows/plugins-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: plugins test
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -14,7 +14,7 @@ jobs:
   python-deps:
     name: install
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 90
     strategy:
       matrix:
         os: [macos-11.0, ubuntu-20.04]

--- a/.github/workflows/relay-integration-test.yml
+++ b/.github/workflows/relay-integration-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: relay test
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/snuba-integration-test.yml
+++ b/.github/workflows/snuba-integration-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: snuba test
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/symbolicator-integration-test.yml
+++ b/.github/workflows/symbolicator-integration-test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     name: symbolicator test
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 90
     strategy:
       matrix:
         python-version: [3.8.12]

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -10,7 +10,7 @@ jobs:
   visual-diff:
     if: github.repository == 'getsentry/sentry'
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 90
 
     steps:
       - name: Diff snapshots


### PR DESCRIPTION
There has been some intermittent issues when pulling docker images that cause our jobs to timeout. As a temporary measure, increase the timeouts so we minimize eng impact.