### PR TITLE
fix(perf): Add 'no results' empty state to vitals widget

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -29,6 +29,7 @@ import SelectableList, {
   ListClose,
   RightAlignedCell,
   Subtitle,
+  WidgetEmptyStateWarning,
 } from '../components/selectableList';
 import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToVitals} from '../transforms/transformEventsToVitals';
@@ -225,6 +226,7 @@ export function VitalWidget(props: Props) {
           </Subtitle>
         );
       }}
+      EmptyComponent={WidgetEmptyStateWarning}
       HeaderActions={provided => {
         const vital = settingToVital[props.chartSetting];
         const target = vitalDetailRouteWithQuery({


### PR DESCRIPTION
### Summary
Previously it was only showing default empty state which is the placeholder.