### PR TITLE
fix(ui) Add styles for blockquotes in setup wizard

### DIFF
--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -237,6 +237,16 @@ const DocumentationWrapper = styled('div')`
     word-break: break-all;
     white-space: pre-wrap;
   }
+
+  blockquote {
+    padding: ${space(1)};
+    margin-left: 0;
+    background: ${p => p.theme.alert.info.backgroundLight};
+    border-left: 2px solid ${p => p.theme.alert.info.border};
+  }
+  blockquote > *:last-child {
+    margin-bottom: 0;
+  }
 `;
 
 const StyledButtonBar = styled(ButtonBar)`


### PR DESCRIPTION
Use info alert styles as that seems to be in the intent when comparing how content is rendered in the docs.

![Screen Shot 2021-11-23 at 12 59 11 PM](https://user-images.githubusercontent.com/24086/143079599-7837c902-96c6-43a0-b02d-fdc319ced544.png)


Fixes getsentry/sentry-docs#4411
Fixes #30126