### PR TITLE
fix(alerts): Check if alert owner is a member on transfer

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -333,9 +333,7 @@ class Project(Model, PendingDeletionMixin):
         for rule in list(chain(alert_rules, rules)):
             actor = rule.owner
             if actor.type == ACTOR_TYPES["user"]:
-                is_member = organization.member_set.filter(
-                    organizationmember__user__id=actor.id
-                ).exists()
+                is_member = organization.member_set.filter(user=actor.resolve()).exists()
             if actor.type == ACTOR_TYPES["team"]:
                 is_member = actor.resolve().organization.id == organization.id
             if not is_member:

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -339,6 +339,8 @@ class Project(Model, PendingDeletionMixin):
             if not is_member:
                 rule.update(owner=None)
 
+        AlertRule.objects.fetch_for_project(self).update(organization=organization)
+
     def add_team(self, team):
         from sentry.models.projectteam import ProjectTeam
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from collections import defaultdict
+from itertools import chain
 from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 from uuid import uuid1
 
@@ -263,6 +264,7 @@ class Project(Model, PendingDeletionMixin):
         # org than the existing one, which is currently the only use case in
         # production
         # TODO(jess): refactor this to make it an org transfer only
+        from sentry.incidents.models import AlertRule
         from sentry.models import (
             Environment,
             EnvironmentProject,
@@ -271,6 +273,7 @@ class Project(Model, PendingDeletionMixin):
             ReleaseProjectEnvironment,
             Rule,
         )
+        from sentry.models.actor import ACTOR_TYPES
 
         if organization is None:
             organization = team.organization
@@ -323,6 +326,21 @@ class Project(Model, PendingDeletionMixin):
         # ensure this actually exists in case from team was null
         if team is not None:
             self.add_team(team)
+
+        # Remove alert owners not in new org
+        alert_rules = AlertRule.objects.fetch_for_project(self).filter(owner_id__isnull=False)
+        rules = Rule.objects.filter(owner_id__isnull=False, project=self)
+        for rule in list(chain(alert_rules, rules)):
+            actor = rule.owner
+            if actor.type == ACTOR_TYPES["user"]:
+                is_member = organization.member_set.filter(
+                    organizationmember__user__id=actor.id
+                ).exists()
+            if actor.type == ACTOR_TYPES["team"]:
+                is_member = actor.resolve().organization.id == organization.id
+            if not is_member:
+                rule.owner = None
+                rule.save()
 
     def add_team(self, team):
         from sentry.models.projectteam import ProjectTeam

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -335,10 +335,9 @@ class Project(Model, PendingDeletionMixin):
             if actor.type == ACTOR_TYPES["user"]:
                 is_member = organization.member_set.filter(user=actor.resolve()).exists()
             if actor.type == ACTOR_TYPES["team"]:
-                is_member = actor.resolve().organization.id == organization.id
+                is_member = actor.resolve().organization_id == organization.id
             if not is_member:
-                rule.owner = None
-                rule.save()
+                rule.update(owner=None)
 
     def add_team(self, team):
         from sentry.models.projectteam import ProjectTeam

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -233,6 +233,7 @@ class ProjectTest(TestCase):
         rule2.refresh_from_db()
         rule3.refresh_from_db()
         rule4.refresh_from_db()
+        assert alert_rule.organization_id == to_org.id
         assert alert_rule.owner is None
         assert rule1.owner is None
         assert rule2.owner is None


### PR DESCRIPTION
attempting to remove owners from alerts that do not exist when moving projects between organizations.

Assign alert rules to the organization