### PR TITLE
feat(dashboard): widget resizing in dashboard edit mode

### DIFF
--- a/static/app/utils/widgetResizing.ts
+++ b/static/app/utils/widgetResizing.ts
@@ -1,0 +1,7 @@
+// TODO: Widget sizes should be enum instead of literal strings
+const DEFAULT_SIZE = 'small';
+
+export const assignWidgetSize = widget => {
+  const size = widget.displayType === 'big_number' ? 'medium' : DEFAULT_SIZE;
+  return {...widget, size};
+};

--- a/static/app/views/dashboardsV2/addWidget.tsx
+++ b/static/app/views/dashboardsV2/addWidget.tsx
@@ -37,6 +37,7 @@ function AddWidget({onAddWidget, onOpenWidgetBuilder, orgFeatures}: Props) {
       key="add"
       ref={setNodeRef}
       displayType={DisplayType.BIG_NUMBER}
+      size="medium"
       layoutId={ADD_WIDGET_BUTTON_DRAG_ID}
       style={{originX: 0, originY: 0}}
       animate={

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -124,6 +124,12 @@ class Dashboard extends Component<Props> {
     this.props.onUpdate(nextList);
   };
 
+  handleSizeChange = (index: number) => (size: string) => {
+    const nextList = [...this.props.dashboard.widgets];
+    nextList[index] = {...nextList[index], size};
+    this.props.onUpdate(nextList);
+  };
+
   handleDeleteWidget = (index: number) => () => {
     const nextList = [...this.props.dashboard.widgets];
     nextList.splice(index, 1);
@@ -200,6 +206,7 @@ class Dashboard extends Component<Props> {
         isEditing={isEditing}
         onDelete={this.handleDeleteWidget(index)}
         onEdit={this.handleEditWidget(widget, index)}
+        onSizeChange={this.handleSizeChange(index)}
       />
     );
   }
@@ -253,7 +260,7 @@ export default withApi(withGlobalSelection(Dashboard));
 const WidgetContainer = styled('div')`
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  grid-auto-flow: row dense;
+  grid-auto-flow: row;
   grid-gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -10,6 +10,7 @@ import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {assignWidgetSize} from 'app/utils/widgetResizing';
 
 import {DashboardDetails, DashboardListItem} from './types';
 
@@ -82,6 +83,11 @@ class OrgDashboards extends AsyncComponent<Props, State> {
   onRequestSuccess({stateKey, data}) {
     const {params, organization, location} = this.props;
     if (params.dashboardId || stateKey === 'selectedDashboard') {
+      if (organization.features.includes('dashboard-widget-resizing')) {
+        this.setState({
+          [stateKey]: {...data, widgets: data.widgets.map(assignWidgetSize)},
+        });
+      }
       return;
     }
 

--- a/static/app/views/dashboardsV2/sizeSelector.tsx
+++ b/static/app/views/dashboardsV2/sizeSelector.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  size: string;
+  onSizeChange: (size: string) => void;
+};
+
+const SizeSelector = ({size, onSizeChange}: Props) => {
+  const handleChange = e => {
+    e.preventDefault();
+    onSizeChange(e.target.value);
+  };
+
+  return (
+    <select value={size} onChange={handleChange}>
+      <option value="small">Small</option>
+      <option value="medium">Medium</option>
+      <option value="large">Large</option>
+    </select>
+  );
+};
+
+export default SizeSelector;

--- a/static/app/views/dashboardsV2/sizeSelector.tsx
+++ b/static/app/views/dashboardsV2/sizeSelector.tsx
@@ -9,6 +9,7 @@ const SizeSelector = ({size, onSizeChange}: Props) => {
   return (
     <SelectField
       name="size"
+      clearable={false}
       choices={[
         ['small', 'Small'],
         ['medium', 'Medium'],
@@ -16,8 +17,6 @@ const SizeSelector = ({size, onSizeChange}: Props) => {
       ]}
       onChange={value => onSizeChange(value as string)}
       value={size}
-      style={{width: '120px', marginTop: '8px'}}
-      clearable={false}
     />
   );
 };

--- a/static/app/views/dashboardsV2/sizeSelector.tsx
+++ b/static/app/views/dashboardsV2/sizeSelector.tsx
@@ -1,20 +1,24 @@
+import {SelectField} from 'app/components/forms';
+
 type Props = {
   size: string;
   onSizeChange: (size: string) => void;
 };
 
 const SizeSelector = ({size, onSizeChange}: Props) => {
-  const handleChange = e => {
-    e.preventDefault();
-    onSizeChange(e.target.value);
-  };
-
   return (
-    <select value={size} onChange={handleChange}>
-      <option value="small">Small</option>
-      <option value="medium">Medium</option>
-      <option value="large">Large</option>
-    </select>
+    <SelectField
+      name="size"
+      choices={[
+        ['small', 'Small'],
+        ['medium', 'Medium'],
+        ['large', 'Large'],
+      ]}
+      onChange={value => onSizeChange(value as string)}
+      value={size}
+      style={{width: '120px', marginTop: '8px'}}
+      clearable={false}
+    />
   );
 };
 

--- a/static/app/views/dashboardsV2/sortableWidget.tsx
+++ b/static/app/views/dashboardsV2/sortableWidget.tsx
@@ -18,10 +18,11 @@ type Props = {
   isEditing: boolean;
   onDelete: () => void;
   onEdit: () => void;
+  onSizeChange: (size: string) => void;
 };
 
 function SortableWidget(props: Props) {
-  const {widget, dragId, isEditing, onDelete, onEdit} = props;
+  const {widget, dragId, isEditing, onDelete, onEdit, onSizeChange} = props;
 
   const {
     attributes,
@@ -51,6 +52,7 @@ function SortableWidget(props: Props) {
     <WidgetWrapper
       ref={setNodeRef}
       displayType={widget.displayType}
+      size={widget.size}
       layoutId={dragId}
       style={{
         // Origin is set to top right-hand corner where the drag handle is placed.
@@ -89,6 +91,7 @@ function SortableWidget(props: Props) {
         isEditing={isEditing}
         onDelete={onDelete}
         onEdit={onEdit}
+        onSizeChange={onSizeChange}
         isSorting={isSorting}
         hideToolbar={isSorting}
         currentWidgetDragging={currentWidgetDragging}

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -36,6 +36,7 @@ export type Widget = {
   interval: string;
   queries: WidgetQuery[];
   type?: WidgetType;
+  size?: string;
 };
 
 /**

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -8,6 +8,7 @@ import isEqual from 'lodash/isEqual';
 
 import {openDashboardWidgetQuerySelectorModal} from 'app/actionCreators/modal';
 import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
 import {HeaderTitle} from 'app/components/charts/styles';
 import ErrorBoundary from 'app/components/errorBoundary';
 import FeatureBadge from 'app/components/featureBadge';
@@ -29,6 +30,7 @@ import {eventViewFromWidget} from 'app/views/dashboardsV2/utils';
 import {DisplayType} from 'app/views/dashboardsV2/widget/utils';
 
 import ContextMenu from './contextMenu';
+import SizeSelector from './sizeSelector';
 import {Widget} from './types';
 import WidgetCardChart from './widgetCardChart';
 import WidgetQueries from './widgetQueries';
@@ -81,6 +83,9 @@ class WidgetCard extends React.Component<Props> {
 
     return (
       <ToolbarPanel>
+        <Feature features={['organizations:dashboard-widget-resizing']}>
+          <SizeSelector size="medium" onSizeChange={() => {}} />
+        </Feature>
         <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
           <IconClick>
             <StyledIconGrabbable

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -84,7 +84,7 @@ class WidgetCard extends React.Component<Props> {
     return (
       <ToolbarPanel>
         <Feature features={['organizations:dashboard-widget-resizing']}>
-          <SizeSelector size="medium" onSizeChange={() => {}} />
+          <SizeSelector size="medium" onSizeChange={_ => {}} />
         </Feature>
         <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
           <IconClick>
@@ -293,7 +293,7 @@ const ToolbarPanel = styled('div')`
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: auto;
 
   width: 100%;
   height: 100%;

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -46,6 +46,7 @@ type Props = WithRouterProps & {
   selection: GlobalSelection;
   onDelete: () => void;
   onEdit: () => void;
+  onSizeChange?: (size: string) => void;
   isSorting: boolean;
   currentWidgetDragging: boolean;
   showContextMenu?: boolean;
@@ -75,7 +76,15 @@ class WidgetCard extends React.Component<Props> {
   }
 
   renderToolbar() {
-    const {onEdit, onDelete, draggableProps, hideToolbar, isEditing} = this.props;
+    const {
+      onEdit,
+      onDelete,
+      onSizeChange,
+      draggableProps,
+      hideToolbar,
+      isEditing,
+      widget,
+    } = this.props;
 
     if (!isEditing) {
       return null;
@@ -84,9 +93,11 @@ class WidgetCard extends React.Component<Props> {
     return (
       <ToolbarPanel>
         <Feature features={['organizations:dashboard-widget-resizing']}>
-          <SizeSelectContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
-            <SizeSelector size="medium" onSizeChange={_ => {}} />
-          </SizeSelectContainer>
+          {widget.size && onSizeChange && (
+            <SizeSelectContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
+              <SizeSelector size={widget.size} onSizeChange={onSizeChange} />
+            </SizeSelectContainer>
+          )}
         </Feature>
         <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
           <IconClick>

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -84,7 +84,9 @@ class WidgetCard extends React.Component<Props> {
     return (
       <ToolbarPanel>
         <Feature features={['organizations:dashboard-widget-resizing']}>
-          <SizeSelector size="medium" onSizeChange={_ => {}} />
+          <SizeSelectContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
+            <SizeSelector size="medium" onSizeChange={_ => {}} />
+          </SizeSelectContainer>
         </Feature>
         <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
           <IconClick>
@@ -304,6 +306,11 @@ const ToolbarPanel = styled('div')`
 
   background-color: ${p => p.theme.overlayBackgroundAlpha};
   border-radius: ${p => p.theme.borderRadius};
+`;
+
+const SizeSelectContainer = styled(`div`)`
+  width: 120px;
+  margin-top: 8px;
 `;
 
 const IconContainer = styled('div')`

--- a/static/app/views/dashboardsV2/widgetWrapper.tsx
+++ b/static/app/views/dashboardsV2/widgetWrapper.tsx
@@ -3,7 +3,36 @@ import {motion} from 'framer-motion';
 
 import {Widget} from './types';
 
-const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
+const getBigNumberArea = size => {
+  switch (size) {
+    case 'small':
+      return `span 1/ span 1`;
+    case 'medium':
+      return `span 1/ span 2`;
+    case 'large':
+      return `span 1/ span 3`;
+    default:
+      return `span 1/ span 2`;
+  }
+};
+
+const getDefaultWidgetArea = size => {
+  switch (size) {
+    case 'small':
+      return `span 2/ span 2`;
+    case 'medium':
+      return `span 2/ span 3`;
+    case 'large':
+      return `span 2/ span 4`;
+    default:
+      return `span 2/ span 2`;
+  }
+};
+
+const WidgetWrapper = styled(motion.div)<{
+  displayType: Widget['displayType'];
+  size?: string;
+}>`
   position: relative;
   touch-action: manipulation;
 
@@ -21,13 +50,13 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
 
           @media (min-width: ${p.theme.breakpoints[3]}) {
             /* 6 and 8 cols */
-            grid-area: span 1 / span 2;
+            grid-area: ${getBigNumberArea(p.size)};
           }
         `;
       default:
         return `
           /* 2, 4, 6 and 8 cols */
-          grid-area: span 2 / span 2;
+          grid-area: ${getDefaultWidgetArea(p.size)};
         `;
     }
   }};


### PR DESCRIPTION
This PR adds the ability to change the sizes of the widgets in the edit mode.

Notes:
- Nothing is saved after clicking "Save and Finish", that work will come in a different PR
- Since the internal milestone is to use localStorage but later store it in the DB, I chose to hook into the `onRequestSuccess` method and update the state with default sizes for each widget to simulate consuming an API with the data

TODO:
- [ ] The sizes should be accessible as enums, e.g. look at usages of `DisplayType.BIG_NUMBER`
- [ ] Determine how to tackle sizes in different breakpoint layouts