### PR TITLE
ref(flags): Remove unused feature flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -994,8 +994,6 @@ SENTRY_FEATURES = {
     "organizations:integrations-incident-management": True,
     # Allow orgs to automatically create Tickets in Issue Alerts
     "organizations:integrations-ticket-rules": True,
-    # Allow orgs to install AzureDevops with limited scopes
-    "organizations:integrations-vsts-limited-scopes": False,
     # Allow orgs to use the stacktrace linking feature
     "organizations:integrations-stacktrace-link": False,
     # Allow orgs to install a custom source code management integration

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1000,9 +1000,6 @@ SENTRY_FEATURES = {
     "organizations:integrations-custom-scm": False,
     # Allow orgs to debug internal/unpublished sentry apps with logging
     "organizations:sentry-app-debugging": False,
-    # Temporary safety measure, turned on for specific orgs only if
-    # absolutely necessary, to be removed shortly
-    "organizations:slack-allow-workspace": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
     # Enable readonly dashboards

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -96,7 +96,6 @@ default_manager.add("organizations:integrations-issue-basic", OrganizationFeatur
 default_manager.add("organizations:integrations-issue-sync", OrganizationFeature)
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature, True)
-default_manager.add("organizations:integrations-vsts-limited-scopes", OrganizationFeature)
 default_manager.add("organizations:invite-members", OrganizationFeature)
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)

--- a/src/sentry/identity/vsts/provider.py
+++ b/src/sentry/identity/vsts/provider.py
@@ -1,4 +1,4 @@
-from sentry import features, http, options
+from sentry import http, options
 from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView, OAuth2Provider
 from sentry.utils.http import absolute_uri
 
@@ -40,18 +40,10 @@ class VSTSIdentityProvider(OAuth2Provider):
     oauth_access_token_url = "https://app.vssps.visualstudio.com/oauth2/token"
     oauth_authorize_url = "https://app.vssps.visualstudio.com/oauth2/authorize"
 
-    @property
-    def use_limited_scopes(self):
-        return use_limited_scopes(self.pipeline)
-
     def get_oauth_client_id(self):
-        if self.use_limited_scopes:
-            return options.get("vsts-limited.client-id")
         return options.get("vsts.client-id")
 
     def get_oauth_client_secret(self):
-        if self.use_limited_scopes:
-            return options.get("vsts-limited.client-secret")
         return options.get("vsts.client-secret")
 
     def get_refresh_token_url(self):
@@ -137,11 +129,3 @@ class VSTSOAuth2CallbackView(OAuth2CallbackView):
         if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):
             return dict(parse_qsl(body))
         return json.loads(body)
-
-
-def use_limited_scopes(pipeline):
-    return features.has(
-        "organizations:integrations-vsts-limited-scopes",
-        pipeline.organization,
-        actor=pipeline.request.user,
-    )

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -13,7 +13,7 @@ from sentry import features, http
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.identity.pipeline import IdentityProviderPipeline
-from sentry.identity.vsts import get_user_info, use_limited_scopes
+from sentry.identity.vsts import get_user_info
 from sentry.integrations import (
     FeatureDescription,
     IntegrationFeatures,
@@ -364,9 +364,6 @@ class VstsIntegrationProvider(IntegrationProvider):  # type: ignore
             )
 
     def get_scopes(self) -> Sequence[str]:
-        if use_limited_scopes(self.pipeline):
-            return ("vso.graph", "vso.serviceendpoint_manage", "vso.work_write")
-
         return ("vso.code", "vso.graph", "vso.serviceendpoint_manage", "vso.work_write")
 
     def get_pipeline_views(self) -> Sequence[PipelineView]:

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -4,7 +4,6 @@ from urllib.parse import parse_qs
 import responses
 
 from sentry.models import Identity, IdentityProvider, Integration
-from sentry.testutils.helpers import with_feature
 from sentry.utils import json
 
 from .testutils import VstsIntegrationTestCase
@@ -48,42 +47,6 @@ class VstsApiClientTest(VstsIntegrationTestCase):
             "vso.serviceendpoint_manage",
             "vso.work_write",
         ]
-        assert identity.data["access_token"] == "new-access-token"
-        assert identity.data["refresh_token"] == "new-refresh-token"
-
-    @with_feature("organizations:integrations-vsts-limited-scopes")
-    def test_refreshes_expired_token_limited_scopes(self):
-        self.assert_installation()
-        integration = Integration.objects.get(provider="vsts")
-
-        # Make the Identity have an expired token
-        idp = IdentityProvider.objects.get(external_id=self.vsts_account_id)
-        identity = Identity.objects.get(idp_id=idp.id)
-        identity.data["expires"] = int(time()) - int(123456789)
-        identity.save()
-
-        # New values VSTS will return on refresh
-        self.access_token = "new-access-token"
-        self.refresh_token = "new-refresh-token"
-        self._stub_vsts()
-
-        # Make a request with expired token
-        integration.get_installation(
-            integration.organizations.first().id
-        ).get_client().get_projects(self.vsts_base_url)
-
-        # Second to last request, before the Projects request, was to refresh
-        # the Access Token.
-        assert responses.calls[-2].request.url == "https://app.vssps.visualstudio.com/oauth2/token"
-
-        # Then we request the Projects with the new token
-        assert (
-            responses.calls[-1].request.url.split("?")[0]
-            == f"{self.vsts_base_url.lower()}_apis/projects"
-        )
-
-        identity = Identity.objects.get(id=identity.id)
-        assert identity.scopes == ["vso.graph", "vso.serviceendpoint_manage", "vso.work_write"]
         assert identity.data["access_token"] == "new-access-token"
         assert identity.data["refresh_token"] == "new-refresh-token"
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -13,7 +13,6 @@ from sentry.models import (
     Repository,
 )
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationProviderError
-from sentry.testutils.helpers import with_feature
 
 from .testutils import CREATE_SUBSCRIPTION, VstsIntegrationTestCase
 
@@ -45,20 +44,6 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
             "vso.serviceendpoint_manage",
             "vso.work_write",
         ]
-        assert metadata["subscription"]["id"] == CREATE_SUBSCRIPTION["id"]
-        assert metadata["domain_name"] == self.vsts_base_url
-
-    @with_feature("organizations:integrations-vsts-limited-scopes")
-    def test_limited_scopes_flow(self):
-        self.assert_installation()
-
-        integration = Integration.objects.get(provider="vsts")
-
-        assert integration.external_id == self.vsts_account_id
-        assert integration.name == self.vsts_account_name
-
-        metadata = integration.metadata
-        assert metadata["scopes"] == LIMITED_SCOPES
         assert metadata["subscription"]["id"] == CREATE_SUBSCRIPTION["id"]
         assert metadata["domain_name"] == self.vsts_base_url
 


### PR DESCRIPTION
Remove the VSTS limited scopes and Slack allow workspace flags and related code as they are unused today. Getsentry PR must be merged first: https://github.com/getsentry/getsentry/pull/6560