### PR TITLE
feat(dashboards): Renamed dashboard Top Events Display Type to Top 5 Events

### DIFF
--- a/static/app/views/dashboardsV2/data.tsx
+++ b/static/app/views/dashboardsV2/data.tsx
@@ -17,7 +17,7 @@ export const DISPLAY_TYPE_CHOICES = [
   {label: t('Table'), value: 'table'},
   {label: t('World Map'), value: 'world_map'},
   {label: t('Big Number'), value: 'big_number'},
-  {label: t('Top Events'), value: 'top_n'},
+  {label: t('Top 5 Events'), value: 'top_n'},
 ];
 
 export const INTERVAL_CHOICES = [

--- a/static/app/views/dashboardsV2/widget/utils.tsx
+++ b/static/app/views/dashboardsV2/widget/utils.tsx
@@ -23,5 +23,5 @@ export const displayTypes = {
   [DisplayType.TABLE]: t('Table'),
   [DisplayType.WORLD_MAP]: t('World Map'),
   [DisplayType.BIG_NUMBER]: t('Big Number'),
-  [DisplayType.TOP_N]: t('Top Events'),
+  [DisplayType.TOP_N]: t('Top 5 Events'),
 };

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -875,7 +875,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       onAddWidget: data => (widget = data),
     });
     // Select Top n display
-    selectByLabel(wrapper, 'Top Events', {name: 'displayType', at: 0, control: true});
+    selectByLabel(wrapper, 'Top 5 Events', {name: 'displayType', at: 0, control: true});
     expect(getDisplayType(wrapper).props().value).toEqual('top_n');
 
     // No delete button as there is only one field.


### PR DESCRIPTION
Renamed dashboard Top Events Display Type to Top 5 Events to more closely match functionality.
![image](https://user-images.githubusercontent.com/83961295/140076097-1f9573a5-f79d-43ac-be65-275665dbb4b8.png)
