### PR TITLE
feat(cmp_alerts): Update change alert tooltips to reflect the change alert better

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -109,7 +109,10 @@ type Props = {
         value: number,
         isTimestamp: boolean,
         utc: boolean,
-        showTimeInTooltip: boolean
+        showTimeInTooltip: boolean,
+        addSecondsToTimeFormat: boolean,
+        bucketSize: number | undefined,
+        seriesParamsOrParam: EChartOption.Tooltip.Format | EChartOption.Tooltip.Format[]
       ) => string;
       valueFormatter?: (
         value: number,

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -10,7 +10,7 @@ import {truncationFormatter} from '../utils';
 
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
-function defaultFormatAxisLabel(
+export function defaultFormatAxisLabel(
   value: number,
   isTimestamp: boolean,
   utc: boolean,
@@ -149,7 +149,8 @@ function getFormatter({
         !!utc,
         !!showTimeInTooltip,
         addSecondsToTimeFormat,
-        bucketSize
+        bucketSize,
+        seriesParamsOrParam
       );
       // eCharts sets seriesName as null when `componentType` !== 'series'
       const truncatedName = truncationFormatter(
@@ -196,7 +197,8 @@ function getFormatter({
         !!utc,
         !!showTimeInTooltip,
         addSecondsToTimeFormat,
-        bucketSize
+        bucketSize,
+        seriesParamsOrParam
       );
 
     return [

--- a/static/app/views/alerts/changeAlerts/comparisonMarklines.tsx
+++ b/static/app/views/alerts/changeAlerts/comparisonMarklines.tsx
@@ -6,7 +6,7 @@ import {MINUTE} from 'app/utils/formatters';
 import theme from 'app/utils/theme';
 import {AlertRuleThresholdType, Trigger} from 'app/views/alerts/incidentRules/types';
 
-const checkChangeStatus = (
+export const checkChangeStatus = (
   value: number,
   thresholdType: AlertRuleThresholdType,
   triggers: Trigger[]

--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -1,16 +1,19 @@
 import {PureComponent} from 'react';
 import color from 'color';
+import {EChartOption} from 'echarts';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 
 import AreaChart, {AreaChartSeries} from 'app/components/charts/areaChart';
 import Graphic from 'app/components/charts/components/graphic';
+import {defaultFormatAxisLabel} from 'app/components/charts/components/tooltip';
 import {LineChartSeries} from 'app/components/charts/lineChart';
 import LineSeries from 'app/components/charts/series/lineSeries';
 import space from 'app/styles/space';
 import {GlobalSelection} from 'app/types';
 import {ReactEchartsRef, Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
+import {checkChangeStatus} from 'app/views/alerts/changeAlerts/comparisonMarklines';
 import {
   ALERT_CHART_MIN_MAX_BUFFER,
   alertAxisFormatter,
@@ -305,6 +308,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
       comparisonSeriesName,
       comparisonMarkLines,
       minutesThresholdToDisplaySeconds,
+      thresholdType,
     } = this.props;
 
     const dataWithoutRecentBucket: AreaChartSeries[] = data?.map(
@@ -343,11 +347,72 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
         valueFormatter: (value: number) =>
           alertTooltipValueFormatter(value, aggregate, aggregate),
 
-        markerFormatter: (marker: string, seriesName?: string) => {
-          if (seriesName === comparisonSeriesName) {
-            return '<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:transparent;"></span>';
+        formatAxisLabel: (
+          value: number,
+          isTimestamp: boolean,
+          utc: boolean,
+          showTimeInTooltip: boolean,
+          addSecondsToTimeFormat: boolean,
+          bucketSize: number | undefined,
+          seriesParamsOrParam: EChartOption.Tooltip.Format | EChartOption.Tooltip.Format[]
+        ) => {
+          const date = defaultFormatAxisLabel(
+            value,
+            isTimestamp,
+            utc,
+            showTimeInTooltip,
+            addSecondsToTimeFormat,
+            bucketSize
+          );
+
+          const seriesParams = Array.isArray(seriesParamsOrParam)
+            ? seriesParamsOrParam
+            : [seriesParamsOrParam];
+
+          const pointY = (
+            seriesParams.length > 1 ? seriesParams[0].data[1] : undefined
+          ) as number | undefined;
+
+          const comparisonSeries =
+            seriesParams.length > 1
+              ? seriesParams.find(({seriesName: _sn}) => _sn === comparisonSeriesName)
+              : undefined;
+
+          const comparisonPointY = comparisonSeries?.data[1] as number | undefined;
+
+          if (comparisonPointY === undefined || pointY === undefined) {
+            return `<span>${date}</span>`;
           }
-          return marker;
+
+          const changePercentage =
+            comparisonPointY === 0 && pointY === 0
+              ? 0
+              : ((pointY - comparisonPointY) * 100) / comparisonPointY;
+
+          const changeStatus = checkChangeStatus(
+            changePercentage,
+            thresholdType,
+            triggers
+          );
+
+          const changeStatusColor =
+            changeStatus === 'critical'
+              ? theme.red300
+              : changeStatus === 'warning'
+              ? theme.yellow300
+              : theme.green300;
+
+          return `<span>${date}<span style="color:${changeStatusColor};margin-left:10px;">${
+            Math.sign(changePercentage) === 1
+              ? '+'
+              : Math.sign(changePercentage) === -1
+              ? '-'
+              : ''
+          }${
+            Math.abs(changePercentage) === Infinity
+              ? `&#8734`
+              : Math.abs(changePercentage)
+          }%</span></span>`;
         },
       },
       yAxis: {
@@ -385,6 +450,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
               name: comparisonSeriesName,
               data: _data.map(({name, value}) => [name, value]),
               lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
+              itemStyle: {color: theme.gray200},
               animation: false,
               animationThreshold: 1,
               animationDuration: 0,

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -584,6 +584,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                             name: comparisonSeriesName,
                             data: _data.map(({name, value}) => [name, value]),
                             lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
+                            itemStyle: {color: theme.gray200},
                             animation: false,
                             animationThreshold: 1,
                             animationDuration: 0,
@@ -623,8 +624,6 @@ class MetricChart extends React.PureComponent<Props, State> {
                           ),
                           'MMM D LT'
                         );
-
-                        const markerPlaceHolder = `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:transparent;"></span>`;
 
                         const comparisonSeries =
                           pointSeries.length > 1
@@ -674,7 +673,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                             )}</strong></span></div>`,
                           `<div><span class="tooltip-label">${marker} <strong>${seriesName}</strong></span>${pointYFormatted}</div>`,
                           comparisonSeries &&
-                            `<div><span class="tooltip-label">${markerPlaceHolder} <strong>${comparisonSeriesName}</strong></span>${comparisonPointYFormatted}</div>`,
+                            `<div><span class="tooltip-label">${comparisonSeries.marker} <strong>${comparisonSeriesName}</strong></span>${comparisonPointYFormatted}</div>`,
                           `</div>`,
                           `<div class="tooltip-date">`,
                           `<span>${startTime} &mdash; ${endTime}</span>`,

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -37,6 +37,7 @@ import {
   MINUTES_THRESHOLD_TO_DISPLAY_SECONDS,
 } from 'app/utils/sessions';
 import theme from 'app/utils/theme';
+import {checkChangeStatus} from 'app/views/alerts/changeAlerts/comparisonMarklines';
 import {alertDetailsLink} from 'app/views/alerts/details';
 import {COMPARISON_DELTA_OPTIONS} from 'app/views/alerts/incidentRules/constants';
 import {makeDefaultCta} from 'app/views/alerts/incidentRules/incidentRulePresets';
@@ -607,18 +608,6 @@ class MetricChart extends React.PureComponent<Props, State> {
                           rule.aggregate
                         );
 
-                        const comparisonSeries = pointSeries.find(
-                          ({seriesName: _seriesName}) =>
-                            _seriesName === comparisonSeriesName
-                        );
-                        const comparisonPointY = comparisonSeries
-                          ? alertTooltipValueFormatter(
-                              comparisonSeries.data[1],
-                              seriesName ?? '',
-                              rule.aggregate
-                            )
-                          : null;
-
                         const isModified =
                           dateModified && pointX <= new Date(dateModified).getTime();
 
@@ -634,25 +623,74 @@ class MetricChart extends React.PureComponent<Props, State> {
                           ),
                           'MMM D LT'
                         );
-                        const title = isModified
-                          ? `<strong>${t('Alert Rule Modified')}</strong>`
-                          : `${marker} <strong>${seriesName}</strong>`;
 
-                        const value = isModified
-                          ? `${seriesName} ${pointYFormatted}`
-                          : pointYFormatted;
+                        const markerPlaceHolder = `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:transparent;"></span>`;
 
-                        const comparisonTitle = isModified
-                          ? `<span>${comparisonSeriesName}</span>`
-                          : `<span style="display:inline-block;margin-right:5px;border-radius:10px;width:10px;height:10px;background-color:transparent;"></span><strong>${comparisonSeriesName}</strong>`;
+                        const comparisonSeries =
+                          pointSeries.length > 1
+                            ? pointSeries.find(
+                                ({seriesName: _sn}) => _sn === comparisonSeriesName
+                              )
+                            : undefined;
+
+                        const comparisonPointY = comparisonSeries?.data[1] as
+                          | number
+                          | undefined;
+                        const comparisonPointYFormatted =
+                          comparisonPointY !== undefined
+                            ? alertTooltipValueFormatter(
+                                comparisonPointY,
+                                seriesName ?? '',
+                                rule.aggregate
+                              )
+                            : undefined;
+
+                        const changePercentage =
+                          comparisonPointY === undefined
+                            ? undefined
+                            : (comparisonPointY === 0 && pointY === 0
+                                ? 0
+                                : (pointY - comparisonPointY) / comparisonPointY) * 100;
+                        const changeStatus =
+                          changePercentage === undefined
+                            ? undefined
+                            : checkChangeStatus(
+                                changePercentage,
+                                rule.thresholdType,
+                                rule.triggers
+                              );
+                        const changeStatusColor =
+                          changeStatus === 'critical'
+                            ? theme.red300
+                            : changeStatus === 'warning'
+                            ? theme.yellow300
+                            : theme.green300;
 
                         return [
                           `<div class="tooltip-series">`,
-                          `<div><span class="tooltip-label">${title}</span>${value}</div>`,
+                          isModified &&
+                            `<div><span class="tooltip-label"><strong>${t(
+                              'Alert Rule Modified'
+                            )}</strong></span></div>`,
+                          `<div><span class="tooltip-label">${marker} <strong>${seriesName}</strong></span>${pointYFormatted}</div>`,
                           comparisonSeries &&
-                            `<div><span class="tooltip-label">${comparisonTitle}</span>${comparisonPointY}</div>`,
+                            `<div><span class="tooltip-label">${markerPlaceHolder} <strong>${comparisonSeriesName}</strong></span>${comparisonPointYFormatted}</div>`,
                           `</div>`,
-                          `<div class="tooltip-date">${startTime} &mdash; ${endTime}</div>`,
+                          `<div class="tooltip-date">`,
+                          `<span>${startTime} &mdash; ${endTime}</span>`,
+                          changePercentage !== undefined &&
+                            `<span style="color:${changeStatusColor};margin-left:10px;">${
+                              Math.sign(changePercentage) === 1
+                                ? '+'
+                                : Math.sign(changePercentage) === -1
+                                ? '-'
+                                : ''
+                            }${
+                              Math.abs(changePercentage) === Infinity
+                                ? `&#8734`
+                                : Math.abs(changePercentage)
+                            }%</span>`,
+                          `</div>`,
                           `<div class="tooltip-arrow"></div>`,
                         ]
                           .filter(e => e)


### PR DESCRIPTION
This updates the change alerts tooltip both in the alert rule builder and alert rule details pages. Added the change percentage to the tooltip and organized the series layouts to be more consistent.

---

Old tooltips:

<img width="467" alt="Screen Shot 2021-11-02 at 12 58 52 PM" src="https://user-images.githubusercontent.com/15015880/139943433-5cee802f-9419-4fb1-a9d8-119341cec7d0.png">

<img width="472" alt="Screen Shot 2021-11-02 at 12 58 58 PM" src="https://user-images.githubusercontent.com/15015880/139943452-e64696e9-2d7b-45c2-9e89-e91a352dc0f7.png">

---

New tooltips:
<img width="300" alt="Screen Shot 2021-11-02 at 12 54 49 PM" src="https://user-images.githubusercontent.com/15015880/139943189-e83d1983-d523-4397-ab32-aeddb996e5d8.png">

<img width="346" alt="Screen Shot 2021-11-02 at 12 55 01 PM" src="https://user-images.githubusercontent.com/15015880/139943200-48bc59d2-7b20-4735-b146-ce8b11749e6f.png">

<img width="346" alt="Screen Shot 2021-11-02 at 12 55 06 PM" src="https://user-images.githubusercontent.com/15015880/139943215-637c92e4-245d-4b34-bdb9-ea995855690d.png">
