### PR TITLE
fix(ui): SidebarItem text color on hover

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -214,7 +214,7 @@ const StyledSidebarItem = styled(Link)`
 
   &:hover,
   &:focus {
-    color: ${p => p.theme.gray200};
+    color: ${p => p.theme.white};
   }
 
   &.focus-visible {


### PR DESCRIPTION
** This is a visual fix accompanying #29917

Right now, we change `SidebarItem`'s text color to `gray200` on hover . However, `gray200` is designed as a border color, not text color. In dark mode, it blends in with the sidebar background.
<img width="182" alt="Screen Shot 2021-11-10 at 12 37 03 PM" src="https://user-images.githubusercontent.com/44172267/141189550-b43da980-0273-47a3-b25b-67f668dd16ed.png">

We can use `white` instead:
<img width="182" alt="Screen Shot 2021-11-10 at 12 35 30 PM" src="https://user-images.githubusercontent.com/44172267/141189352-16645537-d11d-4dc3-831e-681ae2547b5f.png">

Admittedly, this is the same color as the active state. I think this is fine, since the active state still has a blue line on the left as a visual indicator. `white` is the only color that works well in both light and dark mode.
<img width="182" alt="Screen Shot 2021-11-10 at 12 38 33 PM" src="https://user-images.githubusercontent.com/44172267/141189732-71bbb053-80d5-4f46-9c90-bd087a2f6657.png">


