### PR TITLE
feat(discover): Enable snql on the events-geo endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -125,6 +125,9 @@ class OrganizationEventsGeoEndpoint(OrganizationEventsV2EndpointBase):
                 referrer=referrer,
                 use_aggregate_conditions=True,
                 orderby=self.get_orderby(request) or maybe_aggregate,
+                use_snql=features.has(
+                    "organizations:discover-use-snql", organization, actor=request.user
+                ),
             )
 
         with self.handle_query_errors():

--- a/tests/snuba/api/endpoints/test_organization_events_geo.py
+++ b/tests/snuba/api/endpoints/test_organization_events_geo.py
@@ -8,10 +8,12 @@ class OrganizationEventsGeoEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
+        self.features = {}
 
     def do_request(self, query, features=None):
         if features is None:
             features = {"organizations:dashboards-basic": True}
+        features.update(self.features)
         self.login_as(user=self.user)
         url = reverse(
             "sentry-api-0-organization-events-geo",
@@ -183,3 +185,9 @@ class OrganizationEventsGeoEndpointTest(APITestCase, SnubaTestCase):
             {"count": 2, "geo.country_code": "JP"},
             {"count": 3, "geo.country_code": "BR"},
         ]
+
+
+class OrganizationEventsGeoEndpointTestWithSnql(OrganizationEventsGeoEndpointTest):
+    def setUp(self):
+        super().setUp()
+        self.features["organizations:discover-use-snql"] = True


### PR DESCRIPTION
- This was completely painless, turning it on didn't break any tests so
  no other changes except to check for the flag