### PR TITLE
fix(dev): Install Command Line Tools when git is missing

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,6 +5,15 @@
 # If you'd like to override or set any custom environment variables, this .envrc will read a .env file at the end.
 set -e
 
+# Upgrading from Big Sur can give you this error and git not being available
+# xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools),
+# missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
+if [ "$(uname -s)" == "Darwin" ] && [ ! -f "/Library/Developer/CommandLineTools/usr/bin/git" ]; then
+    xcode-select --install
+    echo -e "$(tput setaf 1)\nERROR: Complete the interactive installation (10+ mins) of the Command Line Tools.$(tput sgr0)"
+    return 1
+fi
+
 SENTRY_ROOT="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd -P

--- a/.envrc
+++ b/.envrc
@@ -5,7 +5,8 @@
 # If you'd like to override or set any custom environment variables, this .envrc will read a .env file at the end.
 set -e
 
-# Upgrading from Big Sur can give you this error and git not being available
+# Upgrading Mac can uninstall the Command Line Tools, thus, removing our access to git
+# The message talks about xcrun, however, we can use the lack of git as a way to know that we need this
 # xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools),
 # missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
 if [ "$(uname -s)" == "Darwin" ] && [ ! -f "/Library/Developer/CommandLineTools/usr/bin/git" ]; then

--- a/.envrc
+++ b/.envrc
@@ -10,8 +10,8 @@ set -e
 # xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools),
 # missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun
 if [ "$(uname -s)" == "Darwin" ] && [ ! -f "/Library/Developer/CommandLineTools/usr/bin/git" ]; then
-    xcode-select --install
     echo -e "$(tput setaf 1)\nERROR: Complete the interactive installation (10+ mins) of the Command Line Tools.$(tput sgr0)"
+    xcode-select --install
     return 1
 fi
 


### PR DESCRIPTION
When upgrading Mac, it sometimes seems to remove the Command Line Tools, thus, git becomes unavailable.

This change helps developers to simply install the tools and not be confused about xcrun message.