### PR TITLE
fix(trace): Reducing the size of the orphan trace

### DIFF
--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -81,7 +81,7 @@ class PerformanceTraceDetailTest(AcceptanceTestCase, SnubaTestCase):
         # a chain of transactions that are orphans
         self.task_transactions = []
         last_transaction_id = make_span_id()
-        for i in range(5):
+        for i in range(2):
             transaction_id = make_span_id()
             timestamp = self.day_ago + timedelta(seconds=i, microseconds=30000)
             self.create_error(


### PR DESCRIPTION
- The acceptance tests were flaking here, reducing the size of the
  orphan tree to try to reduce how ofetn this flakes