### PR TITLE
fix(ui) Fix positioning of help popover in mobile layout

### DIFF
--- a/static/app/components/sidebar/help.tsx
+++ b/static/app/components/sidebar/help.tsx
@@ -6,6 +6,7 @@ import Hook from 'app/components/hook';
 import SidebarItem from 'app/components/sidebar/sidebarItem';
 import {IconQuestion} from 'app/icons';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 import {Organization} from 'app/types';
 
 import SidebarDropdownMenu from './sidebarDropdownMenu.styled';
@@ -33,7 +34,7 @@ const SidebarHelp = ({orientation, collapsed, hidePanel, organization}: Props) =
         </HelpActor>
 
         {isOpen && (
-          <HelpMenu {...getMenuProps({})}>
+          <HelpMenu {...getMenuProps({})} orientation={orientation}>
             <SidebarMenuItem
               data-test-id="search-docs-and-faqs"
               onClick={() => openHelpSearchModal({organization})}
@@ -62,7 +63,9 @@ const HelpRoot = styled('div')`
 // how refs are handled.
 const HelpActor = styled('div')``;
 
-const HelpMenu = styled('div')`
+const HelpMenu = styled('div', {shouldForwardProp: p => p !== 'orientation'})<{
+  orientation: Props['orientation'];
+}>`
   ${SidebarDropdownMenu};
-  bottom: 100%;
+  ${p => (p.orientation === 'left' ? 'bottom: 100%' : `top: ${space(4)}; right: 0px;`)}
 `;


### PR DESCRIPTION
Position menu so it is in the viewport.

![Screen Shot 2021-11-16 at 4 33 36 PM](https://user-images.githubusercontent.com/24086/142069347-779371a2-a9b2-4c92-9b66-2e4dbbf9fd9d.png)

Fixes #29986