### PR TITLE
feat(issue_search): Add `regressed_in_release` search term to issue search

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -95,6 +95,7 @@ value_converters = {
     "first_release": convert_first_release_value,
     "release": convert_release_value,
     "status": convert_status_value,
+    "regressed_in_release": convert_first_release_value,
 }
 
 

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -252,7 +252,7 @@ def assigned_or_suggested_filter(owners, projects, field_filter="id"):
 
 def regressed_in_release_filter(versions: Sequence[str], projects: Sequence[Project]) -> Q:
     release_ids = Release.objects.filter(
-        organization=projects[0].organization_id, version__in=versions
+        organization_id=projects[0].organization_id, version__in=versions
     ).values_list("id", flat=True)
     return Q(
         id__in=GroupHistory.objects.filter(

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -2,6 +2,7 @@ import functools
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from datetime import timedelta
+from typing import Sequence
 
 from django.db.models import Q
 from django.utils import timezone
@@ -13,6 +14,8 @@ from sentry.models import (
     Group,
     GroupAssignee,
     GroupEnvironment,
+    GroupHistory,
+    GroupHistoryStatus,
     GroupLink,
     GroupOwner,
     GroupStatus,
@@ -20,6 +23,7 @@ from sentry.models import (
     OrganizationMember,
     OrganizationMemberTeam,
     PlatformExternalIssue,
+    Project,
     Release,
     Team,
     User,
@@ -246,6 +250,19 @@ def assigned_or_suggested_filter(owners, projects, field_filter="id"):
     return query
 
 
+def regressed_in_release_filter(versions: Sequence[str], projects: Sequence[Project]) -> Q:
+    release_ids = Release.objects.filter(
+        organization=projects[0].organization_id, version__in=versions
+    ).values_list("id", flat=True)
+    return Q(
+        id__in=GroupHistory.objects.filter(
+            release_id__in=release_ids,
+            status=GroupHistoryStatus.REGRESSED,
+            project__in=projects,
+        ).values_list("group_id", flat=True),
+    )
+
+
 class Condition:
     """\
     Adds a single filter to a ``QuerySet`` object. Used with
@@ -465,6 +482,9 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             "for_review": QCallbackCondition(functools.partial(inbox_filter, projects=projects)),
             "assigned_or_suggested": QCallbackCondition(
                 functools.partial(assigned_or_suggested_filter, projects=projects)
+            ),
+            "regressed_in_release": QCallbackCondition(
+                functools.partial(regressed_in_release_filter, projects=projects)
             ),
         }
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -271,6 +271,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         "subscribed_by",
         "first_release",
         "first_seen",
+        "regressed_in_release",
     }
     sort_strategies = {
         "date": "last_seen",
@@ -431,6 +432,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
 
         max_time = options.get("snuba.search.max-total-chunk-time-seconds")
         time_start = time.time()
+        more_results = False
 
         # Do smaller searches in chunks until we have enough results
         # to answer the query (or hit the end of possible results). We do


### PR DESCRIPTION
This adds `regressed_in_release` to issue search. This search term will return all groups that
regressed in the given release, regardless of their current status.