### PR TITLE
fix(discover): Handle empty y-axis

### DIFF
--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -283,7 +283,11 @@ class QueryList extends React.Component<Props> {
                   eventView={eventView}
                   organization={organization}
                   referrer={referrer}
-                  yAxis={hasFeature ? savedQuery.yAxis : undefined}
+                  yAxis={
+                    hasFeature && savedQuery.yAxis && savedQuery.yAxis.length
+                      ? savedQuery.yAxis
+                      : ['count()']
+                  }
                 />
               )}
             </Feature>


### PR DESCRIPTION
- Still investigating why there are empty y-axis in the first place, but
  even if this happens we should default to count() like on the results
  page so that we don't error out