### PR TITLE
fix(dashboards): added undefined check to data on line chart

### DIFF
--- a/static/app/components/charts/lineChart.tsx
+++ b/static/app/components/charts/lineChart.tsx
@@ -30,7 +30,7 @@ export default class LineChart extends React.Component<Props> {
             ...seriesOptions,
             ...options,
             name: seriesName,
-            data: dataArray || data.map(({value, name}) => [name, value]),
+            data: dataArray || data?.map(({value, name}) => [name, value]),
             animation: false,
             animationThreshold: 1,
             animationDuration: 0,


### PR DESCRIPTION
Failing widget query request is causing empty entries in timeseries array which results in error due to unsafe reference