### PR TITLE
feat(analytics): adds invited_member_id to analytics event

### DIFF
--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -15,11 +15,11 @@ class InviteOrJoinRequest(InAppRequestSentEvent):
     attributes = InAppRequestSentEvent.attributes + (analytics.Attribute("invited_member_id"),)
 
 
-class InviteRequestSentEvent(InAppRequestSentEvent):
+class InviteRequestSentEvent(InviteOrJoinRequest):
     type = "invite_request.sent"
 
 
-class JoinRequestSentEvent(InAppRequestSentEvent):
+class JoinRequestSentEvent(InviteOrJoinRequest):
     type = "join_request.sent"
 
 

--- a/src/sentry/analytics/events/inapp_request.py
+++ b/src/sentry/analytics/events/inapp_request.py
@@ -11,6 +11,10 @@ class InAppRequestSentEvent(analytics.Event):
     )
 
 
+class InviteOrJoinRequest(InAppRequestSentEvent):
+    attributes = InAppRequestSentEvent.attributes + (analytics.Attribute("invited_member_id"),)
+
+
 class InviteRequestSentEvent(InAppRequestSentEvent):
     type = "invite_request.sent"
 

--- a/src/sentry/notifications/notifications/invitations/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/invitations/abstract_invite_request.py
@@ -90,5 +90,6 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification):
             organization_id=self.organization.id,
             user_id=self.pending_member.inviter.id if self.pending_member.inviter else None,
             target_user_id=recipient.id,
+            invited_member_id=self.pending_member.id,
             providers=provider.name.lower(),
         )


### PR DESCRIPTION
In order to construct a funnel of the `invite_request.sent` event to the `member.invited` event for a single member, we need to have the `invited_member_id` property on both events