### PR TITLE
ref(appstore-connect): Make iTunes credentials optional and stop (re)writing them to DB

### DIFF
--- a/src/sentry/api/endpoints/project_app_store_connect_credentials.py
+++ b/src/sentry/api/endpoints/project_app_store_connect_credentials.py
@@ -27,7 +27,6 @@ Status checks:
     validates and includes the status of API credentials associated with this app.
     See :class:`AppStoreConnectCredentialsValidateEndpoint`.
 """
-import datetime
 import logging
 from typing import Dict, Optional, Union
 from uuid import uuid4
@@ -205,15 +204,6 @@ class AppStoreConnectCreateCredentialsEndpoint(ProjectEndpoint):  # type: ignore
         config["id"] = uuid4().hex
         config["name"] = config["appName"]
 
-        # TODO(itunes): Deprecated fields. Needs to be removed alongside a migration, so this uses
-        # placeholders as a temporary workaround until that migration happens.
-        config["itunesCreated"] = datetime.datetime.now()
-        config["itunesSession"] = "deprecated-field-do-not-use"
-        config["orgPublicId"] = "deprecated-field-please-do-not-use--"
-        config["orgName"] = "deprecated-field-do-not-use"
-        config["itunesUser"] = "deprecated-field-do-not-use"
-        config["itunesPassword"] = "deprecated-field-do-not-use"
-
         try:
             validated_config = appconnect.AppStoreConnectConfig.from_json(config)
         except ValueError:
@@ -289,15 +279,6 @@ class AppStoreConnectUpdateCredentialsEndpoint(ProjectEndpoint):  # type: ignore
             )
         except KeyError:
             return Response(status=404)
-
-        # Deprecated fields. Needs to be removed alongside a migration, so this uses
-        # placeholders as a temporary workaround until that migration happens.
-        data["itunesCreated"] = datetime.datetime.now()
-        data["itunesSession"] = "deprecated-field-do-not-use"
-        data["orgPublicId"] = "deprecated-field-please-do-not-use--"
-        data["orgName"] = "deprecated-field-do-not-use"
-        data["itunesUser"] = "deprecated-field-do-not-use"
-        data["itunesPassword"] = "deprecated-field-do-not-use"
 
         # Any secrets set to None during validation are meant to be no-ops, so remove them to avoid
         # erasing the existing values

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -103,9 +103,9 @@ class AppStoreConnectConfig:
     bundleId: str
 
     def __post_init__(self) -> None:
+        # All fields are required.
         for field in dataclasses.fields(self):
-            # Takes advantage of the fact that all non-optional fields are str.
-            if not getattr(self, field.name, None) and field.type == str:
+            if not getattr(self, field.name, None):
                 raise ValueError(f"Missing field: {field.name}")
 
     @classmethod

--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -7,10 +7,8 @@ this.
 import dataclasses
 import logging
 import pathlib
-from datetime import datetime
 from typing import Any, Dict, List
 
-import dateutil
 import jsonschema
 import requests
 import sentry_sdk
@@ -53,6 +51,17 @@ class NoDsymsError(Exception):
     pass
 
 
+# TODO(itunes): Remove when the fields are removed from DB
+DEPRECATED_FIELDS = [
+    "itunesUser",
+    "itunesCreated",
+    "itunesPassword",
+    "itunesSession",
+    "orgPublicId",
+    "orgName",
+]
+
+
 @dataclasses.dataclass(frozen=True)
 class AppStoreConnectConfig:
     """The symbol source configuration for an App Store Connect source.
@@ -93,18 +102,10 @@ class AppStoreConnectConfig:
     # This is guaranteed to be unique and should map 1:1 to ``appId``.
     bundleId: str
 
-    # TODO(itunes): Deprecated fields. These must be removed alongside a migration.
-    itunesUser: str
-    itunesPassword: str
-    itunesSession: str
-    itunesCreated: datetime
-    orgPublicId: str
-    orgName: str
-
     def __post_init__(self) -> None:
-        # All fields are required.
         for field in dataclasses.fields(self):
-            if not getattr(self, field.name, None):
+            # Takes advantage of the fact that all non-optional fields are str.
+            if not getattr(self, field.name, None) and field.type == str:
                 raise ValueError(f"Missing field: {field.name}")
 
     @classmethod
@@ -120,13 +121,13 @@ class AppStoreConnectConfig:
            symbol source configuration.
         """
         # TODO(itunes): Remove logic related to iTunes fields when the fields are removed
-        if isinstance(data["itunesCreated"], datetime):
-            data["itunesCreated"] = data["itunesCreated"].isoformat()
+        for field in DEPRECATED_FIELDS:
+            if field in data:
+                del data[field]
         try:
             jsonschema.validate(data, APP_STORE_CONNECT_SCHEMA)
         except jsonschema.exceptions.ValidationError as e:
             raise InvalidConfigError from e
-        data["itunesCreated"] = dateutil.parser.isoparse(data["itunesCreated"])
         return cls(**data)
 
     @classmethod
@@ -177,9 +178,6 @@ class AppStoreConnectConfig:
         data = dict()
         for field in dataclasses.fields(self):
             value = getattr(self, field.name)
-            # TODO(itunes): Remove logic related to iTunes fields when the fields are removed
-            if field.name == "itunesCreated":
-                value = value.isoformat()
             data[field.name] = value
         try:
             jsonschema.validate(data, APP_STORE_CONNECT_SCHEMA)
@@ -197,7 +195,8 @@ class AppStoreConnectConfig:
         """
         data = self.to_json()
         for to_redact in secret_fields("appStoreConnect"):
-            data[to_redact] = {"hidden-secret": True}
+            if to_redact in data:
+                data[to_redact] = {"hidden-secret": True}
         return data
 
     def update_project_symbol_source(self, project: Project, allow_multiple: bool) -> json.JSONData:

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -80,13 +80,6 @@ APP_STORE_CONNECT_SCHEMA = {
         "appName",
         "appId",
         "bundleId",
-        # TODO(itunes): All of the below fields are deprecated. Remove together with migration.
-        "itunesUser",
-        "itunesCreated",
-        "itunesPassword",
-        "itunesSession",
-        "orgPublicId",
-        "orgName",
     ],
     "additionalProperties": False,
 }

--- a/tests/sentry/lang/native/test_appconnect.py
+++ b/tests/sentry/lang/native/test_appconnect.py
@@ -31,15 +31,9 @@ class TestAppStoreConnectConfig:
             "appconnectIssuer": "abc123" * 6,
             "appconnectKey": "abc123",
             "appconnectPrivateKey": "---- BEGIN PRIVATE KEY ---- ABC123...",
-            "itunesUser": "someone@example.com",
-            "itunesPassword": "a secret",
-            "itunesSession": "ABC123",
-            "itunesCreated": now.isoformat(),
             "appName": "Sample Application",
             "appId": "1234",
             "bundleId": "com.example.app",
-            "orgPublicId": "71105f98-7743-4844-ab70-2c901e2ea13d",
-            "orgName": "Example Organisation",
         }
 
     def test_from_json_basic(self, data: json.JSONData, now: datetime) -> None:
@@ -49,31 +43,12 @@ class TestAppStoreConnectConfig:
         assert config.name == data["name"]
         assert config.appconnectIssuer == data["appconnectIssuer"]
         assert config.appconnectPrivateKey == data["appconnectPrivateKey"]
-        assert config.itunesUser == data["itunesUser"]
-        assert config.itunesPassword == data["itunesPassword"]
-        assert config.itunesSession == data["itunesSession"]
-        assert config.itunesCreated == now
         assert config.appName == data["appName"]
         assert config.bundleId == data["bundleId"]
-        assert config.orgPublicId == data["orgPublicId"]
-        assert config.orgName == data["orgName"]
-
-    def test_from_json_isoformat(self, data: json.JSONData, now: datetime) -> None:
-        data["itunesCreated"] = now.isoformat()
-        config = appconnect.AppStoreConnectConfig.from_json(data)
-        assert config.itunesCreated == now
-
-    def test_from_json_datetime(self, data: json.JSONData, now: datetime) -> None:
-        data["itunesCreated"] = now
-        config = appconnect.AppStoreConnectConfig.from_json(data)
-        assert config.itunesCreated == now
 
     def test_to_json(self, data: json.JSONData, now: datetime) -> None:
         config = appconnect.AppStoreConnectConfig.from_json(data)
         new_data = config.to_json()
-
-        # Fixup our input to expected JSON format
-        data["itunesCreated"] = now.isoformat()
 
         assert new_data == data
 
@@ -81,13 +56,25 @@ class TestAppStoreConnectConfig:
         config = appconnect.AppStoreConnectConfig.from_json(data)
         new_data = config.to_redacted_json()
 
-        # Fixup our input to expected JSON format
-        data["itunesCreated"] = now.isoformat()
+        # Redacted secrets
+        data["appconnectPrivateKey"] = {"hidden-secret": True}
+        assert "itunesPassword" not in data
+        assert "itunesSession" not in data
+
+        assert new_data == data
+
+    def test_to_redacted_json_with_deprecated(self, data: json.JSONData, now: datetime) -> None:
+        data_with_deprecated = data
+        data_with_deprecated["itunesPassword"] = "honk"
+        data_with_deprecated["itunesSession"] = "beep"
+
+        config = appconnect.AppStoreConnectConfig.from_json(data)
+        new_data = config.to_redacted_json()
 
         # Redacted secrets
         data["appconnectPrivateKey"] = {"hidden-secret": True}
-        data["itunesPassword"] = {"hidden-secret": True}
-        data["itunesSession"] = {"hidden-secret": True}
+        assert "itunesPassword" not in data
+        assert "itunesSession" not in data
 
         assert new_data == data
 
@@ -110,15 +97,9 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
             appconnectIssuer="abc123" * 6,
             appconnectKey="abc123key",
             appconnectPrivateKey="----BEGIN PRIVATE KEY---- blabla",
-            itunesUser="me@example.com",
-            itunesPassword="secret",
-            itunesSession="THE-COOKIE",
-            itunesCreated=datetime.utcnow(),
             appName="My App",
             appId="123",
             bundleId="com.example.app",
-            orgPublicId="71105f98-7743-4844-ab70-2c901e2ea13d",
-            orgName="Example Com",
         )
 
     @pytest.mark.django_db  # type: ignore
@@ -156,7 +137,6 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         new_sources.append(cfg.to_json())
         assert stored_sources == new_sources
 
-    # TODO(itunes): Update when iTunes fields are removed
     @pytest.mark.django_db  # type: ignore
     def test_update(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
@@ -169,24 +149,17 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
             name=config.name,
             appconnectIssuer=config.appconnectIssuer,
             appconnectKey=config.appconnectKey,
-            appconnectPrivateKey=config.appconnectPrivateKey,
-            itunesUser=config.itunesUser,
-            itunesPassword=config.itunesPassword,
-            itunesSession="A NEW COOKIE",
-            itunesCreated=datetime.utcnow(),
+            appconnectPrivateKey="A NEW KEY",
             appName=config.appName,
             appId=config.appId,
             bundleId=config.bundleId,
-            orgPublicId=config.orgPublicId,
-            orgName=config.orgName,
         )
 
         updated.update_project_symbol_source(default_project, allow_multiple=False)
 
         current = appconnect.AppStoreConnectConfig.from_project_config(default_project, config.id)
-        assert current.itunesSession == "A NEW COOKIE"
+        assert current.appconnectPrivateKey == "A NEW KEY"
 
-    # TODO(itunes): Update when iTunes fields are removed
     @pytest.mark.django_db  # type: ignore
     def test_update_no_matching_id(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
@@ -199,16 +172,10 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
             name=config.name,
             appconnectIssuer=config.appconnectIssuer,
             appconnectKey=config.appconnectKey,
-            appconnectPrivateKey=config.appconnectPrivateKey,
-            itunesUser=config.itunesUser,
-            itunesPassword=config.itunesPassword,
-            itunesSession="A NEW COOKIE",
-            itunesCreated=datetime.utcnow(),
+            appconnectPrivateKey="A NEW KEY",
             appName=config.appName,
             appId=config.appId,
             bundleId=config.bundleId,
-            orgPublicId=config.orgPublicId,
-            orgName=config.orgName,
         )
 
         with pytest.raises(ValueError):

--- a/tests/sentry/tasks/test_app_store_connect.py
+++ b/tests/sentry/tasks/test_app_store_connect.py
@@ -20,15 +20,9 @@ class TestUpdateDsyms:
             appconnectIssuer="abc123" * 6,
             appconnectKey="abc123key",
             appconnectPrivateKey="----BEGIN PRIVATE KEY---- blabla",
-            itunesUser="me@example.com",
-            itunesPassword="secret",
-            itunesSession="THE-COOKIE",
-            itunesCreated=datetime.utcnow(),
             appName="My App",
             appId="123",
             bundleId="com.example.app",
-            orgPublicId="71105f98-7743-4844-ab70-2c901e2ea13d",
-            orgName="Example Com",
         )
 
     @pytest.fixture


### PR DESCRIPTION
As suggested in https://github.com/getsentry/sentry/pull/29829, this marks the fields storing iTunes credentials as optional prior to their full removal, and also adds in code to stop writing these to the DB. 

Current behaviour is to write in placeholder values into fields meant to store iTunes credentials. Now, new App Store Connect configs will no longer contain these fields, and existing configs that are edited after this is merged and deployed will also have these fields erased.