### PR TITLE
fix(snuba) Add debug logs for parent API mismatch

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import random
 import re
 import time
 from collections import OrderedDict, namedtuple
@@ -874,6 +875,21 @@ def _raw_snql_query(
             scope = thread_hub.scope
             if scope.transaction:
                 query = query.set_parent_api(scope.transaction.name)
+
+                # XXX(evanh): There seems to be a bug where the parent API is attributed to
+                # the wrong referrer. For one example of this, log a warning so I can capture
+                # the stack trace and try to figure out if this is a bug or not.
+                if (
+                    referrer == "tsdb-modelid:500"
+                    and query.parent_api.name
+                    != "/api/0/projects/{organization_slug}/{project_slug}/keys/{key_id}/stats/"
+                    and random.random() < 0.1
+                ):
+                    logger.warning(
+                        "referrer attributed to incorrect parent api",
+                        stack_info=True,
+                        extra={"parent_api": query.parent_api.name},
+                    )
 
             metrics.incr(
                 "snuba.parent_api",


### PR DESCRIPTION
There seems to be a bug with the parent API that is causing referrers to be
attributed to parent APIs that are seemingly unrelated. Log a sample of times
this happens with a stack trace to try and determine if this is actually a bug
or just an inscrutable code path that causes this.