### PR TITLE
ref(teams): allow useTeams to query by team.id

### DIFF
--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -193,9 +193,9 @@ function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
 
     if (
       slugsOrIds.length !== slugOrIdRef.current.size ||
-      slugsOrIds.some(slug => !slugOrIdRef.current?.has(slug))
+      slugsOrIds.some(slugOrId => !slugOrIdRef.current?.has(slugOrId))
     ) {
-      slugOrIdRef.current = new Set(slugs);
+      slugOrIdRef.current = new Set(slugsOrIds);
     }
   }
 

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -183,8 +183,8 @@ function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
 
   const slugOrIdRef = useRef<Set<string> | null>(null);
 
-  // Only initialize slugsRef.current once and modify it when we receive new
-  // slugs determined through set equality
+  // Only initialize slugOrIdRef.current once and modify it when we receive new
+  // slugs or ids determined through set equality
   if (slugs !== undefined || ids !== undefined) {
     const slugsOrIds = (slugs || ids) ?? [];
     if (slugOrIdRef.current === null) {

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -66,6 +66,10 @@ type Options = {
    */
   slugs?: string[];
   /**
+   * When provided, fetches specified teams by id if necessary and only provides those teams.
+   */
+  ids?: string[];
+  /**
    * When true, fetches user's teams if necessary and only provides user's
    * teams (isMember = true).
    */
@@ -74,6 +78,7 @@ type Options = {
 
 type FetchTeamOptions = {
   slugs?: string[];
+  ids?: string[];
   limit?: Options['limit'];
   cursor?: State['nextCursor'];
   search?: State['lastSearch'];
@@ -86,7 +91,7 @@ type FetchTeamOptions = {
 async function fetchTeams(
   api: Client,
   orgId: string,
-  {slugs, search, limit, lastSearch, cursor}: FetchTeamOptions = {}
+  {slugs, ids, search, limit, lastSearch, cursor}: FetchTeamOptions = {}
 ) {
   const query: {
     query?: string;
@@ -96,6 +101,10 @@ async function fetchTeams(
 
   if (slugs !== undefined && slugs.length > 0) {
     query.query = slugs.map(slug => `slug:${slug}`).join(' ');
+  }
+
+  if (ids !== undefined && ids.length > 0) {
+    query.query = ids.map(id => `id:${id}`).join(' ');
   }
 
   if (search) {
@@ -144,7 +153,7 @@ async function fetchTeams(
  * slugs, or loading more through search.
  *
  */
-function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
+function useTeams({limit, slugs, ids, provideUserTeams}: Options = {}) {
   const api = useApi();
   const {organization} = useLegacyStore(OrganizationStore);
   const store = useLegacyStore(TeamStore);
@@ -153,12 +162,15 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
 
   const storeSlugs = new Set(store.teams.map(t => t.slug));
   const slugsToLoad = slugs?.filter(slug => !storeSlugs.has(slug)) ?? [];
+  const storeIds = new Set(store.teams.map(t => t.id));
+  const idsToLoad = ids?.filter(id => !storeIds.has(id)) ?? [];
   const shouldLoadSlugs = slugsToLoad.length > 0;
+  const shouldLoadIds = idsToLoad.length > 0;
   const shouldLoadTeams = provideUserTeams && !store.loadedUserTeams;
 
   // If we don't need to make a request either for slugs or user teams, set
   // initiallyLoaded to true
-  const initiallyLoaded = !shouldLoadSlugs && !shouldLoadTeams;
+  const initiallyLoaded = !shouldLoadSlugs && !shouldLoadTeams && !shouldLoadIds;
 
   const [state, setState] = useState<State>({
     initiallyLoaded,
@@ -169,20 +181,21 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     fetchError: null,
   });
 
-  const slugsRef = useRef<Set<string> | null>(null);
+  const slugOrIdRef = useRef<Set<string> | null>(null);
 
   // Only initialize slugsRef.current once and modify it when we receive new
   // slugs determined through set equality
-  if (slugs !== undefined) {
-    if (slugsRef.current === null) {
-      slugsRef.current = new Set(slugs);
+  if (slugs !== undefined || ids !== undefined) {
+    const slugsOrIds = (slugs || ids) ?? [];
+    if (slugOrIdRef.current === null) {
+      slugOrIdRef.current = new Set(slugsOrIds);
     }
 
     if (
-      slugs.length !== slugsRef.current.size ||
-      slugs.some(slug => !slugsRef.current?.has(slug))
+      slugsOrIds.length !== slugOrIdRef.current.size ||
+      slugsOrIds.some(slug => !slugOrIdRef.current?.has(slug))
     ) {
-      slugsRef.current = new Set(slugs);
+      slugOrIdRef.current = new Set(slugs);
     }
   }
 
@@ -203,7 +216,7 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     }
   }
 
-  async function loadTeamsBySlug() {
+  async function loadTeamsBySlugOrId() {
     if (orgId === undefined) {
       return;
     }
@@ -212,6 +225,7 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     try {
       const {results, hasMore, nextCursor} = await fetchTeams(api, orgId, {
         slugs: slugsToLoad,
+        ids: idsToLoad,
         limit,
       });
 
@@ -280,8 +294,8 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
 
   useEffect(() => {
     // Load specified team slugs
-    if (shouldLoadSlugs) {
-      loadTeamsBySlug();
+    if (shouldLoadSlugs || shouldLoadIds) {
+      loadTeamsBySlugOrId();
       return;
     }
 
@@ -289,12 +303,14 @@ function useTeams({limit, slugs, provideUserTeams}: Options = {}) {
     if (shouldLoadTeams) {
       loadUserTeams();
     }
-  }, [slugsRef.current, provideUserTeams]);
+  }, [slugOrIdRef.current, provideUserTeams]);
 
   const isSuperuser = isActiveSuperuser();
 
   const filteredTeams = slugs
     ? store.teams.filter(t => slugs.includes(t.slug))
+    : ids
+    ? store.teams.filter(t => ids.includes(t.id))
     : provideUserTeams && !isSuperuser
     ? store.teams.filter(t => t.isMember)
     : store.teams;

--- a/tests/js/spec/utils/useTeams.spec.tsx
+++ b/tests/js/spec/utils/useTeams.spec.tsx
@@ -10,7 +10,7 @@ describe('useTeams', function () {
   const mockTeams = [TestStubs.Team()];
 
   it('provides teams from the team store', function () {
-    act(() => void TeamStore.loadInitialData(mockTeams));
+    TeamStore.loadInitialData(mockTeams);
 
     const {result} = renderHook(() => useTeams());
     const {teams} = result.current;
@@ -19,9 +19,8 @@ describe('useTeams', function () {
   });
 
   it('loads more teams when using onSearch', async function () {
-    act(() => void TeamStore.loadInitialData(mockTeams));
-    act(() => void OrganizationStore.onUpdate(org, {replace: true}));
-
+    TeamStore.loadInitialData(mockTeams);
+    OrganizationStore.onUpdate(org, {replace: true});
     const newTeam2 = TestStubs.Team({id: '2', slug: 'test-team2'});
     const newTeam3 = TestStubs.Team({id: '3', slug: 'test-team3'});
 
@@ -59,7 +58,7 @@ describe('useTeams', function () {
   it('provides only the users teams', async function () {
     const userTeams = [TestStubs.Team({isMember: true})];
     const nonUserTeams = [TestStubs.Team({isMember: false})];
-    act(() => void TeamStore.loadInitialData([...userTeams, ...nonUserTeams]));
+    TeamStore.loadInitialData([...userTeams, ...nonUserTeams]);
 
     const {result} = renderHook(props => useTeams(props), {
       initialProps: {provideUserTeams: true},
@@ -71,7 +70,7 @@ describe('useTeams', function () {
   });
 
   it('provides only the specified slugs', async function () {
-    act(() => void TeamStore.loadInitialData(mockTeams));
+    TeamStore.loadInitialData(mockTeams);
     const teamFoo = TestStubs.Team({slug: 'foo'});
     const mockRequest = MockApiClient.addMockResponse({
       url: `/organizations/${org.slug}/teams/`,
@@ -93,10 +92,45 @@ describe('useTeams', function () {
   });
 
   it('only loads slugs when needed', async function () {
-    act(() => void TeamStore.loadInitialData(mockTeams));
+    TeamStore.loadInitialData(mockTeams);
 
     const {result} = renderHook(props => useTeams(props), {
       initialProps: {slugs: [mockTeams[0].slug]},
+    });
+
+    const {teams, initiallyLoaded} = result.current;
+    expect(initiallyLoaded).toBe(true);
+    expect(teams).toEqual(expect.arrayContaining(mockTeams));
+  });
+
+  it('can load teams by id', async function () {
+    const requestedTeams = [TestStubs.Team({id: '2', slug: 'requested-team'})];
+    const mockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      method: 'GET',
+      body: requestedTeams,
+    });
+
+    TeamStore.loadInitialData(mockTeams);
+
+    const {result, waitFor} = renderHook(props => useTeams(props), {
+      initialProps: {ids: ['2']},
+    });
+
+    expect(result.current.initiallyLoaded).toBe(false);
+    expect(mockRequest).toHaveBeenCalled();
+
+    await waitFor(() => expect(result.current.teams.length).toBe(1));
+
+    const {teams} = result.current;
+    expect(teams).toEqual(expect.arrayContaining(requestedTeams));
+  });
+
+  it('only loads ids when needed', async function () {
+    TeamStore.loadInitialData(mockTeams);
+
+    const {result} = renderHook(props => useTeams(props), {
+      initialProps: {ids: [mockTeams[0].id]},
     });
 
     const {teams, initiallyLoaded} = result.current;


### PR DESCRIPTION
There are multiple instances where we only have the team id and we need to fetch teams in a situation where an org has > 100 teams. (Alert owners, group assignee, etc...)

Extending useTeams to allow for query by id.