### PR TITLE
fix(appconnect): Filter out app clip bundles since they don't have anything we can use

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -370,13 +370,18 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
     # available for download only depends on whether it was a bitcode
     # upload.
 
+    if bundles is None:
+        bundles = []
+
     # Remove all bundles associated with app clips, those don't have dSYMS or really any useful
     # data since they're not apps themselves
-    app_bundles = filter(
-        lambda b: safe.get_path(bundle, "attributes", "bundleType", default="APP") != "APP_CLIP"
-    )
+    app_bundles = [
+        app_bundle
+        for app_bundle in bundles
+        if safe.get_path(app_bundle, "attributes", "bundleType", default="APP") != "APP_CLIP"
+    ]
 
-    if bundles is None or len(bundles) == 0:
+    if len(bundles) == 0:
         return NoDsymUrl.NOT_NEEDED
 
     if len(app_bundles) > 1:

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -373,12 +373,12 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
     if not bundles:
         return NoDsymUrl.NOT_NEEDED
 
-    get_url = lambda bundle: safe.get_path(
+    get_bundle_url = lambda bundle: safe.get_path(
         bundle, "attributes", "dSYMUrl", default=NoDsymUrl.NOT_NEEDED
     )
 
     app_clip_urls = [
-        get_url(b)
+        get_bundle_url(b)
         for b in bundles
         if safe.get_path(b, "attributes", "bundleType", default="APP") == "APP_CLIP"
     ]
@@ -401,9 +401,7 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
     # Because we only ask for processingState=VALID builds we expect the builds to be
     # finished and if there are no dSYMs that means the build doesn't need dSYMs, i.e. it is
     # not a bitcode build.
-    bundle = app_bundles[0]
-    url = safe.get_path(bundle, "attributes", "dSYMUrl", default=NoDsymUrl.NOT_NEEDED)
-
+    url = get_bundle_url(app_bundles[0])
     if isinstance(url, (NoDsymUrl, str)):
         return url
     else:

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -381,7 +381,7 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
         if safe.get_path(app_bundle, "attributes", "bundleType", default="APP") != "APP_CLIP"
     ]
 
-    if len(bundles) == 0:
+    if len(app_bundles) == 0:
         return NoDsymUrl.NOT_NEEDED
 
     if len(app_bundles) > 1:

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -7,7 +7,7 @@ import pathlib
 import time
 from collections import namedtuple
 from http import HTTPStatus
-from typing import Any, Dict, Generator, List, Mapping, NewType, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Generator, List, Mapping, NewType, Optional, Tuple, Union
 
 import sentry_sdk
 from dateutil.parser import parse as parse_date
@@ -373,7 +373,7 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
     if not bundles:
         return NoDsymUrl.NOT_NEEDED
 
-    get_bundle_url = lambda bundle: safe.get_path(
+    get_bundle_url: Callable[[JSONData], Any] = lambda bundle: safe.get_path(
         bundle, "attributes", "dSYMUrl", default=NoDsymUrl.NOT_NEEDED
     )
 


### PR DESCRIPTION
We've started getting some info on apps that have multiple build bundles, and it looks like one way this can happen is when an app has app clips. Build bundles for app clips don't really contain any useful info (ie a majority of their attributes are empty) which makes sense; they're just a fancy link to the application and shouldn't contain any real logic. This filters the build bundles for app clips out.