### PR TITLE
fix(perf): Fix eventView move causing chart issues

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -71,12 +71,11 @@ export function LineChartListWidget(props: Props) {
 
   const isSlowestType = slowList.includes(props.chartSetting);
 
-  const eventView = props.eventView.clone();
-
   const listQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
       fields: field,
       component: provided => {
+        const eventView = props.eventView.clone();
         eventView.sorts = [{kind: 'desc', field}];
         if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
           eventView.fields = [
@@ -125,6 +124,7 @@ export function LineChartListWidget(props: Props) {
       },
       fields: field,
       component: provided => {
+        const eventView = props.eventView.clone();
         eventView.additionalConditions.setFilterValues('transaction', [
           provided.widgetData.list.data[selectedListIndex].transaction as string,
         ]);


### PR DESCRIPTION
### Summary
Moving the eventView outside of the memoization was causing both memoized functions to modify the same eventView, which meant the chart was getting extra conditions, causing it to not render.