### PR TITLE
fix(tags): Set filter transaction filter on conditions

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -50,6 +50,10 @@ function getDocumentTitle(transactionName: string): string {
 function generateEventView(location: Location, transactionName: string): EventView {
   const query = decodeScalar(location.query.query, '');
   const conditions = new MutableSearch(query);
+  conditions
+    .setFilterValues('event.type', ['transaction'])
+    .setFilterValues('transaction', [transactionName]);
+
   const eventView = EventView.fromNewQueryWithLocation(
     {
       id: undefined,
@@ -62,8 +66,6 @@ function generateEventView(location: Location, transactionName: string): EventVi
     location
   );
 
-  eventView.additionalConditions.setFilterValues('event.type', ['transaction']);
-  eventView.additionalConditions.setFilterValues('transaction', [transactionName]);
   return eventView;
 }
 


### PR DESCRIPTION
Set transaction filter on conditions/query instead
of additionalConditions since that just adds a PREWHERE
clause on clickhouse and now we have two txn filters
and it's not performant. This follows the pattern in
other `generateEventView` functions.