### PR TITLE
fix(ui): SelectAllNotice color

### DIFF
--- a/static/app/components/events/interfaces/request.tsx
+++ b/static/app/components/events/interfaces/request.tsx
@@ -140,12 +140,12 @@ const Header = styled('h3')`
 const StyledIconOpen = styled(IconOpen)`
   transition: 0.1s linear color;
   margin: 0 ${space(0.5)};
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.gray200};
   position: relative;
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -363,7 +363,6 @@ const SelectAllNotice = styled('div')`
   background-color: ${p => p.theme.yellow100};
   border-top: 1px solid ${p => p.theme.yellow300};
   border-bottom: 1px solid ${p => p.theme.yellow300};
-  color: ${p => p.theme.black};
   font-size: ${p => p.theme.fontSizeMedium};
   text-align: center;
   padding: ${space(0.5)} ${space(1.5)};


### PR DESCRIPTION
** This is a visual fix accompanying #29917

In the new color system (#29917), SelectAllNotice's background color is semi-transparent (it used to be a full-opacity yellow). As such, it can just use the normal text color instead of black.

Before:
<img width="656" alt="Screen Shot 2021-11-11 at 2 34 32 PM 1" src="https://user-images.githubusercontent.com/44172267/141380475-beb1c447-77df-4956-9d64-fd77e7761db9.png">

After:
<img width="656" alt="Screen Shot 2021-11-11 at 2 53 58 PM" src="https://user-images.githubusercontent.com/44172267/141380517-fbbf9c87-74df-49e2-b5de-cd4c651b1022.png">


