### PR TITLE
fix(dashboards): filter out empty entries in timeseriesResult before passing to children

### DIFF
--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -417,7 +417,13 @@ class WidgetQueries extends React.Component<Props, State> {
     const {children} = this.props;
     const {loading, timeseriesResults, tableResults, errorMessage} = this.state;
 
-    return children({loading, timeseriesResults, tableResults, errorMessage});
+    const filteredTimeseriesResults = timeseriesResults?.filter(result => !!result);
+    return children({
+      loading,
+      timeseriesResults: filteredTimeseriesResults,
+      tableResults,
+      errorMessage,
+    });
   }
 }
 


### PR DESCRIPTION
Child nodes of `widgetQueries` expect that `timeseriesResult` array prop has no undefined, null, etc entries.
This fixes cases where `timeseriesResult` may have empty entries by filtering out those entries before passing to child nodes.