### PR TITLE
ref(github): Use client for installations instead of manually calling API

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -208,7 +208,7 @@ class GitHubIntegrationProvider(IntegrationProvider):
             "Accept": "application/vnd.github.machine-man-preview+json",
         }
         headers.update(jwt.authorization_header(get_jwt()))
-        resp = client.get(headers=headers, path=f"/app/installations/{installation_id}")
+        resp = client.get(f"/app/installations/{installation_id}", headers=headers)
 
         return resp
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -208,12 +208,9 @@ class GitHubIntegrationProvider(IntegrationProvider):
             "Accept": "application/vnd.github.machine-man-preview+json",
         }
         headers.update(jwt.authorization_header(get_jwt()))
-        resp = client.request(
-            method="GET", headers=headers, path=f"/app/installations/{installation_id}34"
-        )
-        installation_resp = resp.json()
+        resp = client.get(headers=headers, path=f"/app/installations/{installation_id}")
 
-        return installation_resp
+        return resp
 
     def build_integration(self, state):
         installation = self.get_installation_info(state["installation_id"])

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -5,7 +5,7 @@ import re
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import http, options
+from sentry import options
 from sentry.integrations import (
     FeatureDescription,
     IntegrationFeatures,
@@ -179,6 +179,9 @@ class GitHubIntegrationProvider(IntegrationProvider):
 
     setup_dialog_config = {"width": 1030, "height": 1000}
 
+    def get_client(self):
+        return GitHubAppsClient(integration=self.integration_cls)
+
     def post_install(self, integration, organization, extra=None):
         repo_ids = Repository.objects.filter(
             organization_id=organization.id,
@@ -199,16 +202,15 @@ class GitHubIntegrationProvider(IntegrationProvider):
         return [GitHubInstallationRedirect()]
 
     def get_installation_info(self, installation_id):
+        client = self.get_client()
         headers = {
             # TODO(jess): remove this whenever it's out of preview
             "Accept": "application/vnd.github.machine-man-preview+json",
         }
         headers.update(jwt.authorization_header(get_jwt()))
-        with http.build_session() as session:
-            resp = session.get(
-                f"https://api.github.com/app/installations/{installation_id}", headers=headers
-            )
-            resp.raise_for_status()
+        resp = client.request(
+            method="GET", headers=headers, path=f"/app/installations/{installation_id}34"
+        )
         installation_resp = resp.json()
 
         return installation_resp


### PR DESCRIPTION
See [API-2241](https://getsentry.atlassian.net/browse/API-2241)

This PR will use the client for installations to ensure the tooling we have in place for recording errors is used when installs go wrong. The errors sent to Sentry will be APIErrors instead of HTTPErrors and will include the response from GH rather than swallowing it and just showing a response code.

**Before**

![image](https://user-images.githubusercontent.com/35509934/141877903-bd843e7d-cd05-4610-97c3-c301b60f02d6.png)


**After**

Using the client for errors, we generate smart `ApiError`s rather than raising the simple `HTTPError`s.

![image](https://user-images.githubusercontent.com/35509934/141877737-1134001d-e6cd-4281-83ad-0b8f679e4d9e.png)

Installations are still working

https://user-images.githubusercontent.com/35509934/141878830-dc9b2ef6-d843-4a90-9d26-6d4be2bc0d82.mov

**TODO**:
- [x] Test with another org
- [x] Record installation process still working
- [x] Fix any failing tests


