### PR TITLE
feat: Set variables on Apple M1 to build Python packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ drop-db \
 create-db \
 apply-migrations \
 reset-db \
+setup-apple-m1 \
 setup-git \
 node-version-check \
 install-js-dev \

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -3,6 +3,8 @@ boto3==1.13.16
 botocore==1.16.16
 celery==4.4.7
 click==7.1.2
+# See if we can remove CPATH from lib.sh
+# https://github.com/getsentry/sentry/pull/30094
 confluent-kafka==1.5.0; python_version == '3.8'
 confluent-kafka==1.6.0; python_version == '3.9'
 croniter==0.3.37
@@ -60,6 +62,8 @@ toronado==0.1.0
 ua-parser==0.10.0
 unidiff==0.6.0
 urllib3==1.24.2
+# See if we can remove LDFLAGS from lib.sh
+# https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.19.1
 zstandard==0.14.1
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -105,7 +105,7 @@ install-py-dev() {
     upgrade-pip
     # It places us within top src dir to be at the same path as setup.py
     # This helps when getsentry calls into this script
-    cd "${HERE}/.." || exit
+    cd "${HERE}/.." :|| exit
 
     echo "--> Installing Sentry (for development)"
     if query-apple-m1; then
@@ -143,7 +143,7 @@ export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib:\${LDFLAGS}"
     if [ "$SHELL" == "/bin/zsh" ]; then
         if ! grep -qF "${header}" "${zshrc_path}"; then
             echo "Added the following to ${zshrc_path}"
-
+            cp "${zshrc_path}" "${zshrc_path}.bak"
             echo -e "$body" >> "${zshrc_path}"
             echo -e "$body"
         fi
@@ -232,6 +232,7 @@ build-platform-assets() {
 }
 
 bootstrap() {
+    setup-apple-m1
     develop
     init-config
     run-dependent-services

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -105,7 +105,7 @@ install-py-dev() {
     upgrade-pip
     # It places us within top src dir to be at the same path as setup.py
     # This helps when getsentry calls into this script
-    cd "${HERE}/.." :|| exit
+    cd "${HERE}/.." || exit
 
     echo "--> Installing Sentry (for development)"
     if query-apple-m1; then

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -106,19 +106,20 @@ install-py-dev() {
     # It places us within top src dir to be at the same path as setup.py
     # This helps when getsentry calls into this script
     cd "${HERE}/.." || exit
+
     echo "--> Installing Sentry (for development)"
     if query-apple-m1; then
         # This installs pyscopg-binary2 since there's no arm64 wheel
         # This saves having to install postgresql on the Developer's machine + using flags
         # https://github.com/psycopg/psycopg2/issues/1286
         pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
-        # This install confluent-kafka from our GC storage since there's no arm64 wheel
-        # https://github.com/confluentinc/confluent-kafka-python/issues/1190
-        pip install https://storage.googleapis.com/python-arm64-wheels/confluent_kafka-1.5.0-cp38-cp38-macosx_11_0_arm64.whl
-        # uwsgi does not properly install via pyenv Python installations
-        # https://github.com/unbit/uwsgi/issues/2361
-        LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib  pip install "uWSGI==2.0.19.1"
     fi
+
+    # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
+    # Webpacked assets are only necessary for devserver (which does it lazily anyways)
+    # and acceptance tests, which webpack automatically if run.
+    SENTRY_LIGHT_BUILD=1 pip install -e '.[dev]'
+
     # This hack is until we can upgrade to a newer version of Selenium
     fx_profile=.venv/lib/python3.8/site-packages/selenium/webdriver/firefox/firefox_profile.py
     # Remove this block when upgrading the selenium package
@@ -126,10 +127,30 @@ install-py-dev() {
         echo "We are patching ${fx_profile}. You will see this message only once."
         patch -p0 <scripts/patches/firefox_profile.diff
     fi
-    # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
-    # Webpacked assets are only necessary for devserver (which does it lazily anyways)
-    # and acceptance tests, which webpack automatically if run.
-    SENTRY_LIGHT_BUILD=1 pip install -e '.[dev]'
+}
+
+setup-apple-m1() {
+    ! query-apple-m1 && return
+
+    zshrc_path="${HOME}/.zshrc"
+    header="# Apple M1 environment variables"
+    # The CPATH is needed for confluent-kakfa --> https://github.com/confluentinc/confluent-kafka-python/issues/1190
+    # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
+    body="
+$header
+export CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include:\${CPATH}
+export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib:\${LDFLAGS}"
+    if [ "$SHELL" == "/bin/zsh" ]; then
+        if ! grep -qF "${header}" "${zshrc_path}"; then
+            echo "Added the following to ${zshrc_path}"
+
+            echo -e "$body" >> "${zshrc_path}"
+            echo -e "$body"
+        fi
+    else
+        echo "You are not using a supported shell. Please add these variables where appropiate."
+        echo -e "$body"
+    fi
 }
 
 setup-git-config() {

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -138,8 +138,8 @@ setup-apple-m1() {
     # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
     body="
 $header
-export CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include:\${CPATH}
-export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib:\${LDFLAGS}"
+export CPATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include
+export LDFLAGS=-L/opt/homebrew/Cellar/gettext/0.21/lib"
     if [ "$SHELL" == "/bin/zsh" ]; then
         if ! grep -qF "${header}" "${zshrc_path}"; then
             echo "Added the following to ${zshrc_path}"


### PR DESCRIPTION
This sets certain flags on the developer's machine in order to allow building confluent-kafka and uWSGI.

Setting the flags globally under `~/.zshrc` benefits other project that depend on these Python libraries (e.g. Snuba needs confluent-kafka since sentry-arroyo is used in the pre-commit hooks).