### PR TITLE
fix(discover): Error correctly on invalid timestamp

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -66,6 +66,11 @@ ARRAY_FIELDS = {
     "spans_group",
     "spans_exclusive_time",
 }
+TIMESTAMP_FIELDS = {
+    "timestamp",
+    "timestamp.to_hour",
+    "timestamp.to_day",
+}
 
 CONFIGURABLE_AGGREGATES = {
     "apdex()": "apdex({threshold}) as apdex",

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -46,6 +46,7 @@ from sentry.search.events.constants import (
     SEMVER_PACKAGE_ALIAS,
     SEMVER_WILDCARDS,
     TEAM_KEY_TRANSACTION_ALIAS,
+    TIMESTAMP_FIELDS,
     TRANSACTION_STATUS_ALIAS,
     USER_DISPLAY_ALIAS,
 )
@@ -1347,6 +1348,7 @@ class QueryFilter(QueryFields):
 
     def _default_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         name = search_filter.key.name
+        operator = search_filter.operator
         value = search_filter.value.value
 
         lhs = self.resolve_column(name)
@@ -1358,7 +1360,7 @@ class QueryFilter(QueryFields):
                 # be replaced with '\%%'.
                 return Condition(
                     lhs,
-                    Op.LIKE if search_filter.operator == "=" else Op.NOT_LIKE,
+                    Op.LIKE if operator == "=" else Op.NOT_LIKE,
                     # Slashes have to be double escaped so they are
                     # interpreted as a string literal.
                     search_filter.value.raw_value.replace("\\", "\\\\")
@@ -1369,23 +1371,19 @@ class QueryFilter(QueryFields):
             elif name in ARRAY_FIELDS and search_filter.is_in_filter:
                 return Condition(
                     Function("hasAny", [self.column(name), value]),
-                    Op.EQ if search_filter.operator == "IN" else Op.NEQ,
+                    Op.EQ if operator == "IN" else Op.NEQ,
                     1,
                 )
             elif name in ARRAY_FIELDS and search_filter.value.raw_value == "":
                 return Condition(
                     Function("notEmpty", [self.column(name)]),
-                    Op.EQ if search_filter.operator == "!=" else Op.NEQ,
+                    Op.EQ if operator == "!=" else Op.NEQ,
                     1,
                 )
 
         # timestamp{,.to_{hour,day}} need a datetime string
         # last_seen needs an integer
-        if isinstance(value, datetime) and name not in {
-            "timestamp",
-            "timestamp.to_hour",
-            "timestamp.to_day",
-        }:
+        if isinstance(value, datetime) and name not in TIMESTAMP_FIELDS:
             value = int(to_timestamp(value)) * 1000
 
         if name in {"trace.span", "trace.parent_span"}:
@@ -1401,6 +1399,17 @@ class QueryFilter(QueryFields):
             elif not search_filter.value.is_event_id():
                 label = "Filter ID" if name == "id" else "Filter Trace ID"
                 raise InvalidSearchQuery(INVALID_ID_DETAILS.format(label))
+
+        if name in TIMESTAMP_FIELDS:
+            if (
+                operator in ["<", "<="]
+                and value < self.params["start"]
+                or operator in [">", ">="]
+                and value > self.params["end"]
+            ):
+                raise InvalidSearchQuery(
+                    "Filter on timestamp is outside of the selected date range."
+                )
 
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -34,9 +34,9 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         super().setUp()
         self.environment = self.create_environment(self.project, name="prod")
         self.release = self.create_release(self.project, version="first-release")
-        self.now = before_now()
-        self.one_min_ago = before_now(minutes=1)
-        self.two_min_ago = before_now(minutes=2)
+        self.now = before_now().replace(tzinfo=timezone.utc)
+        self.one_min_ago = before_now(minutes=1).replace(tzinfo=timezone.utc)
+        self.two_min_ago = before_now(minutes=2).replace(tzinfo=timezone.utc)
 
         self.event_time = self.one_min_ago
         self.event = self.store_event(
@@ -401,9 +401,9 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             ], use_snql
 
     def test_timestamp_rounding_filters(self):
-        one_day_ago = before_now(days=1)
-        two_day_ago = before_now(days=2)
-        three_day_ago = before_now(days=3)
+        one_day_ago = before_now(days=1).replace(tzinfo=timezone.utc)
+        two_day_ago = before_now(days=2).replace(tzinfo=timezone.utc)
+        three_day_ago = before_now(days=3).replace(tzinfo=timezone.utc)
 
         self.store_event(
             data={


### PR DESCRIPTION
- If a timestamp filter is outside the timestamps of the query we
  currently 500 because snuba throws an error.
- This changes it so its a user error instead since the query is invalid
- Fixes SNUBA-2H7