### PR TITLE
fix(ui): Adjust metric alert chart rule change gray area boundaries

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -57,6 +57,10 @@ import {
 
 import {TimePeriodType} from './constants';
 
+// Left and right padding are the gaps between the area that chart is drawn and
+// the boundaries of the entire svg in echarts. Vertical padding is similarly,
+// for the gap between the boundary and the x axis. These are used to contain the
+// graphics elements we draw in the chart area where series are drawn
 const LEFT_PADDING = 30;
 const RIGHT_PADDING = 17;
 const VERTICAL_PADDING = 22;

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -57,7 +57,8 @@ import {
 
 import {TimePeriodType} from './constants';
 
-const X_AXIS_BOUNDARY_GAP = 20;
+const LEFT_PADDING = 30;
+const RIGHT_PADDING = 17;
 const VERTICAL_PADDING = 22;
 
 type Props = WithRouterProps & {
@@ -243,9 +244,9 @@ class MetricChart extends React.PureComponent<Props, State> {
       return [];
     }
 
-    const chartWidth = width - X_AXIS_BOUNDARY_GAP;
+    const chartWidth = width - (LEFT_PADDING + RIGHT_PADDING);
     const position =
-      X_AXIS_BOUNDARY_GAP +
+      LEFT_PADDING +
       Math.round((chartWidth * (ruleChanged - seriesStart)) / (seriesEnd - seriesStart));
 
     return [
@@ -261,10 +262,10 @@ class MetricChart extends React.PureComponent<Props, State> {
       {
         type: 'rect',
         draggable: false,
-        position: [X_AXIS_BOUNDARY_GAP, 0],
+        position: [LEFT_PADDING, 0],
         shape: {
           // +1 makes the gray area go midway onto the dashed line above
-          width: position - X_AXIS_BOUNDARY_GAP + 1,
+          width: position - LEFT_PADDING + 1,
           height: height - VERTICAL_PADDING,
         },
         style: {

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -242,7 +242,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         type: 'line',
         markLine: MarkLine({
           silent: true,
-          lineStyle: {color: theme.gray200, type: 'dashed', width: 1},
+          lineStyle: {color: theme.gray200, width: 1},
           data: [{xAxis: ruleChanged} as any],
           label: {
             show: false,

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -242,7 +242,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         type: 'line',
         markLine: MarkLine({
           silent: true,
-          lineStyle: {color: theme.gray200, width: 1},
+          lineStyle: {color: theme.gray200, type: 'solid', width: 1},
           data: [{xAxis: ruleChanged} as any],
           label: {
             show: false,


### PR DESCRIPTION
This changes the gray area and alert change marker in the alert details from a graphic rectangle and line to MarkArea and MarkLine. Using these is better than graphics because the boundaries are much more accurate. Even though we lose the overflowing effect of using graphics, the confusion due to inaccuracy of them was greater.

Old metric alert (non-session):

![Screen Shot 2021-11-08 at 10 14 39 PM](https://user-images.githubusercontent.com/15015880/140878765-c0cf81e1-ee0b-41a5-ba77-b8c427410182.png)

Old session alert:

![Screen Shot 2021-11-08 at 10 14 29 PM](https://user-images.githubusercontent.com/15015880/140878818-809d5235-95ae-49b1-9cbf-48754ba79e38.png)


New metric alert:

![Screen Shot 2021-11-08 at 11 20 12 PM](https://user-images.githubusercontent.com/15015880/140880415-3ff921c4-342e-45ef-ac6d-ae4f3b0435ac.png)

New session alert:

![Screen Shot 2021-11-08 at 11 26 42 PM](https://user-images.githubusercontent.com/15015880/140880427-2b8fffba-b3a8-45d7-a00b-73da0462e153.png)


Jira: [WOR-1452](https://getsentry.atlassian.net/browse/WOR-1452) 