### PR TITLE
fix(perf): Landing v3 add min filter for fields

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -48,6 +48,15 @@ type DataType = {
   list: WidgetDataResult & ReturnType<typeof transformDiscoverToList>;
 };
 
+const slowList = [
+  PerformanceWidgetSetting.SLOW_HTTP_OPS,
+  PerformanceWidgetSetting.SLOW_DB_OPS,
+  PerformanceWidgetSetting.SLOW_BROWSER_OPS,
+  PerformanceWidgetSetting.SLOW_RESOURCE_OPS,
+  PerformanceWidgetSetting.MOST_SLOW_FRAMES,
+  PerformanceWidgetSetting.MOST_FROZEN_FRAMES,
+];
+
 export function LineChartListWidget(props: Props) {
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const {ContainerActions} = props;
@@ -57,31 +66,24 @@ export function LineChartListWidget(props: Props) {
       `Line chart list widget can only accept a single field (${props.fields})`
     );
   }
+  const field = props.fields[0];
 
-  const slowList = [
-    PerformanceWidgetSetting.SLOW_HTTP_OPS,
-    PerformanceWidgetSetting.SLOW_DB_OPS,
-    PerformanceWidgetSetting.SLOW_BROWSER_OPS,
-    PerformanceWidgetSetting.SLOW_RESOURCE_OPS,
-    PerformanceWidgetSetting.MOST_SLOW_FRAMES,
-    PerformanceWidgetSetting.MOST_FROZEN_FRAMES,
-  ];
   const isSlowestType = slowList.includes(props.chartSetting);
 
   const eventView = props.eventView.clone();
 
   const listQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
-      fields: props.fields[0],
+      fields: field,
       component: provided => {
-        eventView.sorts = [{kind: 'desc', field: props.fields[0]}];
+        eventView.sorts = [{kind: 'desc', field}];
         if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
           eventView.fields = [
             {field: 'issue'},
             {field: 'transaction'},
             {field: 'title'},
             {field: 'project.id'},
-            {field: props.fields[0]},
+            {field},
           ];
           eventView.additionalConditions.setFilterValues('event.type', ['error']);
           eventView.additionalConditions.setFilterValues('!tags[transaction]', ['']);
@@ -90,19 +92,16 @@ export function LineChartListWidget(props: Props) {
           eventView.query = mutableSearch.formatString();
         } else if (isSlowestType) {
           eventView.additionalConditions.setFilterValues('epm()', ['>0.01']);
+          eventView.additionalConditions.setFilterValues(field, ['>0']);
           eventView.fields = [
             {field: 'transaction'},
             {field: 'project.id'},
             {field: 'epm()'},
-            {field: props.fields[0]},
+            {field},
           ];
         } else {
           // Most related errors
-          eventView.fields = [
-            {field: 'transaction'},
-            {field: 'project.id'},
-            {field: props.fields[0]},
-          ];
+          eventView.fields = [{field: 'transaction'}, {field: 'project.id'}, {field}];
         }
         return (
           <DiscoverQuery
@@ -115,7 +114,7 @@ export function LineChartListWidget(props: Props) {
       },
       transform: transformDiscoverToList,
     }),
-    [props.eventView.query, props.fields[0], props.organization.slug]
+    [props.eventView.query, field, props.organization.slug]
   );
 
   const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(() => {
@@ -123,7 +122,7 @@ export function LineChartListWidget(props: Props) {
       enabled: widgetData => {
         return !!widgetData?.list?.data?.length;
       },
-      fields: props.fields[0],
+      fields: field,
       component: provided => {
         eventView.additionalConditions.setFilterValues('transaction', [
           provided.widgetData.list.data[selectedListIndex].transaction as string,
@@ -133,7 +132,7 @@ export function LineChartListWidget(props: Props) {
             {field: 'issue'},
             {field: 'issue.id'},
             {field: 'transaction'},
-            {field: props.fields[0]},
+            {field},
           ];
           eventView.additionalConditions.setFilterValues('issue', [
             provided.widgetData.list.data[selectedListIndex].issue as string,
@@ -144,7 +143,7 @@ export function LineChartListWidget(props: Props) {
           mutableSearch.removeFilter('transaction.duration');
           eventView.query = mutableSearch.formatString();
         } else {
-          eventView.fields = [{field: 'transaction'}, {field: props.fields[0]}];
+          eventView.fields = [{field: 'transaction'}, {field}];
         }
         return (
           <EventsRequest
@@ -153,7 +152,7 @@ export function LineChartListWidget(props: Props) {
             includePrevious
             includeTransformedData
             partial
-            currentSeriesNames={[props.fields[0]]}
+            currentSeriesNames={[field]}
             query={eventView.getQueryWithAdditionalConditions()}
             interval={getInterval(
               {
@@ -168,12 +167,7 @@ export function LineChartListWidget(props: Props) {
       },
       transform: transformEventsRequestToArea,
     };
-  }, [
-    props.eventView.query,
-    props.fields[0],
-    props.organization.slug,
-    selectedListIndex,
-  ]);
+  }, [props.eventView.query, field, props.organization.slug, selectedListIndex]);
 
   const Queries = {
     list: listQuery,
@@ -238,7 +232,7 @@ export function LineChartListWidget(props: Props) {
                   additionalQuery,
                 });
 
-                const fieldString = getAggregateAlias(props.fields[0]);
+                const fieldString = getAggregateAlias(field);
 
                 const valueMap = {
                   [PerformanceWidgetSetting.MOST_RELATED_ERRORS]: listItem.failure_count,


### PR DESCRIPTION
### Summary
This adds a min >0 filter for the widget fields on the line list widget filter. Previously 0 value rows were coming back, which aren't actionable.

#### Screenshot

##### Before
![Screen Shot 2021-11-03 at 10 46 07 AM](https://user-images.githubusercontent.com/6111995/140082907-59b47694-2d47-4bf3-acc4-0c00279adb1f.png)

#### Other
- Moved slow list out of the function
- Switched to a single field var instead of checking fields from props everywhere.
