### PR TITLE
fix(ui): Use subText alias for RequestInterface's icon

### DIFF
--- a/static/app/components/events/interfaces/request.tsx
+++ b/static/app/components/events/interfaces/request.tsx
@@ -140,12 +140,12 @@ const Header = styled('h3')`
 const StyledIconOpen = styled(IconOpen)`
   transition: 0.1s linear color;
   margin: 0 ${space(0.5)};
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   position: relative;
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.subText};
+    color: ${p => p.theme.textColor};
   }
 `;
 


### PR DESCRIPTION
Gray 200 is not an accessible icon color. We should use the subText color alias instead.

Before:
<img width="248" alt="Screen Shot 2021-11-11 at 2 21 25 PM" src="https://user-images.githubusercontent.com/44172267/141378417-53739016-a08a-4d52-ba96-6cb980136bca.png">

After:
<img width="140" alt="Screen Shot 2021-11-11 at 2 21 55 PM" src="https://user-images.githubusercontent.com/44172267/141378435-3d107164-bd0a-47e6-a9b6-35da23b29045.png">
<img width="242" alt="Screen Shot 2021-11-11 at 2 20 47 PM" src="https://user-images.githubusercontent.com/44172267/141378440-780a1da0-980a-4b07-8ef0-8d8c31501c2a.png">

