### PR TITLE
ref(ui): Replace withTeamsForUser with useTeams on ProjectsDashboard

### DIFF
--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -106,8 +106,11 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
     // Note: This is the proper way to handle slug changes but unfortunately not all of our
     // components use stores correctly. To be safe reload browser :((
     if (response.slug !== itemId) {
+      // Overwrite changed fields
+      const oldTeam = this.state.teams.find(({slug}) => slug === itemId);
+      const newTeam = {...oldTeam, ...response};
       // Replace the team
-      const teams = [...this.state.teams.filter(({slug}) => slug !== itemId), response];
+      const teams = [...this.state.teams.filter(({slug}) => slug !== itemId), newTeam];
 
       this.state = {...this.state, teams};
       this.trigger(new Set([response.slug]));
@@ -116,7 +119,7 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
 
     const newTeams = [...this.state.teams];
     const index = newTeams.findIndex(team => team.slug === response.slug);
-    newTeams[index] = response;
+    newTeams[index] = {...newTeams[index], ...response};
 
     this.state = {...this.state, teams: newTeams};
     this.trigger(new Set([itemId]));

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -10,7 +10,6 @@ import {Client} from 'app/api';
 import Button from 'app/components/button';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
-import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import PageHeading from 'app/components/pageHeading';
@@ -31,10 +30,9 @@ import TeamSection from './teamSection';
 type Props = {
   api: Client;
   organization: Organization;
-  error: Error | null;
 } & RouteComponentProps<{orgId: string}, {}>;
 
-function Dashboard({params, organization, error}: Props) {
+function Dashboard({params, organization}: Props) {
   useEffect(() => {
     return function cleanup() {
       ProjectsStatsStore.reset();
@@ -45,10 +43,6 @@ function Dashboard({params, organization, error}: Props) {
 
   if (!initiallyLoaded) {
     return <LoadingIndicator />;
-  }
-
-  if (error) {
-    return <LoadingError message={t('An error occurred while fetching your projects')} />;
   }
 
   const filteredTeams = (teams as TeamWithProjects[]).filter(

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -290,16 +290,5 @@ describe('ProjectsDashboard', function () {
       });
       expect(ProjectsStatsStore.getAll()).toEqual({});
     });
-
-    it('renders an error from withTeamsForUser', function () {
-      act(() => void TeamStore.loadInitialData(teamsWithStatTestProjects));
-
-      const wrapper = mountWithTheme(
-        <Dashboard error={Error('uhoh')} organization={org} params={{orgId: org.slug}} />,
-        routerContext
-      );
-
-      expect(wrapper.find('LoadingError').exists()).toBe(true);
-    });
   });
 });

--- a/tests/js/spec/views/projectsDashboard/index.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/index.spec.jsx
@@ -3,6 +3,7 @@ import {act} from 'sentry-test/reactTestingLibrary';
 
 import * as projectsActions from 'app/actionCreators/projects';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
+import TeamStore from 'app/stores/teamStore';
 import {Dashboard} from 'app/views/projectsDashboard';
 
 jest.unmock('lodash/debounce');
@@ -44,18 +45,16 @@ describe('ProjectsDashboard', function () {
 
   afterEach(function () {
     MockApiClient.clearMockResponses();
+    TeamStore.reset();
   });
 
   describe('empty state', function () {
     it('renders with no projects', function () {
       const noProjectTeams = [TestStubs.Team({projects: []})];
+      act(() => void TeamStore.loadInitialData(noProjectTeams));
 
       const wrapper = mountWithTheme(
-        <Dashboard
-          teams={noProjectTeams}
-          organization={org}
-          params={{orgId: org.slug}}
-        />,
+        <Dashboard organization={org} params={{orgId: org.slug}} />,
         routerContext
       );
 
@@ -67,13 +66,10 @@ describe('ProjectsDashboard', function () {
       const projects = [TestStubs.Project({teams})];
 
       const teamsWithOneProject = [TestStubs.Team({projects})];
+      act(() => void TeamStore.loadInitialData(teamsWithOneProject));
 
       const wrapper = mountWithTheme(
-        <Dashboard
-          teams={teamsWithOneProject}
-          organization={org}
-          params={{orgId: org.slug}}
-        />,
+        <Dashboard organization={org} params={{orgId: org.slug}} />,
         routerContext
       );
 
@@ -100,13 +96,10 @@ describe('ProjectsDashboard', function () {
       ];
 
       const teamsWithTwoProjects = [TestStubs.Team({projects})];
+      act(() => void TeamStore.loadInitialData(teamsWithTwoProjects));
 
       const wrapper = mountWithTheme(
-        <Dashboard
-          teams={teamsWithTwoProjects}
-          organization={org}
-          params={{orgId: org.slug}}
-        />,
+        <Dashboard organization={org} params={{orgId: org.slug}} />,
         routerContext
       );
 
@@ -163,6 +156,7 @@ describe('ProjectsDashboard', function () {
       ];
 
       const teamsWithFavProjects = [TestStubs.Team({projects})];
+      act(() => void TeamStore.loadInitialData(teamsWithFavProjects));
 
       MockApiClient.addMockResponse({
         url: `/organizations/${org.slug}/projects/`,
@@ -257,12 +251,10 @@ describe('ProjectsDashboard', function () {
         })),
       });
 
+      act(() => void TeamStore.loadInitialData(teamsWithStatTestProjects));
+
       const wrapper = mountWithTheme(
-        <Dashboard
-          teams={teamsWithStatTestProjects}
-          organization={org}
-          params={{orgId: org.slug}}
-        />,
+        <Dashboard organization={org} params={{orgId: org.slug}} />,
         routerContext
       );
 
@@ -300,6 +292,8 @@ describe('ProjectsDashboard', function () {
     });
 
     it('renders an error from withTeamsForUser', function () {
+      act(() => void TeamStore.loadInitialData(teamsWithStatTestProjects));
+
       const wrapper = mountWithTheme(
         <Dashboard error={Error('uhoh')} organization={org} params={{orgId: org.slug}} />,
         routerContext


### PR DESCRIPTION
`withTeamsForUser` is only used in this one place and should be removed in favor of the newer `useTeams` and `<Teams>` fetching utilities.