### PR TITLE
style(codeowners): Update CTA for darkmode

### DIFF
--- a/static/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/static/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -175,7 +175,7 @@ const Header = styled('h6')`
 `;
 
 const Content = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.textColor};
   margin-bottom: ${space(2)};
 `;
 


### PR DESCRIPTION
Before:
<img width="313" alt="Screenshot 2021-11-04 at 4 47 11 PM" src="https://user-images.githubusercontent.com/10491193/140421450-aa468598-6911-4f40-9060-e8a3601ea221.png">


After:
![codeowners csta darkmode](https://user-images.githubusercontent.com/10491193/140421408-d67bf597-7d50-4b3e-bd93-fd5534d15378.png)
