### PR TITLE
fix(bitbucket): Identity.DoesNotExist

### DIFF
--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -1,27 +1,16 @@
-import logging
-
 from sentry.app import locks
-from sentry.models import Integration, OrganizationOption
+from sentry.models import OrganizationOption
 from sentry.models.apitoken import generate_token
-from sentry.plugins import providers
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
 from .webhook import parse_raw_user_email, parse_raw_user_name
 
 
-class BitbucketRepositoryProvider(providers.IntegrationRepositoryProvider):
+class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
     name = "Bitbucket"
-    logger = logging.getLogger("sentry.integrations.bitbucket")
-
-    def get_installation(self, integration_id, organization_id):
-        if integration_id is None:
-            raise IntegrationError("Bitbucket requires an integration id.")
-        integration_model = Integration.objects.get(
-            id=integration_id, organizations=organization_id, provider="bitbucket"
-        )
-
-        return integration_model.get_installation(organization_id)
+    repo_provider = "bitbucket"
 
     def get_repository_data(self, organization, config):
         installation = self.get_installation(config.get("installation"), organization.id)

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -3,9 +3,8 @@ from sentry.models import OrganizationOption
 from sentry.models.apitoken import generate_token
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils.email import parse_email, parse_user_name
 from sentry.utils.http import absolute_uri
-
-from .webhook import parse_raw_user_email, parse_raw_user_name
 
 
 class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
@@ -80,8 +79,8 @@ class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
             {
                 "id": c["hash"],
                 "repository": repo.name,
-                "author_email": parse_raw_user_email(c["author"]["raw"]),
-                "author_name": parse_raw_user_name(c["author"]["raw"]),
+                "author_email": parse_email(c["author"]["raw"]),
+                "author_name": parse_user_name(c["author"]["raw"]),
                 "message": c["message"],
                 "timestamp": self.format_date(c["date"]),
                 "patch_set": c.get("patch_set"),

--- a/src/sentry/integrations/bitbucket/urls.py
+++ b/src/sentry/integrations/bitbucket/urls.py
@@ -11,7 +11,9 @@ urlpatterns = [
     url(r"^installed/$", BitbucketInstalledEndpoint.as_view()),
     url(r"^uninstalled/$", BitbucketUninstalledEndpoint.as_view()),
     url(
-        r"^organizations/(?P<organization_id>[^\/]+)/webhook/$", BitbucketWebhookEndpoint.as_view()
+        r"^organizations/(?P<organization_id>[^\/]+)/webhook/$",
+        BitbucketWebhookEndpoint.as_view(),
+        name="sentry-extensions-bitbucket-webhook",
     ),
     url(
         r"^search/(?P<organization_slug>[^\/]+)/(?P<integration_id>\d+)/$",

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -137,7 +137,7 @@ class BitbucketWebhookEndpoint(View):
             organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:
             logger.error(
-                PROVIDER_NAME + ".webhook.invalid-organization",
+                f"{PROVIDER_NAME}.webhook.invalid-organization",
                 extra={"organization_id": organization_id},
             )
             return HttpResponse(status=400)
@@ -145,7 +145,7 @@ class BitbucketWebhookEndpoint(View):
         body = bytes(request.body)
         if not body:
             logger.error(
-                PROVIDER_NAME + ".webhook.missing-body", extra={"organization_id": organization.id}
+                f"{PROVIDER_NAME}.webhook.missing-body", extra={"organization_id": organization.id}
             )
             return HttpResponse(status=400)
 
@@ -153,7 +153,7 @@ class BitbucketWebhookEndpoint(View):
             handler = self.get_handler(request.META["HTTP_X_EVENT_KEY"])
         except KeyError:
             logger.error(
-                PROVIDER_NAME + ".webhook.missing-event", extra={"organization_id": organization.id}
+                f"{PROVIDER_NAME}.webhook.missing-event", extra={"organization_id": organization.id}
             )
             return HttpResponse(status=400)
 
@@ -170,7 +170,7 @@ class BitbucketWebhookEndpoint(View):
 
         if not valid_ip and address_string not in BITBUCKET_IPS:
             logger.error(
-                PROVIDER_NAME + ".webhook.invalid-ip-range",
+                f"{PROVIDER_NAME}.webhook.invalid-ip-range",
                 extra={"organization_id": organization.id},
             )
             return HttpResponse(status=401)
@@ -179,7 +179,7 @@ class BitbucketWebhookEndpoint(View):
             event = json.loads(body.decode("utf-8"))
         except json.JSONDecodeError:
             logger.error(
-                PROVIDER_NAME + ".webhook.invalid-json",
+                f"{PROVIDER_NAME}.webhook.invalid-json",
                 extra={"organization_id": organization.id},
                 exc_info=True,
             )

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -1,7 +1,7 @@
 import ipaddress
 import logging
 
-import dateutil.parser
+from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
@@ -97,9 +97,7 @@ class PushEventWebhook(Webhook):
                             key=commit["hash"],
                             message=commit["message"],
                             author=author,
-                            date_added=dateutil.parser.parse(commit["date"]).astimezone(
-                                timezone.utc
-                            ),
+                            date_added=parse_date(commit["date"]).astimezone(timezone.utc),
                         )
 
                 except IntegrityError:

--- a/src/sentry/integrations/bitbucket/webhook.py
+++ b/src/sentry/integrations/bitbucket/webhook.py
@@ -1,6 +1,5 @@
 import ipaddress
 import logging
-import re
 
 import dateutil.parser
 from django.db import IntegrityError, transaction
@@ -14,23 +13,11 @@ from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCK
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.utils import json
+from sentry.utils.email import parse_email
 
 logger = logging.getLogger("sentry.webhooks")
 
 PROVIDER_NAME = "integrations:bitbucket"
-
-
-def parse_raw_user_email(raw):
-    # captures content between angle brackets
-    match = re.search("(?<=<).*(?=>$)", raw)
-    if match is None:
-        return
-    return match.group(0)
-
-
-def parse_raw_user_name(raw):
-    # captures content before angle bracket
-    return raw.split("<")[0].strip()
 
 
 class Webhook:
@@ -87,7 +74,7 @@ class PushEventWebhook(Webhook):
                 if IntegrationRepositoryProvider.should_ignore_commit(commit["message"]):
                     continue
 
-                author_email = parse_raw_user_email(commit["author"]["raw"])
+                author_email = parse_email(commit["author"]["raw"])
 
                 # TODO(dcramer): we need to deal with bad values here, but since
                 # its optional, lets just throw it out for now

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -1,29 +1,18 @@
-import logging
 from datetime import datetime
 
 from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 
-from sentry.models.integration import Integration
 from sentry.plugins.providers.integration_repository import IntegrationRepositoryProvider
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.hashlib import md5_text
 from sentry.utils.http import absolute_uri
 
 
 class BitbucketServerRepositoryProvider(IntegrationRepositoryProvider):
     name = "Bitbucket Server"
-    logger = logging.getLogger("sentry.integrations.bitbucket_server")
-
-    def get_installation(self, integration_id, organization_id):
-        if integration_id is None:
-            raise IntegrationError("Bitbucket Server requires an integration id.")
-        integration_model = Integration.objects.get(
-            id=integration_id, organizations=organization_id, provider="bitbucket_server"
-        )
-
-        return integration_model.get_installation(organization_id)
+    repo_provider = "bitbucket_server"
 
     def get_repository_data(self, organization, config):
         installation = self.get_installation(config.get("installation"), organization.id)

--- a/src/sentry/integrations/bitbucket_server/webhook.py
+++ b/src/sentry/integrations/bitbucket_server/webhook.py
@@ -115,7 +115,7 @@ class BitbucketServerWebhookEndpoint(View):
             organization = Organization.objects.get_from_cache(id=organization_id)
         except Organization.DoesNotExist:
             logger.error(
-                PROVIDER_NAME + ".webhook.invalid-organization",
+                f"{PROVIDER_NAME}.webhook.invalid-organization",
                 extra={"organization_id": organization_id, "integration_id": integration_id},
             )
             return HttpResponse(status=400)
@@ -123,7 +123,7 @@ class BitbucketServerWebhookEndpoint(View):
         body = bytes(request.body)
         if not body:
             logger.error(
-                PROVIDER_NAME + ".webhook.missing-body", extra={"organization_id": organization.id}
+                f"{PROVIDER_NAME}.webhook.missing-body", extra={"organization_id": organization.id}
             )
             return HttpResponse(status=400)
 
@@ -131,7 +131,7 @@ class BitbucketServerWebhookEndpoint(View):
             handler = self.get_handler(request.META["HTTP_X_EVENT_KEY"])
         except KeyError:
             logger.error(
-                PROVIDER_NAME + ".webhook.missing-event",
+                f"{PROVIDER_NAME}.webhook.missing-event",
                 extra={"organization_id": organization.id, "integration_id": integration_id},
             )
             return HttpResponse(status=400)
@@ -143,7 +143,7 @@ class BitbucketServerWebhookEndpoint(View):
             event = json.loads(body.decode("utf-8"))
         except json.JSONDecodeError:
             logger.error(
-                PROVIDER_NAME + ".webhook.invalid-json",
+                f"{PROVIDER_NAME}.webhook.invalid-json",
                 extra={"organization_id": organization.id, "integration_id": integration_id},
                 exc_info=True,
             )

--- a/src/sentry/integrations/custom_scm/repository.py
+++ b/src/sentry/integrations/custom_scm/repository.py
@@ -1,16 +1,14 @@
-import logging
-
 from django.http import Http404
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
 from sentry.models import Integration, Repository
-from sentry.plugins import providers
+from sentry.plugins.providers import IntegrationRepositoryProvider
 
 
-class CustomSCMRepositoryProvider(providers.IntegrationRepositoryProvider):
+class CustomSCMRepositoryProvider(IntegrationRepositoryProvider):
     name = "CustomSCM"
-    logger = logging.getLogger("sentry.integrations.custom_scm")
+    repo_provider = "custom_scm"
 
     def repository_external_slug(self, repo):
         return repo.name

--- a/src/sentry/integrations/example/repository.py
+++ b/src/sentry/integrations/example/repository.py
@@ -1,13 +1,11 @@
-import logging
-
 from sentry.models import Integration
-from sentry.plugins import providers
+from sentry.plugins.providers import IntegrationRepositoryProvider
 from sentry.shared_integrations.exceptions import IntegrationError
 
 
-class ExampleRepositoryProvider(providers.IntegrationRepositoryProvider):
+class ExampleRepositoryProvider(IntegrationRepositoryProvider):
     name = "Example"
-    logger = logging.getLogger("sentry.integrations.example")
+    repo_provider = "example"
 
     def compare_commits(self, repo, start_sha, end_sha):
         installation = Integration.objects.get(id=repo.integration_id).get_installation(

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -17,7 +17,7 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
         try:
             repo_data = client.get_repo(repo)
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
 
         try:
             # make sure installation has access to this specific repo
@@ -77,7 +77,7 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider):
                     client.get_token(force_refresh=True)
                     return eval_commits(client)
                 except Exception as e:
-                    installation.raise_error(e)
+                    raise installation.raise_error(e)
             installation.raise_error(e)
         except Exception as e:
             installation.raise_error(e)

--- a/src/sentry/integrations/github/webhook.py
+++ b/src/sentry/integrations/github/webhook.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import logging
 
-import dateutil.parser
+from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
 from django.http import HttpResponse
 from django.utils import timezone
@@ -279,9 +279,7 @@ class PushEventWebhook(Webhook):
                         key=commit["id"],
                         message=commit["message"],
                         author=author,
-                        date_added=dateutil.parser.parse(commit["timestamp"]).astimezone(
-                            timezone.utc
-                        ),
+                        date_added=parse_date(commit["timestamp"]).astimezone(timezone.utc),
                     )
                     for fname in commit["added"]:
                         CommitFileChange.objects.create(

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -1,5 +1,3 @@
-import logging
-
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models import Integration
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -9,7 +7,6 @@ WEBHOOK_EVENTS = ["push", "pull_request"]
 
 class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
     name = "GitHub Enterprise"
-    logger = logging.getLogger("sentry.integrations.github_enterprise")
     repo_provider = "github_enterprise"
 
     def _validate_repo(self, client, installation, repo):

--- a/src/sentry/integrations/github_enterprise/repository.py
+++ b/src/sentry/integrations/github_enterprise/repository.py
@@ -13,7 +13,7 @@ class GitHubEnterpriseRepositoryProvider(GitHubRepositoryProvider):
         try:
             repo_data = client.get_repo(repo)
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
 
         try:
             # make sure installation has access to this specific repo

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -1,23 +1,10 @@
-import logging
-
-from sentry.models import Integration
-from sentry.plugins import providers
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.plugins.providers import IntegrationRepositoryProvider
+from sentry.shared_integrations.exceptions import ApiError
 
 
-class GitlabRepositoryProvider(providers.IntegrationRepositoryProvider):
+class GitlabRepositoryProvider(IntegrationRepositoryProvider):
     name = "Gitlab"
-    logger = logging.getLogger("sentry.integrations.gitlab")
-
-    def get_installation(self, integration_id, organization_id):
-        if integration_id is None:
-            raise IntegrationError(f"{self.name} requires an integration id.")
-
-        integration_model = Integration.objects.get(
-            id=integration_id, organizations=organization_id, provider="gitlab"
-        )
-
-        return integration_model.get_installation(organization_id)
+    repo_provider = "gitlab"
 
     def get_repository_data(self, organization, config):
         installation = self.get_installation(config.get("installation"), organization.id)

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -16,7 +16,7 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
         try:
             project = client.get_project(repo_id)
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
         config.update(
             {
                 "instance": instance,
@@ -33,11 +33,10 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
 
         installation = self.get_installation(data.get("installation"), organization.id)
         client = installation.get_client()
-        hook_id = None
         try:
             hook_id = client.create_project_webhook(data["project_id"])
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
         return {
             "name": data["name"],
             "external_id": data["external_id"],
@@ -60,10 +59,10 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
         except ApiError as e:
             if e.code == 404:
                 return
-            installation.raise_error(e)
+            raise installation.raise_error(e)
 
     def compare_commits(self, repo, start_sha, end_sha):
-        """Fetch the commit list and diffed files between two shas"""
+        """Fetch the commit list and diffed files between two SHAs"""
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
         try:
@@ -74,7 +73,7 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider):
                 res = client.compare_commits(repo.config["project_id"], start_sha, end_sha)
                 return self._format_commits(client, repo, res["commits"])
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
 
     def _format_commits(self, client, repo, commit_list):
         """Convert GitLab commits into our internal format"""

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -1,31 +1,14 @@
-import logging
 from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
-from sentry.integrations import IntegrationInstallation
-from sentry.models import Commit, Integration, Organization, Repository
-from sentry.plugins import providers
-from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.models import Commit, Organization, Repository
+from sentry.plugins.providers import IntegrationRepositoryProvider
 
 MAX_COMMIT_DATA_REQUESTS = 90
 
 
-class VstsRepositoryProvider(providers.IntegrationRepositoryProvider):  # type: ignore
+class VstsRepositoryProvider(IntegrationRepositoryProvider):
     name = "Azure DevOps"
-    logger = logging.getLogger("sentry.integrations.vsts")
-
-    def get_installation(
-        self, integration_id: Optional[int], organization_id: int
-    ) -> IntegrationInstallation:
-        if integration_id is None:
-            raise IntegrationError(f"{self.name} requires an integration id.")
-
-        integration_model = Integration.objects.get(
-            id=integration_id, organizations=organization_id, provider="vsts"
-        )
-
-        # Explicitly typing to satisfy mypy.
-        installation: IntegrationInstallation = integration_model.get_installation(organization_id)
-        return installation
+    repo_provider = "vsts"
 
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -6,7 +6,7 @@ from sentry.plugins.providers import IntegrationRepositoryProvider
 MAX_COMMIT_DATA_REQUESTS = 90
 
 
-class VstsRepositoryProvider(IntegrationRepositoryProvider):
+class VstsRepositoryProvider(IntegrationRepositoryProvider):  # type: ignore
     name = "Azure DevOps"
     repo_provider = "vsts"
 
@@ -22,7 +22,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
         try:
             repo = client.get_repo(instance, repo_id)
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
         config.update(
             {
                 "instance": instance,
@@ -106,7 +106,7 @@ class VstsRepositoryProvider(IntegrationRepositoryProvider):
             else:
                 res = client.get_commit_range(instance, repo.external_id, start_sha, end_sha)
         except Exception as e:
-            installation.raise_error(e)
+            raise installation.raise_error(e)
 
         commits = self.zip_commit_data(repo, res["value"], repo.organization_id)
         return self._format_commits(repo, commits)

--- a/src/sentry/plugins/base/bindings.py
+++ b/src/sentry/plugins/base/bindings.py
@@ -1,4 +1,4 @@
-from sentry.plugins import providers
+from sentry.plugins.providers import IntegrationRepositoryProvider, RepositoryProvider
 
 
 class ProviderManager:
@@ -24,11 +24,11 @@ class ProviderManager:
 
 
 class RepositoryProviderManager(ProviderManager):
-    type = providers.RepositoryProvider
+    type = RepositoryProvider
 
 
 class IntegrationRepositoryProviderManager(ProviderManager):
-    type = providers.IntegrationRepositoryProvider
+    type = IntegrationRepositoryProvider
 
 
 class BindingManager:

--- a/src/sentry/plugins/providers/__init__.py
+++ b/src/sentry/plugins/providers/__init__.py
@@ -1,3 +1,9 @@
-from sentry.utils.imports import import_submodules
+__all__ = (
+    "ProviderMixin",
+    "IntegrationRepositoryProvider",
+    "RepositoryProvider",
+)
 
-import_submodules(globals(), __name__, __path__)
+from .base import ProviderMixin
+from .integration_repository import IntegrationRepositoryProvider
+from .repository import RepositoryProvider

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import logging
+
 import dateutil.parser
 from django.db import IntegrityError, transaction
 from django.utils import timezone
@@ -6,6 +10,7 @@ from rest_framework.response import Response
 from sentry import analytics
 from sentry.api.serializers import serialize
 from sentry.constants import ObjectStatus
+from sentry.integrations import IntegrationInstallation
 from sentry.models import Integration, Repository
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.signals import repo_linked
@@ -18,11 +23,27 @@ class IntegrationRepositoryProvider:
     """
 
     name = None
-    logger = None
     repo_provider = None
 
     def __init__(self, id):
         self.id = id
+        self.logger = logging.getLogger(f"sentry.integrations.{self.repo_provider}")
+
+    def get_installation(
+        self,
+        integration_id: int | None,
+        organization_id: int,
+    ) -> IntegrationInstallation:
+        if integration_id is None:
+            raise IntegrationError(f"{self.name} requires an integration id.")
+
+        integration_model = Integration.objects.get(
+            id=integration_id, organizations=organization_id, provider=self.repo_provider
+        )
+
+        # Explicitly typing to satisfy mypy.
+        installation: IntegrationInstallation = integration_model.get_installation(organization_id)
+        return installation
 
     def dispatch(self, request, organization, **kwargs):
         try:

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -38,7 +38,9 @@ class IntegrationRepositoryProvider:
             raise IntegrationError(f"{self.name} requires an integration id.")
 
         integration_model = Integration.objects.get(
-            id=integration_id, organizations=organization_id, provider=self.repo_provider
+            id=integration_id,
+            organizationintegration__organization_id=organization_id,
+            provider=self.repo_provider,
         )
 
         # Explicitly typing to satisfy mypy.

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-import dateutil.parser
+from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 from rest_framework.response import Response
@@ -163,7 +163,7 @@ class IntegrationRepositoryProvider:
     def format_date(self, date):
         if not date:
             return None
-        return dateutil.parser.parse(date).astimezone(timezone.utc)
+        return parse_date(date).astimezone(timezone.utc)
 
     def compare_commits(self, repo, start_sha, end_sha):
         """

--- a/src/sentry/utils/email/__init__.py
+++ b/src/sentry/utils/email/__init__.py
@@ -8,6 +8,7 @@ __all__ = (
     "inline_css",
     "is_smtp_enabled",
     "parse_email",
+    "parse_user_name",
     "ListResolver",
     "MessageBuilder",
     "PreviewBackend",
@@ -21,7 +22,7 @@ parsing email address strings, building and sending messages, and looking up
 user emails in the database.
 """
 
-from .address import email_to_group_id, group_id_to_email, parse_email
+from .address import email_to_group_id, group_id_to_email, parse_email, parse_user_name
 from .backend import PreviewBackend, is_smtp_enabled
 from .faker import create_fake_email
 from .list_resolver import ListResolver

--- a/src/sentry/utils/email/address.py
+++ b/src/sentry/utils/email/address.py
@@ -64,3 +64,8 @@ def is_valid_email_address(value: str) -> bool:
 def parse_email(email: str) -> str:
     matches = EMAIL_PARSER.search(email)
     return matches.group(1) if matches else ""
+
+
+def parse_user_name(email: str) -> str:
+    # captures content before angle bracket
+    return email.split("<")[0].strip()

--- a/src/sentry/web/forms/fields.py
+++ b/src/sentry/web/forms/fields.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.models import User
-from sentry.utils.email import is_valid_email_address
+from sentry.utils.email.address import is_valid_email_address
 
 
 class CustomTypedChoiceField(TypedChoiceField):

--- a/src/sentry/web/forms/fields.py
+++ b/src/sentry/web/forms/fields.py
@@ -6,7 +6,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.models import User
-from sentry.utils.email.address import is_valid_email_address
+from sentry.utils.email import is_valid_email_address
 
 
 class CustomTypedChoiceField(TypedChoiceField):

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -1,6 +1,5 @@
 import ipaddress
 import logging
-import re
 
 import dateutil.parser
 from django.db import IntegrityError, transaction
@@ -14,6 +13,7 @@ from sentry.integrations.bitbucket.constants import BITBUCKET_IP_RANGES, BITBUCK
 from sentry.models import Commit, CommitAuthor, Organization, Repository
 from sentry.plugins.providers import RepositoryProvider
 from sentry.utils import json
+from sentry.utils.email import parse_email
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -21,19 +21,6 @@ logger = logging.getLogger("sentry.webhooks")
 class Webhook:
     def __call__(self, organization, event):
         raise NotImplementedError
-
-
-def parse_raw_user_email(raw):
-    # captures content between angle brackets
-    match = re.search("(?<=<).*(?=>$)", raw)
-    if match is None:
-        return
-    return match.group(0)
-
-
-def parse_raw_user_name(raw):
-    # captures content before angle bracket
-    return raw.split("<")[0].strip()
 
 
 class PushEventWebhook(Webhook):
@@ -59,7 +46,7 @@ class PushEventWebhook(Webhook):
                 if RepositoryProvider.should_ignore_commit(commit["message"]):
                     continue
 
-                author_email = parse_raw_user_email(commit["author"]["raw"])
+                author_email = parse_email(commit["author"]["raw"])
 
                 # TODO(dcramer): we need to deal with bad values here, but since
                 # its optional, lets just throw it out for now

--- a/src/sentry_plugins/bitbucket/endpoints/webhook.py
+++ b/src/sentry_plugins/bitbucket/endpoints/webhook.py
@@ -1,7 +1,7 @@
 import ipaddress
 import logging
 
-import dateutil.parser
+from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
@@ -69,9 +69,7 @@ class PushEventWebhook(Webhook):
                             key=commit["hash"],
                             message=commit["message"],
                             author=author,
-                            date_added=dateutil.parser.parse(commit["date"]).astimezone(
-                                timezone.utc
-                            ),
+                            date_added=parse_date(commit["date"]).astimezone(timezone.utc),
                         )
 
                 except IntegrityError:

--- a/src/sentry_plugins/bitbucket/repository_provider.py
+++ b/src/sentry_plugins/bitbucket/repository_provider.py
@@ -4,9 +4,9 @@ from sentry.app import locks
 from sentry.models import OrganizationOption
 from sentry.plugins.providers import RepositoryProvider
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.utils.email import parse_email, parse_user_name
 from sentry.utils.http import absolute_uri
 
-from .endpoints.webhook import parse_raw_user_email, parse_raw_user_name
 from .mixins import BitbucketMixin
 
 
@@ -101,8 +101,8 @@ class BitbucketRepositoryProvider(BitbucketMixin, RepositoryProvider):
             {
                 "id": c["hash"],
                 "repository": repo.name,
-                "author_email": parse_raw_user_email(c["author"]["raw"]),
-                "author_name": parse_raw_user_name(c["author"]["raw"]),
+                "author_email": parse_email(c["author"]["raw"]),
+                "author_name": parse_user_name(c["author"]["raw"]),
                 "message": c["message"],
                 "patch_set": c.get("patch_set"),
             }

--- a/src/sentry_plugins/bitbucket/repository_provider.py
+++ b/src/sentry_plugins/bitbucket/repository_provider.py
@@ -2,7 +2,7 @@ from uuid import uuid4
 
 from sentry.app import locks
 from sentry.models import OrganizationOption
-from sentry.plugins import providers
+from sentry.plugins.providers import RepositoryProvider
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
 
@@ -10,7 +10,7 @@ from .endpoints.webhook import parse_raw_user_email, parse_raw_user_name
 from .mixins import BitbucketMixin
 
 
-class BitbucketRepositoryProvider(BitbucketMixin, providers.RepositoryProvider):
+class BitbucketRepositoryProvider(BitbucketMixin, RepositoryProvider):
     name = "Bitbucket"
     auth_provider = "bitbucket"
 

--- a/src/sentry_plugins/bitbucket/testutils.py
+++ b/src/sentry_plugins/bitbucket/testutils.py
@@ -269,3 +269,16 @@ index 89821ce..9e09a8a 100644
 \\ No newline at end of file
 +A twitter bot to when words are said by the NYT for the first time.sdfsdf
 \\ No newline at end of file"""
+
+
+REFS_CHANGED_EXAMPLE = b"""{
+    "changes": [],
+    "repository": {
+        "id": "{b128e0f6-196a-4dde-b72d-f42abc6dc239}",
+        "project": {
+            "key": "my-project"
+        },
+        "slug": "marcos"
+    }
+}
+"""

--- a/src/sentry_plugins/github/endpoints/webhook.py
+++ b/src/sentry_plugins/github/endpoints/webhook.py
@@ -2,7 +2,7 @@ import hashlib
 import hmac
 import logging
 
-import dateutil.parser
+from dateutil.parser import parse as parse_date
 from django.db import IntegrityError, transaction
 from django.http import Http404, HttpResponse
 from django.utils import timezone
@@ -220,9 +220,7 @@ class PushEventWebhook(Webhook):
                         key=commit["id"],
                         message=commit["message"],
                         author=author,
-                        date_added=dateutil.parser.parse(commit["timestamp"]).astimezone(
-                            timezone.utc
-                        ),
+                        date_added=parse_date(commit["timestamp"]).astimezone(timezone.utc),
                     )
                     for fname in commit["added"]:
                         CommitFileChange.objects.create(

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -9,8 +9,8 @@ from sentry.app import locks
 from sentry.exceptions import PluginError
 from sentry.integrations import FeatureDescription, IntegrationFeatures
 from sentry.models import Integration, Organization, OrganizationOption, Repository
-from sentry.plugins import providers
 from sentry.plugins.bases.issue2 import IssueGroupActionEndpoint, IssuePlugin2
+from sentry.plugins.providers import RepositoryProvider
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.http import absolute_uri
@@ -256,7 +256,7 @@ class GitHubPlugin(GitHubMixin, IssuePlugin2):
             self.logger.info("apps-not-configured")
 
 
-class GitHubRepositoryProvider(GitHubMixin, providers.RepositoryProvider):
+class GitHubRepositoryProvider(GitHubMixin, RepositoryProvider):
     name = "GitHub"
     auth_provider = "github"
     logger = logging.getLogger("sentry.plugins.github")

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 from datetime import datetime, timedelta
 
-import dateutil
+from dateutil.parser import parse as parse_date
 from django.core import mail
 from django.utils import timezone
 from pytz import UTC
@@ -183,10 +183,10 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             assert response_data[i]["name"] == trusted_relays[i]["name"]
             assert response_data[i]["description"] == trusted_relays[i]["description"]
             # check that last_modified is in the correct range
-            last_modified = dateutil.parser.parse(response_data[i]["lastModified"])
+            last_modified = parse_date(response_data[i]["lastModified"])
             assert start_time < last_modified < end_time
             # check that created is in the correct range
-            created = dateutil.parser.parse(response_data[i]["created"])
+            created = parse_date(response_data[i]["created"])
             assert start_time < created < end_time
 
 
@@ -383,11 +383,11 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             assert response_data[i]["name"] == trusted_relays[i]["name"]
             assert response_data[i]["description"] == trusted_relays[i]["description"]
             # check that last_modified is in the correct range
-            last_modified = dateutil.parser.parse(actual[i]["last_modified"])
+            last_modified = parse_date(actual[i]["last_modified"])
             assert start_time < last_modified < end_time
             assert response_data[i]["lastModified"] == actual[i]["last_modified"]
             # check that created is in the correct range
-            created = dateutil.parser.parse(actual[i]["created"])
+            created = parse_date(actual[i]["created"])
             assert start_time < created < end_time
             assert response_data[i]["created"] == actual[i]["created"]
 
@@ -462,8 +462,8 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             assert actual[i]["name"] == modified_trusted_relays[i]["name"]
             assert actual[i]["description"] == modified_trusted_relays[i]["description"]
 
-            last_modified = dateutil.parser.parse(actual[i]["last_modified"])
-            created = dateutil.parser.parse(actual[i]["created"])
+            last_modified = parse_date(actual[i]["last_modified"])
+            created = parse_date(actual[i]["created"])
             key = modified_trusted_relays[i]["publicKey"]
 
             if key == _VALID_RELAY_KEYS[1]:

--- a/tests/sentry/integrations/bitbucket/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket/test_webhook.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from datetime import datetime
+from typing import Any
+from unittest import TestCase
 
 from django.utils import timezone
 
@@ -8,7 +12,7 @@ from sentry.integrations.bitbucket.webhook import (
     parse_raw_user_name,
 )
 from sentry.models import Commit, CommitAuthor, Repository
-from sentry.testutils import APITestCase, TestCase
+from sentry.testutils import APITestCase
 
 from .testutils import PUSH_EVENT_EXAMPLE
 
@@ -27,75 +31,28 @@ class UtilityFunctionTest(TestCase):
         assert parse_raw_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"
 
 
-class WebhookTest(APITestCase):
+class WebhookBaseTest(APITestCase):
+    endpoint = "sentry-extensions-bitbucket-webhook"
+
     def setUp(self):
         super().setUp()
         project = self.project  # force creation
-        self.url = "/extensions/bitbucket/organizations/%s/webhook/" % project.organization_id
+        self.organization_id = project.organization.id
 
-    def test_get_request_fails(self):
-        response = self.client.get(self.url)
-        assert response.status_code == 405
-
-    def test_unregistered_event(self):
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="UnregisteredEvent",
-            REMOTE_ADDR=BITBUCKET_IP,
+    def send_webhook(self) -> None:
+        self.get_success_response(
+            self.organization_id,
+            raw_data=PUSH_EVENT_EXAMPLE,
+            extra_headers=dict(
+                HTTP_X_EVENT_KEY="repo:push",
+                REMOTE_ADDR=BITBUCKET_IP,
+            ),
+            status_code=204,
         )
 
-        assert response.status_code == 204
-
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="UnregisteredEvent",
-            REMOTE_ADDR=BITBUCKET_IP_IN_RANGE,
-        )
-
-        assert response.status_code == 204
-
-    def test_invalid_signature_ip(self):
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="repo:push",
-            REMOTE_ADDR=BAD_IP,
-        )
-
-        assert response.status_code == 401
-
-
-class PushEventWebhookTest(APITestCase):
-    def setUp(self):
-        super().setUp()
-        project = self.project  # force creation
-        self.url = "/extensions/bitbucket/organizations/%s/webhook/" % project.organization.id
-
-    def test_simple(self):
-        Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="{c78dfb25-7882-4550-97b1-4e0d38f32859}",
-            provider=PROVIDER_NAME,
-            name="maxbittker/newsdiffs",
-        )
-
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="repo:push",
-            REMOTE_ADDR=BITBUCKET_IP,
-        )
-
-        assert response.status_code == 204
-
+    def assert_commit(self) -> None:
         commit_list = list(
-            Commit.objects.filter(organization_id=self.project.organization_id)
+            Commit.objects.filter(organization_id=self.organization_id)
             .select_related("author")
             .order_by("-date_added")
         )
@@ -111,13 +68,71 @@ class PushEventWebhookTest(APITestCase):
         assert commit.author.external_id is None
         assert commit.date_added == datetime(2017, 5, 24, 1, 5, 47, tzinfo=timezone.utc)
 
-    def test_anonymous_lookup(self):
-        Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="{c78dfb25-7882-4550-97b1-4e0d38f32859}",
-            provider=PROVIDER_NAME,
-            name="maxbittker/newsdiffs",
+    def create_repository(self, **kwargs: Any) -> Repository:
+        return Repository.objects.create(
+            **{
+                **dict(
+                    organization_id=self.organization_id,
+                    external_id="{c78dfb25-7882-4550-97b1-4e0d38f32859}",
+                    provider=PROVIDER_NAME,
+                    name="maxbittker/newsdiffs",
+                ),
+                **kwargs,
+            }
         )
+
+
+class WebhookGetTest(WebhookBaseTest):
+    def test_get_request_fails(self):
+        self.get_error_response(self.organization_id, status_code=405)
+
+
+class WebhookTest(WebhookBaseTest):
+    method = "post"
+
+    def test_unregistered_event(self):
+        self.get_success_response(
+            self.organization_id,
+            raw_data=PUSH_EVENT_EXAMPLE,
+            extra_headers=dict(
+                HTTP_X_EVENT_KEY="UnregisteredEvent",
+                REMOTE_ADDR=BITBUCKET_IP,
+            ),
+            status_code=204,
+        )
+        self.get_success_response(
+            self.organization_id,
+            raw_data=PUSH_EVENT_EXAMPLE,
+            extra_headers=dict(
+                HTTP_X_EVENT_KEY="UnregisteredEvent",
+                REMOTE_ADDR=BITBUCKET_IP_IN_RANGE,
+            ),
+            status_code=204,
+        )
+
+    def test_invalid_signature_ip(self):
+        self.get_error_response(
+            self.organization_id,
+            raw_data=PUSH_EVENT_EXAMPLE,
+            extra_headers=dict(
+                HTTP_X_EVENT_KEY="repo:push",
+                REMOTE_ADDR=BAD_IP,
+            ),
+            status_code=401,
+        )
+
+
+class PushEventWebhookTest(WebhookBaseTest):
+    method = "post"
+
+    def test_simple(self):
+        self.create_repository()
+
+        self.send_webhook()
+        self.assert_commit()
+
+    def test_anonymous_lookup(self):
+        self.create_repository()
 
         CommitAuthor.objects.create(
             external_id="bitbucket:baxterthehacker",
@@ -126,101 +141,43 @@ class PushEventWebhookTest(APITestCase):
             name="baxterthehacker",
         )
 
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="repo:push",
-            REMOTE_ADDR=BITBUCKET_IP,
-        )
-
-        assert response.status_code == 204
-
-        commit_list = list(
-            Commit.objects.filter(organization_id=self.project.organization_id)
-            .select_related("author")
-            .order_by("-date_added")
-        )
-
+        self.send_webhook()
         # should be skipping the #skipsentry commit
-        assert len(commit_list) == 1
-
-        commit = commit_list[0]
-
-        assert commit.key == "e0e377d186e4f0e937bdb487a23384fe002df649"
-        assert commit.message == "README.md edited online with Bitbucket"
-        assert commit.author.name == "Max Bittker"
-        assert commit.author.email == "max@getsentry.com"
-        assert commit.author.external_id is None
-        assert commit.date_added == datetime(2017, 5, 24, 1, 5, 47, tzinfo=timezone.utc)
+        self.assert_commit()
 
     def test_update_repo_name(self):
-        repo_out_of_date_name = Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="{c78dfb25-7882-4550-97b1-4e0d38f32859}",
-            provider=PROVIDER_NAME,
+        repo_out_of_date_name = self.create_repository(
             name="maxbittker/newssames",  # out of date
             url="https://bitbucket.org/maxbittker/newsdiffs",
             config={"name": "maxbittker/newsdiffs"},
         )
 
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="repo:push",
-            REMOTE_ADDR=BITBUCKET_IP,
-        )
-
-        assert response.status_code == 204
+        self.send_webhook()
 
         # name has been updated
         repo_out_of_date_name.refresh_from_db()
         assert repo_out_of_date_name.name == "maxbittker/newsdiffs"
 
     def test_update_repo_config_name(self):
-        repo_out_of_date_config_name = Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="{c78dfb25-7882-4550-97b1-4e0d38f32859}",
-            provider=PROVIDER_NAME,
+        repo_out_of_date_config_name = self.create_repository(
             name="maxbittker/newsdiffs",
             url="https://bitbucket.org/maxbittker/newsdiffs",
             config={"name": "maxbittker/newssames"},  # out of date
         )
-
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="repo:push",
-            REMOTE_ADDR=BITBUCKET_IP,
-        )
-
-        assert response.status_code == 204
+        self.send_webhook()
 
         # config name has been updated
         repo_out_of_date_config_name.refresh_from_db()
         assert repo_out_of_date_config_name.config["name"] == "maxbittker/newsdiffs"
 
     def test_update_repo_url(self):
-        repo_out_of_date_url = Repository.objects.create(
-            organization_id=self.project.organization.id,
-            external_id="{c78dfb25-7882-4550-97b1-4e0d38f32859}",
-            provider=PROVIDER_NAME,
+        repo_out_of_date_url = self.create_repository(
             name="maxbittker/newsdiffs",
             url="https://bitbucket.org/maxbittker/newssames",  # out of date
             config={"name": "maxbittker/newsdiffs"},
         )
 
-        response = self.client.post(
-            path=self.url,
-            data=PUSH_EVENT_EXAMPLE,
-            content_type="application/json",
-            HTTP_X_EVENT_KEY="repo:push",
-            REMOTE_ADDR=BITBUCKET_IP,
-        )
-
-        assert response.status_code == 204
+        self.send_webhook()
 
         # url has been updated
         repo_out_of_date_url.refresh_from_db()

--- a/tests/sentry/integrations/bitbucket/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket/test_webhook.py
@@ -2,15 +2,10 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Any
-from unittest import TestCase
 
 from django.utils import timezone
 
-from sentry.integrations.bitbucket.webhook import (
-    PROVIDER_NAME,
-    parse_raw_user_email,
-    parse_raw_user_name,
-)
+from sentry.integrations.bitbucket.webhook import PROVIDER_NAME
 from sentry.models import Commit, CommitAuthor, Repository
 from sentry.testutils import APITestCase
 
@@ -19,16 +14,6 @@ from .testutils import PUSH_EVENT_EXAMPLE
 BAD_IP = "109.111.111.10"
 BITBUCKET_IP_IN_RANGE = "104.192.143.10"
 BITBUCKET_IP = "34.198.178.64"
-
-
-class UtilityFunctionTest(TestCase):
-    def test_parse_raw_user_email(self):
-        assert parse_raw_user_email("Max Bittker <max@getsentry.com>") == "max@getsentry.com"
-
-        assert parse_raw_user_email("Jess MacQueen@JessMacqueen") is None
-
-    def parse_raw_user_name(self):
-        assert parse_raw_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"
 
 
 class WebhookBaseTest(APITestCase):

--- a/tests/sentry/integrations/bitbucket_server/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket_server/test_webhook.py
@@ -1,0 +1,109 @@
+from time import time
+from typing import Any
+
+from sentry.integrations.bitbucket_server.webhook import PROVIDER_NAME
+from sentry.models import Identity, IdentityProvider, Integration, Repository
+from sentry.testutils import APITestCase
+from sentry_plugins.bitbucket.testutils import REFS_CHANGED_EXAMPLE
+
+PROVIDER = "bitbucket_server"
+
+
+class WebhookTestBase(APITestCase):
+    endpoint = "sentry-extensions-bitbucketserver-webhook"
+
+    def setUp(self):
+        super().setUp()
+
+        self.base_url = "https://api.bitbucket.org"
+        self.shared_secret = "234567890"
+        self.subject = "connect:1234567"
+        self.external_id = "{b128e0f6-196a-4dde-b72d-f42abc6dc239}"
+
+        self.integration = Integration.objects.create(
+            provider=PROVIDER,
+            external_id=self.subject,
+            name="sentryuser",
+            metadata={
+                "base_url": self.base_url,
+                "shared_secret": self.shared_secret,
+                "subject": self.subject,
+                "verify_ssl": False,
+            },
+        )
+
+        self.identity = Identity.objects.create(
+            idp=IdentityProvider.objects.create(type=PROVIDER, config={}),
+            user=self.user,
+            external_id="user_identity",
+            data={"access_token": "vsts-access-token", "expires": time() + 50000},
+        )
+
+    def create_repository(self, **kwargs: Any) -> Repository:
+        return Repository.objects.create(
+            **{
+                **dict(
+                    organization_id=self.organization.id,
+                    external_id=self.external_id,
+                    provider=PROVIDER_NAME,
+                    name="maxbittker/newsdiffs",
+                ),
+                **kwargs,
+            }
+        )
+
+    def send_webhook(self) -> None:
+        self.get_success_response(
+            self.organization.id,
+            self.integration.id,
+            raw_data=REFS_CHANGED_EXAMPLE,
+            extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
+            status_code=204,
+        )
+
+
+class WebhookGetTest(WebhookTestBase):
+    def test_get_request_fails(self):
+        self.get_error_response(self.organization.id, self.integration.id, status_code=405)
+
+
+class WebhookPostTest(WebhookTestBase):
+    method = "post"
+
+    def test_invalid_organization(self):
+        self.get_error_response(0, self.integration.id, status_code=400)
+
+    def test_invalid_integration(self):
+        self.get_error_response(self.organization.id, 0, status_code=400)
+
+    def test_missing_event(self):
+        self.get_error_response(self.organization.id, self.integration.id, status_code=400)
+
+    def test_unregistered_event(self):
+        self.get_success_response(
+            self.organization.id,
+            self.integration.id,
+            extra_headers=dict(HTTP_X_EVENT_KEY="UnregisteredEvent"),
+            raw_data=REFS_CHANGED_EXAMPLE,
+            status_code=204,
+        )
+
+
+class RefsChangedWebhookTest(WebhookTestBase):
+    method = "post"
+
+    def test_missing_integration(self):
+        self.create_repository()
+        self.get_error_response(
+            self.organization.id,
+            self.integration.id,
+            raw_data=REFS_CHANGED_EXAMPLE,
+            extra_headers=dict(HTTP_X_EVENT_KEY="repo:refs_changed"),
+            status_code=404,
+        )
+
+    def test_simple(self):
+        self.integration.add_organization(self.organization, default_auth_id=self.identity.id)
+
+        self.create_repository()
+        self.send_webhook()

--- a/tests/sentry/utils/email/test_address.py
+++ b/tests/sentry/utils/email/test_address.py
@@ -1,5 +1,10 @@
 from sentry.testutils import TestCase
-from sentry.utils.email.address import get_from_email_domain, is_valid_email_address, parse_email
+from sentry.utils.email.address import (
+    get_from_email_domain,
+    is_valid_email_address,
+    parse_email,
+    parse_user_name,
+)
 
 
 class GetFromEmailDomainTest(TestCase):
@@ -37,3 +42,17 @@ class ParseEmailTest(TestCase):
 
     def test_simple(self):
         assert parse_email("lauryn <lauryn@sentry.io>") == "lauryn@sentry.io"
+
+
+class ParseUserNameTest(TestCase):
+    def test_empty(self):
+        assert parse_user_name("") == ""
+
+    def test_no_email(self):
+        assert parse_user_name("marcos@sentry.io") == "marcos@sentry.io"
+
+    def test_empty_email(self):
+        assert parse_user_name("<>") == ""
+
+    def test_simple(self):
+        assert parse_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"

--- a/tests/sentry_plugins/bitbucket/endpoints/test_webhooks.py
+++ b/tests/sentry_plugins/bitbucket/endpoints/test_webhooks.py
@@ -3,23 +3,12 @@ from datetime import datetime
 from django.utils import timezone
 
 from sentry.models import Commit, CommitAuthor, Repository
-from sentry.testutils import APITestCase, TestCase
-from sentry_plugins.bitbucket.endpoints.webhook import parse_raw_user_email, parse_raw_user_name
+from sentry.testutils import APITestCase
 from sentry_plugins.bitbucket.testutils import PUSH_EVENT_EXAMPLE
 
 BAD_IP = "109.111.111.10"
 BITBUCKET_IP_IN_RANGE = "104.192.143.10"
 BITBUCKET_IP = "34.198.178.64"
-
-
-class UtilityFunctionTest(TestCase):
-    def test_parse_raw_user_email(self):
-        assert parse_raw_user_email("Max Bittker <max@getsentry.com>") == "max@getsentry.com"
-
-        assert parse_raw_user_email("Jess MacQueen@JessMacqueen") is None
-
-    def parse_raw_user_name(self):
-        assert parse_raw_user_name("Max Bittker <max@getsentry.com>") == "Max Bittker"
 
 
 class WebhookTest(APITestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 from unittest import mock
 from uuid import uuid4
 
-import dateutil.parser as parse_date
 import pytest
+from dateutil.parser import parse as parse_date
 from django.urls import reverse
 from pytz import utc
 from snuba_sdk.column import Column
@@ -779,8 +779,8 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             [{"count": 1}],
             [{"count": 2}],
         ]
-        assert response.data["start"] == parse_date.parse(start).timestamp()
-        assert response.data["end"] == parse_date.parse(end).timestamp()
+        assert response.data["start"] == parse_date(start).timestamp()
+        assert response.data["end"] == parse_date(end).timestamp()
 
     def test_comparison(self):
         self.store_event(


### PR DESCRIPTION
The BitBucket webhook has an unhandled error when an integration does not exist. This PR wraps the `get()` in a try/catch.
Also in this PR I've DRY'd the `get_installation()` method.

Fixes [SENTRY-SG0](https://sentry.io/organizations/sentry/issues/2736069758/).