### PR TITLE
fix(perf): Stop widgets from paginating with the table

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -118,6 +118,8 @@ export function LineChartListWidget(props: Props) {
             eventView={eventView}
             location={props.location}
             limit={3}
+            cursor="0:0:1"
+            noPagination
           />
         );
       },

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -83,6 +83,8 @@ export function TrendsWidget(props: Props) {
           trendChangeType={trendChangeType}
           trendFunctionField={trendFunctionField}
           limit={3}
+          cursor="0:0:1"
+          noPagination
         />
       ),
       transform: transformTrendsDiscover,

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -139,6 +139,8 @@ export function VitalWidget(props: Props) {
               eventView={_eventView}
               location={props.location}
               limit={3}
+              cursor="0:0:1"
+              noPagination
             />
           );
         },


### PR DESCRIPTION
### Summary
Our query components use cursor by default if not provided, so the same url query key is causing all list widgets to paginate.