### PR TITLE
fix(suspect-spans): Clarify the vocabulary used on the span tab

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/opsFilter.tsx
@@ -68,7 +68,7 @@ export default function OpsFilter(props: Props) {
             handleOpChange(undefined);
           }}
         >
-          <HeaderTitle>{t('Operations')}</HeaderTitle>
+          <HeaderTitle>{t('All Operations')}</HeaderTitle>
           <Radio radioSize="small" checked={!defined(currentOp)} onChange={() => {}} />
         </ListHeader>
         <SpanOpsQuery

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -39,7 +39,7 @@ import {getSuspectSpanSortFromEventView} from './utils';
 const SPANS_TABLE_COLUMN_ORDER: SuspectSpanTableColumn[] = [
   {
     key: 'id',
-    name: 'Event ID',
+    name: 'Example Transaction',
     width: COL_WIDTH_UNDEFINED,
   },
   {
@@ -53,8 +53,8 @@ const SPANS_TABLE_COLUMN_ORDER: SuspectSpanTableColumn[] = [
     width: COL_WIDTH_UNDEFINED,
   },
   {
-    key: 'repeated',
-    name: 'Repeated',
+    key: 'occurrences',
+    name: 'Occurrences',
     width: COL_WIDTH_UNDEFINED,
   },
   {
@@ -68,7 +68,7 @@ const SPANS_TABLE_COLUMN_TYPE: Partial<Record<SuspectSpanTableColumnKeys, Column
   id: 'string',
   timestamp: 'date',
   spanDuration: 'duration',
-  repeated: 'integer',
+  occurrences: 'integer',
   cumulativeDuration: 'duration',
 };
 
@@ -103,7 +103,7 @@ export default function SuspectSpanEntry(props: Props) {
     timestamp: example.finishTimestamp * 1000,
     transactionDuration: (example.finishTimestamp - example.startTimestamp) * 1000,
     spanDuration: example.nonOverlappingExclusiveTime,
-    repeated: example.spans.length,
+    occurrences: example.spans.length,
     cumulativeDuration: example.spans.reduce(
       (duration, span) => duration + span.exclusiveTime,
       0
@@ -115,7 +115,7 @@ export default function SuspectSpanEntry(props: Props) {
 
   return (
     <div data-test-id="suspect-card">
-      <UpperPanel>
+      <UpperPanel data-test-id="suspect-card-upper">
         <HeaderItem
           label={t('Span Operation')}
           value={<SpanLabel span={suspectSpan} />}

--- a/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
@@ -25,7 +25,7 @@ export type SuspectSpanTableColumnKeys =
   | 'timestamp'
   | 'transactionDuration'
   | 'spanDuration'
-  | 'repeated'
+  | 'occurrences'
   | 'cumulativeDuration'
   | 'spans';
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -42,22 +42,22 @@ export function spansRouteWithQuery({
 export const SPAN_SORT_OPTIONS: SpanSortOption[] = [
   {
     prefix: t('Percentile'),
-    label: t('p50'),
+    label: t('p50 Duration'),
     field: SpanSortPercentiles.P50_EXCLUSIVE_TIME,
   },
   {
     prefix: t('Percentile'),
-    label: t('p75'),
+    label: t('p75 Duration'),
     field: SpanSortPercentiles.P75_EXCLUSIVE_TIME,
   },
   {
     prefix: t('Percentile'),
-    label: t('p95'),
+    label: t('p95 Duration'),
     field: SpanSortPercentiles.P95_EXCLUSIVE_TIME,
   },
   {
     prefix: t('Percentile'),
-    label: t('p99'),
+    label: t('p99 Duration'),
     field: SpanSortPercentiles.P99_EXCLUSIVE_TIME,
   },
   {

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -266,19 +266,45 @@ describe('Performance > Transaction Spans', function () {
     for (let i = 0; i < cards.length; i++) {
       const card = cards[i];
 
+      // need to narrow the search to the upper half of the card because `Occurrences` appears in the table header as well
+      const upper = await within(card).findByTestId('suspect-card-upper');
       // these headers should be present by default
-      expect(await within(card).findByText('Span Operation')).toBeInTheDocument();
-      expect(await within(card).findByText('p75 Duration')).toBeInTheDocument();
-      expect(await within(card).findByText('Occurrences')).toBeInTheDocument();
+      expect(await within(upper).findByText('Span Operation')).toBeInTheDocument();
+      expect(await within(upper).findByText('p75 Duration')).toBeInTheDocument();
+      expect(await within(upper).findByText('Occurrences')).toBeInTheDocument();
       expect(
-        await within(card).findByText('Total Cumulative Duration')
+        await within(upper).findByText('Total Cumulative Duration')
       ).toBeInTheDocument();
 
-      const arrow = await within(card).findByTestId('span-sort-arrow');
+      const arrow = await within(upper).findByTestId('span-sort-arrow');
       expect(arrow).toBeInTheDocument();
       expect(
         await within(arrow.closest('div')!).findByText('Occurrences')
       ).toBeInTheDocument();
+    }
+  });
+
+  it('renders the right table headers', async function () {
+    const initialData = initializeData();
+    mountWithTheme(
+      <TransactionSpans
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      {context: initialData.routerContext}
+    );
+
+    const cards = await screen.findAllByTestId('suspect-card');
+    expect(cards).toHaveLength(2);
+    for (let i = 0; i < cards.length; i++) {
+      const card = cards[i];
+      const lower = await within(card).findByTestId('suspect-card-lower');
+
+      expect(await within(lower).findByText('Example Transaction')).toBeInTheDocument();
+      expect(await within(lower).findByText('Timestamp')).toBeInTheDocument();
+      expect(await within(lower).findByText('Span Duration')).toBeInTheDocument();
+      expect(await within(lower).findByText('Occurrences')).toBeInTheDocument();
+      expect(await within(lower).findByText('Cumulative Duration')).toBeInTheDocument();
     }
   });
 });


### PR DESCRIPTION
The wording on the span tab is a little inconsisitent and sometimes unclear.
This change attempts to unify the choice of words and clarify some stuff.