### PR TITLE
ref(appstore-connect): Stop asking users to refresh their iTunes credentials [NATIVE-294]

### DIFF
--- a/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
+++ b/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
@@ -7,7 +7,6 @@ import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import Link from 'app/components/links/link';
 import AppStoreConnectContext from 'app/components/projects/appStoreConnectContext';
-import {appStoreConnectAlertMessage} from 'app/components/projects/appStoreConnectContext/utils';
 import {IconClose, IconRefresh} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -85,14 +84,7 @@ function UpdateAlert({api, Wrapper, isCompact, project, organization, className}
         {isCompact && (
           <Fragment>
             &nbsp;
-            <Link
-              to={
-                updateAlertMessage ===
-                appStoreConnectAlertMessage.appStoreCredentialsInvalid
-                  ? projectSettingsLink
-                  : `${projectSettingsLink}&revalidateItunesSession=true`
-              }
-            >
+            <Link to={projectSettingsLink}>
               {t('Update it in the project settings to reconnect')}
             </Link>
           </Fragment>
@@ -120,10 +112,7 @@ function UpdateAlert({api, Wrapper, isCompact, project, organization, className}
           {t('Dismiss')}
         </Button>
         |
-        <Button
-          priority="link"
-          to={`${projectSettingsLink}&revalidateItunesSession=true`}
-        >
+        <Button priority="link" to={projectSettingsLink}>
           {t('Update session')}
         </Button>
       </Actions>

--- a/static/app/components/modals/debugFileCustomRepository/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/index.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/react';
-import {Location} from 'history';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import {AppStoreConnectContextProps} from 'app/components/projects/appStoreConnectContext';
@@ -51,7 +50,6 @@ function DebugFileCustomRepository({
   sourceConfig,
   sourceType,
   params: {orgId, projectId: projectSlug},
-  location,
   appStoreConnectContext,
   closeModal,
 }: Props) {
@@ -77,7 +75,6 @@ function DebugFileCustomRepository({
         projectSlug={projectSlug}
         onSubmit={handleSave}
         initialData={sourceConfig as AppStoreConnectInitialData}
-        location={location as Location}
         appStoreConnectContext={appStoreConnectContext}
       />
     );

--- a/static/app/components/projects/appStoreConnectContext/utils.tsx
+++ b/static/app/components/projects/appStoreConnectContext/utils.tsx
@@ -2,9 +2,6 @@ import {t} from 'app/locale';
 import {AppStoreConnectValidationData} from 'app/types/debugFiles';
 
 export const appStoreConnectAlertMessage = {
-  iTunesSessionInvalid: t(
-    'The iTunes session of your configured App Store Connect needs to be refreshed.'
-  ),
   appStoreCredentialsInvalid: t(
     'The credentials of your configured App Store Connect are invalid.'
   ),
@@ -13,9 +10,6 @@ export const appStoreConnectAlertMessage = {
 export function getAppConnectStoreUpdateAlertMessage(
   appConnectValidationData: AppStoreConnectValidationData
 ) {
-  if (appConnectValidationData.promptItunesSession) {
-    return appStoreConnectAlertMessage.iTunesSessionInvalid;
-  }
   if (appConnectValidationData.appstoreCredentialsValid === false) {
     return appStoreConnectAlertMessage.appStoreCredentialsInvalid;
   }

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -61,11 +61,6 @@ export type AppStoreConnectValidationData = {
    * fetched. This will be null if no builds can be found.
    */
   latestBuildVersion: string | null;
-  /**
-   * Whether the UI should show an alert indicating we need the user to refresh
-   * their iTunes session.
-   */
-  promptItunesSession: boolean;
   lastCheckedBuilds: string | null;
   updateAlertMessage?: string;
 };

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/index.tsx
@@ -158,7 +158,6 @@ function CustomRepositories({
       query: {
         ...location.query,
         customRepository: undefined,
-        revalidateItunesSession: undefined,
       },
     });
   }
@@ -181,16 +180,12 @@ function CustomRepositories({
     });
   }
 
-  function handleEditRepository(
-    repoId: CustomRepo['id'],
-    revalidateItunesSession?: boolean
-  ) {
+  function handleEditRepository(repoId: CustomRepo['id']) {
     router.push({
       ...location,
       query: {
         ...location.query,
         customRepository: repoId,
-        revalidateItunesSession,
       },
     });
   }

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/repository.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/repository.tsx
@@ -13,7 +13,7 @@ import {customRepoTypeLabel} from './utils';
 type Props = {
   repository: CustomRepo;
   onDelete: (repositoryId: string) => void;
-  onEdit: (repositoryId: string, revalidateItunesSession?: boolean) => void;
+  onEdit: (repositoryId: string) => void;
 };
 
 function Repository({repository, onDelete, onEdit}: Props) {
@@ -26,11 +26,7 @@ function Repository({repository, onDelete, onEdit}: Props) {
       <TypeAndStatus>
         {customRepoTypeLabel[type]}
         {repository.type === CustomRepoType.APP_STORE_CONNECT && (
-          <Status
-            details={repository.details}
-            onEditRepository={() => onEdit(id)}
-            onRevalidateItunesSession={() => onEdit(id, true)}
-          />
+          <Status details={repository.details} onEditRepository={() => onEdit(id)} />
         )}
       </TypeAndStatus>
       <CustomRepositoryActions

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -13,37 +13,17 @@ import {AppStoreConnectValidationData} from 'app/types/debugFiles';
 
 type Props = {
   onEditRepository: () => void;
-  onRevalidateItunesSession: () => void;
   details?: AppStoreConnectValidationData;
 };
 
-function Status({details, onEditRepository, onRevalidateItunesSession}: Props) {
+function Status({details, onEditRepository}: Props) {
   const theme = useTheme();
 
   if (!details) {
     return <Placeholder height="14px" />;
   }
 
-  const {
-    pendingDownloads,
-    promptItunesSession,
-    appstoreCredentialsValid,
-    lastCheckedBuilds,
-  } = details ?? {};
-
-  if (promptItunesSession) {
-    return (
-      <Wrapper color={theme.red300} onClick={onRevalidateItunesSession}>
-        <StyledTooltip
-          title={t('Revalidate your iTunes session')}
-          containerDisplayMode="inline-flex"
-        >
-          <IconWarning size="sm" />
-        </StyledTooltip>
-        {t('iTunes Authentication required')}
-      </Wrapper>
-    );
-  }
+  const {pendingDownloads, appstoreCredentialsValid, lastCheckedBuilds} = details ?? {};
 
   if (appstoreCredentialsValid === false) {
     return (


### PR DESCRIPTION
#29513 begins work that removes the last dependency that the App Store Connect integration has on iTunes. This PR removes all of the code related to alerting the user about outdated iTunes credentials as they should no longer be used for anything.

Warnings related to incorrect, invalid, or outdated App Store Connect credentials are preserved.

related: https://github.com/getsentry/sentry/issues/29531