### PR TITLE
fix(metrics): Accept message without tags [INGEST-421]

### DIFF
--- a/src/sentry/sentry_metrics/indexer/indexer_consumer.py
+++ b/src/sentry/sentry_metrics/indexer/indexer_consumer.py
@@ -38,7 +38,7 @@ class MetricsIndexerWorker(AbstractBatchWorker):  # type: ignore
         parsed_message: MutableMapping[str, Any] = json.loads(message.value(), use_rapid_json=True)
 
         metric_name = parsed_message["name"]
-        tags = parsed_message["tags"]
+        tags = parsed_message.get("tags", {})
 
         strings = {
             metric_name,

--- a/tests/snuba/snuba/test_indexer_consumer.py
+++ b/tests/snuba/snuba/test_indexer_consumer.py
@@ -193,3 +193,21 @@ class MetricsIndexerConsumerTest(TestCase):
         # loading the json converts the keys to strings e.g. {"tags": {1: 3}} --> {"tags": {"1": 3}}
         assert parsed["tags"] == {str(k): v for k, v in expected["tags"].items()}
         assert parsed["metric_id"] == expected["metric_id"]
+
+    def test_payload_without_tags(self):
+        """Assert that process_message does not crash when tags are omitted"""
+        payload_without_tags = {
+            "name": "session",
+            "timestamp": ts,
+            "type": "c",
+            "value": 1.0,
+            "org_id": 1,
+            "project_id": 3,
+        }
+
+        class MockMessage:
+            def value(self):
+                return json.dumps(payload_without_tags)
+
+        translated = MetricsIndexerWorker(None).process_message(MockMessage())
+        assert translated["tags"] == {}


### PR DESCRIPTION
Accept metrics Kafka message with missing `tags` field in the indexer consumer.

Relay omits the `tags` field of the metrics Kafka message if there are none: https://github.com/getsentry/relay/blob/master/relay-metrics/src/aggregation.rs#L662-L663

Fixes [SENTRY-FOR-SENTRY-F78](https://sentry.my.sentry.io/organizations/sentry/issues/295452/?project=2).