### PR TITLE
ref(metrics): Replace tag key/value strings with objects [INGEST-542]

### DIFF
--- a/src/sentry/api/endpoints/project_metrics.py
+++ b/src/sentry/api/endpoints/project_metrics.py
@@ -70,11 +70,11 @@ class ProjectMetricsTagsEndpoint(ProjectEndpoint):
             return Response(status=404)
 
         try:
-            tag_names = get_datasource(request).get_tag_names(project, metric_names)
+            tags = get_datasource(request).get_tags(project, metric_names)
         except InvalidParams as exc:
             raise (ParseError(detail=str(exc)))
 
-        return Response(tag_names, status=200)
+        return Response(tags, status=200)
 
 
 class ProjectMetricsTagDetailsEndpoint(ProjectEndpoint):

--- a/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
@@ -6,12 +6,13 @@ import {Organization, Project} from 'app/types';
 
 import GroupByField from './groupByField';
 import SearchQueryField from './searchQueryField';
+import {MetricTag} from './types';
 
 type Props = {
   api: Client;
   orgSlug: Organization['slug'];
   projSlug: Project['slug'];
-  metricTags: string[];
+  metricTags: MetricTag[];
   onChangeSearchQuery: (searchQuery?: string) => void;
   onChangeGroupBy: (groupBy?: string[]) => void;
   searchQuery?: string;
@@ -32,7 +33,7 @@ function FiltersAndGroups({
     <Wrapper>
       <SearchQueryField
         api={api}
-        tags={metricTags}
+        tags={metricTags.map(({key}) => key)}
         orgSlug={orgSlug}
         projectSlug={projSlug}
         query={searchQuery}

--- a/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
@@ -10,11 +10,11 @@ import {t} from 'app/locale';
 import {inputStyles} from 'app/styles/input';
 import space from 'app/styles/space';
 
-import {MetricQuery} from './types';
+import {MetricQuery, MetricTag} from './types';
 
 type Props = {
   onChange: (groupBy: MetricQuery['groupBy']) => void;
-  metricTags: string[];
+  metricTags: MetricTag[];
   groupBy?: MetricQuery['groupBy'];
 };
 
@@ -38,7 +38,7 @@ function GroupByField({metricTags, groupBy = [], onChange}: Props) {
   return (
     <DropdownAutoComplete
       searchPlaceholder={t('Search tag')}
-      items={metricTags.map(metricTag => ({
+      items={metricTags.map(({key: metricTag}) => ({
         value: metricTag,
         searchKey: metricTag,
         label: ({inputValue}) => (

--- a/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
@@ -29,7 +29,7 @@ import {DataSet, DisplayType, displayTypes} from '../utils';
 import Card from './card';
 import FiltersAndGroups from './filtersAndGroups';
 import Queries from './queries';
-import {MetricMeta, MetricQuery} from './types';
+import {MetricMeta, MetricQuery, MetricTag} from './types';
 
 type Props = AsyncView['props'] & {
   dashboardTitle: DashboardDetails['title'];
@@ -49,7 +49,7 @@ type State = AsyncView['state'] &
     title: string;
     displayType: DisplayType;
     metricMetas: MetricMeta[] | null;
-    metricTags: string[] | null;
+    metricTags: MetricTag[] | null;
     queries: MetricQuery[];
   };
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
@@ -8,6 +8,8 @@ import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'app/constants';
 import {t} from 'app/locale';
 import {Organization, Project, Tag} from 'app/types';
 
+import {MetricTagValue} from './types';
+
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
   'g'
@@ -42,7 +44,7 @@ function SearchQueryField({api, orgSlug, projectSlug, tags, onSearch, onBlur}: P
 
   function getTagValues(tag: Tag, _query: string): Promise<string[]> {
     return fetchTagValues(tag.key).then(
-      tagValues => tagValues,
+      tagValues => (tagValues as MetricTagValue[]).map(({value}) => value),
       () => {
         throw new Error('Unable to fetch tag values');
       }

--- a/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
@@ -1,5 +1,14 @@
 import {DisplayType} from '../utils';
 
+export type MetricTag = {
+  key: string;
+};
+
+export type MetricTagValue = {
+  key: string;
+  value: string;
+};
+
 export type MetricMeta = {
   name: string;
   operations: string[];


### PR DESCRIPTION
Replace tag key and tag value strings in the tag endpoints of the metrics API by objects, such that they can be easiliy extended in the future.

Examples:

`/tags/` response:

```
[
    {
        "key": "environment"
    },
    {
        "key": "release"
    },
    {
        "key": "session.status"
    }
]

```

`tags/<key>/` response:

```
[
    {
        "key": "environment",
        "value": "production"
    },
    {
        "key": "environment",
        "value": "staging"
    }
]

```