### PR TITLE
fix(perf): Add abbreviated numbers for histogram widget

### DIFF
--- a/static/app/views/performance/landing/chart/histogramChart.tsx
+++ b/static/app/views/performance/landing/chart/histogramChart.tsx
@@ -16,6 +16,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {Series} from 'app/types/echarts';
 import EventView from 'app/utils/discover/eventView';
+import {formatAbbreviatedNumber} from 'app/utils/formatters';
 import getDynamicText from 'app/utils/getDynamicText';
 import HistogramQuery from 'app/utils/performance/histogram/histogramQuery';
 import {HistogramData} from 'app/utils/performance/histogram/types';
@@ -165,6 +166,7 @@ export function Chart(props: ChartProps) {
     type: 'value' as const,
     axisLabel: {
       color: theme.chartLabel,
+      formatter: formatAbbreviatedNumber,
     },
   };
 


### PR DESCRIPTION
### Summary
The yAxis for counts can get too high on the landing and the mini charts don't have enough horizontal room to show it well without crowding the graph.