### PR TITLE
fix(appstore-connect): Fix empty dSYMUrl detection

### DIFF
--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -386,15 +386,12 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
         for b in bundles
         if safe.get_path(b, "attributes", "bundleType", default="APP") == "APP_CLIP"
     ]
-    if any(app_clip_urls):
-        sentry_sdk.capture_message("App_CLIP has dSYMUrl")
+    if not all(isinstance(url, NoDsymUrl) for url in app_clip_urls):
+        sentry_sdk.capture_message("App Clip's bundle has a dSYMUrl")
 
     app_bundles = [
-        app_bundle
-        for app_bundle in bundles
-        if safe.get_path(app_bundle, "attributes", "bundleType", default="APP") != "APP_CLIP"
+        b for b in bundles if safe.get_path(b, "attributes", "bundleType", default="APP") == "APP"
     ]
-
     if not app_bundles:
         return NoDsymUrl.NOT_NEEDED
     elif len(app_bundles) > 1:

--- a/src/sentry/utils/appleconnect/appstore_connect.py
+++ b/src/sentry/utils/appleconnect/appstore_connect.py
@@ -390,7 +390,9 @@ def _get_dsym_url(bundles: Optional[List[JSONData]]) -> Union[NoDsymUrl, str]:
         sentry_sdk.capture_message("App Clip's bundle has a dSYMUrl")
 
     app_bundles = [
-        b for b in bundles if safe.get_path(b, "attributes", "bundleType", default="APP") == "APP"
+        app_bundle
+        for app_bundle in bundles
+        if safe.get_path(app_bundle, "attributes", "bundleType", default="APP") != "APP_CLIP"
     ]
     if not app_bundles:
         return NoDsymUrl.NOT_NEEDED

--- a/tests/sentry/utils/appleconnect/test_appstore_connect.py
+++ b/tests/sentry/utils/appleconnect/test_appstore_connect.py
@@ -164,17 +164,18 @@ class TestListBuilds:
             appstore_connect.get_build_info(session, api_credentials, app_id, include_expired=True)
         )
 
+        found_build = None
+
         for build in builds:
             if build.build_number == "332":
+                found_build = build
                 break
-        else:
-            pytest.fail("Build 332 not found")
-        build = builds[0]
 
-        assert build.build_number == "332"
-        assert isinstance(build.dsym_url, str)
-        assert build.dsym_url.startswith("http://iosapps.itunes.apple.com/itunes-assets/")
-        assert "accessKey=" in build.dsym_url
+        assert found_build is not None
+        assert found_build.build_number == "332"
+        assert isinstance(found_build.dsym_url, str)
+        assert found_build.dsym_url.startswith("http://iosapps.itunes.apple.com/itunes-assets/")
+        assert "accessKey=" in found_build.dsym_url
 
     def test_no_dsyms_needed(
         self,
@@ -190,14 +191,15 @@ class TestListBuilds:
             appstore_connect.get_build_info(session, api_credentials, app_id, include_expired=True)
         )
 
+        found_build = None
         for build in builds:
             if build.build_number == "333":
+                found_build = build
                 break
-        else:
-            pytest.fail("Build 333 not found")
 
-        assert build.build_number == "333"
-        assert build.dsym_url is appstore_connect.NoDsymUrl.NOT_NEEDED
+        assert found_build is not None
+        assert found_build.build_number == "333"
+        assert found_build.dsym_url is appstore_connect.NoDsymUrl.NOT_NEEDED
 
 
 class TestGetDsymUrl:

--- a/tests/sentry/utils/appleconnect/test_appstore_connect.py
+++ b/tests/sentry/utils/appleconnect/test_appstore_connect.py
@@ -294,10 +294,10 @@ class TestGetDsymUrl:
                 },
             },
         ]
-        assert appstore_connect._get_dsym_url(bundles) is first_url
+        assert appstore_connect._get_dsym_url(bundles) == first_url
 
         bundles.reverse()
-        assert appstore_connect._get_dsym_url(bundles) is second_url
+        assert appstore_connect._get_dsym_url(bundles) == second_url
 
     def test_multi_bundle_mixed_urls(self) -> None:
         url = "http://iosapps.itunes.apple.com/itunes-assets/very-real-url"
@@ -320,7 +320,7 @@ class TestGetDsymUrl:
             },
         ]
 
-        assert appstore_connect._get_dsym_url(bundles) is url
+        assert appstore_connect._get_dsym_url(bundles) == url
 
         bundles.reverse()
         assert appstore_connect._get_dsym_url(bundles) is NoDsymUrl.NOT_NEEDED
@@ -346,7 +346,7 @@ class TestGetDsymUrl:
         ]
 
         with mock.patch("sentry_sdk.capture_message") as capture_message:
-            assert appstore_connect._get_dsym_url(bundles) == NoDsymUrl.NOT_NEEDED
+            assert appstore_connect._get_dsym_url(bundles) is NoDsymUrl.NOT_NEEDED
             assert capture_message.call_count == 0
 
     def test_multi_bundle_appclip_has_urls(self) -> None:
@@ -396,5 +396,5 @@ class TestGetDsymUrl:
         ]
 
         with mock.patch("sentry_sdk.capture_message") as capture_message:
-            assert appstore_connect._get_dsym_url(bundles) == NoDsymUrl.NOT_NEEDED
+            assert appstore_connect._get_dsym_url(bundles) is NoDsymUrl.NOT_NEEDED
             assert capture_message.call_count == 1


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/29704's check for the presence of dSYMS was slightly off, see SENTRY-SN6. The code uses an enum to represent cases where there is no dSYM present, so the truthy check for a url would always pass, causing app clip dsyms to always be reported.

This adds tests to verify the logic as well.