### PR TITLE
feat(slack): Allow team unlinking from slack in the UI

### DIFF
--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -65,5 +65,9 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # 
         """
         self.assert_has_feature(request, team.organization)
 
+        integration = external_team.integration
+        install = integration.get_installation(external_team.organization_id)
+        install.notify_remove_external_actor(external_actor=external_team, message="Sent from API")
+
         external_team.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -66,8 +66,5 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # 
         self.assert_has_feature(request, team.organization)
 
         external_team.delete()
-        integration = external_team.integration
-        install = integration.get_installation(external_team.organization_id)
-        install.notify_remove_external_team(external_team=external_team, team=team)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -65,9 +65,9 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # 
         """
         self.assert_has_feature(request, team.organization)
 
+        external_team.delete()
         integration = external_team.integration
         install = integration.get_installation(external_team.organization_id)
-        install.notify_remove_external_actor(external_actor=external_team, message="Sent from API")
+        install.notify_remove_external_team(external_team=external_team, team=team)
 
-        external_team.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -387,3 +387,11 @@ class IntegrationInstallation:
         task.
         """
         pass
+
+    # NotifyBasicMixin noops
+
+    def notify_remove_external_team(self, *args, **kwargs):
+        pass
+
+    def remove_notification_settings(self, *args, **kwargs):
+        pass

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -19,10 +19,12 @@ from sentry.db.models.manager import M
 from sentry.exceptions import InvalidIdentity
 from sentry.models import (
     AuditLogEntryEvent,
+    ExternalActor,
     Identity,
     Integration,
     Organization,
     OrganizationIntegration,
+    Team,
 )
 from sentry.pipeline import PipelineProvider
 from sentry.shared_integrations.constants import (
@@ -390,8 +392,8 @@ class IntegrationInstallation:
 
     # NotifyBasicMixin noops
 
-    def notify_remove_external_team(self, *args, **kwargs):
+    def notify_remove_external_team(self, external_team: ExternalActor, team: Team) -> None:
         pass
 
-    def remove_notification_settings(self, *args, **kwargs):
+    def remove_notification_settings(self, actor_id: int, provider: str) -> None:
         pass

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -7,7 +7,7 @@ logger = logging.getLogger("sentry.integrations.notifications")
 
 
 class NotifyBasicMixin:
-    def send_message(self, message: str):
+    def send_message(self, channel_id: str, message: str) -> None:
         """
         Send a message through the integration.
         """

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -7,6 +7,12 @@ logger = logging.getLogger("sentry.integrations.notifications")
 
 
 class NotifyBasicMixin:
+    def send_message(self, message: str):
+        """
+        Send a message through the integration.
+        """
+        raise NotImplementedError
+
     def notify_remove_external_team(self, external_team: ExternalActor, team: Team) -> None:
         """
         Notify through the integration that an external team has been removed.

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -5,6 +5,11 @@ from sentry.types.integrations import ExternalProviders
 
 logger = logging.getLogger("sentry.integrations.notifications")
 
+SUCCESS_UNLINKED_TEAM_TITLE = "Team unlinked"
+SUCCESS_UNLINKED_TEAM_MESSAGE = (
+    "This channel will no longer receive issue alert notifications for the {team} team."
+)
+
 
 class NotifyBasicMixin:
     def send_message(self, channel_id: str, message: str) -> None:
@@ -17,7 +22,10 @@ class NotifyBasicMixin:
         """
         Notify through the integration that an external team has been removed.
         """
-        raise NotImplementedError
+        self.send_message(
+            channel_id=external_team.external_id,
+            message=SUCCESS_UNLINKED_TEAM_MESSAGE.format(team=team.slug),
+        )
 
     def remove_notification_settings(self, actor_id: int, provider: str) -> None:
         """

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -1,0 +1,11 @@
+import logging
+
+logger = logging.getLogger("sentry.integrations.notifications")
+
+
+class NotifyBasicMixin:
+    def notify_remove_external_actor(self, external_actor, message):
+        """
+        Notify through the integration that settings have been changed on Sentry.
+        """
+        raise NotImplementedError

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -1,22 +1,23 @@
 import logging
 
-from sentry.models import NotificationSetting
+from sentry.models import ExternalActor, NotificationSetting, Team
 from sentry.types.integrations import ExternalProviders
 
 logger = logging.getLogger("sentry.integrations.notifications")
 
 
 class NotifyBasicMixin:
-    def notify_remove_external_team(self, external_team, team):
+    def notify_remove_external_team(self, external_team: ExternalActor, team: Team) -> None:
         """
         Notify through the integration that an external team has been removed.
         """
         raise NotImplementedError
 
-    def remove_notification_settings(self, actor_id):
+    def remove_notification_settings(self, actor_id: int, provider: str) -> None:
         """
         Delete notification settings based on an actor_id
+        There is no foreign key relationship so we have to manually cascade.
         """
         NotificationSetting.objects._filter(
-            target_ids=[self.actor_id], provider=ExternalProviders(self.provider)
+            target_ids=[actor_id], provider=ExternalProviders(provider)
         ).delete()

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -27,11 +27,9 @@ class NotifyBasicMixin:
             message=SUCCESS_UNLINKED_TEAM_MESSAGE.format(team=team.slug),
         )
 
-    def remove_notification_settings(self, actor_id: int, provider: str) -> None:
+    def remove_notification_settings(self, actor_id: int, provider: ExternalProviders) -> None:
         """
         Delete notification settings based on an actor_id
         There is no foreign key relationship so we have to manually cascade.
         """
-        NotificationSetting.objects._filter(
-            target_ids=[actor_id], provider=ExternalProviders(provider)
-        ).delete()
+        NotificationSetting.objects._filter(target_ids=[actor_id], provider=provider).delete()

--- a/src/sentry/integrations/notifications.py
+++ b/src/sentry/integrations/notifications.py
@@ -1,11 +1,22 @@
 import logging
 
+from sentry.models import NotificationSetting
+from sentry.types.integrations import ExternalProviders
+
 logger = logging.getLogger("sentry.integrations.notifications")
 
 
 class NotifyBasicMixin:
-    def notify_remove_external_actor(self, external_actor, message):
+    def notify_remove_external_team(self, external_team, team):
         """
-        Notify through the integration that settings have been changed on Sentry.
+        Notify through the integration that an external team has been removed.
         """
         raise NotImplementedError
+
+    def remove_notification_settings(self, actor_id):
+        """
+        Delete notification settings based on an actor_id
+        """
+        NotificationSetting.objects._filter(
+            target_ids=[self.actor_id], provider=ExternalProviders(self.provider)
+        ).delete()

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -21,6 +21,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.json import JSONData
 
 from .client import SlackClient
+from .notifications import SlackNotifyBasicMixin
 from .utils import logger
 
 Channel = namedtuple("Channel", ["name", "id"])
@@ -65,7 +66,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class SlackIntegration(IntegrationInstallation):  # type: ignore
+class SlackIntegration(IntegrationInstallation, SlackNotifyBasicMixin):  # type: ignore
     def get_config_data(self) -> Mapping[str, str]:
         metadata_ = self.model.metadata
         # Classic bots had a user_access_token in the metadata.

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -66,7 +66,7 @@ metadata = IntegrationMetadata(
 )
 
 
-class SlackIntegration(IntegrationInstallation, SlackNotifyBasicMixin):  # type: ignore
+class SlackIntegration(SlackNotifyBasicMixin, IntegrationInstallation):  # type: ignore
     def get_config_data(self) -> Mapping[str, str]:
         metadata_ = self.model.metadata
         # Classic bots had a user_access_token in the metadata.

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -12,22 +12,24 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json, metrics
 
+from .views.unlink_team import SUCCESS_UNLINKED_MESSAGE
+
 logger = logging.getLogger("sentry.notifications")
 SLACK_TIMEOUT = 5
 
 
 class SlackNotifyBasicMixin(NotifyBasicMixin):
-    def notify_remove_external_actor(self, external_actor: ExternalActor, message: str):
+    def notify_remove_external_team(self, external_team: ExternalActor, team: Team):
         client = SlackClient()
-        integration = external_actor.integrtation
+        integration = external_team.integration
         token = (
             integration.metadata.get("user_access_token") or integration.metadata["access_token"]
         )
         headers = {"Authorization": f"Bearer {token}"}
         payload = {
             "token": token,
-            "channel": external_actor.external_id,
-            "text": message,
+            "channel": external_team.external_id,
+            "text": SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),
         }
         try:
             client.post("/chat.postMessage", headers=headers, data=payload, json=True)

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("sentry.notifications")
 SLACK_TIMEOUT = 5
 
 
-class SlackNotifyBasicMixin(NotifyBasicMixin):
+class SlackNotifyBasicMixin(NotifyBasicMixin):  # type: ignore
     def send_message(self, channel_id: str, message: str) -> None:
         client = SlackClient()
         token = self.metadata.get("user_access_token") or self.metadata["access_token"]
@@ -36,7 +36,7 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):
                 logger.error("slack.slash-notify.response-error", extra={"error": message})
         return
 
-    def notify_remove_external_team(self, external_team: ExternalActor, team: Team):
+    def notify_remove_external_team(self, external_team: ExternalActor, team: Team) -> None:
         self.send_message(
             channel_id=external_team.external_id,
             message=SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -12,8 +12,6 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json, metrics
 
-from .views.unlink_team import SUCCESS_UNLINKED_MESSAGE
-
 logger = logging.getLogger("sentry.notifications")
 SLACK_TIMEOUT = 5
 
@@ -35,12 +33,6 @@ class SlackNotifyBasicMixin(NotifyBasicMixin):  # type: ignore
             if message != "Expired url":
                 logger.error("slack.slash-notify.response-error", extra={"error": message})
         return
-
-    def notify_remove_external_team(self, external_team: ExternalActor, team: Team) -> None:
-        self.send_message(
-            channel_id=external_team.external_id,
-            message=SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),
-        )
 
 
 def get_context(

--- a/src/sentry/integrations/slack/utils/__init__.py
+++ b/src/sentry/integrations/slack/utils/__init__.py
@@ -8,7 +8,6 @@ __all__ = (
     "get_channel_id_with_timeout",
     "is_valid_role",
     "logger",
-    "send_confirmation",
     "send_incident_alert_notification",
     "send_slack_response",
     "strip_channel_name",
@@ -30,7 +29,6 @@ from .channel import (
 )
 from .notifications import (
     build_notification_footer,
-    send_confirmation,
     send_incident_alert_notification,
     send_slack_response,
 )

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -10,7 +10,6 @@ from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
-from ..utils import send_confirmation
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
 
@@ -90,11 +89,13 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
         for external_team in external_teams:
             external_team.delete()
 
-        return send_confirmation(
-            integration,
-            channel_id,
-            SUCCESS_UNLINKED_TITLE,
-            SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),
+        return render_to_response(
             "sentry/integrations/slack/unlinked-team.html",
-            request,
+            request=request,
+            context={
+                "heading_text": SUCCESS_UNLINKED_TITLE,
+                "body_text": SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),
+                "channel_id": channel_id,
+                "team_id": integration.external_id,
+            },
         )

--- a/src/sentry/integrations/slack/views/unlink_team.py
+++ b/src/sentry/integrations/slack/views/unlink_team.py
@@ -2,6 +2,10 @@ from django.core.signing import BadSignature, SignatureExpired
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry.integrations.notifications import (
+    SUCCESS_UNLINKED_TEAM_MESSAGE,
+    SUCCESS_UNLINKED_TEAM_TITLE,
+)
 from sentry.integrations.utils import get_identity_or_404
 from sentry.models import ExternalActor, Identity, Integration
 from sentry.types.integrations import ExternalProviders
@@ -12,11 +16,6 @@ from sentry.web.helpers import render_to_response
 
 from . import build_linking_url as base_build_linking_url
 from . import never_cache, render_error_page
-
-SUCCESS_UNLINKED_TITLE = "Team unlinked"
-SUCCESS_UNLINKED_MESSAGE = (
-    "This channel will no longer receive issue alert notifications for the {team} team."
-)
 
 
 def build_team_unlinking_url(
@@ -93,8 +92,8 @@ class SlackUnlinkTeamView(BaseView):  # type: ignore
             "sentry/integrations/slack/unlinked-team.html",
             request=request,
             context={
-                "heading_text": SUCCESS_UNLINKED_TITLE,
-                "body_text": SUCCESS_UNLINKED_MESSAGE.format(team=team.slug),
+                "heading_text": SUCCESS_UNLINKED_TEAM_TITLE,
+                "body_text": SUCCESS_UNLINKED_TEAM_MESSAGE.format(team=team.slug),
                 "channel_id": channel_id,
                 "team_id": integration.external_id,
             },

--- a/src/sentry/models/externalactor.py
+++ b/src/sentry/models/externalactor.py
@@ -38,12 +38,10 @@ class ExternalActor(DefaultFieldsModel):
         unique_together = (("organization", "provider", "external_name", "actor"),)
 
     def delete(self, **kwargs):
-        from sentry.models import NotificationSetting
+        install = self.integration.get_installation(self.organization_id)
 
-        # There is no foreign key relationship so we have to manually cascade.
-        NotificationSetting.objects._filter(
-            target_ids=[self.actor_id], provider=ExternalProviders(self.provider)
-        ).delete()
+        install.notify_remove_external_team(external_team=self, team=self.actor.resolve())
+        install.remove_notification_settings(actor_id=self.actor_id, provider=self.provider)
 
         return super().delete(**kwargs)
 

--- a/src/sentry/models/externalactor.py
+++ b/src/sentry/models/externalactor.py
@@ -41,7 +41,9 @@ class ExternalActor(DefaultFieldsModel):
         install = self.integration.get_installation(self.organization_id)
 
         install.notify_remove_external_team(external_team=self, team=self.actor.resolve())
-        install.remove_notification_settings(actor_id=self.actor_id, provider=self.provider)
+        install.remove_notification_settings(
+            actor_id=self.actor_id, provider=ExternalProviders(self.provider)
+        )
 
         return super().delete(**kwargs)
 

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
@@ -11,7 +12,7 @@ import Tooltip from 'app/components/tooltip';
 import {IconDelete} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {Integration, Organization, Team} from 'app/types';
+import {ExternalTeam, Integration, Organization, Team} from 'app/types';
 import {toTitleCase} from 'app/utils';
 import withOrganization from 'app/utils/withOrganization';
 import AsyncView from 'app/views/asyncView';
@@ -52,6 +53,20 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
       ],
     ];
   }
+
+  handleDelete = async (mapping: ExternalTeam) => {
+    try {
+      const {organization, team} = this.props;
+      const endpoint = `/teams/${organization.slug}/${team.slug}/external-teams/${mapping.id}/`;
+      await this.api.requestPromise(endpoint, {
+        method: 'DELETE',
+      });
+      addSuccessMessage(t('Deletion successful'));
+      this.fetchData();
+    } catch {
+      addErrorMessage(t('An error occurred'));
+    }
+  };
 
   renderBody() {
     return (
@@ -132,7 +147,7 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
           >
             <Confirm
               disabled={!hasAccess}
-              onConfirm={() => alert('Time to delete it!')}
+              onConfirm={() => this.handleDelete(externalTeam)}
               message={t('Are you sure you want to remove this Slack team link?')}
             >
               <Button

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -4,8 +4,10 @@ import styled from '@emotion/styled';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
+import Confirm from 'app/components/confirm';
 import ExternalLink from 'app/components/links/externalLink';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import Tooltip from 'app/components/tooltip';
 import {IconDelete} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
@@ -61,6 +63,7 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
   }
 
   renderPanelBody() {
+    const {organization} = this.props;
     const {teamDetails, integrations} = this.state;
 
     const notificationIntegrations = integrations.filter(integration =>
@@ -96,6 +99,9 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
       notificationIntegrations.map(integration => [integration.id, integration])
     );
 
+    const access = new Set(organization.access);
+    const hasAccess = access.has('team:write');
+
     return externalTeams.map(externalTeam => (
       <FormFieldWrapper key={externalTeam.id}>
         <StyledFormField
@@ -118,12 +124,25 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
           value={externalTeam.externalName}
         />
         <DeleteButtonWrapper>
-          <Button
-            size="small"
-            icon={<IconDelete size="md" />}
-            label={t('delete')}
-            disabled={false}
-          />
+          <Tooltip
+            title={t(
+              "You must have the 'team:write' permission to remove a Slack team link"
+            )}
+            disabled={hasAccess}
+          >
+            <Confirm
+              disabled={!hasAccess}
+              onConfirm={() => alert('Time to delete it!')}
+              message={t('Are you sure you want to remove this Slack team link?')}
+            >
+              <Button
+                size="small"
+                icon={<IconDelete size="md" />}
+                label={t('delete')}
+                disabled={!hasAccess}
+              />
+            </Confirm>
+          </Tooltip>
         </DeleteButtonWrapper>
       </FormFieldWrapper>
     ));

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -1,9 +1,12 @@
+import * as React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import AsyncComponent from 'app/components/asyncComponent';
+import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import {IconDelete} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Integration, Organization, Team} from 'app/types';
@@ -94,26 +97,35 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
     );
 
     return externalTeams.map(externalTeam => (
-      <TextField
-        disabled
-        key={externalTeam.id}
-        label={
-          <div>
-            <NotDisabledText>
-              {toTitleCase(externalTeam.provider)}:
-              {integrationsById[externalTeam.integrationId].name}
-            </NotDisabledText>
-            <NotDisabledSubText>
-              {tct('Unlink this channel in Slack with [code]. [link].', {
-                code: <code>/sentry unlink team</code>,
-                link: <ExternalLink href={DOCS_LINK}>{t('Learn more')}</ExternalLink>,
-              })}
-            </NotDisabledSubText>
-          </div>
-        }
-        name="externalName"
-        value={externalTeam.externalName}
-      />
+      <FormFieldWrapper key={externalTeam.id}>
+        <StyledFormField
+          disabled
+          label={
+            <div>
+              <NotDisabledText>
+                {toTitleCase(externalTeam.provider)}:
+                {integrationsById[externalTeam.integrationId].name}
+              </NotDisabledText>
+              <NotDisabledSubText>
+                {tct('Unlink this channel in Slack with [code]. [link].', {
+                  code: <code>/sentry unlink team</code>,
+                  link: <ExternalLink href={DOCS_LINK}>{t('Learn more')}</ExternalLink>,
+                })}
+              </NotDisabledSubText>
+            </div>
+          }
+          name="externalName"
+          value={externalTeam.externalName}
+        />
+        <DeleteButtonWrapper>
+          <Button
+            size="small"
+            icon={<IconDelete size="md" />}
+            label={t('delete')}
+            disabled={false}
+          />
+        </DeleteButtonWrapper>
+      </FormFieldWrapper>
     ));
   }
 }
@@ -128,4 +140,16 @@ const NotDisabledSubText = styled('div')`
   font-size: ${p => p.theme.fontSizeRelativeSmall};
   line-height: 1.4;
   margin-top: ${space(1)};
+`;
+const FormFieldWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+`;
+const StyledFormField = styled(TextField)`
+  flex: 1;
+`;
+const DeleteButtonWrapper = styled('div')`
+  margin-right: ${space(4)};
+  padding-right: ${space(0.5)};
 `;

--- a/tests/js/spec/views/team/teamNotificationSettings.spec.jsx
+++ b/tests/js/spec/views/team/teamNotificationSettings.spec.jsx
@@ -1,5 +1,6 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import TeamNotificationSettings from 'app/views/settings/organizationTeams/teamNotifications';
 
@@ -99,7 +100,51 @@ describe('TeamNotificationSettings', () => {
       routerContext
     );
     const input = wrapper.find('Panel').last().find('input');
+
     expect(input.prop('disabled')).toBe(true);
     expect(input.prop('value')).toBe(EXTERNAL_NAME);
+    expect(wrapper.find('button[aria-label="delete"]').exists()).toBe(true);
+  });
+
+  it('should delete be able to delete the externalTeam', async () => {
+    const {organization, routerContext} = initializeOrg();
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${team.slug}/`,
+      body: {
+        externalTeams: [EXAMPLE_EXTERNAL_TEAM],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [EXAMPLE_INTEGRATION],
+    });
+
+    const deleteMock = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${team.slug}/external-teams/${EXAMPLE_EXTERNAL_TEAM.id}/`,
+      status: 204,
+      method: 'DELETE',
+    });
+
+    const wrapper = mountWithTheme(
+      <TeamNotificationSettings team={team} organization={organization} />,
+      routerContext
+    );
+
+    const deleteButton = wrapper.find('button[aria-label="delete"]');
+    expect(deleteButton.prop('disabled')).toBe(false);
+
+    deleteButton.simulate('click');
+
+    await tick();
+
+    const modal = await mountGlobalModal();
+    const confirmBtn = modal.find('Button').last().simulate('click');
+    expect(confirmBtn.exists()).toBe(true);
+
+    confirmBtn.simulate('click');
+
+    expect(deleteMock).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
See [API-2206](https://getsentry.atlassian.net/browse/API-2206)

This PR will allow for users to unlink teams from slack channels through the UI. If the channel is deleted, or they're unable to run `/sentry unlink team` for any other reason, they'll still be able to go through the UI to remove the mapping.

**TODO**
- [x] Send the "This channel will no longer receive issue alert notifications for the {sentry-team} team." message after unlinking.
- [x] Ensure that other external actor deletions are unaffected
- [x] Upload demo clips or screenshots

**DEMOS**

https://user-images.githubusercontent.com/35509934/139913428-90e75aee-e62a-41aa-8f31-83f7b8fddeec.mov


https://user-images.githubusercontent.com/35509934/139913439-4c6045ad-4691-4b1f-934b-08ee30ddb8aa.mov
