### PR TITLE
ref(native-stack-trace-v2): Add more adjusts

### DIFF
--- a/static/app/components/events/interfaces/exceptionV2.tsx
+++ b/static/app/components/events/interfaces/exceptionV2.tsx
@@ -4,7 +4,6 @@ import {t} from 'app/locale';
 import {ExceptionType, Group, PlatformType, Project} from 'app/types';
 import {Event} from 'app/types/event';
 import {STACK_TYPE, STACK_VIEW} from 'app/types/stacktrace';
-import {defined} from 'app/utils';
 
 import TraceEventDataSection from '../traceEventDataSection';
 import {DisplayOption} from '../traceEventDataSection/displayOptions';
@@ -31,7 +30,7 @@ function Exception({
   hasHierarchicalGrouping,
   groupingCurrentLevel,
 }: Props) {
-  const eventHasThreads = !!event.entries.find(entry => entry.type === 'threads');
+  const eventHasThreads = !!event.entries.some(entry => entry.type === 'threads');
 
   /* in case there are threads in the event data, we don't render the
    exception block.  Instead the exception is contained within the
@@ -42,7 +41,7 @@ function Exception({
 
   function getPlatform(): PlatformType {
     const dataValue = data.values?.find(
-      value => !!value.stacktrace?.frames?.find(frame => !!frame.platform)
+      value => !!value.stacktrace?.frames?.some(frame => !!frame.platform)
     );
 
     if (dataValue) {
@@ -69,27 +68,26 @@ function Exception({
       recentFirst={isStacktraceNewestFirst()}
       fullStackTrace={!data.hasSystemFrames}
       platform={platform}
-      hasMinified={!!data.values?.find(value => value.rawStacktrace)}
+      hasMinified={!!data.values?.some(value => value.rawStacktrace)}
       hasVerboseFunctionNames={
-        !!data.values?.find(
+        !!data.values?.some(
           value =>
-            !!value.stacktrace?.frames?.find(
+            !!value.stacktrace?.frames?.some(
               frame =>
-                defined(frame.rawFunction) &&
-                defined(frame.function) &&
+                !!frame.rawFunction &&
+                !!frame.function &&
                 frame.rawFunction !== frame.function
             )
         )
       }
       hasAbsoluteFilePaths={
-        !!data.values?.find(
-          value => !!value.stacktrace?.frames?.find(frame => defined(frame.filename))
+        !!data.values?.some(
+          value => !!value.stacktrace?.frames?.some(frame => !!frame.filename)
         )
       }
       hasAbsoluteAddresses={
-        !!data.values?.find(
-          value =>
-            !!value.stacktrace?.frames?.find(frame => defined(frame.instructionAddr))
+        !!data.values?.some(
+          value => !!value.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
         )
       }
       hasAppOnlyFrames={
@@ -98,7 +96,7 @@ function Exception({
         )
       }
       hasNewestFirst={
-        !!data.values?.find(value => (value.stacktrace?.frames ?? []).length > 1)
+        !!data.values?.some(value => (value.stacktrace?.frames ?? []).length > 1)
       }
       stackTraceNotFound={stackTraceNotFound}
       showPermalink

--- a/static/app/components/events/interfaces/stackTraceV2.tsx
+++ b/static/app/components/events/interfaces/stackTraceV2.tsx
@@ -5,7 +5,6 @@ import {t} from 'app/locale';
 import {Group, PlatformType, Project} from 'app/types';
 import {Event} from 'app/types/event';
 import {STACK_TYPE, STACK_VIEW} from 'app/types/stacktrace';
-import {defined} from 'app/utils';
 
 import TraceEventDataSection from '../traceEventDataSection';
 import {DisplayOption} from '../traceEventDataSection/displayOptions';
@@ -58,15 +57,15 @@ function StackTrace({
       wrapTitle={false}
       hasMinified={false}
       hasVerboseFunctionNames={
-        !!data.frames?.find(
+        !!data.frames?.some(
           frame =>
-            defined(frame.rawFunction) &&
-            defined(frame.function) &&
+            !!frame.rawFunction &&
+            !!frame.function &&
             frame.rawFunction !== frame.function
         )
       }
-      hasAbsoluteFilePaths={!!data.frames?.find(frame => !!frame.filename)}
-      hasAbsoluteAddresses={!!data.frames?.find(frame => !!frame.instructionAddr)}
+      hasAbsoluteFilePaths={!!data.frames?.some(frame => !!frame.filename)}
+      hasAbsoluteAddresses={!!data.frames?.some(frame => !!frame.instructionAddr)}
       hasAppOnlyFrames={!!data.frames?.some(frame => frame.inApp !== true)}
       hasNewestFirst={(data.frames ?? []).length > 1}
       showPermalink

--- a/static/app/components/events/interfaces/threadsV2.tsx
+++ b/static/app/components/events/interfaces/threadsV2.tsx
@@ -9,7 +9,6 @@ import {Frame, PlatformType, Project} from 'app/types';
 import {Event} from 'app/types/event';
 import {Thread} from 'app/types/events';
 import {STACK_TYPE, STACK_VIEW} from 'app/types/stacktrace';
-import {defined} from 'app/utils';
 
 import TraceEventDataSection from '../traceEventDataSection';
 import {DisplayOption} from '../traceEventDataSection/displayOptions';
@@ -223,33 +222,31 @@ function Threads({
         !!activeThread?.rawStacktrace
       }
       hasVerboseFunctionNames={
-        !!exception?.values?.find(
+        !!exception?.values?.some(
           value =>
-            !!value.stacktrace?.frames?.find(
+            !!value.stacktrace?.frames?.some(
               frame =>
-                defined(frame.rawFunction) &&
-                defined(frame.function) &&
+                !!frame.rawFunction &&
+                !!frame.function &&
                 frame.rawFunction !== frame.function
             )
         ) ||
-        !!activeThread?.stacktrace?.frames?.find(
+        !!activeThread?.stacktrace?.frames?.some(
           frame =>
-            defined(frame.rawFunction) &&
-            defined(frame.function) &&
+            !!frame.rawFunction &&
+            !!frame.function &&
             frame.rawFunction !== frame.function
         )
       }
       hasAbsoluteFilePaths={
-        !!exception?.values?.find(
-          value => !!value.stacktrace?.frames?.find(frame => defined(frame.filename))
-        ) || !!activeThread?.stacktrace?.frames?.find(frame => defined(frame.filename))
+        !!exception?.values?.some(
+          value => !!value.stacktrace?.frames?.some(frame => !!frame.filename)
+        ) || !!activeThread?.stacktrace?.frames?.some(frame => !!frame.filename)
       }
       hasAbsoluteAddresses={
-        !!exception?.values?.find(
-          value =>
-            !!value.stacktrace?.frames?.find(frame => defined(frame.instructionAddr))
-        ) ||
-        !!activeThread?.stacktrace?.frames?.find(frame => defined(frame.instructionAddr))
+        !!exception?.values?.some(
+          value => !!value.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
+        ) || !!activeThread?.stacktrace?.frames?.some(frame => !!frame.instructionAddr)
       }
       hasAppOnlyFrames={
         !!exception?.values?.some(
@@ -257,7 +254,7 @@ function Threads({
         ) || !!activeThread?.stacktrace?.frames?.some(frame => frame.inApp !== true)
       }
       hasNewestFirst={
-        !!exception?.values?.find(value => (value.stacktrace?.frames ?? []).length > 1) ||
+        !!exception?.values?.some(value => (value.stacktrace?.frames ?? []).length > 1) ||
         (activeThread?.stacktrace?.frames ?? []).length > 1
       }
       stackTraceNotFound={stackTraceNotFound}

--- a/static/app/components/events/traceEventDataSection/index.tsx
+++ b/static/app/components/events/traceEventDataSection/index.tsx
@@ -234,16 +234,13 @@ const RawToggler = styled(BooleanField)`
 
 const RawContentWrapper = styled('div')`
   display: grid;
-  grid-template-columns: max-content;
+  grid-auto-flow: column;
   justify-content: flex-end;
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    grid-gap: ${space(1)};
-    grid-template-columns: repeat(2, max-content);
-  }
 `;
 
 const LargeScreenDownloadButton = styled(Button)`
   display: none;
+  margin-left: ${space(1)};
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     display: block;
   }

--- a/static/app/components/events/traceEventDataSection/index.tsx
+++ b/static/app/components/events/traceEventDataSection/index.tsx
@@ -234,9 +234,12 @@ const RawToggler = styled(BooleanField)`
 
 const RawContentWrapper = styled('div')`
   display: grid;
-  grid-template-columns: repeat(2, max-content);
+  grid-template-columns: max-content;
   justify-content: flex-end;
-  grid-gap: ${space(1)};
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-gap: ${space(1)};
+    grid-template-columns: repeat(2, max-content);
+  }
 `;
 
 const LargeScreenDownloadButton = styled(Button)`


### PR DESCRIPTION
- [x] Replace js `.find` with `.some` because it makes more sense
- [x] Remove the usage of the utility function `defined`, because that is not really necessary `!!null` equals false, `!!'' equals` false and` !!undefined` equals false and `!!'something'` equals true
- [x]  Add extra grid column + gap to the RawContentWrapper only on larger devices, otherwise, a small empty space is shown in the UI

**Before:**
![image](https://user-images.githubusercontent.com/29228205/141764124-ac0159bf-2b6d-42d9-af3f-53eba3115997.png)

**After:**

![image](https://user-images.githubusercontent.com/29228205/141764207-510318b1-d629-4bde-8b2d-70f0e5551301.png)

