### PR TITLE
feat(js): Support slug loading + searching in useProjects

### DIFF
--- a/static/app/utils/useProjects.tsx
+++ b/static/app/utils/useProjects.tsx
@@ -1,13 +1,315 @@
+import {useEffect, useRef, useState} from 'react';
+import uniqBy from 'lodash/uniqBy';
+
+import ProjectActions from 'app/actions/projectActions';
+import {Client} from 'app/api';
+import OrganizationStore from 'app/stores/organizationStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import {useLegacyStore} from 'app/stores/useLegacyStore';
+import {AvatarProject, Project} from 'app/types';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
+import RequestError from 'app/utils/requestError/requestError';
+import useApi from 'app/utils/useApi';
+
+type ProjectPlaceholder = AvatarProject;
+
+type State = {
+  /**
+   * Reflects whether or not the initial fetch for the requested projects
+   * was fulfilled. This accounts for both the store and specifically loaded
+   * slugs.
+   */
+  initiallyLoaded: boolean;
+  /**
+   * This is state for when fetching data from API
+   */
+  fetching: boolean;
+  /**
+   * The error that occurred if fetching failed
+   */
+  fetchError: null | RequestError;
+  /**
+   * Indicates that Project results (from API) are paginated and there are more
+   * projects that are not in the initial response
+   */
+  hasMore: null | boolean;
+  /**
+   * The last query we searched. Used to validate the cursor
+   */
+  lastSearch: null | string;
+  /**
+   * Pagination
+   */
+  nextCursor?: null | string;
+};
+
+type Result = {
+  /**
+   * The loaded projects list
+   */
+  projects: Project[];
+  /**
+   * When loading specific slugs, placeholder objects will be returned
+   */
+  placeholders: ProjectPlaceholder[];
+  /**
+   * This is an action provided to consumers for them to update the current
+   * projects result set using a simple search query.
+   *
+   * Will always add new options into the store.
+   */
+  onSearch: (searchTerm: string) => Promise<void>;
+} & Pick<State, 'fetching' | 'hasMore' | 'fetchError' | 'initiallyLoaded'>;
+
+type Options = {
+  /**
+   * Specify an orgId, overriding the organization in the current context
+   */
+  orgId?: string;
+  /**
+   * List of slugs to look for summaries for, this can be from `props.projects`,
+   * otherwise fetch from API
+   */
+  slugs?: string[];
+  /**
+   * Number of projects to return when not using `props.slugs`
+   */
+  limit?: number;
+};
+
+type FetchProjectsOptions = {
+  slugs?: string[];
+  limit?: Options['limit'];
+  cursor?: State['nextCursor'];
+  search?: State['lastSearch'];
+  lastSearch?: State['lastSearch'];
+};
+
+/**
+ * Helper function to actually load projects
+ */
+async function fetchProjects(
+  api: Client,
+  orgId: string,
+  {slugs, search, limit, lastSearch, cursor}: FetchProjectsOptions = {}
+) {
+  const query: {
+    collapse: string[];
+    query?: string;
+    cursor?: typeof cursor;
+    per_page?: number;
+    all_projects?: number;
+  } = {
+    // Never return latestDeploys project property from api
+    collapse: ['latestDeploys'],
+  };
+
+  if (slugs !== undefined && slugs.length > 0) {
+    query.query = slugs.map(slug => `slug:${slug}`).join(' ');
+  }
+
+  if (search) {
+    query.query = `${query.query ?? ''}${search}`.trim();
+  }
+
+  const prevSearchMatches = (!lastSearch && !search) || lastSearch === search;
+
+  if (prevSearchMatches && cursor) {
+    query.cursor = cursor;
+  }
+
+  if (limit !== undefined) {
+    query.per_page = limit;
+  }
+
+  let hasMore: null | boolean = false;
+  let nextCursor: null | string = null;
+  const [data, , resp] = await api.requestPromise(`/organizations/${orgId}/projects/`, {
+    includeAllArgs: true,
+    query,
+  });
+
+  const pageLinks = resp?.getResponseHeader('Link');
+  if (pageLinks) {
+    const paginationObject = parseLinkHeader(pageLinks);
+    hasMore = paginationObject?.next?.results || paginationObject?.previous?.results;
+    nextCursor = paginationObject?.next?.cursor;
+  }
+
+  return {results: data, hasMore, nextCursor};
+}
 
 /**
  * Provides projects from the ProjectStore
+ *
+ * This hook also provides a way to select specific project slugs, and search
+ * (type-ahead) for more projects that may not be in the project store.
+ *
+ * NOTE: Currently ALL projects are always loaded, but this hook is designed
+ * for future-compat in a world where we do _not_ load all projects.
  */
-function useProjects() {
-  const {projects, loading} = useLegacyStore(ProjectsStore);
+function useProjects({limit, slugs, orgId: propOrgId}: Options = {}) {
+  const api = useApi();
 
-  return {projects, loadingProjects: loading};
+  const {organization} = useLegacyStore(OrganizationStore);
+  const store = useLegacyStore(ProjectsStore);
+
+  const orgId = propOrgId ?? organization?.slug;
+
+  const storeSlugs = new Set(store.projects.map(t => t.slug));
+  const slugsToLoad = slugs?.filter(slug => !storeSlugs.has(slug)) ?? [];
+  const shouldLoadSlugs = slugsToLoad.length > 0;
+
+  const [state, setState] = useState<State>({
+    initiallyLoaded: !store.loading && !shouldLoadSlugs,
+    fetching: shouldLoadSlugs,
+    hasMore: null,
+    lastSearch: null,
+    nextCursor: null,
+    fetchError: null,
+  });
+
+  const slugsRef = useRef<Set<string> | null>(null);
+
+  // Only initialize slugsRef.current once and modify it when we receive new
+  // slugs determined through set equality
+  if (slugs !== undefined) {
+    if (slugsRef.current === null) {
+      slugsRef.current = new Set(slugs);
+    }
+
+    if (
+      slugs.length !== slugsRef.current.size ||
+      slugs.some(slug => !slugsRef.current?.has(slug))
+    ) {
+      slugsRef.current = new Set(slugs);
+    }
+  }
+
+  async function loadProjectsBySlug() {
+    if (orgId === undefined) {
+      // eslint-disable-next-line no-console
+      console.error('Cannot use useProjects({slugs}) without an organization in context');
+      return;
+    }
+
+    setState({...state, fetching: true});
+    try {
+      const {results, hasMore, nextCursor} = await fetchProjects(api, orgId, {
+        slugs: slugsToLoad,
+        limit,
+      });
+
+      const fetchedProjects = uniqBy([...store.projects, ...results], ({slug}) => slug);
+      ProjectActions.loadProjects(fetchedProjects);
+
+      setState({
+        ...state,
+        hasMore,
+        fetching: false,
+        initiallyLoaded: !store.loading,
+        nextCursor,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+
+      setState({
+        ...state,
+        fetching: false,
+        initiallyLoaded: !store.loading,
+        fetchError: err,
+      });
+    }
+  }
+
+  async function handleSearch(search: string) {
+    const {lastSearch} = state;
+    const cursor = state.nextCursor;
+
+    if (search === '') {
+      return;
+    }
+
+    if (orgId === undefined) {
+      // eslint-disable-next-line no-console
+      console.error('Cannot use useProjects.onSearch without an organization in context');
+      return;
+    }
+
+    setState({...state, fetching: true});
+
+    try {
+      api.clear();
+      const {results, hasMore, nextCursor} = await fetchProjects(api, orgId, {
+        search,
+        limit,
+        lastSearch,
+        cursor,
+      });
+
+      const fetchedProjects = uniqBy([...store.projects, ...results], ({slug}) => slug);
+
+      // Only update the store if we have more items
+      if (fetchedProjects.length > store.projects.length) {
+        ProjectActions.loadProjects(fetchedProjects);
+      }
+
+      setState({
+        ...state,
+        hasMore,
+        fetching: false,
+        lastSearch: search,
+        nextCursor,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+
+      setState({...state, fetching: false, fetchError: err});
+    }
+  }
+
+  useEffect(() => {
+    // Load specified team slugs
+    if (shouldLoadSlugs) {
+      loadProjectsBySlug();
+      return;
+    }
+  }, [slugsRef.current]);
+
+  // Update initiallyLoaded when we finish loading within the projectStore
+  useEffect(() => {
+    const storeLoaded = !store.loading;
+
+    if (state.initiallyLoaded === storeLoaded) {
+      return;
+    }
+
+    if (shouldLoadSlugs) {
+      return;
+    }
+
+    setState({...state, initiallyLoaded: storeLoaded});
+  }, [store.loading]);
+
+  const {initiallyLoaded, fetching, fetchError, hasMore} = state;
+
+  const filteredProjects = slugs
+    ? store.projects.filter(t => slugs.includes(t.slug))
+    : store.projects;
+
+  const placeholders = slugsToLoad.map(slug => ({slug}));
+
+  const result: Result = {
+    projects: filteredProjects,
+    placeholders,
+    fetching: fetching || store.loading,
+    initiallyLoaded,
+    fetchError,
+    hasMore,
+    onSearch: handleSearch,
+  };
+
+  return result;
 }
 
 export default useProjects;

--- a/static/app/utils/withProjects.tsx
+++ b/static/app/utils/withProjects.tsx
@@ -18,7 +18,8 @@ function withProjects<P extends InjectedProjectsProps>(
   type Props = Omit<P, keyof InjectedProjectsProps>;
 
   const Wrapper: React.FC<Props> = props => {
-    const {projects, loadingProjects} = useProjects();
+    const {projects, initiallyLoaded} = useProjects();
+    const loadingProjects = !initiallyLoaded;
 
     return <WrappedComponent {...(props as P)} {...{projects, loadingProjects}} />;
   };

--- a/tests/js/spec/components/contextPickerModal.spec.jsx
+++ b/tests/js/spec/components/contextPickerModal.spec.jsx
@@ -28,8 +28,8 @@ describe('ContextPickerModal', function () {
   });
 
   afterEach(async function () {
-    OrganizationsStore.load([]);
-    OrganizationStore.reset();
+    act(() => OrganizationsStore.load([]));
+    act(() => OrganizationStore.reset());
     await act(tick);
   });
 

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -1,4 +1,4 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {enforceActOnUseLegacyStoreHook, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mockRouterPush} from 'sentry-test/mockRouterPush';
 import {act} from 'sentry-test/reactTestingLibrary';
@@ -30,6 +30,8 @@ jest.mock('app/utils/localStorage', () => ({
 }));
 
 describe('GlobalSelectionHeader', function () {
+  enforceActOnUseLegacyStoreHook();
+
   let wrapper;
   const {organization, router, routerContext} = initializeOrg({
     organization: {features: ['global-views']},
@@ -60,7 +62,7 @@ describe('GlobalSelectionHeader', function () {
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
-    act(() => ProjectsStore.loadInitialData(organization.projects));
+    ProjectsStore.loadInitialData(organization.projects);
 
     getItem.mockImplementation(() => null);
     MockApiClient.addMockResponse({
@@ -229,7 +231,7 @@ describe('GlobalSelectionHeader', function () {
         params: {orgId: 'org-slug'},
       },
     });
-    act(() => ProjectsStore.loadInitialData(initialData.projects));
+    ProjectsStore.loadInitialData(initialData.projects);
 
     wrapper = mountWithTheme(
       <GlobalSelectionHeader
@@ -532,7 +534,7 @@ describe('GlobalSelectionHeader', function () {
         body: [],
       });
 
-      act(() => ProjectsStore.reset());
+      ProjectsStore.reset();
 
       // This can happen when you switch organization so params.orgId !== the
       // current org in context In this case params.orgId = 'org-slug'
@@ -602,7 +604,7 @@ describe('GlobalSelectionHeader', function () {
       const project = TestStubs.Project({id: '3'});
       const org = TestStubs.Organization({projects: [project]});
 
-      act(() => ProjectsStore.loadInitialData(org.projects));
+      ProjectsStore.loadInitialData(org.projects);
 
       const initializationObj = initializeOrg({
         organization: org,
@@ -642,7 +644,7 @@ describe('GlobalSelectionHeader', function () {
         },
       });
 
-      act(() => ProjectsStore.loadInitialData(initialData.projects));
+      ProjectsStore.loadInitialData(initialData.projects);
 
       wrapper = mountWithTheme(
         <GlobalSelectionHeader
@@ -697,7 +699,7 @@ describe('GlobalSelectionHeader', function () {
       };
 
       beforeEach(function () {
-        act(() => ProjectsStore.loadInitialData(initialData.projects));
+        ProjectsStore.loadInitialData(initialData.projects);
 
         initialData.router.push.mockClear();
         initialData.router.replace.mockClear();
@@ -715,7 +717,7 @@ describe('GlobalSelectionHeader', function () {
       });
 
       it('appends projectId to URL when `forceProject` becomes available (async)', async function () {
-        act(() => ProjectsStore.reset());
+        ProjectsStore.reset();
 
         // forceProject generally starts undefined
         createWrapper({shouldForceProject: true});
@@ -789,7 +791,7 @@ describe('GlobalSelectionHeader', function () {
           params: {orgId: 'org-slug'},
         },
       });
-      act(() => ProjectsStore.loadInitialData(initialData.projects));
+      ProjectsStore.loadInitialData(initialData.projects);
 
       const createWrapper = props => {
         wrapper = mountWithTheme(
@@ -856,7 +858,7 @@ describe('GlobalSelectionHeader', function () {
       };
 
       beforeEach(function () {
-        act(() => ProjectsStore.loadInitialData(initialData.projects));
+        ProjectsStore.loadInitialData(initialData.projects);
 
         initialData.router.push.mockClear();
         initialData.router.replace.mockClear();
@@ -872,7 +874,7 @@ describe('GlobalSelectionHeader', function () {
       });
 
       it('does not append projectId to URL when `loadingProjects` changes and finishes loading', async function () {
-        act(() => ProjectsStore.reset());
+        ProjectsStore.reset();
 
         createWrapper();
 
@@ -887,7 +889,7 @@ describe('GlobalSelectionHeader', function () {
       });
 
       it('appends projectId to URL when `forceProject` becomes available (async)', async function () {
-        act(() => ProjectsStore.reset());
+        ProjectsStore.reset();
 
         // forceProject generally starts undefined
         createWrapper({shouldForceProject: true});
@@ -942,7 +944,7 @@ describe('GlobalSelectionHeader', function () {
         },
       });
 
-      act(() => ProjectsStore.loadInitialData(initialData.projects));
+      ProjectsStore.loadInitialData(initialData.projects);
 
       wrapper = mountWithTheme(
         <GlobalSelectionHeader organization={initialData.organization} />,
@@ -1093,7 +1095,7 @@ describe('GlobalSelectionHeader', function () {
     });
 
     beforeEach(function () {
-      act(() => ProjectsStore.loadInitialData(initialData.projects));
+      ProjectsStore.loadInitialData(initialData.projects);
     });
 
     it('shows IconProject when no projects are selected', async function () {

--- a/tests/js/spec/utils/useProjects.spec.tsx
+++ b/tests/js/spec/utils/useProjects.spec.tsx
@@ -1,0 +1,94 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+
+import OrganizationStore from 'app/stores/organizationStore';
+import ProjectsStore from 'app/stores/projectsStore';
+import useProjects from 'app/utils/useProjects';
+
+describe('useProjects', function () {
+  const org = TestStubs.Organization();
+
+  const mockProjects = [TestStubs.Project()];
+
+  it('provides projects from the team store', function () {
+    act(() => void ProjectsStore.loadInitialData(mockProjects));
+
+    const {result} = renderHook(() => useProjects());
+    const {projects} = result.current;
+
+    expect(projects).toEqual(mockProjects);
+  });
+
+  it('loads more projects when using onSearch', async function () {
+    act(() => void ProjectsStore.loadInitialData(mockProjects));
+    act(() => void OrganizationStore.onUpdate(org, {replace: true}));
+
+    const newProject3 = TestStubs.Project({id: '3', slug: 'test-project3'});
+    const newProject4 = TestStubs.Project({id: '4', slug: 'test-project4'});
+
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      method: 'GET',
+      body: [newProject3, newProject4],
+    });
+
+    const {result, waitFor} = renderHook(() => useProjects());
+    const {onSearch} = result.current;
+
+    // Works with append
+    const onSearchPromise = act(() => onSearch('test'));
+
+    expect(result.current.fetching).toBe(true);
+    await onSearchPromise;
+    expect(result.current.fetching).toBe(false);
+
+    // Wait for state to be reflected from the store
+    await waitFor(() => result.current.projects.length === 3);
+
+    expect(mockRequest).toHaveBeenCalled();
+    expect(result.current.projects).toEqual([...mockProjects, newProject3, newProject4]);
+
+    // de-duplicates itesm in the query results
+    mockRequest.mockClear();
+    await act(() => onSearch('test'));
+
+    // No new items have been added
+    expect(mockRequest).toHaveBeenCalled();
+    expect(result.current.projects).toEqual([...mockProjects, newProject3, newProject4]);
+  });
+
+  it('provides only the specified slugs', async function () {
+    act(() => void ProjectsStore.loadInitialData(mockProjects));
+    act(() => void OrganizationStore.onUpdate(org, {replace: true}));
+
+    const projectFoo = TestStubs.Project({id: 3, slug: 'foo'});
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      method: 'GET',
+      body: [projectFoo],
+    });
+
+    const {result, waitFor} = renderHook(props => useProjects(props), {
+      initialProps: {slugs: ['foo']},
+    });
+
+    expect(result.current.initiallyLoaded).toBe(false);
+    expect(mockRequest).toHaveBeenCalled();
+
+    await waitFor(() => expect(result.current.projects.length).toBe(1));
+
+    const {projects} = result.current;
+    expect(projects).toEqual(expect.arrayContaining([projectFoo]));
+  });
+
+  it('only loads slugs when needed', async function () {
+    act(() => void ProjectsStore.loadInitialData(mockProjects));
+
+    const {result} = renderHook(props => useProjects(props), {
+      initialProps: {slugs: [mockProjects[0].slug]},
+    });
+
+    const {projects, initiallyLoaded} = result.current;
+    expect(initiallyLoaded).toBe(true);
+    expect(projects).toEqual(expect.arrayContaining(mockProjects));
+  });
+});

--- a/tests/js/spec/views/settings/organizationGeneralSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationGeneralSettings/index.spec.jsx
@@ -1,6 +1,6 @@
 import {browserHistory} from 'react-router';
 
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {enforceActOnUseLegacyStoreHook, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
 import {act} from 'sentry-test/reactTestingLibrary';
@@ -9,6 +9,8 @@ import ProjectsStore from 'app/stores/projectsStore';
 import OrganizationGeneralSettings from 'app/views/settings/organizationGeneralSettings';
 
 describe('OrganizationGeneralSettings', function () {
+  enforceActOnUseLegacyStoreHook();
+
   let organization;
   let routerContext;
   const ENDPOINT = '/organizations/org-slug/';
@@ -60,13 +62,22 @@ describe('OrganizationGeneralSettings', function () {
 
     await tick();
     wrapper.update();
-    // Change slug
-    wrapper
-      .find('input[id="slug"]')
-      .simulate('change', {target: {value: 'new-slug'}})
-      .simulate('blur');
 
-    wrapper.find('button[aria-label="Save"]').simulate('click');
+    // Change slug
+    act(() => {
+      wrapper
+        .find('input[id="slug"]')
+        .simulate('change', {target: {value: 'new-slug'}})
+        .simulate('blur');
+    });
+
+    await tick();
+    wrapper.update();
+
+    act(() => {
+      wrapper.find('button[aria-label="Save"]').simulate('click');
+    });
+
     expect(mock).toHaveBeenCalledWith(
       ENDPOINT,
       expect.objectContaining({


### PR DESCRIPTION
Similar to useTeams, adds support to useProject to specify what slugs
you want specifically, and support typehead search + pagination.