### PR TITLE
feat(ui): When hovering over release adoption chart focus on series

### DIFF
--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -1,6 +1,7 @@
 import {Component} from 'react';
 import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
+import type {LineSeriesOption} from 'echarts';
 import {Location} from 'history';
 import compact from 'lodash/compact';
 import pick from 'lodash/pick';
@@ -98,6 +99,9 @@ class ReleasesAdoptionChart extends Component<Props> {
         response?.intervals,
         sessionDisplayToField(activeDisplay)
       ),
+      emphasis: {
+        focus: 'series',
+      } as LineSeriesOption['emphasis'],
     }));
   }
 


### PR DESCRIPTION
This adds a new feature from echarts v5 to the release adoption chart, `focus: 'series'` which highlights a line in the chart when hovered over.

Example of focus:
![Screen Shot 2021-11-12 at 8 53 18 AM](https://user-images.githubusercontent.com/15015880/141505424-babf739b-0ed6-4b5e-921f-d577156f7285.png)

Jira: [WOR-977](https://getsentry.atlassian.net/browse/WOR-977)