### PR TITLE
ref(integrations): Allow pagination on team and user mappings pages

### DIFF
--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -5,6 +5,7 @@ import capitalize from 'lodash/capitalize';
 import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
+import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
 import {IconAdd, IconDelete, IconEdit} from 'app/icons';
@@ -20,13 +21,14 @@ type Props = {
   type: 'team' | 'user';
   onCreateOrEdit: (mapping?: ExternalActorMapping) => void;
   onDelete: (mapping: ExternalActorMapping) => void;
+  pageLinks?: string;
 };
 
 type State = {};
 
 class IntegrationExternalMappings extends Component<Props, State> {
   render() {
-    const {integration, mappings, type, onCreateOrEdit, onDelete} = this.props;
+    const {integration, mappings, type, onCreateOrEdit, onDelete, pageLinks} = this.props;
 
     return (
       <Fragment>
@@ -110,6 +112,7 @@ class IntegrationExternalMappings extends Component<Props, State> {
             ))}
           </PanelBody>
         </Panel>
+        <Pagination pageLinks={pageLinks} />
       </Fragment>
     );
   }

--- a/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import {Fragment} from 'react';
+import {withRouter, WithRouterProps} from 'react-router';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
@@ -10,10 +11,11 @@ import {ExternalActorMapping, Integration, Organization, Team} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 import FormModel from 'app/views/settings/components/forms/model';
 
-type Props = AsyncComponent['props'] & {
-  integration: Integration;
-  organization: Organization;
-};
+type Props = AsyncComponent['props'] &
+  WithRouterProps & {
+    integration: Integration;
+    organization: Organization;
+  };
 
 type State = AsyncComponent['state'] & {
   teams: Team[];
@@ -30,12 +32,12 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization} = this.props;
+    const {organization, location} = this.props;
     return [
       [
         'teams',
         `/organizations/${organization.slug}/teams/`,
-        {query: {query: 'hasExternalTeams:true'}},
+        {query: {...location?.query, query: 'hasExternalTeams:true'}},
       ],
     ];
   }
@@ -124,7 +126,7 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
   openModal = (mapping?: ExternalActorMapping) => {
     const {organization, integration} = this.props;
     openModal(({Body, Header, closeModal}) => (
-      <React.Fragment>
+      <Fragment>
         <Header closeButton>{t('Configure External Team Mapping')}</Header>
         <Body>
           <IntegrationExternalMappingForm
@@ -143,12 +145,13 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
             onResults={results => this.setState({queryResults: results})}
           />
         </Body>
-      </React.Fragment>
+      </Fragment>
     ));
   };
 
   renderBody() {
     const {integration} = this.props;
+    const {teamsPageLinks} = this.state;
     return (
       <IntegrationExternalMappings
         integration={integration}
@@ -156,9 +159,10 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
         mappings={this.mappings}
         onCreateOrEdit={this.openModal}
         onDelete={this.handleDelete}
+        pageLinks={teamsPageLinks}
       />
     );
   }
 }
 
-export default withOrganization(IntegrationExternalTeamMappings);
+export default withRouter(withOrganization(IntegrationExternalTeamMappings));

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -112,7 +112,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {integration} = this.props;
-    const {memberPageLinks} = this.state;
+    const {membersPageLinks} = this.state;
     return (
       <Fragment>
         <IntegrationExternalMappings
@@ -121,7 +121,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
           mappings={this.mappings}
           onCreateOrEdit={this.openModal}
           onDelete={this.handleDelete}
-          pageLinks={memberPageLinks}
+          pageLinks={membersPageLinks}
         />
       </Fragment>
     );

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {withRouter, WithRouterProps} from 'react-router';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
@@ -15,10 +16,11 @@ import {
 } from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 
-type Props = AsyncComponent['props'] & {
-  integration: Integration;
-  organization: Organization;
-};
+type Props = AsyncComponent['props'] &
+  WithRouterProps & {
+    integration: Integration;
+    organization: Organization;
+  };
 
 type State = AsyncComponent['state'] & {
   members: (Member & {externalUsers: ExternalUser[]})[];
@@ -110,6 +112,7 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {integration} = this.props;
+    const {memberPageLinks} = this.state;
     return (
       <Fragment>
         <IntegrationExternalMappings
@@ -118,10 +121,11 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
           mappings={this.mappings}
           onCreateOrEdit={this.openModal}
           onDelete={this.handleDelete}
+          pageLinks={memberPageLinks}
         />
       </Fragment>
     );
   }
 }
 
-export default withOrganization(IntegrationExternalUserMappings);
+export default withRouter(withOrganization(IntegrationExternalUserMappings));


### PR DESCRIPTION
See [API 2204](https://getsentry.atlassian.net/browse/API-2204)

This PR will allow the team mappings and user mappings pages to paginate when they exceed 100 entries. The pagination will be disabled if there are less than 100 entries.

It should be noted that there aren't necessarily only 100 entries in the UI when paginating. We paginate based on the sentry mapping, not the external one. For example: If `#sentry` in sentry maps to `@sentry-fe` and `@sentry-be` in github, both will appear on the page that renders the mappings to `#sentry`. This behavior can be seen in the mocked demo below (where the page limit was changed to 2 entries).

**DEMO**

https://user-images.githubusercontent.com/35509934/140842505-5ba4fa39-ba9e-405f-be3c-e3dd82699701.mov


**TODO**:
- [x] Test preventing deleted entries from taking up pagination space