### PR TITLE
fix(api): N+1 db query in GroupSerializerBase._get_permalink

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -303,6 +303,8 @@ class GroupSerializerBase(Serializer):
         # should only have 1 org at this point
         organization_id = organization_id_list[0]
 
+        authorized = self._is_authorized(user, organization_id)
+
         # find all the integration installs that have issue tracking
         for integration in Integration.objects.filter(organizations=organization_id):
             if not (
@@ -383,6 +385,7 @@ class GroupSerializerBase(Serializer):
                 "resolution_type": resolution_type,
                 "resolution_actor": resolution_actor,
                 "share_id": share_ids.get(item.id),
+                "authorized": authorized,
             }
 
             result[item]["is_unhandled"] = bool(snuba_stats.get(item.id, {}).get("unhandled"))
@@ -447,30 +450,30 @@ class GroupSerializerBase(Serializer):
             status_label = "unresolved"
         return status_details, status_label
 
-    def _get_permalink(self, obj, user):
+    def _is_authorized(self, user, organization_id):
         # If user is not logged in and member of the organization,
         # do not return the permalink which contains private information i.e. org name.
         request = env.request
-        is_superuser = request and is_active_superuser(request) and request.user == user
+        if request and is_active_superuser(request) and request.user == user:
+            return True
 
         # If user is a sentry_app then it's a proxy user meaning we can't do a org lookup via `get_orgs()`
         # because the user isn't an org member. Instead we can use the auth token and the installation
         # it's associated with to find out what organization the token has access to.
-        is_valid_sentryapp = False
         if (
             request
             and getattr(request.user, "is_sentry_app", False)
             and isinstance(request.auth, ApiToken)
         ):
-            is_valid_sentryapp = SentryAppInstallationToken.objects.has_organization_access(
-                request.auth, obj.organization
-            )
+            if SentryAppInstallationToken.objects.has_organization_access(
+                request.auth, organization_id
+            ):
+                return True
 
-        if (
-            is_superuser
-            or is_valid_sentryapp
-            or (user.is_authenticated and user.get_orgs().filter(id=obj.organization.id).exists())
-        ):
+        return user.is_authenticated and user.get_orgs().filter(id=organization_id).exists()
+
+    def _get_permalink(self, attrs, obj):
+        if attrs["authorized"]:
             with sentry_sdk.start_span(op="GroupSerializerBase.serialize.permalink.build"):
                 return obj.get_absolute_url()
         else:
@@ -478,7 +481,7 @@ class GroupSerializerBase(Serializer):
 
     def serialize(self, obj, attrs, user):
         status_details, status_label = self._get_status(attrs, obj)
-        permalink = self._get_permalink(obj, user)
+        permalink = self._get_permalink(attrs, obj)
         is_subscribed, subscription_details = get_subscription_from_attributes(attrs)
         share_id = attrs["share_id"]
         group_dict = {

--- a/src/sentry/models/sentryappinstallationtoken.py
+++ b/src/sentry/models/sentryappinstallationtoken.py
@@ -7,7 +7,7 @@ from django.db.models import QuerySet
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model
 
 if TYPE_CHECKING:
-    from sentry.models import ApiToken, Organization
+    from sentry.models import ApiToken
 
 
 class SentryAppInstallationTokenManager(BaseManager):
@@ -40,12 +40,12 @@ class SentryAppInstallationTokenManager(BaseManager):
             organization_id=install_token.sentry_app_installation.organization_id
         )
 
-    def has_organization_access(self, token: ApiToken, organization: Organization) -> bool:
+    def has_organization_access(self, token: ApiToken, organization_id: int) -> bool:
         install_token = self._get_token(token)
         if not install_token:
             return False
 
-        return install_token.sentry_app_installation.organization_id == organization.id
+        return install_token.sentry_app_installation.organization_id == organization_id
 
 
 class SentryAppInstallationToken(Model):


### PR DESCRIPTION
The `_get_permalink` method was being invoked per object, and each time it is
invoked, it checks if the user is authorized to get the permalink. This change
moves the authorization check to `get_attr` to avoid this N+1 db query.