### PR TITLE
fix(perf): Landing all transactions view should have p75

### DIFF
--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -20,6 +20,7 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
             PerformanceWidgetSetting.FAILURE_RATE_AREA,
             PerformanceWidgetSetting.APDEX_AREA,
             PerformanceWidgetSetting.P50_DURATION_AREA,
+            PerformanceWidgetSetting.P75_DURATION_AREA,
             PerformanceWidgetSetting.P95_DURATION_AREA,
             PerformanceWidgetSetting.P99_DURATION_AREA,
           ]}


### PR DESCRIPTION
### Summary
P75 is a common percentile, and exists on other views. We can remove it later if it isn't heavily used.