### PR TITLE
fix(discover): Add validation for invalid span ID (#271)

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -30,14 +30,12 @@ from sentry.search.utils import (
 )
 from sentry.utils.compat import filter, map
 from sentry.utils.snuba import is_duration_measurement, is_measurement, is_span_op_breakdown
-from sentry.utils.validators import is_event_id
+from sentry.utils.validators import is_event_id, is_span_id
 
 # A wildcard is an asterisk prefixed by an even number of back slashes.
 # If there are an odd number of back slashes, then the back slash immediately
 # before the asterisk is actually escaping the asterisk.
 WILDCARD_CHARS = re.compile(r"(?<!\\)(\\\\)*\*")
-
-HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{16}$")
 
 event_search_grammar = Grammar(
     r"""
@@ -350,12 +348,11 @@ class SearchValue(NamedTuple):
     def is_span_id(self) -> bool:
         """Return whether the current value is a valid span id
 
-        Span IDs are 16 digit hexadecimal strings.
         Empty strings are valid, so that it can be used for has:trace.span queries
         """
         if not isinstance(self.raw_value, str):
             return False
-        return bool(HEXADECIMAL_16_DIGITS.search(self.raw_value)) or self.raw_value == ""
+        return is_span_id(self.raw_value) or self.raw_value == ""
 
 
 class SearchFilter(NamedTuple):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -37,6 +37,8 @@ from sentry.utils.validators import is_event_id
 # before the asterisk is actually escaping the asterisk.
 WILDCARD_CHARS = re.compile(r"(?<!\\)(\\\\)*\*")
 
+HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{16}$")
+
 event_search_grammar = Grammar(
     r"""
 search = spaces term*
@@ -344,6 +346,16 @@ class SearchValue(NamedTuple):
         if not isinstance(self.raw_value, str):
             return False
         return is_event_id(self.raw_value) or self.raw_value == ""
+
+    def is_span_id(self) -> bool:
+        """Return whether the current value is a valid span id
+
+        Span IDs are 16 digit hexadecimal strings.
+        Empty strings are valid, so that it can be used for has:trace.span queries
+        """
+        if not isinstance(self.raw_value, str):
+            return False
+        return bool(HEXADECIMAL_16_DIGITS.search(self.raw_value)) or self.raw_value == ""
 
 
 class SearchFilter(NamedTuple):

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -5,6 +5,10 @@ from django.utils.encoding import force_text
 
 INVALID_ID_DETAILS = "{} must be a valid UUID hex (32-36 characters long, containing only digits, dashes, or a-f characters)"
 
+WILDCARD_NOT_ALLOWED = "Wildcard conditions are not permitted on `{}` field"
+
+INVALID_SPAN_ID = "{} must be a valid 16 character hex (containing only digits, or a-f characters)"
+
 
 def validate_ip(value, required=True):
     if not required and not value:

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -1,4 +1,5 @@
 import ipaddress
+import re
 import uuid
 
 from django.utils.encoding import force_text
@@ -8,6 +9,8 @@ INVALID_ID_DETAILS = "{} must be a valid UUID hex (32-36 characters long, contai
 WILDCARD_NOT_ALLOWED = "Wildcard conditions are not permitted on `{}` field"
 
 INVALID_SPAN_ID = "{} must be a valid 16 character hex (containing only digits, or a-f characters)"
+
+HEXADECIMAL_16_DIGITS = re.compile("^[0-9a-fA-F]{16}$")
 
 
 def validate_ip(value, required=True):
@@ -36,3 +39,7 @@ def normalize_event_id(value):
 
 def is_event_id(value):
     return normalize_event_id(value) is not None
+
+
+def is_span_id(value):
+    return bool(HEXADECIMAL_16_DIGITS.search(force_text(value)))

--- a/tests/sentry/utils/test_validators.py
+++ b/tests/sentry/utils/test_validators.py
@@ -1,4 +1,4 @@
-from sentry.utils.validators import is_event_id, normalize_event_id
+from sentry.utils.validators import is_event_id, is_span_id, normalize_event_id
 
 
 def test_is_event_id():
@@ -42,3 +42,19 @@ def test_normalize_event_id():
     assert normalize_event_id(4711) is None
     assert normalize_event_id(False) is None
     assert normalize_event_id(None) is None
+
+
+def test_is_span_id():
+    assert is_span_id("202ab439bb9c4f31")
+    assert is_span_id("202AB439BB9C4F31")
+    assert is_span_id("202AB439bb9c4f31")
+    assert is_span_id(b"202AB439bb9c4f31")
+
+    assert not is_span_id("")
+    assert not is_span_id("202a-b439-bb9c-4f31")
+    assert not is_span_id("ZZZZZZZZZZZZZZZZ")
+    assert not is_span_id("202ab439bb9c4f31AAAAAAAAAA")
+    assert not is_span_id("202ab439")
+    assert not is_span_id(4711)
+    assert not is_span_id(False)
+    assert not is_span_id(None)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1926,6 +1926,9 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 val = self.base_datetime.isoformat()
             elif key in issue_search_config.boolean_keys:
                 val = "true"
+            elif key in {"trace.span", "trace.parent_span"}:
+                val = "abcdef1234abcdef"
+                test_query(f"!{key}:{val}")
             else:
                 val = "abadcafedeadbeefdeaffeedabadfeed"
                 test_query(f"!{key}:{val}")


### PR DESCRIPTION
Reject trace.span and trace.parent_span in discover queries if not valid
16 digit hexadecimal strings, or contains wildcards.