### PR TITLE
fix(discover): fixed eventView isEqualTo to evaluate undefined display as equal to 'default' display

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -508,7 +508,6 @@ class EventView {
       'sorts',
       'project',
       'environment',
-      'display',
       'topEvents',
     ];
 
@@ -547,6 +546,13 @@ class EventView {
       return false;
     }
 
+    // compare Display Mode selections
+    // undefined Display Mode values default to "default"
+    const currentDisplayMode = this.display ?? DisplayModes.DEFAULT;
+    const otherDisplayMode = other.display ?? DisplayModes.DEFAULT;
+    if (!isEqual(currentDisplayMode, otherDisplayMode)) {
+      return false;
+    }
     return true;
   }
 

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2671,6 +2671,25 @@ describe('EventView.isEqualTo()', function () {
       expect(eventView.isEqualTo(eventView2)).toBe(false);
     }
   });
+
+  it('undefined display type equals default display type', function () {
+    const state = {
+      id: '1234',
+      name: 'best query',
+      fields: [{field: 'count()'}, {field: 'project.id'}],
+      sorts: generateSorts(['count']),
+      query: 'event.type:error',
+      project: [42],
+      start: '2019-10-01T00:00:00',
+      end: '2019-10-02T00:00:00',
+      statsPeriod: '14d',
+      environment: ['staging'],
+      yAxis: 'fam',
+    };
+    const eventView = new EventView(state);
+    const eventView2 = new EventView({...state, display: 'default'});
+    expect(eventView.isEqualTo(eventView2)).toBe(true);
+  });
 });
 
 describe('EventView.getResultsViewUrlTarget()', function () {


### PR DESCRIPTION
A saved query with `undefined` displayMode is defaulted to `default` but is evaluated as different from `default` when checking for changes (for saved button). This update to isEqualTo fixes this issue.