### PR TITLE
fix(notifications): adds email to context

### DIFF
--- a/src/sentry/notifications/notifications/invitations/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/invitations/abstract_invite_request.py
@@ -50,6 +50,7 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification):
         self, recipient: Team | User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         context = super().get_recipient_context(recipient, extra_context)
+        context["email"] = self.pending_member.email
         context["organization_name"] = self.org_name
         context["pending_requests_link"] = self.members_url + self.get_sentry_query_params(
             ExternalProviders.EMAIL

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -180,6 +180,7 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
 
         expected_subject = f"Access request to {self.organization.name}"
         assert mail.outbox[0].subject == expected_subject
+        assert "eric@localhost" in mail.outbox[0].body
 
     @responses.activate
     @with_feature("organizations:slack-requests")


### PR DESCRIPTION
Looks like I accidentally forgot to include the email of the person being requested to join an organization when we switched to sending emails through the notification platform (https://github.com/getsentry/sentry/pull/29708)

The impact of this bug was that the email we are sending out doesn't say the email of the person joining