### PR TITLE
feat: devservices docker-compose

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -155,50 +155,20 @@ runs:
     - name: Start devservices
       shell: bash
       env:
+        NEED_REDIS: "1"
+        NEED_POSTGRES: "1"
         NEED_KAFKA: ${{ inputs.kafka }}
         NEED_SNUBA: ${{ inputs.snuba }}
         NEED_CLICKHOUSE: ${{ inputs.clickhouse }}
         NEED_CHARTCUTERIE: ${{ inputs.chartcuterie }}
       run: |
-        sentry init
+        pip install "pyyaml==5.4"
+        python docker-compose.py up
 
-        # redis, postgres are needed for almost every code path.
-        sentry devservices up redis postgres
+        sentry init
 
         if [ "$BIGTABLE_EMULATOR_HOST" ]; then
           sentry devservices up --skip-only-if bigtable
-        fi
-
-        # TODO: Use devservices kafka. See https://github.com/getsentry/sentry/pull/20986#issuecomment-704510570
-        if [ "$NEED_KAFKA" = "true" ]; then
-          # This is *not* the production version. Unclear reason as to why this was chosen
-          # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L631
-          docker run \
-            --name sentry_zookeeper \
-            -d --network host \
-            -e ZOOKEEPER_CLIENT_PORT=2181 \
-            confluentinc/cp-zookeeper:4.1.0
-
-          # This is the production version; do not change w/o changing it there as well
-          # https://github.com/getsentry/ops/blob/c823e62f930ecc6c97bb08898c71e49edc7232f6/cookbooks/getsentry/attributes/default.rb#L643
-          docker run \
-            --name sentry_kafka \
-            -d --network host \
-            -e KAFKA_ZOOKEEPER_CONNECT=127.0.0.1:2181 \
-            -e KAFKA_LISTENERS=INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092 \
-            -e KAFKA_ADVERTISED_LISTENERS=INTERNAL://127.0.0.1:9093,EXTERNAL://127.0.0.1:9092 \
-            -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT \
-            -e KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL \
-            -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
-            confluentinc/cp-kafka:5.1.2
-        fi
-
-        if [ "$NEED_SNUBA" = "true" ]; then
-          sentry devservices up clickhouse snuba
-        fi
-
-        if [ "$NEED_CLICKHOUSE" = "true" ]; then
-          sentry devservices up clickhouse
         fi
 
         if [ "$NEED_CHARTCUTERIE" = "true" ]; then

--- a/docker-compose.py
+++ b/docker-compose.py
@@ -1,0 +1,217 @@
+# TODO
+# - conditionals with sentry settings... hmm
+# - devservices pull=true
+# - durable defaults, and make them less durable for IS_CI
+
+import os
+import sys
+from tempfile import NamedTemporaryFile
+
+import yaml
+
+if len(sys.argv) < 2:
+    sys.exit(
+        """usage: docker-compose.py up|down
+"""
+    )
+
+# todo: replace with argparse
+cmd = sys.argv[1]
+
+IS_CI = os.environ.get("IS_CI", True)  # todo: this is placeholder flag
+NEED_REDIS = os.environ.get("NEED_REDIS", False)
+NEED_POSTGRES = os.environ.get("NEED_POSTGRES", False)
+NEED_SNUBA = os.environ.get("NEED_SNUBA", False)
+NEED_CLICKHOUSE = os.environ.get("NEED_CLICKHOUSE", False)
+NEED_KAFKA = os.environ.get("NEED_KAFKA", False)
+
+base = """
+version: "3.8"
+services: {}
+volumes: {}
+"""
+
+config = yaml.load(base, Loader=yaml.BaseLoader)
+
+service_redis = """
+image: "redis:5.0-alpine"
+container_name: sentry_redis
+ports:
+  - "6379:6379"
+command:
+  [
+    "redis-server",
+    "--appendonly",
+    "yes",
+    "--save",
+    "60",
+    "20",
+    "--auto-aof-rewrite-percentage",
+    "100",
+    "--auto-aof-rewrite-min-size",
+    "64mb",
+  ]
+volumes:
+  - "sentry-redis:/data"
+deploy:
+  x-restart-policy:
+    condition: "none"
+healthcheck:
+  disable: true
+"""
+
+# TODO: could disable autovaccuum
+
+service_postgres = """
+image: "postgres:9.6-alpine"
+container_name: sentry_postgres
+ports:
+  - "5432:5432"
+command:
+  [
+    "postgres",
+    "-c",
+    "wal_level=logical",
+    "-c",
+    "max_replication_slots=1",
+    "-c",
+    "max_wal_senders=1",
+  ]
+environment:
+  POSTGRES_DB: "sentry"
+  POSTGRES_HOST_AUTH_METHOD: "trust"
+volumes:
+  - "sentry-postgres:/var/lib/postgresql/data"
+deploy:
+  x-restart-policy:
+    condition: "none"
+healthcheck:
+  disable: true
+"""
+
+service_snuba = """
+image: "getsentry/snuba:nightly"
+container_name: sentry_snuba
+ports:
+  - "1218:1218"
+command:
+  [
+    "devserver",
+  ]
+environment:
+  PYTHONUNBUFFERED: "1"
+  SNUBA_SETTINGS: "docker"
+  DEBUG: "1"
+  CLICKHOUSE_HOST: "sentry_clickhouse"
+  CLICKHOUSE_PORT: "9000"
+  CLICKHOUSE_HTTP_PORT: "8123"
+  DEFAULT_BROKERS: "sentry_kafka:9093"
+  REDIS_HOST: "sentry_redis"
+  REDIS_PORT: "6379"
+  REDIS_DB: "1"
+deploy:
+  x-restart-policy:
+    condition: "none"
+healthcheck:
+  disable: true
+"""
+
+# TODO: match what we're running in production
+# todo APPLE_ARM64 stuff and other conditionals
+# i think zookeeper needs to be older
+# see also 767bf793c18
+
+service_clickhouse = """
+image: "yandex/clickhouse-server:20.3.9.70"
+container_name: sentry_clickhouse
+ports:
+  - "8123:8123"
+  - "9000:9000"
+  - "9009:9009"
+ulimits:
+  nofile:
+    soft: 262144
+    hard: 262144
+volumes:
+  - "sentry-clickhouse:/var/lib/clickhouse"
+  - "sentry-clickhouse-log:/var/log/clickhouse-server"
+  - "./config/clickhouse/loc_config.xml:/etc/clickhouse-server/config.d/sentry.xml:ro"
+deploy:
+  x-restart-policy:
+    condition: "none"
+healthcheck:
+  disable: true
+"""
+
+service_kafka = """
+image: "confluentinc/cp-kafka:5.1.2"
+container_name: sentry_kafka
+ports:
+  - "9092:9092"
+depends_on:
+  - "zookeeper"
+environment:
+  KAFKA_ZOOKEEPER_CONNECT: "sentry_zookeeper:2181"
+  KAFKA_LISTENERS: "INTERNAL://sentry_kafka:9093,EXTERNAL://sentry_kafka:9092"
+  KAFKA_ADVERTISED_LISTENERS: "INTERNAL://sentry_kafka:9093,EXTERNAL://sentry_kafka:9092"
+  KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+  KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+volumes:
+  - "sentry-kafka:/var/lib/kafka/data"
+  - "sentry-kafka-log:/var/lib/kafka/log"
+deploy:
+  x-restart-policy:
+    condition: "none"
+healthcheck:
+  disable: true
+"""
+
+service_zookeeper = """
+image: "confluentinc/cp-zookeeper:4.1.0"
+container_name: sentry_zookeeper
+ports:
+  - "2181:2181"
+environment:
+    ZOOKEEPER_CLIENT_PORT: "2181"
+deploy:
+  x-restart-policy:
+    condition: "none"
+healthcheck:
+  disable: true
+"""
+
+if NEED_REDIS:
+    config["services"]["redis"] = yaml.load(service_redis, Loader=yaml.BaseLoader)
+    config["volumes"]["sentry-redis"] = {}
+
+if NEED_POSTGRES:
+    config["services"]["postgres"] = yaml.load(service_postgres, Loader=yaml.BaseLoader)
+    config["volumes"]["sentry-postgres"] = {}
+
+if NEED_SNUBA:
+    config["services"]["snuba"] = yaml.load(service_snuba, Loader=yaml.BaseLoader)
+
+if NEED_CLICKHOUSE:
+    config["services"]["clickhouse"] = yaml.load(service_clickhouse, Loader=yaml.BaseLoader)
+    config["volumes"]["sentry-clickhouse"] = {}
+    config["volumes"]["sentry-clickhouse-log"] = {}
+
+if NEED_KAFKA:
+    config["services"]["kafka"] = yaml.load(service_kafka, Loader=yaml.BaseLoader)
+    config["volumes"]["sentry-kafka"] = {}
+    config["volumes"]["sentry-kafka-log"] = {}
+    config["services"]["zookeeper"] = yaml.load(service_zookeeper, Loader=yaml.BaseLoader)
+
+with NamedTemporaryFile(mode="wt", delete=False) as f:
+    commands = {
+        "up": ["docker-compose", "-f", f.name, "up", "-d"],
+        "down": ["docker-compose", "-f", f.name, "down"],
+    }
+    command = commands[cmd]
+    manifest = yaml.dump(config)
+    # todo: put behind debug flag for CI
+    # print(manifest)
+    f.write(manifest)
+
+os.execvp(command[0], command)


### PR DESCRIPTION
devservices was added in early 2019 because brew started making it difficult to install exact versions of services we needed. It could have been replaced with docker-compose, but I'm guessing we needed the additional flexibility. 

- Still figuring this out with sentry settings conditionals. Worst case, we have a fast docker-compose exclusively for CI, keep devservices for local, and try to get devservices to reuse as much config as possible (maybe, not worth the additional complications).

Pulling images sequentially is slow, especially with the possibility that things need to be retried. I started putting each pull on a thread but felt like exploring docker-compose would be more worthwhile, given that it's already present on CI and does nonblocking pulling by default.

- lol actually this isn't true. was conflating layers and images. Not sure how docker-py pulls layers.

Since docker-compose only works on a static manifest, we need to dynamically generate it. The plan is to port all of `docker-py` based devservices to it. Further, in CI, we can run faster and nondurable configurations of services like postgres without fsync, and for dev we can run more durable configurations.

TODO:
- docker-compose retry configuration 

Some other notes:
- Only care about initial healthchecking, not persistent. Docker eats up CPU doing this even if it's infrequent. This can be a script that can also be reused for troubleshooting dev environments. It can just be rolled up into the cli, like `docker-compose.py healthcheck`.

Future TODOs:
- Tests that only require redis + postgres should be pytest marked and run separately, and ignored in normal test sharding. Unfortunately we don't have 100% tests using pytest.
  - Similar things can be done for tests that use settings.SENTRY_NODESTORE = "bigtable", symbolicator, and relay integration tests and probably missing few more.
  - Bigtable is tricky since there's so few tests to justify an entirely separate environment.
- There seems to be poor support for startup dependency order. For example, zookeeper needs to be ready before kafka. If your computer's really slow, it can time out despite the really generous retries.