### PR TITLE
feat(suspect-spans): Add rollout percentage option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -376,7 +376,10 @@ register("subscriptions-query.sample-rate", default=0.01)
 # removed once it is fully rolled out.
 register("symbolicate-event.low-priority.metrics.submission-rate", default=0.0)
 
+# This is to enable the ingestion of suspect spans by project ids.
 register("performance.suspect-spans-ingestion-projects", default={})
+# This is to enable the ingestion of suspect spans by project groups.
+register("performance.suspect-spans-ingestion.rollout-rate", default=0)
 
 # Sampling rate for controlled rollout of a change where ignest-consumer spawns
 # special save_event task for transactions avoiding the preprocess.


### PR DESCRIPTION
Currently, the rollout strategy requires specifying projects one by one because
we were targeting specific projects during the initial rollout. As the rollout
happens for more projects, we want to be able to roll it out for a percentage of
projects at a time.