### PR TITLE
fix(grouping): Tag first grouping variant's name on transaction [INGEST-494]

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -372,6 +372,16 @@ class Event:
             hierarchical_variants
         )
 
+        if flat_hashes:
+            sentry_sdk.set_tag("event.get_hashes.first_flat_variant_name", flat_hashes[0][0])
+        if hierarchical_hashes:
+            sentry_sdk.set_tag(
+                "event.get_hashes.first_hierarchical_variant_name", hierarchical_hashes[0][0]
+            )
+
+        flat_hashes = [hash_ for _, hash_ in flat_hashes]
+        hierarchical_hashes = [hash_ for _, hash_ in hierarchical_hashes]
+
         return CalculatedHashes(
             hashes=flat_hashes, hierarchical_hashes=hierarchical_hashes, tree_labels=tree_labels
         )
@@ -392,7 +402,7 @@ class Event:
         filtered_hashes = []
         tree_labels = []
         seen_hashes = set()
-        for variant in variants:
+        for name, variant in variants:
             hash_ = variant.get_hash()
             if hash_ is None or hash_ in seen_hashes:
                 continue

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -408,7 +408,7 @@ class Event:
                 continue
 
             seen_hashes.add(hash_)
-            filtered_hashes.append(hash_)
+            filtered_hashes.append((name, hash_))
             tree_labels.append(
                 variant.component.tree_label or None
                 if isinstance(variant, ComponentVariant)

--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -338,13 +338,11 @@ def sort_grouping_variants(variants):
     # Sort system variant to the back of the list to resolve ambiguities when
     # choosing primary_hash for Snuba
     flat_variants.sort(key=lambda name_and_variant: 1 if name_and_variant[0] == "system" else 0)
-    flat_variants = [variant for name, variant in flat_variants]
 
     # Sort hierarchical_variants by order defined in HIERARCHICAL_VARIANTS
     hierarchical_variants.sort(
         key=lambda name_and_variant: HIERARCHICAL_VARIANTS.index(name_and_variant[0])
     )
-    hierarchical_variants = [variant for name, variant in hierarchical_variants]
 
     return flat_variants, hierarchical_variants
 


### PR DESCRIPTION
* I want to get a general feeling for how many events in save_event are
grouped by message vs stacktrace. Adding this tag to the save_event
transaction.

* When `short_id.timeout` message is emitted in event manager, it's
often because of bad grouping. It's useful to know which variant created
so many different hashes. Then we can use this data to improve either
message grouping or stacktrace grouping.