### PR TITLE
ui(performance): Increase precision of performance duration

### DIFF
--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -297,7 +297,7 @@ export function PerformanceDuration(props: PerformanceDurationProps) {
     <Duration
       abbreviation={props.abbreviation}
       seconds={normalizedSeconds}
-      fixedDigits={normalizedSeconds > 1 ? 2 : 0}
+      fixedDigits={2}
     />
   );
 }


### PR DESCRIPTION
For sub second durations, we show up to the nearest millisecond. This becomes a
problem when we have sub millisecond durations, particularly in spans. This
change ensures that we always show at least 2 decimal places for additional
precision.