### PR TITLE
chore: Add feature gating around creating change and crash rate alerts

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -506,6 +506,12 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 )
 
             dataset = Dataset(data["dataset"].value)
+            if dataset == Dataset.Sessions and not features.has(
+                "organizations:crash-rate-alerts", self.context["organization"]
+            ):
+                raise serializers.ValidationError(
+                    "You don't have access to the crash rate alerts feature"
+                )
             self._validate_time_window(dataset, data.get("time_window"))
 
             try:


### PR DESCRIPTION
We want to restrict access to this functionality on the backend as well as the frontend