### PR TITLE
Temporarily limit `project_events` to offsets < 10k

### DIFF
--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -74,3 +74,16 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["eventID"] == event_2.event_id
+
+    def test_cursor_limit(self):
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+        response = self.client.get(url + "?cursor=0:10000:0", format="json")
+        assert response.status_code == 200, response.content
+        response = self.client.get(url + "?cursor=0:10001:0", format="json")
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
We've noticed a lot of expensive queries coming from this endpoint. This seems related to larger
offsets, so temporarily limiting the max offset that we allow on this endpoint.