### PR TITLE
fix(stack-trace): SharedGroupDetails failed to render Exceptions

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.tsx
@@ -1,7 +1,7 @@
 import {Panel} from 'app/components/panels';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
-import {ExceptionValue, Group, PlatformType} from 'app/types';
+import {ExceptionValue, Group, Organization, PlatformType} from 'app/types';
 import {Event} from 'app/types/event';
 import {STACK_VIEW} from 'app/types/stacktrace';
 import {defined} from 'app/utils';
@@ -37,7 +37,14 @@ function StackTrace({
   expandFirstFrame,
   event,
 }: Props) {
-  const organization = useOrganization();
+  let organization: Organization | null = null;
+
+  try {
+    organization = useOrganization();
+  } catch {
+    // Organization context may be unavailable for the shared event view. We
+    // don't need to do anything if it's unavailable.
+  }
 
   if (!defined(stacktrace)) {
     return null;

--- a/tests/js/spec/views/sharedGroupDetails/index.spec.jsx
+++ b/tests/js/spec/views/sharedGroupDetails/index.spec.jsx
@@ -1,15 +1,18 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/reactTestingLibrary';
 
 import SharedGroupDetails from 'app/views/sharedGroupDetails';
 
 describe('SharedGroupDetails', function () {
+  const eventEntry = TestStubs.EventEntry();
+  const exception = TestStubs.EventStacktraceException().entries[0];
+
   beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/shared/issues/a/',
       body: TestStubs.Group({
         title: 'ZeroDivisionError',
         latestEvent: TestStubs.Event({
-          entries: [TestStubs.EventEntry()],
+          entries: [eventEntry, exception],
         }),
         project: TestStubs.Project({organization: {slug: 'test-org'}}),
       }),
@@ -25,10 +28,7 @@ describe('SharedGroupDetails', function () {
       params: {shareId: 'a'},
     };
 
-    const wrapper = mountWithTheme(
-      <SharedGroupDetails {...props} />,
-      TestStubs.routerContext()
-    );
-    expect(wrapper).toSnapshot();
+    const {container} = mountWithTheme(<SharedGroupDetails {...props} />);
+    expect(container).toSnapshot();
   });
 });


### PR DESCRIPTION
useOrganization will fail when the organization isn't in context. We
know it might fail here since we may be using this out of context, it's
safe since this is just being used right now for feature flag checking.