### PR TITLE
fix(typing): Bad import

### DIFF
--- a/src/sentry/db/models/manager/__init__.py
+++ b/src/sentry/db/models/manager/__init__.py
@@ -5,7 +5,7 @@ from django.utils.encoding import smart_text
 
 from sentry.utils.hashlib import md5_text
 
-__all__ = ("BaseManager", "BaseQuerySet", "OptionManager", "Value", "ValidateFunction")
+__all__ = ("BaseManager", "BaseQuerySet", "OptionManager", "M", "Value", "ValidateFunction")
 
 M = TypeVar("M", bound=Model)
 Value = Any

--- a/src/sentry/utils/email/list_resolver.py
+++ b/src/sentry/utils/email/list_resolver.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections import Mapping
-from typing import Callable, Generic, Iterable
+from typing import Callable, Generic, Iterable, Mapping
 
 from sentry.db.models import Model
 from sentry.db.models.manager import M


### PR DESCRIPTION
I accidentally imported `collection.Mapping` instead of `typing.Mapping`.