### PR TITLE
feat(discover): Render saved Query error messages to MiniGraph

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -244,6 +244,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     this.setState(state => ({
       reloading: state.timeseriesData !== null,
       errored: false,
+      errorMessage: undefined,
     }));
 
     let errorMessage;

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -38,7 +38,7 @@ type LoadingStatus = {
    * Whether there was an error retrieving data
    */
   errored: boolean;
-  errorMessage: null | string;
+  errorMessage?: string;
 };
 
 export type RenderProps = LoadingStatus &
@@ -187,7 +187,7 @@ export type EventsRequestProps = DefaultProps &
 type EventsRequestState = {
   reloading: boolean;
   errored: boolean;
-  errorMessage: null | string;
+  errorMessage?: string;
   timeseriesData: null | EventsStats | MultiSeriesEventsStats;
   fetchedWithPrevious: boolean;
 };
@@ -212,7 +212,6 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   state: EventsRequestState = {
     reloading: !!this.props.loading,
     errored: false,
-    errorMessage: null,
     timeseriesData: null,
     fetchedWithPrevious: false,
   };
@@ -245,7 +244,6 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     this.setState(state => ({
       reloading: state.timeseriesData !== null,
       errored: false,
-      errorMessage: null,
     }));
 
     let errorMessage;

--- a/static/app/views/eventsV2/miniGraph.tsx
+++ b/static/app/views/eventsV2/miniGraph.tsx
@@ -204,13 +204,15 @@ class MiniGraph extends React.Component<Props> {
         expired={expired}
         name={name}
         referrer={referrer}
+        hideError
         partial
       >
-        {({loading, timeseriesData, results, errored}) => {
+        {({loading, timeseriesData, results, errored, errorMessage}) => {
           if (errored) {
             return (
               <StyledGraphContainer>
                 <IconWarning color="gray300" size="md" />
+                <StyledErrorMessage>{errorMessage}</StyledErrorMessage>
               </StyledGraphContainer>
             );
           }
@@ -315,6 +317,11 @@ const StyledGraphContainer = styled(props => (
   display: flex;
   justify-content: center;
   align-items: center;
+`;
+
+const StyledErrorMessage = styled('div')`
+  color: ${p => p.theme.gray300};
+  margin-left: 4px;
 `;
 
 export default withApi(withTheme(MiniGraph));

--- a/tests/js/spec/views/eventsV2/miniGraph.spec.tsx
+++ b/tests/js/spec/views/eventsV2/miniGraph.spec.tsx
@@ -59,6 +59,14 @@ describe('EventsV2 > MiniGraph', function () {
     });
     // @ts-expect-error
     eventView = EventView.fromSavedQueryOrLocation(undefined, location);
+
+    // @ts-expect-error
+    MockApiClient.clearMockResponses();
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      statusCode: 200,
+    });
   });
 
   it('makes an EventsRequest with all selected multi y axis', async function () {
@@ -117,5 +125,38 @@ describe('EventsV2 > MiniGraph', function () {
         seriesName: 'Country',
       },
     ]);
+  });
+
+  it('renders error message', async function () {
+    const errorMessage = 'something went wrong';
+    // @ts-expect-error
+    const api = new MockApiClient();
+    // @ts-expect-error
+    MockApiClient.clearMockResponses();
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: {
+        detail: errorMessage,
+      },
+      statusCode: 400,
+    });
+
+    const wrapper = mountWithTheme(
+      <MiniGraph
+        // @ts-expect-error
+        location={location}
+        eventView={eventView}
+        organization={organization}
+        api={api}
+      />,
+      initialData.routerContext
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MiniGraph').text()).toBe(errorMessage);
   });
 });


### PR DESCRIPTION
Adds a render prop to EventsRequest component for passing along the
error message and rendering in MiniGraph