### PR TITLE
fix(alerts): Fix bug where issue alerts could be fetched by users without access permissions.

### DIFF
--- a/src/sentry/api/endpoints/organization_has_mobile_app_events.py
+++ b/src/sentry/api/endpoints/organization_has_mobile_app_events.py
@@ -30,8 +30,7 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
 
     # find a match not using the cache
     def _get(self, request, organization):
-        project_ids = self.get_requested_project_ids(request)
-        projects = self.get_projects(request, organization, project_ids)
+        projects = self.get_projects(request, organization)
         if len(projects) == 0:
             return None
 

--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -62,11 +62,9 @@ def serialize(data, projects):
 
 class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization):
+        projects = self.get_projects(request, organization)
 
-        project_ids = self.get_requested_project_ids(request)
-        projects = self.get_projects(request, organization, project_ids)
-
-        len_projects = len(project_ids)
+        len_projects = len(projects)
         sentry_sdk.set_tag("query.num_projects", len_projects)
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
 

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -50,7 +50,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
         # look at the raw project_id filter passed in, if its empty
         # and project_id is not in groupBy filter, treat it as an
         # org wide query and don't pass project_id in to QueryDefinition
-        req_proj_ids = self.get_requested_project_ids(request)
+        req_proj_ids = self.get_requested_project_ids_unchecked(request)
         if self._is_org_total_query(request, req_proj_ids):
             return None
         else:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -152,7 +152,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        projects = self.get_projects(request)
+        projects = self.get_projects(request, organization)
         alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
         if not features.has("organizations:performance-view", organization):
             # Filter to only error alert rules

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -50,7 +50,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         # Materialize the project ids here. This helps us to not overwhelm the query planner with
         # overcomplicated subqueries. Previously, this was causing Postgres to use a suboptimal
         # index to filter on. Also enforces permission checks.
-        projects = self.get_projects(request, organization, project_ids=project_ids)
+        projects = self.get_projects(request, organization, project_ids=set(project_ids))
 
         teams = request.GET.getlist("team", [])
         team_filter_query = None

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -31,7 +31,7 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         """
         Fetches alert rules and legacy rules for an organization
         """
-        project_ids = self.get_requested_project_ids(request) or None
+        project_ids = self.get_requested_project_ids_unchecked(request) or None
         if project_ids == {-1}:  # All projects for org:
             project_ids = Project.objects.filter(organization=organization).values_list(
                 "id", flat=True
@@ -49,8 +49,8 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
 
         # Materialize the project ids here. This helps us to not overwhelm the query planner with
         # overcomplicated subqueries. Previously, this was causing Postgres to use a suboptimal
-        # index to filter on.
-        project_ids = list(project_ids)
+        # index to filter on. Also enforces permission checks.
+        projects = self.get_projects(request, organization, project_ids=project_ids)
 
         teams = request.GET.getlist("team", [])
         team_filter_query = None
@@ -64,12 +64,12 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
             if unassigned:
                 team_filter_query = team_filter_query | Q(owner_id=None)
 
-        alert_rules = AlertRule.objects.fetch_for_organization(organization, project_ids)
+        alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
         if not features.has("organizations:performance-view", organization):
             # Filter to only error alert rules
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)
         issue_rules = Rule.objects.filter(
-            status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE], project__in=project_ids
+            status__in=[RuleStatus.ACTIVE, RuleStatus.INACTIVE], project__in=projects
         )
         name = request.GET.get("name", None)
         if name:
@@ -152,8 +152,8 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
         if not features.has("organizations:incidents", organization, actor=request.user):
             raise ResourceDoesNotExist
 
-        project_ids = self.get_requested_project_ids(request) or None
-        alert_rules = AlertRule.objects.fetch_for_organization(organization, project_ids)
+        projects = self.get_projects(request)
+        alert_rules = AlertRule.objects.fetch_for_organization(organization, projects)
         if not features.has("organizations:performance-view", organization):
             # Filter to only error alert rules
             alert_rules = alert_rules.filter(snuba_query__dataset=Dataset.Events.value)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -646,6 +646,23 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.assert_alert_rule_serialized(self.three_alert_rule, result[0], skip_dates=True)
         self.assert_alert_rule_serialized(self.one_alert_rule, result[1], skip_dates=True)
 
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        self.issue_rule = self.create_issue_alert_rule(
+            data={
+                "project": other_project,
+                "name": "Issue Rule Test",
+                "conditions": [],
+                "actions": [],
+                "actionMatch": "all",
+                "date_added": before_now(minutes=4).replace(tzinfo=pytz.UTC),
+            }
+        )
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            response = self.get_error_response(self.organization.slug, project=[other_project.id])
+            assert response.data["detail"] == "You do not have permission to perform this action."
+
     def test_team_filter(self):
         self.setup_project_and_rules()
         with self.feature(["organizations:incidents", "organizations:performance-view"]):


### PR DESCRIPTION
This fixes a bug where `OrganizationCombinedRuleIndexEndpoint` could return issue alerts that the
user doesn't have access to. This doesn't apply to metric alerts because we filter them by the
passed `organization`, which is already permission checked.

This also improves `OrganizationAlertRuleIndexEndpoint` to use the right function to fetch projects,
but it shouldn't affect permissions too much since we're already filtering by org here.

To help prevent these mistakes in the future, renamed `get_requested_project_ids` to
`get_requested_project_ids_unchecked` to make it more obvious, and moved it further down so that
it's not the first method people see. Also removed unnecessary uses of it in the codebase so that
it's not randomly copy/pasted so easily.