### PR TITLE
fix(ui): Pill text color in dark mode

### DIFF
--- a/static/app/components/events/interfaces/request.tsx
+++ b/static/app/components/events/interfaces/request.tsx
@@ -140,12 +140,12 @@ const Header = styled('h3')`
 const StyledIconOpen = styled(IconOpen)`
   transition: 0.1s linear color;
   margin: 0 ${space(0.5)};
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.gray200};
   position: relative;
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/components/pill.tsx
+++ b/static/app/components/pill.tsx
@@ -61,8 +61,6 @@ const getPillStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
   switch (type) {
     case 'error':
       return `
-        color: ${theme.black};
-        background: ${theme.red100};
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
       `;
@@ -77,7 +75,6 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
   switch (type) {
     case 'positive':
       return `
-        color: ${theme.black};
         background: ${theme.green100};
         border: 1px solid ${theme.green300};
         border-left-color: ${theme.green300};
@@ -86,7 +83,6 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       `;
     case 'error':
       return `
-        color: ${theme.black};
         border-left-color: ${theme.red300};
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
@@ -94,7 +90,6 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       `;
     case 'negative':
       return `
-        color: ${theme.black};
         border-left-color: ${theme.red300};
         background: ${theme.red100};
         border: 1px solid ${theme.red300};


### PR DESCRIPTION
** This is a visual fix accompanying #29917

In the new color system (#29917), Pill's background color is semi-transparent (it used to be at full opacity). As such, we no longer need to explicitly its text color to `black`.

Before:
<img width="519" alt="Screen Shot 2021-11-11 at 10 33 52 AM" src="https://user-images.githubusercontent.com/44172267/141350848-80cd7087-59ca-482f-b210-b9f29115881c.png">
<img width="515" alt="Screen Shot 2021-11-11 at 10 28 39 AM" src="https://user-images.githubusercontent.com/44172267/141350286-9faca0af-023d-4032-af42-a529681a6ec1.png">


After:
<img width="519" alt="Screen Shot 2021-11-11 at 10 33 03 AM" src="https://user-images.githubusercontent.com/44172267/141350759-21e6478e-fe31-43ad-b91a-b58ede63e08e.png">
<img width="515" alt="Screen Shot 2021-11-11 at 10 28 15 AM" src="https://user-images.githubusercontent.com/44172267/141350235-b020df87-f54a-49f7-a640-c779c720297b.png">


