### PR TITLE
fix(performance): Cache transaction threshold configs

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2,10 +2,10 @@ import re
 from collections import defaultdict, namedtuple
 from copy import deepcopy
 from datetime import datetime
-from functools import lru_cache
 from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Sequence, Set, Tuple, Union
 
 import sentry_sdk
+from django.utils.functional import cached_property
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
@@ -2329,7 +2329,7 @@ class QueryFields(QueryBase):
             TIMESTAMP_TO_HOUR_ALIAS: self._resolve_timestamp_to_hour_alias,
             TIMESTAMP_TO_DAY_ALIAS: self._resolve_timestamp_to_day_alias,
             USER_DISPLAY_ALIAS: self._resolve_user_display_alias,
-            PROJECT_THRESHOLD_CONFIG_ALIAS: self._resolve_project_threshold_config,
+            PROJECT_THRESHOLD_CONFIG_ALIAS: lambda _: self._resolve_project_threshold_config,
             ERROR_UNHANDLED_ALIAS: self._resolve_error_unhandled_alias,
             TEAM_KEY_TRANSACTION_ALIAS: self._resolve_team_key_transaction_alias,
             MEASUREMENTS_FRAMES_SLOW_RATE: self._resolve_measurements_frames_slow_rate,
@@ -3114,8 +3114,8 @@ class QueryFields(QueryBase):
         columns = ["user.email", "user.username", "user.ip"]
         return Function("coalesce", [self.column(column) for column in columns], USER_DISPLAY_ALIAS)
 
-    @lru_cache
-    def _resolve_project_threshold_config(self, _: str) -> SelectType:
+    @cached_property
+    def _resolve_project_threshold_config(self) -> SelectType:
         org_id = self.params.get("organization_id")
         project_ids = self.params.get("project_id")
 

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2,6 +2,7 @@ import re
 from collections import defaultdict, namedtuple
 from copy import deepcopy
 from datetime import datetime
+from functools import lru_cache
 from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Sequence, Set, Tuple, Union
 
 import sentry_sdk
@@ -3113,6 +3114,7 @@ class QueryFields(QueryBase):
         columns = ["user.email", "user.username", "user.ip"]
         return Function("coalesce", [self.column(column) for column in columns], USER_DISPLAY_ALIAS)
 
+    @lru_cache
     def _resolve_project_threshold_config(self, _: str) -> SelectType:
         org_id = self.params.get("organization_id")
         project_ids = self.params.get("project_id")


### PR DESCRIPTION
The transaction threshold configs is used repeatedly in the query for things
like apdex and user misery. Each time it is used, the column resolution
procedure is re-run resulting in redundant db calls to fetch the configs each
time. This change caches the resolved config so that is fast to reuse the result
in other parts of the query.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/142333710-884bcfc5-edfe-4ab4-ade8-1f04855e5b49.png)

## After

![image](https://user-images.githubusercontent.com/10239353/142333760-c942e433-dc50-402e-96e3-11410a6057cf.png)