### PR TITLE
feat(logo-upload): Update serializer to account for popularity

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_details.py
+++ b/src/sentry/api/endpoints/sentry_app_details.py
@@ -53,7 +53,6 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
 
         if serializer.is_valid():
             result = serializer.validated_data
-
             updated_app = Updater.run(
                 user=request.user,
                 sentry_app=sentry_app,
@@ -69,6 +68,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                 schema=result.get("schema"),
                 overview=result.get("overview"),
                 allowed_origins=result.get("allowedOrigins"),
+                popularity=result.get("popularity"),
             )
 
             return Response(serialize(updated_app, request.user, access=request.access))

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -62,6 +62,9 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             "schema": request.json_body.get("schema", {}),
             "overview": request.json_body.get("overview"),
             "allowedOrigins": request.json_body.get("allowedOrigins", []),
+            "popularity": request.json_body.get("popularity")
+            if request.user.is_superuser
+            else None,
         }
 
         if self._has_hook_events(request) and not features.has(

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -27,6 +27,7 @@ class SentryAppSerializer(Serializer):
             "verifyInstall": obj.verify_install,
             "overview": obj.overview,
             "allowedOrigins": obj.application.get_allowed_origins(),
+            "popularity": obj.popularity,
         }
 
         data["featureData"] = []

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -80,7 +80,13 @@ class SentryAppSerializer(Serializer):
     overview = serializers.CharField(required=False, allow_null=True)
     verifyInstall = serializers.BooleanField(required=False, default=True)
     allowedOrigins = ListField(child=serializers.CharField(max_length=255), required=False)
-    popularity = serializers.IntegerField(min_value=0, max_value=32767, required=False)
+    # Bounds chosen to match PositiveSmallIntegerField (https://docs.djangoproject.com/en/3.2/ref/models/fields/#positivesmallintegerfield)
+    popularity = serializers.IntegerField(
+        min_value=0,
+        max_value=32767,
+        required=False,
+        allow_null=True,
+    )
 
     def __init__(self, *args, **kwargs):
         self.access = kwargs["access"]

--- a/src/sentry/api/serializers/rest_framework/sentry_app.py
+++ b/src/sentry/api/serializers/rest_framework/sentry_app.py
@@ -80,6 +80,7 @@ class SentryAppSerializer(Serializer):
     overview = serializers.CharField(required=False, allow_null=True)
     verifyInstall = serializers.BooleanField(required=False, default=True)
     allowedOrigins = ListField(child=serializers.CharField(max_length=255), required=False)
+    popularity = serializers.IntegerField(min_value=0, max_value=32767, required=False)
 
     def __init__(self, *args, **kwargs):
         self.access = kwargs["access"]

--- a/src/sentry/mediators/sentry_apps/creator.py
+++ b/src/sentry/mediators/sentry_apps/creator.py
@@ -34,6 +34,7 @@ class Creator(Mediator, SentryAppMixin):
     schema = Param(dict, default=lambda self: {})
     overview = Param((str,), required=False)
     allowed_origins = Param(Iterable, default=lambda self: [])
+    popularity = Param(int, required=False)
     request = Param("rest_framework.request.Request", required=False)
     user = Param("sentry.models.User")
     is_internal = Param(bool)
@@ -87,6 +88,7 @@ class Creator(Mediator, SentryAppMixin):
             "is_alertable": self.is_alertable,
             "verify_install": self.verify_install,
             "overview": self.overview,
+            "popularity": self.popularity or SentryApp._meta.get_field("popularity").default,
             "creator_user": self.user,
             "creator_label": self.user.email
             or self.user.username,  # email is not required for some users (sentry apps)

--- a/src/sentry/mediators/sentry_apps/updater.py
+++ b/src/sentry/mediators/sentry_apps/updater.py
@@ -28,6 +28,7 @@ class Updater(Mediator, SentryAppMixin):
     schema = Param(dict, required=False)
     overview = Param((str,), required=False)
     allowed_origins = Param(Iterable, required=False)
+    popularity = Param(int, required=False)
     user = Param("sentry.models.User")
 
     def call(self):
@@ -44,6 +45,7 @@ class Updater(Mediator, SentryAppMixin):
         self._update_allowed_origins()
         self._update_schema()
         self._update_service_hooks()
+        self._update_popularity()
         self.sentry_app.save()
         return self.sentry_app
 
@@ -142,6 +144,11 @@ class Updater(Mediator, SentryAppMixin):
     def _update_allowed_origins(self):
         self.sentry_app.application.allowed_origins = "\n".join(self.allowed_origins)
         self.sentry_app.application.save()
+
+    @if_param("popularity")
+    def _update_popularity(self):
+        if self.user.is_superuser:
+            self.sentry_app.popularity = self.popularity
 
     @if_param("schema")
     def _update_schema(self):

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from sentry.models import SentryApp
 from sentry.testutils import APITestCase
 from sentry.utils import json
 
@@ -58,6 +59,7 @@ class GetOrganizationSentryAppsTest(OrganizationSentryAppsTest):
                             "description": "Testin can **utilize the Sentry API** to pull data or update resources in Sentry (with permissions granted, of course).",
                         }
                     ],
+                    "popularity": SentryApp._meta.get_field("popularity").default,
                 }
             ],
         )

--- a/tests/sentry/mediators/sentry_apps/test_creator.py
+++ b/tests/sentry/mediators/sentry_apps/test_creator.py
@@ -34,6 +34,16 @@ class TestCreator(TestCase):
         app = self.creator.call()
         assert app.slug == "nulldb"
 
+    def test_default_popularity(self):
+        app = self.creator.call()
+        assert app.popularity == SentryApp._meta.get_field("popularity").default
+
+    def test_popularity(self):
+        popularity = 27
+        self.creator.popularity = popularity
+        app = self.creator.call()
+        assert app.popularity == popularity
+
     def test_creates_proxy_user(self):
         self.creator.call()
 

--- a/tests/sentry/mediators/sentry_apps/test_updater.py
+++ b/tests/sentry/mediators/sentry_apps/test_updater.py
@@ -6,7 +6,7 @@ from sentry.constants import SentryAppStatus
 from sentry.coreapi import APIError
 from sentry.mediators.sentry_apps import Updater
 from sentry.mediators.service_hooks.creator import expand_events
-from sentry.models import ApiToken, SentryAppComponent, ServiceHook
+from sentry.models import ApiToken, SentryApp, SentryAppComponent, ServiceHook
 from sentry.testutils import TestCase
 
 
@@ -157,6 +157,18 @@ class TestUpdater(TestCase):
         self.updater.overview = "Description of my very cool application"
         self.updater.call()
         assert self.sentry_app.overview == "Description of my very cool application"
+
+    def test_update_popularity_if_superuser(self):
+        popularity = 27
+        self.updater.popularity = popularity
+        self.user.is_superuser = True
+        self.updater.call()
+        assert self.sentry_app.popularity == popularity
+
+    def test_doesnt_update_popularity_if_not_superuser(self):
+        self.updater.popularity = 27
+        self.updater.call()
+        assert self.sentry_app.popularity == SentryApp._meta.get_field("popularity").default
 
     def test_update_status_if_superuser(self):
         self.updater.status = "published"


### PR DESCRIPTION
See [API-2250](https://getsentry.atlassian.net/browse/API-2250)

This PR will add the popularity field to serialized Sentry Apps. In addition, since Sentry Apps are created through a creator, it will also use the default if no popularity field is provided. 

~~New sentry apps cannot manually change their payload to set a high popularity since the POST endpoint to create SentryApps `src/sentry/api/endpoints/sentry_apps.py` does NOT accept the popularity field.~~

The POST endpoint to create sentry apps now accepts the `popularity` key, only being read if the user is a super user. Only having the behaviour on update felt half baked, especially for testing/debugging down the line.


**Making new sentry apps and updating existing ones is unaffected**

https://user-images.githubusercontent.com/35509934/141384699-ddb0973d-68b0-4b14-badd-4fd3131588c4.mov


https://user-images.githubusercontent.com/35509934/141384682-910c836b-2406-46e8-a335-6e1376f8e225.mov

**Only superusers can update popularity**

https://user-images.githubusercontent.com/35509934/141384700-8772b4a4-4b1e-4881-bfea-32d687ae0309.mov

**Only superusers can create sentryapps with non-default popularities**

https://user-images.githubusercontent.com/35509934/141521849-85c79ff8-d88d-4109-8181-d212fc7d6fe4.mov


