### PR TITLE
fix(ui): Allow actor avatar to fetch teams not in the store

### DIFF
--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -3,10 +3,11 @@ import * as Sentry from '@sentry/react';
 
 import TeamAvatar from 'app/components/avatar/teamAvatar';
 import UserAvatar from 'app/components/avatar/userAvatar';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import Tooltip from 'app/components/tooltip';
 import MemberListStore from 'app/stores/memberListStore';
-import TeamStore from 'app/stores/teamStore';
 import {Actor} from 'app/types';
+import Teams from 'app/utils/teams';
 
 type DefaultProps = {
   hasTooltip: boolean;
@@ -40,8 +41,17 @@ class ActorAvatar extends React.Component<Props> {
     }
 
     if (actor.type === 'team') {
-      const team = TeamStore.getById(actor.id);
-      return <TeamAvatar team={team} {...props} />;
+      return (
+        <Teams ids={[actor.id]}>
+          {({initiallyLoaded, teams}) =>
+            initiallyLoaded ? (
+              <TeamAvatar team={teams[0]} {...props} />
+            ) : (
+              <LoadingIndicator mini />
+            )
+          }
+        </Teams>
+      );
     }
 
     Sentry.withScope(scope => {

--- a/tests/js/spec/components/avatar/actorAvatar.spec.jsx
+++ b/tests/js/spec/components/avatar/actorAvatar.spec.jsx
@@ -1,7 +1,9 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {act} from 'sentry-test/reactTestingLibrary';
 
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import MemberListStore from 'app/stores/memberListStore';
+import OrganizationStore from 'app/stores/organizationStore';
 import TeamStore from 'app/stores/teamStore';
 
 describe('ActorAvatar', function () {
@@ -20,9 +22,11 @@ describe('ActorAvatar', function () {
       },
     ],
   };
+  const org = TestStubs.Organization();
+  OrganizationStore.onUpdate(org, {replace: true});
   beforeEach(function () {
     MemberListStore.loadInitialData([USER]);
-    TeamStore.loadInitialData([TEAM_1]);
+    act(() => void TeamStore.loadInitialData([TEAM_1]));
   });
 
   afterEach(function () {});
@@ -68,6 +72,33 @@ describe('ActorAvatar', function () {
       );
 
       expect(avatar.html()).toBe(null);
+    });
+
+    it('should fetch a team not in the store', async function () {
+      const team2 = TestStubs.Team({id: '2'});
+
+      const mockRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/teams/`,
+        method: 'GET',
+        body: [team2],
+      });
+
+      const avatar = mountWithTheme(
+        <ActorAvatar
+          actor={{
+            id: '2',
+            name: 'COOL TEAM',
+            type: 'team',
+          }}
+        />
+      );
+
+      expect(mockRequest).toHaveBeenCalled();
+
+      await act(() => tick());
+      avatar.update();
+
+      expect(avatar.find('LetterAvatar')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
There are cases in which actor avatar will be rendered with a team id that is not in the store such as the assignee selector, alert page, etc...

Use the teams render prop to allow actor avatar to fetch a team if it is not found in the store.