### PR TITLE
ref(js): Make repositoryStore useLegacyStore compatible

### DIFF
--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -3,32 +3,28 @@ import Reflux from 'reflux';
 import RepoActions from 'app/actions/repositoryActions';
 import {Repository} from 'app/types';
 
+type State = {
+  orgSlug?: string;
+  repositories: Repository[];
+  repositoriesLoading: boolean;
+  repositoriesError?: Error;
+};
+
 type RepositoryStoreInterface = {
-  get(): {
-    orgSlug?: string;
-    repositories?: Repository[];
-    repositoriesLoading?: boolean;
-    repositoriesError?: Error;
-  };
-
-  state: {
-    orgSlug?: string;
-    repositories?: Repository[];
-    repositoriesLoading?: boolean;
-    repositoriesError?: Error;
-  };
-
+  get(): State;
+  state: State;
   loadRepositories(orgSlug: string): void;
   loadRepositoriesSuccess(data: Repository[]): void;
   loadRepositoriesError(error: Error): void;
+  getState(): State;
 };
 
 const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   listenables: RepoActions,
   state: {
     orgSlug: undefined,
-    repositories: undefined,
-    repositoriesLoading: undefined,
+    repositories: [],
+    repositoriesLoading: false,
     repositoriesError: undefined,
   },
 
@@ -39,8 +35,8 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   resetRepositories() {
     this.state = {
       orgSlug: undefined,
-      repositories: undefined,
-      repositoriesLoading: undefined,
+      repositories: [],
+      repositoriesLoading: false,
       repositoriesError: undefined,
     };
     this.trigger(this.state);
@@ -49,7 +45,7 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   loadRepositories(orgSlug: string) {
     this.state = {
       orgSlug,
-      repositories: orgSlug === this.state.orgSlug ? this.state.repositories : undefined,
+      repositories: orgSlug === this.state.orgSlug ? this.state.repositories : [],
       repositoriesLoading: true,
       repositoriesError: undefined,
     };
@@ -59,7 +55,7 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   loadRepositoriesError(err: Error) {
     this.state = {
       ...this.state,
-      repositories: undefined,
+      repositories: [],
       repositoriesLoading: false,
       repositoriesError: err,
     };
@@ -77,6 +73,10 @@ const storeConfig: Reflux.StoreDefinition & RepositoryStoreInterface = {
   },
 
   get() {
+    return {...this.state};
+  },
+
+  getState() {
     return {...this.state};
   },
 };

--- a/tests/js/spec/actionCreators/repositories.spec.jsx
+++ b/tests/js/spec/actionCreators/repositories.spec.jsx
@@ -55,7 +55,7 @@ describe('RepositoryActionCreator', function () {
   });
 
   it('short-circuits the JS event loop', async () => {
-    expect(RepositoryStore.state.repositoriesLoading).toEqual(undefined);
+    expect(RepositoryStore.state.repositoriesLoading).toEqual(false);
 
     getRepositories(api, {orgSlug}); // Fire Action.loadRepositories
     expect(RepositoryActions.loadRepositories).toHaveBeenCalled();


### PR DESCRIPTION
## Objective:
The `useLegacyStore` hook requires our Reflux stores to have a common interface, which is the `getState` function to return the current state of the store. This PR adds that functionality to the RepositoryStore so that we can use it with the `useLegacyStore` hook. Also I refactored the types.