### PR TITLE
fix(ui): Cropped letter descenders in TextOverflow

### DIFF
--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -24,7 +24,7 @@ const TextOverflow = styled(
 )`
   ${p => (p.ellipsisDirection === 'right' ? overflowEllipsis : overflowEllipsisLeft)};
   width: auto;
-  line-height: 1.1;
+  line-height: 1.2;
 `;
 
 TextOverflow.defaultProps = {


### PR DESCRIPTION
Due to the low `line-height` (`1.1`), the letter g's descender (the hook at the bottom) is cropped off. Setting `line-height` to `1.2` fixes this. I'm not sure why we used `1.1` in the first place (?). A value of `1.2` doesn't seem to noticeably affect the vertical alignment.

Before:
<img width="386" alt="Screen Shot 2021-11-01 at 11 20 34 AM" src="https://user-images.githubusercontent.com/44172267/139722753-8be4f0ed-3778-4709-a557-8fd2cca8683e.png">

After:
<img width="377" alt="Screen Shot 2021-11-01 at 11 32 55 AM" src="https://user-images.githubusercontent.com/44172267/139722777-0de93be3-4a52-4072-b86a-2bb8dce2d861.png">


