### PR TITLE
fix(appstore-connect): Add a new endpoint that returns the status of all configured apps [NATIVE-294]

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -459,7 +459,7 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
 
     def get(self, request: Request, project: Project) -> Response:
         config_ids = appconnect.AppStoreConnectConfig.all_config_ids(project)
-        statuses = []
+        statuses = {}
         for config_id in config_ids:
             try:
                 symbol_source_cfg = appconnect.AppStoreConnectConfig.from_project_config(
@@ -523,15 +523,13 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
             else:
                 last_checked_builds = check_entry.last_checked
 
-            statuses.append(
-                {
-                    "id": config_id,
-                    "credentials": asc_credentials,
-                    "pendingDownloads": pending_downloads,
-                    "latestBuildVersion": latestBuildVersion,
-                    "latestBuildNumber": latestBuildNumber,
-                    "lastCheckedBuilds": last_checked_builds,
-                }
-            )
+            statuses[config_id] = {
+                "id": config_id,
+                "credentials": asc_credentials,
+                "pendingDownloads": pending_downloads,
+                "latestBuildVersion": latestBuildVersion,
+                "latestBuildNumber": latestBuildNumber,
+                "lastCheckedBuilds": last_checked_builds,
+            }
 
         return Response(statuses, status=200)

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -494,8 +494,9 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
                         "code": AppConnectAuthenticationError.code,
                     }
 
+            # TODO: is it possible to set up two configs pointing to the same app?
             pending_downloads = AppConnectBuild.objects.filter(
-                project=project, fetched=False
+                project=project, app_id=symbol_source_cfg.appId, fetched=False
             ).count()
 
             latest_build = (

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -481,17 +481,17 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
             except appstore_connect.UnauthorizedError:
                 asc_credentials = {
                     "status": "invalid",
-                    "code": AppConnectAuthenticationError().code,
+                    "code": AppConnectAuthenticationError.code,
                 }
             except appstore_connect.ForbiddenError:
-                asc_credentials = {"status": "invalid", "code": AppConnectForbiddenError().code}
+                asc_credentials = {"status": "invalid", "code": AppConnectForbiddenError.code}
             else:
                 if apps:
                     asc_credentials = {"status": "valid"}
                 else:
                     asc_credentials = {
                         "status": "invalid",
-                        "code": AppConnectAuthenticationError().code,
+                        "code": AppConnectAuthenticationError.code,
                     }
 
             asc_credentials = {

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -494,11 +494,6 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
                         "code": AppConnectAuthenticationError.code,
                     }
 
-            asc_credentials = {
-                "status": "invalid",
-                "code": AppConnectAuthenticationError().code,
-            }
-
             pending_downloads = AppConnectBuild.objects.filter(
                 project=project, fetched=False
             ).count()

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -421,21 +421,19 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
     """Returns a summary of the project's App Store Connect configuration
     and builds.
 
-    ``GET projects/{org_slug}/{proj_slug}/appstoreconnect/status``
+    ``GET projects/{org_slug}/{proj_slug}/appstoreconnect/status/``
 
     Response:
     ```json
-    [
-        {
-            "id": "abc123",
+    {
+       "abc123": {
             "credentials": { status: "valid" } | { status: "invalid", code: "app-connect-forbidden-error" },
             "pendingDownloads": 123,
             "latestBuildVersion: "9.8.7" | null,
             "latestBuildNumber": "987000" | null,
             "lastCheckedBuilds": "YYYY-MM-DDTHH:MM:SS.SSSSSSZ" | null
         },
-        {
-            "id": ...,
+        "...": {
             "credentials": ...,
             "pendingDownloads": ...,
             "latestBuildVersion: ...,
@@ -443,7 +441,7 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
             "lastCheckedBuilds": ...
         },
         ...
-    ]
+    }
     ```
 
     * ``pendingDownloads`` is the number of pending build dSYM downloads.
@@ -525,7 +523,6 @@ class AppStoreConnectStatusEndpoint(ProjectEndpoint):  # type: ignore
                 last_checked_builds = check_entry.last_checked
 
             statuses[config_id] = {
-                "id": config_id,
                 "credentials": asc_credentials,
                 "pendingDownloads": pending_downloads,
                 "latestBuildVersion": latestBuildVersion,

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -97,6 +97,12 @@ class TwoFactorRequired(SentryAPIException):
     message = "Organization requires two-factor authentication to be enabled"
 
 
+class AppConnectForbiddenError(SentryAPIException):
+    status_code = status.HTTP_403_FORBIDDEN
+    code = "app-connect-forbidden-error"
+    message = "App connect Forbidden error"
+
+
 class AppConnectAuthenticationError(SentryAPIException):
     status_code = status.HTTP_401_UNAUTHORIZED
     code = "app-connect-authentication-error"

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2034,7 +2034,7 @@ urlpatterns = [
                     name="sentry-api-0-project-appstoreconnect-credentials-update",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/status/(?P<credentials_id>[^\/]+)$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/status$",
                     AppStoreConnectStatusEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-status",
                 ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2029,14 +2029,14 @@ urlpatterns = [
                     name="sentry-api-0-project-appstoreconnect-validate",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
-                    AppStoreConnectUpdateCredentialsEndpoint.as_view(),
-                    name="sentry-api-0-project-appstoreconnect-credentials-update",
-                ),
-                url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/status/$",
                     AppStoreConnectStatusEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-status",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
+                    AppStoreConnectUpdateCredentialsEndpoint.as_view(),
+                    name="sentry-api-0-project-appstoreconnect-credentials-update",
                 ),
             ]
         ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -282,6 +282,7 @@ from .endpoints.project_app_store_connect_credentials import (
     AppStoreConnectAppsEndpoint,
     AppStoreConnectCreateCredentialsEndpoint,
     AppStoreConnectCredentialsValidateEndpoint,
+    AppStoreConnectStatusEndpoint,
     AppStoreConnectUpdateCredentialsEndpoint,
 )
 from .endpoints.project_avatar import ProjectAvatarEndpoint
@@ -2031,6 +2032,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/(?P<credentials_id>[^\/]+)/$",
                     AppStoreConnectUpdateCredentialsEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-credentials-update",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/status/(?P<credentials_id>[^\/]+)$",
+                    AppStoreConnectStatusEndpoint.as_view(),
+                    name="sentry-api-0-project-appstoreconnect-status",
                 ),
             ]
         ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -2034,7 +2034,7 @@ urlpatterns = [
                     name="sentry-api-0-project-appstoreconnect-credentials-update",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/status$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/appstoreconnect/status/$",
                     AppStoreConnectStatusEndpoint.as_view(),
                     name="sentry-api-0-project-appstoreconnect-status",
                 ),

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -36,7 +36,7 @@ class UnauthorizedError(RequestError):
 
 
 class ForbiddenError(RequestError):
-    """The App Store Connect session does not have access to the requested dSYM."""
+    """Forbidden: authentication token does not have sufficient permissions."""
 
     pass
 
@@ -154,6 +154,8 @@ def _get_appstore_json(
 
             if response.status_code == HTTPStatus.UNAUTHORIZED:
                 raise UnauthorizedError(full_url)
+            elif response.status_code == HTTPStatus.FORBIDDEN:
+                raise ForbiddenError(full_url)
             else:
                 raise RequestError(full_url)
         try:

--- a/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
+++ b/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
@@ -11,7 +11,7 @@ import {IconClose, IconRefresh} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
-import {AppStoreConnectValidationData} from 'app/types/debugFiles';
+import {AppStoreConnectStatusData} from 'app/types/debugFiles';
 import {promptIsDismissed} from 'app/utils/promptIsDismissed';
 import withApi from 'app/utils/withApi';
 
@@ -69,14 +69,14 @@ function UpdateAlert({api, Wrapper, isCompact, project, organization, className}
   }
 
   function renderMessage(
-    appStoreConnectValidationData: AppStoreConnectValidationData,
+    appStoreConnectStatusData: AppStoreConnectStatusData,
     projectSettingsLink: string
   ) {
-    if (!appStoreConnectValidationData.updateAlertMessage) {
+    if (!appStoreConnectStatusData.updateAlertMessage) {
       return null;
     }
 
-    const {updateAlertMessage} = appStoreConnectValidationData;
+    const {updateAlertMessage} = appStoreConnectStatusData;
 
     return (
       <div>

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
@@ -9,7 +9,6 @@ import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {AppStoreConnectContextProps} from 'app/components/projects/appStoreConnectContext';
-import {appStoreConnectAlertMessage} from 'app/components/projects/appStoreConnectContext/utils';
 import {IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
@@ -57,7 +56,7 @@ function AppStoreConnect({
   onSubmit,
   appStoreConnectContext,
 }: Props) {
-  const {updateAlertMessage} = appStoreConnectContext ?? {};
+  const {credentials} = appStoreConnectContext ?? {};
 
   const [isLoading, setIsLoading] = useState(false);
   const [activeStep, setActiveStep] = useState(0);
@@ -114,6 +113,7 @@ function AppStoreConnect({
       const appStoreConnnectError = getAppStoreErrorMessage(error);
       if (typeof appStoreConnnectError === 'string') {
         // app-connect-authentication-error
+        // 'app-connect-forbidden-error'
         addErrorMessage(appStoreConnnectError);
         return;
       }
@@ -238,15 +238,27 @@ function AppStoreConnect({
     if (activeStep !== 0) {
       return alerts;
     }
-
-    if (updateAlertMessage === appStoreConnectAlertMessage.appStoreCredentialsInvalid) {
-      alerts.push(
-        <StyledAlert type="warning" icon={<IconWarning />}>
-          {t(
-            'Your App Store Connect credentials are invalid. To reconnect, update your credentials.'
-          )}
-        </StyledAlert>
-      );
+    if (credentials?.status === 'invalid') {
+      switch (credentials.code) {
+        case 'app-connect-forbidden-error':
+          alerts.push(
+            <StyledAlert type="warning" icon={<IconWarning />}>
+              {t(
+                'Your App Store Connect credentials have insufficient permissions. To reconnect, update your credentials.'
+              )}
+            </StyledAlert>
+          );
+          break;
+        case 'app-connect-authentication-error':
+        default:
+          alerts.push(
+            <StyledAlert type="warning" icon={<IconWarning />}>
+              {t(
+                'Your App Store Connect credentials are invalid. To reconnect, update your credentials.'
+              )}
+            </StyledAlert>
+          );
+      }
     }
 
     return alerts;

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/index.tsx
@@ -113,7 +113,7 @@ function AppStoreConnect({
       const appStoreConnnectError = getAppStoreErrorMessage(error);
       if (typeof appStoreConnnectError === 'string') {
         // app-connect-authentication-error
-        // 'app-connect-forbidden-error'
+        // app-connect-forbidden-error
         addErrorMessage(appStoreConnnectError);
         return;
       }
@@ -239,26 +239,17 @@ function AppStoreConnect({
       return alerts;
     }
     if (credentials?.status === 'invalid') {
-      switch (credentials.code) {
-        case 'app-connect-forbidden-error':
-          alerts.push(
-            <StyledAlert type="warning" icon={<IconWarning />}>
-              {t(
+      alerts.push(
+        <StyledAlert type="warning" icon={<IconWarning />}>
+          {credentials.code === 'app-connect-forbidden-error'
+            ? t(
                 'Your App Store Connect credentials have insufficient permissions. To reconnect, update your credentials.'
-              )}
-            </StyledAlert>
-          );
-          break;
-        case 'app-connect-authentication-error':
-        default:
-          alerts.push(
-            <StyledAlert type="warning" icon={<IconWarning />}>
-              {t(
+              )
+            : t(
                 'Your App Store Connect credentials are invalid. To reconnect, update your credentials.'
               )}
-            </StyledAlert>
-          );
-      }
+        </StyledAlert>
+      );
     }
 
     return alerts;

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/utils.tsx
@@ -113,7 +113,7 @@ export function getAppStoreValidationErrorMessage(
   switch (error.code) {
     case 'app-connect-authentication-error':
       return t(
-        'Credentials are invalid, missing, or expired. Check the entered App Store Connect credentials are correct and have not expired.'
+        'Credentials are invalid or missing. Check the entered App Store Connect credentials are correct.'
       );
     case 'app-connect-forbidden-error':
       return t('The supplied API key does not have sufficient permissions.');

--- a/static/app/components/projects/appStoreConnectContext/index.tsx
+++ b/static/app/components/projects/appStoreConnectContext/index.tsx
@@ -95,7 +95,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
           ? {
               ...appStoreConnectValidationData,
               updateAlertMessage: getAppConnectStoreUpdateAlertMessage(
-                appStoreConnectValidationData
+                appStoreConnectValidationData.credentials
               ),
             }
           : undefined

--- a/static/app/components/projects/appStoreConnectContext/index.tsx
+++ b/static/app/components/projects/appStoreConnectContext/index.tsx
@@ -1,10 +1,10 @@
 import {createContext, useEffect, useState} from 'react';
 
 import {Organization, Project} from 'app/types';
-import {AppStoreConnectValidationData} from 'app/types/debugFiles';
+import {AppStoreConnectStatusData} from 'app/types/debugFiles';
 import useApi from 'app/utils/useApi';
 
-export type AppStoreConnectContextProps = AppStoreConnectValidationData | undefined;
+export type AppStoreConnectContextProps = AppStoreConnectStatusData | undefined;
 
 const AppStoreConnectContext = createContext<AppStoreConnectContextProps>(undefined);
 
@@ -20,7 +20,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
   const api = useApi();
 
   const [projectDetails, setProjectDetails] = useState<undefined | Project>();
-  const [appStoreConnectValidationData, setAppStoreConnectValidationData] =
+  const [appStoreConnectStatusData, setAppStoreConnectStatusData] =
     useState<AppStoreConnectContextProps>(undefined);
 
   const orgSlug = organization.slug;
@@ -30,7 +30,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
   }, [project]);
 
   useEffect(() => {
-    fetchAppStoreConnectValidationData();
+    fetchAppStoreConnectStatusData();
   }, [projectDetails]);
 
   async function fetchProjectDetails() {
@@ -57,7 +57,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
     )?.id;
   }
 
-  async function fetchAppStoreConnectValidationData() {
+  async function fetchAppStoreConnectStatusData() {
     if (!projectDetails) {
       return;
     }
@@ -71,15 +71,14 @@ const Provider = ({children, project, organization}: ProviderProps) => {
     }
 
     try {
-      const response: Map<string, AppStoreConnectValidationData> =
-        await api.requestPromise(
-          `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status`
-        );
+      const response: Map<string, AppStoreConnectStatusData> = await api.requestPromise(
+        `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status`
+      );
 
-      const sourceStatus: AppStoreConnectValidationData | undefined =
+      const sourceStatus: AppStoreConnectStatusData | undefined =
         response[appStoreConnectSymbolSourceId];
       if (sourceStatus) {
-        setAppStoreConnectValidationData(sourceStatus);
+        setAppStoreConnectStatusData(sourceStatus);
       }
     } catch {
       // do nothing
@@ -89,11 +88,11 @@ const Provider = ({children, project, organization}: ProviderProps) => {
   return (
     <AppStoreConnectContext.Provider
       value={
-        appStoreConnectValidationData
+        appStoreConnectStatusData
           ? {
-              ...appStoreConnectValidationData,
+              ...appStoreConnectStatusData,
               updateAlertMessage: getAppConnectStoreUpdateAlertMessage(
-                appStoreConnectValidationData.credentials
+                appStoreConnectStatusData.credentials
               ),
             }
           : undefined

--- a/static/app/components/projects/appStoreConnectContext/index.tsx
+++ b/static/app/components/projects/appStoreConnectContext/index.tsx
@@ -71,15 +71,13 @@ const Provider = ({children, project, organization}: ProviderProps) => {
     }
 
     try {
-      const response: AppStoreConnectValidationData[] = await api.requestPromise(
-        `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status`
-      );
+      const response: Map<string, AppStoreConnectValidationData> =
+        await api.requestPromise(
+          `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status`
+        );
 
-      const sourceStatus = response.find(
-        s => s.id === appStoreConnectSymbolSourceId,
-        response
-      );
-
+      const sourceStatus: AppStoreConnectValidationData | undefined =
+        response[appStoreConnectSymbolSourceId];
       if (sourceStatus) {
         setAppStoreConnectValidationData(sourceStatus);
       }

--- a/static/app/components/projects/appStoreConnectContext/index.tsx
+++ b/static/app/components/projects/appStoreConnectContext/index.tsx
@@ -71,13 +71,18 @@ const Provider = ({children, project, organization}: ProviderProps) => {
     }
 
     try {
-      const response = await api.requestPromise(
-        `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/validate/${appStoreConnectSymbolSourceId}/`
+      const response: AppStoreConnectValidationData[] = await api.requestPromise(
+        `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status`
       );
-      setAppStoreConnectValidationData({
-        id: appStoreConnectSymbolSourceId,
-        ...response,
-      });
+
+      const sourceStatus = response.find(
+        s => s.id === appStoreConnectSymbolSourceId,
+        response
+      );
+
+      if (sourceStatus) {
+        setAppStoreConnectValidationData(sourceStatus);
+      }
     } catch {
       // do nothing
     }

--- a/static/app/components/projects/appStoreConnectContext/index.tsx
+++ b/static/app/components/projects/appStoreConnectContext/index.tsx
@@ -75,10 +75,13 @@ const Provider = ({children, project, organization}: ProviderProps) => {
         `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status/`
       );
 
-      const sourceStatus: AppStoreConnectStatusData | undefined =
+      const sourceStatus: Omit<AppStoreConnectStatusData, 'id'> | undefined =
         response[appStoreConnectSymbolSourceId];
       if (sourceStatus) {
-        setAppStoreConnectStatusData(sourceStatus);
+        setAppStoreConnectStatusData({
+          ...sourceStatus,
+          id: appStoreConnectSymbolSourceId,
+        });
       }
     } catch {
       // do nothing

--- a/static/app/components/projects/appStoreConnectContext/index.tsx
+++ b/static/app/components/projects/appStoreConnectContext/index.tsx
@@ -72,7 +72,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
 
     try {
       const response: Map<string, AppStoreConnectStatusData> = await api.requestPromise(
-        `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status`
+        `/projects/${orgSlug}/${projectDetails.slug}/appstoreconnect/status/`
       );
 
       const sourceStatus: AppStoreConnectStatusData | undefined =

--- a/static/app/components/projects/appStoreConnectContext/utils.tsx
+++ b/static/app/components/projects/appStoreConnectContext/utils.tsx
@@ -1,17 +1,20 @@
-import {t} from 'app/locale';
-import {AppStoreConnectValidationData} from 'app/types/debugFiles';
+import {
+  getAppStoreValidationErrorMessage,
+  ValidationErrorDetailed,
+} from 'app/components/modals/debugFileCustomRepository/appStoreConnect/utils';
+import {AppStoreConnectCredentialsStatus} from 'app/types/debugFiles';
 
-export const appStoreConnectAlertMessage = {
-  appStoreCredentialsInvalid: t(
-    'The credentials of your configured App Store Connect are invalid.'
-  ),
-};
+export function areAppStoreConnectCredentialsValid(
+  credentialsStatus: AppStoreConnectCredentialsStatus | undefined
+): boolean {
+  return credentialsStatus?.status === 'valid';
+}
 
 export function getAppConnectStoreUpdateAlertMessage(
-  appConnectValidationData: AppStoreConnectValidationData
-) {
-  if (appConnectValidationData.appstoreCredentialsValid === false) {
-    return appStoreConnectAlertMessage.appStoreCredentialsInvalid;
+  credentialsStatus: AppStoreConnectCredentialsStatus
+): string | undefined {
+  if (areAppStoreConnectCredentialsValid(credentialsStatus)) {
+    return undefined;
   }
-  return undefined;
+  return getAppStoreValidationErrorMessage(credentialsStatus as ValidationErrorDetailed);
 }

--- a/static/app/components/projects/appStoreConnectContext/utils.tsx
+++ b/static/app/components/projects/appStoreConnectContext/utils.tsx
@@ -6,13 +6,13 @@ import {AppStoreConnectCredentialsStatus} from 'app/types/debugFiles';
 
 export function areAppStoreConnectCredentialsValid(
   credentialsStatus: AppStoreConnectCredentialsStatus | undefined
-): boolean {
+) {
   return credentialsStatus?.status === 'valid';
 }
 
 export function getAppConnectStoreUpdateAlertMessage(
   credentialsStatus: AppStoreConnectCredentialsStatus
-): string | undefined {
+) {
   if (areAppStoreConnectCredentialsValid(credentialsStatus)) {
     return undefined;
   }

--- a/static/app/components/projects/appStoreConnectContext/utils.tsx
+++ b/static/app/components/projects/appStoreConnectContext/utils.tsx
@@ -4,16 +4,10 @@ import {
 } from 'app/components/modals/debugFileCustomRepository/appStoreConnect/utils';
 import {AppStoreConnectCredentialsStatus} from 'app/types/debugFiles';
 
-export function areAppStoreConnectCredentialsValid(
-  credentialsStatus: AppStoreConnectCredentialsStatus | undefined
-) {
-  return credentialsStatus?.status === 'valid';
-}
-
 export function getAppConnectStoreUpdateAlertMessage(
   credentialsStatus: AppStoreConnectCredentialsStatus
 ) {
-  if (areAppStoreConnectCredentialsValid(credentialsStatus)) {
+  if (credentialsStatus?.status === 'valid') {
     return undefined;
   }
   return getAppStoreValidationErrorMessage(credentialsStatus as ValidationErrorDetailed);

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -47,7 +47,7 @@ export type AppStoreConnectCredentialsStatus =
   | {status: 'valid'}
   | ({status: 'invalid'} & ValidationErrorDetailed);
 
-export type AppStoreConnectValidationData = {
+export type AppStoreConnectStatusData = {
   id: string;
   credentials: AppStoreConnectCredentialsStatus;
   /**
@@ -81,7 +81,7 @@ type CustomRepoAppStoreConnect = {
   bundleId: string;
   id: string;
   name: string;
-  details?: AppStoreConnectValidationData;
+  details?: AppStoreConnectStatusData;
 };
 
 type CustomRepoHttp = {

--- a/static/app/types/debugFiles.tsx
+++ b/static/app/types/debugFiles.tsx
@@ -1,3 +1,5 @@
+import {ValidationErrorDetailed} from 'app/components/modals/debugFileCustomRepository/appStoreConnect/utils';
+
 export enum DebugFileType {
   EXE = 'exe',
   DBG = 'dbg',
@@ -41,9 +43,13 @@ export enum CustomRepoType {
   APP_STORE_CONNECT = 'appStoreConnect',
 }
 
+export type AppStoreConnectCredentialsStatus =
+  | {status: 'valid'}
+  | ({status: 'invalid'} & ValidationErrorDetailed);
+
 export type AppStoreConnectValidationData = {
   id: string;
-  appstoreCredentialsValid: boolean;
+  credentials: AppStoreConnectCredentialsStatus;
   /**
    * Indicates the number of downloads waiting to be processed and completed,
    * or the number of downloads waiting for valid credentials to be completed if applicable.

--- a/static/app/views/settings/project/appStoreConnectContext.tsx
+++ b/static/app/views/settings/project/appStoreConnectContext.tsx
@@ -41,15 +41,13 @@ const Provider = withApi(
       }
 
       try {
-        const response: AppStoreConnectValidationData[] = await api.requestPromise(
-          `/projects/${orgSlug}/${project.slug}/appstoreconnect/status`
-        );
+        const response: Map<string, AppStoreConnectValidationData> =
+          await api.requestPromise(
+            `/projects/${orgSlug}/${project.slug}/appstoreconnect/status`
+          );
 
-        const sourceStatus = response.find(
-          s => s.id === appStoreConnectSymbolSourceId,
-          response
-        );
-
+        const sourceStatus: AppStoreConnectValidationData | undefined =
+          response[appStoreConnectSymbolSourceId];
         if (sourceStatus) {
           setAppStoreConnectValidationData(sourceStatus);
         }

--- a/static/app/views/settings/project/appStoreConnectContext.tsx
+++ b/static/app/views/settings/project/appStoreConnectContext.tsx
@@ -41,13 +41,18 @@ const Provider = withApi(
       }
 
       try {
-        const response = await api.requestPromise(
-          `/projects/${orgSlug}/${project.slug}/appstoreconnect/validate/${appStoreConnectSymbolSourceId}/`
+        const response: AppStoreConnectValidationData[] = await api.requestPromise(
+          `/projects/${orgSlug}/${project.slug}/appstoreconnect/status`
         );
-        setAppStoreConnectValidationData({
-          id: appStoreConnectSymbolSourceId,
-          ...response,
-        });
+
+        const sourceStatus = response.find(
+          s => s.id === appStoreConnectSymbolSourceId,
+          response
+        );
+
+        if (sourceStatus) {
+          setAppStoreConnectValidationData(sourceStatus);
+        }
       } catch {
         // do nothing
       }

--- a/static/app/views/settings/project/appStoreConnectContext.tsx
+++ b/static/app/views/settings/project/appStoreConnectContext.tsx
@@ -2,11 +2,11 @@ import {createContext, useEffect, useState} from 'react';
 
 import {Client} from 'app/api';
 import {Organization, Project} from 'app/types';
-import {AppStoreConnectValidationData} from 'app/types/debugFiles';
+import {AppStoreConnectStatusData} from 'app/types/debugFiles';
 import withApi from 'app/utils/withApi';
 import withProject from 'app/utils/withProject';
 
-const AppStoreConnectContext = createContext<AppStoreConnectValidationData | undefined>(
+const AppStoreConnectContext = createContext<AppStoreConnectStatusData | undefined>(
   undefined
 );
 
@@ -19,12 +19,12 @@ type ProviderProps = {
 
 const Provider = withApi(
   withProject(({api, children, project, orgSlug}: ProviderProps) => {
-    const [appStoreConnectValidationData, setAppStoreConnectValidationData] = useState<
-      AppStoreConnectValidationData | undefined
+    const [appStoreConnectStatusData, setAppStoreConnectStatusData] = useState<
+      AppStoreConnectStatusData | undefined
     >();
 
     useEffect(() => {
-      fetchAppStoreConnectValidationData();
+      fetchAppStoreConnectStatusData();
     }, [project]);
 
     function getAppStoreConnectSymbolSourceId() {
@@ -33,7 +33,7 @@ const Provider = withApi(
       )?.id;
     }
 
-    async function fetchAppStoreConnectValidationData() {
+    async function fetchAppStoreConnectStatusData() {
       const appStoreConnectSymbolSourceId = getAppStoreConnectSymbolSourceId();
 
       if (!appStoreConnectSymbolSourceId) {
@@ -41,15 +41,14 @@ const Provider = withApi(
       }
 
       try {
-        const response: Map<string, AppStoreConnectValidationData> =
-          await api.requestPromise(
-            `/projects/${orgSlug}/${project.slug}/appstoreconnect/status`
-          );
+        const response: Map<string, AppStoreConnectStatusData> = await api.requestPromise(
+          `/projects/${orgSlug}/${project.slug}/appstoreconnect/status`
+        );
 
-        const sourceStatus: AppStoreConnectValidationData | undefined =
+        const sourceStatus: AppStoreConnectStatusData | undefined =
           response[appStoreConnectSymbolSourceId];
         if (sourceStatus) {
-          setAppStoreConnectValidationData(sourceStatus);
+          setAppStoreConnectStatusData(sourceStatus);
         }
       } catch {
         // do nothing
@@ -57,7 +56,7 @@ const Provider = withApi(
     }
 
     return (
-      <AppStoreConnectContext.Provider value={appStoreConnectValidationData}>
+      <AppStoreConnectContext.Provider value={appStoreConnectStatusData}>
         {children}
       </AppStoreConnectContext.Provider>
     );

--- a/static/app/views/settings/project/appStoreConnectContext.tsx
+++ b/static/app/views/settings/project/appStoreConnectContext.tsx
@@ -42,7 +42,7 @@ const Provider = withApi(
 
       try {
         const response: Map<string, AppStoreConnectStatusData> = await api.requestPromise(
-          `/projects/${orgSlug}/${project.slug}/appstoreconnect/status`
+          `/projects/${orgSlug}/${project.slug}/appstoreconnect/status/`
         );
 
         const sourceStatus: AppStoreConnectStatusData | undefined =

--- a/static/app/views/settings/project/appStoreConnectContext.tsx
+++ b/static/app/views/settings/project/appStoreConnectContext.tsx
@@ -45,10 +45,13 @@ const Provider = withApi(
           `/projects/${orgSlug}/${project.slug}/appstoreconnect/status/`
         );
 
-        const sourceStatus: AppStoreConnectStatusData | undefined =
+        const sourceStatus: Omit<AppStoreConnectStatusData, 'id'> | undefined =
           response[appStoreConnectSymbolSourceId];
         if (sourceStatus) {
-          setAppStoreConnectStatusData(sourceStatus);
+          setAppStoreConnectStatusData({
+            ...sourceStatus,
+            id: appStoreConnectSymbolSourceId,
+          });
         }
       } catch {
         // do nothing

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/details.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/details.tsx
@@ -4,10 +4,10 @@ import DateTime from 'app/components/dateTime';
 import NotAvailable from 'app/components/notAvailable';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {AppStoreConnectValidationData} from 'app/types/debugFiles';
+import {AppStoreConnectStatusData} from 'app/types/debugFiles';
 
 type Props = {
-  details?: AppStoreConnectValidationData;
+  details?: AppStoreConnectStatusData;
 };
 
 function Details({details}: Props) {

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -10,11 +10,11 @@ import {IconRefresh} from 'app/icons/iconRefresh';
 import {IconWarning} from 'app/icons/iconWarning';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
-import {AppStoreConnectValidationData} from 'app/types/debugFiles';
+import {AppStoreConnectStatusData} from 'app/types/debugFiles';
 
 type Props = {
   onEditRepository: () => void;
-  details?: AppStoreConnectValidationData;
+  details?: AppStoreConnectStatusData;
 };
 
 function Status({details, onEditRepository}: Props) {

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -2,6 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Placeholder from 'app/components/placeholder';
+import {areAppStoreConnectCredentialsValid} from 'app/components/projects/appStoreConnectContext/utils';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import {IconDownload} from 'app/icons/iconDownload';
@@ -23,9 +24,9 @@ function Status({details, onEditRepository}: Props) {
     return <Placeholder height="14px" />;
   }
 
-  const {pendingDownloads, appstoreCredentialsValid, lastCheckedBuilds} = details ?? {};
+  const {pendingDownloads, credentials, lastCheckedBuilds} = details ?? {};
 
-  if (appstoreCredentialsValid === false) {
+  if (areAppStoreConnectCredentialsValid(credentials) === false) {
     return (
       <Wrapper color={theme.red300} onClick={onEditRepository}>
         <StyledTooltip

--- a/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/externalSources/customRepositories/status.tsx
@@ -2,7 +2,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Placeholder from 'app/components/placeholder';
-import {areAppStoreConnectCredentialsValid} from 'app/components/projects/appStoreConnectContext/utils';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import {IconDownload} from 'app/icons/iconDownload';
@@ -26,7 +25,7 @@ function Status({details, onEditRepository}: Props) {
 
   const {pendingDownloads, credentials, lastCheckedBuilds} = details ?? {};
 
-  if (areAppStoreConnectCredentialsValid(credentials) === false) {
+  if (credentials?.status === 'invalid') {
     return (
       <Wrapper color={theme.red300} onClick={onEditRepository}>
         <StyledTooltip


### PR DESCRIPTION
@ potential reviewers: i would really recommend reviewing this commit-by-commit, or to at least review the code without 3116b92 included as it performs a rename that only clutters the diff

This creates a new endpoint `appstoreconnect/status` meant to replace `appstoreconnect/validate/{id}/`.

This new endpoint does the following things differently from its predecessor:
- Returns more detailed diagnostics if API keys are invalid
- Returns statuses of all apps(/sources) configured for a project if multiple apps(/sources) are found for the project

The following frontend changes have been made in response:
- Parses the aforementioned more detailed diagnostics and shows more specific messages accordingly during update
- Handles lists of statuses being returned properly
- Since since the detailed diagnostics are going to be reused when validating the API keys when creating a new app(/source), some preliminary work has been done to use the same code to handle those diagnostics responses for both the `/validate` and the `/apps` endpoints.

## Screenshots
### When submitting invalid credentials (changed from "An unexpected error occurred while configuring...")
<img width="1028" alt="Screenshot 2021-11-04 at 12 13 46 AM" src="https://user-images.githubusercontent.com/5597345/140266511-74a38732-ea33-46b4-a6c0-ceb2aa8ab1f8.png">

### Inline warning
<img width="1022" alt="Screenshot 2021-11-04 at 12 11 22 AM" src="https://user-images.githubusercontent.com/5597345/140266510-f31b0337-ddc7-4a1b-891f-8149a00c03de.png">

### Context shown after clicking on inline warning
<img width="672" alt="Screenshot 2021-11-04 at 1 12 38 AM" src="https://user-images.githubusercontent.com/5597345/140266150-47ea23e6-f043-4bb9-a4f9-7bd2cfaa3d63.png">
<img width="688" alt="Screenshot 2021-11-04 at 1 13 18 AM" src="https://user-images.githubusercontent.com/5597345/140266152-bba6c0c5-f2fd-4a22-ade7-b3c6a499033e.png">
