### PR TITLE
tests(suspect-spans): Mock snql calls

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -1,8 +1,12 @@
 import time
 from datetime import timedelta
+from unittest.mock import patch
 
-import pytest
 from django.urls import reverse
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.function import Function
+from snuba_sdk.orderby import Direction, OrderBy
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
@@ -99,13 +103,138 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
 
         return self.store_event(data, project_id=self.project.id)
 
-    def suspect_span_results(self, key, event):
-        if key == "sum":
+    def suspect_span_group_snuba_results(self, op, event):
+        results = {
+            "project.id": self.project.id,
+            "project": self.project.slug,
+            "transaction": event.transaction,
+            "array_join_spans_op": op,
+        }
+
+        if op == "http.server":
+            results.update(
+                {
+                    "array_join_spans_group": "ab" * 8,
+                    "count_unique_id": 1,
+                    "count": 1,
+                    "sumArray_spans_exclusive_time": 4.0,
+                    "percentileArray_spans_exclusive_time_0_50": 4.0,
+                    "percentileArray_spans_exclusive_time_0_75": 4.0,
+                    "percentileArray_spans_exclusive_time_0_95": 4.0,
+                    "percentileArray_spans_exclusive_time_0_99": 4.0,
+                }
+            )
+        elif op == "django.middleware":
+            results.update(
+                {
+                    "array_join_spans_group": "cd" * 8,
+                    "count_unique_id": 1,
+                    "count": 2,
+                    "sumArray_spans_exclusive_time": 6.0,
+                    "percentileArray_spans_exclusive_time_0_50": 3.0,
+                    "percentileArray_spans_exclusive_time_0_75": 3.0,
+                    "percentileArray_spans_exclusive_time_0_95": 3.0,
+                    "percentileArray_spans_exclusive_time_0_99": 3.0,
+                }
+            )
+        elif op == "django.view":
+            results.update(
+                {
+                    "array_join_spans_group": "ef" * 8,
+                    "count_unique_id": 1,
+                    "count": 3,
+                    "sumArray_spans_exclusive_time": 3.0,
+                    "percentileArray_spans_exclusive_time_0_50": 1.0,
+                    "percentileArray_spans_exclusive_time_0_75": 1.0,
+                    "percentileArray_spans_exclusive_time_0_95": 1.0,
+                    "percentileArray_spans_exclusive_time_0_99": 1.0,
+                }
+            )
+        else:
+            assert False, f"Unexpected Op: {op}"
+
+        return results
+
+    def suspect_span_examples_snuba_results(self, op, event):
+        results = {
+            "id": event.event_id,
+            "array_join_spans_op": op,
+        }
+
+        if op == "http.server":
+            results.update(
+                {
+                    "array_join_spans_group": "ab" * 8,
+                    "count": 1,
+                    "sumArray_spans_exclusive_time": 4.0,
+                    "maxArray_spans_exclusive_time": 4.0,
+                }
+            )
+        elif op == "django.middleware":
+            results.update(
+                {
+                    "array_join_spans_group": "cd" * 8,
+                    "count": 2,
+                    "sumArray_spans_exclusive_time": 6.0,
+                    "maxArray_spans_exclusive_time": 3.0,
+                }
+            )
+        elif op == "django.view":
+            results.update(
+                {
+                    "array_join_spans_group": "ef" * 8,
+                    "count": 3,
+                    "sumArray_spans_exclusive_time": 3.0,
+                    "maxArray_spans_exclusive_time": 1.0,
+                }
+            )
+        else:
+            assert False, f"Unexpected Op: {op}"
+
+        return results
+
+    def suspect_span_results(self, op, event):
+        if op == "http.server":
             return {
                 "projectId": self.project.id,
                 "project": self.project.slug,
                 "transaction": event.transaction,
-                "op": "django.middleware",
+                "op": op,
+                "group": "ab" * 8,
+                "frequency": 1,
+                "count": 1,
+                "sumExclusiveTime": 4.0,
+                "p50ExclusiveTime": 4.0,
+                "p75ExclusiveTime": 4.0,
+                "p95ExclusiveTime": 4.0,
+                "p99ExclusiveTime": 4.0,
+                "examples": [
+                    {
+                        "id": event.event_id,
+                        "description": "root transaction",
+                        "startTimestamp": self.min_ago.timestamp(),
+                        "finishTimestamp": (self.min_ago + timedelta(seconds=8)).timestamp(),
+                        "nonOverlappingExclusiveTime": 4000.0,
+                        "spans": [
+                            {
+                                "id": "a" * 16,
+                                "startTimestamp": self.min_ago.timestamp(),
+                                "finishTimestamp": (
+                                    self.min_ago + timedelta(seconds=8)
+                                ).timestamp(),
+                                "exclusiveTime": 4.0,
+                            }
+                        ],
+                    },
+                ],
+            }
+
+        if op == "django.middleware":
+            return {
+                "projectId": self.project.id,
+                "project": self.project.slug,
+                "transaction": event.transaction,
+                "op": op,
                 "group": "cd" * 8,
                 "frequency": 1,
                 "count": 2,
@@ -136,12 +265,12 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                 ],
             }
 
-        if key == "count":
+        if op == "django.view":
             return {
                 "projectId": self.project.id,
                 "project": self.project.slug,
                 "transaction": event.transaction,
-                "op": "django.view",
+                "op": op,
                 "group": "ef" * 8,
                 "frequency": 1,
                 "count": 3,
@@ -172,40 +301,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                 ],
             }
 
-        if key == "percentiles":
-            return {
-                "projectId": self.project.id,
-                "project": self.project.slug,
-                "transaction": event.transaction,
-                "op": "http.server",
-                "group": "ab" * 8,
-                "frequency": 1,
-                "count": 1,
-                "sumExclusiveTime": 4.0,
-                "p50ExclusiveTime": 4.0,
-                "p75ExclusiveTime": 4.0,
-                "p95ExclusiveTime": 4.0,
-                "p99ExclusiveTime": 4.0,
-                "examples": [
-                    {
-                        "id": event.event_id,
-                        "description": "root transaction",
-                        "startTimestamp": self.min_ago.timestamp(),
-                        "finishTimestamp": (self.min_ago + timedelta(seconds=8)).timestamp(),
-                        "nonOverlappingExclusiveTime": 4000.0,
-                        "spans": [
-                            {
-                                "id": "a" * 16,
-                                "startTimestamp": self.min_ago.timestamp(),
-                                "finishTimestamp": (
-                                    self.min_ago + timedelta(seconds=8)
-                                ).timestamp(),
-                                "exclusiveTime": 4.0,
-                            }
-                        ],
-                    },
-                ],
-            }
+        assert False, f"Unexpected Op: {op}"
 
     def assert_suspect_span(self, result, expected_result):
         assert len(result) == len(expected_result)
@@ -282,12 +378,50 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             "detail": "Can only order by one of count, sumExclusiveTime, p50ExclusiveTime, p75ExclusiveTime, p95ExclusiveTime, p99ExclusiveTime"
         }
 
-    def test_sort_sum(self):
+    def test_sort_default(self):
         # TODO: remove this and the @pytest.skip once the config
         # is no longer necessary as this can add ~10s to the test
         self.update_snuba_config_ensure({"write_span_columns_projects": f"[{self.project.id}]"})
 
         event = self.create_event()
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"project": self.project.id},
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        self.assert_suspect_span(
+            response.data,
+            [
+                self.suspect_span_results("django.middleware", event),
+                self.suspect_span_results("http.server", event),
+                self.suspect_span_results("django.view", event),
+            ],
+        )
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_sort_sum(self, mock_raw_snql_query):
+        event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {
+                "data": [
+                    self.suspect_span_group_snuba_results("django.middleware", event),
+                    self.suspect_span_group_snuba_results("http.server", event),
+                    self.suspect_span_group_snuba_results("django.view", event),
+                ],
+            },
+            {
+                "data": [
+                    self.suspect_span_examples_snuba_results("django.middleware", event),
+                    self.suspect_span_examples_snuba_results("http.server", event),
+                    self.suspect_span_examples_snuba_results("django.view", event),
+                ],
+            },
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -303,15 +437,66 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         self.assert_suspect_span(
             response.data,
             [
-                self.suspect_span_results("sum", event),
-                self.suspect_span_results("percentiles", event),
-                self.suspect_span_results("count", event),
+                self.suspect_span_results("django.middleware", event),
+                self.suspect_span_results("http.server", event),
+                self.suspect_span_results("django.view", event),
             ],
         )
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_sort_count(self):
+        assert mock_raw_snql_query.call_count == 2
+
+        # the first call is the get the suspects, and should be using the specified sort
+        assert mock_raw_snql_query.call_args_list[0][0][0].orderby == [
+            OrderBy(
+                exp=Function(
+                    "sum",
+                    [Function("arrayJoin", [Column("spans.exclusive_time")])],
+                    "sumArray_spans_exclusive_time",
+                ),
+                direction=Direction.DESC,
+            )
+        ]
+        assert (
+            mock_raw_snql_query.call_args_list[0][0][1]
+            == "api.organization-events-spans-performance-suspects"
+        )
+
+        # the second call is the get the examples, and should also be using the specified sort
+        assert mock_raw_snql_query.call_args_list[1][0][0].orderby == [
+            OrderBy(
+                exp=Function(
+                    "sum",
+                    [Function("arrayJoin", [Column("spans.exclusive_time")])],
+                    "sumArray_spans_exclusive_time",
+                ),
+                direction=Direction.DESC,
+            )
+        ]
+        assert (
+            mock_raw_snql_query.call_args_list[1][0][1]
+            == "api.organization-events-spans-performance-examples"
+        )
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_sort_count(self, mock_raw_snql_query):
         event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {
+                "data": [
+                    self.suspect_span_group_snuba_results("django.view", event),
+                    self.suspect_span_group_snuba_results("django.middleware", event),
+                    self.suspect_span_group_snuba_results("http.server", event),
+                ],
+            },
+            {
+                "data": [
+                    self.suspect_span_examples_snuba_results("django.view", event),
+                    self.suspect_span_examples_snuba_results("django.middleware", event),
+                    self.suspect_span_examples_snuba_results("http.server", event),
+                ],
+            },
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -327,22 +512,61 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         self.assert_suspect_span(
             response.data,
             [
-                self.suspect_span_results("count", event),
-                self.suspect_span_results("sum", event),
-                self.suspect_span_results("percentiles", event),
+                self.suspect_span_results("django.view", event),
+                self.suspect_span_results("django.middleware", event),
+                self.suspect_span_results("http.server", event),
             ],
         )
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_sort_percentiles(self):
+        assert mock_raw_snql_query.call_count == 2
+
+        # the first call is the get the suspects, and should be using the specified sort
+        assert mock_raw_snql_query.call_args_list[0][0][0].orderby == [
+            OrderBy(exp=Function("count", [], "count"), direction=Direction.DESC)
+        ]
+        assert (
+            mock_raw_snql_query.call_args_list[0][0][1]
+            == "api.organization-events-spans-performance-suspects"
+        )
+
+        # the second call is the get the examples, and should also be using the specified sort
+        assert mock_raw_snql_query.call_args_list[1][0][0].orderby == [
+            OrderBy(exp=Function("count", [], "count"), direction=Direction.DESC)
+        ]
+        assert (
+            mock_raw_snql_query.call_args_list[1][0][1]
+            == "api.organization-events-spans-performance-examples"
+        )
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_sort_percentiles(self, mock_raw_snql_query):
         event = self.create_event()
 
-        for sort in [
-            "p50ExclusiveTime",
-            "p75ExclusiveTime",
-            "p95ExclusiveTime",
-            "p99ExclusiveTime",
-        ]:
+        for i, sort in enumerate(
+            [
+                "p50ExclusiveTime",
+                "p75ExclusiveTime",
+                "p95ExclusiveTime",
+                "p99ExclusiveTime",
+            ]
+        ):
+            mock_raw_snql_query.side_effect = [
+                {
+                    "data": [
+                        self.suspect_span_group_snuba_results("http.server", event),
+                        self.suspect_span_group_snuba_results("django.middleware", event),
+                        self.suspect_span_group_snuba_results("django.view", event),
+                    ],
+                },
+                {
+                    "data": [
+                        self.suspect_span_examples_snuba_results("http.server", event),
+                        self.suspect_span_examples_snuba_results("django.middleware", event),
+                        self.suspect_span_examples_snuba_results("django.view", event),
+                    ],
+                },
+            ]
+
             with self.feature(self.FEATURES):
                 response = self.client.get(
                     self.url,
@@ -357,15 +581,57 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             self.assert_suspect_span(
                 response.data,
                 [
-                    self.suspect_span_results("percentiles", event),
-                    self.suspect_span_results("sum", event),
-                    self.suspect_span_results("count", event),
+                    self.suspect_span_results("http.server", event),
+                    self.suspect_span_results("django.middleware", event),
+                    self.suspect_span_results("django.view", event),
                 ],
             )
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_op_filters(self):
+            offset = 2 * i
+            percentile = sort[1:3]
+
+            assert mock_raw_snql_query.call_count == offset + 2
+
+            # the first call is the get the suspects, and should be using the specified sort
+            assert mock_raw_snql_query.call_args_list[offset][0][0].orderby == [
+                OrderBy(
+                    exp=Function(
+                        f"quantile(0.{percentile.rstrip('0')})",
+                        [Function("arrayJoin", [Column("spans.exclusive_time")])],
+                        f"percentileArray_spans_exclusive_time_0_{percentile}",
+                    ),
+                    direction=Direction.DESC,
+                )
+            ]
+            assert (
+                mock_raw_snql_query.call_args_list[offset][0][1]
+                == "api.organization-events-spans-performance-suspects"
+            )
+
+            # the second call is the get the examples, and should also be using the specified sort
+            assert mock_raw_snql_query.call_args_list[offset + 1][0][0].orderby == [
+                OrderBy(
+                    exp=Function(
+                        "max",
+                        [Function("arrayJoin", [Column("spans.exclusive_time")])],
+                        "maxArray_spans_exclusive_time",
+                    ),
+                    direction=Direction.DESC,
+                )
+            ]
+            assert (
+                mock_raw_snql_query.call_args_list[offset + 1][0][1]
+                == "api.organization-events-spans-performance-examples"
+            )
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_op_filters(self, mock_raw_snql_query):
         event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {"data": [self.suspect_span_group_snuba_results("http.server", event)]},
+            {"data": [self.suspect_span_examples_snuba_results("http.server", event)]},
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -383,12 +649,53 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             response.data,
             # when sorting by -count, this should be the last of the 3 results
             # but the spanOp filter means it should be the only result
-            [self.suspect_span_results("percentiles", event)],
+            [self.suspect_span_results("http.server", event)],
         )
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_pagination_first_page(self):
-        self.create_event()
+        assert mock_raw_snql_query.call_count == 2
+
+        # the first call is the get the suspects, and should be using the specified sort
+        assert mock_raw_snql_query.call_args_list[0][0][0].orderby == [
+            OrderBy(exp=Function("count", [], "count"), direction=Direction.DESC)
+        ]
+        # the first call should also contain the additional condition on the span op
+        assert (
+            Condition(
+                lhs=Function("arrayJoin", [Column("spans.op")], "array_join_spans_op"),
+                op=Op.IN,
+                rhs=Function("tuple", ["http.server"]),
+            )
+            in mock_raw_snql_query.call_args_list[0][0][0].where
+        )
+        assert (
+            mock_raw_snql_query.call_args_list[0][0][1]
+            == "api.organization-events-spans-performance-suspects"
+        )
+
+        # the second call is the get the examples, and should also be using the specified sort
+        assert mock_raw_snql_query.call_args_list[1][0][0].orderby == [
+            OrderBy(exp=Function("count", [], "count"), direction=Direction.DESC)
+        ]
+        assert (
+            mock_raw_snql_query.call_args_list[1][0][1]
+            == "api.organization-events-spans-performance-examples"
+        )
+
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_pagination_first_page(self, mock_raw_snql_query):
+        event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {
+                "data": [
+                    self.suspect_span_group_snuba_results("django.middleware", event),
+                    # make sure to return 1 extra result to indicate that there is a next page
+                    self.suspect_span_group_snuba_results("http.server", event),
+                ],
+            },
+            # the results for the next page do not need examples
+            {"data": [self.suspect_span_examples_snuba_results("django.middleware", event)]},
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -409,9 +716,21 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             # first page does not have a previous page, only next
             assert info["results"] == "true" if info["rel"] == "next" else "false"
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_pagination_middle_page(self):
-        self.create_event()
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_pagination_middle_page(self, mock_raw_snql_query):
+        event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {
+                "data": [
+                    self.suspect_span_group_snuba_results("http.server", event),
+                    # make sure to return 1 extra result to indicate that there is a next page
+                    self.suspect_span_group_snuba_results("django.view", event),
+                ],
+            },
+            # the results for the next page do not need examples
+            {"data": [self.suspect_span_examples_snuba_results("http.server", event)]},
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -433,9 +752,14 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             # middle page has both a previous and next
             assert info["results"] == "true"
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_pagination_last_page(self):
-        self.create_event()
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_pagination_last_page(self, mock_raw_snql_query):
+        event = self.create_event()
+
+        mock_raw_snql_query.side_effect = [
+            {"data": [self.suspect_span_group_snuba_results("http.server", event)]},
+            {"data": [self.suspect_span_examples_snuba_results("http.server", event)]},
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -457,8 +781,8 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             # last page does not have a next page, only previous
             assert info["results"] == ("true" if info["rel"] == "previous" else "false")
 
-    @pytest.mark.skip("setting snuba config is too slow")
-    def test_span_group_prefixed_with_zeros(self):
+    @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
+    def test_span_group_prefixed_with_zeros(self, mock_raw_snql_query):
         trace_context = {
             "op": "http.server",
             "hash": "00" + "ab" * 7,
@@ -466,6 +790,19 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         }
 
         event = self.create_event(trace_context=trace_context)
+
+        group_results = self.suspect_span_group_snuba_results("http.server", event)
+        # make sure the span group is missing the zero prefix
+        group_results["array_join_spans_group"] = "ab" * 7
+
+        example_results = self.suspect_span_examples_snuba_results("http.server", event)
+        # make sure the span group is missing the zero prefix
+        example_results["array_join_spans_group"] = "ab" * 7
+
+        mock_raw_snql_query.side_effect = [
+            {"data": [group_results]},
+            {"data": [example_results]},
+        ]
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -479,6 +816,6 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
             )
 
         assert response.status_code == 200, response.content
-        results = self.suspect_span_results("percentiles", event)
+        results = self.suspect_span_results("http.server", event)
         results["group"] = "00" + "ab" * 7
         self.assert_suspect_span(response.data, [results])


### PR DESCRIPTION
Previously, these tests were being skipped due to the need to set a snuba config
which adds ~10s per test. This change mocks the snuba calls as needed and adds
additional assertions that the queries have the most critical components.