### PR TITLE
fix(docs): Updating configure-scms urls

### DIFF
--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -391,7 +391,7 @@ class AssigneeSelector extends React.Component<Props, State> {
     const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
       suspectCommit: tct('Based on [commit:commit data]', {
         commit: (
-          <TooltipSubExternalLink href="https://docs.sentry.io/product/sentry-basics/guides/integrate-frontend/configure-scms/" />
+          <TooltipSubExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/configure-scms/" />
         ),
       }),
       ownershipRule: t('Matching Issue Owners Rule'),

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -160,7 +160,7 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
                 <ExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
               ),
               committed: (
-                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/guides/integrate-frontend/configure-scms/" />
+                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/configure-scms/" />
               ),
             }
           ),


### PR DESCRIPTION
- These docs no longer have `guides/` in the url