### PR TITLE
fix(appstore-connect): Return more detailed errors when API credentials are unusable during setup

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -154,7 +154,12 @@ class AppStoreConnectAppsEndpoint(ProjectEndpoint):  # type: ignore
         )
         session = requests.Session()
 
-        apps = appstore_connect.get_apps(session, credentials)
+        try:
+            apps = appstore_connect.get_apps(session, credentials)
+        except appstore_connect.UnauthorizedError:
+            raise AppConnectAuthenticationError()
+        except appstore_connect.ForbiddenError:
+            raise AppConnectForbiddenError()
 
         if apps is None:
             raise AppConnectAuthenticationError()

--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -157,12 +157,12 @@ class AppStoreConnectAppsEndpoint(ProjectEndpoint):  # type: ignore
         try:
             apps = appstore_connect.get_apps(session, credentials)
         except appstore_connect.UnauthorizedError:
-            raise AppConnectAuthenticationError()
+            raise AppConnectAuthenticationError
         except appstore_connect.ForbiddenError:
-            raise AppConnectForbiddenError()
+            raise AppConnectForbiddenError
 
         if apps is None:
-            raise AppConnectAuthenticationError()
+            raise AppConnectAuthenticationError
 
         all_apps = [
             {"name": app.name, "bundleId": app.bundle_id, "appId": app.app_id} for app in apps


### PR DESCRIPTION
When setting up credentials the only feedback that's returned when they're wrong (invalid, not enough perms) is this:

<img width="603" alt="Screenshot 2021-11-03 at 10 08 20 PM" src="https://user-images.githubusercontent.com/5597345/140437911-1892f6ec-dc0e-441d-82ac-3675c62aea15.png">

This changes things so that the user will see the following two errors instead based on what App Store Connect tells us:

<img width="1028" alt="Screenshot 2021-11-04 at 12 13 46 AM" src="https://user-images.githubusercontent.com/5597345/140437957-b335e735-f5dc-4516-9ac8-4e2118758915.png">
<img width="533" alt="Screenshot 2021-11-04 at 12 14 31 AM" src="https://user-images.githubusercontent.com/5597345/140437958-b85dcdbc-3901-4078-a77a-46206b69bf7a.png">

Front end work was already completed as a part of https://github.com/getsentry/sentry/pull/29728 since there's some shared FE code between these two PRs.

I don't believe there should be any issues deploying this change as the FE already is capable of handling what this endpoint returns prior to and after this change. 