### PR TITLE
fix(async-csv): Prevent direct object reference on data exports

### DIFF
--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -1,11 +1,13 @@
 from django.http import StreamingHttpResponse
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.organization import OrganizationDataExportPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Project
+from sentry.models.organization import Organization
 from sentry.utils import metrics
 from sentry.utils.compat import map
 
@@ -15,7 +17,7 @@ from ..models import ExportedData
 class DataExportDetailsEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationDataExportPermission,)
 
-    def get(self, request, organization, **kwargs):
+    def get(self, request: Request, organization: Organization, data_export_id: str) -> Response:
         """
         Retrieve information about the temporary file record.
         Used to populate page emailed to the user.
@@ -25,23 +27,21 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         try:
-            data_export = ExportedData.objects.get(
-                id=kwargs["data_export_id"], organization=organization
-            )
-            # Check data export permissions
-            if data_export.query_info.get("project"):
-                project_ids = map(int, data_export.query_info.get("project", []))
-                projects = Project.objects.filter(organization=organization, id__in=project_ids)
-                if any(p for p in projects if not request.access.has_project_access(p)):
-                    raise PermissionDenied(
-                        detail="You don't have access to some of the data this export contains."
-                    )
-            # Ignore the download parameter unless we have a file to stream
-            if request.GET.get("download") is not None and data_export._get_file() is not None:
-                return self.download(data_export)
-            return Response(serialize(data_export, request.user))
+            data_export = ExportedData.objects.get(id=data_export_id, organization=organization)
         except ExportedData.DoesNotExist:
             return Response(status=404)
+        # Check data export permissions
+        if data_export.query_info.get("project"):
+            project_ids = map(int, data_export.query_info.get("project", []))
+            projects = Project.objects.filter(organization=organization, id__in=project_ids)
+            if any(p for p in projects if not request.access.has_project_access(p)):
+                raise PermissionDenied(
+                    detail="You don't have access to some of the data this export contains."
+                )
+        # Ignore the download parameter unless we have a file to stream
+        if request.GET.get("download") is not None and data_export._get_file() is not None:
+            return self.download(data_export)
+        return Response(serialize(data_export, request.user))
 
     def download(self, data_export):
         metrics.incr("dataexport.download", sample_rate=1.0)

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -25,7 +25,9 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         try:
-            data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
+            data_export = ExportedData.objects.get(
+                id=kwargs["data_export_id"], organization=organization
+            )
             # Check data export permissions
             if data_export.query_info.get("project"):
                 project_ids = map(int, data_export.query_info.get("project", []))

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -36,7 +36,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
             projects = Project.objects.filter(organization=organization, id__in=project_ids)
             if any(p for p in projects if not request.access.has_project_access(p)):
                 raise PermissionDenied(
-                    detail="You don't have access to some of the data this export contains."
+                    detail="You don't have permissions to view some of the data this export contains."
                 )
         # Ignore the download parameter unless we have a file to stream
         if request.GET.get("download") is not None and data_export._get_file() is not None:


### PR DESCRIPTION
See VULN-4

This PR will prevent directly being able to download data exports with their ID regardless of the organization they belong to. 

**Before**
_Invalid org for this export_
<img width="1002" alt="Screen Shot 2021-11-10 at 11 36 21 AM" src="https://user-images.githubusercontent.com/35509934/141188456-9d27a679-9d14-47a2-ab8b-2f28f5833b74.png">

**After**
_Invalid org for this export_
<img width="712" alt="Screen Shot 2021-11-10 at 12 26 37 PM" src="https://user-images.githubusercontent.com/35509934/141188453-de9591bb-4678-43d0-a4a4-cf4a28bc16b7.png">
<img width="810" alt="image" src="https://user-images.githubusercontent.com/35509934/141188726-dd0d3dd6-8aca-4ecb-8ba1-3e096432a29b.png">


_Valid org for this export_
<img width="1002" alt="Screen Shot 2021-11-10 at 12 27 11 PM" src="https://user-images.githubusercontent.com/35509934/141188446-eafe635a-52cb-4775-8fe5-fd4bab253248.png">

**TODO**
 - [x] Add tests for this behavior