### PR TITLE
ref(metrics-prototype): Update with new metrics tag/tags endpoint resp

### DIFF
--- a/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
@@ -6,12 +6,13 @@ import {Organization, Project} from 'app/types';
 
 import GroupByField from './groupByField';
 import SearchQueryField from './searchQueryField';
+import {MetricTags} from './types';
 
 type Props = {
   api: Client;
   orgSlug: Organization['slug'];
   projSlug: Project['slug'];
-  metricTags: string[];
+  metricTags: MetricTags;
   onChangeSearchQuery: (searchQuery?: string) => void;
   onChangeGroupBy: (groupBy?: string[]) => void;
   searchQuery?: string;
@@ -32,7 +33,7 @@ function FiltersAndGroups({
     <Wrapper>
       <SearchQueryField
         api={api}
-        tags={metricTags}
+        tags={metricTags.map(({key}) => key)}
         orgSlug={orgSlug}
         projectSlug={projSlug}
         query={searchQuery}

--- a/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/filtersAndGroups.tsx
@@ -6,13 +6,13 @@ import {Organization, Project} from 'app/types';
 
 import GroupByField from './groupByField';
 import SearchQueryField from './searchQueryField';
-import {MetricTags} from './types';
+import {MetricTag} from './types';
 
 type Props = {
   api: Client;
   orgSlug: Organization['slug'];
   projSlug: Project['slug'];
-  metricTags: MetricTags;
+  metricTags: MetricTag[];
   onChangeSearchQuery: (searchQuery?: string) => void;
   onChangeGroupBy: (groupBy?: string[]) => void;
   searchQuery?: string;

--- a/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
@@ -10,11 +10,11 @@ import {t} from 'app/locale';
 import {inputStyles} from 'app/styles/input';
 import space from 'app/styles/space';
 
-import {MetricQuery, MetricTags} from './types';
+import {MetricQuery, MetricTag} from './types';
 
 type Props = {
   onChange: (groupBy: MetricQuery['groupBy']) => void;
-  metricTags: MetricTags;
+  metricTags: MetricTag[];
   groupBy?: MetricQuery['groupBy'];
 };
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/groupByField.tsx
@@ -10,11 +10,11 @@ import {t} from 'app/locale';
 import {inputStyles} from 'app/styles/input';
 import space from 'app/styles/space';
 
-import {MetricQuery} from './types';
+import {MetricQuery, MetricTags} from './types';
 
 type Props = {
   onChange: (groupBy: MetricQuery['groupBy']) => void;
-  metricTags: string[];
+  metricTags: MetricTags;
   groupBy?: MetricQuery['groupBy'];
 };
 
@@ -38,7 +38,7 @@ function GroupByField({metricTags, groupBy = [], onChange}: Props) {
   return (
     <DropdownAutoComplete
       searchPlaceholder={t('Search tag')}
-      items={metricTags.map(metricTag => ({
+      items={metricTags.map(({key: metricTag}) => ({
         value: metricTag,
         searchKey: metricTag,
         label: ({inputValue}) => (

--- a/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
@@ -29,7 +29,7 @@ import {DataSet, DisplayType, displayTypes} from '../utils';
 import Card from './card';
 import FiltersAndGroups from './filtersAndGroups';
 import Queries from './queries';
-import {MetricMeta, MetricQuery} from './types';
+import {MetricMeta, MetricQuery, MetricTags} from './types';
 
 type Props = AsyncView['props'] & {
   dashboardTitle: DashboardDetails['title'];
@@ -49,7 +49,7 @@ type State = AsyncView['state'] &
     title: string;
     displayType: DisplayType;
     metricMetas: MetricMeta[] | null;
-    metricTags: string[] | null;
+    metricTags: MetricTags | null;
     queries: MetricQuery[];
   };
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/index.tsx
@@ -29,7 +29,7 @@ import {DataSet, DisplayType, displayTypes} from '../utils';
 import Card from './card';
 import FiltersAndGroups from './filtersAndGroups';
 import Queries from './queries';
-import {MetricMeta, MetricQuery, MetricTags} from './types';
+import {MetricMeta, MetricQuery, MetricTag} from './types';
 
 type Props = AsyncView['props'] & {
   dashboardTitle: DashboardDetails['title'];
@@ -49,7 +49,7 @@ type State = AsyncView['state'] &
     title: string;
     displayType: DisplayType;
     metricMetas: MetricMeta[] | null;
-    metricTags: MetricTags | null;
+    metricTags: MetricTag[] | null;
     queries: MetricQuery[];
   };
 

--- a/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
@@ -42,7 +42,7 @@ function SearchQueryField({api, orgSlug, projectSlug, tags, onSearch, onBlur}: P
 
   function getTagValues(tag: Tag, _query: string): Promise<string[]> {
     return fetchTagValues(tag.key).then(
-      tagValues => tagValues,
+      tagValues => tagValues.map(({value}) => value),
       () => {
         throw new Error('Unable to fetch tag values');
       }

--- a/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
@@ -8,7 +8,7 @@ import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'app/constants';
 import {t} from 'app/locale';
 import {Organization, Project, Tag} from 'app/types';
 
-import {MetricTagValues} from './types';
+import {MetricTagValue} from './types';
 
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
@@ -44,7 +44,7 @@ function SearchQueryField({api, orgSlug, projectSlug, tags, onSearch, onBlur}: P
 
   function getTagValues(tag: Tag, _query: string): Promise<string[]> {
     return fetchTagValues(tag.key).then(
-      tagValues => (tagValues as MetricTagValues).map(({value}) => value),
+      tagValues => (tagValues as MetricTagValue[]).map(({value}) => value),
       () => {
         throw new Error('Unable to fetch tag values');
       }

--- a/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
@@ -8,7 +8,7 @@ import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'app/constants';
 import {t} from 'app/locale';
 import {Organization, Project, Tag} from 'app/types';
 
-import {MetricValues} from './types';
+import {MetricTagValues} from './types';
 
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
@@ -44,7 +44,7 @@ function SearchQueryField({api, orgSlug, projectSlug, tags, onSearch, onBlur}: P
 
   function getTagValues(tag: Tag, _query: string): Promise<string[]> {
     return fetchTagValues(tag.key).then(
-      tagValues => (tagValues as MetricValues).map(({value}) => value),
+      tagValues => (tagValues as MetricTagValues).map(({value}) => value),
       () => {
         throw new Error('Unable to fetch tag values');
       }

--- a/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/searchQueryField.tsx
@@ -8,6 +8,8 @@ import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'app/constants';
 import {t} from 'app/locale';
 import {Organization, Project, Tag} from 'app/types';
 
+import {MetricValues} from './types';
+
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
   'g'
@@ -42,7 +44,7 @@ function SearchQueryField({api, orgSlug, projectSlug, tags, onSearch, onBlur}: P
 
   function getTagValues(tag: Tag, _query: string): Promise<string[]> {
     return fetchTagValues(tag.key).then(
-      tagValues => tagValues.map(({value}) => value),
+      tagValues => (tagValues as MetricValues).map(({value}) => value),
       () => {
         throw new Error('Unable to fetch tag values');
       }

--- a/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
@@ -4,7 +4,7 @@ export type MetricTags = {
   key: string;
 }[];
 
-export type MetricValues = {
+export type MetricTagValues = {
   key: string;
   value: string;
 }[];

--- a/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
@@ -4,6 +4,11 @@ export type MetricTags = {
   key: string;
 }[];
 
+export type MetricValues = {
+  key: string;
+  value: string;
+}[];
+
 export type MetricMeta = {
   name: string;
   operations: string[];

--- a/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
@@ -1,13 +1,13 @@
 import {DisplayType} from '../utils';
 
-export type MetricTags = {
+export type MetricTag = {
   key: string;
-}[];
+};
 
-export type MetricTagValues = {
+export type MetricTagValue = {
   key: string;
   value: string;
-}[];
+};
 
 export type MetricMeta = {
   name: string;

--- a/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
@@ -1,9 +1,5 @@
 import {DisplayType} from '../utils';
 
-export type MetricTag = {
-  key: string;
-};
-
 export type MetricTags = {
   key: string;
 }[];

--- a/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
+++ b/static/app/views/dashboardsV2/widget/metricWidget/types.tsx
@@ -1,5 +1,13 @@
 import {DisplayType} from '../utils';
 
+export type MetricTag = {
+  key: string;
+};
+
+export type MetricTags = {
+  key: string;
+}[];
+
 export type MetricMeta = {
   name: string;
   operations: string[];


### PR DESCRIPTION
because the response of the metrics endpoints `/tags/` and `tags/<key>/` have a new format, the UI needed to be updated 