### PR TITLE
fix(ui): Change multiple team selector to not have an icon

### DIFF
--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -100,7 +100,7 @@ type TeamActor = {
 
 type TeamOption = {
   value: string | null;
-  label: React.ReactElement;
+  label: React.ReactElement | string;
   searchKey: string;
   actor: TeamActor | null;
   disabled?: boolean;
@@ -118,7 +118,7 @@ function TeamSelector(props: Props) {
 
   const createTeamOption = (team: Team): TeamOption => ({
     value: useId ? team.id : team.slug,
-    label: <IdBadge team={team} />,
+    label: multiple ? `#${team.slug}` : <IdBadge team={team} />,
     searchKey: `#${team.slug}`,
     actor: {
       type: 'team',

--- a/static/app/components/forms/teamSelector.tsx
+++ b/static/app/components/forms/teamSelector.tsx
@@ -100,7 +100,7 @@ type TeamActor = {
 
 type TeamOption = {
   value: string | null;
-  label: React.ReactElement | string;
+  label: React.ReactNode;
   searchKey: string;
   actor: TeamActor | null;
   disabled?: boolean;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9372512/140848398-cdd6f3d9-6df8-4b32-a8ed-a31fdd53625d.png)


After:
![image](https://user-images.githubusercontent.com/9372512/140849580-c9610f44-9669-4043-826b-49910a18e096.png)
