### PR TITLE
ref(ratelimit): Change RedisRatelimiter to use redis cluster

### DIFF
--- a/src/sentry/ratelimits/redis.py
+++ b/src/sentry/ratelimits/redis.py
@@ -1,24 +1,25 @@
 from time import time
 
+from django.conf import settings
 from redis.exceptions import RedisError
 from sentry_sdk import capture_exception
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.ratelimits.base import RateLimiter
+from sentry.utils import redis
 from sentry.utils.hashlib import md5_text
-from sentry.utils.redis import get_cluster_from_options
 
 
 class RedisRateLimiter(RateLimiter):
     window = 60
 
     def __init__(self, **options):
-        self.cluster, options = get_cluster_from_options("SENTRY_RATELIMITER_OPTIONS", options)
+        cluster_key = getattr(settings, "SENTRY_RATE_LIMIT_REDIS_CLUSTER", "default")
+        self.client = redis.redis_clusters.get(cluster_key)
 
     def validate(self):
         try:
-            with self.cluster.all() as client:
-                client.ping()
+            self.client.ping()
         except Exception as e:
             raise InvalidConfiguration(str(e))
 
@@ -35,10 +36,9 @@ class RedisRateLimiter(RateLimiter):
             key = f"rl:{key_hex}:{bucket}"
 
         try:
-            with self.cluster.map() as client:
-                result = client.incr(key)
-                client.expire(key, window)
-            return result.value > limit
+            result = self.client.incr(key)
+            self.client.expire(key, window)
+            return result > limit
         except RedisError as e:
             # We don't want rate limited endpoints to fail when ratelimits
             # can't be updated. We do want to know when that happens.


### PR DESCRIPTION
Should make the redis rate limiter more robust to node failures and removes another reference to rb