### PR TITLE
fix(perf): Fix passing chartHeight to miniChart widgets

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -114,7 +114,12 @@ const _WidgetContainer = (props: Props) => {
     return <h1>{t('Using metrics')}</h1>;
   }
 
-  const passedProps = pick(props, ['eventView', 'location', 'organization']);
+  const passedProps = pick(props, [
+    'eventView',
+    'location',
+    'organization',
+    'chartHeight',
+  ]);
 
   switch (widgetProps.dataType) {
     case GenericPerformanceWidgetDataType.trends:


### PR DESCRIPTION
### Summary
The widgets were falling back on their default height of 200 because of the change to omit all unnecessary props to reduce re-renders. This adds back chartHeight so there aren't mismatched height charts in the mini chart row.