### PR TITLE
fix(dashboards): updated widgetQueries fetchTimeseriesData to preserve query order for timeseriesResults

### DIFF
--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -358,7 +358,11 @@ class WidgetQueries extends React.Component<Props, State> {
             widget.queries[requestIndex],
             rawResults
           );
-          // We insert at a specific index instead of just pushing to timeseriesResults since we need to preserve the order of results because order determines color
+          // When charting timeseriesData on echarts, color association to a timeseries result
+          // is order sensitive, ie series at index i on the timeseries array will use color at
+          // index i on the color array. This means that on multi series results, we need to make
+          // sure that the order of series in our results do not change between fetches to avoid
+          // coloring inconsistencies between renders.
           transformedResult.forEach((result, resultIndex) => {
             timeseriesResults[requestIndex * transformedResult.length + resultIndex] =
               result;

--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -341,7 +341,7 @@ class WidgetQueries extends React.Component<Props, State> {
     });
 
     let completed = 0;
-    promises.forEach(async (promise, i) => {
+    promises.forEach(async (promise, requestIndex) => {
       try {
         const rawResults = await promise;
         if (!this._isMounted) {
@@ -353,12 +353,19 @@ class WidgetQueries extends React.Component<Props, State> {
             return prevState;
           }
 
-          const timeseriesResults = (prevState.timeseriesResults ?? []).concat(
-            transformResult(widget.queries[i], rawResults)
+          const timeseriesResults = [...(prevState.timeseriesResults ?? [])];
+          const transformedResult = transformResult(
+            widget.queries[requestIndex],
+            rawResults
           );
+          // We insert at a specific index instead of just pushing to timeseriesResults since we need to preserve the order of results because order determines color
+          transformedResult.forEach((result, resultIndex) => {
+            timeseriesResults[requestIndex * transformedResult.length + resultIndex] =
+              result;
+          });
 
           const rawResultsClone = cloneDeep(prevState.rawResults ?? []);
-          rawResultsClone[i] = rawResults;
+          rawResultsClone[requestIndex] = rawResults;
 
           return {
             ...prevState,


### PR DESCRIPTION
`WidgetQueries` returns `timeseriesResults` in order of which queries finished first. This can vary depending on response times on the same set of requests. `timeseriesResults` order determines what colour each series will get when displayed on the widget chart.

This update preserves the widget query order in `timeseriesResults` so that colours will remain the same across multiple executions of the same `WidgetQueries`