### PR TITLE
fix(ui): Use gray300 for project chart labels

### DIFF
--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -105,7 +105,6 @@ class ProjectBaseEventsChart extends Component<Props> {
             grid: {left: '10px', right: '10px', top: '40px', bottom: '0px'},
             yAxis: {
               axisLabel: {
-                color: theme.gray200,
                 formatter: (value: number) => axisLabelFormatter(value, yAxis),
               },
               scale: true,

--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -1,5 +1,4 @@
 import {Component} from 'react';
-import {withTheme} from '@emotion/react';
 import * as Sentry from '@sentry/react';
 
 import {fetchTotalCount} from 'app/actionCreators/events';
@@ -12,7 +11,6 @@ import {t} from 'app/locale';
 import {GlobalSelection} from 'app/types';
 import {axisLabelFormatter} from 'app/utils/discover/charts';
 import getDynamicText from 'app/utils/getDynamicText';
-import {Theme} from 'app/utils/theme';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 type Props = Omit<
@@ -22,7 +20,6 @@ type Props = Omit<
   title: string;
   selection: GlobalSelection;
   onTotalValuesChange: (value: number | null) => void;
-  theme: Theme;
   help?: string;
   yAxis: string;
 };
@@ -67,7 +64,6 @@ class ProjectBaseEventsChart extends Component<Props> {
       query,
       field,
       title,
-      theme,
       help,
       ...eventsChartProps
     } = this.props;
@@ -117,4 +113,4 @@ class ProjectBaseEventsChart extends Component<Props> {
   }
 }
 
-export default withGlobalSelection(withTheme(ProjectBaseEventsChart));
+export default withGlobalSelection(ProjectBaseEventsChart);

--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -249,7 +249,7 @@ class Chart extends Component<ChartProps, ChartState> {
   }
 
   get chartOptions() {
-    const {theme, displayMode} = this.props;
+    const {displayMode} = this.props;
 
     return {
       grid: {left: '10px', right: '10px', top: '40px', bottom: '0px'},

--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -275,7 +275,6 @@ class Chart extends Component<ChartProps, ChartState> {
         displayMode === DisplayModes.STABILITY
           ? {
               axisLabel: {
-                color: theme.gray200,
                 formatter: (value: number) => displayCrashFreePercent(value),
               },
               scale: true,


### PR DESCRIPTION
** This is a visual fix accompanying #29917

Gray 200 is not an accessible text color. We should use Gray 300 instead.

Before:
<img width="131" alt="Screen Shot 2021-11-15 at 3 42 06 PM" src="https://user-images.githubusercontent.com/44172267/141869960-cd9a08a6-4acb-4407-9a27-219211bcc470.png">

After:
<img width="131" alt="Screen Shot 2021-11-15 at 3 42 35 PM" src="https://user-images.githubusercontent.com/44172267/141870006-65a03bb4-5f26-424d-ac97-127df8edf317.png">


