### PR TITLE
feat: Add API to identify available permissions

### DIFF
--- a/src/sentry/api/endpoints/user_permissions_config.py
+++ b/src/sentry/api/endpoints/user_permissions_config.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+from sentry.api.bases.user import UserEndpoint
+
+
+class UserPermissionsConfigEndpoint(UserEndpoint):
+    def get(self, request, user):
+        """
+        List all available permissions that can be applied to a user.
+        """
+        return self.respond([p for p in settings.SENTRY_USER_PERMISSIONS])

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -427,6 +427,7 @@ from .endpoints.user_organizations import UserOrganizationsEndpoint
 from .endpoints.user_password import UserPasswordEndpoint
 from .endpoints.user_permission_details import UserPermissionDetailsEndpoint
 from .endpoints.user_permissions import UserPermissionsEndpoint
+from .endpoints.user_permissions_config import UserPermissionsConfigEndpoint
 from .endpoints.user_social_identities_index import UserSocialIdentitiesIndexEndpoint
 from .endpoints.user_social_identity_details import UserSocialIdentityDetailsEndpoint
 from .endpoints.user_subscriptions import UserSubscriptionsEndpoint
@@ -693,6 +694,11 @@ urlpatterns = [
                     r"^(?P<user_id>[^\/]+)/permissions/$",
                     UserPermissionsEndpoint.as_view(),
                     name="sentry-api-0-user-permissions",
+                ),
+                url(
+                    r"^(?P<user_id>[^\/]+)/permissions/config/$",
+                    UserPermissionsConfigEndpoint.as_view(),
+                    name="sentry-api-0-user-permissions-config",
                 ),
                 url(
                     r"^(?P<user_id>[^\/]+)/permissions/(?P<permission_name>[^\/]+)/$",

--- a/tests/sentry/api/endpoints/test_user_permissions_config.py
+++ b/tests/sentry/api/endpoints/test_user_permissions_config.py
@@ -1,9 +1,8 @@
-from sentry.models import UserPermission
 from sentry.testutils import APITestCase
 
 
 class UserPermissionsConfigTest(APITestCase):
-    endpoint = "sentry-api-0-user-permissions"
+    endpoint = "sentry-api-0-user-permissions-config"
 
     def setUp(self):
         super().setUp()
@@ -11,10 +10,8 @@ class UserPermissionsConfigTest(APITestCase):
         self.login_as(user=self.user)
 
 
-class UserPermissionsGetTest(UserPermissionsConfigTest):
+class UserPermissionsConfigGetTest(UserPermissionsConfigTest):
     def test_lookup_self(self):
-        UserPermission.objects.create(user=self.user, permission="broadcasts.admin")
-        UserPermission.objects.create(user=self.user, permission="users.admin")
         resp = self.get_response("me")
         assert resp.status_code == 200
         assert len(resp.data) == 2, resp.data


### PR DESCRIPTION
Will be utilized when building a configuration form in admin, and makes use of the currently unused configurable list of permissions.
