### PR TITLE
fix(sessions): Disallow querying by issue.id

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -217,10 +217,17 @@ GROUPBY_MAP = {
 }
 
 CONDITION_COLUMNS = ["project", "environment", "release"]
+FILTER_KEY_COLUMNS = ["project_id"]
 
 
 def resolve_column(col):
     if col in CONDITION_COLUMNS:
+        return col
+    raise InvalidField(f'Invalid query field: "{col}"')
+
+
+def resolve_filter_key(col):
+    if col in FILTER_KEY_COLUMNS:
         return col
     raise InvalidField(f'Invalid query field: "{col}"')
 
@@ -289,10 +296,13 @@ class QueryDefinition:
         # this makes sure that literals in complex queries are properly quoted,
         # and unknown fields are raised as errors
         conditions = [resolve_condition(c, resolve_column) for c in snuba_filter.conditions]
+        filter_keys = {
+            resolve_filter_key(key): value for key, value in snuba_filter.filter_keys.items()
+        }
 
         self.aggregations = snuba_filter.aggregations
         self.conditions = conditions
-        self.filter_keys = snuba_filter.filter_keys
+        self.filter_keys = filter_keys
 
 
 MAX_POINTS = 1000

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -131,6 +131,12 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.content
         assert response.data == {"detail": 'Invalid groupBy: "envriomnent"'}
 
+    def test_illegal_groupby(self):
+        response = self.do_request({"field": ["sum(session)"], "groupBy": ["issue.id"]})
+
+        assert response.status_code == 400, response.content
+        assert response.data == {"detail": 'Invalid groupBy: "issue.id"'}
+
     def test_invalid_query(self):
         response = self.do_request(
             {"statsPeriod": "1d", "field": ["sum(session)"], "query": ["foo:bar"]}
@@ -151,6 +157,13 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
         # TODO: it would be good to provide a better error here,
         # since its not obvious where `message` comes from.
         assert response.data == {"detail": 'Invalid query field: "message"'}
+
+    def test_illegal_query(self):
+        response = self.do_request(
+            {"statsPeriod": "1d", "field": ["sum(session)"], "query": ["issue.id:123"]}
+        )
+        assert response.status_code == 400, response.content
+        assert response.data == {"detail": 'Invalid query field: "group_id"'}
 
     def test_too_many_points(self):
         # default statsPeriod is 90d


### PR DESCRIPTION
The `/sessions` endpoint reuses a helper function from event search for parsing some of its query parameters. This helper function produces `conditions` and `filter_keys` to plug into a snuba query. The `filter_keys` are not checked against the snuba schema, however, so a query like `issue.id:123` causes a 500 response on this endpoint.

Partially fixes [SENTRY-SGT](https://sentry.io/organizations/sentry/issues/2737372157/events/b594db3270d3476ea9ee7c5ab48873f6/?project=1), which contains several other `QueryMissingColumn` errors.