### PR TITLE
fix(notification): Correct overriding in `where_should_be_participating`

### DIFF
--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -72,7 +72,7 @@ def _get_setting_mapping_from_mapping(
     }
 
     notification_settings_mapping = notification_settings_by_recipient.get(recipient, {})
-    for scope in [get_scope_type(type), NotificationScopeType.USER, NotificationScopeType.TEAM]:
+    for scope in [NotificationScopeType.USER, NotificationScopeType.TEAM, get_scope_type(type)]:
         notification_setting_option.update(notification_settings_mapping.get(scope, {}))
 
     return notification_setting_option

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -71,15 +71,9 @@ def _get_setting_mapping_from_mapping(
         for provider in notification_providers()
     }
 
-    notification_settings_mapping = notification_settings_by_recipient.get(recipient)
-    if notification_settings_mapping:
-        specific_scope = get_scope_type(type)
-        notification_setting_option.update(
-            notification_settings_mapping.get(specific_scope)
-            or notification_settings_mapping.get(NotificationScopeType.USER)
-            or notification_settings_mapping.get(NotificationScopeType.TEAM)
-            or {}
-        )
+    notification_settings_mapping = notification_settings_by_recipient.get(recipient, {})
+    for scope in [get_scope_type(type), NotificationScopeType.USER, NotificationScopeType.TEAM]:
+        notification_setting_option.update(notification_settings_mapping.get(scope, {}))
 
     return notification_setting_option
 

--- a/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
+++ b/tests/sentry/notifications/utils/test_get_setting_mapping_from_mapping.py
@@ -114,3 +114,26 @@ class GetSettingMappingFromMappingTest(TestCase):
             ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
             ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
         }
+
+    def test_get_setting_mapping_from_mapping_project(self):
+        notification_settings = {
+            self.user: {
+                NotificationScopeType.USER: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+                    ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+                },
+                NotificationScopeType.PROJECT: {
+                    ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+                },
+            }
+        }
+
+        mapping = _get_setting_mapping_from_mapping(
+            notification_settings,
+            self.user,
+            NotificationSettingTypes.ISSUE_ALERTS,
+        )
+        assert mapping == {
+            ExternalProviders.EMAIL: NotificationSettingOptionValues.NEVER,
+            ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+        }

--- a/tests/sentry/notifications/utils/test_should_be_participating.py
+++ b/tests/sentry/notifications/utils/test_should_be_participating.py
@@ -74,7 +74,6 @@ class WhereShouldBeParticipatingTest(TestCase):
         assert providers == [ExternalProviders.EMAIL, ExternalProviders.SLACK]
 
     def test_subscription_null(self):
-        self.user = User(id=1)
         notification_settings = {
             self.user: {
                 NotificationScopeType.USER: {


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/29757 we were on the right track but were implementing the `update()` incorrectly.
In this fix we apply the different levels of NotificationSettings in order.