### PR TITLE
fix(team-stats): Add more helpful team misery empty state

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import AsyncComponent from 'app/components/asyncComponent';
+import Button from 'app/components/button';
 import {DateTimeObject} from 'app/components/charts/utils';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
@@ -82,6 +83,16 @@ function TeamMisery({
     <Fragment>
       <StyledPanelTable
         isEmpty={projects.length === 0 || periodTableData?.data.length === 0}
+        emptyMessage={t('No key Transactions Starred By This Team')}
+        emptyAction={
+          <Button
+            size="small"
+            external
+            href="https://docs.sentry.io/product/performance/transaction-summary/#starring-key-transactions"
+          >
+            {t('Learn More')}
+          </Button>
+        }
         headers={[
           t('Key transaction'),
           t('Project'),

--- a/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamMisery.spec.jsx
@@ -114,7 +114,9 @@ describe('TeamMisery', () => {
       {context: routerContext}
     );
 
-    expect(screen.getByText('There are no items to display')).toBeInTheDocument();
+    expect(
+      screen.getByText('No key Transactions Starred By This Team')
+    ).toBeInTheDocument();
   });
 
   it('should render empty state on error', async () => {

--- a/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
@@ -41,8 +41,6 @@ describe('TeamStability', () => {
       <TeamStability projects={[]} organization={TestStubs.Organization()} period="7d" />
     );
 
-    expect(
-      screen.getByText('No key Transactions Starred By This Team')
-    ).toBeInTheDocument();
+    expect(screen.getByText('There are no items to display')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/teamStability.spec.jsx
@@ -41,6 +41,8 @@ describe('TeamStability', () => {
       <TeamStability projects={[]} organization={TestStubs.Organization()} period="7d" />
     );
 
-    expect(screen.getByText('There are no items to display')).toBeInTheDocument();
+    expect(
+      screen.getByText('No key Transactions Starred By This Team')
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Adds a link to key transaction docs

![image](https://user-images.githubusercontent.com/1400464/142308969-693fffc4-0f24-447d-9169-4a31d2621264.png)
