### PR TITLE
fix(ui): NavTab font size

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -111,7 +111,6 @@ export const HeaderNavTabs = styled(NavTabs)`
   }
   & > li > a {
     padding: ${space(1)} 0;
-    font-size: ${p => p.theme.fontSizeLarge};
     margin-bottom: 4px;
   }
   & > li.active > a {

--- a/static/less/shared-components.less
+++ b/static/less/shared-components.less
@@ -1168,7 +1168,6 @@ header + .alert {
     }
 
     > a {
-      font-size: 15px;
       padding: 0 0 10px;
       margin: 0;
       border: 0;


### PR DESCRIPTION
NavTabs should consistently use the default font size (16px). Due to a hard-coded value in `shared-components.less`, the font size is 15px in some views (e.g. Issue Details) and 16px in others. Removing this hard-coded value makes the font sizes consistent.

<img width="589" alt="Screen Shot 2021-11-15 at 3 02 09 PM" src="https://user-images.githubusercontent.com/44172267/141866331-18ed9def-3e7a-4d93-b649-eccd7a1d05fa.png">