### PR TITLE
fix(dashboards): fix dashboardId event view event for default-overview 

### DIFF
--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -66,7 +66,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
         eventKey: 'dashboards2.view',
         eventName: 'Dashboards2: View dashboard',
         organization_id: parseInt(this.props.organization.id, 10),
-        dashboard_id: parseInt(params.dashboardId, 10),
+        dashboard_id: params.dashboardId,
       });
     }
 


### PR DESCRIPTION
Saw this line introduces a fix for `RELOAD-29` but I can't view the issue.`default-overview` can't be parseInt'd causing dashboard_id to be get lost in amplitude.