### PR TITLE
fix(notifications): adds analytics for sending email

### DIFF
--- a/src/sentry/analytics/events/email_notification_sent.py
+++ b/src/sentry/analytics/events/email_notification_sent.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class EmailNotificationSent(analytics.Event):  # type: ignore
+    type = "integrations.email.notification_sent"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("category"),
+        analytics.Attribute("actor_id"),
+    )
+
+
+analytics.register(EmailNotificationSent)

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -108,6 +108,7 @@ def send_notification_as_email(
             add_users_kwargs["project"] = notification.project
         msg.add_users([recipient.id], **add_users_kwargs)
         msg.send_async()
+        notification.record_notification_sent(recipient, ExternalProviders.EMAIL)
 
 
 def get_builder_args(


### PR DESCRIPTION
Need to record analytics when we send an email notification which we are already doing for Slack