### PR TITLE
fix(notifications): Get default settings in `where_should_be_participating`

### DIFF
--- a/src/sentry/testutils/helpers/slack.py
+++ b/src/sentry/testutils/helpers/slack.py
@@ -92,8 +92,9 @@ def link_team(team: Team, integration: Integration, channel_name: str, channel_i
 
 
 def send_notification(*args):
-    args_list = list(args)[1:]
-    send_notification_as_slack(*args_list, {})
+    provider, *args_list = args
+    if provider == ExternalProviders.SLACK:
+        send_notification_as_slack(*args_list, {})
 
 
 def get_attachment():

--- a/tests/sentry/notifications/notifications/test_organization_request.py
+++ b/tests/sentry/notifications/notifications/test_organization_request.py
@@ -34,7 +34,6 @@ class GetParticipantsTest(TestCase):
 
     @with_feature("organizations:slack-requests")
     def test_turn_off_settings(self):
-
         NotificationSetting.objects.update_settings(
             ExternalProviders.SLACK,
             NotificationSettingTypes.APPROVAL,
@@ -53,6 +52,6 @@ class GetParticipantsTest(TestCase):
         notification = DummyRequestNotification(self.organization, self.user, member_ids)
 
         assert notification.get_participants() == {
-            ExternalProviders.EMAIL: {self.user2},
-            ExternalProviders.SLACK: {self.user1},
+            ExternalProviders.EMAIL: {self.user1, self.user2},
+            ExternalProviders.SLACK: {self.user1, self.user2},
         }

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -1,6 +1,5 @@
 from sentry.models import NotificationSetting
 from sentry.notifications.helpers import (
-    _get_setting_mapping_from_mapping,
     collect_groups_by_project,
     get_scope_type,
     get_settings_by_provider,
@@ -41,51 +40,6 @@ class NotificationHelpersTest(TestCase):
             NotificationSettingOptionValues.ALWAYS,
             user=self.user,
         )
-
-    def test_get_setting_mapping_from_mapping_issue_alerts(self):
-        notification_settings = {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
-                }
-            }
-        }
-        mapping = _get_setting_mapping_from_mapping(
-            notification_settings,
-            self.user,
-            NotificationSettingTypes.ISSUE_ALERTS,
-        )
-        assert mapping == {ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS}
-
-    def test_get_setting_mapping_from_mapping_deploy(self):
-        notification_settings = {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY
-                }
-            }
-        }
-        mapping = _get_setting_mapping_from_mapping(
-            notification_settings,
-            self.user,
-            NotificationSettingTypes.DEPLOY,
-        )
-        assert mapping == {ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY}
-
-    def test_get_setting_mapping_from_mapping_workflow(self):
-        notification_settings = {
-            self.user: {
-                NotificationScopeType.USER: {
-                    ExternalProviders.EMAIL: NotificationSettingOptionValues.SUBSCRIBE_ONLY
-                }
-            }
-        }
-        mapping = _get_setting_mapping_from_mapping(
-            notification_settings,
-            self.user,
-            NotificationSettingTypes.WORKFLOW,
-        )
-        assert mapping == {ExternalProviders.EMAIL: NotificationSettingOptionValues.SUBSCRIBE_ONLY}
 
     def test_get_deploy_values_by_provider_empty_settings(self):
         values_by_provider = get_values_by_provider_by_type(

--- a/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
+++ b/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from sentry.notifications.helpers import _get_setting_mapping_from_mapping
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
+
+
+class NotificationHelpersTest(TestCase):
+    def test_get_setting_mapping_from_mapping_issue_alerts(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS
+                }
+            }
+        }
+        mapping = _get_setting_mapping_from_mapping(
+            notification_settings,
+            self.user,
+            NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }
+
+    def test_get_setting_mapping_from_mapping_deploy(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY
+                }
+            }
+        }
+        mapping = _get_setting_mapping_from_mapping(
+            notification_settings,
+            self.user,
+            NotificationSettingTypes.DEPLOY,
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.COMMITTED_ONLY,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }
+
+    def test_get_setting_mapping_from_mapping_workflow(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.SUBSCRIBE_ONLY
+                }
+            }
+        }
+        mapping = _get_setting_mapping_from_mapping(
+            notification_settings,
+            self.user,
+            NotificationSettingTypes.WORKFLOW,
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }
+
+    def test_get_setting_mapping_from_mapping_empty(self):
+        mapping = _get_setting_mapping_from_mapping(
+            {}, self.user, NotificationSettingTypes.ISSUE_ALERTS
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }
+
+    def test_get_setting_mapping_from_mapping_never(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER
+                }
+            }
+        }
+
+        mapping = _get_setting_mapping_from_mapping(
+            notification_settings,
+            self.user,
+            NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }

--- a/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
+++ b/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
@@ -77,7 +77,7 @@ class GetSettingMappingFromMappingTest(TestCase):
             ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
         }
 
-    def test_get_setting_mapping_from_mapping_never(self):
+    def test_get_setting_mapping_from_mapping_slack_never(self):
         notification_settings = {
             self.user: {
                 NotificationScopeType.USER: {
@@ -94,4 +94,23 @@ class GetSettingMappingFromMappingTest(TestCase):
         assert mapping == {
             ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
             ExternalProviders.SLACK: NotificationSettingOptionValues.NEVER,
+        }
+
+    def test_get_setting_mapping_from_mapping_slack_always(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS
+                }
+            }
+        }
+
+        mapping = _get_setting_mapping_from_mapping(
+            notification_settings,
+            self.user,
+            NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
         }

--- a/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
+++ b/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from sentry.notifications.helpers import _get_setting_mapping_from_mapping
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -10,7 +8,7 @@ from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 
 
-class NotificationHelpersTest(TestCase):
+class GetSettingMappingFromMappingTest(TestCase):
     def test_get_setting_mapping_from_mapping_issue_alerts(self):
         notification_settings = {
             self.user: {

--- a/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
+++ b/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
@@ -1,14 +1,19 @@
+from unittest import TestCase
+
+from sentry.models import User
 from sentry.notifications.helpers import _get_setting_mapping_from_mapping
 from sentry.notifications.types import (
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 
 
 class GetSettingMappingFromMappingTest(TestCase):
+    def setUp(self):
+        self.user = User(id=1)
+
     def test_get_setting_mapping_from_mapping_issue_alerts(self):
         notification_settings = {
             self.user: {


### PR DESCRIPTION
When an alert rule is triggered and we've determined eligible notification recipients, we check each of those recipient's NotificationSettings to filter to the correct provider (e.g. Slack, Email). 

The way the NotificationSettings are saved in the DB is "a little funny". A missing row can be interpreted as "read the next level up". For example if there is not project-specific row, we should check the project-independent row. If there is no project-independent row, fall back to the repo's default.

The code that does that last level of falling back was broken. This PR fixes it by first creating a mapping with the default settings first and then overriding the values from the DB.

@wedamija Found this with an incredible bout of debugging.