### PR TITLE
feat(suspect-spans): Restrict global selection header to 30d on spans tab

### DIFF
--- a/static/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/static/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -149,6 +149,16 @@ type Props = {
    * Message to display at the bottom of project list
    */
   projectsFooterMessage?: React.ReactNode;
+
+  /**
+   * Override default relative date options from DEFAULT_RELATIVE_PERIODS
+   */
+  relativeDateOptions?: Record<string, React.ReactNode>;
+
+  /**
+   * The maximum number of days in the past you can pick
+   */
+  maxPickableDays?: number;
 } & Partial<typeof defaultProps> &
   Omit<WithRouterProps, 'router'> & {
     router: WithRouterProps['router'] | null;
@@ -290,6 +300,8 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
       disableMultipleProjectSelection,
       projectsFooterMessage,
       defaultSelection,
+      relativeDateOptions,
+      maxPickableDays,
     } = this.props;
 
     const {period, start, end, utc} = this.props.selection.datetime || {};
@@ -387,6 +399,8 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
                   organization={organization}
                   defaultPeriod={defaultPeriod}
                   hint={timeRangeHint}
+                  relativeOptions={relativeDateOptions}
+                  maxPickableDays={maxPickableDays}
                 />
               </HeaderItemPosition>
             </React.Fragment>

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -143,6 +143,11 @@ type Props = WithRouterProps & {
    * Set an optional default value to prefill absolute date with
    */
   defaultAbsolute?: {start?: Date; end?: Date};
+
+  /**
+   * The maximum number of days in the past you can pick
+   */
+  maxPickableDays?: number;
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -366,6 +371,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
       hint,
       label,
       relativeOptions,
+      maxPickableDays,
     } = this.props;
     const {start, end, relative} = this.state;
 
@@ -435,6 +441,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
                       utc={this.state.utc}
                       onChange={this.handleSelectDateRange}
                       onChangeUtc={this.handleUseUtc}
+                      maxPickableDays={maxPickableDays}
                     />
                     <SubmitRow>
                       <MultipleSelectorSubmitRow

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -45,6 +45,8 @@ type Props = {
   getDocumentTitle: (name: string) => string;
   generateEventView: (location: Location, transactionName: string) => EventView;
   childComponent: (props: ChildProps) => JSX.Element;
+  relativeDateOptions?: Record<string, ReactNode>;
+  maxPickableDays?: number;
   features?: string[];
 };
 
@@ -57,6 +59,8 @@ function PageLayout(props: Props) {
     getDocumentTitle,
     generateEventView,
     childComponent: ChildComponent,
+    relativeDateOptions,
+    maxPickableDays,
     features = [],
   } = props;
 
@@ -110,6 +114,8 @@ function PageLayout(props: Props) {
             specificProjectSlugs={defined(project) ? [project.slug] : []}
             disableMultipleProjectSelection
             showProjectSettingsLink
+            relativeDateOptions={relativeDateOptions}
+            maxPickableDays={maxPickableDays}
           >
             <StyledPageContent>
               <NoProjectMessage organization={organization}>

--- a/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/index.tsx
@@ -1,5 +1,7 @@
 import {Location} from 'history';
+import pick from 'lodash/pick';
 
+import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
@@ -14,6 +16,14 @@ import Tab from '../tabs';
 import SpansContent from './content';
 import {SpanSortOthers, SpanSortPercentiles} from './types';
 import {getSuspectSpanSortFromLocation} from './utils';
+
+const RELATIVE_PERIODS = pick(DEFAULT_RELATIVE_PERIODS, [
+  '1h',
+  '24h',
+  '7d',
+  '14d',
+  '30d',
+]);
 
 type Props = {
   location: Location;
@@ -33,6 +43,8 @@ function TransactionSpans(props: Props) {
       getDocumentTitle={getDocumentTitle}
       generateEventView={generateEventView}
       childComponent={SpansContent}
+      relativeDateOptions={RELATIVE_PERIODS}
+      maxPickableDays={30}
     />
   );
 }


### PR DESCRIPTION
Span data only has a 30 day retention. This restricts the global selection
header on the spans tab to only allow selecting the last 30 days.

Depends on getsentry/getsentry#6621