### PR TITLE
feat(perf): Add tooltip to closeContainer for widgets

### DIFF
--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -1,7 +1,12 @@
 import React, {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
+import EmptyStateWarning from 'app/components/emptyStateWarning';
+import Link from 'app/components/links/link';
 import Radio from 'app/components/radio';
+import Tooltip from 'app/components/tooltip';
+import {IconClose} from 'app/icons';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {RadioLineItem} from 'app/views/settings/components/forms/controls/radioGroup';
 
@@ -50,6 +55,57 @@ function SelectableItem({
 
 export const RightAlignedCell = styled('div')`
   text-align: right;
+`;
+
+export const Subtitle = styled('span')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+export const GrowLink = styled(Link)`
+  flex-grow: 1;
+`;
+
+export const WidgetEmptyStateWarning = () => {
+  return <StyledEmptyStateWarning small>{t('No results')}</StyledEmptyStateWarning>;
+};
+
+export function ListClose(props: {
+  onClick: () => void;
+  setSelectListIndex: (n: number) => void;
+}) {
+  return (
+    <CloseContainer>
+      <Tooltip title={t('Exclude this transaction from the search filter.')}>
+        <StyledIconClose
+          onClick={() => {
+            props.onClick();
+            props.setSelectListIndex(0);
+          }}
+        />
+      </Tooltip>
+    </CloseContainer>
+  );
+}
+
+const CloseContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: ${space(1)};
+`;
+
+const StyledIconClose = styled(IconClose)`
+  cursor: pointer;
+  color: ${p => p.theme.gray200};
+
+  &:hover {
+    color: ${p => p.theme.gray300};
+  }
+`;
+
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  min-height: 300px;
+  justify-content: center;
 `;
 
 const ListItemContainer = styled('div')`

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -1,19 +1,15 @@
 import {Fragment, FunctionComponent, useMemo, useState} from 'react';
 import {withRouter} from 'react-router';
-import styled from '@emotion/styled';
 import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import _EventsRequest from 'app/components/charts/eventsRequest';
 import {getInterval} from 'app/components/charts/utils';
 import Count from 'app/components/count';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
 import Truncate from 'app/components/truncate';
-import {IconClose} from 'app/icons';
 import {t, tct} from 'app/locale';
-import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
@@ -26,7 +22,13 @@ import {getPerformanceDuration} from 'app/views/performance/utils';
 
 import {excludeTransaction} from '../../utils';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
-import SelectableList, {RightAlignedCell} from '../components/selectableList';
+import SelectableList, {
+  GrowLink,
+  ListClose,
+  RightAlignedCell,
+  Subtitle,
+  WidgetEmptyStateWarning,
+} from '../components/selectableList';
 import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
 import {QueryDefinition, WidgetDataResult} from '../types';
@@ -196,9 +198,7 @@ export function LineChartListWidget(props: Props) {
       HeaderActions={provided => (
         <ContainerActions isLoading={provided.widgetData.list?.isLoading} />
       )}
-      EmptyComponent={() => (
-        <StyledEmptyStateWarning small>{t('No results')}</StyledEmptyStateWarning>
-      )}
+      EmptyComponent={WidgetEmptyStateWarning}
       Queries={Queries}
       Visualizations={[
         {
@@ -276,13 +276,10 @@ export function LineChartListWidget(props: Props) {
                             </Link>
                           </Tooltip>
                         </RightAlignedCell>
-                        <CloseContainer>
-                          <StyledIconClose
-                            onClick={() =>
-                              excludeTransaction(listItem.transaction, props)
-                            }
-                          />
-                        </CloseContainer>
+                        <ListClose
+                          setSelectListIndex={setSelectListIndex}
+                          onClick={() => excludeTransaction(listItem.transaction, props)}
+                        />
                       </Fragment>
                     );
                   case PerformanceWidgetSetting.MOST_RELATED_ERRORS:
@@ -296,13 +293,10 @@ export function LineChartListWidget(props: Props) {
                             count: <Count value={rightValue} />,
                           })}
                         </RightAlignedCell>
-                        <CloseContainer>
-                          <StyledIconClose
-                            onClick={() =>
-                              excludeTransaction(listItem.transaction, props)
-                            }
-                          />
-                        </CloseContainer>
+                        <ListClose
+                          setSelectListIndex={setSelectListIndex}
+                          onClick={() => excludeTransaction(listItem.transaction, props)}
+                        />
                       </Fragment>
                     );
                   default:
@@ -312,13 +306,10 @@ export function LineChartListWidget(props: Props) {
                           <Truncate value={transaction} maxLength={40} />
                         </GrowLink>
                         <RightAlignedCell>{rightValue}</RightAlignedCell>
-                        <CloseContainer>
-                          <StyledIconClose
-                            onClick={() =>
-                              excludeTransaction(listItem.transaction, props)
-                            }
-                          />
-                        </CloseContainer>
+                        <ListClose
+                          setSelectListIndex={setSelectListIndex}
+                          onClick={() => excludeTransaction(listItem.transaction, props)}
+                        />
                       </Fragment>
                     );
                 }
@@ -335,30 +326,3 @@ export function LineChartListWidget(props: Props) {
 
 const EventsRequest = withApi(_EventsRequest);
 const DurationChart = withRouter(_DurationChart);
-const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-const CloseContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-left: ${space(1)};
-`;
-const GrowLink = styled(Link)`
-  flex-grow: 1;
-`;
-
-const StyledIconClose = styled(IconClose)`
-  cursor: pointer;
-  color: ${p => p.theme.gray200};
-
-  &:hover {
-    color: ${p => p.theme.gray300};
-  }
-`;
-
-const StyledEmptyStateWarning = styled(EmptyStateWarning)`
-  min-height: 300px;
-  justify-content: center;
-`;

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -1,12 +1,8 @@
 import {Fragment, FunctionComponent, useMemo, useState} from 'react';
 import {withRouter} from 'react-router';
-import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import EmptyStateWarning from 'app/components/emptyStateWarning';
-import Link from 'app/components/links/link';
 import Truncate from 'app/components/truncate';
-import {IconClose} from 'app/icons';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
@@ -20,7 +16,13 @@ import {Chart} from '../../../trends/chart';
 import {TrendChangeType, TrendFunctionField} from '../../../trends/types';
 import {excludeTransaction} from '../../utils';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
-import SelectableList, {RightAlignedCell} from '../components/selectableList';
+import SelectableList, {
+  GrowLink,
+  ListClose,
+  RightAlignedCell,
+  Subtitle,
+  WidgetEmptyStateWarning,
+} from '../components/selectableList';
 import {transformTrendsDiscover} from '../transforms/transformTrendsDiscover';
 import {QueryDefinition, WidgetDataResult} from '../types';
 import {PerformanceWidgetSetting} from '../widgetDefinitions';
@@ -96,6 +98,7 @@ export function TrendsWidget(props: Props) {
       {...rest}
       Subtitle={() => <Subtitle>{t('Trending Transactions')}</Subtitle>}
       HeaderActions={provided => <ContainerActions {...provided.widgetData.chart} />}
+      EmptyComponent={WidgetEmptyStateWarning}
       Queries={Queries}
       Visualizations={[
         {
@@ -146,14 +149,10 @@ export function TrendsWidget(props: Props) {
                     <RightAlignedCell>
                       <CompareDurations transaction={listItem} />
                     </RightAlignedCell>
-                    <CloseContainer>
-                      <StyledIconClose
-                        onClick={() => {
-                          excludeTransaction(listItem.transaction, props);
-                          setSelectListIndex(0);
-                        }}
-                      />
-                    </CloseContainer>
+                    <ListClose
+                      setSelectListIndex={setSelectListIndex}
+                      onClick={() => excludeTransaction(listItem.transaction, props)}
+                    />
                   </Fragment>
                 );
               })}
@@ -163,37 +162,8 @@ export function TrendsWidget(props: Props) {
           noPadding: true,
         },
       ]}
-      EmptyComponent={() => (
-        <StyledEmptyStateWarning small>{t('No results')}</StyledEmptyStateWarning>
-      )}
     />
   );
 }
 
 const TrendsChart = withRouter(withProjects(Chart));
-const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-const CloseContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-const GrowLink = styled(Link)`
-  flex-grow: 1;
-`;
-
-const StyledIconClose = styled(IconClose)`
-  cursor: pointer;
-  color: ${p => p.theme.gray200};
-
-  &:hover {
-    color: ${p => p.theme.gray300};
-  }
-`;
-
-const StyledEmptyStateWarning = styled(EmptyStateWarning)`
-  min-height: 300px;
-  justify-content: center;
-`;

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -6,9 +6,7 @@ import pick from 'lodash/pick';
 import Button from 'app/components/button';
 import _EventsRequest from 'app/components/charts/eventsRequest';
 import {getInterval} from 'app/components/charts/utils';
-import Link from 'app/components/links/link';
 import Truncate from 'app/components/truncate';
-import {IconClose} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
@@ -25,7 +23,12 @@ import {_VitalChart} from 'app/views/performance/vitalDetail/vitalChart';
 import {excludeTransaction} from '../../utils';
 import {VitalBar} from '../../vitalsCards';
 import {GenericPerformanceWidget} from '../components/performanceWidget';
-import SelectableList, {RightAlignedCell} from '../components/selectableList';
+import SelectableList, {
+  GrowLink,
+  ListClose,
+  RightAlignedCell,
+  Subtitle,
+} from '../components/selectableList';
 import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToVitals} from '../transforms/transformEventsToVitals';
 import {QueryDefinition, WidgetDataResult} from '../types';
@@ -255,14 +258,10 @@ export function VitalWidget(props: Props) {
                         barHeight={24}
                       />
                     </VitalBarCell>
-                    <CloseContainer>
-                      <StyledIconClose
-                        onClick={() => {
-                          excludeTransaction(listItem.transaction, props);
-                          setSelectListIndex(0);
-                        }}
-                      />
-                    </CloseContainer>
+                    <ListClose
+                      setSelectListIndex={setSelectListIndex}
+                      onClick={() => excludeTransaction(listItem.transaction, props)}
+                    />
                   </Fragment>
                 );
               })}
@@ -300,23 +299,3 @@ const VitalBarCell = styled(RightAlignedCell)`
   margin-right: ${space(1)};
 `;
 const EventsRequest = withApi(_EventsRequest);
-const Subtitle = styled('span')`
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeMedium};
-`;
-const CloseContainer = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-const GrowLink = styled(Link)`
-  flex-grow: 1;
-`;
-
-const StyledIconClose = styled(IconClose)`
-  cursor: pointer;
-  color: ${p => p.theme.gray200};
-  &:hover {
-    color: ${p => p.theme.gray300};
-  }
-`;


### PR DESCRIPTION
### Summary
This cleans up some styling code around the selectable list items, and separates close container into a re-usable container for all the mini list widgets to use. The new component also adds the tooltip explaining what clicking the 'x' does so people don't think it's a destructive operation.