### PR TITLE
feat(suspect-spans): Render suspect span attributes better

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import map from 'lodash/map';
 
 import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import DateTime from 'app/components/dateTime';
@@ -32,6 +33,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 import {assert} from 'app/types/utils';
+import {defined} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
 import {generateEventSlug} from 'app/utils/discover/urls';
 import getDynamicText from 'app/utils/getDynamicText';
@@ -372,6 +374,19 @@ class SpanDetail extends React.Component<Props, State> {
                   ? String(span.same_process_as_parent)
                   : null}
               </Row>
+              <Feature
+                organization={organization}
+                features={['organizations:performance-suspect-spans-view']}
+              >
+                <Row title="Span Group">
+                  {defined(span.hash) ? String(span.hash) : null}
+                </Row>
+                <Row title="Span Exclusive Time">
+                  {defined(span.exclusive_time)
+                    ? `${Number(span.exclusive_time.toFixed(3)).toLocaleString()}ms`
+                    : null}
+                </Row>
+              </Feature>
               <Tags span={span} />
               {allZeroSizes && (
                 <TextTr>

--- a/static/app/components/events/interfaces/spans/types.tsx
+++ b/static/app/components/events/interfaces/spans/types.tsx
@@ -18,6 +18,8 @@ export type RawSpanType = {
   status?: string;
   data: Object;
   tags?: {[key: string]: string};
+  hash?: string;
+  exclusive_time?: number;
 };
 
 export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
@@ -32,6 +34,8 @@ export const rawSpanKeys: Set<keyof RawSpanType> = new Set([
   'status',
   'data',
   'tags',
+  'hash',
+  'exclusive_time',
 ]);
 
 export type OrphanSpanType = {
@@ -119,6 +123,8 @@ export type ParsedTraceType = {
   traceEndTimestamp: number;
   spans: SpanType[];
   description?: string;
+  hash?: string;
+  exclusiveTime?: number;
 };
 
 export enum TickAlignment {
@@ -135,6 +141,8 @@ export type TraceContextType = {
   parent_span_id?: string;
   description?: string;
   status?: string;
+  hash?: string;
+  exclusive_time?: number;
 };
 
 type SpanTreeDepth = number;

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -191,6 +191,8 @@ export function generateRootSpan(trace: ParsedTraceType): RawSpanType {
     description: trace.description,
     data: {},
     status: trace.rootSpanStatus,
+    hash: trace.hash,
+    exclusive_time: trace.exclusiveTime,
   };
 
   return rootSpan;
@@ -293,6 +295,8 @@ export function parseTrace(event: Readonly<EventTransaction>): ParsedTraceType {
   const description = traceContext && traceContext.description;
   const parentSpanID = traceContext && traceContext.parent_span_id;
   const rootSpanStatus = traceContext && traceContext.status;
+  const hash = traceContext && traceContext.hash;
+  const exclusiveTime = traceContext && traceContext.exclusive_time;
 
   if (!spanEntry || spans.length <= 0) {
     return {
@@ -306,6 +310,8 @@ export function parseTrace(event: Readonly<EventTransaction>): ParsedTraceType {
       parentSpanID,
       spans: [],
       description,
+      hash,
+      exclusiveTime,
     };
   }
 
@@ -332,6 +338,8 @@ export function parseTrace(event: Readonly<EventTransaction>): ParsedTraceType {
     parentSpanID,
     spans,
     description,
+    hash,
+    exclusiveTime,
   };
 
   const reduced: ParsedTraceType = spans.reduce((acc, inputSpan) => {


### PR DESCRIPTION
Currently, this is being rendered with the fallback to render everything as a
string. But these are special fields that require additional handling to be
formatted appropriately.