### PR TITLE
fix(appstore-connect): Relax timeout for build fetching [NATIVE-294]

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 AppConnectCredentials = namedtuple("AppConnectCredentials", ["key_id", "key", "issuer_id"])
 
-REQUEST_TIMEOUT = 15.0
+REQUEST_TIMEOUT = 30.0
 
 
 class RequestError(Exception):
@@ -137,8 +137,8 @@ def _get_appstore_json(
             full_url = ""
         full_url += url
         logger.debug(f"GET {full_url}")
-        with sentry_sdk.start_span(op="http", description="AppStoreConnect request"):
-            response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT * 2)
+        with sentry_sdk.start_transaction(op="http", description="AppStoreConnect request"):
+            response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT)
         if not response.ok:
             err_info = {
                 "url": full_url,

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -138,7 +138,7 @@ def _get_appstore_json(
         full_url += url
         logger.debug(f"GET {full_url}")
         with sentry_sdk.start_span(op="http", description="AppStoreConnect request"):
-            response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT)
+            response = session.get(full_url, headers=headers, timeout=REQUEST_TIMEOUT * 2)
         if not response.ok:
             err_info = {
                 "url": full_url,


### PR DESCRIPTION
Tries to cut down on instances of SENTRY-FOR-SENTRY-F0V.

