### PR TITLE
feat(notifications): use fine tuning key in org request notifications

### DIFF
--- a/src/sentry/notifications/notifications/organization_request.py
+++ b/src/sentry/notifications/notifications/organization_request.py
@@ -22,6 +22,7 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
     analytics_event: str = ""
     referrer_base: str = ""
     member_by_user_id: MutableMapping[int, OrganizationMember] = {}
+    fine_tuning_key = "approval"
 
     def __init__(self, organization: Organization, requester: User) -> None:
         super().__init__(organization)

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -222,6 +222,10 @@ class OrganizationInviteRequestCreateTest(APITestCase, SlackActivityNotification
                 "type": "button",
             },
         ]
+        assert (
+            attachment["footer"]
+            == "You are receiving this notification because you're listed as an organization Manager | <http://testserver/settings/account/notifications/approval/?referrer=InviteRequestSlackUser|Notification Settings>"
+        )
         member = OrganizationMember.objects.get(email="eric@localhost")
         assert json.loads(attachment["callback_id"]) == {
             "member_id": member.id,


### PR DESCRIPTION
Now that we have a notification fine-tuning key for `approval`, we should use it