### PR TITLE
feat(hooks): Create useRepositories hook

### DIFF
--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -3,32 +3,29 @@ import Reflux from 'reflux';
 import RepoActions from 'app/actions/repositoryActions';
 import {Repository} from 'app/types';
 
+type State = {
+  orgSlug?: string;
+  repositories: Repository[];
+  repositoriesLoading: boolean;
+  repositoriesError?: Error;
+};
 type RepositoryStoreInterface = {
-  get(): {
-    orgSlug?: string;
-    repositories?: Repository[];
-    repositoriesLoading?: boolean;
-    repositoriesError?: Error;
-  };
+  get(): State;
 
-  state: {
-    orgSlug?: string;
-    repositories?: Repository[];
-    repositoriesLoading?: boolean;
-    repositoriesError?: Error;
-  };
+  state: State;
 
   loadRepositories(orgSlug: string): void;
   loadRepositoriesSuccess(data: Repository[]): void;
   loadRepositoriesError(error: Error): void;
+  getState(): State;
 };
 
 const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   listenables: RepoActions,
   state: {
     orgSlug: undefined,
-    repositories: undefined,
-    repositoriesLoading: undefined,
+    repositories: [],
+    repositoriesLoading: false,
     repositoriesError: undefined,
   },
 
@@ -39,8 +36,8 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   resetRepositories() {
     this.state = {
       orgSlug: undefined,
-      repositories: undefined,
-      repositoriesLoading: undefined,
+      repositories: [],
+      repositoriesLoading: false,
       repositoriesError: undefined,
     };
     this.trigger(this.state);
@@ -49,7 +46,7 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   loadRepositories(orgSlug: string) {
     this.state = {
       orgSlug,
-      repositories: orgSlug === this.state.orgSlug ? this.state.repositories : undefined,
+      repositories: orgSlug === this.state.orgSlug ? this.state.repositories : [],
       repositoriesLoading: true,
       repositoriesError: undefined,
     };
@@ -59,7 +56,7 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   loadRepositoriesError(err: Error) {
     this.state = {
       ...this.state,
-      repositories: undefined,
+      repositories: [],
       repositoriesLoading: false,
       repositoriesError: err,
     };
@@ -78,6 +75,10 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
 
   get() {
     return {...this.state};
+  },
+
+  getState() {
+    return this.get();
   },
 };
 

--- a/static/app/utils/useRepositories.tsx
+++ b/static/app/utils/useRepositories.tsx
@@ -1,53 +1,18 @@
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
 
 import RepositoryActions from 'app/actions/repositoryActions';
-import {Client} from 'app/api';
 import OrganizationStore from 'app/stores/organizationStore';
 import RepositoryStore from 'app/stores/repositoryStore';
 import {useLegacyStore} from 'app/stores/useLegacyStore';
 import {Repository} from 'app/types';
-import parseLinkHeader from 'app/utils/parseLinkHeader';
-import RequestError from 'app/utils/requestError/requestError';
-import useApi from 'app/utils/useApi';
-
-type State = {
-  /**
-   * This is state for when fetching data from API
-   */
-  loading: boolean;
-  /**
-   * The error that occurred if fetching failed
-   */
-  error: null | RequestError;
-  /**
-   * Indicates that Team results (from API) are paginated and there are more
-   * Teams that are not in the initial response.
-   */
-  hasMore: null | boolean;
-  /**
-   * The last query we searched. Used to validate the cursor
-   */
-  lastSearch: null | string;
-  /**
-   * Pagination
-   */
-  nextCursor?: null | string;
-};
+import useRequest, {Result as useRequestResult} from 'app/utils/useRequest';
 
 export type Result = {
   /**
    * The loaded repositories list
    */
   repositories: Repository[];
-  /**
-   * This is an action provided to consumers for them to update the current
-   * result set using a simple search query.
-   *
-   * Will always add new options into the store.
-   */
-  onSearch: (searchTerm: string) => Promise<void>;
-  nextPage: () => Promise<void>;
-} & State;
+} & Omit<useRequestResult, 'data'>;
 
 type Options = {
   /**
@@ -56,63 +21,10 @@ type Options = {
   limit?: number;
 };
 
-type FetchRepositoryOptions = {
-  limit?: Options['limit'];
-  cursor?: State['nextCursor'];
-  search?: State['lastSearch'];
-  lastSearch?: State['lastSearch'];
-};
-
-/**
- * Helper function to actually load repositories
- */
-async function fetchRepositories(
-  api: Client,
-  orgId: string,
-  {search, limit, lastSearch, cursor}: FetchRepositoryOptions = {}
-) {
-  const query: {
-    query?: string;
-    cursor?: typeof cursor;
-    per_page?: number;
-  } = {};
-
-  if (search) {
-    query.query = `${query.query ?? ''} ${search}`.trim();
-  }
-
-  const isSameSearch = lastSearch === search || (!lastSearch && !search);
-
-  if (isSameSearch && cursor) {
-    query.cursor = cursor;
-  }
-
-  if (limit !== undefined) {
-    query.per_page = limit;
-  }
-
-  let hasMore: null | boolean = false;
-  let nextCursor: null | string = null;
-  const [data, , resp] = await api.requestPromise(`/organizations/${orgId}/repos/`, {
-    includeAllArgs: true,
-    query,
-  });
-
-  const pageLinks = resp?.getResponseHeader('Link');
-  if (pageLinks) {
-    const paginationObject = parseLinkHeader(pageLinks);
-    hasMore = paginationObject?.next?.results || paginationObject?.previous?.results;
-    nextCursor = paginationObject?.next?.cursor;
-  }
-
-  return {results: data, hasMore, nextCursor};
-}
-
 /**
  * Provides repositories from the RepositoryStore
  */
 function useRepositories({limit}: Options = {}) {
-  const api = useApi();
   const {organization} = useLegacyStore(OrganizationStore);
   const store = useLegacyStore(RepositoryStore);
 
@@ -122,101 +34,26 @@ function useRepositories({limit}: Options = {}) {
     RepositoryActions.resetRepositories();
   }
 
-  const [state, setState] = useState<State>({
-    loading: false,
-    hasMore: null,
-    lastSearch: null,
-    nextCursor: null,
-    error: null,
-  });
-
-  async function loadRepositories(cursor: string | null = null) {
-    if (orgId === undefined) {
-      return;
-    }
-
-    setState({...state, loading: true});
-    try {
-      const {results, hasMore, nextCursor} = await fetchRepositories(api, orgId, {
-        limit,
-        cursor,
-      });
-      RepositoryActions.loadRepositoriesSuccess(results);
-
-      setState({
-        ...state,
-        hasMore,
-        loading: false,
-        nextCursor,
-      });
-    } catch (err) {
-      console.error(err); // eslint-disable-line no-console
-      setState({...state, loading: false, error: err});
-    }
-  }
-
-  async function handleSearch(search: string) {
-    const {lastSearch} = state;
-    const cursor = state.nextCursor;
-
-    if (search === '') {
-      return;
-    }
-
-    if (orgId === undefined) {
-      // eslint-disable-next-line no-console
-      console.error(
-        'Cannot use useRepositories.onSearch without an organization in context'
-      );
-      return;
-    }
-
-    setState({...state, loading: true});
-
-    try {
-      api.clear();
-      const {results, hasMore, nextCursor} = await fetchRepositories(api, orgId, {
-        search,
-        limit,
-        lastSearch,
-        cursor,
-      });
-
-      RepositoryActions.loadRepositoriesSuccess(results);
-
-      setState({
-        ...state,
-        hasMore,
-        loading: false,
-        lastSearch: search,
-        nextCursor,
-      });
-    } catch (err) {
-      console.error(err); // eslint-disable-line no-console
-
-      setState({...state, loading: false, error: err});
-    }
-  }
+  const {get, ...rest} = useRequest(
+    `/organizations/${orgId}/repos/`,
+    {
+      limit,
+    },
+    data => RepositoryActions.loadRepositoriesSuccess(data)
+  );
 
   useEffect(() => {
     /** Multiple components may call useRepositories.
      * We want to prevent making multiple calls for the same org. */
-    if (orgId !== store.orgSlug) {
-      loadRepositories();
+    if (orgId !== store.orgSlug && orgId !== undefined) {
+      get();
     }
   }, [orgId]);
 
   const result: Result = {
     repositories: store.repositories,
-    loading: state.loading,
-    error: state.error,
-    hasMore: state.hasMore,
-    nextCursor: state.nextCursor,
-    lastSearch: state.lastSearch,
-    onSearch: handleSearch,
-    nextPage: state.hasMore
-      ? () => loadRepositories(state.nextCursor)
-      : () => new Promise(resolve => resolve()),
+    get,
+    ...rest,
   };
 
   return result;

--- a/static/app/utils/useRepositories.tsx
+++ b/static/app/utils/useRepositories.tsx
@@ -1,0 +1,225 @@
+import {useEffect, useState} from 'react';
+
+import RepositoryActions from 'app/actions/repositoryActions';
+import {Client} from 'app/api';
+import OrganizationStore from 'app/stores/organizationStore';
+import RepositoryStore from 'app/stores/repositoryStore';
+import {useLegacyStore} from 'app/stores/useLegacyStore';
+import {Repository} from 'app/types';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
+import RequestError from 'app/utils/requestError/requestError';
+import useApi from 'app/utils/useApi';
+
+type State = {
+  /**
+   * This is state for when fetching data from API
+   */
+  loading: boolean;
+  /**
+   * The error that occurred if fetching failed
+   */
+  error: null | RequestError;
+  /**
+   * Indicates that Team results (from API) are paginated and there are more
+   * Teams that are not in the initial response.
+   */
+  hasMore: null | boolean;
+  /**
+   * The last query we searched. Used to validate the cursor
+   */
+  lastSearch: null | string;
+  /**
+   * Pagination
+   */
+  nextCursor?: null | string;
+};
+
+export type Result = {
+  /**
+   * The loaded repositories list
+   */
+  repositories: Repository[];
+  /**
+   * This is an action provided to consumers for them to update the current
+   * result set using a simple search query.
+   *
+   * Will always add new options into the store.
+   */
+  onSearch: (searchTerm: string) => Promise<void>;
+  nextPage: () => Promise<void>;
+} & State;
+
+type Options = {
+  /**
+   * Number of repositories to return
+   */
+  limit?: number;
+};
+
+type FetchRepositoryOptions = {
+  limit?: Options['limit'];
+  cursor?: State['nextCursor'];
+  search?: State['lastSearch'];
+  lastSearch?: State['lastSearch'];
+};
+
+/**
+ * Helper function to actually load repositories
+ */
+async function fetchRepositories(
+  api: Client,
+  orgId: string,
+  {search, limit, lastSearch, cursor}: FetchRepositoryOptions = {}
+) {
+  const query: {
+    query?: string;
+    cursor?: typeof cursor;
+    per_page?: number;
+  } = {};
+
+  if (search) {
+    query.query = `${query.query ?? ''} ${search}`.trim();
+  }
+
+  const isSameSearch = lastSearch === search || (!lastSearch && !search);
+
+  if (isSameSearch && cursor) {
+    query.cursor = cursor;
+  }
+
+  if (limit !== undefined) {
+    query.per_page = limit;
+  }
+
+  let hasMore: null | boolean = false;
+  let nextCursor: null | string = null;
+  const [data, , resp] = await api.requestPromise(`/organizations/${orgId}/repos/`, {
+    includeAllArgs: true,
+    query,
+  });
+
+  const pageLinks = resp?.getResponseHeader('Link');
+  if (pageLinks) {
+    const paginationObject = parseLinkHeader(pageLinks);
+    hasMore = paginationObject?.next?.results || paginationObject?.previous?.results;
+    nextCursor = paginationObject?.next?.cursor;
+  }
+
+  return {results: data, hasMore, nextCursor};
+}
+
+/**
+ * Provides repositories from the RepositoryStore
+ */
+function useRepositories({limit}: Options = {}) {
+  const api = useApi();
+  const {organization} = useLegacyStore(OrganizationStore);
+  const store = useLegacyStore(RepositoryStore);
+
+  const orgId = organization?.slug;
+
+  if (store.orgSlug && store.orgSlug !== orgId) {
+    RepositoryActions.resetRepositories();
+  }
+
+  const [state, setState] = useState<State>({
+    loading: false,
+    hasMore: null,
+    lastSearch: null,
+    nextCursor: null,
+    error: null,
+  });
+
+  async function loadRepositories(cursor: string | null = null) {
+    if (orgId === undefined) {
+      return;
+    }
+
+    setState({...state, loading: true});
+    try {
+      const {results, hasMore, nextCursor} = await fetchRepositories(api, orgId, {
+        limit,
+        cursor,
+      });
+      RepositoryActions.loadRepositoriesSuccess(results);
+
+      setState({
+        ...state,
+        hasMore,
+        loading: false,
+        nextCursor,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+      setState({...state, loading: false, error: err});
+    }
+  }
+
+  async function handleSearch(search: string) {
+    const {lastSearch} = state;
+    const cursor = state.nextCursor;
+
+    if (search === '') {
+      return;
+    }
+
+    if (orgId === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Cannot use useRepositories.onSearch without an organization in context'
+      );
+      return;
+    }
+
+    setState({...state, loading: true});
+
+    try {
+      api.clear();
+      const {results, hasMore, nextCursor} = await fetchRepositories(api, orgId, {
+        search,
+        limit,
+        lastSearch,
+        cursor,
+      });
+
+      RepositoryActions.loadRepositoriesSuccess(results);
+
+      setState({
+        ...state,
+        hasMore,
+        loading: false,
+        lastSearch: search,
+        nextCursor,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+
+      setState({...state, loading: false, error: err});
+    }
+  }
+
+  useEffect(() => {
+    /** Multiple components may call useRepositories.
+     * We want to prevent making multiple calls for the same org. */
+    if (orgId !== store.orgSlug) {
+      loadRepositories();
+    }
+  }, [orgId]);
+
+  const result: Result = {
+    repositories: store.repositories,
+    loading: state.loading,
+    error: state.error,
+    hasMore: state.hasMore,
+    nextCursor: state.nextCursor,
+    lastSearch: state.lastSearch,
+    onSearch: handleSearch,
+    nextPage: state.hasMore
+      ? () => loadRepositories(state.nextCursor)
+      : () => new Promise(resolve => resolve()),
+  };
+
+  return result;
+}
+
+export default useRepositories;

--- a/static/app/utils/useRepositories.tsx
+++ b/static/app/utils/useRepositories.tsx
@@ -12,7 +12,7 @@ export type Result = {
    * The loaded repositories list
    */
   repositories: Repository[];
-} & Omit<useRequestResult, 'data'>;
+} & useRequestResult;
 
 type Options = {
   /**
@@ -39,21 +39,34 @@ function useRepositories({limit}: Options = {}) {
     {
       limit,
     },
-    data => RepositoryActions.loadRepositoriesSuccess(data)
+    results => RepositoryActions.loadRepositoriesSuccess(results),
+    err => RepositoryActions.loadRepositoriesError(err)
   );
 
   useEffect(() => {
     /** Multiple components may call useRepositories.
-     * We want to prevent making multiple calls for the same org. */
-    if (orgId !== store.orgSlug && orgId !== undefined) {
+     * We want to prevent making multiple calls for the same org.
+     *
+     * HACK(leedongwei & nisanthan): Actions fired by the ActionCreators are queued to the back of the event loop, allowing another getRepo for the same repo to be fired before the loading state is updated in store. We will directly manipulate the state of the store, rather than wait for the ActionCreator.
+     * This hack short-circuits that and update the state immediately.
+     *
+     * */
+    if (
+      orgId !== store.orgSlug &&
+      orgId !== undefined &&
+      !RepositoryStore.state.repositoriesLoading
+    ) {
+      RepositoryActions.loadRepositories(orgId);
+      RepositoryStore.state.repositoriesLoading = true;
       get();
     }
   }, [orgId]);
 
   const result: Result = {
-    repositories: store.repositories,
-    get,
     ...rest,
+    get,
+    repositories: store.repositories,
+    loading: store.repositoriesLoading,
   };
 
   return result;

--- a/static/app/utils/useRequest.tsx
+++ b/static/app/utils/useRequest.tsx
@@ -1,0 +1,254 @@
+import {useState} from 'react';
+
+import {Client} from 'app/api';
+import OrganizationStore from 'app/stores/organizationStore';
+import {useLegacyStore} from 'app/stores/useLegacyStore';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
+import RequestError from 'app/utils/requestError/requestError';
+import useApi from 'app/utils/useApi';
+
+type State = {
+  data: null | any;
+  /**
+   * This is state for when fetching data from API
+   */
+  loading: boolean;
+  /**
+   * The error that occurred if fetching failed
+   */
+  error: null | RequestError;
+  /**
+   * Indicates that Team results (from API) are paginated and there are more
+   * Teams that are not in the initial response.
+   */
+  hasMore: null | boolean;
+  /**
+   * The last query we searched. Used to validate the cursor
+   */
+  lastSearch: null | string;
+  /**
+   * Pagination
+   */
+  nextCursor?: null | string;
+};
+
+export type Result = {
+  /**
+   * This is an action provided to consumers for them to update the current
+   * result set using a simple search query.
+   *
+   * Will always add new options into the store.
+   */
+  onSearch: (searchTerm: string) => Promise<void>;
+  nextPage: () => Promise<void>;
+  get: () => Promise<void>;
+  post: (_) => Promise<void>;
+  update: (_) => Promise<void>;
+  del: () => Promise<void>;
+} & State;
+
+type Options = {
+  /**
+   * Number of repositories to return
+   */
+  limit?: number;
+};
+
+type FetchRequestOptions = {
+  limit?: Options['limit'];
+  cursor?: State['nextCursor'];
+  search?: State['lastSearch'];
+  lastSearch?: State['lastSearch'];
+};
+
+/**
+ * Helper function to actually load repositories
+ */
+async function fetch(
+  api: Client,
+  url: string,
+  {search, limit, lastSearch, cursor}: FetchRequestOptions = {}
+) {
+  const query: {
+    query?: string;
+    cursor?: typeof cursor;
+    per_page?: number;
+  } = {};
+
+  if (search) {
+    query.query = `${query.query ?? ''} ${search}`.trim();
+  }
+
+  const isSameSearch = lastSearch === search || (!lastSearch && !search);
+
+  if (isSameSearch && cursor) {
+    query.cursor = cursor;
+  }
+
+  if (limit !== undefined) {
+    query.per_page = limit;
+  }
+
+  let hasMore: null | boolean = false;
+  let nextCursor: null | string = null;
+  const [data, , resp] = await api.requestPromise(url, {
+    includeAllArgs: true,
+    query,
+  });
+
+  const pageLinks = resp?.getResponseHeader('Link');
+  if (pageLinks) {
+    const paginationObject = parseLinkHeader(pageLinks);
+    hasMore = paginationObject?.next?.results || paginationObject?.previous?.results;
+    nextCursor = paginationObject?.next?.cursor;
+  }
+
+  return {results: data, hasMore, nextCursor};
+}
+
+function useRequest(
+  url,
+  {limit}: Options = {},
+  onSuccessCb = _ => {},
+  onErrorCb = _ => {}
+) {
+  const api = useApi();
+  const {organization} = useLegacyStore(OrganizationStore);
+
+  const orgId = organization?.slug;
+
+  const [state, setState] = useState<State>({
+    data: null,
+    loading: false,
+    hasMore: null,
+    lastSearch: null,
+    nextCursor: null,
+    error: null,
+  });
+
+  async function get(cursor: string | null = null) {
+    setState({...state, loading: true});
+    try {
+      const {results, hasMore, nextCursor} = await fetch(api, url, {
+        limit,
+        cursor,
+      });
+      onSuccessCb(results);
+      setState({
+        ...state,
+        data: results,
+        hasMore,
+        loading: false,
+        nextCursor,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+      setState({...state, loading: false, error: err});
+      onErrorCb(err);
+    }
+  }
+
+  async function handleSearch(search: string) {
+    const {lastSearch} = state;
+    const cursor = state.nextCursor;
+
+    if (search === '') {
+      return;
+    }
+
+    if (orgId === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(
+        'Cannot use useRepositories.onSearch without an organization in context'
+      );
+      return;
+    }
+
+    setState({...state, loading: true});
+
+    try {
+      api.clear();
+      const {results, hasMore, nextCursor} = await fetch(api, url, {
+        search,
+        limit,
+        lastSearch,
+        cursor,
+      });
+
+      onSuccessCb(results);
+
+      setState({
+        ...state,
+        data: results,
+        hasMore,
+        loading: false,
+        lastSearch: search,
+        nextCursor,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+
+      setState({...state, loading: false, error: err});
+      onErrorCb(err);
+    }
+  }
+
+  async function createOrUpdate(data: any, method: 'POST' | 'PUT' = 'POST') {
+    setState({...state, loading: true});
+    try {
+      const [results] = await api.requestPromise(url, {
+        method,
+        data,
+      });
+      onSuccessCb(results);
+      setState({
+        ...state,
+        data: results,
+        loading: false,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+      setState({...state, loading: false, error: err});
+      onErrorCb(err);
+    }
+  }
+
+  async function del() {
+    setState({...state, loading: true});
+    try {
+      const [results] = await api.requestPromise(url, {
+        method: 'DELETE',
+      });
+      onSuccessCb(results);
+      setState({
+        ...state,
+        data: results,
+        loading: false,
+      });
+    } catch (err) {
+      console.error(err); // eslint-disable-line no-console
+      setState({...state, loading: false, error: err});
+      onErrorCb(err);
+    }
+  }
+  const result: Result = {
+    data: state.data,
+    loading: state.loading,
+    error: state.error,
+    hasMore: state.hasMore,
+    nextCursor: state.nextCursor,
+    lastSearch: state.lastSearch,
+    onSearch: handleSearch,
+    nextPage: state.hasMore
+      ? () => get(state.nextCursor)
+      : () => new Promise(resolve => resolve()),
+    get: () => get(),
+    post: data => createOrUpdate(data),
+    update: data => createOrUpdate(data, 'PUT'),
+    del: () => del(),
+  };
+
+  return result;
+}
+
+export default useRequest;

--- a/static/app/utils/withRepositories.tsx
+++ b/static/app/utils/withRepositories.tsx
@@ -1,16 +1,9 @@
 import * as React from 'react';
 
-import {getRepositories} from 'app/actionCreators/repositories';
-import RepositoryActions from 'app/actions/repositoryActions';
-import {Client} from 'app/api';
-import RepositoryStore from 'app/stores/repositoryStore';
-import {Organization, Repository} from 'app/types';
+import {Repository} from 'app/types';
 import getDisplayName from 'app/utils/getDisplayName';
 
-type DependentProps = {
-  api: Client;
-  organization: Organization;
-};
+import useRepositories from './useRepositories';
 
 type InjectedProps = {
   repositories?: Repository[];
@@ -18,72 +11,25 @@ type InjectedProps = {
   repositoriesError?: Error;
 };
 
-const INITIAL_STATE: InjectedProps = {
-  repositories: undefined,
-  repositoriesLoading: undefined,
-  repositoriesError: undefined,
-};
-
-function withRepositories<P extends DependentProps>(
+const withRepositories = <P extends InjectedProps>(
   WrappedComponent: React.ComponentType<P>
-) {
-  class WithRepositories extends React.Component<P & DependentProps, InjectedProps> {
-    static displayName = `withRepositories(${getDisplayName(WrappedComponent)})`;
+) => {
+  const WithRepositories: React.FC<Omit<P, keyof InjectedProps> & InjectedProps> =
+    props => {
+      const {repositories, loading, error} = useRepositories();
+      return (
+        <WrappedComponent
+          // renaming props for legacy consistency
+          repositories={repositories}
+          repositoriesLoading={loading}
+          repositoriesError={error}
+          {...(props as P)}
+        />
+      );
+    };
 
-    constructor(props: P & DependentProps, context: any) {
-      super(props, context);
-
-      const {organization} = this.props;
-      const orgSlug = organization.slug;
-      const repoData = RepositoryStore.get();
-
-      if (repoData.orgSlug !== orgSlug) {
-        RepositoryActions.resetRepositories();
-      }
-
-      this.state =
-        repoData.orgSlug === orgSlug
-          ? {...INITIAL_STATE, ...repoData}
-          : {...INITIAL_STATE};
-    }
-
-    componentDidMount() {
-      // XXX(leedongwei): Do not move this function call unless you modify the
-      // unit test named "prevents repeated calls"
-      this.fetchRepositories();
-    }
-    componentWillUnmount() {
-      this.unsubscribe();
-    }
-    unsubscribe = RepositoryStore.listen(() => this.onStoreUpdate(), undefined);
-
-    fetchRepositories() {
-      const {api, organization} = this.props;
-      const orgSlug = organization.slug;
-      const repoData = RepositoryStore.get();
-
-      // XXX(leedongwei): Do not check the orgSlug here. It would have been
-      // verified at `getInitialState`. The short-circuit hack in actionCreator
-      // does not update the orgSlug in the store.
-      if (
-        (!repoData.repositories && !repoData.repositoriesLoading) ||
-        repoData.repositoriesError
-      ) {
-        getRepositories(api, {orgSlug});
-      }
-    }
-
-    onStoreUpdate() {
-      const repoData = RepositoryStore.get();
-      this.setState({...repoData});
-    }
-
-    render() {
-      return <WrappedComponent {...this.props} {...this.state} />;
-    }
-  }
+  WithRepositories.displayName = `withRepositories(${getDisplayName(WrappedComponent)})`;
 
   return WithRepositories;
-}
-
+};
 export default withRepositories;

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -55,7 +55,7 @@ describe('RepositoryActionCreator', function () {
   });
 
   it('short-circuits the JS event loop', async () => {
-    expect(RepositoryStore.state.repositoriesLoading).toEqual(undefined);
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
 
     getRepositories(api, {orgSlug}); // Fire Action.loadRepositories
     expect(RepositoryActions.loadRepositories).toHaveBeenCalled();


### PR DESCRIPTION
## Objective:
Creates the useRepositories hook. This should work with our existing RepositoryStore in Reflux. I refactored the withRepositories HOC to use the useRepositories hook internally to minimize duplicate logic. The hook handles fetching, pagination, error handling, and other niceties. 