### PR TITLE
fix(slack): MessageAction dataclass

### DIFF
--- a/src/sentry/notifications/utils/actions.py
+++ b/src/sentry/notifications/utils/actions.py
@@ -31,3 +31,5 @@ class MessageAction:
     # TODO(mgaeta): Refactor this to be provider-agnostic
     selected_options: Sequence[Mapping[str, Any]] | None = None
     option_groups: Sequence[Mapping[str, Any]] | None = None
+    block_id: str | None = None
+    elements: Sequence[Mapping[str, Any]] | None = None


### PR DESCRIPTION
The action buttons in Slack messages got turned into a `dataclass` so we need to support more fields in `__init__()`.
 
Fixes [SENTRY-SPD](https://sentry.io/organizations/sentry/issues/2777875623/).