### PR TITLE
fix(worldmap): Fix params that are passed to the endpoint

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -152,7 +152,9 @@ def unfurl_discover(
         # Only override if key doesn't exist since we want to account for
         # an intermediate state where the query could have been cleared
         if "query" not in params:
-            params.setlist("query", params.getlist("query") or to_list(saved_query.get("query")))
+            params.setlist(
+                "query", params.getlist("query") or to_list(saved_query.get("query", ""))
+            )
 
         display_mode = str(params.get("display") or saved_query.get("display", "default"))
 
@@ -187,6 +189,8 @@ def unfurl_discover(
         endpoint = "events-stats/"
         if "worldmap" in display_mode:
             endpoint = "events-geo/"
+            params.setlist("field", params.getlist("yAxis"))
+            params.pop("sort", None)
 
         try:
             resp = client.get(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -515,7 +515,7 @@ class UnfurlTest(TestCase):
             project_id=self.project.id,
         )
 
-        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=worldmap&field=count()&name=All+Events&project={self.project.id}&query=&statsPeriod=24h"
+        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=worldmap&field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All+Events&project={self.project.id}&query=&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29"
         link_type, args = match_link(url)
 
         if not args or not link_type:


### PR DESCRIPTION
Only pass yAxis as field and remove orderby since the
orderby field doesn't make sense to specify.

Screenshot from discover saved query link
![Screen Shot 2021-10-29 at 4 07 06 PM](https://user-images.githubusercontent.com/63818634/139495609-16412127-ed04-4ff2-baa4-4afa37c084ba.png)
