### PR TITLE
ref(sentryapps): Change API behavior for logo-upload prep

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.rest_framework import SentryAppSerializer
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Creator, InternalCreator
-from sentry.models import SentryApp, SentryAppAvatar
+from sentry.models import SentryApp
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)
@@ -106,10 +106,6 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             except ValidationError as e:
                 # we generate and validate the slug here instead of the serializer since the slug never changes
                 return Response(e.detail, status=400)
-
-            if features.has("organizations:sentry-app-logo-upload", sentry_app.owner):
-                SentryAppAvatar.objects.create(sentry_app=sentry_app, color=True, avatar_type=0)
-                SentryAppAvatar.objects.create(sentry_app=sentry_app, color=False, avatar_type=0)
 
             return Response(serialize(sentry_app, access=request.access), status=201)
 

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -57,7 +57,7 @@ class SentryAppSerializer(Serializer):
             {
                 "avatars": [
                     {
-                        "avatarType": img.avatar_type,
+                        "avatarType": img.get_avatar_type_display(),
                         "avatarUuid": img.ident,
                         "color": img.color,
                     }


### PR DESCRIPTION
See PR https://github.com/getsentry/sentry/pull/30084

Some small backend changes that were required for the larger frontend change linked above. Required before merging the above PR. This will prevent SentryAppAvatars from being created when SentryApps are created, and return the avatar type text from the serializer instead of the number (`upload` rather than `1`)