### PR TITLE
feat(suspect-spans): Support custom number of examples

### DIFF
--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -72,10 +72,10 @@ class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsEndpointBase)
 
         try:
             per_suspect = int(request.GET.get("perSuspect", 4))
-            if per_suspect < 0 or per_suspect > 4:
+            if per_suspect < 0 or per_suspect > 10:
                 raise ValueError
         except ValueError:
-            raise ParseError(detail="perSuspect must be integer between 0 and 4.")
+            raise ParseError(detail="perSuspect must be integer between 0 and 10.")
 
         direction, orderby_column = self.get_orderby_column(request)
 

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -365,7 +365,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
         assert response.status_code == 404, response.content
 
     def test_bad_per_suspect(self):
-        for per_suspect in [-1000, 1000]:
+        for per_suspect in [-1, 11]:
             with self.feature(self.FEATURES):
                 response = self.client.get(
                     self.url,
@@ -376,7 +376,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                     format="json",
                 )
             assert response.status_code == 400, response.content
-            assert response.data == {"detail": "perSuspect must be integer between 0 and 4."}
+            assert response.data == {"detail": "perSuspect must be integer between 0 and 10."}
 
     @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")
     def test_default_per_suspect(self, mock_raw_snql_query):
@@ -445,7 +445,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
     def test_custom_per_suspect(self, mock_raw_snql_query):
         event = self.create_event()
 
-        for i, per_suspect in enumerate(range(1, 5)):
+        for i, per_suspect in enumerate(range(1, 11)):
             mock_raw_snql_query.side_effect = [
                 {
                     "data": [

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -438,7 +438,7 @@ class OrganizationEventsSpansPerformanceEndpointBase(APITestCase, SnubaTestCase)
                 format="json",
             )
         assert response.status_code == 200, response.content
-        # since per suspect is 0, the second
+        # since per suspect is 0, the second query to get examples is skipped entirely
         assert mock_raw_snql_query.call_count == 1
 
     @patch("sentry.api.endpoints.organization_events_spans_performance.raw_snql_query")


### PR DESCRIPTION
Currently, the number of examples returned is fixed at 4. This exposes a
parameter `perSuspect` to control the number of examples returned.