### PR TITLE
ref(dashboards): adds source prop dashboard widget

### DIFF
--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -1,6 +1,9 @@
 import {Fragment, memo} from 'react';
 import styled from '@emotion/styled';
+import moment from 'moment';
 
+import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
+import Button from 'app/components/button';
 import GroupReleaseChart from 'app/components/group/releaseChart';
 import SeenInfo from 'app/components/group/seenInfo';
 import Placeholder from 'app/components/placeholder';
@@ -10,6 +13,7 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {CurrentRelease, Environment, Group, Organization, Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
+import {DisplayType} from 'app/views/dashboardsV2/types';
 
 import SidebarSection from './sidebarSection';
 
@@ -47,12 +51,37 @@ const GroupReleaseStats = ({
   const hasRelease = new Set(project.features).has('releases');
   const releaseTrackingUrl = `/settings/${organization.slug}/projects/${project.slug}/release-tracking/`;
 
+  const time30dAgo = moment().subtract(30, 'days');
+
+  const openWidget = () =>
+    group &&
+    openAddDashboardWidgetModal({
+      organization,
+      widget: {
+        title: group.title,
+        displayType: DisplayType.AREA,
+        interval: '1h',
+        queries: [
+          {
+            name: '',
+            fields: ['count()'],
+            conditions: `issue.id:${group.id}`,
+            orderby: '',
+          },
+        ],
+      },
+      start: time30dAgo.toDate().toString(),
+      end: moment().toDate().toString(),
+      source: 'issueDetail',
+    });
+
   return (
     <SidebarSection title={<span data-test-id="env-label">{environmentLabel}</span>}>
       {!group || !allEnvironments ? (
         <Placeholder height="288px" />
       ) : (
         <Fragment>
+          <Button onClick={openWidget}>Add to Dashoard</Button>
           <GroupReleaseChart
             group={allEnvironments}
             environment={environmentLabel}

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -1,9 +1,6 @@
 import {Fragment, memo} from 'react';
 import styled from '@emotion/styled';
-import moment from 'moment';
 
-import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
-import Button from 'app/components/button';
 import GroupReleaseChart from 'app/components/group/releaseChart';
 import SeenInfo from 'app/components/group/seenInfo';
 import Placeholder from 'app/components/placeholder';
@@ -13,7 +10,6 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {CurrentRelease, Environment, Group, Organization, Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
-import {DisplayType} from 'app/views/dashboardsV2/types';
 
 import SidebarSection from './sidebarSection';
 
@@ -51,37 +47,12 @@ const GroupReleaseStats = ({
   const hasRelease = new Set(project.features).has('releases');
   const releaseTrackingUrl = `/settings/${organization.slug}/projects/${project.slug}/release-tracking/`;
 
-  const time30dAgo = moment().subtract(30, 'days');
-
-  const openWidget = () =>
-    group &&
-    openAddDashboardWidgetModal({
-      organization,
-      widget: {
-        title: group.title,
-        displayType: DisplayType.AREA,
-        interval: '1h',
-        queries: [
-          {
-            name: '',
-            fields: ['count()'],
-            conditions: `issue.id:${group.id}`,
-            orderby: '',
-          },
-        ],
-      },
-      start: time30dAgo.toDate().toString(),
-      end: moment().toDate().toString(),
-      source: 'issueDetail',
-    });
-
   return (
     <SidebarSection title={<span data-test-id="env-label">{environmentLabel}</span>}>
       {!group || !allEnvironments ? (
         <Placeholder height="288px" />
       ) : (
         <Fragment>
-          <Button onClick={openWidget}>Add to Dashoard</Button>
           <GroupReleaseChart
             group={allEnvironments}
             environment={environmentLabel}

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -147,6 +147,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
   }
 
   get omitDashboardProp() {
+    // when opening from discover or issues page, the user selects the dashboard in the widget UI
     return ['discoverv2', 'issueDetails'].includes(this.props.source || '');
   }
 

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -152,7 +152,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     return [
       DashboardWidgetSource.DISCOVERV2,
       DashboardWidgetSource.ISSUE_DETAILS,
-    ].includes(this.props.source ?? '');
+    ].includes(this.props.source);
   }
 
   get fromLibrary() {

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -38,6 +38,7 @@ import {DISPLAY_TYPE_CHOICES} from 'app/views/dashboardsV2/data';
 import {
   DashboardDetails,
   DashboardListItem,
+  DashboardWidgetSource,
   DisplayType,
   MAX_WIDGETS,
   Widget,
@@ -67,7 +68,7 @@ export type DashboardWidgetModalOptions = {
   defaultTableColumns?: readonly string[];
   defaultTitle?: string;
   displayType?: DisplayType;
-  source: 'discoverv2' | 'dashboards' | 'library' | 'issueDetail';
+  source: DashboardWidgetSource;
   start?: DateString;
   end?: DateString;
   statsPeriod?: RelativePeriod | string;
@@ -148,11 +149,14 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
 
   get omitDashboardProp() {
     // when opening from discover or issues page, the user selects the dashboard in the widget UI
-    return ['discoverv2', 'issueDetails'].includes(this.props.source || '');
+    return [
+      DashboardWidgetSource.DISCOVERV2,
+      DashboardWidgetSource.ISSUE_DETAILS,
+    ].includes(this.props.source || '');
   }
 
   get fromLibrary() {
-    return this.props.source === 'library';
+    return this.props.source === DashboardWidgetSource.LIBRARY;
   }
 
   handleSubmit = async (event: React.FormEvent) => {
@@ -200,7 +204,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           organization,
         });
       }
-      if (source === 'dashboards') {
+      if (source === DashboardWidgetSource.DASHBOARDS) {
         closeModal();
       }
     } catch (err) {

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -67,8 +67,7 @@ export type DashboardWidgetModalOptions = {
   defaultTableColumns?: readonly string[];
   defaultTitle?: string;
   displayType?: DisplayType;
-  fromDiscover?: boolean;
-  fromLibrary?: boolean;
+  source: 'discoverv2' | 'dashboards' | 'library' | 'issueDetail';
   start?: DateString;
   end?: DateString;
   statsPeriod?: RelativePeriod | string;
@@ -111,7 +110,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    const {widget, defaultWidgetQuery, defaultTitle, displayType, fromDiscover} = props;
+    const {widget, defaultWidgetQuery, defaultTitle, displayType} = props;
     if (!widget) {
       this.state = {
         title: defaultTitle ?? '',
@@ -119,7 +118,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
         interval: '5m',
         queries: [defaultWidgetQuery ? {...defaultWidgetQuery} : {...newQuery}],
         errors: undefined,
-        loading: !!fromDiscover,
+        loading: !!this.omitDashboardProp,
         dashboards: [],
         userHasModified: false,
         widgetType: WidgetType.DISCOVER,
@@ -141,11 +140,18 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    const {fromDiscover} = this.props;
-    if (fromDiscover) {
+    if (this.omitDashboardProp) {
       this.fetchDashboards();
     }
     this.handleDefaultFields();
+  }
+
+  get omitDashboardProp() {
+    return ['discoverv2', 'issueDetails'].includes(this.props.source || '');
+  }
+
+  get fromLibrary() {
+    return this.props.source === 'library';
   }
 
   handleSubmit = async (event: React.FormEvent) => {
@@ -158,8 +164,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       onAddWidget,
       onUpdateWidget,
       widget: previousWidget,
-      fromDiscover,
-      fromLibrary,
+      source,
     } = this.props;
     this.setState({loading: true});
     let errors: FlatValidationError = {};
@@ -194,7 +199,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           organization,
         });
       }
-      if (!fromDiscover && !fromLibrary) {
+      if (source === 'dashboards') {
         closeModal();
       }
     } catch (err) {
@@ -202,16 +207,19 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       this.setState({errors});
     } finally {
       this.setState({loading: false});
-      if (fromDiscover) {
-        this.handleSubmitFromDiscover(errors, widgetData);
+      if (this.omitDashboardProp) {
+        this.handleSubmitFromSelectedDashboard(errors, widgetData);
       }
-      if (fromLibrary) {
+      if (this.fromLibrary) {
         this.handleSubmitFromLibrary(errors, widgetData);
       }
     }
   };
 
-  handleSubmitFromDiscover = async (errors: FlatValidationError, widgetData: Widget) => {
+  handleSubmitFromSelectedDashboard = async (
+    errors: FlatValidationError,
+    widgetData: Widget
+  ) => {
     const {closeModal, organization} = this.props;
     const {selectedDashboard, dashboards} = this.state;
     // Validate that a dashboard was selected since api call to /dashboards/widgets/ does not check for dashboard
@@ -315,13 +323,13 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
   };
 
   handleFieldChange = (field: string) => (value: string) => {
-    const {fromDiscover, organization} = this.props;
+    const {organization, source} = this.props;
     this.setState(prevState => {
       const newState = cloneDeep(prevState);
       set(newState, field, value);
 
       trackAdvancedAnalyticsEvent('dashboards_views.add_widget_modal.change', {
-        from: fromDiscover ? 'discoverv2' : 'dashboards',
+        from: source,
         field,
         value,
         widgetType: 'discover',
@@ -471,8 +479,6 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       organization,
       selection,
       tags,
-      fromDiscover,
-      fromLibrary,
       widget: previousWidget,
       start,
       end,
@@ -499,14 +505,13 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       });
 
     const isUpdatingWidget = typeof onUpdateWidget === 'function' && !!previousWidget;
-
     return (
       <React.Fragment>
         <Header closeButton>
           <h4>
-            {fromDiscover
+            {this.omitDashboardProp
               ? t('Add Widget to Dashboard')
-              : fromLibrary
+              : this.fromLibrary
               ? t('Add Custom Widget')
               : isUpdatingWidget
               ? t('Edit Widget')
@@ -514,7 +519,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           </h4>
         </Header>
         <Body>
-          {fromDiscover && this.renderDashboardSelector()}
+          {this.omitDashboardProp && this.renderDashboardSelector()}
           <DoubleFieldWrapper>
             <StyledField
               data-test-id="widget-name"
@@ -604,7 +609,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               {t('Read the docs')}
             </Button>
             <ButtonBar gap={1}>
-              {fromLibrary && dashboard && onAddLibraryWidget ? (
+              {this.fromLibrary && dashboard && onAddLibraryWidget ? (
                 <Button
                   data-test-id="back-to-library"
                   type="button"
@@ -629,7 +634,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                 disabled={state.loading}
                 busy={state.loading}
               >
-                {fromLibrary
+                {this.fromLibrary
                   ? t('Confirm')
                   : isUpdatingWidget
                   ? t('Update Widget')

--- a/static/app/components/modals/addDashboardWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardWidgetModal.tsx
@@ -152,7 +152,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     return [
       DashboardWidgetSource.DISCOVERV2,
       DashboardWidgetSource.ISSUE_DETAILS,
-    ].includes(this.props.source || '');
+    ].includes(this.props.source ?? '');
   }
 
   get fromLibrary() {

--- a/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
+++ b/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
@@ -67,7 +67,7 @@ function DashboardWidgetLibraryModal({
                 dashboard,
                 selectedWidgets,
                 widget: customWidget,
-                fromLibrary: true,
+                source: 'library',
                 onAddLibraryWidget: onAddWidget,
               });
             }}

--- a/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
+++ b/static/app/components/modals/dashboardWidgetLibraryModal/index.tsx
@@ -8,7 +8,11 @@ import Tag from 'app/components/tagDeprecated';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
-import {DashboardDetails, Widget} from 'app/views/dashboardsV2/types';
+import {
+  DashboardDetails,
+  DashboardWidgetSource,
+  Widget,
+} from 'app/views/dashboardsV2/types';
 import {WidgetTemplate} from 'app/views/dashboardsV2/widgetLibrary/data';
 
 import Button from '../../button';
@@ -67,7 +71,7 @@ function DashboardWidgetLibraryModal({
                 dashboard,
                 selectedWidgets,
                 widget: customWidget,
-                source: 'library',
+                source: DashboardWidgetSource.LIBRARY,
                 onAddLibraryWidget: onAddWidget,
               });
             }}

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -93,6 +93,7 @@ class Dashboard extends Component<Props> {
       dashboard,
       selection,
       onAddWidget: this.handleAddComplete,
+      source: 'dashboards',
     });
   };
 
@@ -182,6 +183,7 @@ class Dashboard extends Component<Props> {
       openAddDashboardWidgetModal({
         ...modalProps,
         dashboard,
+        source: 'dashboards',
       });
     }
   };

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -22,7 +22,13 @@ import withGlobalSelection from 'app/utils/withGlobalSelection';
 import {DataSet} from './widget/utils';
 import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import SortableWidget from './sortableWidget';
-import {DashboardDetails, MAX_WIDGETS, Widget, WidgetType} from './types';
+import {
+  DashboardDetails,
+  DashboardWidgetSource,
+  MAX_WIDGETS,
+  Widget,
+  WidgetType,
+} from './types';
 
 type Props = {
   api: Client;
@@ -93,7 +99,7 @@ class Dashboard extends Component<Props> {
       dashboard,
       selection,
       onAddWidget: this.handleAddComplete,
-      source: 'dashboards',
+      source: DashboardWidgetSource.DASHBOARDS,
     });
   };
 
@@ -183,7 +189,7 @@ class Dashboard extends Component<Props> {
       openAddDashboardWidgetModal({
         ...modalProps,
         dashboard,
-        source: 'dashboards',
+        source: DashboardWidgetSource.DASHBOARDS,
       });
     }
   };

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -66,3 +66,11 @@ export enum DashboardState {
   CREATE = 'create',
   PENDING_DELETE = 'pending_delete',
 }
+
+// where we launch the dashboard widget from
+export enum DashboardWidgetSource {
+  DISCOVERV2 = 'discoverv2',
+  DASHBOARDS = 'dashboards',
+  LIBRARY = 'library',
+  ISSUE_DETAILS = 'issueDetail',
+}

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -123,7 +123,7 @@ class QueryList extends React.Component<Props> {
         start: eventView.start,
         end: eventView.end,
         statsPeriod: eventView.statsPeriod,
-        fromDiscover: true,
+        source: 'discoverv2',
         defaultWidgetQuery,
         defaultTableColumns: eventView.fields.map(({field}) => field),
         defaultTitle:

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -27,7 +27,7 @@ import {DisplayModes} from 'app/utils/discover/types';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import {decodeList} from 'app/utils/queryString';
 import withApi from 'app/utils/withApi';
-import {WidgetQuery} from 'app/views/dashboardsV2/types';
+import {DashboardWidgetSource, WidgetQuery} from 'app/views/dashboardsV2/types';
 
 import {
   displayModeToDisplayType,
@@ -123,7 +123,7 @@ class QueryList extends React.Component<Props> {
         start: eventView.start,
         end: eventView.end,
         statsPeriod: eventView.statsPeriod,
-        source: 'discoverv2',
+        source: DashboardWidgetSource.DISCOVERV2,
         defaultWidgetQuery,
         defaultTableColumns: eventView.fields.map(({field}) => field),
         defaultTitle:

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -27,7 +27,7 @@ import {DisplayModes} from 'app/utils/discover/types';
 import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
 import withApi from 'app/utils/withApi';
 import withProjects from 'app/utils/withProjects';
-import {WidgetQuery} from 'app/views/dashboardsV2/types';
+import {DashboardWidgetSource, WidgetQuery} from 'app/views/dashboardsV2/types';
 import InputControl from 'app/views/settings/components/forms/controls/input';
 
 import {
@@ -247,7 +247,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
 
     openAddDashboardWidgetModal({
       organization,
-      source: 'discoverv2',
+      source: DashboardWidgetSource.DISCOVERV2,
       defaultWidgetQuery,
       defaultTableColumns: eventView.fields.map(({field}) => field),
       defaultTitle:

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -247,7 +247,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
 
     openAddDashboardWidgetModal({
       organization,
-      fromDiscover: true,
+      source: 'discoverv2',
       defaultWidgetQuery,
       defaultTableColumns: eventView.fields.map(({field}) => field),
       defaultTitle:

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -22,8 +22,7 @@ function mountModal({
   onUpdateWidget,
   widget,
   dashboard,
-  fromDiscover,
-  fromLibrary,
+  source,
   defaultWidgetQuery,
   displayType,
   defaultTableColumns,
@@ -41,8 +40,7 @@ function mountModal({
       widget={widget}
       dashboard={dashboard}
       closeModal={() => void 0}
-      fromDiscover={fromDiscover}
-      fromLibrary={fromLibrary}
+      source={source || types.DashboardWidgetSource.DASHBOARDS}
       defaultWidgetQuery={defaultWidgetQuery}
       displayType={displayType}
       defaultTableColumns={defaultTableColumns}
@@ -137,7 +135,10 @@ describe('Modals -> AddDashboardWidgetModal', function () {
   });
 
   it('redirects correctly when creating a new dashboard', async function () {
-    const wrapper = mountModal({initialData, fromDiscover: true});
+    const wrapper = mountModal({
+      initialData,
+      source: types.DashboardWidgetSource.DISCOVERV2,
+    });
     await tick();
     await wrapper.update();
     selectDashboard(wrapper, {label: t('+ Create New Dashboard'), value: 'new'});
@@ -151,7 +152,10 @@ describe('Modals -> AddDashboardWidgetModal', function () {
   });
 
   it('redirects correctly when choosing an existing dashboard', async function () {
-    const wrapper = mountModal({initialData, fromDiscover: true});
+    const wrapper = mountModal({
+      initialData,
+      source: types.DashboardWidgetSource.DISCOVERV2,
+    });
     await tick();
     await wrapper.update();
     selectDashboard(wrapper, {label: t('Test Dashboard'), value: '1'});
@@ -166,7 +170,10 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
   it('disables dashboards with max widgets', async function () {
     types.MAX_WIDGETS = 1;
-    const wrapper = mountModal({initialData, fromDiscover: true});
+    const wrapper = mountModal({
+      initialData,
+      source: types.DashboardWidgetSource.DISCOVERV2,
+    });
     await tick();
     await wrapper.update();
     openMenu(wrapper, {name: 'dashboard', control: true});
@@ -931,7 +938,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       onAddWidget: () => undefined,
       onUpdateWidget: () => undefined,
       widget: undefined,
-      fromDiscover: true,
+      source: types.DashboardWidgetSource.DISCOVERV2,
       defaultWidgetQuery: {
         name: '',
         fields: ['count()', 'failure_count()', 'count_unique(user)'],
@@ -954,7 +961,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       onAddWidget: () => undefined,
       onUpdateWidget: () => undefined,
-      fromDiscover: true,
+      source: types.DashboardWidgetSource.DISCOVERV2,
       displayType: types.DisplayType.BAR,
     });
 
@@ -967,7 +974,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       onAddWidget: () => undefined,
       onUpdateWidget: () => undefined,
-      fromDiscover: true,
+      source: types.DashboardWidgetSource.DISCOVERV2,
       displayType: types.DisplayType.TOP_N,
       defaultWidgetQuery: {fields: ['count_unique(user)'], orderby: '-count_unique_user'},
       defaultTableColumns: ['title', 'count()'],
@@ -991,7 +998,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       dashboard,
       onAddLibraryWidget: onAddLibraryWidgetMock,
-      fromLibrary: true,
+      source: types.DashboardWidgetSource.LIBRARY,
     });
 
     const input = wrapper.find('Input[name="title"] input');
@@ -1008,7 +1015,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       initialData,
       dashboard,
       onAddLibraryWidget: onAddLibraryWidgetMock,
-      fromLibrary: true,
+      source: types.DashboardWidgetSource.LIBRARY,
     });
 
     expect(wrapper.find('Button[data-test-id="back-to-library"]')).toHaveLength(1);


### PR DESCRIPTION
This PR removes the `fromDiscover` and `fromLibrary` props from `DashboardWidgetModalOptions` and replaces it with the more generic `source` prop to denote where we are launching the dashboard widget. The reason for this change is so we can add a way of generating a widget from the issues page that will be similar to `fromDiscover`.