### PR TITLE
fix(grouping) Don't crash on None

### DIFF
--- a/src/sentry/grouping/fingerprinting.py
+++ b/src/sentry/grouping/fingerprinting.py
@@ -58,6 +58,8 @@ class InvalidFingerprintingConfig(Exception):
 
 
 def get_crashing_thread(threads):
+    if threads is None:
+        return None
     if len(threads) == 1:
         return threads[0]
     filtered = [x for x in threads if x and x.get("crashed")]


### PR DESCRIPTION
If we don't have any threads, return early. The caller of get_crashing_thread handles the none.