### PR TITLE
ref(appstore-connect): Remove iTunes credentials from soft schema

### DIFF
--- a/src/sentry/lang/native/appconnect.py
+++ b/src/sentry/lang/native/appconnect.py
@@ -51,17 +51,6 @@ class NoDsymsError(Exception):
     pass
 
 
-# TODO(itunes): Remove when the fields are removed from DB
-DEPRECATED_FIELDS = [
-    "itunesUser",
-    "itunesCreated",
-    "itunesPassword",
-    "itunesSession",
-    "orgPublicId",
-    "orgName",
-]
-
-
 @dataclasses.dataclass(frozen=True)
 class AppStoreConnectConfig:
     """The symbol source configuration for an App Store Connect source.
@@ -112,18 +101,13 @@ class AppStoreConnectConfig:
     def from_json(cls, data: Dict[str, Any]) -> "AppStoreConnectConfig":
         """Creates a new instance from **deserialised** JSON data.
 
-        This will include the JSON schema validation.  It accepts both a str or a datetime
-        for the ``itunesCreated``.  Thus you can safely use this to create and validate the
-        config as deserialised by both plain JSON deserialiser or by Django Rest Framework's
-        deserialiser.
+        This will include the JSON schema validation.  You can safely use this to create and
+        validate the config as deserialised by both plain JSON deserialiser or by Django Rest
+        Framework's deserialiser.
 
         :raises InvalidConfigError: if the data does not contain a valid App Store Connect
            symbol source configuration.
         """
-        # TODO(itunes): Remove logic related to iTunes fields when the fields are removed
-        for field in DEPRECATED_FIELDS:
-            if field in data:
-                del data[field]
         try:
             jsonschema.validate(data, APP_STORE_CONNECT_SCHEMA)
         except jsonschema.exceptions.ValidationError as e:

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -61,14 +61,7 @@ APP_STORE_CONNECT_SCHEMA = {
         "appconnectPrivateKey": {"type": "string"},
         "appName": {"type": "string", "minLength": 1, "maxLength": 512},
         "appId": {"type": "string", "minLength": 1},
-        # TODO(itunes): All of the below fields are deprecated. Remove together with migration.
-        "itunesUser": {"type": "string", "minLength": 1, "maxLength": 100},
-        "itunesCreated": {"type": "string", "format": "date-time"},
-        "itunesPassword": {"type": "string"},
-        "itunesSession": {"type": "string"},
         "bundleId": {"type": "string", "minLength": 1},
-        "orgPublicId": {"type": "string", "minLength": 36, "maxLength": 36},
-        "orgName": {"type": "string", "minLength": 1, "maxLength": 512},
     },
     "required": [
         "type",
@@ -297,13 +290,12 @@ def normalize_user_source(source):
     return source
 
 
-# TODO(itunes): Remove logic related to iTunes fields when the fields are removed
 def secret_fields(source_type):
     """
     Returns a string list of all of the fields that contain a secret in a given source.
     """
     if source_type == "appStoreConnect":
-        yield from ["appconnectPrivateKey", "itunesPassword", "itunesSession"]
+        yield from ["appconnectPrivateKey"]
     elif source_type == "http":
         yield "password"
     elif source_type == "s3":

--- a/tests/sentry/lang/native/test_appconnect.py
+++ b/tests/sentry/lang/native/test_appconnect.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:
 
 
 class TestAppStoreConnectConfig:
-    # TODO(itunes): Update suite when iTunes fields are removed
-
     @pytest.fixture  # type: ignore
     def now(self) -> datetime:
         # Fixture so we can have one "now" for the entire test and its fixtures.
@@ -58,23 +56,6 @@ class TestAppStoreConnectConfig:
 
         # Redacted secrets
         data["appconnectPrivateKey"] = {"hidden-secret": True}
-        assert "itunesPassword" not in data
-        assert "itunesSession" not in data
-
-        assert new_data == data
-
-    def test_to_redacted_json_with_deprecated(self, data: json.JSONData, now: datetime) -> None:
-        data_with_deprecated = data
-        data_with_deprecated["itunesPassword"] = "honk"
-        data_with_deprecated["itunesSession"] = "beep"
-
-        config = appconnect.AppStoreConnectConfig.from_json(data)
-        new_data = config.to_redacted_json()
-
-        # Redacted secrets
-        data["appconnectPrivateKey"] = {"hidden-secret": True}
-        assert "itunesPassword" not in data
-        assert "itunesSession" not in data
 
         assert new_data == data
 
@@ -87,7 +68,6 @@ class TestAppStoreConnectConfig:
 
 
 class TestAppStoreConnectConfigUpdateProjectSymbolSource:
-    # TODO(itunes): Update when iTunes fields are removed
     @pytest.fixture  # type: ignore
     def config(self) -> appconnect.AppStoreConnectConfig:
         return appconnect.AppStoreConnectConfig(


### PR DESCRIPTION
This performs the final act of removing the iTunes credentials fully from the DB "schema", hopefully wiping the existence of these fields out of the codebase for good.

**Do not merge and deploy until ops confirmed that https://github.com/getsentry/sentry/pull/29829 's migration has been applied to production.**