### PR TITLE
fix(ui): Use gray300 in QuestionTooltip

### DIFF
--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -16,11 +16,12 @@ const QuestionIconContainer = styled('span')<ContainerProps>`
   line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
 
   & svg {
-    transition: 120ms color;
-    color: ${p => p.theme.gray200};
+    transition: 120ms opacity;
+    color: ${p => p.theme.gray300};
+    opacity: 0.6;
 
     &:hover {
-      color: ${p => p.theme.gray300};
+      opacity: 1;
     }
   }
 `;


### PR DESCRIPTION
** This is a visual fix accompanying #29917

The new gray200 in the new color system (#29917) is too light - it is meant as a border color. Gray 300 is a darker and more accessible color.

Before:
<img width="277" alt="Screen Shot 2021-11-11 at 1 58 02 PM" src="https://user-images.githubusercontent.com/44172267/141374893-a303a4be-cef0-46f3-9134-8f123d148707.png">
<img width="277" alt="Screen Shot 2021-11-11 at 1 59 45 PM" src="https://user-images.githubusercontent.com/44172267/141374968-5b984bd3-2a9a-4a4e-b80f-8310d73c2176.png">

After:
<img width="277" alt="Screen Shot 2021-11-11 at 1 58 19 PM" src="https://user-images.githubusercontent.com/44172267/141374911-b117e75d-6a57-4ef7-a7bb-0c400ea388e0.png">
<img width="277" alt="Screen Shot 2021-11-11 at 1 59 33 PM" src="https://user-images.githubusercontent.com/44172267/141374955-86de4659-143d-4b1c-9a59-989654191bc7.png">
