### PR TITLE
chore(reports): Add retry and acks_late to tasks

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -564,6 +564,7 @@ class RedisReportBackend(ReportBackend):
 backend = RedisReportBackend(redis.clusters.get("default"), 60 * 60 * 3)
 
 
+@retry()
 @instrumented_task(
     name="sentry.tasks.reports.prepare_reports", queue="reports.prepare", acks_late=True
 )


### PR DESCRIPTION
Some weekly reports are not getting sent to customers and this is an attempt to help the tasks run smoothly so that the reports send.

I had added some logging [here](https://github.com/getsentry/sentry/pull/29725) and [here](https://github.com/getsentry/sentry/pull/29819) that unfortunately wasn't very helpful, so I am hoping that adding `acks_late` and `max_retries` to the reports tasks will help.