### PR TITLE
fix(notifications): provider name in analytics

### DIFF
--- a/src/sentry/notifications/notifications/invitations/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/invitations/abstract_invite_request.py
@@ -89,5 +89,5 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification):
             organization_id=self.organization.id,
             user_id=self.pending_member.inviter.id if self.pending_member.inviter else None,
             target_user_id=recipient.id,
-            providers=provider,
+            providers=provider.name.lower(),
         )

--- a/src/sentry/notifications/notifications/organization_request.py
+++ b/src/sentry/notifications/notifications/organization_request.py
@@ -135,7 +135,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
             organization_id=self.organization.id,
             user_id=self.requester.id,
             target_user_id=recipient.id,
-            providers=provider,
+            providers=provider.name.lower(),
         )
 
     def get_title_link(self) -> str | None:


### PR DESCRIPTION
This PR fixes a bug where the provider in certain analytics events looks like `ExternalProviders.EMAIL` instead of just `email`