### PR TITLE
fix(discover): Disabled widgetCard lazy load on Add Widget Modal

### DIFF
--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -549,6 +549,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
             }
             isSorting={false}
             currentWidgetDragging={false}
+            noLazyLoad
           />
         </Body>
         <Footer>


### PR DESCRIPTION
Fixes an issue with widgetCards not rendering on the Add Widget Modal when viewed in a smaller screen.

Lazy loading component doesn't render the widget chart if it is off screen in the modal. Scrolling should trigger loading but it doesn't because the Modal container itself doesn't detect any scroll events. Added a `noLazyLoad` prop to just disable lazy loading for the Add Widget Modal. Alternatively, we could have probably passed in a `scrollContainer` prop LazyLoad instead to detect scrolls on the window but this fix seemed simpler.

Also added `resize` to LazyLoad to load widgetCharts when a screen resize would display the container.