### PR TITLE
feat(access logs): add request duration to API access logs

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -168,7 +168,7 @@ class Endpoint(APIView):
         try:
 
             token_class = getattr(self.request.auth, "__class__", None)
-            token_name = token_class.__name__
+            token_name = token_class.__name__ if token_class else None
 
             view_obj = self.request.parser_context["view"]
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -195,7 +195,7 @@ class Endpoint(APIView):
                 caller_ip=str(self.request.META.get("REMOTE_ADDR")),
                 user_agent=str(self.request.META.get("HTTP_USER_AGENT")),
                 rate_limited=str(getattr(self.request, "will_be_rate_limited", False)),
-                request_duration_seconds=time.perf_counter() - request_start_time,
+                request_duration_seconds=time.time() - request_start_time,
             )
             api_access_logger.info("api.access", extra=log_metrics)
         except Exception:


### PR DESCRIPTION
### Context
The API access logs tell us how many ties an API was hit per second but not every API call costs the same. Having this in our logs will allow us to do more detailed analysis on problematic endpoints.

### Solution
Record the time it takes to perform the request and log it with the access logs