### PR TITLE
feat(api-ratelimit): Create a rate limit middleware

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -194,6 +194,7 @@ class Endpoint(APIView):
                 path=str(self.request.path),
                 caller_ip=str(self.request.META.get("REMOTE_ADDR")),
                 user_agent=str(self.request.META.get("HTTP_USER_AGENT")),
+                rate_limited=str(getattr(self.request, "will_be_rate_limited", False)),
             )
             api_access_logger.info("api.access", extra=log_metrics)
         except Exception:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -290,6 +290,7 @@ MIDDLEWARE = (
     "sentry.middleware.sudo.SudoMiddleware",
     "sentry.middleware.superuser.SuperuserMiddleware",
     "sentry.middleware.locale.SentryLocaleMiddleware",
+    "sentry.middleware.ratelimit.RatelimitMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
 )
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -18,12 +18,16 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request):
 
 
 def get_default_rate_limit() -> tuple[int, int]:
-    """Read a config file to the get the default rate limit based on the request property"""
+    """
+    Read the rate limit from the view function to be used for the rate limit check
+    """
+
+    # TODO: Remove hard coded value with actual function logic
     return 100, 1
 
 
 def above_rate_limit_check(key, limit=None, window=None):
-    if limit is None and window is None:
+    if limit is None:
         limit, window = get_default_rate_limit()
 
     return ratelimiter.is_limited(key, limit=limit, window=window)

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -1,0 +1,43 @@
+# ratelimit.py
+#
+# Middleware that applies a rate limit to every endpoint
+
+
+from __future__ import annotations
+
+from django.utils.deprecation import MiddlewareMixin
+from rest_framework.request import Request
+
+from sentry.api.helpers.group_index.index import EndpointFunction, build_rate_limit_key
+from sentry.app import ratelimiter
+
+
+def get_rate_limit_key(view_func: EndpointFunction, request: Request):
+    """Construct a consistent global rate limit key using the arguments provided"""
+    return build_rate_limit_key(view_func, request)
+
+
+def get_default_rate_limit() -> tuple[int, int]:
+    """Read a config file to the get the default rate limit based on the request property"""
+    return 100, 1
+
+
+def above_rate_limit_check(key, limit=None, window=None):
+    if limit is None and window is None:
+        limit, window = get_default_rate_limit()
+
+    return ratelimiter.is_limited(key, limit=limit, window=window)
+
+
+class RatelimitMiddleware(MiddlewareMixin):
+    def _can_be_ratelimited(self, request: Request):
+        return True
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        """Check if the endpoint call will violate"""
+        if not self._can_be_ratelimited(request):
+            return
+
+        key = get_rate_limit_key(view_func, request)
+        request.will_be_rate_limited = above_rate_limit_check(key)
+        return

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -16,7 +16,7 @@ class RatelimitMiddlewareTest(TestCase):
     @patch("sentry.middleware.ratelimit.get_default_rate_limit")
     def test_positive_rate_limit_check(self, default_rate_limit_mock):
         request = self.factory.get("/")
-        default_rate_limit_mock.return_value = (1, 100)
+        default_rate_limit_mock.return_value = (0, 100)
         self.middleware.process_view(request, self.view, [], {})
         assert request.will_be_rate_limited
 

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -1,0 +1,46 @@
+import time
+from unittest.mock import patch
+
+from django.test import RequestFactory
+from exam import fixture
+
+from sentry.middleware.ratelimit import RatelimitMiddleware
+from sentry.testutils import TestCase
+
+
+class RatelimitMiddlewareTest(TestCase):
+    middleware = fixture(RatelimitMiddleware)
+    factory = fixture(RequestFactory)
+    view = lambda x: None
+
+    @patch("sentry.middleware.ratelimit.get_default_rate_limit")
+    def test_positive_rate_limit_check(self, default_rate_limit_mock):
+        request = self.factory.get("/")
+        default_rate_limit_mock.return_value = (1, 100)
+        self.middleware.process_view(request, self.view, [], {})
+        assert request.will_be_rate_limited
+
+        # 10th request in a 10 request window should get rate limited
+        # the call above still counts
+        default_rate_limit_mock.return_value = (10, 100)
+        for _ in range(9):
+            self.middleware.process_view(request, self.view, [], {})
+            assert not request.will_be_rate_limited
+
+        self.middleware.process_view(request, self.view, [], {})
+        assert request.will_be_rate_limited
+
+    @patch("sentry.middleware.ratelimit.get_default_rate_limit")
+    def test_negative_rate_limit_check(self, default_rate_limit_mock):
+        request = self.factory.get("/")
+        default_rate_limit_mock.return_value = (10, 100)
+        self.middleware.process_view(request, self.view, [], {})
+        assert not request.will_be_rate_limited
+
+        # Requests outside the current window should get
+        default_rate_limit_mock.return_value = (1, 1)
+        self.middleware.process_view(request, self.view, [], {})
+        assert not request.will_be_rate_limited
+        time.sleep(1)
+        self.middleware.process_view(request, self.view, [], {})
+        assert not request.will_be_rate_limited


### PR DESCRIPTION
At this point, all the middleware does is check if an IP has hit same endpoint 100 times in a second and if it has, set a flag in the request and logs it in the API access logs.

No request will be blocked by the middleware at this point

Closes API-2209