### PR TITLE
ref(ui): Marginally better time icon spacing in group item

### DIFF
--- a/static/app/components/group/inboxBadges/timesTag.tsx
+++ b/static/app/components/group/inboxBadges/timesTag.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import TimeSince from 'app/components/timeSince';
 import {IconClock} from 'app/icons';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 import getDynamicText from 'app/utils/getDynamicText';
 
 /**
@@ -63,7 +64,7 @@ const Separator = styled('span')`
 `;
 
 const StyledIconClock = styled(IconClock)`
-  margin-right: 2px;
+  margin-right: ${space(0.5)};
 `;
 
 export default TimesTag;


### PR DESCRIPTION
old ![image](https://user-images.githubusercontent.com/1421724/142916172-d84d0d02-2385-4656-8043-383192b35fe5.png)

new 
![image](https://user-images.githubusercontent.com/1421724/142916188-fd09f138-7e72-4d88-b1d4-d5a0502a9d43.png)
