### PR TITLE
fix(api): Use Filter.start to pass the start date

### DIFF
--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -82,9 +82,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         event = self.store_event(
             data={"timestamp": iso_format(before_now(days=2))}, project_id=project.id
         )
-        event_2 = self.store_event(
-            data={"timestamp": iso_format(before_now(days=8))}, project_id=project.id
-        )
+        self.store_event(data={"timestamp": iso_format(before_now(days=8))}, project_id=project.id)
 
         url = reverse(
             "sentry-api-0-project-events",
@@ -93,12 +91,6 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
                 "project_slug": project.slug,
             },
         )
-
-        response = self.client.get(url, format="json")
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 2
-        assert response.data[0]["eventID"] == event.event_id
-        assert response.data[1]["eventID"] == event_2.event_id
 
         with self.feature("organizations:project-event-date-limit"):
             response = self.client.get(url, format="json")


### PR DESCRIPTION
Using start in conditions like we do currently causes extra query clauses in clickhouse. 
Just use the Filter.start property so that we have just the one clause for the lower bound.