### PR TITLE
fix(teamStats): Prevent team misery from showing other teams

### DIFF
--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -262,6 +262,7 @@ function TeamInsightsOverview({location, router}: Props) {
               <TeamMisery
                 organization={organization}
                 projects={projects}
+                teamId={currentTeam!.id}
                 period={period}
                 start={start?.toString()}
                 end={end?.toString()}

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -166,6 +166,7 @@ function TeamMisery({
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
+  teamId: string;
   projects: Project[];
   location: Location;
   period?: string;
@@ -175,6 +176,7 @@ type Props = AsyncComponent['props'] & {
 
 function TeamMiseryWrapper({
   organization,
+  teamId,
   projects,
   location,
   period,
@@ -198,9 +200,10 @@ function TeamMiseryWrapper({
   const commonEventView = {
     id: undefined,
     query: 'transaction.duration:<15m team_key_transaction:true',
-    projects: projects.map(project => Number(project.id)),
+    projects: [],
     version: 2 as SavedQueryVersions,
     orderby: '-tpm',
+    teams: [Number(teamId)],
     fields: [
       'transaction',
       'project',


### PR DESCRIPTION
Switch from passing projects to the team ID. By default, team_key_transaction pulls key transactions for all teams the user is in.