### PR TITLE
fix(ui): Sidebar' UserNameOrEmail text color on hover

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -243,7 +243,7 @@ const SidebarDropdownActor = styled('button')`
       text-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
     }
     ${UserNameOrEmail} {
-      color: ${p => p.theme.gray200};
+      color: ${p => p.theme.white};
     }
   }
 `;


### PR DESCRIPTION
** This is a visual fix accompanying #29917

Same issue as in #29919: we should use `white` instead of `gray200` on hover, since in the new color system (#29917), `gray200` blends in with the background.

With `gray200`:
<img width="213" alt="Screen Shot 2021-11-10 at 12 56 30 PM" src="https://user-images.githubusercontent.com/44172267/141192116-dfd3a8b5-b62c-458a-b465-a82c6cd143ca.png">

With `white`:
<img width="213" alt="Screen Shot 2021-11-10 at 12 56 50 PM" src="https://user-images.githubusercontent.com/44172267/141192156-da22b68a-c8da-453f-a84c-4d6cfdc68e28.png">


