### PR TITLE
ref(tests) Move tests for MutedBox to RTL

### DIFF
--- a/tests/js/spec/components/mutedBox.spec.jsx
+++ b/tests/js/spec/components/mutedBox.spec.jsx
@@ -1,38 +1,56 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountWithTheme, screen} from 'sentry-test/reactTestingLibrary';
 
 import MutedBox from 'app/components/mutedBox';
 
 describe('MutedBox', function () {
   describe('render()', function () {
     it('handles ignoreUntil', function () {
-      const wrapper = mountWithTheme(
+      const {container} = mountWithTheme(
         <MutedBox statusDetails={{ignoreUntil: '2017-06-21T19:45:10Z'}} />
       );
-      expect(wrapper).toSnapshot();
+      expect(screen.getByText(/This issue has been ignored until/)).toBeInTheDocument();
+      expect(container).toSnapshot();
     });
     it('handles ignoreCount', function () {
-      const wrapper = mountWithTheme(<MutedBox statusDetails={{ignoreUserCount: 100}} />);
-      expect(wrapper).toSnapshot();
+      const {container} = mountWithTheme(
+        <MutedBox statusDetails={{ignoreUserCount: 100}} />
+      );
+      expect(
+        screen.getByText(/This issue has been ignored until it affects/)
+      ).toBeInTheDocument();
+      expect(container).toSnapshot();
     });
     it('handles ignoreCount with ignoreWindow', function () {
-      const wrapper = mountWithTheme(
+      const {container} = mountWithTheme(
         <MutedBox statusDetails={{ignoreCount: 100, ignoreWindow: 1}} />
       );
-      expect(wrapper).toSnapshot();
+      expect(
+        screen.getByText(/This issue has been ignored until it occurs/)
+      ).toBeInTheDocument();
+      expect(container).toSnapshot();
     });
     it('handles ignoreUserCount', function () {
-      const wrapper = mountWithTheme(<MutedBox statusDetails={{ignoreUserCount: 100}} />);
-      expect(wrapper).toSnapshot();
+      const {container} = mountWithTheme(
+        <MutedBox statusDetails={{ignoreUserCount: 100}} />
+      );
+      expect(
+        screen.getByText(/This issue has been ignored until it affects/)
+      ).toBeInTheDocument();
+      expect(container).toSnapshot();
     });
     it('handles ignoreUserCount with ignoreUserWindow', function () {
-      const wrapper = mountWithTheme(
+      const {container} = mountWithTheme(
         <MutedBox statusDetails={{ignoreUserCount: 100, ignoreUserWindow: 1}} />
       );
-      expect(wrapper).toSnapshot();
+      expect(
+        screen.getByText(/This issue has been ignored until it affects/)
+      ).toBeInTheDocument();
+      expect(container).toSnapshot();
     });
     it('handles default', function () {
-      const wrapper = mountWithTheme(<MutedBox statusDetails={{}} />);
-      expect(wrapper).toSnapshot();
+      const {container} = mountWithTheme(<MutedBox statusDetails={{}} />);
+      expect(screen.getByText(/This issue has been ignored/)).toBeInTheDocument();
+      expect(container).toSnapshot();
     });
   });
 });


### PR DESCRIPTION
Add some text assertions so we aren't entirely reliant on snapshots which don't run locally.