### PR TITLE
feat: Add user permission API endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,7 @@
 /src/sentry/api/permissions.py      @getsentry/security @getsentry/enterprise
 /src/sentry/api/authentication.py   @getsentry/security @getsentry/enterprise
 /src/sentry/api/endpoints/auth*     @getsentry/security @getsentry/enterprise
+/src/sentry/api/endpoints/user_permission*     @getsentry/security @getsentry/enterprise
 
 # Dev
 /.github/                   @getsentry/owners-sentry-dev

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -1,0 +1,33 @@
+from django.db import IntegrityError, transaction
+
+from sentry.api.bases.user import UserEndpoint
+from sentry.auth.superuser import has_superuser_permission
+from sentry.models import UserPermission
+
+
+class UserPermissionDetailsEndpoint(UserEndpoint):
+    def get(self, request, user, permission_name):
+        has_perm = UserPermission.objects.filter(user=user, permission=permission_name).exists()
+        return self.respond(status=204 if has_perm else 404)
+
+    def post(self, request, user, permission_name):
+        if not has_superuser_permission(request, "users.admin"):
+            return self.respond(status=403)
+
+        try:
+            with transaction.atomic():
+                UserPermission.objects.create(user=user, permission=permission_name)
+        except IntegrityError as e:
+            if "already exists" in str(e):
+                return self.respond(status=410)
+            raise
+        return self.respond(status=201)
+
+    def delete(self, request, user, permission_name):
+        if not has_superuser_permission(request, "users.admin"):
+            return self.respond(status=403)
+
+        deleted, _ = UserPermission.objects.filter(user=user, permission=permission_name).delete()
+        if deleted:
+            return self.respond(status=204)
+        return self.respond(status=404)

--- a/src/sentry/api/endpoints/user_permissions.py
+++ b/src/sentry/api/endpoints/user_permissions.py
@@ -1,0 +1,8 @@
+from sentry.api.bases.user import UserEndpoint
+from sentry.models import UserPermission
+
+
+class UserPermissionsEndpoint(UserEndpoint):
+    def get(self, request, user):
+        permission_list = list(UserPermission.objects.filter(user=user))
+        return self.respond([p.permission for p in permission_list])

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -428,6 +428,8 @@ from .endpoints.user_notification_settings_details import UserNotificationSettin
 from .endpoints.user_organizationintegrations import UserOrganizationIntegrationsEndpoint
 from .endpoints.user_organizations import UserOrganizationsEndpoint
 from .endpoints.user_password import UserPasswordEndpoint
+from .endpoints.user_permission_details import UserPermissionDetailsEndpoint
+from .endpoints.user_permissions import UserPermissionsEndpoint
 from .endpoints.user_social_identities_index import UserSocialIdentitiesIndexEndpoint
 from .endpoints.user_social_identity_details import UserSocialIdentityDetailsEndpoint
 from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
@@ -685,6 +687,16 @@ urlpatterns = [
                     r"^(?P<user_id>[^\/]+)/password/$",
                     UserPasswordEndpoint.as_view(),
                     name="sentry-api-0-user-password",
+                ),
+                url(
+                    r"^(?P<user_id>[^\/]+)/permissions/$",
+                    UserPermissionsEndpoint.as_view(),
+                    name="sentry-api-0-user-permissions",
+                ),
+                url(
+                    r"^(?P<user_id>[^\/]+)/permissions/(?P<permission_name>[^\/]+)/$",
+                    UserPermissionDetailsEndpoint.as_view(),
+                    name="sentry-api-0-user-permission-details",
                 ),
                 url(
                     r"^(?P<user_id>[^\/]+)/social-identities/$",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -392,7 +392,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
             query_string = urlencode(params.pop("qs_params"), doseq=True)
             url = f"{url}?{query_string}"
 
-        method = params.pop("method", self.method)
+        method = params.pop("method", self.method).lower()
 
         return getattr(self.client, method)(url, format="json", data=params)
 

--- a/tests/sentry/api/endpoints/test_user_permission_details.py
+++ b/tests/sentry/api/endpoints/test_user_permission_details.py
@@ -1,0 +1,96 @@
+from sentry.models import UserPermission
+from sentry.testutils import APITestCase
+
+
+class UserDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-user-permission-details"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.login_as(user=self.user)
+
+
+class UserPermissionDetailsGetTest(UserDetailsTest):
+    def test_with_permission(self):
+        UserPermission.objects.create(user=self.user, permission="broadcasts.admin")
+        resp = self.get_response("me", "broadcasts.admin")
+        assert resp.status_code == 204
+
+    def test_without_permission(self):
+        resp = self.get_response("me", "broadcasts.admin")
+        assert resp.status_code == 404
+
+
+class UserPermissionDetailsPostTest(UserDetailsTest):
+    def test_required_access(self):
+        resp = self.get_response("me", "broadcasts.admin", method="POST")
+        assert resp.status_code == 403
+
+        self.user.update(is_superuser=True)
+        resp = self.get_response("me", "broadcasts.admin", method="POST")
+        assert resp.status_code == 403
+
+        self.login_as(user=self.user, superuser=True)
+        resp = self.get_response("me", "broadcasts.admin", method="POST")
+        assert resp.status_code == 403
+
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        resp = self.get_response("me", "broadcasts.admin", method="POST")
+        assert resp.status_code != 403
+
+    def test_with_permission(self):
+        self.user.update(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        UserPermission.objects.create(user=self.user, permission="broadcasts.admin")
+        resp = self.get_response("me", "broadcasts.admin", method="POST")
+        assert resp.status_code == 410
+        assert UserPermission.objects.filter(user=self.user, permission="broadcasts.admin").exists()
+
+    def test_without_permission(self):
+        self.user.update(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        resp = self.get_response("me", "broadcasts.admin", method="POST")
+        assert resp.status_code == 201
+        assert UserPermission.objects.filter(user=self.user, permission="broadcasts.admin").exists()
+
+
+class UserPermissionDetailsDeleteTest(UserDetailsTest):
+    def test_required_access(self):
+        resp = self.get_response("me", "broadcasts.admin", method="DELETE")
+        assert resp.status_code == 403
+
+        self.user.update(is_superuser=True)
+        resp = self.get_response("me", "broadcasts.admin", method="DELETE")
+        assert resp.status_code == 403
+
+        self.login_as(user=self.user, superuser=True)
+        resp = self.get_response("me", "broadcasts.admin", method="DELETE")
+        assert resp.status_code == 403
+
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        resp = self.get_response("me", "broadcasts.admin", method="DELETE")
+        assert resp.status_code != 403
+
+    def test_with_permission(self):
+        self.user.update(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        UserPermission.objects.create(user=self.user, permission="broadcasts.admin")
+        resp = self.get_response("me", "broadcasts.admin", method="DELETE")
+        assert resp.status_code == 204
+        assert not UserPermission.objects.filter(
+            user=self.user, permission="broadcasts.admin"
+        ).exists()
+
+    def test_without_permission(self):
+        self.user.update(is_superuser=True)
+        self.login_as(user=self.user, superuser=True)
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        resp = self.get_response("me", "broadcasts.admin", method="DELETE")
+        assert resp.status_code == 404
+        assert not UserPermission.objects.filter(
+            user=self.user, permission="broadcasts.admin"
+        ).exists()

--- a/tests/sentry/api/endpoints/test_user_permissions.py
+++ b/tests/sentry/api/endpoints/test_user_permissions.py
@@ -1,0 +1,22 @@
+from sentry.models import UserPermission
+from sentry.testutils import APITestCase
+
+
+class UserDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-user-permissions"
+
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.login_as(user=self.user)
+
+
+class UserPermissionsGetTest(UserDetailsTest):
+    def test_lookup_self(self):
+        UserPermission.objects.create(user=self.user, permission="broadcasts.admin")
+        UserPermission.objects.create(user=self.user, permission="users.admin")
+        resp = self.get_response("me")
+        assert resp.status_code == 200
+        assert len(resp.data) == 2, resp.data
+        assert "broadcasts.admin" in resp.data
+        assert "users.admin" in resp.data


### PR DESCRIPTION
Add ability to list, test, add, and delete permissions from individual users.

- GET /users/me/permissions/
- GET /users/me/permissions/permission.name/
- POST /users/me/permissions/permission.name/
- DELETE /users/me/permissions/permission.name/
