### PR TITLE
fix(discover): events-stats snql check for empty project string

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -310,7 +310,13 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
                 ][0]
                 self.where.remove(project_condition)
                 if field == "project":
-                    projects = list({self.project_slugs[event["project"]] for event in top_events})
+                    projects = list(
+                        {
+                            self.project_slugs[event["project"]]
+                            for event in top_events
+                            if event["project"]
+                        }
+                    )
                 else:
                     projects = list({event["project.id"] for event in top_events})
                 self.where.append(Condition(self.column("project_id"), Op.IN, projects))


### PR DESCRIPTION
adds an empty string check to fix a KeyError on snql events stats when querying for top events with a project column and with empty string result

Discover without snql doesn't have empty project string results so we can probably avoid this in the future by matching behaviour more closely