### PR TITLE
Add rate limit to `ProjectEventsEndpoint`

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -7,7 +7,7 @@ from sentry.api.serializers import EventSerializer, SimpleEventSerializer, seria
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
-    @rate_limit_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=1, window=1)
     def get(self, request, project):
         """
         List a Project's Events

--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -2,10 +2,12 @@ from functools import partial
 
 from sentry import eventstore
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
+    @rate_limit_endpoint(limit=10, window=1)
     def get(self, request, project):
         """
         List a Project's Events


### PR DESCRIPTION
We're getting a large number of hits to this endpoint and it's causing our system issues, adding a
rate limit here.