### PR TITLE
ref(perf): Change landing widget dropdown to exclude existing

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -5,7 +6,10 @@ import {Location} from 'history';
 import {PerformanceLayoutBodyRow} from 'app/components/performance/layouts';
 import space from 'app/styles/space';
 import EventView from 'app/utils/discover/eventView';
+import {usePerformanceDisplayType} from 'app/utils/performance/contexts/performanceDisplayContext';
+import {PROJECT_PERFORMANCE_TYPE} from 'app/views/performance/utils';
 
+import {getChartSetting} from '../utils';
 import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 import WidgetContainer from './widgetContainer';
@@ -18,25 +22,45 @@ export type ChartRowProps = {
   chartCount: number;
 };
 
-const ChartRow = (props: ChartRowProps) => {
-  const charts = props.chartCount;
-  const theme = useTheme();
-  const palette = theme.charts.getColorPalette(charts);
+function getInitialChartSettings(
+  chartCount: number,
+  chartHeight: number,
+  performanceType: PROJECT_PERFORMANCE_TYPE,
+  allowedCharts: PerformanceWidgetSetting[]
+) {
+  return new Array(chartCount)
+    .fill(0)
+    .map((_, index) =>
+      getChartSetting(index, chartHeight, performanceType, allowedCharts[index])
+    );
+}
 
-  if (props.allowedCharts.length < charts) {
+const ChartRow = (props: ChartRowProps) => {
+  const {chartCount, chartHeight, allowedCharts} = props;
+  const theme = useTheme();
+  const performanceType = usePerformanceDisplayType();
+  const palette = theme.charts.getColorPalette(chartCount);
+
+  const [chartSettings, setChartSettings] = useState(
+    getInitialChartSettings(chartCount, chartHeight, performanceType, allowedCharts)
+  );
+
+  if (props.allowedCharts.length < chartCount) {
     throw new Error('Not enough allowed chart types to show row.');
   }
 
   return (
     <StyledRow minSize={200}>
-      {new Array(charts).fill(0).map((_, index) => (
+      {new Array(chartCount).fill(0).map((_, index) => (
         <WidgetContainer
           {...props}
           key={index}
           index={index}
-          chartHeight={props.chartHeight}
+          chartHeight={chartHeight}
           chartColor={palette[index]}
-          defaultChartSetting={props.allowedCharts[index]}
+          defaultChartSetting={allowedCharts[index]}
+          rowChartSettings={chartSettings}
+          setRowChartSettings={setChartSettings}
         />
       ))}
     </StyledRow>

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -1,19 +1,19 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import pick from 'lodash/pick';
 
 import MenuItem from 'app/components/menuItem';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import trackAdvancedAnalyticsEvent from 'app/utils/analytics/trackAdvancedAnalyticsEvent';
-import localStorage from 'app/utils/localStorage';
 import {usePerformanceDisplayType} from 'app/utils/performance/contexts/performanceDisplayContext';
 import useOrganization from 'app/utils/useOrganization';
 import withOrganization from 'app/utils/withOrganization';
 import ContextMenu from 'app/views/dashboardsV2/contextMenu';
 import {useMetricsSwitch} from 'app/views/performance/metricsSwitch';
-import {PROJECT_PERFORMANCE_TYPE} from 'app/views/performance/utils';
 
 import {GenericPerformanceWidgetDataType} from '../types';
+import {_setChartSetting, getChartSetting} from '../utils';
 import {PerformanceWidgetSetting, WIDGET_DEFINITIONS} from '../widgetDefinitions';
 import {HistogramWidget} from '../widgets/histogramWidget';
 import {LineChartListWidget} from '../widgets/lineChartListWidget';
@@ -30,63 +30,10 @@ type Props = {
   allowedCharts: PerformanceWidgetSetting[];
   chartHeight: number;
   chartColor?: string;
-  forceDefaultChartSetting?: boolean; // Used for testing.
+  forceDefaultChartSetting?: boolean;
+  rowChartSettings: PerformanceWidgetSetting[];
+  setRowChartSettings: (settings: PerformanceWidgetSetting[]) => void;
 } & ChartRowProps;
-
-// Use local storage for chart settings for now.
-const getContainerLocalStorageObjectKey = 'landing-chart-container';
-const getContainerKey = (
-  index: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
-  height: number
-) => `landing-chart-container#${performanceType}#${height}#${index}`;
-
-function getWidgetStorageObject() {
-  const localObject = JSON.parse(
-    localStorage.getItem(getContainerLocalStorageObjectKey) || '{}'
-  );
-  return localObject;
-}
-
-function setWidgetStorageObject(localObject: Record<string, string>) {
-  localStorage.setItem(getContainerLocalStorageObjectKey, JSON.stringify(localObject));
-}
-
-const getChartSetting = (
-  index: number,
-  height: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
-  defaultType: PerformanceWidgetSetting,
-  forceDefaultChartSetting?: boolean // Used for testing.
-): PerformanceWidgetSetting => {
-  if (forceDefaultChartSetting) {
-    return defaultType;
-  }
-  const key = getContainerKey(index, performanceType, height);
-  const localObject = getWidgetStorageObject();
-  const value = localObject?.[key];
-
-  if (
-    value &&
-    Object.values(PerformanceWidgetSetting).includes(value as PerformanceWidgetSetting)
-  ) {
-    const _value: PerformanceWidgetSetting = value as PerformanceWidgetSetting;
-    return _value;
-  }
-  return defaultType;
-};
-const _setChartSetting = (
-  index: number,
-  height: number,
-  performanceType: PROJECT_PERFORMANCE_TYPE,
-  setting: PerformanceWidgetSetting
-) => {
-  const key = getContainerKey(index, performanceType, height);
-  const localObject = getWidgetStorageObject();
-  localObject[key] = setting;
-
-  setWidgetStorageObject(localObject);
-};
 
 function trackChartSettingChange(
   previousChartSetting: PerformanceWidgetSetting,
@@ -103,7 +50,15 @@ function trackChartSettingChange(
 }
 
 const _WidgetContainer = (props: Props) => {
-  const {organization, index, chartHeight, allowedCharts, ...rest} = props;
+  const {
+    organization,
+    index,
+    chartHeight,
+    allowedCharts,
+    rowChartSettings,
+    setRowChartSettings,
+    ...rest
+  } = props;
   const {isMetricsData} = useMetricsSwitch();
   const performanceType = usePerformanceDisplayType();
   let _chartSetting = getChartSetting(
@@ -125,6 +80,9 @@ const _WidgetContainer = (props: Props) => {
       _setChartSetting(index, chartHeight, performanceType, setting);
     }
     setChartSettingState(setting);
+    const newSettings = [...rowChartSettings];
+    newSettings[index] = setting;
+    setRowChartSettings(newSettings);
     trackChartSettingChange(
       chartSetting,
       setting,
@@ -147,6 +105,7 @@ const _WidgetContainer = (props: Props) => {
         {...containerProps}
         allowedCharts={props.allowedCharts}
         setChartSetting={setChartSetting}
+        rowChartSettings={rowChartSettings}
       />
     ),
   };
@@ -155,17 +114,19 @@ const _WidgetContainer = (props: Props) => {
     return <h1>{t('Using metrics')}</h1>;
   }
 
+  const passedProps = pick(props, ['eventView', 'location', 'organization']);
+
   switch (widgetProps.dataType) {
     case GenericPerformanceWidgetDataType.trends:
-      return <TrendsWidget {...props} {...widgetProps} />;
+      return <TrendsWidget {...passedProps} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.area:
-      return <SingleFieldAreaWidget {...props} {...widgetProps} />;
+      return <SingleFieldAreaWidget {...passedProps} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.vitals:
-      return <VitalWidget {...props} {...widgetProps} />;
+      return <VitalWidget {...passedProps} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.line_list:
-      return <LineChartListWidget {...props} {...widgetProps} />;
+      return <LineChartListWidget {...passedProps} {...widgetProps} />;
     case GenericPerformanceWidgetDataType.histogram:
-      return <HistogramWidget {...props} {...widgetProps} />;
+      return <HistogramWidget {...passedProps} {...widgetProps} />;
     default:
       throw new Error(`Widget type "${widgetProps.dataType}" has no implementation.`);
   }
@@ -174,16 +135,19 @@ const _WidgetContainer = (props: Props) => {
 export const WidgetContainerActions = ({
   setChartSetting,
   allowedCharts,
+  rowChartSettings,
 }: {
-  loading: boolean;
   setChartSetting: (setting: PerformanceWidgetSetting) => void;
   allowedCharts: PerformanceWidgetSetting[];
+  rowChartSettings: PerformanceWidgetSetting[];
 }) => {
   const organization = useOrganization();
   const menuOptions: React.ReactNode[] = [];
 
+  const inactiveCharts = allowedCharts.filter(chart => !rowChartSettings.includes(chart));
+
   const settingsMap = WIDGET_DEFINITIONS({organization});
-  for (const setting of allowedCharts) {
+  for (const setting of inactiveCharts) {
     const options = settingsMap[setting];
     menuOptions.push(
       <MenuItem

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -1,3 +1,7 @@
+import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
+
+import {PerformanceWidgetSetting} from './widgetDefinitions';
+
 export const eventsRequestQueryProps = [
   'children',
   'organization',
@@ -8,3 +12,57 @@ export const eventsRequestQueryProps = [
   'environment',
   'project',
 ] as const;
+
+function setWidgetStorageObject(localObject: Record<string, string>) {
+  localStorage.setItem(getContainerLocalStorageObjectKey, JSON.stringify(localObject));
+}
+
+const getContainerLocalStorageObjectKey = 'landing-chart-container';
+const getContainerKey = (
+  index: number,
+  performanceType: PROJECT_PERFORMANCE_TYPE,
+  height: number
+) => `landing-chart-container#${performanceType}#${height}#${index}`;
+
+function getWidgetStorageObject() {
+  const localObject = JSON.parse(
+    localStorage.getItem(getContainerLocalStorageObjectKey) || '{}'
+  );
+  return localObject;
+}
+
+export const getChartSetting = (
+  index: number,
+  height: number,
+  performanceType: PROJECT_PERFORMANCE_TYPE,
+  defaultType: PerformanceWidgetSetting,
+  forceDefaultChartSetting?: boolean // Used for testing.
+): PerformanceWidgetSetting => {
+  if (forceDefaultChartSetting) {
+    return defaultType;
+  }
+  const key = getContainerKey(index, performanceType, height);
+  const localObject = getWidgetStorageObject();
+  const value = localObject?.[key];
+
+  if (
+    value &&
+    Object.values(PerformanceWidgetSetting).includes(value as PerformanceWidgetSetting)
+  ) {
+    const _value: PerformanceWidgetSetting = value as PerformanceWidgetSetting;
+    return _value;
+  }
+  return defaultType;
+};
+export const _setChartSetting = (
+  index: number,
+  height: number,
+  performanceType: PROJECT_PERFORMANCE_TYPE,
+  setting: PerformanceWidgetSetting
+) => {
+  const key = getContainerKey(index, performanceType, height);
+  const localObject = getWidgetStorageObject();
+  localObject[key] = setting;
+
+  setWidgetStorageObject(localObject);
+};

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -22,14 +22,15 @@ const WrappedComponent = ({data, ...rest}) => {
     <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
       <OrganizationContext.Provider value={data.organization}>
         <WidgetContainer
-          {...data}
-          {...rest}
           allowedCharts={[
             PerformanceWidgetSetting.TPM_AREA,
             PerformanceWidgetSetting.FAILURE_RATE_AREA,
             PerformanceWidgetSetting.USER_MISERY_AREA,
           ]}
+          rowChartSettings={[]}
           forceDefaultChartSetting
+          {...data}
+          {...rest}
         />
       </OrganizationContext.Provider>
     </PerformanceDisplayProvider>
@@ -576,10 +577,13 @@ describe('Performance > Widgets > WidgetContainer', function () {
   it('Able to change widget type from menu', async function () {
     const data = initializeData();
 
+    const setRowChartSettings = jest.fn(() => {});
+
     const wrapper = mountWithTheme(
       <WrappedComponent
         data={data}
         defaultChartSetting={PerformanceWidgetSetting.FAILURE_RATE_AREA}
+        setRowChartSettings={setRowChartSettings}
       />,
       data.routerContext
     );
@@ -590,6 +594,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       'Failure Rate'
     );
     expect(eventStatsMock).toHaveBeenCalledTimes(1);
+    expect(setRowChartSettings).toHaveBeenCalledTimes(0);
 
     wrapper.find('IconEllipsis[data-test-id="context-menu"]').simulate('click');
 
@@ -597,6 +602,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
     wrapper.update();
 
     expect(wrapper.find('MenuItem').at(2).text()).toEqual('User Misery');
+
     wrapper.find('MenuItem').at(2).simulate('click');
 
     await tick();
@@ -606,5 +612,35 @@ describe('Performance > Widgets > WidgetContainer', function () {
       'User Misery'
     );
     expect(eventStatsMock).toHaveBeenCalledTimes(2);
+    expect(setRowChartSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('Chart settings passed from the row are not shown in menu', async function () {
+    const data = initializeData();
+
+    const setRowChartSettings = jest.fn(() => {});
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.FAILURE_RATE_AREA}
+        setRowChartSettings={setRowChartSettings}
+        rowChartSettings={[PerformanceWidgetSetting.FAILURE_RATE_AREA]}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="performance-widget-title"]').text()).toEqual(
+      'Failure Rate'
+    );
+
+    wrapper.find('IconEllipsis[data-test-id="context-menu"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('MenuItem').at(1).text()).toEqual('User Misery');
   });
 });


### PR DESCRIPTION
### Summary 

This will exclude existing chart types from the dropdowns on the landing page by keep tracking of chart settings for each row (this works since there is currently no overlap, we can switch to using a context in the future if there are overlapping chart types between rows).