### PR TITLE
ref(notifications): Only use fallthrough to override unmatched issues

### DIFF
--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -169,13 +169,11 @@ def get_owners(project: Project, event: Event | None = None) -> Iterable[Team | 
 
     else:
         outcome = "match"
-        matched_recipients = ActorTuple.resolve_many(owners)
+        recipients = ActorTuple.resolve_many(owners)
         # Used to suppress extra notifications to all matched owners, only notify the would-be auto-assignee
-        recipients = (
-            matched_recipients
-            if features.has("organizations:notification-all-recipients", project.organization)
-            else matched_recipients[-1:]
-        )
+        if features.has("organizations:notification-all-recipients", project.organization):
+            recipients = recipients[-1:]
+
     metrics.incr(
         "features.owners.send_to",
         tags={"organization": project.organization_id, "outcome": outcome},

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -169,17 +169,13 @@ def get_owners(project: Project, event: Event | None = None) -> Iterable[Team | 
 
     else:
         outcome = "match"
-        recipients = ActorTuple.resolve_many(owners)
-
-    if len(recipients) > 1:
-        ownership = ProjectOwnership.get_ownership_cached(project.id)
-        # Used to suppress extra notifications to all project members, only notify the would-be auto-assignee
-        if (
-            ownership
-            and not ownership.fallthrough
-            and not features.has("organizations:notification-all-recipients", project.organization)
-        ):
-            return list(recipients)[-1:]
+        matched_recipients = ActorTuple.resolve_many(owners)
+        # Used to suppress extra notifications to all matched owners, only notify the would-be auto-assignee
+        recipients = (
+            matched_recipients
+            if features.has("organizations:notification-all-recipients", project.organization)
+            else matched_recipients[-1:]
+        )
 
     metrics.incr(
         "features.owners.send_to",

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -176,7 +176,6 @@ def get_owners(project: Project, event: Event | None = None) -> Iterable[Team | 
             if features.has("organizations:notification-all-recipients", project.organization)
             else matched_recipients[-1:]
         )
-
     metrics.incr(
         "features.owners.send_to",
         tags={"organization": project.organization_id, "outcome": outcome},

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -469,9 +469,11 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ),
             fallthrough=True,
         )
-
-        event_all_users = self.store_event(data=make_event_data("foo.cbl"), project_id=project.id)
-        self.assert_notify(event_all_users, [user.email, user2.email])
+        with self.feature({"organizations:notification-all-recipients": True}):
+            event_all_users = self.store_event(
+                data=make_event_data("foo.cbl"), project_id=project.id
+            )
+            self.assert_notify(event_all_users, [user.email, user2.email])
 
         event_team = self.store_event(data=make_event_data("foo.py"), project_id=project.id)
         self.assert_notify(event_team, [user.email, user2.email])
@@ -487,8 +489,12 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             user=user2,
             project=project,
         )
-        event_all_users = self.store_event(data=make_event_data("foo.cbl"), project_id=project.id)
-        self.assert_notify(event_all_users, [user.email])
+
+        with self.feature({"organizations:notification-all-recipients": True}):
+            event_all_users = self.store_event(
+                data=make_event_data("foo.cbl"), project_id=project.id
+            )
+            self.assert_notify(event_all_users, [user.email])
 
     def test_notify_team_members(self):
         """Test that each member of a team is notified"""

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -469,7 +469,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             ),
             fallthrough=True,
         )
-        with self.feature({"organizations:notification-all-recipients": True}):
+        with self.feature("organizations:notification-all-recipients"):
             event_all_users = self.store_event(
                 data=make_event_data("foo.cbl"), project_id=project.id
             )
@@ -490,7 +490,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             project=project,
         )
 
-        with self.feature({"organizations:notification-all-recipients": True}):
+        with self.feature("organizations:notification-all-recipients"):
             event_all_users = self.store_event(
                 data=make_event_data("foo.cbl"), project_id=project.id
             )

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -9,7 +9,7 @@ from sentry.notifications.types import (
 )
 from sentry.notifications.utils.participants import get_send_to
 from sentry.ownership import grammar
-from sentry.ownership.grammar import Matcher, Owner, dump_schema
+from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 from tests.sentry.mail import make_event_data
@@ -243,3 +243,40 @@ class GetSendToOwnersTest(TestCase):
         event = self.store_event("no_rule.cpp")
 
         assert self.get_send_to_owners(event) == {}
+
+
+class ParticipantsTestCase(TestCase):
+    def setUp(self):
+        self.organzation = self.create_organization(name="Padishah Emperor", owner=None)
+        self.user = self.create_user(email="paul@atreides.space")
+        self.team_1 = self.create_team(organization=self.organization, name="House Atreides")
+        self.team_2 = self.create_team(organization=self.organization, name="Bene Gesserit")
+        self.project1 = self.create_project(
+            name="Settle Arrakis", organization=self.organization, teams=[self.team1, self.team2]
+        )
+        self.project2 = self.create_project(name="Survive", organization=self.organization)
+        rule1 = Rule(Matcher("path", "*"), [Owner("user", self.user.email)])
+        rule2 = Rule(Matcher("path", "*.py"), [Owner("team", self.team1.slug)])
+        rule3 = Rule(Matcher("path", "magic/*.js"), [Owner("team", self.team2.slug)])
+
+        self.project_ownership1 = ProjectOwnership.objects.create(
+            project_id=self.project1.id, schema=dump_schema([rule1, rule2, rule3]), fallthrough=True
+        )
+        self.project_ownership2 = ProjectOwnership.objects.create(
+            project_id=self.project2.id, fallthrough=True
+        )
+
+    def test_get_owners_no_event(self):
+        pass
+
+    def test_get_owners_empty(self):
+        pass
+
+    def test_get_owners_everyone(self):
+        pass
+
+    def test_get_owners_match(self):
+        pass
+
+    def test_only_autoassignee(self):
+        pass

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -268,15 +268,6 @@ class GetOwnersCase(TestCase):
         self.rule_2 = Rule(Matcher("path", "*.js"), [Owner("team", self.team_2.slug)])
         self.rule_3 = Rule(Matcher("path", "*.js"), [Owner("user", self.user_1.email)])
 
-        # self.project_ownership1 = ProjectOwnership.objects.create(
-        #     project_id=self.project_1.id,
-        #     schema=dump_schema([self.rule_1, self.rule_2, self.rule_3]),
-        #     fallthrough=True,
-        # )
-        # self.project_ownership2 = ProjectOwnership.objects.create(
-        #     project_id=self.project_2.id, fallthrough=True
-        # )
-
     def tearDown(self):
         cache.delete(ProjectOwnership.get_cache_key(self.project.id))
         super().tearDown()

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -326,7 +326,7 @@ class GetOwnersCase(TestCase):
 
     # If matched, and all-recipients flag
     def test_get_owners_match(self):
-        with self.feature({"organizations:notification-all-recipients": True}):
+        with self.feature("organizations:notification-all-recipients"):
             self.create_ownership(self.project, [self.rule_1, self.rule_2, self.rule_3])
             event = self.create_event(self.project)
             recipients = get_owners(project=self.project, event=event)


### PR DESCRIPTION
Related [API-2200](https://getsentry.atlassian.net/browse/API-2200)

If an issue does match an issue owners rule, we should only notify the last match, regardless of whether or not fallthrough is enabled. Fallthrough should only matter if there has been no match via issue owners rules.

Also added explicit tests for this behavior.