### PR TITLE
fix(ui): Fix alertThreshold resolveThreshold comparison in alert builder

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/alerts/incidentRules/ruleForm/index.tsx
@@ -251,8 +251,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     // without modifying the values, this boundary case will fail.
     const isValid =
       thresholdType === AlertRuleThresholdType.BELOW
-        ? alertThreshold - 1 <= resolveThreshold + 1
-        : alertThreshold + 1 >= resolveThreshold - 1;
+        ? alertThreshold - 1 < resolveThreshold + 1
+        : alertThreshold + 1 > resolveThreshold - 1;
 
     const otherErrors = errors.get(triggerIndex) || {};
 


### PR DESCRIPTION
This fixes an issue in the metric alert builder where you can set alert thresholds that intersect incorrectly
Right now these are fine:
`critical: > 20
warning: > 10
resolve: < 11`
`critical: > 20
warning: > 10
resolve: < 12`

But this is not:
`critical: > 20
warning: > 10
resolve: < 13`

It should be that this should be fine:
`critical: > 20
warning: > 10
resolve: < 11`

These should not:
`critical: > 20
warning: > 10
resolve: < 12`
`critical: > 20
warning: > 10
resolve: < 13`