### PR TITLE
fix(events): Apply a rate limit to GroupEventsLatestEndpoint

### DIFF
--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -3,9 +3,11 @@ from rest_framework.response import Response
 from sentry.api import client
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.helpers.environments import get_environments
+from sentry.api.helpers.group_index import rate_limit_endpoint
 
 
 class GroupEventsLatestEndpoint(GroupEndpoint):
+    @rate_limit_endpoint(limit=15, window=1)
     def get(self, request, group):
         """
         Retrieve the Latest Event for an Issue


### PR DESCRIPTION
We've seen an uptick in requests hitting this endpoint causing a ~10% increase in ClickHouse load.

Current p99 for this endpoint by org and p99 by ip is 13 RPS. Adding a 15 RPS rate limit.
