### PR TITLE
security(metric_alerts): Validate the metric alert owner is a member of the organization.

### DIFF
--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -29,7 +29,11 @@ class GroupNotesEndpoint(GroupEndpoint):
     def post(self, request, group):
         serializer = NoteSerializer(
             data=request.data,
-            context={"organization_id": group.organization.id, "projects": [group.project]},
+            context={
+                "organization": group.organization,
+                "organization_id": group.organization.id,
+                "projects": [group.project],
+            },
         )
 
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/group_notes_details.py
+++ b/src/sentry/api/endpoints/group_notes_details.py
@@ -40,7 +40,7 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
         except Activity.DoesNotExist:
             raise ResourceDoesNotExist
 
-        serializer = NoteSerializer(data=request.data)
+        serializer = NoteSerializer(data=request.data, context={"organization": group.organization})
 
         if serializer.is_valid():
             payload = serializer.validated_data

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from sentry.models import ActorTuple
+from sentry.models import ActorTuple, OrganizationMember, Team, User
 
 
 class ActorField(serializers.Field):
@@ -12,6 +12,22 @@ class ActorField(serializers.Field):
             return None
 
         try:
-            return ActorTuple.from_actor_identifier(data)
+            actor = ActorTuple.from_actor_identifier(data)
         except Exception:
-            raise serializers.ValidationError("Unknown actor input")
+            raise serializers.ValidationError(
+                "Could not parse actor. Format should be `type:id` where type is `team` or `user`."
+            )
+        try:
+            obj = actor.resolve()
+        except (Team.DoesNotExist, User.DoesNotExist):
+            raise serializers.ValidationError(f"{actor.type.__name__} does not exist")
+
+        if actor.type == Team:
+            if obj.organization != self.context["organization"]:
+                raise serializers.ValidationError("Team is not a member of this organization")
+        elif actor.type == User:
+            if not OrganizationMember.objects.filter(
+                organization=self.context["organization"], user=obj
+            ).exists():
+                raise serializers.ValidationError("User is not a member of this organization")
+        return actor

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -201,6 +201,9 @@ def update_groups(
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
+    if serializer is None:
+        return
+
     result = dict(serializer.validated_data)
 
     # so we won't have to requery for each group
@@ -241,7 +244,7 @@ def update_groups(
     commit = None
     res_type = None
     activity_type = None
-    activity_data = None
+    activity_data: MutableMapping[str, Any | None] | None = None
     if status in ("resolved", "resolvedInNextRelease"):
         res_status = None
         if status == "resolvedInNextRelease" or statusDetails.get("inNextRelease"):
@@ -260,7 +263,7 @@ def update_groups(
                 .order_by("-sort")[0]
             )
             activity_type = Activity.SET_RESOLVED_IN_RELEASE
-            activity_data: MutableMapping[str, Any | None] = {
+            activity_data = {
                 # no version yet
                 "version": ""
             }

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -183,6 +183,8 @@ def update_groups(
             return Response(status=204)
     else:
         group_list = None
+
+    serializer = None
     # TODO(jess): We may want to look into refactoring GroupValidator
     # to support multiple projects, but this is pretty complicated
     # because of the assignee validation. Punting on this for now.
@@ -190,7 +192,11 @@ def update_groups(
         serializer = GroupValidator(
             data=data,
             partial=True,
-            context={"project": project, "access": getattr(request, "access", None)},
+            context={
+                "project": project,
+                "organization": project.organization,
+                "access": getattr(request, "access", None),
+            },
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
@@ -233,7 +239,11 @@ def update_groups(
     status = result.get("status")
     release = None
     commit = None
+    res_type = None
+    activity_type = None
+    activity_data = None
     if status in ("resolved", "resolvedInNextRelease"):
+        res_status = None
         if status == "resolvedInNextRelease" or statusDetails.get("inNextRelease"):
             # TODO(jess): We may want to support this for multi project, but punting on it for now
             if len(projects) > 1:
@@ -330,6 +340,7 @@ def update_groups(
         for group in group_list:
             with transaction.atomic():
                 resolution = None
+                created = None
                 if release:
                     resolution_params = {
                         "release": release,
@@ -495,6 +506,12 @@ def update_groups(
 
     elif status:
         new_status = STATUS_UPDATE_CHOICES[result["status"]]
+        ignore_duration = None
+        ignore_count = None
+        ignore_window = None
+        ignore_user_count = None
+        ignore_user_window = None
+        ignore_until = None
 
         with transaction.atomic():
             happened = queryset.exclude(status=new_status).update(status=new_status)
@@ -561,7 +578,7 @@ def update_groups(
                 for group in group_list:
                     if group.status == GroupStatus.IGNORED:
                         issue_unignored.send_robust(
-                            project=project,
+                            project=project_lookup[group.project_id],
                             user=acting_user,
                             group=group,
                             transition_type="manual",
@@ -569,7 +586,7 @@ def update_groups(
                         )
                     else:
                         issue_unresolved.send_robust(
-                            project=project,
+                            project=project_lookup[group.project_id],
                             user=acting_user,
                             group=group,
                             transition_type="manual",
@@ -813,7 +830,7 @@ def update_groups(
                     referrer=request.META.get("HTTP_REFERER"),
                 )
                 issue_mark_reviewed.send_robust(
-                    project=project,
+                    project=project_lookup[group.project_id],
                     user=acting_user,
                     group=group,
                     sender=update_groups,

--- a/src/sentry/incidents/endpoints/organization_incident_comment_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_comment_index.py
@@ -25,7 +25,11 @@ class OrganizationIncidentCommentIndexEndpoint(IncidentEndpoint):
     def post(self, request, organization, incident):
         serializer = CommentSerializer(
             data=request.data,
-            context={"projects": incident.projects.all(), "organization_id": organization.id},
+            context={
+                "projects": incident.projects.all(),
+                "organization": organization,
+                "organization_id": organization.id,
+            },
         )
         if serializer.is_valid():
             mentions = extract_user_ids_from_mentions(

--- a/tests/sentry/api/serializers/test_fields.py
+++ b/tests/sentry/api/serializers/test_fields.py
@@ -47,34 +47,56 @@ class TestListField(TestCase):
 
 class TestActorField(TestCase):
     def test_simple(self):
-        data = {"actor_field": "user:1"}
+        data = {"actor_field": f"user:{self.user.id}"}
 
-        serializer = DummySerializer(data=data)
+        serializer = DummySerializer(data=data, context={"organization": self.organization})
         assert serializer.is_valid()
 
         assert serializer.validated_data["actor_field"].type == User
-        assert serializer.validated_data["actor_field"].id == 1
+        assert serializer.validated_data["actor_field"].id == self.user.id
 
     def test_legacy_user_fallback(self):
-        data = {"actor_field": "1"}
+        data = {"actor_field": f"{self.user.id}"}
 
-        serializer = DummySerializer(data=data)
+        serializer = DummySerializer(data=data, context={"organization": self.organization})
         assert serializer.is_valid()
 
         assert serializer.validated_data["actor_field"].type == User
-        assert serializer.validated_data["actor_field"].id == 1
+        assert serializer.validated_data["actor_field"].id == self.user.id
 
     def test_team(self):
-        data = {"actor_field": "team:1"}
+        data = {"actor_field": f"team:{self.team.id}"}
 
-        serializer = DummySerializer(data=data)
+        serializer = DummySerializer(data=data, context={"organization": self.organization})
         assert serializer.is_valid()
         assert serializer.validated_data["actor_field"].type == Team
-        assert serializer.validated_data["actor_field"].id == 1
+        assert serializer.validated_data["actor_field"].id == self.team.id
+
+    def test_permissions(self):
+        other_org = self.create_organization()
+        serializer = DummySerializer(
+            data={"actor_field": f"user:{self.user.id}"}, context={"organization": other_org}
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors["actor_field"] == [
+            ErrorDetail("User is not a member of this organization", "invalid")
+        ]
+
+        serializer = DummySerializer(
+            data={"actor_field": f"team:{self.team.id}"}, context={"organization": other_org}
+        )
+        assert not serializer.is_valid()
+        assert serializer.errors["actor_field"] == [
+            ErrorDetail("Team is not a member of this organization", "invalid")
+        ]
 
     def test_validates(self):
         data = {"actor_field": "foo:1"}
 
-        serializer = DummySerializer(data=data)
+        serializer = DummySerializer(data=data, context={"organization": self.organization})
         assert not serializer.is_valid()
-        assert serializer.errors == {"actor_field": ["Unknown actor input"]}
+        assert serializer.errors == {
+            "actor_field": [
+                "Could not parse actor. Format should be `type:id` where type is `team` or `user`."
+            ]
+        }

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -505,18 +505,32 @@ class TestAlertRuleSerializer(TestCase):
             {"owner": f"meow:{self.user.id}"},
             {
                 "owner": [
-                    "Could not parse owner. Format should be `type:id` where type is `team` or `user`."
+                    "Could not parse actor. Format should be `type:id` where type is `team` or `user`."
                 ]
             },
         )
         self.run_fail_validation_test(
             {"owner": "user:1234567"},
-            {"owner": ["Could not resolve owner to existing team or user."]},
+            {"owner": ["User does not exist"]},
         )
         self.run_fail_validation_test(
             {"owner": "team:1234567"},
-            {"owner": ["Could not resolve owner to existing team or user."]},
+            {"owner": ["Team does not exist"]},
         )
+        other_org = self.create_organization()
+        other_team = self.create_team(organization=other_org)
+        other_user = self.create_user()
+        self.create_member(user=other_user, organization=other_org, teams=[other_team])
+
+        self.run_fail_validation_test(
+            {"owner": f"user:{other_user.id}"},
+            {"owner": ["User is not a member of this organization"]},
+        )
+        self.run_fail_validation_test(
+            {"owner": f"team:{other_team.id}"},
+            {"owner": ["Team is not a member of this organization"]},
+        )
+
         base_params = self.valid_params.copy()
         base_params.update({"owner": f"team:{self.team.id}"})
         serializer = AlertRuleSerializer(context=self.context, data=base_params)

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -170,5 +170,10 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         )
         assert response.status_code == 400
         assert response.data == {
-            "assignedTo": [ErrorDetail(string="Unknown actor input", code="invalid")]
+            "assignedTo": [
+                ErrorDetail(
+                    string="Could not parse actor. Format should be `type:id` where type is `team` or `user`.",
+                    code="invalid",
+                )
+            ]
         }


### PR DESCRIPTION
This fixes a bug where the owner of an alert rule could be any sentry user/team, rather than one
from the org that the rule belongs to.

I built this into the `ActorField`. This will result in some double validation around note creation,
but I think this is a safe place to put it so that we don't run into this again.

Will follow up with a similar pr for issue alerts.