### PR TITLE
fix(snql): Snql tags collide with fields

### DIFF
--- a/src/sentry/search/events/base.py
+++ b/src/sentry/search/events/base.py
@@ -48,7 +48,7 @@ class QueryBase:
 
         return {p.slug: p.id for p in project_slugs}
 
-    def aliased_column(self, name: str, alias: str) -> SelectType:
+    def aliased_column(self, name: str) -> SelectType:
         """Given an unresolved sentry name and an expected alias, return a snql
         column that will be aliased to the expected alias.
 
@@ -67,13 +67,13 @@ class QueryBase:
         #
         # Additionally, tags of the form `tags[...]` can't be aliased again
         # because it confuses the sdk.
-        if alias == resolved:
+        if name == resolved:
             return column
 
         # If the expected aliases differs from the resolved snuba column,
         # make sure to alias the expression appropriately so we get back
         # the column with the correct names.
-        return AliasedExpression(column, alias)
+        return AliasedExpression(column, name)
 
     def column(self, name: str) -> Column:
         """Given an unresolved sentry name and return a snql column.

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -2915,7 +2915,7 @@ class QueryFields(QueryBase):
         field = tag_match.group("tag") if tag_match else raw_field
 
         if VALID_FIELD_PATTERN.match(field):
-            return self.aliased_column(field, raw_field) if alias else self.column(field)
+            return self.aliased_column(raw_field) if alias else self.column(raw_field)
         else:
             raise InvalidSearchQuery(f"Invalid characters in field {field}")
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -328,10 +328,49 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                         "end": self.now,
                     },
                     orderby=column,
-                    use_snql=True,
+                    use_snql=use_snql,
                 )
                 data = result["data"]
                 assert len(data) == len(expected), (use_snql, column, query, expected)
+                assert [item[column] for item in data] == expected, use_snql
+
+    def test_tags_colliding_with_fields(self):
+        event = self.store_event(
+            data={
+                "message": "oh no",
+                "release": "first-release",
+                "environment": "prod",
+                "platform": "python",
+                "user": {"id": "99", "email": "bruce@example.com", "username": "brucew"},
+                "timestamp": iso_format(self.event_time),
+                "tags": [["id", "new"]],
+            },
+            project_id=self.project.id,
+        )
+
+        tests = [
+            ("id", "", sorted([self.event.event_id, event.event_id])),
+            ("id", f"id:{event.event_id}", [event.event_id]),
+            ("tags[id]", "", ["", "new"]),
+            ("tags[id]", "tags[id]:new", ["new"]),
+        ]
+
+        for use_snql in [False, True]:
+            for column, query, expected in tests:
+                result = discover.query(
+                    selected_columns=[column],
+                    query=query,
+                    params={
+                        "organization_id": self.organization.id,
+                        "project_id": [self.project.id],
+                        "start": self.two_min_ago,
+                        "end": self.now,
+                    },
+                    orderby=column,
+                    use_snql=use_snql,
+                )
+                data = result["data"]
+                assert len(data) == len(expected), (use_snql, query, expected)
                 assert [item[column] for item in data] == expected, use_snql
 
     def test_reverse_sorting_issue(self):


### PR DESCRIPTION
When a tag collide with a predefined field, the query builder incorrectly
resolves the tag to the field. Instead, when the `tags[...]` syntax is used, we
should always resolve it as a tag.