### PR TITLE
fix(slack): SlackUnlinkIdentityView Identity.DoesNotExist

### DIFF
--- a/src/sentry/integrations/slack/views/unlink_identity.py
+++ b/src/sentry/integrations/slack/views/unlink_identity.py
@@ -56,10 +56,8 @@ class SlackUnlinkIdentityView(BaseView):  # type: ignore
                 context={"organization": organization, "provider": integration.get_provider()},
             )
 
-        # Delete the wrong slack identity.
         try:
-            identity = Identity.objects.get(idp=idp, external_id=params["slack_id"])
-            identity.delete()
+            Identity.objects.filter(idp=idp, external_id=params["slack_id"]).delete()
         except IntegrityError as e:
             logger.error("slack.unlink.integrity-error", extra=e)
             raise Http404


### PR DESCRIPTION
Unlinking an identity twice is 500ing. Instead of showing a 404 just pretend it unlinked again.

Fixes [SENTRY-S49](https://sentry.io/organizations/sentry/issues/2629093951/activity).