### PR TITLE
feat(perf): Add analytics to landing v3

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -18,6 +18,14 @@ export type PerformanceEventParameters = {
     field?: string;
     direction?: string;
   };
+  'performance_views.landingv3.widget.interaction': {
+    widget_type?: string;
+  };
+  'performance_views.landingv3.widget.switch': {
+    from_widget?: string;
+    to_widget?: string;
+    from_default?: boolean;
+  };
   'performance_views.overview.navigate.summary': {};
   'performance_views.overview.cellaction': {action?: string};
 };
@@ -34,4 +42,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.overview.navigate.summary':
     'Performance Views: Overview view summary',
   'performance_views.overview.cellaction': 'Performance Views: Cell Action Clicked',
+  'performance_views.landingv3.widget.interaction':
+    'Performance Views: Landing Widget Interaction',
+  'performance_views.landingv3.widget.switch':
+    'Performance Views: Landing Widget Switched',
 };

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -6,6 +6,8 @@ import ErrorPanel from 'app/components/charts/errorPanel';
 import Placeholder from 'app/components/placeholder';
 import {IconWarning} from 'app/icons/iconWarning';
 import space from 'app/styles/space';
+import {Organization} from 'app/types';
+import trackAdvancedAnalyticsEvent from 'app/utils/analytics/trackAdvancedAnalyticsEvent';
 import useApi from 'app/utils/useApi';
 import getPerformanceWidgetContainer from 'app/views/performance/landing/widgets/components/performanceWidgetContainer';
 
@@ -16,6 +18,7 @@ import {
   WidgetDataResult,
   WidgetPropUnion,
 } from '../types';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 import {DataStateSwitch} from './dataStateSwitch';
 import {QueryHandler} from './queryHandler';
@@ -75,6 +78,16 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
   );
 }
 
+function trackDataComponentClicks(
+  chartSetting: PerformanceWidgetSetting,
+  organization: Organization
+) {
+  trackAdvancedAnalyticsEvent('performance_views.landingv3.widget.interaction', {
+    organization,
+    widget_type: chartSetting,
+  });
+}
+
 function _DataDisplay<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> & WidgetDataProps<T> & {totalHeight: number}
 ) {
@@ -109,6 +122,9 @@ function _DataDisplay<T extends WidgetDataConstraint>(
             key={index}
             noPadding={Visualization.noPadding}
             bottomPadding={Visualization.bottomPadding}
+            onClick={() =>
+              trackDataComponentClicks(props.chartSetting, props.organization)
+            }
           >
             <Visualization.component
               grid={defaultGrid}

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import MenuItem from 'app/components/menuItem';
 import {Organization} from 'app/types';
+import trackAdvancedAnalyticsEvent from 'app/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'app/utils/localStorage';
 import {usePerformanceDisplayType} from 'app/utils/performance/contexts/performanceDisplayContext';
 import useOrganization from 'app/utils/useOrganization';
@@ -85,6 +86,20 @@ const _setChartSetting = (
   setWidgetStorageObject(localObject);
 };
 
+function trackChartSettingChange(
+  previousChartSetting: PerformanceWidgetSetting,
+  chartSetting: PerformanceWidgetSetting,
+  fromDefault: boolean,
+  organization: Organization
+) {
+  trackAdvancedAnalyticsEvent('performance_views.landingv3.widget.switch', {
+    organization,
+    from_widget: previousChartSetting,
+    to_widget: chartSetting,
+    from_default: fromDefault,
+  });
+}
+
 const _WidgetContainer = (props: Props) => {
   const {organization, index, chartHeight, allowedCharts, ...rest} = props;
   const performanceType = usePerformanceDisplayType();
@@ -107,6 +122,12 @@ const _WidgetContainer = (props: Props) => {
       _setChartSetting(index, chartHeight, performanceType, setting);
     }
     setChartSettingState(setting);
+    trackChartSettingChange(
+      chartSetting,
+      setting,
+      rest.defaultChartSetting === chartSetting,
+      organization
+    );
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
This adds analytics to check usage over widgets and which are preferred or interacted with the most.

Related:
- https://github.com/getsentry/reload/pull/231