### PR TITLE
fix(perf): Remove display type on default display

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -102,7 +102,12 @@ export function PerformanceLanding(props: Props) {
               key={label}
               className={currentLandingDisplay.field === field ? 'active' : ''}
             >
-              <a href="#" onClick={() => handleLandingDisplayChange(field, location)}>
+              <a
+                href="#"
+                onClick={() =>
+                  handleLandingDisplayChange(field, location, projects, eventView)
+                }
+              >
                 {t(label)}
               </a>
             </li>


### PR DESCRIPTION
### Summary
This removes the display condition on the default display for the landing v3 tabs change. This should fix the issue where clicking a view type stops any default display changes from changing the project.


