### PR TITLE
feat(growth): add prompt activity for trial highlights

### DIFF
--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -11,6 +11,8 @@ DEFAULT_PROMPTS = {
     "distributed_tracing": {"required_fields": ["organization_id", "project_id"]},
     "quick_trace_missing": {"required_fields": ["organization_id", "project_id"]},
     "code_owners": {"required_fields": ["organization_id", "project_id"]},
+    "trial_started": {"required_fields": ["organization_id"]},
+    "trial_first_event": {"required_fields": ["organization_id"]},
 }
 
 


### PR DESCRIPTION
Added two prompt_activity types:
- `trial_started`: The sidebar highlight on trial start
- `trial_first_event`: The highlight on first event