### PR TITLE
fix(ui) Align UTC transforms in usage charts

### DIFF
--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -18,8 +18,8 @@ export const FORMAT_DATETIME_HOURLY = 'MMM D LT';
  * Ensure that this method is idempotent and doesn't change the moment object
  * that is passed in
  *
- * If hours are not shown, this method will need to use UTC to avoid oddities
- * caused by the user being ahead/behind UTC.
+ * Use the `useUtc` parameter to get the UTC date for the provided
+ * moment instance.
  */
 export function getDateFromMoment(
   m: moment.Moment,
@@ -28,7 +28,9 @@ export function getDateFromMoment(
 ) {
   const days = parsePeriodToHours(interval) / 24;
   if (days >= 1) {
-    return moment.utc(m).format(FORMAT_DATETIME_DAILY);
+    return useUtc
+      ? moment.utc(m).format(FORMAT_DATETIME_DAILY)
+      : m.format(FORMAT_DATETIME_DAILY);
   }
 
   const parsedInterval = parseStatsPeriod(interval);
@@ -49,11 +51,11 @@ export function getDateFromUnixTimestamp(timestamp: number) {
 export function getXAxisDates(
   dateStart: string,
   dateEnd: string,
-  dateUtc: boolean = true,
+  dateUtc: boolean = false,
   interval: IntervalPeriod = '1d'
 ): string[] {
   const range: string[] = [];
-  const start = moment(dateStart).utc().startOf('h');
+  const start = moment(dateStart).startOf('h');
   const end = moment(dateEnd).startOf('h');
 
   if (!start.isValid() || !end.isValid()) {

--- a/tests/js/spec/views/organizationStats/usageChart/utils.spec.jsx
+++ b/tests/js/spec/views/organizationStats/usageChart/utils.spec.jsx
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import {
   getDateFromMoment,
   getXAxisDates,
@@ -7,28 +9,30 @@ const TS_START = 1531094400000; // 2018 July 9, 12am UTC
 const TS_END = 1531180800000; // 2018 July 10, 12am UTC
 
 describe('getDateFromMoment', () => {
+  const start = moment.unix(TS_START / 1000);
   // Ensure date remains in UTC
   it('shows the date if interval is >= 24h', () => {
-    expect(getDateFromMoment(TS_START)).toBe('Jul 9');
-    expect(getDateFromMoment(TS_START, '7d')).toBe('Jul 9');
+    expect(getDateFromMoment(start)).toBe('Jul 9');
+    expect(getDateFromMoment(start, '7d')).toBe('Jul 9');
+    expect(getDateFromMoment(moment('2021-10-31'))).toBe('Oct 31');
   });
 
   // Ensure datetime is shifted to localtime
   it('shows the date and time if interval is <24h', () => {
-    expect(getDateFromMoment(TS_START, '6h')).toBe('Jul 8 8:00 PM - 2:00 AM (-04:00)');
-    expect(getDateFromMoment(TS_START, '1h')).toBe('Jul 8 8:00 PM - 9:00 PM (-04:00)');
-    expect(getDateFromMoment(TS_START, '5m')).toBe('Jul 8 8:00 PM - 8:05 PM (-04:00)');
+    expect(getDateFromMoment(start, '6h')).toBe('Jul 8 8:00 PM - 2:00 AM (-04:00)');
+    expect(getDateFromMoment(start, '1h')).toBe('Jul 8 8:00 PM - 9:00 PM (-04:00)');
+    expect(getDateFromMoment(start, '5m')).toBe('Jul 8 8:00 PM - 8:05 PM (-04:00)');
   });
 
   // Ensure datetime is shifted to localtime
   it('coerces date and time into UTC', () => {
-    expect(getDateFromMoment(TS_START, '6h', true)).toBe(
+    expect(getDateFromMoment(start, '6h', true)).toBe(
       'Jul 9 12:00 AM - 6:00 AM (+00:00)'
     );
-    expect(getDateFromMoment(TS_START, '1h', true)).toBe(
+    expect(getDateFromMoment(start, '1h', true)).toBe(
       'Jul 9 12:00 AM - 1:00 AM (+00:00)'
     );
-    expect(getDateFromMoment(TS_START, '5m', true)).toBe(
+    expect(getDateFromMoment(start, '5m', true)).toBe(
       'Jul 9 12:00 AM - 12:05 AM (+00:00)'
     );
   });
@@ -37,8 +41,11 @@ describe('getDateFromMoment', () => {
 describe('getXAxisDates', () => {
   // Ensure date remains in UTC
   it('calculates 1d intervals', () => {
-    const dates = getXAxisDates(TS_START, TS_END);
+    let dates = getXAxisDates(TS_START, TS_END);
     expect(dates).toEqual(['Jul 9', 'Jul 10']);
+
+    dates = getXAxisDates('2021-10-29', '2021-10-31');
+    expect(dates).toEqual(['Oct 29', 'Oct 30', 'Oct 31']);
   });
 
   // Datetime remains in UTC


### PR DESCRIPTION
The billing subscription page was suffering a problem where the start date was off by a day if a user was set their account timezone to Europe/London. This issue also resulted in days like October 31 not displaying at all. While I've updated tests they don't entirely cover this scenario as our tests always run in UTC which doesn't exhibit the problem.

I've checked organization stats, and verified that start/end times are still aligned for users both in and outside of UTC timezones but I'm not well versed in the nuances of that view.