### PR TITLE
fix(ui): Remove inf percentage from change alert graphs

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -385,10 +385,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
             return `<span>${date}</span>`;
           }
 
-          const changePercentage =
-            comparisonPointY === 0 && pointY === 0
-              ? 0
-              : ((pointY - comparisonPointY) * 100) / comparisonPointY;
+          const changePercentage = (pointY - comparisonPointY) * 100 / comparisonPointY;
 
           const changeStatus = checkChangeStatus(
             changePercentage,
@@ -397,23 +394,21 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
           );
 
           const changeStatusColor =
-            changeStatus === 'critical'
-              ? theme.red300
-              : changeStatus === 'warning'
-              ? theme.yellow300
-              : theme.green300;
+            Math.abs(changePercentage) === Infinity || isNaN(changePercentage) ?
+              theme.gray300
+              : changeStatus === 'critical'
+                ? theme.red300
+                : changeStatus === 'warning'
+                  ? theme.yellow300
+                  : theme.green300;
+
 
           return `<span>${date}<span style="color:${changeStatusColor};margin-left:10px;">${
-            Math.sign(changePercentage) === 1
-              ? '+'
-              : Math.sign(changePercentage) === -1
-              ? '-'
-              : ''
-          }${
-            Math.abs(changePercentage) === Infinity
-              ? `&#8734`
-              : Math.abs(changePercentage).toFixed(2)
-          }%</span></span>`;
+            Math.abs(changePercentage) === Infinity || isNaN(changePercentage)
+              ? 'n/a'
+              : (`${Math.sign(changePercentage) === 1 
+                ? '+' 
+                : '-'}${Math.abs(changePercentage).toFixed(2)}%`)}</span></span>`;
         },
       },
       yAxis: {

--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -381,11 +381,15 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
 
           const comparisonPointY = comparisonSeries?.data[1] as number | undefined;
 
-          if (comparisonPointY === undefined || pointY === undefined) {
+          if (
+            comparisonPointY === undefined ||
+            pointY === undefined ||
+            comparisonPointY === 0
+          ) {
             return `<span>${date}</span>`;
           }
 
-          const changePercentage = (pointY - comparisonPointY) * 100 / comparisonPointY;
+          const changePercentage = ((pointY - comparisonPointY) * 100) / comparisonPointY;
 
           const changeStatus = checkChangeStatus(
             changePercentage,
@@ -394,21 +398,16 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
           );
 
           const changeStatusColor =
-            Math.abs(changePercentage) === Infinity || isNaN(changePercentage) ?
-              theme.gray300
-              : changeStatus === 'critical'
-                ? theme.red300
-                : changeStatus === 'warning'
-                  ? theme.yellow300
-                  : theme.green300;
+            changeStatus === 'critical'
+              ? theme.red300
+              : changeStatus === 'warning'
+              ? theme.yellow300
+              : theme.green300;
 
-
-          return `<span>${date}<span style="color:${changeStatusColor};margin-left:10px;">${
-            Math.abs(changePercentage) === Infinity || isNaN(changePercentage)
-              ? 'n/a'
-              : (`${Math.sign(changePercentage) === 1 
-                ? '+' 
-                : '-'}${Math.abs(changePercentage).toFixed(2)}%`)}</span></span>`;
+          return `<span>${date}<span style="color:${changeStatusColor};margin-left:10px;">
+            ${Math.sign(changePercentage) === 1 ? '+' : '-'}${Math.abs(
+            changePercentage
+          ).toFixed(2)}%</span></span>`;
         },
       },
       yAxis: {

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -647,7 +647,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                         const changePercentage =
                           comparisonPointY === undefined
                             ? NaN
-                            : (pointY - comparisonPointY) * 100 / comparisonPointY ;
+                            : ((pointY - comparisonPointY) * 100) / comparisonPointY;
 
                         const changeStatus = checkChangeStatus(
                           changePercentage,
@@ -656,13 +656,11 @@ class MetricChart extends React.PureComponent<Props, State> {
                         );
 
                         const changeStatusColor =
-                          Math.abs(changePercentage) === Infinity || isNaN(changePercentage) ?
-                            theme.gray300
-                            : changeStatus === 'critical'
-                              ? theme.red300
-                              : changeStatus === 'warning'
-                              ? theme.yellow300
-                              : theme.green300;
+                          changeStatus === 'critical'
+                            ? theme.red300
+                            : changeStatus === 'warning'
+                            ? theme.yellow300
+                            : theme.green300;
 
                         return [
                           `<div class="tooltip-series">`,
@@ -677,11 +675,11 @@ class MetricChart extends React.PureComponent<Props, State> {
                           `<div class="tooltip-date">`,
                           `<span>${startTime} &mdash; ${endTime}</span>`,
                           comparisonPointY !== undefined &&
+                            Math.abs(changePercentage) !== Infinity &&
+                            !isNaN(changePercentage) &&
                             `<span style="color:${changeStatusColor};margin-left:10px;">${
-                              Math.abs(changePercentage) === Infinity || isNaN(changePercentage) ?
-                                'n/a' :
-                                `${Math.sign(changePercentage) === 1 ? '+' : '-'}${Math.abs(changePercentage).toFixed(2)}%`
-                            }</span>`,
+                              Math.sign(changePercentage) === 1 ? '+' : '-'
+                            }${Math.abs(changePercentage).toFixed(2)}%</span>`,
                           `</div>`,
                           `<div class="tooltip-arrow"></div>`,
                         ]

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -646,24 +646,23 @@ class MetricChart extends React.PureComponent<Props, State> {
 
                         const changePercentage =
                           comparisonPointY === undefined
-                            ? undefined
-                            : (comparisonPointY === 0 && pointY === 0
-                                ? 0
-                                : (pointY - comparisonPointY) / comparisonPointY) * 100;
-                        const changeStatus =
-                          changePercentage === undefined
-                            ? undefined
-                            : checkChangeStatus(
-                                changePercentage,
-                                rule.thresholdType,
-                                rule.triggers
-                              );
+                            ? NaN
+                            : (pointY - comparisonPointY) * 100 / comparisonPointY ;
+
+                        const changeStatus = checkChangeStatus(
+                          changePercentage,
+                          rule.thresholdType,
+                          rule.triggers
+                        );
+
                         const changeStatusColor =
-                          changeStatus === 'critical'
-                            ? theme.red300
-                            : changeStatus === 'warning'
-                            ? theme.yellow300
-                            : theme.green300;
+                          Math.abs(changePercentage) === Infinity || isNaN(changePercentage) ?
+                            theme.gray300
+                            : changeStatus === 'critical'
+                              ? theme.red300
+                              : changeStatus === 'warning'
+                              ? theme.yellow300
+                              : theme.green300;
 
                         return [
                           `<div class="tooltip-series">`,
@@ -677,18 +676,12 @@ class MetricChart extends React.PureComponent<Props, State> {
                           `</div>`,
                           `<div class="tooltip-date">`,
                           `<span>${startTime} &mdash; ${endTime}</span>`,
-                          changePercentage !== undefined &&
+                          comparisonPointY !== undefined &&
                             `<span style="color:${changeStatusColor};margin-left:10px;">${
-                              Math.sign(changePercentage) === 1
-                                ? '+'
-                                : Math.sign(changePercentage) === -1
-                                ? '-'
-                                : ''
-                            }${
-                              Math.abs(changePercentage) === Infinity
-                                ? `&#8734`
-                                : Math.abs(changePercentage).toFixed(2)
-                            }%</span>`,
+                              Math.abs(changePercentage) === Infinity || isNaN(changePercentage) ?
+                                'n/a' :
+                                `${Math.sign(changePercentage) === 1 ? '+' : '-'}${Math.abs(changePercentage).toFixed(2)}%`
+                            }</span>`,
                           `</div>`,
                           `<div class="tooltip-arrow"></div>`,
                         ]


### PR DESCRIPTION
This removes the `inf%` from change alert graphs, we instead show nothing, because the alert ignores if comparison stats for an interval is 0.

Old tooltip:
<img width="400" alt="Screen Shot 2021-11-03 at 1 42 49 PM" src="https://user-images.githubusercontent.com/15015880/140189692-deb004ff-6750-4af3-a389-425914e3e001.png">

New tooltip:
<img width="400" alt="Screen Shot 2021-11-03 at 1 42 00 PM" src="https://user-images.githubusercontent.com/15015880/140189706-25cfbd23-c281-42c5-ba32-c847d91ccb06.png">


