### PR TITLE
ci(lint): Avoid changing Optional[int] -> int | None

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     - id: pyupgrade
       name: pyupgrade
       entry: pyupgrade
-      args: ['--py38-plus']
+      args: ['--py38-plus', '--keep-runtime-typing']
       language: system
       types: [python]
       # We can't change this mock to unittest.mock until Python 3.8,


### PR DESCRIPTION
This is making too many changes right now that we're not sure if we're happy with.

This also turns off `Union[a, b] -> a | b` unfortunately. but we're ok w/ that for now