### PR TITLE
fix(dashboards): Fix loading indicator moving page footer

### DIFF
--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -7,6 +7,7 @@ import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import NoProjectMessage from 'app/components/noProjectMessage';
 import SearchBar from 'app/components/searchBar';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -178,6 +179,14 @@ class ManageDashboards extends AsyncView<Props, State> {
       pathname: `/organizations/${organization.slug}/dashboards/new/`,
       query: location.query,
     });
+  }
+
+  renderLoading() {
+    return (
+      <PageContent>
+        <LoadingIndicator />
+      </PageContent>
+    );
   }
 
   renderBody() {

--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -6,8 +6,10 @@ import isEqual from 'lodash/isEqual';
 import {Client} from 'app/api';
 import AsyncComponent from 'app/components/asyncComponent';
 import NotFound from 'app/components/errors/notFound';
+import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
+import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 
@@ -95,6 +97,14 @@ class OrgDashboards extends AsyncComponent<Props, State> {
         ...location.query,
       },
     });
+  }
+
+  renderLoading() {
+    return (
+      <PageContent>
+        <LoadingIndicator />
+      </PageContent>
+    );
   }
 
   renderBody() {


### PR DESCRIPTION
The components were falling back to the renderLoading
function in AsyncComponent. Fixed by subclassing it
in and wrapping loading indicator in with PageContent
so the footer doesn't move up.