### PR TITLE
fix(gitlab): Revert change to setup instructions

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -255,7 +255,6 @@ class InstallationGuideView(PipelineView):
                 "setup_values": [
                     {"label": "Name", "value": "Sentry"},
                     {"label": "Redirect URI", "value": absolute_uri("/extensions/gitlab/setup/")},
-                    {"label": "Expire access tokens", "value": "Unchecked"},
                     {"label": "Scopes", "value": "api"},
                 ],
             },


### PR DESCRIPTION
## Objective:

Reverts the PR: https://github.com/getsentry/sentry/pull/29578

We now support refreshing GitLab tokens: https://github.com/getsentry/sentry/pull/29747