### PR TITLE
feat(discover): pull columns, y-axis, and orderby from query when adding top-n widget

### DIFF
--- a/static/app/views/eventsV2/savedQuery/utils.tsx
+++ b/static/app/views/eventsV2/savedQuery/utils.tsx
@@ -248,6 +248,8 @@ export function displayModeToDisplayType(displayMode: DisplayModes): DisplayType
       return DisplayType.BAR;
     case DisplayModes.WORLDMAP:
       return DisplayType.WORLD_MAP;
+    case DisplayModes.TOP5:
+      return DisplayType.TOP_N;
     default:
       return DisplayType.LINE;
   }

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -943,4 +943,26 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(wrapper.find('SelectPicker').at(1).props().value.value).toEqual('bar');
     wrapper.unmount();
   });
+
+  it('correctly defaults fields and orderby when in Top N display', async function () {
+    const wrapper = mountModal({
+      initialData,
+      onAddWidget: () => undefined,
+      onUpdateWidget: () => undefined,
+      fromDiscover: true,
+      displayType: types.DisplayType.TOP_N,
+      defaultWidgetQuery: {fields: ['count_unique(user)'], orderby: '-count_unique_user'},
+      defaultTableColumns: ['title', 'count()', 'count_unique(user)'],
+    });
+
+    expect(wrapper.find('SelectPicker').at(1).props().value.value).toEqual('top_n');
+    expect(wrapper.find('WidgetQueriesForm').props().queries[0].fields).toEqual([
+      'title',
+      'count_unique(user)',
+    ]);
+    expect(wrapper.find('WidgetQueriesForm').props().queries[0].orderby).toEqual(
+      '-count_unique_user'
+    );
+    wrapper.unmount();
+  });
 });

--- a/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/savedQuery/index.spec.jsx
@@ -2,6 +2,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {mountGlobalModal} from 'sentry-test/modal';
 
 import EventView from 'app/utils/discover/eventView';
+import {DisplayModes} from 'app/utils/discover/types';
 import DiscoverBanner from 'app/views/eventsV2/banner';
 import {ALL_VIEWS} from 'app/views/eventsV2/data';
 import SavedQueryButtonGroup from 'app/views/eventsV2/savedQuery';
@@ -49,6 +50,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
   const errorsQuery = {
     ...ALL_VIEWS.find(view => view.name === 'Errors by Title'),
     yAxis: 'count()',
+    display: DisplayModes.DEFAULT,
   };
   const errorsView = EventView.fromSavedQuery(errorsQuery);
 
@@ -443,9 +445,9 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       await tick();
       await tick();
       const modal = await mountGlobalModal();
-      expect(modal.find('AddDashboardWidgetModal').find('h4').children().html()).toEqual(
-        'Add Widget to Dashboard'
-      );
+      expect(
+        modal.find('AddDashboardWidgetModal').find('h4').children().at(0).html()
+      ).toEqual('Add Widget to Dashboard');
     });
 
     it('populates dashboard widget modal with saved query data if created from discover', async () => {


### PR DESCRIPTION
When creating a widget from a Top-n query, automatically default the widget to Top Events display type and pull columns, y-axis, and orderby from the saved query.