### PR TITLE
ref(types): Use python 3.8 types in `sentry.notifications`

### DIFF
--- a/src/sentry/digests/utilities.py
+++ b/src/sentry/digests/utilities.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from collections import Counter, OrderedDict, defaultdict
 from datetime import datetime
 from typing import Counter as CounterType
-from typing import Iterable, Mapping, MutableMapping, Optional, Set, Tuple
+from typing import Iterable, Mapping, MutableMapping
 
 from sentry.digests import Digest
 from sentry.eventstore.models import Event
@@ -11,10 +13,10 @@ from sentry.notifications.types import ActionTargetType
 
 def get_digest_metadata(
     digest: Digest,
-) -> Tuple[Optional[datetime], Optional[datetime], CounterType[str]]:
+) -> tuple[datetime | None, datetime | None, CounterType[str]]:
     """TODO(mgaeta): This should probably just be part of `build_digest`."""
-    start: Optional[datetime] = None
-    end: Optional[datetime] = None
+    start: datetime | None = None
+    end: datetime | None = None
 
     counts: CounterType[str] = Counter()
     for rule, groups in digest.items():
@@ -41,7 +43,7 @@ def should_get_personalized_digests(target_type: ActionTargetType, project_id: i
 
 def get_personalized_digests(
     target_type: ActionTargetType, project_id: int, digest: Digest, user_ids: Iterable[int]
-) -> Iterable[Tuple[int, Digest]]:
+) -> Iterable[tuple[int, Digest]]:
     """
     TODO(mgaeta): I know this is inefficient. In the case that ProjectOwnership
      does exist, I do the same query twice. Once with this statement and again
@@ -95,7 +97,7 @@ def build_events_by_actor(
      create a follow-up PR to address this method's efficiency problem.
      Just wanted to make as few changes as possible for now.
     """
-    events_by_actor: MutableMapping[ActorTuple, Set[Event]] = defaultdict(set)
+    events_by_actor: MutableMapping[ActorTuple, set[Event]] = defaultdict(set)
     for event in events:
         actors, __ = ProjectOwnership.get_owners(project_id, event.data)
         if actors == ProjectOwnership.Everyone:
@@ -108,7 +110,7 @@ def build_events_by_actor(
 def convert_actors_to_users(
     events_by_actor: Mapping[ActorTuple, Iterable[Event]], user_ids: Iterable[int]
 ) -> Mapping[int, Iterable[Event]]:
-    events_by_user: MutableMapping[int, Set[Event]] = defaultdict(set)
+    events_by_user: MutableMapping[int, set[Event]] = defaultdict(set)
     team_actors = [actor for actor in events_by_actor.keys() if actor.type == Team]
     teams_to_user_ids = team_actors_to_user_ids(team_actors, user_ids)
     for actor, events in events_by_actor.items():

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -57,7 +57,7 @@ def get_unsubscribe_link(
 
 def log_message(notification: BaseNotification, recipient: Union["Team", "User"]) -> None:
     extra = notification.get_log_params(recipient)
-    logger.info("mail.adapter.notify.mail_user", extra=extra)
+    logger.info("mail.adapter.notify.mail_user", extra={**extra})
 
 
 def get_context(

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,17 +1,7 @@
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 from sentry import features
 from sentry.notifications.defaults import (
@@ -59,10 +49,10 @@ def _get_notification_setting_default(
 
 def _get_setting_mapping_from_mapping(
     notification_settings_by_recipient: Mapping[
-        Union["Team", "User"],
+        Team | User,
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
-    recipient: Union["Team", "User"],
+    recipient: Team | User,
     type: NotificationSettingTypes,
     should_use_slack_automatic: bool = False,
 ) -> Mapping[ExternalProviders, NotificationSettingOptionValues]:
@@ -91,12 +81,12 @@ def _get_setting_mapping_from_mapping(
 
 def where_should_recipient_be_notified(
     notification_settings_by_recipient: Mapping[
-        Union["Team", "User"],
+        Team | User,
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
-    recipient: Union["Team", "User"],
+    recipient: Team | User,
     should_use_slack_automatic: bool = False,
-) -> List[ExternalProviders]:
+) -> list[ExternalProviders]:
     """
     Given a mapping of default and specific notification settings by user,
     return the list of providers after verifying the user has opted into this notification.
@@ -115,7 +105,7 @@ def where_should_recipient_be_notified(
 
 
 def should_be_participating(
-    subscription: Optional[Any],
+    subscription: Any | None,
     value: NotificationSettingOptionValues,
 ) -> bool:
     """
@@ -129,14 +119,14 @@ def should_be_participating(
 
 
 def where_should_be_participating(
-    recipient: Union["Team", "User"],
-    subscription: Optional["GroupSubscription"],
+    recipient: Team | User,
+    subscription: GroupSubscription | None,
     notification_settings_by_recipient: Mapping[
-        Union["Team", "User"],
+        Team | User,
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
     should_use_slack_automatic: bool = False,
-) -> List[ExternalProviders]:
+) -> list[ExternalProviders]:
     """
     Given a mapping of users to subscriptions and a mapping of default and
     specific notification settings by user, determine where a user should receive
@@ -191,10 +181,10 @@ def get_values_by_provider_by_type(
 
 
 def transform_to_notification_settings_by_recipient(
-    notification_settings: Iterable["NotificationSetting"],
-    recipients: Iterable[Union["Team", "User"]],
+    notification_settings: Iterable[NotificationSetting],
+    recipients: Iterable[Team | User],
 ) -> Mapping[
-    Union["Team", "User"],
+    Team | User,
     Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
 ]:
     """
@@ -202,9 +192,12 @@ def transform_to_notification_settings_by_recipient(
     to a map of notification scopes to setting values.
     """
     actor_mapping = {recipient.actor_id: recipient for recipient in recipients}
-    notification_settings_by_recipient: Dict[
-        Union["Team", "User"],
-        Dict[NotificationScopeType, Dict[ExternalProviders, NotificationSettingOptionValues]],
+    notification_settings_by_recipient: MutableMapping[
+        Team | User,
+        MutableMapping[
+            NotificationScopeType,
+            MutableMapping[ExternalProviders, NotificationSettingOptionValues],
+        ],
     ] = defaultdict(lambda: defaultdict(dict))
     for notification_setting in notification_settings:
         recipient = actor_mapping.get(notification_setting.target_id)
@@ -216,7 +209,7 @@ def transform_to_notification_settings_by_recipient(
 
 
 def transform_to_notification_settings_by_scope(
-    notification_settings: Iterable["NotificationSetting"],
+    notification_settings: Iterable[NotificationSetting],
 ) -> Mapping[
     NotificationScopeType,
     Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],
@@ -225,8 +218,9 @@ def transform_to_notification_settings_by_scope(
     Given an unsorted list of notification settings, create a mapping of scopes
     (user or parent) and their IDs to a map of provider to notifications setting values.
     """
-    notification_settings_by_scopes: Dict[
-        NotificationScopeType, Dict[int, Dict[ExternalProviders, NotificationSettingOptionValues]]
+    notification_settings_by_scopes: MutableMapping[
+        NotificationScopeType,
+        MutableMapping[int, MutableMapping[ExternalProviders, NotificationSettingOptionValues]],
     ] = defaultdict(lambda: defaultdict(lambda: dict()))
 
     for notification_setting in notification_settings:
@@ -257,11 +251,11 @@ def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
 
 
 def get_scope(
-    user: Optional["User"] = None,
-    team: Optional["Team"] = None,
-    project: Optional["Project"] = None,
-    organization: Optional["Organization"] = None,
-) -> Tuple[NotificationScopeType, int]:
+    user: User | None = None,
+    team: Team | None = None,
+    project: Project | None = None,
+    organization: Organization | None = None,
+) -> tuple[NotificationScopeType, int]:
     """
     Figure out the scope from parameters and return it as a tuple.
     TODO(mgaeta): Make sure the user/team is in the project/organization.
@@ -282,7 +276,7 @@ def get_scope(
     raise Exception("scope must be either user, team, organization, or project")
 
 
-def get_target_id(user: Optional["User"] = None, team: Optional["Team"] = None) -> int:
+def get_target_id(user: User | None = None, team: Team | None = None) -> int:
     """:returns the actor ID from a User or Team."""
     if user:
         return int(user.actor_id)
@@ -294,8 +288,8 @@ def get_target_id(user: Optional["User"] = None, team: Optional["Team"] = None) 
 
 def get_subscription_from_attributes(
     attrs: Mapping[str, Any]
-) -> Tuple[bool, Optional[Mapping[str, Union[str, bool]]]]:
-    subscription_details: Optional[Mapping[str, Union[str, bool]]] = None
+) -> tuple[bool, Mapping[str, str | bool] | None]:
+    subscription_details: Mapping[str, str | bool] | None = None
     is_disabled, is_subscribed, subscription = attrs["subscription"]
     if is_disabled:
         subscription_details = {"disabled": True}
@@ -308,13 +302,13 @@ def get_subscription_from_attributes(
 
 
 def get_groups_for_query(
-    groups_by_project: Mapping["Project", Set["Group"]],
+    groups_by_project: Mapping[Project, set[Group]],
     notification_settings_by_scope: Mapping[
         NotificationScopeType,
         Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
-    user: "User",
-) -> Set["Group"]:
+    user: User,
+) -> set[Group]:
     """
     If there is a subscription record associated with the group, we can just use
     that to know if a user is subscribed or not, as long as notifications aren't
@@ -343,7 +337,7 @@ def get_groups_for_query(
     return output
 
 
-def collect_groups_by_project(groups: Iterable["Group"]) -> Mapping["Project", Set["Group"]]:
+def collect_groups_by_project(groups: Iterable[Group]) -> Mapping[Project, set[Group]]:
     """
     Collect all of the projects to look up, and keep a set of groups that are
     part of that project. (Note that the common -- but not only -- case here is
@@ -356,14 +350,14 @@ def collect_groups_by_project(groups: Iterable["Group"]) -> Mapping["Project", S
 
 
 def get_user_subscriptions_for_groups(
-    groups_by_project: Mapping["Project", Set["Group"]],
+    groups_by_project: Mapping[Project, set[Group]],
     notification_settings_by_scope: Mapping[
         NotificationScopeType,
         Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
-    subscriptions_by_group_id: Mapping[int, "GroupSubscription"],
-    user: "User",
-) -> Mapping[int, Tuple[bool, bool, Optional["GroupSubscription"]]]:
+    subscriptions_by_group_id: Mapping[int, GroupSubscription],
+    user: User,
+) -> Mapping[int, tuple[bool, bool, GroupSubscription | None]]:
     """Takes collected data and returns a mapping of group IDs to a three-tuple of values."""
     # TODO(mgaeta): Remove `should_use_slack_automatic` parameter.
     should_use_slack_automatic_by_organization_id = {
@@ -421,7 +415,7 @@ def get_fallback_settings(
     types_to_serialize: Iterable[NotificationSettingTypes],
     project_ids: Iterable[int],
     organization_ids: Iterable[int],
-    recipient: Optional[Union["Team", "User"]] = None,
+    recipient: Team | User | None = None,
     should_use_slack_automatic: bool = False,
 ) -> MutableMapping[str, MutableMapping[str, MutableMapping[int, MutableMapping[str, str]]]]:
     """
@@ -475,7 +469,7 @@ def get_reason_context(extra_context: Mapping[str, Any]) -> MutableMapping[str, 
 
 def get_highest_notification_setting_value(
     notification_settings_by_provider: Mapping[ExternalProviders, NotificationSettingOptionValues],
-) -> Optional[NotificationSettingOptionValues]:
+) -> NotificationSettingOptionValues | None:
     """
     Find the "most specific" notification setting value. Currently non-NEVER
     values are locked together (for example, you cannot have
@@ -494,7 +488,7 @@ def get_most_specific_notification_setting_value(
         NotificationScopeType,
         Mapping[int, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
-    recipient: Union["Team", "User"],
+    recipient: Team | User,
     parent_id: int,
     type: NotificationSettingTypes,
     should_use_slack_automatic: bool = False,

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Tuple
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from sentry.models import Team, User
 
@@ -9,7 +11,7 @@ class AssignedActivityNotification(GroupActivityNotification):
     def get_activity_name(self) -> str:
         return "Assigned"
 
-    def get_description(self) -> Tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         activity = self.activity
         data = activity.data
 
@@ -57,7 +59,7 @@ class AssignedActivityNotification(GroupActivityNotification):
     def get_category(self) -> str:
         return "assigned_activity_email"
 
-    def build_notification_title(self) -> Tuple[str, str]:
+    def build_notification_title(self) -> tuple[str, str]:
         activity = self.activity
         data = activity.data
         user = self.activity.user

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -1,4 +1,6 @@
-from typing import Any, MutableMapping, Optional
+from __future__ import annotations
+
+from typing import Any, MutableMapping
 
 from sentry.models import Activity, Mapping, NotificationSetting, User
 from sentry.notifications.types import GroupSubscriptionReason
@@ -37,7 +39,7 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
             ),
         }
 
-    def get_subject(self, context: Optional[Mapping[str, Any]] = None) -> str:
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return f"Processing Issues on {self.project.slug}"
 
     def get_title(self) -> str:

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Tuple
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from .base import GroupActivityNotification
 
@@ -9,7 +11,7 @@ class NoteActivityNotification(GroupActivityNotification):
     def get_activity_name(self) -> str:
         return "Note"
 
-    def get_description(self) -> Tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return str(self.activity.data["text"]), {}, {}
 
     def get_filename(self) -> str:

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Tuple
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
@@ -10,7 +12,7 @@ class RegressionActivityNotification(GroupActivityNotification):
     def get_activity_name(self) -> str:
         return "Regression"
 
-    def get_description(self) -> Tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         data = self.activity.data
 
         if data.get("version"):

--- a/src/sentry/notifications/notifications/activity/resolved.py
+++ b/src/sentry/notifications/notifications/activity/resolved.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Tuple
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from .base import GroupActivityNotification
 
@@ -7,7 +9,7 @@ class ResolvedActivityNotification(GroupActivityNotification):
     def get_activity_name(self) -> str:
         return "Resolved Issue"
 
-    def get_description(self) -> Tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} marked {an issue} as resolved", {}, {}
 
     def get_category(self) -> str:

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Tuple
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from sentry.utils.html import escape
 from sentry.utils.http import absolute_uri
@@ -10,7 +12,7 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
     def get_activity_name(self) -> str:
         return "Resolved Issue"
 
-    def get_description(self) -> Tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         data = self.activity.data
 
         url = "/organizations/{}/releases/{}/?project={}".format(

--- a/src/sentry/notifications/notifications/activity/unassigned.py
+++ b/src/sentry/notifications/notifications/activity/unassigned.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Tuple
+from __future__ import annotations
+
+from typing import Any, Mapping
 
 from .base import GroupActivityNotification
 
@@ -7,7 +9,7 @@ class UnassignedActivityNotification(GroupActivityNotification):
     def get_activity_name(self) -> str:
         return "Unassigned"
 
-    def get_description(self) -> Tuple[str, Mapping[str, Any], Mapping[str, Any]]:
+    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} unassigned {an issue}", {}, {}
 
     def get_category(self) -> str:

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Mapping, MutableMapping, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping
 
 from typing_extensions import Literal
 
@@ -22,7 +24,7 @@ if TYPE_CHECKING:
 class MessageAction:
     label: str
     url: str
-    style: Optional[Literal["primary", "danger", "default"]] = None
+    style: Literal["primary", "danger", "default"] | None = None
 
     def as_slack(self) -> Mapping[str, Any]:
         return {
@@ -35,14 +37,14 @@ class MessageAction:
 
 
 class BaseNotification:
-    fine_tuning_key: Optional[str] = None
+    fine_tuning_key: str | None = None
     metrics_key: str = ""
 
-    def __init__(self, organization: "Organization"):
+    def __init__(self, organization: Organization):
         self.organization = organization
 
     @property
-    def SlackMessageBuilderClass(self) -> Type["SlackNotificationsMessageBuilder"]:
+    def SlackMessageBuilderClass(self) -> type[SlackNotificationsMessageBuilder]:
         from sentry.integrations.slack.message_builder.notifications import (
             SlackNotificationsMessageBuilder,
         )
@@ -59,17 +61,17 @@ class BaseNotification:
     def get_category(self) -> str:
         raise NotImplementedError
 
-    def get_subject(self, context: Optional[Mapping[str, Any]] = None) -> str:
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         """The subject line when sending this notifications as an email."""
         raise NotImplementedError
 
-    def get_subject_with_prefix(self, context: Optional[Mapping[str, Any]] = None) -> bytes:
+    def get_subject_with_prefix(self, context: Mapping[str, Any] | None = None) -> bytes:
         return self.get_subject(context).encode()
 
     def get_reference(self) -> Any:
         raise NotImplementedError
 
-    def get_reply_reference(self) -> Optional[Any]:
+    def get_reply_reference(self) -> Any | None:
         return None
 
     def should_email(self) -> bool:
@@ -82,7 +84,7 @@ class BaseNotification:
         return f"sentry/emails/{self.get_filename()}.html"
 
     def get_recipient_context(
-        self, recipient: Union["Team", "User"], extra_context: Mapping[str, Any]
+        self, recipient: Team | User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         # Basically a noop.
         return {**extra_context}
@@ -97,20 +99,18 @@ class BaseNotification:
     def get_type(self) -> str:
         raise NotImplementedError
 
-    def get_unsubscribe_key(self) -> Optional[Tuple[str, int, Optional[str]]]:
+    def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
         return None
 
     def build_slack_attachment(
-        self, context: Mapping[str, Any], recipient: Union["Team", "User"]
-    ) -> "SlackAttachment":
+        self, context: Mapping[str, Any], recipient: Team | User
+    ) -> SlackAttachment:
         return self.SlackMessageBuilderClass(self, context, recipient).build()
 
-    def record_notification_sent(
-        self, recipient: Union["Team", "User"], provider: ExternalProviders
-    ) -> None:
+    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         raise NotImplementedError
 
-    def get_log_params(self, recipient: Union["Team", "User"]) -> Dict[str, Any]:
+    def get_log_params(self, recipient: Team | User) -> Mapping[str, Any]:
         return {
             "organization_id": self.organization.id,
             "actor_id": recipient.actor_id,
@@ -120,12 +120,12 @@ class BaseNotification:
 class ProjectNotification(BaseNotification, abc.ABC):
     is_message_issue_unfurl = False
 
-    def __init__(self, project: "Project") -> None:
+    def __init__(self, project: Project) -> None:
         self.project = project
         super().__init__(project.organization)
 
     @property
-    def SlackMessageBuilderClass(self) -> Type["SlackProjectNotificationsMessageBuilder"]:
+    def SlackMessageBuilderClass(self) -> type[SlackProjectNotificationsMessageBuilder]:
         from sentry.integrations.slack.message_builder.notifications import (
             SlackProjectNotificationsMessageBuilder,
         )
@@ -135,9 +135,7 @@ class ProjectNotification(BaseNotification, abc.ABC):
     def get_project_link(self) -> str:
         return str(absolute_uri(f"/{self.organization.slug}/{self.project.slug}/"))
 
-    def record_notification_sent(
-        self, recipient: Union["Team", "User"], provider: ExternalProviders
-    ) -> None:
+    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         analytics.record(
             f"integrations.{provider.name.lower()}.notification_sent",
             actor_id=recipient.id,
@@ -146,7 +144,7 @@ class ProjectNotification(BaseNotification, abc.ABC):
             project_id=self.project.id,
         )
 
-    def get_log_params(self, recipient: Union["Team", "User"]) -> Dict[str, Any]:
+    def get_log_params(self, recipient: Team | User) -> Mapping[str, Any]:
         from sentry.notifications.notifications.activity.base import ActivityNotification
         from sentry.notifications.notifications.rules import AlertRuleNotification
 
@@ -167,7 +165,7 @@ class ProjectNotification(BaseNotification, abc.ABC):
             extra.update({"activity": self.activity})
         return extra
 
-    def get_subject_with_prefix(self, context: Optional[Mapping[str, Any]] = None) -> bytes:
+    def get_subject_with_prefix(self, context: Mapping[str, Any] | None = None) -> bytes:
         from sentry.mail.notifications import build_subject_prefix
 
         prefix = build_subject_prefix(self.project)

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 from sentry.digests import Digest
 from sentry.digests.utilities import (
@@ -29,17 +31,17 @@ logger = logging.getLogger(__name__)
 class DigestNotification(ProjectNotification):
     def __init__(
         self,
-        project: "Project",
+        project: Project,
         digest: Digest,
         target_type: ActionTargetType,
-        target_identifier: Optional[int] = None,
+        target_identifier: int | None = None,
     ) -> None:
         super().__init__(project)
         self.digest = digest
         self.target_type = target_type
         self.target_identifier = target_identifier
 
-    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | User]]:
         event = [
             record
             for records_by_group in self.digest.values()
@@ -62,10 +64,10 @@ class DigestNotification(ProjectNotification):
     def get_type(self) -> str:
         return "notify.digest"
 
-    def get_unsubscribe_key(self) -> Optional[Tuple[str, int, Optional[str]]]:
+    def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
         return "project", self.project.id, "alert_digest"
 
-    def get_subject(self, context: Optional[Mapping[str, Any]] = None) -> str:
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         if not context:
             # This shouldn't be possible but adding a message just in case.
             return "Digest Report"

--- a/src/sentry/notifications/notifications/organization_request.py
+++ b/src/sentry/notifications/notifications/organization_request.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import abc
 import logging
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence
 
 from sentry import analytics, features, roles
 from sentry.integrations.slack.utils.notifications import get_settings_url
@@ -23,12 +25,12 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
     referrer_base: str = ""
     member_by_user_id: MutableMapping[int, OrganizationMember] = {}
 
-    def __init__(self, organization: "Organization", requester: "User") -> None:
+    def __init__(self, organization: Organization, requester: User) -> None:
         super().__init__(organization)
         self.requester = requester
 
     @property
-    def SlackMessageBuilderClass(self) -> Type["SlackOrganizationRequestMessageBuilder"]:
+    def SlackMessageBuilderClass(self) -> type[SlackOrganizationRequestMessageBuilder]:
         from sentry.integrations.slack.message_builder.organization_requests import (
             SlackOrganizationRequestMessageBuilder,
         )
@@ -48,7 +50,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
     def get_sentry_query_params(self, provider: ExternalProviders) -> str:
         return f"?referrer={self.get_referrer(provider)}"
 
-    def determine_recipients(self) -> Iterable[Union["Team", "User"]]:
+    def determine_recipients(self) -> Iterable[Team | User]:
         members = self.determine_member_recipients()
         # store the members in our cache
         for member in members:
@@ -56,14 +58,14 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
         # convert members to users
         return map(lambda member: member.user, members)
 
-    def determine_member_recipients(self) -> Iterable["OrganizationMember"]:
+    def determine_member_recipients(self) -> Iterable[OrganizationMember]:
         """
         Depending on the type of request this might be all organization owners,
         a specific person, or something in between.
         """
         raise NotImplementedError
 
-    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | User]]:
         available_providers: Iterable[ExternalProviders] = {ExternalProviders.EMAIL}
         if features.has("organizations:slack-requests", self.organization):
             available_providers = notification_providers()
@@ -86,7 +88,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
             # TODO: use safe_excute
             notify(provider, self, recipients, context)
 
-    def get_member(self, user: "User") -> "OrganizationMember":
+    def get_member(self, user: User) -> OrganizationMember:
         # cache the result
         if user.id not in self.member_by_user_id:
             self.member_by_user_id[user.id] = OrganizationMember.objects.get(
@@ -120,7 +122,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
         role_string: str = roles.get(member.role).name
         return role_string
 
-    def build_notification_footer(self, recipient: Union["Team", "User"]) -> str:
+    def build_notification_footer(self, recipient: Team | User) -> str:
         # not implemented for teams
         if isinstance(recipient, Team):
             raise NotImplementedError
@@ -131,9 +133,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
             f"{self.get_role_string(recipient_member)} | <{settings_url}|Notification Settings>"
         )
 
-    def record_notification_sent(
-        self, recipient: Union["Team", "User"], provider: ExternalProviders
-    ) -> None:
+    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         # this event is meant to work for multiple providers but architecture
         # limitations mean we will fire individual for each provider
         analytics.record(

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Iterable, Mapping, MutableMapping, Optional, Union
+from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
 
@@ -32,7 +34,7 @@ class AlertRuleNotification(ProjectNotification):
         self,
         notification: Notification,
         target_type: ActionTargetType,
-        target_identifier: Optional[int] = None,
+        target_identifier: int | None = None,
     ) -> None:
         event = notification.event
         group = event.group
@@ -44,7 +46,7 @@ class AlertRuleNotification(ProjectNotification):
         self.target_identifier = target_identifier
         self.rules = notification.rules
 
-    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | User]]:
         return get_send_to(
             project=self.project,
             target_type=self.target_type,
@@ -58,14 +60,14 @@ class AlertRuleNotification(ProjectNotification):
     def get_category(self) -> str:
         return "issue_alert_email"
 
-    def get_subject(self, context: Optional[Mapping[str, Any]] = None) -> str:
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return str(self.event.get_email_subject())
 
     def get_reference(self) -> Any:
         return self.group
 
     def get_recipient_context(
-        self, recipient: Union["Team", "User"], extra_context: Mapping[str, Any]
+        self, recipient: Team | User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         parent_context = super().get_recipient_context(recipient, extra_context)
         user_context = {"timezone": pytz.timezone("UTC"), **parent_context}

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Union
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping
 
 from django.utils.encoding import force_text
 
@@ -17,14 +19,14 @@ logger = logging.getLogger(__name__)
 
 
 class UserReportNotification(ProjectNotification):
-    def __init__(self, project: "Project", report: Mapping[str, Any]) -> None:
+    def __init__(self, project: Project, report: Mapping[str, Any]) -> None:
         super().__init__(project)
         self.group = Group.objects.get(id=report["issue"]["id"])
         self.report = report
 
     def get_participants_with_group_subscription_reason(
         self,
-    ) -> Mapping[ExternalProviders, Mapping["User", int]]:
+    ) -> Mapping[ExternalProviders, Mapping[User, int]]:
         data_by_provider = GroupSubscription.objects.get_participants(group=self.group)
         return {
             provider: data
@@ -41,7 +43,7 @@ class UserReportNotification(ProjectNotification):
     def get_type(self) -> str:
         return "notify.user-report"
 
-    def get_subject(self, context: Optional[Mapping[str, Any]] = None) -> str:
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         # Explicitly typing to satisfy mypy.
         message = f"{self.group.qualified_short_id} - New Feedback from {self.report['name']}"
         message = force_text(message)
@@ -71,7 +73,7 @@ class UserReportNotification(ProjectNotification):
         }
 
     def get_recipient_context(
-        self, recipient: Union["Team", "User"], extra_context: Mapping[str, Any]
+        self, recipient: Team | User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         return get_reason_context(extra_context)
 

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Union
 
 from sentry.models import Team, User
@@ -42,9 +44,9 @@ def register_notification_provider(
 def notify(
     provider: ExternalProviders,
     notification: Any,
-    recipients: Iterable[Union["Team", "User"]],
+    recipients: Iterable[Team | User],
     shared_context: Mapping[str, Any],
-    extra_context_by_user_id: Optional[Mapping[int, Mapping[str, Any]]] = None,
+    extra_context_by_user_id: Mapping[int, Mapping[str, Any]] | None = None,
 ) -> None:
     """Send notifications to these users or team."""
     registry[provider](notification, recipients, shared_context, extra_context_by_user_id)

--- a/src/sentry/notifications/utils/digest.py
+++ b/src/sentry/notifications/utils/digest.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import itertools
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Counter, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Counter, Mapping
 
 from django.utils import dateformat
 
@@ -11,7 +13,7 @@ if TYPE_CHECKING:
     from sentry.models import Group
 
 
-def get_digest_subject(group: "Group", counts: Counter["Group"], date: datetime) -> str:
+def get_digest_subject(group: Group, counts: Counter[Group], date: datetime) -> str:
     return "{short_id} - {count} new {noun} since {date}".format(
         short_id=group.qualified_short_id,
         count=len(counts),
@@ -38,7 +40,7 @@ def get_timestamp(record_param: Any) -> float:
 def send_as_alert_notification(
     context: Mapping[str, Any],
     target_type: ActionTargetType,
-    target_identifier: Optional[int] = None,
+    target_identifier: int | None = None,
 ) -> None:
     """If there is more than one record for a group, just choose the most recent one."""
     from sentry.mail import mail_adapter

--- a/src/sentry/notifications/utils/legacy_mappings.py
+++ b/src/sentry/notifications/utils/legacy_mappings.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections import namedtuple
-from typing import Any, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Iterable, Mapping
 
 from sentry.notifications.types import (
     FineTuningAPIKey,
@@ -93,9 +95,7 @@ LEGACY_VALUE_TO_KEY = {
 }
 
 
-def get_legacy_key(
-    type: NotificationSettingTypes, scope_type: NotificationScopeType
-) -> Optional[str]:
+def get_legacy_key(type: NotificationSettingTypes, scope_type: NotificationScopeType) -> str | None:
     """Temporary mapping from new enum types to legacy strings."""
     if scope_type == NotificationScopeType.USER and type == NotificationSettingTypes.ISSUE_ALERTS:
         return "subscribe_by_default"
@@ -120,11 +120,11 @@ def get_option_value_from_boolean(value: bool) -> NotificationSettingOptionValue
 
 def get_option_value_from_int(
     type: NotificationSettingTypes, value: int
-) -> Optional[NotificationSettingOptionValues]:
+) -> NotificationSettingOptionValues | None:
     return LEGACY_VALUE_TO_KEY.get(type, {}).get(value)
 
 
-def get_type_from_fine_tuning_key(key: FineTuningAPIKey) -> Optional[NotificationSettingTypes]:
+def get_type_from_fine_tuning_key(key: FineTuningAPIKey) -> NotificationSettingTypes | None:
     return {
         FineTuningAPIKey.ALERTS: NotificationSettingTypes.ISSUE_ALERTS,
         FineTuningAPIKey.DEPLOY: NotificationSettingTypes.DEPLOY,
@@ -134,7 +134,7 @@ def get_type_from_fine_tuning_key(key: FineTuningAPIKey) -> Optional[Notificatio
 
 def get_type_from_user_option_settings_key(
     key: UserOptionsSettingsKey,
-) -> Optional[NotificationSettingTypes]:
+) -> NotificationSettingTypes | None:
     return {
         UserOptionsSettingsKey.DEPLOY: NotificationSettingTypes.DEPLOY,
         UserOptionsSettingsKey.WORKFLOW: NotificationSettingTypes.WORKFLOW,
@@ -142,7 +142,7 @@ def get_type_from_user_option_settings_key(
     }.get(key)
 
 
-def get_key_from_legacy(key: str) -> Optional[NotificationSettingTypes]:
+def get_key_from_legacy(key: str) -> NotificationSettingTypes | None:
     return {
         "deploy-emails": NotificationSettingTypes.DEPLOY,
         "mail:alert": NotificationSettingTypes.ISSUE_ALERTS,
@@ -153,7 +153,7 @@ def get_key_from_legacy(key: str) -> Optional[NotificationSettingTypes]:
 
 def get_key_value_from_legacy(
     key: str, value: Any
-) -> Tuple[Optional[NotificationSettingTypes], Optional[NotificationSettingOptionValues]]:
+) -> tuple[NotificationSettingTypes | None, NotificationSettingOptionValues | None]:
     type = get_key_from_legacy(key)
     if type not in LEGACY_VALUE_TO_KEY:
         return None, None
@@ -192,7 +192,7 @@ def get_legacy_object(
 def map_notification_settings_to_legacy(
     notification_settings: Iterable[Any],
     actor_mapping: Mapping[int, Any],
-) -> List[Any]:
+) -> list[Any]:
     """A hack for legacy serializers. Pretend a list of NotificationSettings is a list of UserOptions."""
     project_mapping, organization_mapping = get_parent_mappings(notification_settings)
     return [
@@ -205,7 +205,7 @@ def map_notification_settings_to_legacy(
 
 def get_parent_mappings(
     notification_settings: Iterable[Any],
-) -> Tuple[Mapping[int, Any], Mapping[int, Any]]:
+) -> tuple[Mapping[int, Any], Mapping[int, Any]]:
     """Prefetch a list of Project or Organization objects for the Serializer."""
     from sentry.models.organization import Organization
     from sentry.models.project import Project

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -1,16 +1,8 @@
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
 
 from sentry import features
 from sentry.models import (
@@ -56,7 +48,7 @@ AVAILABLE_PROVIDERS = {
 def get_providers_from_which_to_remove_user(
     user: User,
     participants_by_provider: Mapping[ExternalProviders, Mapping[User, int]],
-) -> Set[ExternalProviders]:
+) -> set[ExternalProviders]:
     """
     Given a mapping of provider to mappings of users to why they should receive
     notifications for an activity, return the set of providers where the user
@@ -77,7 +69,7 @@ def get_providers_from_which_to_remove_user(
 
 
 def get_participants_for_group(
-    group: Group, user: Optional[User] = None
+    group: Group, user: User | None = None
 ) -> Mapping[ExternalProviders, Mapping[User, int]]:
     # TODO(dcramer): not used yet today except by Release's
     if not group:
@@ -95,8 +87,8 @@ def get_participants_for_group(
 
 
 def get_reason(
-    user: User, value: NotificationSettingOptionValues, user_ids: Set[int]
-) -> Optional[int]:
+    user: User, value: NotificationSettingOptionValues, user_ids: set[int]
+) -> int | None:
     # Members who opt into all deploy emails.
     if value == NotificationSettingOptionValues.ALWAYS:
         return GroupSubscriptionReason.deploy_setting
@@ -108,7 +100,7 @@ def get_reason(
 
 
 def get_participants_for_release(
-    projects: Iterable[Project], organization: Organization, user_ids: Set[int]
+    projects: Iterable[Project], organization: Organization, user_ids: set[int]
 ) -> Mapping[ExternalProviders, Mapping[User, int]]:
     # Collect all users with verified emails on a team in the related projects.
     users = set(User.objects.get_team_members_with_verified_email_for_projects(projects))
@@ -150,7 +142,7 @@ def get_participants_for_release(
 
 def split_participants_and_context(
     participants_with_reasons: Mapping[User, int]
-) -> Tuple[Set[User], Mapping[int, Mapping[str, Any]]]:
+) -> tuple[set[User], Mapping[int, Mapping[str, Any]]]:
     participants = set()
     extra_context = {}
     for user, reason in participants_with_reasons.items():
@@ -159,9 +151,7 @@ def split_participants_and_context(
     return participants, extra_context
 
 
-def get_owners(
-    project: Project, event: Optional["Event"] = None
-) -> Iterable[Union["Team", "User"]]:
+def get_owners(project: Project, event: Event | None = None) -> Iterable[Team | User]:
     """Given a project and an event, decide which users and teams are the owners."""
 
     if event:
@@ -189,7 +179,7 @@ def get_owners(
     return recipients
 
 
-def disabled_users_from_project(project: Project) -> Mapping[ExternalProviders, Set[User]]:
+def disabled_users_from_project(project: Project) -> Mapping[ExternalProviders, set[User]]:
     """Get a set of users that have disabled Issue Alert notifications for a given project."""
     user_ids = project.member_set.values_list("user", flat=True)
     users = User.objects.filter(id__in=user_ids)
@@ -220,11 +210,11 @@ def disabled_users_from_project(project: Project) -> Mapping[ExternalProviders, 
 
 
 def determine_eligible_recipients(
-    project: "Project",
+    project: Project,
     target_type: ActionTargetType,
-    target_identifier: Optional[int] = None,
-    event: Optional["Event"] = None,
-) -> Iterable[Union["Team", "User"]]:
+    target_identifier: int | None = None,
+    event: Event | None = None,
+) -> Iterable[Team | User]:
     """
     Either get the individual recipient from the target type/id or user the the
     owners as determined by rules for this project and event.
@@ -249,18 +239,16 @@ def determine_eligible_recipients(
 
 
 def get_send_to(
-    project: "Project",
+    project: Project,
     target_type: ActionTargetType,
-    target_identifier: Optional[int] = None,
-    event: Optional["Event"] = None,
-) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+    target_identifier: int | None = None,
+    event: Event | None = None,
+) -> Mapping[ExternalProviders, Iterable[Team | User]]:
     recipients = determine_eligible_recipients(project, target_type, target_identifier, event)
     return get_recipients_by_provider(project, recipients)
 
 
-def get_user_from_identifier(
-    project: "Project", target_identifier: Optional[Union[str, int]]
-) -> Optional["User"]:
+def get_user_from_identifier(project: Project, target_identifier: str | int | None) -> User | None:
     if target_identifier is None:
         return None
 
@@ -277,9 +265,7 @@ def get_user_from_identifier(
         return None
 
 
-def get_team_from_identifier(
-    project: "Project", target_identifier: Optional[Union[str, int]]
-) -> Optional["Team"]:
+def get_team_from_identifier(project: Project, target_identifier: str | int | None) -> Team | None:
     if target_identifier is None:
         return None
 
@@ -290,8 +276,8 @@ def get_team_from_identifier(
 
 
 def partition_recipients(
-    recipients: Iterable[Union["Team", "User"]]
-) -> Tuple[Iterable["Team"], Iterable["User"]]:
+    recipients: Iterable[Team | User],
+) -> tuple[Iterable[Team], Iterable[User]]:
     teams, users = set(), set()
     for recipient in recipients:
         if isinstance(recipient, User):
@@ -302,9 +288,9 @@ def partition_recipients(
 
 
 def get_users_from_team_fall_back(
-    teams: Iterable["Team"],
-    recipients_by_provider: Mapping[ExternalProviders, Iterable[Union["Team", "User"]]],
-) -> Iterable["User"]:
+    teams: Iterable[Team],
+    recipients_by_provider: Mapping[ExternalProviders, Iterable[Team | User]],
+) -> Iterable[User]:
     teams_to_fall_back = set(teams)
     for recipients in recipients_by_provider.values():
         for recipient in recipients:
@@ -319,9 +305,9 @@ def get_users_from_team_fall_back(
 
 
 def combine_recipients_by_provider(
-    teams_by_provider: Mapping[ExternalProviders, Iterable[Union["Team", "User"]]],
-    users_by_provider: Mapping[ExternalProviders, Iterable[Union["Team", "User"]]],
-) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+    teams_by_provider: Mapping[ExternalProviders, Iterable[Team | User]],
+    users_by_provider: Mapping[ExternalProviders, Iterable[Team | User]],
+) -> Mapping[ExternalProviders, Iterable[Team | User]]:
     """TODO(mgaeta): Make this more generic and move it to utils."""
     recipients_by_provider = defaultdict(set)
     for provider, teams in teams_by_provider.items():
@@ -334,8 +320,8 @@ def combine_recipients_by_provider(
 
 
 def get_recipients_by_provider(
-    project: Project, recipients: Iterable[Union["Team", "User"]]
-) -> Mapping[ExternalProviders, Iterable[Union["Team", "User"]]]:
+    project: Project, recipients: Iterable[Team | User]
+) -> Mapping[ExternalProviders, Iterable[Team | User]]:
     """Get the lists of recipients that should receive an Issue Alert by ExternalProvider."""
     teams, users = partition_recipients(recipients)
 


### PR DESCRIPTION
Now that we're on python 3.8 we have access to `|` notation in types and no longer need to quote models. To create this PR, I added `from __future__ import annotations` to every file and let `pyupgrade` automatically retype everything.