### PR TITLE
fix(discover): Set field to prev value if required but empty (#269)

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -676,7 +676,11 @@ class BufferedInput extends React.Component<InputProps, InputState> {
   }
 
   handleBlur = () => {
-    if (this.isValid) {
+    if (this.props.required && this.state.value === '') {
+      // Handle empty strings separately because we don't pass required
+      // to input elements, causing isValid to return true
+      this.setState({value: this.props.value});
+    } else if (this.isValid) {
       this.props.onUpdate(this.state.value);
     } else {
       this.setState({value: this.props.value});


### PR DESCRIPTION
Since we don't pass required as a prop to the input element*, an empty
string was considered valid for required fields and incorrectly set.

---

*See:
>  Do not forward required to `input` to avoid default browser behavior

in `app/views/settings/components/forms/controls/input.tsx`