### PR TITLE
feat(alerts): Show related issues not available on query error

### DIFF
--- a/static/app/views/alerts/rules/details/relatedIssuesNotAvailable.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssuesNotAvailable.tsx
@@ -20,27 +20,21 @@ export const RELATED_ISSUES_QUERY_ERROR =
 /**
  * Renders an Alert box of type "info" for boolean queries in alert details. Renders a discover link if the feature is available.
  */
-export class RelatedIssuesNotAvailable extends React.Component<Props> {
-  render() {
-    const {buttonTo, buttonText} = this.props;
-
-    return (
-      <StyledAlert type="info">
-        <Content>
-          <IconInfo size="lg" />
-          <div data-test-id="loading-error-message">
-            Related Issues unavailable for this alert.
-          </div>
-          <Feature features={['discover-basic']}>
-            <Button type="button" priority="default" size="small" to={buttonTo}>
-              {buttonText}
-            </Button>
-          </Feature>
-        </Content>
-      </StyledAlert>
-    );
-  }
-}
+export const RelatedIssuesNotAvailable = ({buttonTo, buttonText}: Props) => (
+  <StyledAlert type="info">
+    <Content>
+      <IconInfo size="lg" />
+      <div data-test-id="loading-error-message">
+        Related Issues unavailable for this alert.
+      </div>
+      <Feature features={['discover-basic']}>
+        <Button type="button" priority="default" size="small" to={buttonTo}>
+          {buttonText}
+        </Button>
+      </Feature>
+    </Content>
+  </StyledAlert>
+);
 
 const StyledAlert = styled(Alert)`
   ${/* sc-selector */ Panel} & {

--- a/static/app/views/alerts/rules/details/relatedIssuesNotAvailable.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssuesNotAvailable.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import styled from '@emotion/styled';
+
+import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
+import Link from 'app/components/links/link';
+import {Panel} from 'app/components/panels';
+import {IconInfo} from 'app/icons';
+import space from 'app/styles/space';
+
+type Props = {
+  buttonTo: React.ComponentProps<typeof Link>['to'];
+  buttonText: string;
+};
+
+export const RELATED_ISSUES_QUERY_ERROR =
+  'Error parsing search query: Boolean statements containing "OR" or "AND" are not supported in this search';
+
+/**
+ * Renders an Alert box of type "info" for boolean queries in alert details. Renders a discover link if the feature is available.
+ */
+export class RelatedIssuesNotAvailable extends React.Component<Props> {
+  render() {
+    const {buttonTo, buttonText} = this.props;
+
+    return (
+      <StyledAlert type="info">
+        <Content>
+          <IconInfo size="lg" />
+          <div data-test-id="loading-error-message">
+            Related Issues unavailable for this alert.
+          </div>
+          <Feature features={['discover-basic']}>
+            <Button type="button" priority="default" size="small" to={buttonTo}>
+              {buttonText}
+            </Button>
+          </Feature>
+        </Content>
+      </StyledAlert>
+    );
+  }
+}
+
+const StyledAlert = styled(Alert)`
+  ${/* sc-selector */ Panel} & {
+    border-radius: 0;
+    border-width: 1px 0;
+  }
+`;
+
+const Content = styled('div')`
+  display: grid;
+  grid-gap: ${space(1)};
+  grid-template-columns: min-content auto max-content;
+  align-items: center;
+`;


### PR DESCRIPTION
This shows an info message in alert details if related issues query fails due to the error metric containing a boolean query. They are not yet implemented for issue search, this with a discover link is an alternative to the error message in the meanwhile.

Before the info-alert:

![Screen Shot 2021-11-08 at 12 10 44 PM](https://user-images.githubusercontent.com/15015880/140811025-2d160b68-0a24-4c04-9a77-36e127a19d7e.png)

After the info-alert:

![Screen Shot 2021-11-08 at 12 10 05 PM](https://user-images.githubusercontent.com/15015880/140811039-8e080ade-24ef-4cc4-9c30-1a62e9032e6a.png)


Jira: [WOR-1171](https://getsentry.atlassian.net/browse/WOR-1171)