### PR TITLE
fix(discover): Catch unknown errors

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -194,6 +194,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):  # type: ignore
             ):
                 sentry_sdk.capture_exception(error)
                 message = "Internal error. Your query failed to run."
+            else:
+                sentry_sdk.capture_exception(error)
             raise APIException(detail=message)
 
 


### PR DESCRIPTION
- We weren't seeing the 500 on this endpoint as errors cause we werent
  capturing the exceptions in these cases