### PR TITLE
perf(api): Add feature flag to limit `project_events` to events from the last week

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -1,6 +1,7 @@
+from datetime import datetime, timedelta
 from functools import partial
 
-from sentry import eventstore
+from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.helpers.group_index import rate_limit_endpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
@@ -32,6 +33,15 @@ class ProjectEventsEndpoint(ProjectEndpoint):
         conditions = []
         if query:
             conditions.append([["positionCaseInsensitive", ["message", f"'{query}'"]], "!=", 0])
+
+        if features.has(
+            "organizations:project-event-date-limit", project.organization, actor=request.user
+        ):
+            conditions.extend(
+                [
+                    ["timestamp", ">", datetime.now() - timedelta(days=7)],
+                ]
+            )
 
         full = request.GET.get("full", False)
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -996,6 +996,8 @@ SENTRY_FEATURES = {
     "organizations:integrations-stacktrace-link": False,
     # Allow orgs to install a custom source code management integration
     "organizations:integrations-custom-scm": False,
+    # Limit project events endpoint to only query back a certain number of days
+    "organizations:project-event-date-limit": False,
     # Allow orgs to debug internal/unpublished sentry apps with logging
     "organizations:sentry-app-debugging": False,
     # Enable data forwarding functionality for organizations.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -129,6 +129,7 @@ default_manager.add("organizations:performance-tag-explorer", OrganizationFeatur
 default_manager.add("organizations:performance-tag-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-snql", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
+default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:prompt-dashboards", OrganizationFeature)
 default_manager.add("organizations:related-events", OrganizationFeature)
 default_manager.add("organizations:relay", OrganizationFeature)


### PR DESCRIPTION
For large customers this endpoint can scan all 90 days of their data if they attempt to page through it. To
help reduce the impact of this, we limit the end date to the last week.