### PR TITLE
fix(perf): Landing issues errors widget switch

### DIFF
--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useState} from 'react';
+import {Fragment, useCallback, useRef, useState} from 'react';
 import {withRouter} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -28,19 +28,23 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
   // Use object keyed to chart setting so switching between charts of a similar type doesn't retain data with query components still having inflight requests.
   const [allWidgetData, setWidgetData] = useState<{[chartSetting: string]: T}>({});
   const widgetData = allWidgetData[props.chartSetting] ?? {};
+  const widgetDataRef = useRef(widgetData);
 
   const setWidgetDataForKey = useCallback(
     (dataKey: string, result?: WidgetDataResult) => {
-      if (result) {
-        setWidgetData({[props.chartSetting]: {...widgetData, [dataKey]: result}});
-      }
+      const _widgetData = widgetDataRef.current;
+      const newWidgetData = {..._widgetData, [dataKey]: result};
+      widgetDataRef.current = newWidgetData;
+      setWidgetData({[props.chartSetting]: newWidgetData});
     },
     [allWidgetData, setWidgetData]
   );
   const removeWidgetDataForKey = useCallback(
     (dataKey: string) => {
-      const newWidgetData = {...widgetData};
+      const _widgetData = widgetDataRef.current;
+      const newWidgetData = {..._widgetData};
       delete newWidgetData[dataKey];
+      widgetDataRef.current = newWidgetData;
       setWidgetData({[props.chartSetting]: newWidgetData});
     },
     [allWidgetData, setWidgetData]

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import MenuItem from 'app/components/menuItem';
@@ -108,6 +108,10 @@ const _WidgetContainer = (props: Props) => {
     }
     setChartSettingState(setting);
   };
+
+  useEffect(() => {
+    setChartSettingState(_chartSetting);
+  }, [rest.defaultChartSetting]);
 
   const widgetProps = {
     chartSetting,

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -8,6 +8,7 @@ import {DateString, Organization, OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 
 import {PerformanceWidgetContainerTypes} from './components/performanceWidgetContainer';
+import {PerformanceWidgetSetting} from './widgetDefinitions';
 
 export enum VisualizationDataState {
   ERROR = 'error',
@@ -97,6 +98,8 @@ type Subtitle<T> = FunctionComponent<{
 }>;
 
 export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
+  chartSetting: PerformanceWidgetSetting;
+
   // Header;
   title: string;
   titleTooltip: string;
@@ -124,6 +127,7 @@ export type GenericPerformanceWithData<T extends WidgetDataConstraint> =
 export type WidgetDataProps<T> = {
   widgetData: T;
   setWidgetDataForKey: (dataKey: string, result?: WidgetDataResult) => void;
+  removeWidgetDataForKey: (dataKey: string) => void;
 };
 
 export type EventsRequestChildrenProps = RenderProps;

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -12,8 +12,10 @@ import {Chart as HistogramChart} from 'app/views/performance/landing/chart/histo
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformHistogramQuery} from '../transforms/transformHistogramQuery';
 import {WidgetDataResult} from '../types';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
+  chartSetting: PerformanceWidgetSetting;
   title: string;
   titleTooltip: string;
   fields: string[];

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -16,8 +16,10 @@ import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
 import {QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
+  chartSetting: PerformanceWidgetSetting;
   title: string;
   titleTooltip: string;
   fields: string[];

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -3,7 +3,6 @@ import {useTheme} from '@emotion/react';
 
 import ChartZoom from 'app/components/charts/chartZoom';
 import LineChart from 'app/components/charts/lineChart';
-import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
@@ -236,13 +235,10 @@ export function Chart({
   trendChangeType,
   router,
   statsPeriod,
-  project,
-  environment,
   transaction,
   statsData,
   isLoading,
   location,
-  projects,
   start: propsStart,
   end: propsEnd,
   trendFunctionField,
@@ -311,11 +307,6 @@ export function Chart({
   const loading = isLoading;
   const reloading = isLoading;
 
-  const transactionProject = parseInt(
-    projects.find(({slug}) => transaction?.project === slug)?.id || '',
-    10
-  );
-
   const yMax = Math.max(
     maxValue,
     transaction?.aggregate_range_2 || 0,
@@ -328,11 +319,6 @@ export function Chart({
   );
   const yDiff = yMax - yMin;
   const yMargin = yDiff * 0.1;
-
-  const queryExtra = {
-    showTransactions: trendChangeType,
-    yAxis: 'countDuration',
-  };
 
   const chartOptions = {
     tooltip: {

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -380,50 +380,37 @@ export function Chart({
         );
 
         return (
-          <ReleaseSeries
-            start={start}
-            end={end}
-            queryExtra={queryExtra}
-            period={statsPeriod}
-            utc={utc === 'true'}
-            projects={isNaN(transactionProject) ? project : [transactionProject]}
-            environments={environment}
-            memoized
-          >
-            {({releaseSeries}) => (
-              <TransitionChart loading={loading} reloading={reloading}>
-                <TransparentLoadingMask visible={reloading} />
-                {getDynamicText({
-                  value: (
-                    <LineChart
-                      height={height}
-                      {...zoomRenderProps}
-                      {...chartOptions}
-                      onLegendSelectChanged={handleLegendSelectChanged}
-                      series={[...smoothedSeries, ...releaseSeries, ...intervalSeries]}
-                      seriesOptions={{
-                        showSymbol: false,
-                      }}
-                      legend={legend}
-                      toolBox={{
-                        show: false,
-                      }}
-                      grid={
-                        grid ?? {
-                          left: '10px',
-                          right: '10px',
-                          top: '40px',
-                          bottom: '0px',
-                        }
-                      }
-                      xAxis={disableXAxis ? {show: false} : undefined}
-                    />
-                  ),
-                  fixed: 'Duration Chart',
-                })}
-              </TransitionChart>
-            )}
-          </ReleaseSeries>
+          <TransitionChart loading={loading} reloading={reloading}>
+            <TransparentLoadingMask visible={reloading} />
+            {getDynamicText({
+              value: (
+                <LineChart
+                  height={height}
+                  {...zoomRenderProps}
+                  {...chartOptions}
+                  onLegendSelectChanged={handleLegendSelectChanged}
+                  series={[...smoothedSeries, ...intervalSeries]}
+                  seriesOptions={{
+                    showSymbol: false,
+                  }}
+                  legend={legend}
+                  toolBox={{
+                    show: false,
+                  }}
+                  grid={
+                    grid ?? {
+                      left: '10px',
+                      right: '10px',
+                      top: '40px',
+                      bottom: '0px',
+                    }
+                  }
+                  xAxis={disableXAxis ? {show: false} : undefined}
+                />
+              ),
+              fixed: 'Duration Chart',
+            })}
+          </TransitionChart>
         );
       }}
     </ChartZoom>

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -67,12 +67,12 @@ describe('Performance > Widgets > WidgetContainer', function () {
         body: {
           data: [
             {
-              'issue.id': 2754060735,
-              transaction: '/share/issue/:shareId/',
-              title: 'Error: useOrganization called but organization is not set.',
-              'project.id': 11276,
-              count: 3182,
-              issue: 'JAVASCRIPT-25ZY',
+              'issue.id': 123,
+              transaction: '/issue/:id/',
+              title: 'Error: Something is broken.',
+              'project.id': 1,
+              count: 3100,
+              issue: 'JAVASCRIPT-ABCD',
             },
           ],
         },


### PR DESCRIPTION
### Summary
Switching between issues and errors was causing issues because of leftover widget data from the previous request. This PR tags widgetData into the state based on the current chart setting, which stops data from being leaked, and additionally adds a wrapping component around each query to perform cleanup on unmounted query components (due to enabled changing when a dependent query can't be called).

#### Other
- Removed releases from trends widget since it's distracting.