### PR TITLE
fix(discover): disable bar chart animation on discover

### DIFF
--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -33,6 +33,7 @@ class BarChart extends React.Component<Props> {
               }
               return {value: [name, value], itemStyle};
             }),
+            animation: false,
             ...options,
           })
         )}

--- a/static/app/components/charts/barChart.tsx
+++ b/static/app/components/charts/barChart.tsx
@@ -13,11 +13,12 @@ export type BarChartSeries = Series & Omit<EChartOption.SeriesBar, 'data' | 'nam
 type Props = Omit<ChartProps, 'series'> & {
   series: BarChartSeries[];
   stacked?: boolean;
+  animation?: boolean;
 };
 
 class BarChart extends React.Component<Props> {
   render() {
-    const {series, stacked, xAxis, ...props} = this.props;
+    const {series, stacked, xAxis, animation, ...props} = this.props;
 
     return (
       <BaseChart
@@ -33,7 +34,7 @@ class BarChart extends React.Component<Props> {
               }
               return {value: [name, value], itemStyle};
             }),
-            animation: false,
+            animation,
             ...options,
           })
         )}

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -295,6 +295,7 @@ class Chart extends React.Component<ChartProps, State> {
         },
       },
       ...(chartOptionsProp ?? {}),
+      animation: typeof Component === typeof BarChart ? false : undefined,
     };
 
     return (


### PR DESCRIPTION
Bar chart animation activating on every rerender in Discover causes some visual jank. Disabling animation for barcharts in discover to fix this issue. 