### PR TITLE
feat(dashboards): Add a confirm on dashboard deletion

### DIFF
--- a/static/app/views/dashboardsV2/manage/dashboardList.tsx
+++ b/static/app/views/dashboardsV2/manage/dashboardList.tsx
@@ -17,6 +17,7 @@ import {
 } from 'app/actionCreators/dashboards';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
+import {openConfirmModal} from 'app/components/confirm';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import MenuItem from 'app/components/menuItem';
 import Pagination from 'app/components/pagination';
@@ -141,11 +142,15 @@ function DashboardList({
             <ContextMenu>
               <MenuItem
                 data-test-id="dashboard-delete"
+                disabled={dashboards.length <= 1}
                 onClick={event => {
                   event.preventDefault();
-                  handleDelete(dashboard);
+                  openConfirmModal({
+                    message: t('Are you sure you want to delete this dashboard?'),
+                    priority: 'danger',
+                    onConfirm: () => handleDelete(dashboard),
+                  });
                 }}
-                disabled={dashboards.length <= 1}
               >
                 {t('Delete')}
               </MenuItem>

--- a/tests/js/spec/views/dashboardsV2/manage/dashboardList.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/manage/dashboardList.spec.jsx
@@ -1,4 +1,5 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import DashboardList from 'app/views/dashboardsV2/manage/dashboardList';
 
@@ -191,6 +192,12 @@ describe('Dashboards > DashboardList', function () {
 
     card = wrapper.find('DashboardCard').last();
     clickMenuItem(card, 'dashboard-delete');
+
+    expect(deleteMock).not.toHaveBeenCalled();
+
+    // Confirm
+    const modal = await mountGlobalModal();
+    modal.find('Button').last().simulate('click');
 
     await tick();
 


### PR DESCRIPTION
- Show a message to confirm that deletion is desired on the dashboard
  management page
  
<img width="878" alt="image" src="https://user-images.githubusercontent.com/4205004/141379066-d4e693de-3b28-40c3-b9e0-33bff577fe56.png">