### PR TITLE
fix(metric_alerts): Fix bug where an existing metric alert couldn't unassign owner

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -554,7 +554,7 @@ def update_alert_rule(
     dataset=None,
     projects=None,
     name=None,
-    owner=None,
+    owner=NOT_SET,
     query=None,
     aggregate=None,
     time_window=None,
@@ -626,8 +626,10 @@ def update_alert_rule(
         updated_query_fields["dataset"] = dataset
     if event_types is not None:
         updated_query_fields["event_types"] = event_types
-    if owner is not None:
-        updated_fields["owner"] = owner.resolve_to_actor()
+    if owner is not NOT_SET:
+        if owner is not None:
+            owner = owner.resolve_to_actor()
+        updated_fields["owner"] = owner
     if comparison_delta is not NOT_SET:
         resolution = DEFAULT_ALERT_RULE_RESOLUTION
         if comparison_delta is not None:

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -393,9 +393,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         alert_rule.refresh_from_db()
         assert resp.data == serialize(alert_rule, self.user)
-        assert (
-            resp.data["owner"] == self.user.actor.get_actor_identifier()
-        )  # Doesn't unassign yet - TDB in future though
+        assert resp.data["owner"] is None
 
     def test_team_permission(self):
         # Test ensures you can only edit alerts owned by your team or no one.

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -417,9 +417,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         alert_rule.refresh_from_db()
         alert_rule.snuba_query.refresh_from_db()
         assert resp.data == serialize(alert_rule, self.user)
-        assert (
-            resp.data["owner"] == self.user.actor.get_actor_identifier()
-        )  # Doesn't unassign yet - TDB in future though
+        assert resp.data["owner"] is None
 
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -845,6 +845,12 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         assert alert_rule.owner.id == self.user.actor.id
 
+        update_alert_rule(
+            alert_rule=alert_rule,
+            owner=None,
+        )
+        assert alert_rule.owner is None
+
     def test_comparison_delta(self):
         comparison_delta = 60
 


### PR DESCRIPTION
When updating a metric alert rule, setting owner to unassigned would silently fail and just leave
the existing owner in place.