### PR TITLE
feat(perf): Add remaining frontend vital widgets

### DIFF
--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -40,6 +40,8 @@ export enum PERFORMANCE_TERM {
   P99 = 'p99',
   LCP = 'lcp',
   FCP = 'fcp',
+  FID = 'fid',
+  CLS = 'cls',
   USER_MISERY = 'userMisery',
   STATUS_BREAKDOWN = 'statusBreakdown',
   DURATION_DISTRIBUTION = 'durationDistribution',
@@ -333,6 +335,14 @@ export const PERFORMANCE_TERMS: Record<PERFORMANCE_TERM, TermFormatter> = {
     t('Largest contentful paint (LCP) is a web vital meant to represent user load times'),
   fcp: () =>
     t('First contentful paint (FCP) is a web vital meant to represent user load times'),
+  fid: () =>
+    t(
+      'First input delay (FID) is a web vital representing load for the first user interaction on a page.'
+    ),
+  cls: () =>
+    t(
+      'Cumultative layout shift (CLS) is a web vital measuring unexpected visual shifting a user experiences.'
+    ),
   userMisery: organization =>
     t(
       "User Misery is a score that represents the number of unique users who have experienced load times 4x your organization's apdex threshold of %sms.",

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -341,7 +341,7 @@ export const PERFORMANCE_TERMS: Record<PERFORMANCE_TERM, TermFormatter> = {
     ),
   cls: () =>
     t(
-      'Cumultative layout shift (CLS) is a web vital measuring unexpected visual shifting a user experiences.'
+      'Cumulative layout shift (CLS) is a web vital measuring unexpected visual shifting a user experiences.'
     ),
   userMisery: organization =>
     t(

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -28,9 +28,11 @@ export function FrontendPageloadView(props: BasePerformanceViewProps) {
         <DoubleChartRow
           {...props}
           allowedCharts={[
+            PerformanceWidgetSetting.WORST_LCP_VITALS,
+            PerformanceWidgetSetting.WORST_FCP_VITALS,
+            PerformanceWidgetSetting.WORST_FID_VITALS,
             PerformanceWidgetSetting.MOST_RELATED_ERRORS,
             PerformanceWidgetSetting.MOST_RELATED_ISSUES,
-            PerformanceWidgetSetting.WORST_LCP_VITALS,
             PerformanceWidgetSetting.SLOW_HTTP_OPS,
             PerformanceWidgetSetting.SLOW_BROWSER_OPS,
             PerformanceWidgetSetting.SLOW_RESOURCE_OPS,

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -113,9 +113,11 @@ const _WidgetContainer = (props: Props) => {
     setChartSettingState(_chartSetting);
   }, [rest.defaultChartSetting]);
 
+  const chartDefinition = WIDGET_DEFINITIONS({organization})[chartSetting];
   const widgetProps = {
+    ...chartDefinition,
     chartSetting,
-    ...WIDGET_DEFINITIONS({organization})[chartSetting],
+    chartDefinition,
     ContainerActions: containerProps => (
       <WidgetContainerActions
         {...containerProps}

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -8,7 +8,7 @@ import {DateString, Organization, OrganizationSummary} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 
 import {PerformanceWidgetContainerTypes} from './components/performanceWidgetContainer';
-import {PerformanceWidgetSetting} from './widgetDefinitions';
+import {ChartDefinition, PerformanceWidgetSetting} from './widgetDefinitions';
 
 export enum VisualizationDataState {
   ERROR = 'error',
@@ -99,6 +99,7 @@ type Subtitle<T> = FunctionComponent<{
 
 export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
 
   // Header;
   title: string;

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -6,7 +6,7 @@ import {getTermHelp, PERFORMANCE_TERM} from '../../data';
 
 import {GenericPerformanceWidgetDataType} from './types';
 
-export interface BaseChartSetting {
+export interface ChartDefinition {
   dataType: GenericPerformanceWidgetDataType;
   title: string;
 
@@ -14,6 +14,11 @@ export interface BaseChartSetting {
   fields: string[];
 
   chartColor?: string; // Optional. Will default to colors depending on placement in list or colors from the chart itself.
+
+  vitalStops?: {
+    poor: number;
+    meh: number;
+  };
 }
 
 export enum PerformanceWidgetSetting {
@@ -31,6 +36,9 @@ export enum PerformanceWidgetSetting {
   FAILURE_RATE_AREA = 'failure_rate_area',
   USER_MISERY_AREA = 'user_misery_area',
   WORST_LCP_VITALS = 'worst_lcp_vitals',
+  WORST_FCP_VITALS = 'worst_fcp_vitals',
+  WORST_CLS_VITALS = 'worst_cls_vitals',
+  WORST_FID_VITALS = 'worst_fid_vitals',
   MOST_IMPROVED = 'most_improved',
   MOST_REGRESSED = 'most_regressed',
   MOST_RELATED_ERRORS = 'most_related_errors',
@@ -50,7 +58,7 @@ export enum PerformanceWidgetSetting {
 const WIDGET_PALETTE = CHART_PALETTE[5];
 export const WIDGET_DEFINITIONS: ({
   organization,
-}) => Record<PerformanceWidgetSetting, BaseChartSetting> = ({
+}) => Record<PerformanceWidgetSetting, ChartDefinition> = ({
   organization,
 }: {
   organization: Organization;
@@ -86,13 +94,41 @@ export const WIDGET_DEFINITIONS: ({
   [PerformanceWidgetSetting.WORST_LCP_VITALS]: {
     title: t('Worst LCP Web Vitals'),
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.LCP),
-    fields: [
-      'count_if(measurements.lcp,greaterOrEquals,4000)',
-      'count_if(measurements.lcp,greaterOrEquals,2500)',
-      'count_if(measurements.lcp,greaterOrEquals,0)',
-      'equation|count_if(measurements.lcp,greaterOrEquals,2500) - count_if(measurements.lcp,greaterOrEquals,4000)',
-      'equation|count_if(measurements.lcp,greaterOrEquals,0) - count_if(measurements.lcp,greaterOrEquals,2500)',
-    ],
+    fields: ['measurements.lcp'],
+    vitalStops: {
+      poor: 4000,
+      meh: 2500,
+    },
+    dataType: GenericPerformanceWidgetDataType.vitals,
+  },
+  [PerformanceWidgetSetting.WORST_FCP_VITALS]: {
+    title: t('Worst FCP Web Vitals'),
+    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FCP),
+    fields: ['measurements.fcp'],
+    vitalStops: {
+      poor: 3000,
+      meh: 1000,
+    },
+    dataType: GenericPerformanceWidgetDataType.vitals,
+  },
+  [PerformanceWidgetSetting.WORST_FID_VITALS]: {
+    title: t('Worst FID Web Vitals'),
+    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FID),
+    fields: ['measurements.fid'],
+    vitalStops: {
+      poor: 300,
+      meh: 100,
+    },
+    dataType: GenericPerformanceWidgetDataType.vitals,
+  },
+  [PerformanceWidgetSetting.WORST_CLS_VITALS]: {
+    title: t('Worst CLS Web Vitals'),
+    titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.CLS),
+    fields: ['measurements.cls'],
+    vitalStops: {
+      poor: 0.25,
+      meh: 0.1,
+    },
     dataType: GenericPerformanceWidgetDataType.vitals,
   },
   [PerformanceWidgetSetting.TPM_AREA]: {

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -12,10 +12,11 @@ import {Chart as HistogramChart} from 'app/views/performance/landing/chart/histo
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformHistogramQuery} from '../transforms/transformHistogramQuery';
 import {WidgetDataResult} from '../types';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
+import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
   chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
   title: string;
   titleTooltip: string;
   fields: string[];

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -30,7 +30,7 @@ import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
 import {QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
+import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
   title: string;
@@ -42,6 +42,7 @@ type Props = {
   location: Location;
   organization: Organization;
   chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
 
   ContainerActions: FunctionComponent<{isLoading: boolean}>;
 };

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -16,10 +16,12 @@ import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
 import {QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
+import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
   chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
+
   title: string;
   titleTooltip: string;
   fields: string[];

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -23,7 +23,7 @@ import {GenericPerformanceWidget} from '../components/performanceWidget';
 import SelectableList, {RightAlignedCell} from '../components/selectableList';
 import {transformTrendsDiscover} from '../transforms/transformTrendsDiscover';
 import {QueryDefinition, WidgetDataResult} from '../types';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
+import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
   title: string;
@@ -35,6 +35,7 @@ type Props = {
   location: Location;
   organization: Organization;
   chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
 
   ContainerActions: FunctionComponent<{isLoading: boolean}>;
 };

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -12,6 +12,7 @@ import {IconClose} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
+import {defined} from 'app/utils';
 import DiscoverQuery, {TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {WebVital} from 'app/utils/discover/fields';
@@ -30,7 +31,7 @@ import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToVitals} from '../transforms/transformEventsToVitals';
 import {QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
-import {PerformanceWidgetSetting} from '../widgetDefinitions';
+import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type Props = {
   title: string;
@@ -42,6 +43,7 @@ type Props = {
   location: Location;
   organization: Organization;
   chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
 
   ContainerActions: FunctionComponent<{isLoading: boolean}>;
 };
@@ -51,24 +53,74 @@ type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToVitals>;
 };
 
+export function transformFieldsWithStops(props: {
+  field: string;
+  fields: string[];
+  vitalStops: ChartDefinition['vitalStops'];
+}) {
+  const {field, fields, vitalStops} = props;
+  const poorStop = vitalStops?.poor;
+  const mehStop = vitalStops?.meh;
+
+  if (!defined(poorStop) || !defined(mehStop)) {
+    return {
+      sortField: fields[0],
+      fieldsList: fields,
+    };
+  }
+
+  const poorCountField = `count_if(${field},greaterOrEquals,${poorStop})`;
+  const mehCountField = `equation|count_if(${field},greaterOrEquals,${mehStop}) - count_if(${field},greaterOrEquals,${poorStop})`;
+  const goodCountField = `equation|count_if(${field},greaterOrEquals,0) - count_if(${field},greaterOrEquals,${mehStop})`;
+
+  const otherRequiredFieldsForQuery = [
+    `count_if(${field},greaterOrEquals,${mehStop})`,
+    `count_if(${field},greaterOrEquals,0)`,
+  ];
+
+  const vitalFields = {
+    poorCountField,
+    mehCountField,
+    goodCountField,
+  };
+
+  const fieldsList = [
+    poorCountField,
+    ...otherRequiredFieldsForQuery,
+    mehCountField,
+    goodCountField,
+  ];
+
+  return {
+    sortField: poorCountField,
+    vitalFields,
+    fieldsList,
+  };
+}
+
 export function VitalWidget(props: Props) {
   const {ContainerActions, eventView, organization, location} = props;
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
-
   const field = props.fields[0];
+
+  const {fieldsList, vitalFields, sortField} = transformFieldsWithStops({
+    field,
+    fields: props.fields,
+    vitalStops: props.chartDefinition.vitalStops,
+  });
 
   const Queries = {
     list: useMemo<QueryDefinition<DataType, WidgetDataResult>>(
       () => ({
-        fields: field,
+        fields: sortField,
         component: provided => {
           const _eventView = props.eventView.clone();
 
-          const fieldFromProps = props.fields.map(propField => ({
+          const fieldFromProps = fieldsList.map(propField => ({
             field: propField,
           }));
 
-          _eventView.sorts = [{kind: 'desc', field}];
+          _eventView.sorts = [{kind: 'desc', field: sortField}];
 
           _eventView.fields = [
             {field: 'transaction'},
@@ -89,14 +141,14 @@ export function VitalWidget(props: Props) {
         },
         transform: transformDiscoverToList,
       }),
-      [props.eventView, props.fields, props.organization.slug]
+      [props.eventView, fieldsList, props.organization.slug]
     ),
     chart: useMemo<QueryDefinition<DataType, WidgetDataResult>>(
       () => ({
         enabled: widgetData => {
           return !!widgetData?.list?.data?.length;
         },
-        fields: props.fields,
+        fields: fieldsList,
         component: provided => {
           const _eventView = props.eventView.clone();
 
@@ -108,7 +160,7 @@ export function VitalWidget(props: Props) {
             <EventsRequest
               {...pick(provided, eventsRequestQueryProps)}
               limit={1}
-              currentSeriesNames={[field]}
+              currentSeriesNames={[sortField]}
               includePrevious={false}
               partial={false}
               includeTransformedData
@@ -126,12 +178,15 @@ export function VitalWidget(props: Props) {
         },
         transform: transformEventsRequestToVitals,
       }),
-      [props.eventView, selectedListIndex, props.organization.slug]
+      [props.eventView, selectedListIndex, props.chartSetting, props.organization.slug]
     ),
   };
 
   const settingToVital: {[x: string]: WebVital} = {
     [PerformanceWidgetSetting.WORST_LCP_VITALS]: WebVital.LCP,
+    [PerformanceWidgetSetting.WORST_FCP_VITALS]: WebVital.FCP,
+    [PerformanceWidgetSetting.WORST_FID_VITALS]: WebVital.FID,
+    [PerformanceWidgetSetting.WORST_CLS_VITALS]: WebVital.CLS,
   };
 
   const handleViewAllClick = () => {
@@ -145,7 +200,7 @@ export function VitalWidget(props: Props) {
         const listItem = provided.widgetData.list?.data[selectedListIndex];
 
         if (!listItem) {
-          return <Subtitle />;
+          return <Subtitle> </Subtitle>;
         }
 
         const data = {
@@ -198,6 +253,7 @@ export function VitalWidget(props: Props) {
               {...provided.widgetData.chart}
               {...provided}
               field={field}
+              vitalFields={vitalFields}
               organization={organization}
               query={eventView.query}
               project={eventView.project}
@@ -297,7 +353,11 @@ function getVitalDataForListItem(listItem: TableDataRow) {
 
 const VitalBarCell = styled(RightAlignedCell)`
   width: 120px;
+  margin-left: ${space(1)};
   margin-right: ${space(1)};
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 const EventsRequest = withApi(_EventsRequest);
 const Subtitle = styled('span')`

--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -33,32 +33,6 @@ export enum VitalState {
   GOOD = 'Good',
 }
 
-// For mapping field equations for the vitals widget
-export function fieldToVital(field: string) {
-  const FIELD_TO_VITAL_MAP: Record<string, VitalState> = {
-    'count_if(measurements.lcp,greaterOrEquals,0) - count_if(measurements.lcp,greaterOrEquals,2500)':
-      VitalState.GOOD,
-    'count_if(measurements.lcp,greaterOrEquals,2500) - count_if(measurements.lcp,greaterOrEquals,4000)':
-      VitalState.MEH,
-    'count_if(measurements.lcp,greaterOrEquals,4000)': VitalState.POOR,
-  };
-
-  return FIELD_TO_VITAL_MAP[field];
-}
-
-// For mapping field equations for the vitals widget
-export function vitalToField(vital: VitalState) {
-  const VITAL_MAP: Record<VitalState, string> = {
-    [VitalState.GOOD]:
-      'count_if(measurements.lcp,greaterOrEquals,0) - count_if(measurements.lcp,greaterOrEquals,2500)',
-    [VitalState.MEH]:
-      'count_if(measurements.lcp,greaterOrEquals,2500) - count_if(measurements.lcp,greaterOrEquals,4000)',
-    [VitalState.POOR]: 'count_if(measurements.lcp,greaterOrEquals,4000)',
-  };
-
-  return VITAL_MAP[vital];
-}
-
 export const vitalStateColors: Record<VitalState, Color> = {
   [VitalState.POOR]: 'red300',
   [VitalState.MEH]: 'yellow300',

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -114,8 +114,8 @@ describe('Performance > Landing > Index', function () {
     expect(titles.at(0).text()).toEqual('p75 LCP');
     expect(titles.at(1).text()).toEqual('LCP Distribution');
     expect(titles.at(2).text()).toEqual('FCP Distribution');
-    expect(titles.at(3).text()).toEqual('Most Related Errors');
-    expect(titles.at(4).text()).toEqual('Most Related Issues');
+    expect(titles.at(3).text()).toEqual('Worst LCP Web Vitals');
+    expect(titles.at(4).text()).toEqual('Worst FCP Web Vitals');
   });
 
   it('renders frontend other view', async function () {

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -199,6 +199,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
       'Worst LCP Web Vitals'
     );
+
     expect(wrapper.find('a[data-test-id="view-all-button"]').text()).toEqual('View All');
     expect(eventsV2Mock).toHaveBeenCalledTimes(1);
     expect(eventsV2Mock).toHaveBeenNthCalledWith(
@@ -221,6 +222,94 @@ describe('Performance > Widgets > WidgetContainer', function () {
           project: ['-42'],
           query: 'transaction.op:pageload',
           sort: '-count_if(measurements.lcp,greaterOrEquals,4000)',
+          statsPeriod: '7d',
+        }),
+      })
+    );
+  });
+
+  it('Worst FCP widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.WORST_FCP_VITALS}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'Worst FCP Web Vitals'
+    );
+    expect(wrapper.find('a[data-test-id="view-all-button"]').text()).toEqual('View All');
+    expect(eventsV2Mock).toHaveBeenCalledTimes(1);
+    expect(eventsV2Mock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: ['prod'],
+          field: [
+            'transaction',
+            'title',
+            'project.id',
+            'count_if(measurements.fcp,greaterOrEquals,3000)',
+            'count_if(measurements.fcp,greaterOrEquals,1000)',
+            'count_if(measurements.fcp,greaterOrEquals,0)',
+            'equation|count_if(measurements.fcp,greaterOrEquals,1000) - count_if(measurements.fcp,greaterOrEquals,3000)',
+            'equation|count_if(measurements.fcp,greaterOrEquals,0) - count_if(measurements.fcp,greaterOrEquals,1000)',
+          ],
+          per_page: 3,
+          project: ['-42'],
+          query: 'transaction.op:pageload',
+          sort: '-count_if(measurements.fcp,greaterOrEquals,3000)',
+          statsPeriod: '7d',
+        }),
+      })
+    );
+  });
+
+  it('Worst FID widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.WORST_FID_VITALS}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'Worst FID Web Vitals'
+    );
+    expect(wrapper.find('a[data-test-id="view-all-button"]').text()).toEqual('View All');
+    expect(eventsV2Mock).toHaveBeenCalledTimes(1);
+    expect(eventsV2Mock).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          environment: ['prod'],
+          field: [
+            'transaction',
+            'title',
+            'project.id',
+            'count_if(measurements.fid,greaterOrEquals,300)',
+            'count_if(measurements.fid,greaterOrEquals,100)',
+            'count_if(measurements.fid,greaterOrEquals,0)',
+            'equation|count_if(measurements.fid,greaterOrEquals,100) - count_if(measurements.fid,greaterOrEquals,300)',
+            'equation|count_if(measurements.fid,greaterOrEquals,0) - count_if(measurements.fid,greaterOrEquals,100)',
+          ],
+          per_page: 3,
+          project: ['-42'],
+          query: 'transaction.op:pageload',
+          sort: '-count_if(measurements.fid,greaterOrEquals,300)',
           statsPeriod: '7d',
         }),
       })


### PR DESCRIPTION
### Summary
Adding FCP and FID widgets (CLS can't use the discover query so it still needs to be worked on, on top of us potentially using the cls layout information in the future). This extends the widget definition to include the stop points for poor and meh vitals to let the fields and equations be generated instead of hardcoded.