### PR TITLE
Use bullseye as base docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.12-slim-buster
+FROM python:3.8.12-slim-bullseye
 
 LABEL maintainer="oss@sentry.io"
 LABEL org.opencontainers.image.title="Sentry"


### PR DESCRIPTION
I could not build this locally as `dist/requirements.txt` was not available.

This was first brought up in getsentry/onpremise#1128.

Also https://github.com/getsentry/symbolicator/pull/578 has already been done.