### PR TITLE
ref(sentry-metrics): Remove unneeded option

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -528,11 +528,6 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 
 @run.command("ingest-metrics-consumer")
 @log_options()
-@click.option(
-    "--group_id",
-    default="ingest-metrics-consumer",
-    help="Consumer group to track metric indexer offsets. ",
-)
 @click.option("--topic", default="ingest-metrics", help="Topic to get subscription updates from.")
 @batching_kafka_options("ingest-metrics-consumer")
 @configuration


### PR DESCRIPTION
I think this was brought up in a comment on an older PR and I forgot to address but because we already have:

`@batching_kafka_options("ingest-metrics-consumer")`

we shouldn't need the `--group_id` option