### PR TITLE
chore(discover): remove new feature badges from open in discover and add to dashboard buttons

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -11,7 +11,6 @@ import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import {HeaderTitle} from 'app/components/charts/styles';
 import ErrorBoundary from 'app/components/errorBoundary';
-import FeatureBadge from 'app/components/featureBadge';
 import {SelectField} from 'app/components/forms';
 import MenuItem from 'app/components/menuItem';
 import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
@@ -189,12 +188,7 @@ class WidgetCard extends React.Component<Props> {
                 });
               }}
             >
-              <StyledMenuItem key="open-discover">
-                {t('Open in Discover')}
-                {widget.displayType !== DisplayType.TABLE && (
-                  <FeatureBadge type="new" noTooltip />
-                )}
-              </StyledMenuItem>
+              <StyledMenuItem key="open-discover">{t('Open in Discover')}</StyledMenuItem>
             </Link>
           );
         } else {

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -12,7 +12,6 @@ import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import DropdownMenu from 'app/components/dropdownMenu';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
-import FeatureBadge from 'app/components/featureBadge';
 import MenuItem from 'app/components/menuItem';
 import Pagination from 'app/components/pagination';
 import TimeSince from 'app/components/timeSince';
@@ -222,7 +221,7 @@ class QueryList extends React.Component<Props> {
                         data-test-id="add-query-to-dashboard"
                         onClick={this.handleAddQueryToDashboard(eventView)}
                       >
-                        {t('Add to Dashboard')} <FeatureBadge type="new" noTooltip />
+                        {t('Add to Dashboard')}
                       </StyledMenuItem>
                     </ContextMenu>
                   )
@@ -304,7 +303,7 @@ class QueryList extends React.Component<Props> {
                       data-test-id="add-query-to-dashboard"
                       onClick={this.handleAddQueryToDashboard(eventView, savedQuery)}
                     >
-                      {t('Add to Dashboard')} <FeatureBadge type="new" noTooltip />
+                      {t('Add to Dashboard')}
                     </StyledMenuItem>
                   )
                 }

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -14,7 +14,6 @@ import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
 import DropdownControl from 'app/components/dropdownControl';
-import FeatureBadge from 'app/components/featureBadge';
 import Hovercard from 'app/components/hovercard';
 import {IconDelete, IconStar} from 'app/icons';
 import {t} from 'app/locale';
@@ -377,7 +376,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
         key="add-dashboard-widget-from-discover"
         onClick={this.handleAddDashboardWidget}
       >
-        {t('Add to Dashboard')} <StyledFeatureBadge type="new" noTooltip />
+        {t('Add to Dashboard')}
       </AddToDashboardButton>
     );
   }
@@ -464,7 +463,4 @@ const AddToDashboardButton = styled(Button)`
   }
 `;
 
-const StyledFeatureBadge = styled(FeatureBadge)`
-  overflow: auto;
-`;
 export default withProjects(withApi(SavedQueryButtonGroup));


### PR DESCRIPTION
Removes the new feature badges from `Add to Dashboard` button in Discover and `Open in Discover` buttons in Dashboards