### PR TITLE
fix(suspect-spans): Span ops endpoint should not be paged yet

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.tsx
@@ -75,6 +75,8 @@ export default function OpsFilter(props: Props) {
           location={location}
           orgSlug={organization.slug}
           eventView={opsFilterEventView}
+          cursor="0:0:1"
+          noPagination
         >
           {({spanOps, isLoading, error}) => {
             if (isLoading) {


### PR DESCRIPTION
The span ops endpoint is being accidentally paged along with the spans tab. This
should not be paginating at all.