### PR TITLE
fix(analytics): Put a check for organization in alert rule details page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1013,16 +1013,16 @@ function buildRoutes() {
         componentPromise={() => import('sentry/views/alerts/list')}
         component={SafeLazyLoad}
       />
-      <Route
-        path="rules/details/:ruleId/"
-        name={t('Alert Rule Details')}
-        component={SafeLazyLoad}
-        componentPromise={() => import('sentry/views/alerts/rules/details')}
-      />
       <Route path="rules/">
         <IndexRoute
           component={SafeLazyLoad}
           componentPromise={() => import('sentry/views/alerts/rules')}
+        />
+        <Route
+          path="details/:ruleId/"
+          name={t('Alert Rule Details')}
+          component={SafeLazyLoad}
+          componentPromise={() => import('sentry/views/alerts/rules/details')}
         />
         <Route
           path=":projectId/"
@@ -1054,11 +1054,6 @@ function buildRoutes() {
           />
         </Route>
       </Route>
-      <Route
-        path="rules/"
-        componentPromise={() => import('sentry/views/alerts/rules')}
-        component={SafeLazyLoad}
-      />
       <Route
         path=":alertId/"
         componentPromise={() => import('sentry/views/alerts/details')}

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -71,7 +71,7 @@ class AlertRuleDetails extends Component<Props, State> {
     trackAnalyticsEvent({
       eventKey: 'alert_rule_details.viewed',
       eventName: 'Alert Rule Details: Viewed',
-      organization_id: organization.id,
+      organization_id: organization ? organization.id : null,
       rule_id: parseInt(params.ruleId, 10),
       alert: location.query.alert ?? '',
     });


### PR DESCRIPTION
This fixes an issue in the alert rule details page analytics event where organization is null, this is an unexpected behavior since by the time this page mounts organization should be defined. However since this is only for analytics it's fine to put a guard for now.

Also tidied up routes for `/alerts/`

Fixes: JAVASCRIPT-25TN