### PR TITLE
fix(ui): Remove adoption stage chart filtering by query

### DIFF
--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -88,18 +88,16 @@ class ReleasesAdoptionChart extends Component<Props> {
       return null;
     }
 
-    return releases.map(release => {
-      return {
-        id: release as string,
-        seriesName: formatVersion(release as string),
-        data: getAdoptionSeries(
-          [response?.groups.find(({by}) => by.release === release)!],
-          response?.groups,
-          response?.intervals,
-          sessionDisplayToField(activeDisplay)
-        ),
-      };
-    });
+    return releases.map(release => ({
+      id: release as string,
+      seriesName: formatVersion(release as string),
+      data: getAdoptionSeries(
+        [response?.groups.find(({by}) => by.release === release)!],
+        response?.groups,
+        response?.intervals,
+        sessionDisplayToField(activeDisplay)
+      ),
+    }));
   }
 
   handleClick = (params: {seriesId: string}) => {
@@ -134,8 +132,6 @@ class ReleasesAdoptionChart extends Component<Props> {
   render() {
     const {activeDisplay, router, selection, api, organization, location} = this.props;
     const {start, end, period, utc} = selection.datetime;
-    const query = decodeScalar(location.query.query);
-    const hasSemver = organization.features.includes('semver');
     const interval = this.getInterval();
     const field = sessionDisplayToField(activeDisplay);
 
@@ -146,7 +142,6 @@ class ReleasesAdoptionChart extends Component<Props> {
         interval={interval}
         groupBy={['release']}
         field={[field]}
-        query={query ? (hasSemver ? query : `release:${query}`) : undefined}
         {...getParams(pick(location.query, Object.values(URL_PARAM)))}
       >
         {({response, loading, reloading}) => {


### PR DESCRIPTION
This removes the `query` filter from sessions request for adoption chart. This prevents the inconsistency of search changing the scale of the releases' adoptions in the chart.

Jira: [WOR-1128](https://getsentry.atlassian.net/browse/WOR-1128)
