### PR TITLE
`fix(ui): Storybook's <DocsContainer /> overwriting theme object

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import 'focus-visible';
 import 'docs-ui/index.js';
 
+import {Fragment} from 'react';
 import {DocsContainer, Meta} from '@storybook/addon-docs';
 import {addDecorator, addParameters, DecoratorFn, Parameters} from '@storybook/react';
 import Code from 'docs-ui/components/code';
@@ -47,12 +48,16 @@ const withThemeDocs: DecoratorFn = ({children, context}) => {
   }
 
   return (
-    <ThemeProvider theme={currentTheme}>
-      <GlobalStyles isDark={isDark} theme={currentTheme} />
-      <PreviewGlobalStyles theme={currentTheme} />
-      <DocsContainer context={context}>{children}</DocsContainer>
-      <TableOfContents />
-    </ThemeProvider>
+    <Fragment>
+      <DocsContainer context={context}>
+        <GlobalStyles isDark={isDark} theme={currentTheme} />
+        <PreviewGlobalStyles theme={currentTheme} />
+        <ThemeProvider theme={currentTheme}>{children}</ThemeProvider>
+      </DocsContainer>
+      <ThemeProvider theme={currentTheme}>
+        <TableOfContents />
+      </ThemeProvider>
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
Storybook's `<DocsContainer />` implements its own theme context. In the current configuration, that theme context is a descendant of the custom theme context that we implemented:

```
<ThemeProvider> // our custom theme context, from utils/theme.tsx
    <DocsContainer /> // DocsContainer and its own theme context
</ThemeProvider>
```

This means `DocsContainer`'s theme object will overwrite any property in our theme object. This is a problem because both have the `background` property. Any component inside `DocsContainer` will see only `DocsContainer`'s `background` and not ours:
<img width="491" alt="Screen Shot 2021-11-03 at 4 57 42 PM" src="https://user-images.githubusercontent.com/44172267/140236704-b2f95e85-c045-4075-924e-3fa84c1d38b1.png">

To fix this, we can move our custom `ThemeProvider` context inside `DocsContainer`, making it more specific and thus overwriting whatever value is in `DocsContainer`'s theme. As a result, components inside `DocsContainer` will now get the correct theme values:
<img width="491" alt="Screen Shot 2021-11-03 at 4 58 29 PM" src="https://user-images.githubusercontent.com/44172267/140237059-90fd7ce0-dc4e-43f7-9752-3ab9da6eb3aa.png">

