### PR TITLE
security(issue-alerts): Validate the issue alert owner is a member of the organization

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -71,7 +71,11 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             }}
 
         """
-        serializer = RuleSerializer(context={"project": project}, data=request.data, partial=True)
+        serializer = RuleSerializer(
+            context={"project": project, "organization": project.organization},
+            data=request.data,
+            partial=True,
+        )
 
         if serializer.is_valid():
             data = serializer.validated_data

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -88,7 +88,9 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             }}
 
         """
-        serializer = RuleSerializer(context={"project": project}, data=request.data)
+        serializer = RuleSerializer(
+            context={"project": project, "organization": project.organization}, data=request.data
+        )
 
         if serializer.is_valid():
             data = serializer.validated_data

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
 
 from sentry import features
+from sentry.api.fields.actor import ActorField
+from sentry.api.serializers.rest_framework.list import ListField
 from sentry.constants import MIGRATED_CONDITIONS, SCHEMA_FORM_ACTIONS, TICKET_ACTIONS
-from sentry.models import ActorTuple, Environment, Team, User
+from sentry.models import Environment
 from sentry.rules import rules
-
-from . import ListField
 
 ValidationError = serializers.ValidationError
 
@@ -77,25 +77,7 @@ class RuleSerializer(serializers.Serializer):
     conditions = ListField(child=RuleNodeField(type="condition/event"), required=False)
     filters = ListField(child=RuleNodeField(type="filter/event"), required=False)
     frequency = serializers.IntegerField(min_value=5, max_value=60 * 24 * 30)
-    owner = serializers.CharField(required=False, allow_null=True)
-
-    def validate_owner(self, owner):
-        # owner should be team:id or user:id
-        if owner is None:
-            return
-
-        try:
-            actor = ActorTuple.from_actor_identifier(owner)
-        except Exception:
-            raise serializers.ValidationError(
-                "Could not parse owner. Format should be `type:id` where type is `team` or `user`."
-            )
-
-        try:
-            if actor.resolve():
-                return actor
-        except (User.DoesNotExist, Team.DoesNotExist):
-            raise serializers.ValidationError("Could not resolve owner to existing team or user.")
+    owner = ActorField(required=False, allow_null=True)
 
     def validate_environment(self, environment):
         if environment is None:

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -187,6 +187,35 @@ class CreateProjectRuleTest(APITestCase):
             status_code=400,
         )
 
+    def test_owner_perms(self):
+        self.login_as(user=self.user)
+        other_user = self.create_user()
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=other_user.actor.get_actor_identifier(),
+            actionMatch="any",
+            filterMatch="any",
+            actions=[],
+            conditions=[],
+            status_code=400,
+        )
+        assert str(response.data["owner"][0]) == "User is not a member of this organization"
+        other_team = self.create_team(self.create_organization())
+        response = self.get_error_response(
+            self.organization.slug,
+            self.project.slug,
+            name="test",
+            owner=other_team.actor.get_actor_identifier(),
+            actionMatch="any",
+            filterMatch="any",
+            actions=[],
+            conditions=[],
+            status_code=400,
+        )
+        assert str(response.data["owner"][0]) == "Team is not a member of this organization"
+
     def test_frequency_percent_validation(self):
         self.login_as(user=self.user)
         condition = {


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/29939, this fixes the same problem in issue
alerts.

Also noticed some tests weren't running since they were accidentally nested. One could be removed
since it was no longer valid, put the other back in place.