### PR TITLE
feat(ui): Sanitize RequestError paths

### DIFF
--- a/static/app/utils/requestError/requestError.tsx
+++ b/static/app/utils/requestError/requestError.tsx
@@ -1,5 +1,7 @@
 import {ResponseMeta} from 'app/api';
 
+import {sanitizePath} from './sanitizePath';
+
 export default class RequestError extends Error {
   responseText?: string;
   responseJSON?: any;
@@ -7,7 +9,7 @@ export default class RequestError extends Error {
   statusText?: string;
 
   constructor(method: string | undefined, path: string) {
-    super(`${method || 'GET'} ${path}`);
+    super(`${method || 'GET'} ${sanitizePath(path)}`);
     this.name = 'RequestError';
     Object.setPrototypeOf(this, new.target.prototype);
   }

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -1,0 +1,56 @@
+/**
+ * Remove organization slugs from the path - we do not want them displayed in the Issues Stream (having them in issue details is ok)
+ */
+
+const SHORTENED_TYPE = {
+  organizations: 'org',
+  projects: 'project',
+  teams: 'team',
+};
+
+export function sanitizePath(path: string) {
+  return path.replace(
+    /(?<start>.*?)\/(?<type>organizations|projects|teams)\/(?<primarySlug>[^/]+)\/(?<contentType>[^/]+\/)?(?<tertiarySlug>[^/]+\/)?(?<end>.*)/,
+    function (...args) {
+      const matches = args[args.length - 1];
+
+      // console.log({matches});
+      // console.log(args);
+      const {start, type, contentType, tertiarySlug, end} = matches;
+
+      let suffix = `${tertiarySlug}${end}`;
+      const isOrg = type === 'organizations';
+      const isProject = type === 'projects';
+      const isRuleConditions = isProject && contentType === 'rule-conditions/';
+
+      if (isOrg && contentType === 'events/') {
+        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1004
+        // r"^(?P<organization_slug>[^\/]+)/events/(?P<project_slug>[^\/]+):(?P<event_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
+        suffix = tertiarySlug.replace(/[^:]+(.*)/, '{projectSlug}$1');
+      } else if (isOrg && contentType === 'members/') {
+        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1235
+        // r"^(?P<organization_slug>[^\/]+)/members/(?P<member_id>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
+        suffix = `${tertiarySlug}${end.replace(
+          /teams\/([^/]+)\/$/,
+          'teams/{teamSlug}/'
+        )}`;
+      } else if (isProject && tertiarySlug === 'teams/') {
+        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1894
+        // r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
+        suffix = `${tertiarySlug}{teamSlug}/`;
+      } else if (isRuleConditions) {
+        // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1595
+        // r"^(?P<organization_slug>[^\/]+)/rule-conditions/$",
+        suffix = '';
+      }
+
+      const contentTypeOrSecondarySlug = isOrg
+        ? contentType
+        : isRuleConditions
+        ? 'rule-conditions/'
+        : `{${SHORTENED_TYPE[type]}Slug}/`;
+
+      return `${start}/${type}/{orgSlug}/${contentTypeOrSecondarySlug}${suffix}`;
+    }
+  );
+}

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -1,5 +1,5 @@
 /**
- * Remove organization slugs from the path - we do not want them displayed in the Issues Stream (having them in issue details is ok)
+ * Remove slugs from the path - we do not want them displayed in the Issues Stream (having them in issue details is ok)
  */
 
 const SHORTENED_TYPE = {

--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -13,15 +13,12 @@ export function sanitizePath(path: string) {
     /(?<start>.*?)\/(?<type>organizations|projects|teams)\/(?<primarySlug>[^/]+)\/(?<contentType>[^/]+\/)?(?<tertiarySlug>[^/]+\/)?(?<end>.*)/,
     function (...args) {
       const matches = args[args.length - 1];
-
-      // console.log({matches});
-      // console.log(args);
       const {start, type, contentType, tertiarySlug, end} = matches;
-
-      let suffix = `${tertiarySlug}${end}`;
       const isOrg = type === 'organizations';
       const isProject = type === 'projects';
       const isRuleConditions = isProject && contentType === 'rule-conditions/';
+
+      let suffix = `${tertiarySlug}${end}`;
 
       if (isOrg && contentType === 'events/') {
         // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1004

--- a/tests/js/spec/utils/requestError/sanitizePath.spec.tsx
+++ b/tests/js/spec/utils/requestError/sanitizePath.spec.tsx
@@ -1,0 +1,63 @@
+import {sanitizePath} from 'app/utils/requestError/sanitizePath';
+
+describe('sanitizePath', function () {
+  test.each([
+    // /organizations/ endpoints
+
+    ['/organizations/sentry-test/issues/123/', '/organizations/{orgSlug}/issues/123/'],
+
+    // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1004
+    // r"^(?P<organization_slug>[^\/]+)/events/(?P<project_slug>[^\/]+):(?P<event_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
+    [
+      '/organizations/sentry-test/events/project-test:123/',
+      '/organizations/{orgSlug}/events/{projectSlug}:123/',
+    ],
+
+    // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1235
+    // r"^(?P<organization_slug>[^\/]+)/members/(?P<member_id>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
+    [
+      '/organizations/sentry-test/members/123/teams/team-test/',
+      '/organizations/{orgSlug}/members/123/teams/{teamSlug}/',
+    ],
+
+    [
+      'https://sentry.io/api/0/organizations/sentry-test/issues/123/',
+      'https://sentry.io/api/0/organizations/{orgSlug}/issues/123/',
+    ],
+
+    // /projects/ endpoints
+    [
+      '/projects/sentry-test/project-test/alert-rules/123/',
+      '/projects/{orgSlug}/{projectSlug}/alert-rules/123/',
+    ],
+
+    [
+      'https://sentry.io/api/0/projects/sentry-test/project-test/alert-rules/123/',
+      'https://sentry.io/api/0/projects/{orgSlug}/{projectSlug}/alert-rules/123/',
+    ],
+
+    // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1894
+    // r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
+    [
+      '/projects/sentry-test/project-test/teams/test-team/',
+      '/projects/{orgSlug}/{projectSlug}/teams/{teamSlug}/',
+    ],
+
+    // XXX: This should probably be an organization endpoint...
+    // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1595
+    // r"^(?P<organization_slug>[^\/]+)/rule-conditions/$",
+    ['/projects/sentry-test/rule-conditions/', '/projects/{orgSlug}/rule-conditions/'],
+
+    [
+      '/teams/sentry-test/team-test/release-count/',
+      '/teams/{orgSlug}/{teamSlug}/release-count/',
+    ],
+
+    [
+      'https://sentry.io/api/0/teams/sentry-test/team-test/release-count/',
+      'https://sentry.io/api/0/teams/{orgSlug}/{teamSlug}/release-count/',
+    ],
+  ])('sanitizes %s', (path, expected) => {
+    expect(sanitizePath(path)).toBe(expected);
+  });
+});


### PR DESCRIPTION
This will sanitize the URLs in our RequestError exceptions that get captured to Sentry. It will replace organization, project, and team slugs with a placeholder so that it is not exposed in the exception message.

We are doing this to specifically make our Issues Stream more free of customer data.