### PR TITLE
reverts changes that changed notification events

### DIFF
--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence
 
+from sentry import analytics
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.utils.actions import MessageAction
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
@@ -91,3 +93,14 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
         # Explicitly typing to satisfy mypy.
         recipients: Iterable[Team | User] = self.organization.get_owners()
         return recipients
+
+    def record_notification_sent(
+        self, recipient: Team | User, provider: ExternalProviders, **kwargs: Any
+    ) -> None:
+        # TODO: refactor since this is identical to BaseNotification.record_notification_sent
+        analytics.record(
+            f"integrations.{provider.name}.notification_sent",
+            category=self.get_category(),
+            **self.get_log_params(recipient),
+            **kwargs,
+        )

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -97,7 +97,7 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
     def record_notification_sent(
         self, recipient: Team | User, provider: ExternalProviders, **kwargs: Any
     ) -> None:
-        # TODO: refactor since this is identical to BaseNotification.record_notification_sent
+        # TODO: refactor since this is identical to ProjectNotification.record_notification_sent
         analytics.record(
             f"integrations.{provider.name}.notification_sent",
             category=self.get_category(),


### PR DESCRIPTION
We lost analytics events like `invite_request.sent` when this PR was merged: https://github.com/getsentry/sentry/pull/29065

This PR reverts the change related to analytics