### PR TITLE
chore: Enable workflow Q3 features by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -906,11 +906,11 @@ SENTRY_FEATURES = {
     # Enable the linked event feature in the issue details breadcrumb.
     "organizations:breadcrumb-linked-event": False,
     # Enable change alerts for an org
-    "organizations:change-alerts": False,
+    "organizations:change-alerts": True,
     # Enable unfurling charts using the Chartcuterie service
     "organizations:chart-unfurls": False,
     # Enable alerting based on crash free sessions/users
-    "organizations:crash-rate-alerts": False,
+    "organizations:crash-rate-alerts": True,
     # Enable creating organizations within sentry (if SENTRY_SINGLE_ORGANIZATION
     # is not enabled).
     "organizations:create": True,
@@ -1096,7 +1096,7 @@ SENTRY_FEATURES = {
     # send organization request notifications through Slack
     "organizations:slack-requests": False,
     # Enable team insights page
-    "organizations:team-insights": False,
+    "organizations:team-insights": True,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -19,6 +19,8 @@ class OrganizationSerializerTest(TestCase):
         assert result["id"] == str(organization.id)
         assert result["features"] == {
             "advanced-search",
+            "change-alerts",
+            "crash-rate-alerts",
             "custom-event-title",
             "custom-symbol-sources",
             "data-forwarding",
@@ -52,6 +54,7 @@ class OrganizationSerializerTest(TestCase):
             "sso-basic",
             "sso-saml2",
             "symbol-sources",
+            "team-insights",
             "unhandled-issue-flag",
         }
 


### PR DESCRIPTION
We want to enable change alerts, crash rate alerts and insights for all ST and self hosted users, so
making these features true by default.