### PR TITLE
fix(discover): Column does not have alias attribute

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -103,8 +103,9 @@ class QueryBuilder(QueryFilter):
                     if len(conflicting_functions) > 2
                     else ""
                 )
+                alias = column.name if type(column) == Column else column.alias
                 raise InvalidSearchQuery(
-                    f"A single field cannot be used both inside and outside a function in the same query. To use {column.alias} you must first remove the function(s): {function_msg}"
+                    f"A single field cannot be used both inside and outside a function in the same query. To use '{alias}'' you must first remove the function(s): {function_msg}"
                 )
 
     def validate_having_clause(self) -> None:

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -105,7 +105,7 @@ class QueryBuilder(QueryFilter):
                 )
                 alias = column.name if type(column) == Column else column.alias
                 raise InvalidSearchQuery(
-                    f"A single field cannot be used both inside and outside a function in the same query. To use '{alias}' you must first remove the function(s): {function_msg}"
+                    f"A single field cannot be used both inside and outside a function in the same query. To use {alias} you must first remove the function(s): {function_msg}"
                 )
 
     def validate_having_clause(self) -> None:

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -105,7 +105,7 @@ class QueryBuilder(QueryFilter):
                 )
                 alias = column.name if type(column) == Column else column.alias
                 raise InvalidSearchQuery(
-                    f"A single field cannot be used both inside and outside a function in the same query. To use '{alias}'' you must first remove the function(s): {function_msg}"
+                    f"A single field cannot be used both inside and outside a function in the same query. To use '{alias}' you must first remove the function(s): {function_msg}"
                 )
 
     def validate_having_clause(self) -> None:


### PR DESCRIPTION
In surfacing the error message, we try to access
alias on select type when it might not always be
valid.

Before:
![Screen Shot 2021-11-08 at 9 37 33 AM](https://user-images.githubusercontent.com/63818634/140761392-9fa2ff5a-e661-4720-9fe6-63ed6d1a9a89.png)

After:
![Screen Shot 2021-11-08 at 9 40 11 AM](https://user-images.githubusercontent.com/63818634/140761829-112984fe-b3fd-48e8-bd3b-ea591011685d.png)

Fixes SENTRY-SND