### PR TITLE
chore(insights): Add feature gating around insights endpoints

### DIFF
--- a/src/sentry/api/endpoints/team_issue_breakdown.py
+++ b/src/sentry/api/endpoints/team_issue_breakdown.py
@@ -6,6 +6,7 @@ from django.db.models.functions import TruncDay
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
@@ -20,6 +21,8 @@ class TeamIssueBreakdownEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignor
 
         Right now the stats we return are the count of reviewed issues and the total count of issues.
         """
+        if not features.has("organizations:team-insights", team.organization, actor=request.user):
+            return Response({"detail": "You do not have the insights feature enabled"}, status=400)
         start, end = get_date_range_from_params(request.GET)
         end = end.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
         start = start.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)

--- a/src/sentry/api/endpoints/team_release_count.py
+++ b/src/sentry/api/endpoints/team_release_count.py
@@ -6,6 +6,7 @@ from django.db.models.functions import TruncDay
 from django.utils.timezone import now
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
@@ -17,6 +18,8 @@ class TeamReleaseCountEndpoint(TeamEndpoint, EnvironmentMixin):
         """
         Returns a dict of team projects, and a time-series list of release counts for each.
         """
+        if not features.has("organizations:team-insights", team.organization, actor=request.user):
+            return Response({"detail": "You do not have the insights feature enabled"}, status=400)
         project_list = Project.objects.get_for_team_ids(team_ids=[team.id])
         start, end = get_date_range_from_params(request.GET)
         end = end.date() + timedelta(days=1)

--- a/src/sentry/api/endpoints/team_time_to_resolution.py
+++ b/src/sentry/api/endpoints/team_time_to_resolution.py
@@ -5,6 +5,7 @@ from django.db.models import Avg, F
 from django.db.models.functions import Coalesce, TruncDay
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.utils import get_date_range_from_params
@@ -16,6 +17,9 @@ class TeamTimeToResolutionEndpoint(TeamEndpoint, EnvironmentMixin):
         """
         Return a a time bucketed list of mean group resolution times for a given team.
         """
+        if not features.has("organizations:team-insights", team.organization, actor=request.user):
+            return Response({"detail": "You do not have the insights feature enabled"}, status=400)
+
         start, end = get_date_range_from_params(request.GET)
         end = end.date() + timedelta(days=1)
         start = start.date() + timedelta(days=1)


### PR DESCRIPTION
We want to enforce this on the backend so that people can't hit these endpoints without appropriate
feature access.