### PR TITLE
fix(integrations): Use try/except on externalissue

### DIFF
--- a/src/sentry/tasks/integrations/create_comment.py
+++ b/src/sentry/tasks/integrations/create_comment.py
@@ -12,7 +12,7 @@ from sentry.types.activity import ActivityType
     max_retries=5,
 )
 # TODO(jess): Add more retry exclusions once ApiClients have better error handling
-@retry(exclude=(ExternalIssue.DoesNotExist, Integration.DoesNotExist))
+@retry(exclude=(Integration.DoesNotExist))
 def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
     try:
         external_issue = ExternalIssue.objects.get(id=external_issue_id)

--- a/src/sentry/tasks/integrations/create_comment.py
+++ b/src/sentry/tasks/integrations/create_comment.py
@@ -14,7 +14,11 @@ from sentry.types.activity import ActivityType
 # TODO(jess): Add more retry exclusions once ApiClients have better error handling
 @retry(exclude=(ExternalIssue.DoesNotExist, Integration.DoesNotExist))
 def create_comment(external_issue_id: int, user_id: int, group_note_id: int) -> None:
-    external_issue = ExternalIssue.objects.get(id=external_issue_id)
+    try:
+        external_issue = ExternalIssue.objects.get(id=external_issue_id)
+    except ExternalIssue.DoesNotExist:
+        return
+
     installation = external_issue.get_installation()
 
     if not should_comment_sync(installation, external_issue):


### PR DESCRIPTION
Wrap getting an external issue in a try/except when creating a comment.

Fixes [SENTRY-SCC](https://sentry.io/organizations/sentry/issues/2700087866/?project=1&referrer=slack)