### PR TITLE
feat: Only apply permissions to superusers

### DIFF
--- a/src/sentry/api/endpoints/broadcast_details.py
+++ b/src/sentry/api/endpoints/broadcast_details.py
@@ -9,7 +9,6 @@ from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import AdminBroadcastSerializer, BroadcastSerializer, serialize
 from sentry.api.validators import AdminBroadcastValidator, BroadcastValidator
-from sentry.auth.superuser import has_superuser_permission
 from sentry.models import Broadcast, BroadcastSeen
 
 logger = logging.getLogger("sentry")
@@ -19,7 +18,7 @@ class BroadcastDetailsEndpoint(Endpoint):
     permission_classes = (IsAuthenticated,)
 
     def _get_broadcast(self, request, broadcast_id):
-        if has_superuser_permission(request, "broadcasts.admin"):
+        if request.access.has_permission("broadcasts.admin"):
             queryset = Broadcast.objects.all()
         else:
             queryset = Broadcast.objects.filter(
@@ -31,12 +30,12 @@ class BroadcastDetailsEndpoint(Endpoint):
             raise ResourceDoesNotExist
 
     def _get_validator(self, request):
-        if has_superuser_permission(request, "broadcasts.admin"):
+        if request.access.has_permission("broadcasts.admin"):
             return AdminBroadcastValidator
         return BroadcastValidator
 
     def _get_serializer(self, request):
-        if has_superuser_permission(request, "broadcasts.admin"):
+        if request.access.has_permission("broadcasts.admin"):
             return AdminBroadcastSerializer
         return BroadcastSerializer
 

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -16,7 +16,6 @@ from sentry.api.decorators import sudo_required
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import DetailedUserSerializer
 from sentry.api.serializers.rest_framework import ListField
-from sentry.auth.superuser import has_superuser_permission
 from sentry.constants import LANGUAGES
 from sentry.models import Organization, OrganizationMember, OrganizationStatus, User, UserOption
 
@@ -142,7 +141,7 @@ class UserDetailsEndpoint(UserEndpoint):
         :auth: required
         """
 
-        if has_superuser_permission(request, "users.admin"):
+        if request.access.has_permission("users.admin"):
             serializer_cls = PrivilegedUserSerializer
         else:
             serializer_cls = UserSerializer
@@ -246,7 +245,7 @@ class UserDetailsEndpoint(UserEndpoint):
         hard_delete = serializer.validated_data.get("hardDelete", False)
 
         # Only active superusers can hard delete accounts
-        if hard_delete and not has_superuser_permission(request, "users.admin"):
+        if hard_delete and not request.access.has_permission("users.admin"):
             return Response(
                 {"detail": "Missing required permission to hard delete account."},
                 status=status.HTTP_403_FORBIDDEN,

--- a/src/sentry/api/endpoints/user_permission_details.py
+++ b/src/sentry/api/endpoints/user_permission_details.py
@@ -1,7 +1,6 @@
 from django.db import IntegrityError, transaction
 
 from sentry.api.bases.user import UserEndpoint
-from sentry.auth.superuser import has_superuser_permission
 from sentry.models import UserPermission
 
 
@@ -11,7 +10,7 @@ class UserPermissionDetailsEndpoint(UserEndpoint):
         return self.respond(status=204 if has_perm else 404)
 
     def post(self, request, user, permission_name):
-        if not has_superuser_permission(request, "users.admin"):
+        if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 
         try:
@@ -24,7 +23,7 @@ class UserPermissionDetailsEndpoint(UserEndpoint):
         return self.respond(status=201)
 
     def delete(self, request, user, permission_name):
-        if not has_superuser_permission(request, "users.admin"):
+        if not request.access.has_permission("users.admin"):
             return self.respond(status=403)
 
         deleted, _ = UserPermission.objects.filter(user=user, permission=permission_name).delete()

--- a/src/sentry/auth/superuser.py
+++ b/src/sentry/auth/superuser.py
@@ -58,10 +58,6 @@ def is_active_superuser(request):
     return su.is_active
 
 
-def has_superuser_permission(request, permission):
-    return is_active_superuser(request) and request.access.has_permission(permission)
-
-
 class Superuser:
     allowed_ips = [ipaddress.ip_network(str(v), strict=False) for v in ALLOWED_IPS]
 
@@ -131,7 +127,7 @@ class Superuser:
                     "superuser.missing-cookie-token",
                     extra={"ip_address": request.META["REMOTE_ADDR"], "user_id": request.user.id},
                 )
-            return False
+            return
         elif not data:
             logger.warning(
                 "superuser.missing-session-data",

--- a/src/sentry/models/userpermission.py
+++ b/src/sentry/models/userpermission.py
@@ -4,6 +4,12 @@ from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 
 
 class UserPermission(Model):
+    """
+    Permissions are applied to administrative users and control explicit scope-like permissions within the API.
+
+    Generally speaking, they should only apply to active superuser sessions.
+    """
+
     __include_in_export__ = True
 
     user = FlexibleForeignKey("sentry.User")

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -179,21 +179,23 @@ class BaseTestCase(Fixtures, Exam):
         self.client.cookies[name] = value
         self.client.cookies[name].update({k.replace("_", "-"): v for k, v in params.items()})
 
-    def make_request(self, user=None, auth=None, method=None):
+    def make_request(self, user=None, auth=None, method=None, is_superuser=False):
         request = HttpRequest()
         if method:
             request.method = method
         request.META["REMOTE_ADDR"] = "127.0.0.1"
         request.META["SERVER_NAME"] = "testserver"
         request.META["SERVER_PORT"] = 80
-        request.GET = {}
-        request.POST = {}
 
         # order matters here, session -> user -> other things
         request.session = self.session
         request.auth = auth
         request.user = user or AnonymousUser()
+        # must happen after request.user/request.session is populated
         request.superuser = Superuser(request)
+        if is_superuser:
+            # XXX: this is gross, but its a one off and apis change only once in a great while
+            request.superuser.set_logged_in(user)
         request.is_superuser = lambda: request.superuser.is_active
         request.successful_authenticator = None
         return request

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -88,7 +88,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         )
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 36
+        expected_queries = 35
 
         # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
         expected_queries += 1

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -41,8 +41,7 @@ class EndpointTest(APITestCase):
         org = self.create_organization()
         apikey = ApiKey.objects.create(organization=org, allowed_origins="*")
 
-        request = HttpRequest()
-        request.method = "GET"
+        request = self.make_request(method="GET")
         request.META["HTTP_ORIGIN"] = "http://example.com"
         request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
             apikey.key.encode("utf-8")
@@ -56,8 +55,7 @@ class EndpointTest(APITestCase):
         assert response["Access-Control-Allow-Origin"] == "http://example.com"
 
     def test_invalid_cors_without_auth(self):
-        request = HttpRequest()
-        request.method = "GET"
+        request = self.make_request(method="GET")
         request.META["HTTP_ORIGIN"] = "http://example.com"
 
         with self.settings(SENTRY_ALLOW_ORIGIN="https://sentry.io"):
@@ -67,8 +65,7 @@ class EndpointTest(APITestCase):
         assert response.status_code == 400, response.content
 
     def test_valid_cors_without_auth(self):
-        request = HttpRequest()
-        request.method = "GET"
+        request = self.make_request(method="GET")
         request.META["HTTP_ORIGIN"] = "http://example.com"
 
         with self.settings(SENTRY_ALLOW_ORIGIN="*"):
@@ -80,8 +77,7 @@ class EndpointTest(APITestCase):
 
     # XXX(dcramer): The default setting needs to allow requests to work or it will be a regression
     def test_cors_not_configured_is_valid(self):
-        request = HttpRequest()
-        request.method = "GET"
+        request = self.make_request(method="GET")
         request.META["HTTP_ORIGIN"] = "http://example.com"
 
         with self.settings(SENTRY_ALLOW_ORIGIN=None):
@@ -95,8 +91,7 @@ class EndpointTest(APITestCase):
 class PaginateTest(APITestCase):
     def setUp(self):
         super().setUp()
-        self.request = HttpRequest()
-        self.request.method = "GET"
+        self.request = self.make_request(method="GET")
         self.view = DummyPaginationEndpoint().as_view()
 
     def test_success(self):

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.auth import access
-from sentry.models import AuthIdentity, AuthProvider, ObjectStatus, Organization
+from sentry.models import AuthIdentity, AuthProvider, ObjectStatus, Organization, UserPermission
 from sentry.testutils import TestCase
 
 
@@ -27,6 +27,7 @@ class FromUserTest(TestCase):
             assert not result.has_projects_access([project])
             assert not result.has_project_scope(project, "project:read")
             assert not result.has_project_membership(project)
+            assert not result.permissions
 
     def test_no_deleted_projects(self):
         user = self.create_user()
@@ -223,6 +224,30 @@ class FromUserTest(TestCase):
         for result in results:
             assert result is access.DEFAULT
 
+    def test_superuser_permissions(self):
+        user = self.create_user(is_superuser=True)
+        UserPermission.objects.create(user=user, permission="test.permission")
+
+        result = access.from_user(user)
+        assert not result.has_permission("test.permission")
+
+        result = access.from_user(user, is_superuser=True)
+        assert result.has_permission("test.permission")
+
+
+class FromRequestTest(TestCase):
+    def test_superuser(self):
+        user = self.create_user(is_superuser=True)
+        UserPermission.objects.create(user=user, permission="test.permission")
+
+        request = self.make_request(user=user, is_superuser=False)
+        result = access.from_request(request)
+        assert not result.has_permission("test.permission")
+
+        request = self.make_request(user=user, is_superuser=True)
+        result = access.from_request(request)
+        assert result.has_permission("test.permission")
+
 
 class FromSentryAppTest(TestCase):
     def setUp(self):
@@ -267,6 +292,7 @@ class FromSentryAppTest(TestCase):
         assert result.teams == [self.team]
         assert result.has_project_access(self.project)
         assert not result.has_project_access(self.out_of_scope_project)
+        assert not result.permissions
 
     def test_no_access_due_to_no_installation_unowned(self):
         request = self.make_request(user=self.proxy_user)
@@ -320,3 +346,4 @@ class DefaultAccessTest(TestCase):
         assert not result.has_projects_access([Mock()])
         assert not result.has_project_scope(Mock(), "project:read")
         assert not result.has_project_membership(Mock())
+        assert not result.permissions


### PR DESCRIPTION
Adjust `request.access` to only apply `permissions` when an active superuser session is available.

Additionally remove the extra check for superuser in various code paths.
