### PR TITLE
fix(reprocessing): Add a lot of metrics and explicitly opt tasks into sentry performance product [INGEST-574]

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -452,7 +452,11 @@ GROUP_URLS = [
         GroupingLevelNewIssuesEndpoint.as_view(),
     ),
     url(r"^(?P<issue_id>[^\/]+)/hashes/split/$", GroupHashesSplitEndpoint.as_view()),
-    url(r"^(?P<issue_id>[^\/]+)/reprocessing/$", GroupReprocessingEndpoint.as_view()),
+    url(
+        r"^(?P<issue_id>[^\/]+)/reprocessing/$",
+        GroupReprocessingEndpoint.as_view(),
+        name="sentry-api-0-issues-reprocessing",
+    ),
     url(r"^(?P<issue_id>[^\/]+)/stats/$", GroupStatsEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/tags/$", GroupTagsEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/tags/(?P<key>[^/]+)/$", GroupTagKeyDetailsEndpoint.as_view()),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1199,6 +1199,9 @@ SENTRY_SUSPECT_COMMITS_APM_SAMPLING = 0
 # sample rate for post_process_group task
 SENTRY_POST_PROCESS_GROUP_APM_SAMPLING = 0
 
+# sample rate for all reprocessing tasks (except for the per-event ones)
+SENTRY_REPROCESSING_APM_SAMPLING = 0
+
 # ----
 # end APM config
 # ----

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -514,6 +514,8 @@ def start_group_reprocessing(
         referrer="reprocessing2.start_group_reprocessing",
     )["data"][0]["times_seen"]
 
+    sentry_sdk.set_extra("event_count", event_count)
+
     if max_events is not None:
         event_count = min(max_events, event_count)
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -69,6 +69,8 @@ SAMPLED_URL_NAMES = {
     "sentry-logout": 0.1,
     "sentry-register": settings.SAMPLED_DEFAULT_RATE,
     "sentry-2fa-dialog": settings.SAMPLED_DEFAULT_RATE,
+    # reprocessing
+    "sentry-api-0-issues-reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
 }
 if settings.ADDITIONAL_SAMPLED_URLS:
     SAMPLED_URL_NAMES.update(settings.ADDITIONAL_SAMPLED_URLS)
@@ -84,6 +86,9 @@ SAMPLED_TASKS = {
     "sentry.tasks.app_store_connect.refresh_all_builds": settings.SENTRY_APPCONNECT_APM_SAMPLING,
     "sentry.tasks.process_suspect_commits": settings.SENTRY_SUSPECT_COMMITS_APM_SAMPLING,
     "sentry.tasks.post_process.post_process_group": settings.SENTRY_POST_PROCESS_GROUP_APM_SAMPLING,
+    "sentry.tasks.reprocessing2.handle_remaining_events": settings.SENTRY_REPROCESSING_APM_SAMPLING,
+    "sentry.tasks.reprocessing2.reprocess_group": settings.SENTRY_REPROCESSING_APM_SAMPLING,
+    "sentry.tasks.reprocessing2.finish_reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
 }
 
 


### PR DESCRIPTION


We have some metrics reported inconsistently reported via statsd and
sentry, I am not sure why they only show up sometimes but let me add
some more with explicit sample rate.