### PR TITLE
feat(jira): Add badges to issue glance

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -88,6 +88,7 @@ class JiraApiClient(ApiClient):
     TRANSITION_URL = "/rest/api/2/issue/%s/transitions"
     EMAIL_URL = "/rest/api/3/user/email"
     AUTOCOMPLETE_URL = "/rest/api/2/jql/autocompletedata/suggestions"
+    PROPERTIES_URL = "/rest/api/3/issue/%s/properties/%s"
 
     integration_name = "jira"
 
@@ -231,6 +232,12 @@ class JiraApiClient(ApiClient):
     def assign_issue(self, key, name_or_account_id):
         user_id_field = self.user_id_field()
         return self.put(self.ASSIGN_URL % key, data={user_id_field: name_or_account_id})
+
+    def set_issue_property(self, issue_key, badge_num):
+        module_key = "sentry-issues-glance"
+        properties_key = f"com.atlassian.jira.issue:{JIRA_KEY}:{module_key}:status"
+        data = {"type": "badge", "value": {"label": badge_num}}
+        return self.put(self.PROPERTIES_URL % (issue_key, properties_key), data=data)
 
     def get_email(self, account_id):
         user = self.get_cached(self.EMAIL_URL, params={"accountId": account_id})

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -70,12 +70,13 @@ class BaseApiResponse:
                     response.headers.get("Content-Type", ""), response.status_code
                 )
         else:
-            data = json.loads(response.text, object_pairs_hook=OrderedDict)
-
+            data = json.loads(response.text or "null", object_pairs_hook=OrderedDict)
         if isinstance(data, dict):
             return MappingApiResponse(data, response.headers, response.status_code)
         elif isinstance(data, (list, tuple)):
             return SequenceApiResponse(data, response.headers, response.status_code)
+        elif data is None:
+            return TextApiResponse(response.text, response.headers, response.status_code)
         else:
             raise NotImplementedError
 

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -69,14 +69,14 @@ class BaseApiResponse:
                 raise UnsupportedResponseType(
                     response.headers.get("Content-Type", ""), response.status_code
                 )
+        elif response.text == "":
+            return TextApiResponse(response.text, response.headers, response.status_code)
         else:
-            data = json.loads(response.text or "null", object_pairs_hook=OrderedDict)
+            data = json.loads(response.text, object_pairs_hook=OrderedDict)
         if isinstance(data, dict):
             return MappingApiResponse(data, response.headers, response.status_code)
         elif isinstance(data, (list, tuple)):
             return SequenceApiResponse(data, response.headers, response.status_code)
-        elif data is None:
-            return TextApiResponse(response.text, response.headers, response.status_code)
         else:
             raise NotImplementedError
 


### PR DESCRIPTION
Add an indication of whether or not there is a linked issue on the Jira issue glance view. I chose to hard code it as 1 since we do not currently show details of more than 1 issue even if more than 1 are linked, and figured it'd be a weird experience to see "2" and then click and only see details for 1 issue. When we get around to showing details for more than 1, this can be updated to use the actual count. If there are no linked issues, the badge simply doesn't show rather than showing 0. 

**Note**: I have both a local Jira installation and prod Jira installation, so the top one where it says "linked kitties" is the local one that reflects this change, it's just easier to differentiate.

<img width="442" alt="Screen Shot 2021-11-09 at 3 58 52 PM" src="https://user-images.githubusercontent.com/29959063/141027580-5217383c-41f2-4202-8159-2f1f07c93203.png">


References:
https://developer.atlassian.com/cloud/jira/platform/modules/issue-glance/
https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-properties/#api-rest-api-3-issue-issueidorkey-properties-propertykey-put