### PR TITLE
fix(similarity): Avoid leaking processingstore when similarity is slow [INGEST-154]

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -274,7 +274,6 @@ def post_process_group(
                 event=event,
             )
 
-            event_processing_store.delete_by_key(cache_key)
             return
 
         is_reprocessed = is_reprocessed_event(event.data)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -254,6 +254,9 @@ def post_process_group(
         # renormalize when loading old data from the database.
         event.data = EventDict(event.data, skip_renormalization=True)
 
+        with metrics.timer("tasks.post_process.delete_event_cache"):
+            event_processing_store.delete_by_key(cache_key)
+
         # Re-bind Project and Org since we're reading the Event object
         # from cache which may contain stale parent models.
         event.project = Project.objects.get_from_cache(id=event.project_id)
@@ -410,6 +413,11 @@ def post_process_group(
                     plugin_slug=plugin.slug, event=event, is_new=is_new, is_regresion=is_regression
                 )
 
+            from sentry import similarity
+
+            with sentry_sdk.start_span(op="tasks.post_process_group.similarity"):
+                safe_execute(similarity.record, event.project, [event], _with_transaction=False)
+
         # Patch attachments that were ingested on the standalone path.
         with sentry_sdk.start_span(op="tasks.post_process_group.update_existing_attachments"):
             try:
@@ -424,10 +432,6 @@ def post_process_group(
                 event=event,
                 primary_hash=kwargs.get("primary_hash"),
             )
-
-        index_similarity.delay(
-            project_id=event.project_id, group_id=event.group_id, cache_key=cache_key
-        )
 
 
 def process_snoozes(group):
@@ -496,49 +500,3 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         _with_transaction=False,
         **kwargs,
     )
-
-
-@instrumented_task(
-    name="sentry.tasks.post_process.index_similarity",
-    queue="similarity.index",
-    time_limit=120,
-    soft_time_limit=110,
-)
-def index_similarity(project_id: int, group_id: int, cache_key: str):
-    """
-    Index the event into similarity. This task is responsible for
-    dropping the event payload from processing store, and is isolated
-    from the rest of post_process due to stability problems of
-    similarity.
-    """
-    from sentry.eventstore.models import Event
-    from sentry.eventstore.processing import event_processing_store
-    from sentry.models import EventDict, Group, Organization, Project
-
-    data = event_processing_store.get(cache_key)
-    set_current_event_project(data["project"])
-
-    # Delete key now such that timing out task does not cause
-    # processing store to leak.
-    with metrics.timer("tasks.post_process.delete_event_cache"):
-        event_processing_store.delete_by_key(cache_key)
-
-    event = Event(
-        project_id=data["project"], event_id=data["event_id"], group_id=group_id, data=data
-    )
-
-    # Bind project, org, group explicitly such that we don't fetch
-    # them directly from the DB by accident
-    event.group = Group.objects.get_from_cache(id=event.group_id)
-    event.project = event.group.project = Project.objects.get_from_cache(id=event.project_id)
-    event.project.organization = Organization.objects.get_from_cache(
-        id=event.project.organization_id
-    )
-
-    # Re-bind node data to avoid renormalization. We only want to
-    # renormalize when loading old data from the database.
-    event.data = EventDict(event.data, skip_renormalization=True)
-
-    from sentry import similarity
-
-    safe_execute(similarity.record, event.project, [event], _with_transaction=False)


### PR DESCRIPTION
We want to move similarity out of post-process such that it doesn't affect our processing times and doesn't create backlogs in alerting.

Since similarity still needs the entire payload to work, a backlog in similarity still means increased usage of the event processing store. If we want to fix this problem too we need to add the entire event as task argument, or tear apart the similarity API such that feature extraction and the actual invocation of the lua script are two separate steps that can be done in two separate tasks.

Adding @markstory since he has previously been successful at moving eventstore deletion to a different task.