### PR TITLE
ref(symbolicator): Handle cases where realtime metrics isn't available at all

### DIFF
--- a/src/sentry/tasks/symbolication.py
+++ b/src/sentry/tasks/symbolication.py
@@ -73,9 +73,14 @@ def should_demote_symbolication(project_id: int) -> bool:
     elif always_lowpri:
         return True
     else:
-        return settings.SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE and realtime_metrics.is_lpq_project(
-            project_id
-        )
+        try:
+            return (
+                settings.SENTRY_ENABLE_AUTO_LOW_PRIORITY_QUEUE
+                and realtime_metrics.is_lpq_project(project_id)
+            )
+        # realtime_metrics is empty in getsentry
+        except AttributeError:
+            return False
 
 
 def submit_symbolicate(


### PR DESCRIPTION
https://github.com/getsentry/getsentry/pull/6617 needs this for its tests to pass. `realtime_metrics` is empty when run in getsentry test environments. I assume on-prem instances will be bumping into the same issue, so just act as if the LPQ is permanently off when this happens.