### PR TITLE
feat(invitations): adds invited_member_id to slack member invitation events

### DIFF
--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -54,6 +54,7 @@ class IntegrationSlackApproveMemberInvitation(analytics.Event):  # type: ignore
         analytics.Attribute("organization_id"),
         analytics.Attribute("actor_id"),
         analytics.Attribute("invitation_type"),
+        analytics.Attribute("invited_member_id"),
     )
 
 

--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -438,6 +438,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
             actor_id=identity.user_id,
             organization_id=member.organization_id,
             invitation_type=invite_type.lower(),
+            invited_member_id=member_id,
         )
 
         verb = "approved" if approve_member else "rejected"


### PR DESCRIPTION
We can construct better funnels for member invitations if we pass in an `invited_member_id`