### PR TITLE
feat(sentry apps): Don't allow publication without logos

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/api/endpoints/sentry_app_publish_request.py
@@ -4,11 +4,13 @@ from sentry import options
 from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Updater
+from sentry.models import SentryAppAvatar
 from sentry.utils import email
 
 
 class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
     def post(self, request, sentry_app):
+
         # check status of app to make sure it is unpublished
         if sentry_app.is_published:
             return Response({"detail": "Cannot publish already published integration."}, status=400)
@@ -18,6 +20,19 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
 
         if sentry_app.is_publish_request_inprogress:
             return Response({"detail": "Publish request in progress."}, status=400)
+
+        # TODO: add feature flag after other PR is merged
+        if not SentryAppAvatar.objects.filter(sentry_app=sentry_app, color=True).exists():
+            return Response({"detail": "Must upload a logo for the integration."}, status=400)
+
+        if (
+            self.is_issue_link_integration(sentry_app)
+            and not SentryAppAvatar.objects.filter(sentry_app=sentry_app, color=False).exists()
+        ):
+            return Response(
+                {"detail": "Must upload a black and white logo for issue linking integrations."},
+                status=400,
+            )
 
         Updater.run(
             user=request.user,
@@ -41,3 +56,14 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
         )
 
         return Response(status=201)
+
+    def is_issue_link_integration(self, sentry_app):
+        """Determine if the sentry app supports issue linking"""
+        if not sentry_app.schema:
+            return False
+
+        for element in sentry_app.schema.get("elements"):
+            if element.get("type") and element.get("type") == "issue-link":
+                return True
+
+        return False

--- a/src/sentry/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/api/endpoints/sentry_app_publish_request.py
@@ -4,7 +4,7 @@ from sentry import features, options
 from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Updater
-from sentry.models import SentryAppAvatar
+from sentry.models import SentryAppAvatar, SentryAppAvatarTypes
 from sentry.utils import email
 
 
@@ -29,14 +29,16 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
 
         if features.has("organizations:sentry-app-logo-upload", sentry_app.owner):
             if not SentryAppAvatar.objects.filter(
-                sentry_app=sentry_app, color=True, avatar_type=1
+                sentry_app=sentry_app, color=True, avatar_type=SentryAppAvatarTypes.UPLOAD.value
             ).exists():
                 return Response({"detail": "Must upload a logo for the integration."}, status=400)
 
             if (
                 is_issue_link_integration(sentry_app)
                 and not SentryAppAvatar.objects.filter(
-                    sentry_app=sentry_app, color=False, avatar_type=1
+                    sentry_app=sentry_app,
+                    color=False,
+                    avatar_type=SentryAppAvatarTypes.UPLOAD.value,
                 ).exists()
             ):
                 return Response(

--- a/src/sentry/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/api/endpoints/sentry_app_publish_request.py
@@ -28,12 +28,16 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
             return Response({"detail": "Publish request in progress."}, status=400)
 
         if features.has("organizations:sentry-app-logo-upload", sentry_app.owner):
-            if not SentryAppAvatar.objects.filter(sentry_app=sentry_app, color=True).exists():
+            if not SentryAppAvatar.objects.filter(
+                sentry_app=sentry_app, color=True, avatar_type=1
+            ).exists():
                 return Response({"detail": "Must upload a logo for the integration."}, status=400)
 
             if (
                 is_issue_link_integration(sentry_app)
-                and not SentryAppAvatar.objects.filter(sentry_app=sentry_app, color=False).exists()
+                and not SentryAppAvatar.objects.filter(
+                    sentry_app=sentry_app, color=False, avatar_type=1
+                ).exists()
             ):
                 return Response(
                     {

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -22,12 +22,12 @@ class SentryAppAvatar(AvatarBase):
     and specifies which type of logo it is.
     """
 
+    AVATAR_TYPES = SentryAppAvatarTypes.get_choices()
+
     FILE_TYPE = "avatar.file"
 
     sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="avatar")
-    avatar_type = models.PositiveSmallIntegerField(
-        default=0, choices=SentryAppAvatarTypes.get_choices()
-    )
+    avatar_type = models.PositiveSmallIntegerField(default=0, choices=AVATAR_TYPES)
     color = models.BooleanField(default=False)
     # e.g. issue linking logos will not have color
 

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -1,8 +1,19 @@
+from enum import Enum
+
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey
 
 from . import AvatarBase
+
+
+class SentryAppAvatarTypes(Enum):
+    DEFAULT = 0
+    UPLOAD = 1
+
+    @classmethod
+    def get_choices(cls):
+        return tuple((_.value, _.name.lower()) for _ in SentryAppAvatarTypes)
 
 
 class SentryAppAvatar(AvatarBase):
@@ -11,12 +22,12 @@ class SentryAppAvatar(AvatarBase):
     and specifies which type of logo it is.
     """
 
-    AVATAR_TYPES = ((0, "default"), (1, "upload"))
-
     FILE_TYPE = "avatar.file"
 
     sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="avatar")
-    avatar_type = models.PositiveSmallIntegerField(default=0, choices=AVATAR_TYPES)
+    avatar_type = models.PositiveSmallIntegerField(
+        default=0, choices=SentryAppAvatarTypes.get_choices()
+    )
     color = models.BooleanField(default=False)
     # e.g. issue linking logos will not have color
 

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -3,22 +3,33 @@ from unittest import mock
 from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
+from sentry.models import SentryAppAvatar
 from sentry.testutils import APITestCase
 
 
 class SentryAppPublishRequestTest(APITestCase):
+    def upload_logo(self):
+        SentryAppAvatar.objects.create(sentry_app=self.sentry_app, avatar_type=1, color=True)
+
+    def upload_issue_link_logo(self):
+        SentryAppAvatar.objects.create(sentry_app=self.sentry_app, avatar_type=1, color=False)
+
     def setUp(self):
         # create user as superuser
         self.user = self.create_user(email="boop@example.com", is_superuser=True)
         self.org = self.create_organization(owner=self.user, name="My Org")
         self.project = self.create_project(organization=self.org)
-
-        self.sentry_app = self.create_sentry_app(name="Testin", organization=self.org)
-
+        self.sentry_app = self.create_sentry_app(
+            name="Testin",
+            organization=self.org,
+            schema={"elements": [self.create_issue_link_schema()]},
+        )
         self.url = reverse("sentry-api-0-sentry-app-publish-request", args=[self.sentry_app.slug])
 
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_request(self, send_mail):
+        self.upload_logo()
+        self.upload_issue_link_logo()
         self.login_as(user=self.user)
         response = self.client.post(
             self.url,
@@ -61,4 +72,24 @@ class SentryAppPublishRequestTest(APITestCase):
         response = self.client.post(self.url, format="json")
         assert response.status_code == 400
         assert response.data["detail"] == "Cannot publish internal integration."
+        send_mail.asssert_not_called()
+
+    @mock.patch("sentry.utils.email.send_mail")
+    def test_publish_no_logo(self, send_mail):
+        self.login_as(user=self.user)
+        response = self.client.post(self.url, format="json")
+        assert response.status_code == 400
+        assert response.data["detail"] == "Must upload a logo for the integration."
+        send_mail.asssert_not_called()
+
+    @mock.patch("sentry.utils.email.send_mail")
+    def test_publish_no_issue_link_logo(self, send_mail):
+        self.upload_logo()
+        self.login_as(user=self.user)
+        response = self.client.post(self.url, format="json")
+        assert response.status_code == 400
+        assert (
+            response.data["detail"]
+            == "Must upload a black and white logo for issue linking integrations."
+        )
         send_mail.asssert_not_called()

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -77,7 +77,8 @@ class SentryAppPublishRequestTest(APITestCase):
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_no_logo(self, send_mail):
         self.login_as(user=self.user)
-        response = self.client.post(self.url, format="json")
+        with self.feature("organizations:sentry-app-logo-upload"):
+            response = self.client.post(self.url, format="json")
         assert response.status_code == 400
         assert response.data["detail"] == "Must upload a logo for the integration."
         send_mail.asssert_not_called()
@@ -86,7 +87,8 @@ class SentryAppPublishRequestTest(APITestCase):
     def test_publish_no_issue_link_logo(self, send_mail):
         self.upload_logo()
         self.login_as(user=self.user)
-        response = self.client.post(self.url, format="json")
+        with self.feature("organizations:sentry-app-logo-upload"):
+            response = self.client.post(self.url, format="json")
         assert response.status_code == 400
         assert (
             response.data["detail"]


### PR DESCRIPTION
We want to prevent developers from being able to submit a publication request for their integration if they haven't uploaded their integration's logo. If it is an issue link integration, they will be prevented from submitting the publication request if they have not also uploaded a logo for the issue linking sidebar. 