### PR TITLE
feat(sentryapps): Create SentryApp with default avatars

### DIFF
--- a/src/sentry/api/bases/avatar.py
+++ b/src/sentry/api/bases/avatar.py
@@ -26,18 +26,16 @@ class AvatarSerializer(serializers.Serializer):
 
 
 class SentryAppLogoSerializer(serializers.Serializer):
-    avatar_photo = AvatarField(required=True)
-    avatar_type = serializers.ChoiceField(choices=(("upload", "upload")))
+    avatar_photo = AvatarField(required=False)
+    avatar_type = serializers.ChoiceField(choices=(("default", "default"), ("upload", "upload")))
     color = serializers.BooleanField(required=True)
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
-        if attrs.get("avatar_type") != "upload":
-            raise serializers.ValidationError(
-                {"avatar_type": "avatar_type must be set to 'upload'."}
-            )
-        if not attrs.get("avatar_photo"):
+
+        if attrs.get("avatar_type") == "upload" and not attrs.get("avatar_photo"):
             raise serializers.ValidationError({"avatar_photo": "A logo is required."})
+
         return attrs
 
 

--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator, InternalCreator
-from sentry.models import SentryApp
+from sentry.models import SentryApp, SentryAppAvatar
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -106,6 +106,10 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             except ValidationError as e:
                 # we generate and validate the slug here instead of the serializer since the slug never changes
                 return Response(e.detail, status=400)
+
+            if features.has("organizations:sentry-app-logo-upload", sentry_app.owner):
+                SentryAppAvatar.objects.create(sentry_app=sentry_app, color=True, avatar_type=0)
+                SentryAppAvatar.objects.create(sentry_app=sentry_app, color=False, avatar_type=0)
 
             return Response(serialize(sentry_app, access=request.access), status=201)
 

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -11,7 +11,7 @@ class SentryAppAvatar(AvatarBase):
     and specifies which type of logo it is.
     """
 
-    AVATAR_TYPES = ((0, "letter_avatar"), (1, "upload"))
+    AVATAR_TYPES = ((0, "default"), (1, "upload"))
 
     FILE_TYPE = "avatar.file"
 

--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -8,8 +8,9 @@ class SentryAppAvatarTestBase(APITestCase):
     def setUp(self):
         super().setUp()
         self.unpublished_app = self.create_sentry_app(name="Meow", organization=self.organization)
+        SentryAppAvatar.objects.create(sentry_app=self.unpublished_app, color=True, avatar_type=0)
+        SentryAppAvatar.objects.create(sentry_app=self.unpublished_app, color=False, avatar_type=0)
         self.endpoint = "sentry-api-0-sentry-app-avatar"
-
         self.login_as(self.user)
 
 
@@ -17,7 +18,15 @@ class SentryAppAvatarTest(SentryAppAvatarTestBase):
     def test_get(self):
         with self.feature("organizations:sentry-app-logo-upload"):
             response = self.get_success_response(self.unpublished_app.slug)
-            assert response.data["uuid"] == str(self.unpublished_app.uuid)
+
+        assert response.data["avatars"][0]["avatarType"] == 0
+        assert response.data["avatars"][0]["avatarUuid"] is not None
+        assert response.data["avatars"][0]["color"] is True
+
+        assert response.data["avatars"][1]["avatarType"] == 0
+        assert response.data["avatars"][1]["avatarUuid"] is not None
+        assert response.data["avatars"][1]["color"] is False
+        assert response.data["uuid"] == str(self.unpublished_app.uuid)
 
 
 class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
@@ -32,12 +41,12 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
             }
             resp = self.get_success_response(self.unpublished_app.slug, **data)
 
-        avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app)
+        avatar = SentryAppAvatar.objects.get(sentry_app=self.unpublished_app, color=True)
         assert avatar.file_id
         assert avatar.get_avatar_type_display() == "upload"
-        assert resp.data["avatars"][0]["avatarType"] == 1
-        assert resp.data["avatars"][0]["avatarUuid"] is not None
-        assert resp.data["avatars"][0]["color"] is True
+        assert resp.data["avatars"][1]["avatarType"] == 1
+        assert resp.data["avatars"][1]["avatarUuid"] is not None
+        assert resp.data["avatars"][1]["color"] is True
 
     def test_upload_both(self):
         with self.feature("organizations:sentry-app-logo-upload"):
@@ -49,7 +58,6 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
             }
             self.get_success_response(self.unpublished_app.slug, **data)
 
-        with self.feature("organizations:sentry-app-logo-upload"):
             # upload the issue link logo
             data2 = {
                 "color": False,
@@ -72,6 +80,47 @@ class SentryAppAvatarPutTest(SentryAppAvatarTestBase):
         assert resp.data["avatars"][1]["color"] is False
         assert resp.data["avatars"][1]["avatarType"] == 1
         assert resp.data["avatars"][1]["avatarUuid"] is not None
+
+    def test_revert_to_default(self):
+        """Test that a user can go back to the default avatars after having uploaded one"""
+        with self.feature("organizations:sentry-app-logo-upload"):
+            # upload the regular logo
+            data = {
+                "color": True,
+                "avatar_type": "upload",
+                "avatar_photo": b64encode(self.load_fixture("avatar.jpg")),
+            }
+            self.get_success_response(self.unpublished_app.slug, **data)
+
+            # upload the issue link logo
+            data2 = {
+                "color": False,
+                "avatar_type": "upload",
+                "avatar_photo": b64encode(self.load_fixture("avatar.jpg")),
+            }
+            self.get_success_response(self.unpublished_app.slug, **data2)
+
+            # revert to default
+            data = {
+                "color": True,
+                "avatar_type": "default",
+            }
+            self.get_success_response(self.unpublished_app.slug, **data)
+
+            # revert to default
+            data2 = {
+                "color": False,
+                "avatar_type": "default",
+            }
+            response = self.get_success_response(self.unpublished_app.slug, **data2)
+
+        assert response.data["avatars"][0]["avatarType"] == 0
+        assert response.data["avatars"][0]["avatarUuid"] is not None
+        assert response.data["avatars"][0]["color"] is True
+
+        assert response.data["avatars"][1]["avatarType"] == 0
+        assert response.data["avatars"][1]["avatarUuid"] is not None
+        assert response.data["avatars"][1]["color"] is False
 
     def test_put_bad(self):
         SentryAppAvatar.objects.create(sentry_app=self.unpublished_app)


### PR DESCRIPTION
Add a new avatar type of "default" and create new sentry apps with them. This is done so that if after a user has uploaded a logo they want to revert to the default, we can do that. This is similar behavior to how organization and user avatars work - consider the "default" to be like the letter avatars or gravatars. The file they uploaded previously will still be there, but if we detect the default type we'll render the default image for integrations and issue linking. 