### PR TITLE
ref(select): Choices -> options keySettings

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -155,7 +155,14 @@ class KeySettings extends Component<Props, State> {
                   </Field>
                   <SelectField
                     name="browserSdkVersion"
-                    choices={data.browserSdk ? data.browserSdk.choices : []}
+                    options={
+                      data.browserSdk
+                        ? data.browserSdk.choices.map(([value, label]) => ({
+                            value,
+                            label,
+                          }))
+                        : []
+                    }
                     placeholder={t('4.x')}
                     allowClear={false}
                     disabled={!hasAccess}


### PR DESCRIPTION
Changes from legacy react-select `choices` to `options` here:

![image](https://user-images.githubusercontent.com/9372512/141382678-8582a587-3997-4ac8-87dd-2c1e74748b3f.png)
