### PR TITLE
fix(insights): Change issue breakdown and time to resolution endpoints to filter to assigned groups (WOR-1478)

### DIFF
--- a/src/sentry/api/endpoints/team_time_to_resolution.py
+++ b/src/sentry/api/endpoints/team_time_to_resolution.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
-from sentry.models import GroupHistory, GroupHistoryStatus, Project
+from sentry.models import GroupHistory, GroupHistoryStatus
 
 
 class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
@@ -16,14 +16,13 @@ class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
         """
         Return a a time bucketed list of mean group resolution times for a given team.
         """
-        project_list = Project.objects.get_for_team_ids(team_ids=[team.id])
         start, end = get_date_range_from_params(request.GET)
         end = end.date() + timedelta(days=1)
         start = start.date() + timedelta(days=1)
         history_list = (
-            GroupHistory.objects.filter(
+            GroupHistory.objects.filter_to_team(team)
+            .filter(
                 status=GroupHistoryStatus.RESOLVED,
-                project__in=project_list,
                 date_added__gte=start,
                 date_added__lte=end,
             )

--- a/tests/sentry/api/endpoints/test_team_issue_breakdown.py
+++ b/tests/sentry/api/endpoints/test_team_issue_breakdown.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from sentry.models import GroupHistory, GroupHistoryStatus
+from sentry.models import GroupAssignee, GroupHistory, GroupHistoryStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -18,6 +18,8 @@ class TeamIssueBreakdownTest(APITestCase):
         project2 = self.create_project(teams=[self.team], slug="bar")
         group1 = self.create_group(checksum="a" * 32, project=project1, times_seen=10)
         group2 = self.create_group(checksum="b" * 32, project=project2, times_seen=5)
+        GroupAssignee.objects.assign(group1, self.user)
+        GroupAssignee.objects.assign(group2, self.user)
 
         GroupHistory.objects.create(
             organization=self.organization,

--- a/tests/sentry/api/endpoints/test_team_time_to_resolution.py
+++ b/tests/sentry/api/endpoints/test_team_time_to_resolution.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from sentry.models import GroupHistoryStatus
+from sentry.models import GroupAssignee, GroupHistoryStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -19,6 +19,8 @@ class TeamTimeToResolutionTest(APITestCase):
         group2 = self.create_group(
             checksum="b" * 32, project=project2, times_seen=5, first_seen=before_now(days=20)
         )
+        GroupAssignee.objects.assign(group1, self.user)
+        GroupAssignee.objects.assign(group2, self.user)
 
         gh1 = self.create_group_history(
             group1,

--- a/tests/sentry/models/test_grouphistory.py
+++ b/tests/sentry/models/test_grouphistory.py
@@ -1,5 +1,23 @@
-from sentry.models import GroupHistoryStatus, get_prev_history
+from sentry.models import GroupAssignee, GroupHistory, GroupHistoryStatus, get_prev_history
 from sentry.testutils import TestCase
+
+
+class FilterToTeamTest(TestCase):
+    def test(self):
+        other_org = self.create_organization()
+        other_team = self.create_team(other_org, members=[self.user])
+        other_project = self.create_project(organization=other_org, teams=[other_team])
+        GroupAssignee.objects.assign(self.group, self.user)
+
+        history = GroupHistory.objects.filter(group=self.group).get()
+        other_group = self.store_event(data={}, project_id=other_project.id).group
+        GroupAssignee.objects.assign(other_group, self.user)
+        other_history = GroupHistory.objects.filter(group=other_group).get()
+
+        # Even though the user is a member of both orgs, and is assigned to both groups, we should
+        # filter down to just the history that each team has access to here.
+        assert list(GroupHistory.objects.filter_to_team(self.team)) == [history]
+        assert list(GroupHistory.objects.filter_to_team(other_team)) == [other_history]
 
 
 class GetPrevHistoryTest(TestCase):

--- a/tests/sentry/models/test_grouphistory.py
+++ b/tests/sentry/models/test_grouphistory.py
@@ -4,20 +4,24 @@ from sentry.testutils import TestCase
 
 class FilterToTeamTest(TestCase):
     def test(self):
+        GroupAssignee.objects.assign(self.group, self.user)
+        proj_1_group_2 = self.store_event(data={}, project_id=self.project.id).group
+        GroupAssignee.objects.assign(self.group, self.team)
+        history = set(GroupHistory.objects.filter(group__in=[self.group, proj_1_group_2]))
+
         other_org = self.create_organization()
         other_team = self.create_team(other_org, members=[self.user])
         other_project = self.create_project(organization=other_org, teams=[other_team])
-        GroupAssignee.objects.assign(self.group, self.user)
-
-        history = GroupHistory.objects.filter(group=self.group).get()
         other_group = self.store_event(data={}, project_id=other_project.id).group
+        other_group_2 = self.store_event(data={}, project_id=other_project.id).group
         GroupAssignee.objects.assign(other_group, self.user)
-        other_history = GroupHistory.objects.filter(group=other_group).get()
+        GroupAssignee.objects.assign(other_group_2, other_team)
+        other_history = set(GroupHistory.objects.filter(group__in=[other_group, other_group_2]))
 
         # Even though the user is a member of both orgs, and is assigned to both groups, we should
         # filter down to just the history that each team has access to here.
-        assert list(GroupHistory.objects.filter_to_team(self.team)) == [history]
-        assert list(GroupHistory.objects.filter_to_team(other_team)) == [other_history]
+        assert set(GroupHistory.objects.filter_to_team(self.team)) == history
+        assert set(GroupHistory.objects.filter_to_team(other_team)) == other_history
 
 
 class GetPrevHistoryTest(TestCase):


### PR DESCRIPTION
Currently these endpoints just filter to groups that belong to projects that your team is associated
with. We'd prefer this to filter to groups that your team or team members are directly assigned to
instead.