### PR TITLE
ref(sentry-metrics): Run ingest-metrics-consumer in devserver

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1668,6 +1668,10 @@ SENTRY_ATTACHMENT_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 # store. MUST be a power of two.
 SENTRY_CHUNK_UPLOAD_BLOB_SIZE = 8 * 1024 * 1024  # 8MB
 
+# This flag tell DEVSERVICES to start the ingest-metrics-consumer in order to work on
+# metrics in the development environment. Note: this is "metrics" the product
+SENTRY_USE_METRICS_DEV = False
+
 # This flags activates the Change Data Capture backend in the development environment
 SENTRY_USE_CDC_DEV = False
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -30,6 +30,7 @@ _DEFAULT_DAEMONS = {
         "--force-offset-reset",
         "latest",
     ],
+    "metrics": ["sentry", "run", "ingest-metrics-consumer"],
 }
 
 
@@ -231,6 +232,9 @@ def devserver(
                 )
             for name, topic in settings.KAFKA_SUBSCRIPTION_RESULT_TOPICS.items():
                 daemons += [_get_daemon("subscription-consumer", "--topic", topic, suffix=name)]
+
+        if settings.SENTRY_USE_METRICS_DEV:
+            daemons += [_get_daemon("metrics")]
 
     if settings.SENTRY_USE_RELAY:
         daemons += [_get_daemon("ingest")]

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -233,7 +233,7 @@ def devserver(
             for name, topic in settings.KAFKA_SUBSCRIPTION_RESULT_TOPICS.items():
                 daemons += [_get_daemon("subscription-consumer", "--topic", topic, suffix=name)]
 
-        if settings.SENTRY_USE_METRICS_DEV:
+        if settings.SENTRY_USE_METRICS_DEV and settings.SENTRY_USE_RELAY:
             daemons += [_get_daemon("metrics")]
 
     if settings.SENTRY_USE_RELAY:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -526,15 +526,15 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
         get_ingest_consumer(consumer_types=consumer_types, executor=executor, **options).run()
 
 
-@run.command("metrics-consumer")
+@run.command("ingest-metrics-consumer")
 @log_options()
 @click.option(
     "--group_id",
-    default="metrics-consumer",
+    default="ingest-metrics-consumer",
     help="Consumer group to track metric indexer offsets. ",
 )
 @click.option("--topic", default="ingest-metrics", help="Topic to get subscription updates from.")
-@batching_kafka_options("metrics-consumer")
+@batching_kafka_options("ingest-metrics-consumer")
 @configuration
 def metrics_consumer(**options):
 


### PR DESCRIPTION
Adds option `SENTRY_USE_METRICS_DEV` to allow the ingest metrics consumer to start when running the devserver with workers.

Also changed the command from `metrics-consumer` to `ingest-metrics-consumer` to be more specific about which topic it's consuming from. 