### PR TITLE
fix(trends): Fixing trends with snql breaking with sort

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -3039,9 +3039,6 @@ class QueryFields(QueryBase):
         if not match:
             raise InvalidSearchQuery(f"Invalid characters in field {function}")
 
-        if function in self.params.get("aliases", {}):
-            raise NotImplementedError("Aggregate aliases not implemented in snql field parsing yet")
-
         name, combinator_name, parsed_arguments, alias = self.parse_function(match)
         if overwrite_alias is not None:
             alias = overwrite_alias

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -238,6 +238,28 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
 
             assert len(events["data"]) == query_data[2], query_data
 
+    def test_trend_percentage_query_alias_as_sort(self):
+        with self.feature(self.features):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "start": iso_format(self.day_ago),
+                    "field": ["project", "transaction"],
+                    "query": "event.type:transaction",
+                    "trendType": "improved",
+                    "trendFunction": "p50()",
+                    "sort": "trend_percentage()",
+                },
+            )
+
+        assert response.status_code == 200, response.content
+
+        events = response.data
+
+        assert len(events["data"]) == 1
+
     def test_trend_difference_query_alias(self):
         queries = [
             ("trend_difference():>7s", "regression", 1),


### PR DESCRIPTION
- The orderby on trends was broken because it couldn't resolve the trend
  aliases
- Fixes SENTRY-SRC