### PR TITLE
fix(integration dashboard): Show seconds in 24hr time

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -17,10 +17,12 @@ import {IconChevron, IconFlag, IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {SentryApp, SentryAppSchemaIssueLink, SentryAppWebhookRequest} from 'app/types';
+import {use24Hours} from 'app/utils/dates';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 const ALL_EVENTS = t('All Events');
 const MAX_PER_PAGE = 10;
+const is24Hours = use24Hours();
 
 const componentHasSelectUri = (issueLinkComponent: SentryAppSchemaIssueLink): boolean => {
   const hasSelectUri = (fields: any[]): boolean =>
@@ -98,7 +100,7 @@ const TimestampLink = ({date, link}: {date: moment.MomentInput; link?: string}) 
       <StyledIconOpen size="12px" />
     </ExternalLink>
   ) : (
-    <DateTime date={date} />
+    <DateTime date={date} format={is24Hours ? 'MMM D, YYYY HH:mm:ss z' : 'll LTS z'} />
   );
 
 type Props = AsyncComponent['props'] & {


### PR DESCRIPTION
Pass the `format` prop to `DateTime` to show seconds in the integration dashboard when the user's preferences are set to a 24hr clock.

**Before 12hr:**
<img width="961" alt="Screen Shot 2021-11-08 at 6 10 59 PM" src="https://user-images.githubusercontent.com/29959063/140848956-984812be-936f-4990-a6c3-9255d17c6e7f.png">
**Before 24hr:**
<img width="960" alt="Screen Shot 2021-11-08 at 6 10 43 PM" src="https://user-images.githubusercontent.com/29959063/140848941-5551d716-2b70-479f-8c1a-fb981e595449.png">



**After 12hr:**
<img width="961" alt="Screen Shot 2021-11-08 at 6 06 45 PM" src="https://user-images.githubusercontent.com/29959063/140848682-9d7c29cf-250e-4916-930c-fb8e16059698.png">
**After 24hr:**
<img width="966" alt="Screen Shot 2021-11-08 at 6 07 09 PM" src="https://user-images.githubusercontent.com/29959063/140848691-816bb07d-d50c-476b-8bb0-ec52ffe0ffce.png">

Fixes [ISSUE-1269](https://getsentry.atlassian.net/browse/ISSUE-1269)