### PR TITLE
feat(sentryappavatars): Delete avatar(s) when SentryApp is deleted

### DIFF
--- a/src/sentry/models/sentryapp.py
+++ b/src/sentry/models/sentryapp.py
@@ -24,6 +24,7 @@ from sentry.db.models import (
     ParanoidModel,
 )
 from sentry.models.apiscopes import HasApiScopes
+from sentry.models.sentryappavatar import SentryAppAvatar
 from sentry.models.sentryappinstallation import SentryAppInstallation
 from sentry.utils import metrics
 
@@ -215,3 +216,7 @@ class SentryApp(ParanoidModel, HasApiScopes):
     def show_auth_info(self, access):
         encoded_scopes = set({"%s" % scope for scope in list(access.scopes)})
         return set(self.scope_list).issubset(encoded_scopes)
+
+    def delete(self):
+        SentryAppAvatar.objects.filter(sentry_app=self).delete()
+        return super().delete()

--- a/tests/sentry/api/endpoints/test_sentry_app_avatar.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_avatar.py
@@ -21,7 +21,6 @@ class SentryAppAvatarTestBase(APITestCase):
 
     def create_avatar(self, is_color):
         with self.feature("organizations:sentry-app-logo-upload"):
-            # upload the regular logo
             data = {
                 "color": is_color,
                 "avatar_type": "upload",


### PR DESCRIPTION
When a SentryApp is "deleted", because it inherits from `ParanoidModel` it's not actually deleted, but rather we simply set a `date_deleted` value. Because of this, we can't simply rely on the cascade delete to clean up old `SentryAppAvatar`s, since the foreign key is never truly deleted. Instead, create a delete method that finds the associated avatars and deletes this before setting the `date_deleted` value. 