### PR TITLE
feat(dashboard-layout): Replace old feature flag and remove size selector

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1002,8 +1002,8 @@ SENTRY_FEATURES = {
     "organizations:sentry-app-debugging": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
-    # Enable widget resizing in dashboards
-    "organizations:dashboard-widget-resizing": False,
+    # Enable react-grid-layout dashboards
+    "organizations:dashboard-grid-layout": False,
     # Enable readonly dashboards
     "organizations:dashboards-basic": True,
     # Enable custom editable dashboards

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -64,7 +64,7 @@ default_manager.add("organizations:connect-discover-and-dashboards", Organizatio
 default_manager.add("organizations:crash-rate-alerts", OrganizationFeature, True)
 default_manager.add("organizations:custom-event-title", OrganizationFeature)
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)
-default_manager.add("organizations:dashboard-widget-resizing", OrganizationFeature, True)
+default_manager.add("organizations:dashboard-grid-layout", OrganizationFeature, True)
 default_manager.add("organizations:dashboards-basic", OrganizationFeature)
 default_manager.add("organizations:dashboards-edit", OrganizationFeature)
 default_manager.add("organizations:widget-library", OrganizationFeature, True)

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -8,11 +8,9 @@ import isEqual from 'lodash/isEqual';
 
 import {openDashboardWidgetQuerySelectorModal} from 'app/actionCreators/modal';
 import {Client} from 'app/api';
-import Feature from 'app/components/acl/feature';
 import {HeaderTitle} from 'app/components/charts/styles';
 import ErrorBoundary from 'app/components/errorBoundary';
 import FeatureBadge from 'app/components/featureBadge';
-import {SelectField} from 'app/components/forms';
 import MenuItem from 'app/components/menuItem';
 import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
 import {Panel} from 'app/components/panels';
@@ -34,27 +32,6 @@ import ContextMenu from './contextMenu';
 import {Widget} from './types';
 import WidgetCardChart from './widgetCardChart';
 import WidgetQueries from './widgetQueries';
-
-type SizeSelectorProps = {
-  size: string;
-  onSizeChange: (size: string) => void;
-};
-
-const SizeSelector = ({size, onSizeChange}: SizeSelectorProps) => {
-  return (
-    <SelectField
-      name="size"
-      clearable={false}
-      choices={[
-        ['small', 'Small'],
-        ['medium', 'Medium'],
-        ['large', 'Large'],
-      ]}
-      onChange={value => onSizeChange(value as string)}
-      value={size}
-    />
-  );
-};
 
 type DraggableProps = Pick<ReturnType<typeof useSortable>, 'attributes' | 'listeners'>;
 
@@ -104,11 +81,6 @@ class WidgetCard extends React.Component<Props> {
 
     return (
       <ToolbarPanel>
-        <Feature features={['dashboard-widget-resizing']}>
-          <SizeSelectContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
-            <SizeSelector size="medium" onSizeChange={_ => {}} />
-          </SizeSelectContainer>
-        </Feature>
         <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
           <IconClick>
             <StyledIconGrabbable
@@ -327,11 +299,6 @@ const ToolbarPanel = styled('div')`
 
   background-color: ${p => p.theme.overlayBackgroundAlpha};
   border-radius: ${p => p.theme.borderRadius};
-`;
-
-const SizeSelectContainer = styled(`div`)`
-  width: 120px;
-  margin-top: 8px;
 `;
 
 const IconContainer = styled('div')`

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.jsx
@@ -176,42 +176,4 @@ describe('Dashboards > WidgetCard', function () {
       })
     );
   });
-
-  it('renders a select field for choosing widget size when editing', async function () {
-    const resizeFeatureData = initializeOrg({
-      organization: TestStubs.Organization({
-        features: [
-          'connect-discover-and-dashboards',
-          'dashboards-edit',
-          'discover-basic',
-          'dashboard-widget-resizing',
-        ],
-        projects: [TestStubs.Project()],
-      }),
-    });
-
-    const wrapper = mountWithTheme(
-      <WidgetCard
-        isEditing
-        api={api}
-        organization={resizeFeatureData.organization}
-        widget={multipleQueryWidget}
-        selection={selection}
-        onDelete={() => undefined}
-        onEdit={() => undefined}
-        renderErrorMessage={() => undefined}
-        isSorting={false}
-        currentWidgetDragging={false}
-        showContextMenu
-      >
-        {() => <div data-test-id="child" />}
-      </WidgetCard>,
-      resizeFeatureData.routerContext
-    );
-
-    await tick();
-
-    const sizeSelector = wrapper.find('SizeSelector');
-    expect(sizeSelector.length).toEqual(1);
-  });
 });


### PR DESCRIPTION
Since we're taking a different direction with dashboard layout improvements, I decided to rename the feature flag to something more descriptive and remove the old code that was added for that feature.