### PR TITLE
ref(ui): Deprecate withTeams

### DIFF
--- a/static/app/utils/withTeams.tsx
+++ b/static/app/utils/withTeams.tsx
@@ -10,6 +10,8 @@ type InjectedTeamsProps = {
 
 /**
  * Higher order component that provides a list of teams
+ *
+ * @deprecated Prefer `useTeams` or `<Teams />`.
  */
 const withTeams = <P extends InjectedTeamsProps>(
   WrappedComponent: React.ComponentType<P>

--- a/static/app/views/onboarding/platform.tsx
+++ b/static/app/views/onboarding/platform.tsx
@@ -187,4 +187,5 @@ class OnboardingPlatform extends Component<Props, State> {
   }
 }
 
+// TODO(davidenwang): change to functional component and replace withTeams with useTeams
 export default withApi(withTeams(OnboardingPlatform));

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -318,6 +318,7 @@ class CreateProject extends React.Component<Props, State> {
   }
 }
 
+// TODO(davidenwang): change to functional component and replace withTeams with useTeams
 export default withApi(withRouter(withOrganization(withTeams(CreateProject))));
 export {CreateProject};
 

--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -207,6 +207,7 @@ class TeamDetails extends React.Component<Props, State> {
   }
 }
 
+// TODO(davidenwang): change to functional component and replace withTeams with useTeams
 export default withApi(withOrganization(withTeams(TeamDetails)));
 
 const RequestAccessWrapper = styled('div')`


### PR DESCRIPTION
All usages of `withTeams` to provide a list of teams that components would assume is all teams have been removed. This HOC should be deprecated in favor of `useTeams` or `Teams` which allow components to have more granularity of the list of teams they want to request and provide searching/pagination functionality. 

- Marked `withTeams` as deprecated
- Added TODOs for remaining usages