### PR TITLE
fix(sdk): Reduce the sampled rate of some transactions

### DIFF
--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -1,5 +1,6 @@
 import logging
 from collections import OrderedDict
+from random import random
 
 import requests
 import sentry_sdk
@@ -363,7 +364,7 @@ class BaseInternalApiClient(ApiClient, TrackResponseMixin):
             name=f"{self.integration_type}.http_response.{self.name}",
             parent_span_id=parent_span_id,
             trace_id=trace_id,
-            sampled=True,
+            sampled=random() < 0.05,
         ) as span:
             resp = ApiClient.request(self, *args, **kwargs)
             self.track_response_data(resp.status_code, span, None, resp)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -53,7 +53,7 @@ SAMPLED_URL_NAMES = {
     # stats
     "sentry-api-0-organization-stats": settings.SAMPLED_DEFAULT_RATE,
     "sentry-api-0-organization-stats-v2": settings.SAMPLED_DEFAULT_RATE,
-    "sentry-api-0-project-stats": 0.1,  # lower rate because of high TPM
+    "sentry-api-0-project-stats": 0.05,  # lower rate because of high TPM
     # debug files
     "sentry-api-0-assemble-dif-files": 0.1,
     # scim
@@ -67,7 +67,7 @@ SAMPLED_URL_NAMES = {
     "sentry-api-0-organization-join-request": settings.SAMPLED_DEFAULT_RATE,
     # login
     "sentry-login": 0.1,
-    "sentry-auth-organization": settings.SAMPLED_DEFAULT_RATE,
+    "sentry-auth-organization": 0.2,
     "sentry-auth-link-identity": settings.SAMPLED_DEFAULT_RATE,
     "sentry-auth-sso": settings.SAMPLED_DEFAULT_RATE,
     "sentry-logout": 0.1,


### PR DESCRIPTION
- These three transactions were picked as they were low hanging fruit
  for having the highest TPM and likely least amount of applicable use
  as transactions