### PR TITLE
fix(discover): Set field to prev value if required but empty (#269)

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -676,7 +676,11 @@ class BufferedInput extends React.Component<InputProps, InputState> {
   }
 
   handleBlur = () => {
-    if (this.isValid) {
+    if (this.props.required && this.state.value === '') {
+      // Handle empty strings separately because we don't pass required
+      // to input elements, causing isValid to return true
+      this.setState({value: this.props.value});
+    } else if (this.isValid) {
       this.props.onUpdate(this.state.value);
     } else {
       this.setState({value: this.props.value});

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -357,6 +357,45 @@ describe('EventsV2 -> ColumnEditModal', function () {
         'Maximum operators exceeded'
       );
     });
+
+    it('resets required field to previous value if cleared', function () {
+      const initialColumnVal = '0.6';
+      const newWrapper = mountModal(
+        {
+          columns: [
+            {
+              kind: 'function',
+              function: [
+                'percentile',
+                'transaction.duration',
+                initialColumnVal,
+                undefined,
+              ],
+            },
+          ],
+          onApply,
+          tagKeys,
+        },
+        initialData
+      );
+
+      const field = newWrapper.find('QueryField input[name="refinement"]');
+      changeInputValue(field, '');
+      newWrapper.update();
+      field.simulate('blur');
+
+      expect(newWrapper.find('QueryField input[name="refinement"]').prop('value')).toBe(
+        initialColumnVal
+      );
+
+      newWrapper.find('Button[priority="primary"]').simulate('click');
+      expect(onApply).toHaveBeenCalledWith([
+        {
+          kind: 'function',
+          function: ['percentile', 'transaction.duration', initialColumnVal, undefined],
+        },
+      ]);
+    });
   });
 
   describe('equation automatic update', function () {


### PR DESCRIPTION
Since we don't pass required as a prop to the input element*, an empty
string was considered valid for required fields and incorrectly set.

---

*See:

> Do not forward required to input to avoid default browser behavior

in `app/views/settings/components/forms/controls/input.tsx`