### PR TITLE
feat(org-stats): adds hook and experiment

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -31,6 +31,12 @@ export const experimentList = [
     parameter: 'exposed',
     assignments: [0, 1],
   },
+  {
+    key: 'OrgStatsBannerExperiment',
+    type: ExperimentType.Organization,
+    parameter: 'exposed',
+    assignments: [0, 1],
+  },
 ] as const;
 
 export const experimentConfig = experimentList.reduce(

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -79,6 +79,7 @@ export type ComponentHooks = {
   'component:disabled-member-tooltip': () => React.ComponentType<DisabledMemberTooltipProps>;
   'component:disabled-app-store-connect-item': () => React.ComponentType<DisabledAppStoreConnectItem>;
   'component:dashboards-header': () => React.ComponentType<DashboardHeadersProps>;
+  'component:org-stats-banner': () => React.ComponentType<DashboardHeadersProps>;
 };
 
 /**

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import {DateTimeObject} from 'app/components/charts/utils';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import ErrorBoundary from 'app/components/errorBoundary';
+import HookOrDefault from 'app/components/hookOrDefault';
 import * as Layout from 'app/components/layouts/thirds';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {ChangeData} from 'app/components/organizations/timeRangeSelector';
@@ -33,6 +34,8 @@ import HeaderTabs from 'app/views/organizationStats/header';
 import {CHART_OPTIONS_DATACATEGORY, ChartDataTransform} from './usageChart';
 import UsageStatsOrg from './usageStatsOrg';
 import UsageStatsProjects from './usageStatsProjects';
+
+const HookHeader = HookOrDefault({hookName: 'component:org-stats-banner'});
 
 const PAGE_QUERY_PARAMS = [
   'pageStatsPeriod',
@@ -289,6 +292,7 @@ export class OrganizationStats extends Component<Props> {
                   </p>
                 </Fragment>
               )}
+              <HookHeader organization={organization} />
 
               <PageGrid>
                 {this.renderPageControl()}


### PR DESCRIPTION
This PR adds the `OrgStatsBannerExperiment` and `component:org-stats-banner` hook. See https://github.com/getsentry/getsentry/pull/6603