### PR TITLE
feat(ci): Drop ubuntu from dev env CI

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        os: [macos-11.0, ubuntu-20.04]
+        os: [macos-11.0]
       fail-fast: false
     env:
       # Make the environment more similar to what Mac defaults to


### PR DESCRIPTION
It was a nice wish to test out what some community members would use, however, it breaks often and most development happens on Macs.