### PR TITLE
fix(gitlab): Refresh access token process

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -89,9 +89,12 @@ class GitLabApiClient(ApiClient):
     def metadata(self):
         return self.installation.model.metadata
 
+    def request_headers(self, identity):
+        access_token = identity.data["access_token"]
+        return {"Authorization": f"Bearer {access_token}"}
+
     def request(self, method, path, data=None, params=None):
-        access_token = self.identity.data["access_token"]
-        headers = {"Authorization": f"Bearer {access_token}"}
+        headers = self.request_headers(self.identity)
         url = GitLabApiClientPath.build_api_url(self.metadata["base_url"], path)
         try:
             return self._request(method, url, headers=headers, data=data, params=params)
@@ -99,8 +102,14 @@ class GitLabApiClient(ApiClient):
             if self.is_refreshing_token:
                 raise e
             self.is_refreshing_token = True
-            self.refresh_auth()
-            resp = self._request(method, url, headers=headers, data=data, params=params)
+            new_identity = self.refresh_auth()
+            resp = self._request(
+                method,
+                url,
+                headers=self.request_headers(new_identity),
+                data=data,
+                params=params,
+            )
             self.is_refreshing_token = False
             return resp
 
@@ -111,7 +120,7 @@ class GitLabApiClient(ApiClient):
 
         https://github.com/doorkeeper-gem/doorkeeper/wiki/Enable-Refresh-Token-Credentials#testing-with-oauth2-gem
         """
-        self.identity.get_provider().refresh_identity(
+        return self.identity.get_provider().refresh_identity(
             self.identity,
             refresh_token_url="{}{}".format(
                 self.metadata["base_url"], GitLabApiClientPath.oauth_token

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -332,7 +332,16 @@ class GitlabIntegrationProvider(IntegrationProvider):
 
     def build_integration(self, state):
         data = state["identity"]["data"]
-        oauth_data = get_oauth_data(data)
+
+        # Gitlab requires the client_id and client_secret for refreshing the access tokens
+        client_id = state.get("oauth_config_information", {}).get("client_id")
+        client_secret = state.get("oauth_config_information", {}).get("client_secret")
+        oauth_data = {
+            **get_oauth_data(data),
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+
         user = get_user_info(data["access_token"], state["installation_data"])
         group = self.get_group_info(data["access_token"], state["installation_data"])
         include_subgroups = state["installation_data"]["include_subgroups"]

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -334,12 +334,11 @@ class GitlabIntegrationProvider(IntegrationProvider):
         data = state["identity"]["data"]
 
         # Gitlab requires the client_id and client_secret for refreshing the access tokens
-        client_id = state.get("oauth_config_information", {}).get("client_id")
-        client_secret = state.get("oauth_config_information", {}).get("client_secret")
+        oauth_config = state.get("oauth_config_information", {})
         oauth_data = {
             **get_oauth_data(data),
-            "client_id": client_id,
-            "client_secret": client_secret,
+            "client_id": oauth_config.get("client_id"),
+            "client_secret": oauth_config.get("client_secret"),
         }
 
         user = get_user_info(data["access_token"], state["installation_data"])

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -293,6 +293,9 @@ class GitlabIntegrationTest(IntegrationTestCase):
             installation.get_stacktrace_link(repo, "README.md", ref, version)
         except Exception as e:
             assert e.code == 401
+        else:
+            # check that the call throws.
+            assert False
 
     @responses.activate
     def test_get_stacktrace_link_use_default_if_version_404(self):

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -58,11 +58,11 @@ class GitlabIntegrationTest(IntegrationTestCase):
         authorize_params = {k: v[0] for k, v in params.items()}
 
         access_token = "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
-
+        refresh_token = "rrrrr-rrrrrrrrr-rrrrrrrrrr-rrrrrrrrrrrr"
         responses.add(
             responses.POST,
             "https://gitlab.example.com/oauth/token",
-            json={"access_token": access_token},
+            json={"access_token": access_token, "refresh_token": refresh_token},
         )
         responses.add(responses.GET, "https://gitlab.example.com/api/v4/user", json={"id": user_id})
         responses.add(
@@ -133,7 +133,12 @@ class GitlabIntegrationTest(IntegrationTestCase):
             idp=idp, user=self.user, external_id="gitlab.example.com:user_id_1"
         )
         assert identity.status == IdentityStatus.VALID
-        assert identity.data == {"access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"}
+        assert identity.data == {
+            "access_token": "xxxxx-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+            "client_id": "client_id",
+            "client_secret": "client_secret",
+            "refresh_token": "rrrrr-rrrrrrrrr-rrrrrrrrrr-rrrrrrrrrrrr",
+        }
 
     def test_goback_to_instructions(self):
         # Go to instructions
@@ -283,8 +288,11 @@ class GitlabIntegrationTest(IntegrationTestCase):
             status=401,
             json={},
         )
-        source_url = installation.get_stacktrace_link(repo, "README.md", ref, version)
-        assert not source_url
+
+        try:
+            installation.get_stacktrace_link(repo, "README.md", ref, version)
+        except Exception as e:
+            assert e.code == 401
 
     @responses.activate
     def test_get_stacktrace_link_use_default_if_version_404(self):


### PR DESCRIPTION
## Objective:
When creating a Gitlab integration, the defaults have changed. Previously, there was no checkbox for "Expire access tokens". Presumably, the tokens did not expire. But now this is the default and we should really support refresh tokens.

We are using the Authorization flow described here: https://docs.gitlab.com/ee/api/oauth2.html#authorization-code-flow

There will be a followup PR to update the instructions.