### PR TITLE
fix(slack): Allow identity unlinking from slack.

### DIFF
--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -63,8 +63,5 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # 
         """
         Delete an External Team
         """
-        self.assert_has_feature(request, team.organization)
-
         external_team.delete()
-
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -65,7 +65,5 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMix
         """
         Delete an External Team
         """
-        self.assert_has_feature(request, organization)
-
         external_user.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -141,7 +141,7 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
         <DeleteButtonWrapper>
           <Tooltip
             title={t(
-              "You must have the 'team:write' permission to remove a Slack team link"
+              'You must be an organization owner, manager or admin to remove a Slack team link'
             )}
             disabled={hasAccess}
           >

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -15,10 +15,9 @@ class ExternalTeamDetailsTest(APITestCase):
         )
 
     def test_basic_delete(self):
-        with self.feature({"organizations:integrations-codeowners": True}):
-            self.get_success_response(
-                self.organization.slug, self.team.slug, self.external_team.id, method="delete"
-            )
+        self.get_success_response(
+            self.organization.slug, self.team.slug, self.external_team.id, method="delete"
+        )
         assert not ExternalActor.objects.filter(id=str(self.external_team.id)).exists()
 
     def test_basic_update(self):

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -14,10 +14,7 @@ class ExternalUserDetailsTest(APITestCase):
         )
 
     def test_basic_delete(self):
-        with self.feature({"organizations:integrations-codeowners": True}):
-            self.get_success_response(
-                self.organization.slug, self.external_user.id, method="delete"
-            )
+        self.get_success_response(self.organization.slug, self.external_user.id, method="delete")
         assert not ExternalActor.objects.filter(id=str(self.external_user.id)).exists()
 
     def test_basic_update(self):


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/29682

The previous PR included all the business logic for unlinking slack identities from the UI, but I reused an endpoint that was behind a feature flag I was opted in to, so I didn't notice it would 403 unless you had that feature (CODEOWNERS).

The delete methods for external actor endpoints are now NOT feature flagged.