### PR TITLE
fix(ui): Fix legend label alignment on release charts

### DIFF
--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -196,7 +196,13 @@ function ReleaseEventsChart({
               </HeaderValue>
             </Fragment>
           }
-          legendOptions={{right: 10, top: 0}}
+          legendOptions={{
+            right: 10,
+            top: 0,
+            textStyle: {
+              padding: [2, 0, 0, 0],
+            },
+          }}
           chartOptions={{
             grid: {left: '10px', right: '10px', top: '70px', bottom: '0px'},
             tooltip: {

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -602,6 +602,9 @@ class ReleaseSessionsChart extends React.Component<Props> {
     const legend = {
       right: 10,
       top: 0,
+      textStyle: {
+        padding: [2, 0, 0, 0],
+      },
       data: [...(series ?? []), ...(previousSeries ?? [])].map(s => s.seriesName),
     };
 


### PR DESCRIPTION
With no padding:

![Screen Shot 2021-11-09 at 10 42 13 PM](https://user-images.githubusercontent.com/15015880/141070992-0415bd9f-2207-40c9-9f11-656c1a9d6600.png)

With padding:

![Screen Shot 2021-11-09 at 10 43 12 PM](https://user-images.githubusercontent.com/15015880/141071011-cf033e9d-806f-4ae9-a9c0-483589a36a57.png)


Jira: [WOR-1302](https://getsentry.atlassian.net/browse/WOR-1302)