### PR TITLE
chore(api): Relax ratelimit on `ProjectEventsEndpoint` to 5/s

### DIFF
--- a/src/sentry/api/endpoints/project_events.py
+++ b/src/sentry/api/endpoints/project_events.py
@@ -8,7 +8,7 @@ from sentry.api.serializers import EventSerializer, SimpleEventSerializer, seria
 
 
 class ProjectEventsEndpoint(ProjectEndpoint):
-    @rate_limit_endpoint(limit=1, window=1)
+    @rate_limit_endpoint(limit=5, window=1)
     def get(self, request, project):
         """
         List a Project's Events


### PR DESCRIPTION
Relax this more now that the incident has passed and the cause of this issue has been improved.