### PR TITLE
fix(stacktrace-linking): Swallow Identity error

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -47,9 +47,9 @@ class GitLabSetupClient(ApiClient):
     integration_name = "gitlab_setup"
 
     def __init__(self, base_url, access_token, verify_ssl):
+        super().__init__(verify_ssl)
         self.base_url = base_url
         self.token = access_token
-        self.verify_ssl = verify_ssl
 
     def get_group(self, group):
         """Get a group based on `path` which is a slug.

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -6,7 +6,7 @@ from sentry_sdk import configure_scope
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
-from sentry.models import Repository
+from sentry.models import Identity, Repository
 from sentry.shared_integrations.exceptions import ApiError
 
 
@@ -34,8 +34,12 @@ class RepositoryMixin:
         """
         filepath = filepath.lstrip("/")
         try:
-            resp = self.get_client().check_file(repo, filepath, branch)
-            if resp is None:
+            client = self.get_client()
+        except Identity.DoesNotExist:
+            return None
+        try:
+            response = client.check_file(repo, filepath, branch)
+            if response is None:
                 return None
         except IdentityNotValid:
             return None


### PR DESCRIPTION
When there is no default identity for an organization, we're raising an error. This PR swallows the error.