### PR TITLE
ref(tests) Replace usage of predicate in MockApiClient

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -140,11 +140,13 @@ class Client implements ApiNamespace.Client {
 
   static findMockResponse(url: string, options: Readonly<ApiNamespace.RequestOptions>) {
     return Client.mockResponses.find(([response]) => {
-      const matchesURL = url === response.url;
-      const matchesMethod = (options.method || 'GET') === response.method;
-      const matchersMatch = response.match.every(matcher => matcher(url, options));
-
-      return matchesURL && matchesMethod && matchersMatch;
+      if (url !== response.url) {
+        return false;
+      }
+      if ((options.method || 'GET') !== response.method) {
+        return false;
+      }
+      return response.match.every(matcher => matcher(url, options));
     });
   }
 

--- a/tests/js/spec/components/discover/transactionsList.spec.jsx
+++ b/tests/js/spec/components/discover/transactionsList.spec.jsx
@@ -72,36 +72,28 @@ describe('TransactionsList', function () {
         }),
       };
 
-      MockApiClient.addMockResponse(
-        {
-          url: `/organizations/${organization.slug}/eventsv2/`,
-          body: {
-            meta: {transaction: 'string', count: 'number'},
-            data: [
-              {transaction: '/a', count: 100},
-              {transaction: '/b', count: 1000},
-            ],
-          },
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/eventsv2/`,
+        body: {
+          meta: {transaction: 'string', count: 'number'},
+          data: [
+            {transaction: '/a', count: 100},
+            {transaction: '/b', count: 1000},
+          ],
         },
-        {
-          predicate: (_, opts) => opts?.query?.sort === 'transaction',
-        }
-      );
-      MockApiClient.addMockResponse(
-        {
-          url: `/organizations/${organization.slug}/eventsv2/`,
-          body: {
-            meta: {transaction: 'string', count: 'number'},
-            data: [
-              {transaction: '/b', count: 1000},
-              {transaction: '/a', count: 100},
-            ],
-          },
+        match: [MockApiClient.matchQuery({sort: 'transaction'})],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/eventsv2/`,
+        body: {
+          meta: {transaction: 'string', count: 'number'},
+          data: [
+            {transaction: '/b', count: 1000},
+            {transaction: '/a', count: 100},
+          ],
         },
-        {
-          predicate: (_, opts) => opts?.query?.sort === '-count',
-        }
-      );
+        match: [MockApiClient.matchQuery({sort: '-count'})],
+      });
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/events-trends/`,
         body: {

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -35,15 +35,11 @@ describe('ExternalIssueForm', () => {
   });
 
   const generateWrapper = (action = 'create') => {
-    MockApiClient.addMockResponse(
-      {
-        url: `/groups/${group.id}/integrations/${integration.id}/`,
-        body: formConfig,
-      },
-      {
-        predicate: (_, options) => options?.query?.action === 'create',
-      }
-    );
+    MockApiClient.addMockResponse({
+      url: `/groups/${group.id}/integrations/${integration.id}/`,
+      body: formConfig,
+      match: [MockApiClient.matchQuery({action: 'create'})],
+    });
     const component = mountWithTheme(
       <ExternalIssueForm
         Body={p => p.children}
@@ -134,15 +130,11 @@ describe('ExternalIssueForm', () => {
         },
         id: '5',
       };
-      getFormConfigRequest = MockApiClient.addMockResponse(
-        {
-          url: `/groups/${group.id}/integrations/${integration.id}/`,
-          body: formConfig,
-        },
-        {
-          predicate: (_, options) => options?.query?.action === 'link',
-        }
-      );
+      getFormConfigRequest = MockApiClient.addMockResponse({
+        url: `/groups/${group.id}/integrations/${integration.id}/`,
+        body: formConfig,
+        match: [MockApiClient.matchQuery({action: 'link'})],
+      });
     });
     it('renders', () => {
       wrapper = generateWrapper('link');

--- a/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueForm.spec.jsx
@@ -233,44 +233,34 @@ describe('SentryAppExternalIssueForm Dependent fields', () => {
   describe('create', () => {
     it('load options for field that has dependencies when the dependent option is selected', async () => {
       const url = `/sentry-app-installations/${sentryAppInstallation.uuid}/external-requests/`;
-      Client.addMockResponse(
-        {
-          method: 'GET',
-          url,
-          body: {
-            choices: [
-              ['A', 'project A'],
-              ['B', 'project B'],
-            ],
-          },
+      Client.addMockResponse({
+        method: 'GET',
+        url,
+        body: {
+          choices: [
+            ['A', 'project A'],
+            ['B', 'project B'],
+          ],
         },
-        {
-          predicate: (_url, options) => {
-            return options.query.uri === '/integrations/sentry/projects';
-          },
-        }
-      );
+        match: [MockApiClient.matchQuery({uri: '/integrations/sentry/projects'})],
+      });
 
-      const boardMock = Client.addMockResponse(
-        {
-          method: 'GET',
-          url,
-          body: {
-            choices: [
-              ['R', 'board R'],
-              ['S', 'board S'],
-            ],
-          },
+      const boardMock = Client.addMockResponse({
+        method: 'GET',
+        url,
+        body: {
+          choices: [
+            ['R', 'board R'],
+            ['S', 'board S'],
+          ],
         },
-        {
-          predicate: (_url, {query}) => {
-            return (
-              query.uri === '/integrations/sentry/boards' &&
-              query.dependentData === JSON.stringify({project_id: 'A'})
-            );
-          },
-        }
-      );
+        match: [
+          MockApiClient.matchQuery({
+            uri: '/integrations/sentry/boards',
+            dependentData: JSON.stringify({project_id: 'A'}),
+          }),
+        ],
+      });
 
       const projectInput = wrapper.find('[data-test-id="project_id"] input').at(0);
       changeInputValue(projectInput, 'p');

--- a/tests/js/spec/utils/discover/teamKeyTransactionField.spec.jsx
+++ b/tests/js/spec/utils/discover/teamKeyTransactionField.spec.jsx
@@ -188,22 +188,15 @@ describe('TeamKeyTransactionField', function () {
       })),
     });
 
-    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'POST',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'POST' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 1 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({team: [teams[0].id], transaction: 'transaction'}),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionManager.Provider
@@ -249,22 +242,15 @@ describe('TeamKeyTransactionField', function () {
       })),
     });
 
-    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'DELETE',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'DELETE' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 1 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'DELETE',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({team: [teams[0].id], transaction: 'transaction'}),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionManager.Provider
@@ -310,23 +296,18 @@ describe('TeamKeyTransactionField', function () {
       })),
     });
 
-    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'POST',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'POST' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 2 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.team[1] === teams[1].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({
+          team: [teams[0].id, teams[1].id],
+          transaction: 'transaction',
+        }),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionManager.Provider
@@ -369,23 +350,18 @@ describe('TeamKeyTransactionField', function () {
       })),
     });
 
-    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'DELETE',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'DELETE' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 2 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.team[1] === teams[1].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'DELETE',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({
+          team: [teams[0].id, teams[1].id],
+          transaction: 'transaction',
+        }),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionManager.Provider

--- a/tests/js/spec/utils/performance/quickTrace/quickTraceQuery.spec.jsx
+++ b/tests/js/spec/utils/performance/quickTrace/quickTraceQuery.spec.jsx
@@ -44,15 +44,11 @@ describe('TraceLiteQuery', function () {
       },
       type: 'transaction',
     };
-    traceLiteMock = MockApiClient.addMockResponse(
-      {
-        url: `/organizations/test-org/events-trace-light/${traceId}/`,
-        body: [],
-      },
-      {
-        predicate: (_, {query}) => query.event_id === eventId,
-      }
-    );
+    traceLiteMock = MockApiClient.addMockResponse({
+      url: `/organizations/test-org/events-trace-light/${traceId}/`,
+      body: [],
+      match: [MockApiClient.matchQuery({event_id: eventId})],
+    });
     traceFullMock = MockApiClient.addMockResponse({
       url: `/organizations/test-org/events-trace/${traceId}/`,
       body: [],
@@ -127,15 +123,11 @@ describe('TraceLiteQuery', function () {
   });
 
   it('uses full results when it finds current event', async function () {
-    traceLiteMock = MockApiClient.addMockResponse(
-      {
-        url: `/organizations/test-org/events-trace-light/0${traceId}/`,
-        body: [],
-      },
-      {
-        predicate: (_, {query}) => query.event_id === eventId,
-      }
-    );
+    traceLiteMock = MockApiClient.addMockResponse({
+      url: `/organizations/test-org/events-trace-light/0${traceId}/`,
+      body: [],
+      match: [MockApiClient.matchQuery({event_id: eventId})],
+    });
     traceFullMock = MockApiClient.addMockResponse({
       url: `/organizations/test-org/events-trace/0${traceId}/`,
       body: [{event_id: eventId, children: []}],

--- a/tests/js/spec/utils/performance/quickTrace/traceFullQuery.spec.jsx
+++ b/tests/js/spec/utils/performance/quickTrace/traceFullQuery.spec.jsx
@@ -62,15 +62,11 @@ describe('TraceFullQuery', function () {
   });
 
   it('fetches data on mount with detailed param', async function () {
-    const getMock = MockApiClient.addMockResponse(
-      {
-        url: `/organizations/test-org/events-trace/${traceId}/`,
-        body: [],
-      },
-      {
-        predicate: (_, {query}) => query.detailed === '1',
-      }
-    );
+    const getMock = MockApiClient.addMockResponse({
+      url: `/organizations/test-org/events-trace/${traceId}/`,
+      body: [],
+      match: [MockApiClient.matchQuery({detailed: '1'})],
+    });
     const wrapper = mountWithTheme(
       <TraceFullDetailedQuery
         api={api}

--- a/tests/js/spec/utils/performance/quickTrace/traceLiteQuery.spec.jsx
+++ b/tests/js/spec/utils/performance/quickTrace/traceLiteQuery.spec.jsx
@@ -38,15 +38,11 @@ describe('TraceLiteQuery', function () {
   });
 
   it('fetches data on mount and passes the event id', async function () {
-    const getMock = MockApiClient.addMockResponse(
-      {
-        url: `/organizations/test-org/events-trace-light/${traceId}/`,
-        body: [],
-      },
-      {
-        predicate: (_, {query}) => query.event_id === eventId,
-      }
-    );
+    const getMock = MockApiClient.addMockResponse({
+      url: `/organizations/test-org/events-trace-light/${traceId}/`,
+      body: [],
+      match: [MockApiClient.matchQuery({event_id: eventId})],
+    });
     const wrapper = mountWithTheme(
       <TraceLiteQuery
         api={api}

--- a/tests/js/spec/utils/performance/suspectSpans/suspectSpansQuery.spec.tsx
+++ b/tests/js/spec/utils/performance/suspectSpans/suspectSpansQuery.spec.tsx
@@ -50,7 +50,7 @@ describe('SuspectSpansQuery', function () {
       url: '/organizations/test-org/events-spans-performance/',
       // just asserting that the data is being fetched, no need for actual data here
       body: [],
-      match: [MockApiClient.matchQuery({spanOp: 'op1'})],
+      match: [MockApiClient.matchQuery({spanOp: ['op1']})],
     });
 
     mountWithTheme(

--- a/tests/js/spec/utils/performance/suspectSpans/suspectSpansQuery.spec.tsx
+++ b/tests/js/spec/utils/performance/suspectSpans/suspectSpansQuery.spec.tsx
@@ -46,19 +46,12 @@ describe('SuspectSpansQuery', function () {
   });
 
   it('fetches data with the right ops filter', async function () {
-    const getMock = MockApiClient.addMockResponse(
-      {
-        url: '/organizations/test-org/events-spans-performance/',
-        // just asserting that the data is being fetched, no need for actual data here
-        body: [],
-      },
-      {
-        predicate: (_url, options) => {
-          const spanOp = options.query?.spanOp;
-          return spanOp.length && spanOp[0] === 'op1';
-        },
-      }
-    );
+    const getMock = MockApiClient.addMockResponse({
+      url: '/organizations/test-org/events-spans-performance/',
+      // just asserting that the data is being fetched, no need for actual data here
+      body: [],
+      match: [MockApiClient.matchQuery({spanOp: 'op1'})],
+    });
 
     mountWithTheme(
       <SuspectSpansQuery

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -45,20 +45,16 @@ describe('Dashboards > WidgetQueries', function () {
   });
 
   it('can send multiple API requests', async function () {
-    const errorMock = MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/events-stats/',
-        body: [],
-      },
-      {
-        predicate(_url, options) {
-          return (
-            options.query.query === 'event.type:error' ||
-            options.query.query === 'event.type:default'
-          );
-        },
-      }
-    );
+    const errorMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+      match: [MockApiClient.matchQuery({query: 'event.type:error'})],
+    });
+    const defaultMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+      match: [MockApiClient.matchQuery({query: 'event.type:default'})],
+    });
     const wrapper = mountWithTheme(
       <WidgetQueries
         api={api}
@@ -75,7 +71,8 @@ describe('Dashboards > WidgetQueries', function () {
 
     // Child should be rendered and 2 requests should be sent.
     expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
-    expect(errorMock).toHaveBeenCalledTimes(2);
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(defaultMock).toHaveBeenCalledTimes(1);
   });
 
   it('sets errorMessage when the first request fails', async function () {

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -105,42 +105,40 @@ describe('Performance > Content', function () {
       url: '/prompts-activity/',
       body: {},
     });
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          meta: {
-            user: 'string',
-            transaction: 'string',
-            'project.id': 'integer',
-            tpm: 'number',
-            p50: 'number',
-            p95: 'number',
-            failure_rate: 'number',
-            apdex_300: 'number',
-            count_unique_user: 'number',
-            count_miserable_user_300: 'number',
-            user_misery_300: 'number',
-          },
-          data: [
-            {
-              transaction: '/apple/cart',
-              'project.id': 1,
-              user: 'uhoh@example.com',
-              tpm: 30,
-              p50: 100,
-              p95: 500,
-              failure_rate: 0.1,
-              apdex_300: 0.6,
-              count_unique_user: 1000,
-              count_miserable_user_300: 122,
-              user_misery_300: 0.114,
-            },
-          ],
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          user: 'string',
+          transaction: 'string',
+          'project.id': 'integer',
+          tpm: 'number',
+          p50: 'number',
+          p95: 'number',
+          failure_rate: 'number',
+          apdex_300: 'number',
+          count_unique_user: 'number',
+          count_miserable_user_300: 'number',
+          user_misery_300: 'number',
         },
+        data: [
+          {
+            transaction: '/apple/cart',
+            'project.id': 1,
+            user: 'uhoh@example.com',
+            tpm: 30,
+            p50: 100,
+            p95: 500,
+            failure_rate: 0.1,
+            apdex_300: 0.6,
+            count_unique_user: 1000,
+            count_miserable_user_300: 122,
+            user_misery_300: 0.114,
+          },
+        ],
       },
-      {
-        predicate: (_, options) => {
+      match: [
+        (_, options) => {
           if (!options.hasOwnProperty('query')) {
             return false;
           }
@@ -149,59 +147,57 @@ describe('Performance > Content', function () {
           }
           return !options.query.field.includes('team_key_transaction');
         },
-      }
-    );
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          meta: {
-            user: 'string',
-            transaction: 'string',
-            'project.id': 'integer',
-            tpm: 'number',
-            p50: 'number',
-            p95: 'number',
-            failure_rate: 'number',
-            apdex_300: 'number',
-            count_unique_user: 'number',
-            count_miserable_user_300: 'number',
-            user_misery_300: 'number',
-          },
-          data: [
-            {
-              team_key_transaction: 1,
-              transaction: '/apple/cart',
-              'project.id': 1,
-              user: 'uhoh@example.com',
-              tpm: 30,
-              p50: 100,
-              p95: 500,
-              failure_rate: 0.1,
-              apdex_300: 0.6,
-              count_unique_user: 1000,
-              count_miserable_user_300: 122,
-              user_misery_300: 0.114,
-            },
-            {
-              team_key_transaction: 0,
-              transaction: '/apple/checkout',
-              'project.id': 1,
-              user: 'uhoh@example.com',
-              tpm: 30,
-              p50: 100,
-              p95: 500,
-              failure_rate: 0.1,
-              apdex_300: 0.6,
-              count_unique_user: 1000,
-              count_miserable_user_300: 122,
-              user_misery_300: 0.114,
-            },
-          ],
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          user: 'string',
+          transaction: 'string',
+          'project.id': 'integer',
+          tpm: 'number',
+          p50: 'number',
+          p95: 'number',
+          failure_rate: 'number',
+          apdex_300: 'number',
+          count_unique_user: 'number',
+          count_miserable_user_300: 'number',
+          user_misery_300: 'number',
         },
+        data: [
+          {
+            team_key_transaction: 1,
+            transaction: '/apple/cart',
+            'project.id': 1,
+            user: 'uhoh@example.com',
+            tpm: 30,
+            p50: 100,
+            p95: 500,
+            failure_rate: 0.1,
+            apdex_300: 0.6,
+            count_unique_user: 1000,
+            count_miserable_user_300: 122,
+            user_misery_300: 0.114,
+          },
+          {
+            team_key_transaction: 0,
+            transaction: '/apple/checkout',
+            'project.id': 1,
+            user: 'uhoh@example.com',
+            tpm: 30,
+            p50: 100,
+            p95: 500,
+            failure_rate: 0.1,
+            apdex_300: 0.6,
+            count_unique_user: 1000,
+            count_miserable_user_300: 122,
+            user_misery_300: 0.114,
+          },
+        ],
       },
-      {
-        predicate: (_, options) => {
+      match: [
+        (_, options) => {
           if (!options.hasOwnProperty('query')) {
             return false;
           }
@@ -210,8 +206,8 @@ describe('Performance > Content', function () {
           }
           return options.query.field.includes('team_key_transaction');
         },
-      }
-    );
+      ],
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-meta/',
       body: {

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -52,33 +52,29 @@ describe('Performance > Widgets > WidgetContainer', function () {
       url: `/organizations/org-slug/events-stats/`,
       body: [],
     });
-    eventsV2Mock = MockApiClient.addMockResponse(
-      {
-        method: 'GET',
-        url: `/organizations/org-slug/eventsv2/`,
-        body: [],
+    eventsV2Mock = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/eventsv2/`,
+      body: [],
+      match: [(...args) => !issuesPredicate(...args)],
+    });
+    issuesListMock = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/eventsv2/`,
+      body: {
+        data: [
+          {
+            'issue.id': 123,
+            transaction: '/issue/:id/',
+            title: 'Error: Something is broken.',
+            'project.id': 1,
+            count: 3100,
+            issue: 'JAVASCRIPT-ABCD',
+          },
+        ],
       },
-      {predicate: (...args) => !issuesPredicate(...args)}
-    );
-    issuesListMock = MockApiClient.addMockResponse(
-      {
-        method: 'GET',
-        url: `/organizations/org-slug/eventsv2/`,
-        body: {
-          data: [
-            {
-              'issue.id': 123,
-              transaction: '/issue/:id/',
-              title: 'Error: Something is broken.',
-              'project.id': 1,
-              count: 3100,
-              issue: 'JAVASCRIPT-ABCD',
-            },
-          ],
-        },
-      },
-      {predicate: (...args) => issuesPredicate(...args)}
-    );
+      match: [(...args) => issuesPredicate(...args)],
+    });
 
     eventsTrendsStats = MockApiClient.addMockResponse({
       method: 'GET',

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -54,81 +54,75 @@ describe('Performance > TransactionSummary', function () {
       url: '/organizations/org-slug/sdk-updates/',
       body: [],
     });
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          data: [
-            {
-              p100: 9502,
-              p99: 9285.7,
-              p95: 7273.6,
-              p75: 3639.5,
-              p50: 755.5,
-            },
-          ],
-          meta: {
-            p100: 'duration',
-            p99: 'duration',
-            p95: 'duration',
-            p75: 'duration',
-            p50: 'duration',
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        data: [
+          {
+            p100: 9502,
+            p99: 9285.7,
+            p95: 7273.6,
+            p75: 3639.5,
+            p50: 755.5,
           },
+        ],
+        meta: {
+          p100: 'duration',
+          p99: 'duration',
+          p95: 'duration',
+          p75: 'duration',
+          p50: 'duration',
         },
       },
-      {
-        predicate: (url, options) => {
-          return url.includes('eventsv2') && options.query?.field.includes('p95()');
+      match: [
+        (_, options) => {
+          return options.query?.field?.includes('p95()');
         },
-      }
-    );
+      ],
+    });
     // Transaction list response
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        headers: {
-          Link:
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
-        },
-        body: {
-          meta: {
-            id: 'string',
-            'user.display': 'string',
-            'transaction.duration': 'duration',
-            'project.id': 'integer',
-            timestamp: 'date',
-          },
-          data: [
-            {
-              id: 'deadbeef',
-              'user.display': 'uhoh@example.com',
-              'transaction.duration': 400,
-              'project.id': 1,
-              timestamp: '2020-05-21T15:31:18+00:00',
-              trace: '1234',
-              'measurements.lcp': 200,
-            },
-            {
-              id: 'moredeadbeef',
-              'user.display': 'moreuhoh@example.com',
-              'transaction.duration': 600,
-              'project.id': 1,
-              timestamp: '2020-05-22T15:31:18+00:00',
-              trace: '4321',
-              'measurements.lcp': 300,
-            },
-          ],
-        },
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') && options.query?.field.includes('user.display')
-          );
+      body: {
+        meta: {
+          id: 'string',
+          'user.display': 'string',
+          'transaction.duration': 'duration',
+          'project.id': 'integer',
+          timestamp: 'date',
         },
-      }
-    );
+        data: [
+          {
+            id: 'deadbeef',
+            'user.display': 'uhoh@example.com',
+            'transaction.duration': 400,
+            'project.id': 1,
+            timestamp: '2020-05-21T15:31:18+00:00',
+            trace: '1234',
+            'measurements.lcp': 200,
+          },
+          {
+            id: 'moredeadbeef',
+            'user.display': 'moreuhoh@example.com',
+            'transaction.duration': 600,
+            'project.id': 1,
+            timestamp: '2020-05-22T15:31:18+00:00',
+            trace: '4321',
+            'measurements.lcp': 300,
+          },
+        ],
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('user.display');
+        },
+      ],
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-has-measurements/',
       body: {measurements: false},

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -90,104 +90,93 @@ describe('Performance > TransactionSummary', function () {
     });
 
     // Mock totals for the sidebar and other summary data
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          meta: {
-            count: 'number',
-            apdex: 'number',
-            count_miserable_user: 'number',
-            user_misery: 'number',
-            count_unique_user: 'number',
-            p95: 'number',
-            failure_rate: 'number',
-            tpm: 'number',
-            project_threshold_config: 'string',
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          count: 'number',
+          apdex: 'number',
+          count_miserable_user: 'number',
+          user_misery: 'number',
+          count_unique_user: 'number',
+          p95: 'number',
+          failure_rate: 'number',
+          tpm: 'number',
+          project_threshold_config: 'string',
+        },
+        data: [
+          {
+            count: 2,
+            apdex: 0.6,
+            count_miserable_user: 122,
+            user_misery: 0.114,
+            count_unique_user: 1,
+            p95: 750.123,
+            failure_rate: 1,
+            tpm: 1,
+            project_threshold_config: ['duration', 300],
           },
-          data: [
-            {
-              count: 2,
-              apdex: 0.6,
-              count_miserable_user: 122,
-              user_misery: 0.114,
-              count_unique_user: 1,
-              p95: 750.123,
-              failure_rate: 1,
-              tpm: 1,
-              project_threshold_config: ['duration', 300],
-            },
-          ],
-        },
+        ],
       },
-      {
-        predicate: (url, options) => {
-          return url.includes('eventsv2') && options.query?.field.includes('p95()');
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('p95()');
         },
-      }
-    );
+      ],
+    });
     // Transaction list response
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        headers: {
-          Link:
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
-        },
-        body: {
-          meta: {
-            id: 'string',
-            'user.display': 'string',
-            'transaction.duration': 'duration',
-            'project.id': 'integer',
-            timestamp: 'date',
-          },
-          data: [
-            {
-              id: 'deadbeef',
-              'user.display': 'uhoh@example.com',
-              'transaction.duration': 400,
-              'project.id': 2,
-              timestamp: '2020-05-21T15:31:18+00:00',
-            },
-          ],
-        },
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') && options.query?.field.includes('user.display')
-          );
+      body: {
+        meta: {
+          id: 'string',
+          'user.display': 'string',
+          'transaction.duration': 'duration',
+          'project.id': 'integer',
+          timestamp: 'date',
         },
-      }
-    );
+        data: [
+          {
+            id: 'deadbeef',
+            'user.display': 'uhoh@example.com',
+            'transaction.duration': 400,
+            'project.id': 2,
+            timestamp: '2020-05-21T15:31:18+00:00',
+          },
+        ],
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('user.display');
+        },
+      ],
+    });
     // Mock totals for status breakdown
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          meta: {
-            'transaction.status': 'string',
-            count: 'number',
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          'transaction.status': 'string',
+          count: 'number',
+        },
+        data: [
+          {
+            count: 2,
+            'transaction.status': 'ok',
           },
-          data: [
-            {
-              count: 2,
-              'transaction.status': 'ok',
-            },
-          ],
-        },
+        ],
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') &&
-            options.query?.field.includes('transaction.status')
-          );
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('transaction.status');
         },
-      }
-    );
+      ],
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-facets/',
       body: [
@@ -533,18 +522,16 @@ describe('Performance > TransactionSummary', function () {
   });
 
   it('does not forward event type to related issues', async function () {
-    const issueGet = MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/issues/?limit=5&project=2&query=tag%3Avalue%20is%3Aunresolved%20transaction%3A%2Fperformance&sort=new&statsPeriod=14d',
-        body: [],
-      },
-      {
-        predicate: (url, options) =>
-          url.startsWith(`/organizations/org-slug/issues/`) &&
+    const issueGet = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/?limit=5&project=2&query=tag%3Avalue%20is%3Aunresolved%20transaction%3A%2Fperformance&sort=new&statsPeriod=14d',
+      body: [],
+      match: [
+        (_, options) => {
           // event.type must NOT be in the query params
-          !options.query?.query?.includes('event.type'),
-      }
-    );
+          return !options.query?.query?.includes('event.type');
+        },
+      ],
+    });
 
     const initialData = initializeData({
       query: {query: 'tag:value event.type:transaction'},

--- a/tests/js/spec/views/performance/transactionSummary/teamKeyTransactionButton.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary/teamKeyTransactionButton.spec.jsx
@@ -40,28 +40,16 @@ describe('TeamKeyTransactionButton', function () {
   });
 
   it('fetches key transactions with project param', async function () {
-    const getTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'GET',
-        url: '/organizations/org-slug/key-transactions-list/',
-        body: teams.map(({id}) => ({
-          team: id,
-          count: 1,
-          keyed: [{project_id: String(project.id), transaction: 'transaction'}],
-        })),
-      },
-      {
-        predicate: (_, options) => {
-          return (
-            options.method === 'GET' &&
-            options.query.project.length === 1 &&
-            options.query.project[0] === project.id &&
-            options.query.team.length === 1 &&
-            options.query.team[0] === 'myteams'
-          );
-        },
-      }
-    );
+    const getTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'GET',
+      url: '/organizations/org-slug/key-transactions-list/',
+      body: teams.map(({id}) => ({
+        team: id,
+        count: 1,
+        keyed: [{project_id: String(project.id), transaction: 'transaction'}],
+      })),
+      match: [MockApiClient.matchQuery({project: [project.id], team: ['myteams']})],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionButton
@@ -207,22 +195,15 @@ describe('TeamKeyTransactionButton', function () {
       })),
     });
 
-    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'POST',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'POST' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 1 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({team: [teams[0].id], transaction: 'transaction'}),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionButton
@@ -256,22 +237,15 @@ describe('TeamKeyTransactionButton', function () {
       })),
     });
 
-    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'DELETE',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'DELETE' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 1 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'DELETE',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({team: [teams[0].id], transaction: 'transaction'}),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionButton
@@ -305,23 +279,18 @@ describe('TeamKeyTransactionButton', function () {
       })),
     });
 
-    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'POST',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'POST' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 2 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.team[1] === teams[1].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const postTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'POST',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({
+          team: [teams[0].id, teams[1].id],
+          transaction: 'transaction',
+        }),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionButton
@@ -363,23 +332,18 @@ describe('TeamKeyTransactionButton', function () {
       })),
     });
 
-    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse(
-      {
-        method: 'DELETE',
-        url: '/organizations/org-slug/key-transactions/',
-        body: [],
-      },
-      {
-        predicate: (_, options) =>
-          options.method === 'DELETE' &&
-          options.query.project.length === 1 &&
-          options.query.project[0] === project.id &&
-          options.data.team.length === 2 &&
-          options.data.team[0] === teams[0].id &&
-          options.data.team[1] === teams[1].id &&
-          options.data.transaction === 'transaction',
-      }
-    );
+    const deleteTeamKeyTransactionsMock = MockApiClient.addMockResponse({
+      method: 'DELETE',
+      url: '/organizations/org-slug/key-transactions/',
+      body: [],
+      match: [
+        MockApiClient.matchQuery({project: [project.id]}),
+        MockApiClient.matchData({
+          team: [teams[0].id, teams[1].id],
+          transaction: 'transaction',
+        }),
+      ],
+    });
 
     const wrapper = mountWithTheme(
       <TeamKeyTransactionButton

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -107,33 +107,29 @@ describe('Performance Transaction Events Content', function () {
       },
     ];
     // Transaction list response
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        headers: {
-          Link:
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
-        },
-        body: {
-          meta: {
-            id: 'string',
-            'user.display': 'string',
-            'transaction.duration': 'duration',
-            'project.id': 'integer',
-            timestamp: 'date',
-          },
-          data,
-        },
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') && options.query?.field.includes('user.display')
-          );
+      body: {
+        meta: {
+          id: 'string',
+          'user.display': 'string',
+          'transaction.duration': 'duration',
+          'project.id': 'integer',
+          timestamp: 'date',
         },
-      }
-    );
+        data,
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('user.display');
+        },
+      ],
+    });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-has-measurements/',
       body: {measurements: false},

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -111,33 +111,29 @@ describe('Performance GridEditable Table', function () {
       },
     ];
     // Transaction list response
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        headers: {
-          Link:
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
-            '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
-        },
-        body: {
-          meta: {
-            id: 'string',
-            'user.display': 'string',
-            'transaction.duration': 'duration',
-            'project.id': 'integer',
-            timestamp: 'date',
-          },
-          data,
-        },
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      headers: {
+        Link:
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=2:0:0>; rel="next"; results="true"; cursor="2:0:0",' +
+          '<http://localhost/api/0/organizations/org-slug/eventsv2/?cursor=1:0:0>; rel="previous"; results="false"; cursor="1:0:0"',
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') && options.query?.field.includes('user.display')
-          );
+      body: {
+        meta: {
+          id: 'string',
+          'user.display': 'string',
+          'transaction.duration': 'duration',
+          'project.id': 'integer',
+          timestamp: 'date',
         },
-      }
-    );
+        data,
+      },
+      match: [
+        (_url, options) => {
+          return options.query?.field?.includes('user.display');
+        },
+      ],
+    });
   });
 
   afterEach(function () {

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.jsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.jsx
@@ -87,85 +87,75 @@ describe('Performance > VitalDetail', function () {
         },
       },
     });
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          meta: {
-            count: 'integer',
-            p95_measurements_lcp: 'duration',
-            transaction: 'string',
-            p50_measurements_lcp: 'duration',
-            project: 'string',
-            compare_numeric_aggregate_p75_measurements_lcp_greater_4000: 'number',
-            'project.id': 'integer',
-            count_unique_user: 'integer',
-            p75_measurements_lcp: 'duration',
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          count: 'integer',
+          p95_measurements_lcp: 'duration',
+          transaction: 'string',
+          p50_measurements_lcp: 'duration',
+          project: 'string',
+          compare_numeric_aggregate_p75_measurements_lcp_greater_4000: 'number',
+          'project.id': 'integer',
+          count_unique_user: 'integer',
+          p75_measurements_lcp: 'duration',
+        },
+        data: [
+          {
+            count: 100000,
+            p95_measurements_lcp: 5000,
+            transaction: 'something',
+            p50_measurements_lcp: 3500,
+            project: 'javascript',
+            compare_numeric_aggregate_p75_measurements_lcp_greater_4000: 1,
+            count_unique_user: 10000,
+            p75_measurements_lcp: 4500,
           },
-          data: [
-            {
-              count: 100000,
-              p95_measurements_lcp: 5000,
-              transaction: 'something',
-              p50_measurements_lcp: 3500,
-              project: 'javascript',
-              compare_numeric_aggregate_p75_measurements_lcp_greater_4000: 1,
-              count_unique_user: 10000,
-              p75_measurements_lcp: 4500,
-            },
-          ],
-        },
+        ],
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') &&
-            options.query?.field.find(f => f === 'p50(measurements.lcp)')
-          );
+      match: [
+        (_url, options) => {
+          return options.query?.field?.find(f => f === 'p50(measurements.lcp)');
         },
-      }
-    );
-    MockApiClient.addMockResponse(
-      {
-        url: '/organizations/org-slug/eventsv2/',
-        body: {
-          meta: {
-            compare_numeric_aggregate_p75_measurements_cls_greater_0_1: 'number',
-            compare_numeric_aggregate_p75_measurements_cls_greater_0_25: 'number',
-            count: 'integer',
-            count_unique_user: 'integer',
-            team_key_transaction: 'boolean',
-            p50_measurements_cls: 'number',
-            p75_measurements_cls: 'number',
-            p95_measurements_cls: 'number',
-            project: 'string',
-            transaction: 'string',
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {
+          compare_numeric_aggregate_p75_measurements_cls_greater_0_1: 'number',
+          compare_numeric_aggregate_p75_measurements_cls_greater_0_25: 'number',
+          count: 'integer',
+          count_unique_user: 'integer',
+          team_key_transaction: 'boolean',
+          p50_measurements_cls: 'number',
+          p75_measurements_cls: 'number',
+          p95_measurements_cls: 'number',
+          project: 'string',
+          transaction: 'string',
+        },
+        data: [
+          {
+            compare_numeric_aggregate_p75_measurements_cls_greater_0_1: 1,
+            compare_numeric_aggregate_p75_measurements_cls_greater_0_25: 0,
+            count: 10000,
+            count_unique_user: 2740,
+            team_key_transaction: 1,
+            p50_measurements_cls: 0.143,
+            p75_measurements_cls: 0.215,
+            p95_measurements_cls: 0.302,
+            project: 'javascript',
+            transaction: 'something',
           },
-          data: [
-            {
-              compare_numeric_aggregate_p75_measurements_cls_greater_0_1: 1,
-              compare_numeric_aggregate_p75_measurements_cls_greater_0_25: 0,
-              count: 10000,
-              count_unique_user: 2740,
-              team_key_transaction: 1,
-              p50_measurements_cls: 0.143,
-              p75_measurements_cls: 0.215,
-              p95_measurements_cls: 0.302,
-              project: 'javascript',
-              transaction: 'something',
-            },
-          ],
-        },
+        ],
       },
-      {
-        predicate: (url, options) => {
-          return (
-            url.includes('eventsv2') &&
-            options.query?.field.find(f => f === 'p50(measurements.cls)')
-          );
+      match: [
+        (_url, options) => {
+          return options.query?.field?.find(f => f === 'p50(measurements.cls)');
         },
-      }
-    );
+      ],
+    });
     MockApiClient.addMockResponse({
       method: 'GET',
       url: `/organizations/org-slug/key-transactions-list/`,

--- a/tests/js/spec/views/releases/list/releasesRequest.spec.tsx
+++ b/tests/js/spec/views/releases/list/releasesRequest.spec.tsx
@@ -1,5 +1,3 @@
-import isEqual from 'lodash/isEqual';
-
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
@@ -21,181 +19,145 @@ describe('ReleasesRequest', function () {
     },
   };
 
-  MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.SessionStatusCountByReleaseInPeriod(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query:
-            'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
-          interval: '1d',
-          statsPeriod: '14d',
-          project: [projectId],
-          field: ['sum(session)'],
-          groupBy: ['project', 'release', 'session.status'],
-        });
-      },
-    }
-  );
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.SessionStatusCountByReleaseInPeriod(),
+    match: [
+      MockApiClient.matchQuery({
+        query:
+          'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
+        interval: '1d',
+        statsPeriod: '14d',
+        project: [projectId],
+        field: ['sum(session)'],
+        groupBy: ['project', 'release', 'session.status'],
+      }),
+    ],
+  });
 
-  const requestForAutoHealthStatsPeriodSessionHistogram = MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.SessionStatusCountByProjectInPeriod(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query: undefined,
-          interval: '1d',
-          statsPeriod: '14d',
-          project: [projectId],
-          field: ['sum(session)'],
-          groupBy: ['project', 'session.status'],
-        });
-      },
-    }
-  );
+  const requestForAutoHealthStatsPeriodSessionHistogram = MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.SessionStatusCountByProjectInPeriod(),
+    match: [
+      MockApiClient.matchQuery({
+        query: undefined,
+        interval: '1d',
+        statsPeriod: '14d',
+        project: [projectId],
+        field: ['sum(session)'],
+        groupBy: ['project', 'session.status'],
+      }),
+    ],
+  });
 
-  const requestForAutoTotalCountByProjectInPeriod = MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.SessionTotalCountByProjectIn24h(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query: undefined,
-          interval: '1d',
-          statsPeriod: '14d',
-          project: [123],
-          field: ['sum(session)'],
-          groupBy: ['project'],
-        });
-      },
-    }
-  );
+  const requestForAutoTotalCountByProjectInPeriod = MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.SessionTotalCountByProjectIn24h(),
+    match: [
+      MockApiClient.matchQuery({
+        query: undefined,
+        interval: '1d',
+        statsPeriod: '14d',
+        project: [123],
+        field: ['sum(session)'],
+        groupBy: ['project'],
+      }),
+    ],
+  });
 
-  const requestForAutoTotalCountByReleaseInPeriod = MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.SesssionTotalCountByReleaseIn24h(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query:
-            'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
-          interval: '1d',
-          statsPeriod: '14d',
-          project: [123],
-          field: ['sum(session)'],
-          groupBy: ['project', 'release'],
-        });
-      },
-    }
-  );
+  const requestForAutoTotalCountByReleaseInPeriod = MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.SesssionTotalCountByReleaseIn24h(),
+    match: [
+      MockApiClient.matchQuery({
+        query:
+          'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
+        interval: '1d',
+        statsPeriod: '14d',
+        project: [123],
+        field: ['sum(session)'],
+        groupBy: ['project', 'release'],
+      }),
+    ],
+  });
 
-  MockApiClient.addMockResponse(
-    {
-      url: `/organizations/${organization.slug}/sessions/`,
-      body: TestStubs.SesssionTotalCountByReleaseIn24h(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query:
-            'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
-          interval: '1h',
-          statsPeriod: '24h',
-          project: [projectId],
-          field: ['sum(session)'],
-          groupBy: ['project', 'release'],
-        });
-      },
-    }
-  );
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/sessions/`,
+    body: TestStubs.SesssionTotalCountByReleaseIn24h(),
+    match: [
+      MockApiClient.matchQuery({
+        query:
+          'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
+        interval: '1h',
+        statsPeriod: '24h',
+        project: [projectId],
+        field: ['sum(session)'],
+        groupBy: ['project', 'release'],
+      }),
+    ],
+  });
 
-  MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.SessionTotalCountByProjectIn24h(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query: undefined,
-          interval: '1h',
-          statsPeriod: '24h',
-          project: [projectId],
-          field: ['sum(session)'],
-          groupBy: ['project'],
-        });
-      },
-    }
-  );
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.SessionTotalCountByProjectIn24h(),
+    match: [
+      MockApiClient.matchQuery({
+        query: undefined,
+        interval: '1h',
+        statsPeriod: '24h',
+        project: [projectId],
+        field: ['sum(session)'],
+        groupBy: ['project'],
+      }),
+    ],
+  });
 
-  MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.SessionUserStatusCountByReleaseInPeriod(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query:
-            'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
-          interval: '1d',
-          statsPeriod: '14d',
-          project: [projectId],
-          field: ['count_unique(user)', 'sum(session)'],
-          groupBy: ['project', 'release', 'session.status'],
-        });
-      },
-    }
-  );
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.SessionUserStatusCountByReleaseInPeriod(),
+    match: [
+      MockApiClient.matchQuery({
+        query:
+          'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
+        interval: '1d',
+        statsPeriod: '14d',
+        project: [projectId],
+        field: ['count_unique(user)', 'sum(session)'],
+        groupBy: ['project', 'release', 'session.status'],
+      }),
+    ],
+  });
 
-  MockApiClient.addMockResponse(
-    {
-      url: `/organizations/${organization.slug}/sessions/`,
-      body: TestStubs.UserTotalCountByReleaseIn24h(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query:
-            'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
-          interval: '1h',
-          statsPeriod: '24h',
-          project: [projectId],
-          field: ['count_unique(user)'],
-          groupBy: ['project', 'release'],
-        });
-      },
-    }
-  );
+  MockApiClient.addMockResponse({
+    url: `/organizations/${organization.slug}/sessions/`,
+    body: TestStubs.UserTotalCountByReleaseIn24h(),
+    match: [
+      MockApiClient.matchQuery({
+        query:
+          'release:7a82c130be9143361f20bc77252df783cf91e4fc OR release:e102abb2c46e7fe8686441091005c12aed90da99',
+        interval: '1h',
+        statsPeriod: '24h',
+        project: [projectId],
+        field: ['count_unique(user)'],
+        groupBy: ['project', 'release'],
+      }),
+    ],
+  });
 
-  MockApiClient.addMockResponse(
-    {
-      url: `/organizations/org-slug/sessions/`,
-      body: TestStubs.UserTotalCountByProjectIn24h(),
-    },
-    {
-      predicate(_url, {query}) {
-        return isEqual(query, {
-          query: undefined,
-          interval: '1h',
-          statsPeriod: '24h',
-          project: [projectId],
-          field: ['count_unique(user)'],
-          groupBy: ['project'],
-        });
-      },
-    }
-  );
+  MockApiClient.addMockResponse({
+    url: `/organizations/org-slug/sessions/`,
+    body: TestStubs.UserTotalCountByProjectIn24h(),
+    match: [
+      MockApiClient.matchQuery({
+        query: undefined,
+        interval: '1h',
+        statsPeriod: '24h',
+        project: [projectId],
+        field: ['count_unique(user)'],
+        groupBy: ['project'],
+      }),
+    ],
+  });
 
   it('calculates correct session health data', async function () {
     let healthData;


### PR DESCRIPTION
Replace the deprecated `predicate` option with the new `match` option. This helps improve the readability of tests without sacrificing the custom logic used in performance tests.