### PR TITLE
fix(idp-migration): added 2fa to idp migration flow

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -440,6 +440,7 @@ class AuthIdentityHandler:
                 try:
                     self._login(acting_user)
                 except self._NotCompletedSecurityChecks:
+                    # adding is_account_verified to the check below in order to redirect to 2fa when the user migrates their idp but has 2fa enabled, otherwise it would stop them from linking their sso provider
                     if acting_user.has_usable_password() or is_account_verified:
                         return self._post_login_redirect()
                     else:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -440,7 +440,7 @@ class AuthIdentityHandler:
                 try:
                     self._login(acting_user)
                 except self._NotCompletedSecurityChecks:
-                    if acting_user.has_usable_password():
+                    if acting_user.has_usable_password() or is_account_verified:
                         return self._post_login_redirect()
                     else:
                         acting_user = None


### PR DESCRIPTION
Problem: During the idp migration flow, the user won't be be linked to their SSO provider if they had 2fa enabled. This was due to the user not completing the security checks during after their redis has been verified. 

Now if their account has been verified and they dont pass security checks, we redirect them to the 2fa flow so they could be linked with their SSO provider

https://getsentry.atlassian.net/browse/ER-856