### PR TITLE
fix(discover): Format tag keys with colliding names

### DIFF
--- a/static/app/components/tagDistributionMeter.tsx
+++ b/static/app/components/tagDistributionMeter.tsx
@@ -153,7 +153,11 @@ export default class TagDistributionMeter extends React.Component<Props> {
           };
 
           return (
-            <div key={value.value} style={{width: pct + '%'}}>
+            <div
+              data-test-id={`tag-${title}-segment-${value.value}`}
+              key={value.value}
+              style={{width: pct + '%'}}
+            >
               <Tooltip title={tooltipHtml} containerDisplayMode="block">
                 {value.isOther ? <OtherSegment /> : <Segment {...segmentProps} />}
               </Tooltip>

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -638,6 +638,22 @@ export const SEMVER_TAGS = {
   },
 };
 
+/**
+ * Some tag keys should never be formatted as `tag[...]`
+ * when used as a filter because they are predefined.
+ */
+const EXCLUDED_TAG_KEYS = new Set(['release']);
+
+export function formatTagKey(key: string): string {
+  // Some tags may be normalized from context, but not all of them are.
+  // This supports a user making a custom tag with the same name as one
+  // that comes from context as all of these are also tags.
+  if (key in FIELD_TAGS && !EXCLUDED_TAG_KEYS.has(key)) {
+    return `tags[${key}]`;
+  }
+  return key;
+}
+
 // Allows for a less strict field key definition in cases we are returning custom strings as fields
 export type LooseFieldKey = FieldKey | string | '';
 

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -25,7 +25,7 @@ import {Organization, Project} from 'app/types';
 import {Event, EventTag} from 'app/types/event';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
-import {FIELD_TAGS} from 'app/utils/discover/fields';
+import {formatTagKey} from 'app/utils/discover/fields';
 import {eventDetailsRoute} from 'app/utils/discover/urls';
 import {getMessage} from 'app/utils/events';
 import * as QuickTraceContext from 'app/utils/performance/quickTrace/quickTraceContext';
@@ -43,12 +43,6 @@ import DiscoverBreadcrumb from '../breadcrumb';
 import {generateTitle, getExpandedResults} from '../utils';
 
 import LinkedIssue from './linkedIssue';
-
-/**
- * Some tag keys should never be formatted as `tag[...]`
- * when used as a filter because they are predefined.
- */
-const EXCLUDED_TAG_KEYS = new Set(['release']);
 
 type Props = Pick<
   RouteComponentProps<{eventSlug: string}, {}>,
@@ -101,16 +95,6 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return this.props.eventSlug.split(':')[0];
   }
 
-  generateTagKey = (tag: EventTag) => {
-    // Some tags may be normalized from context, but not all of them are.
-    // This supports a user making a custom tag with the same name as one
-    // that comes from context as all of these are also tags.
-    if (tag.key in FIELD_TAGS && !EXCLUDED_TAG_KEYS.has(tag.key)) {
-      return `tags[${tag.key}]`;
-    }
-    return tag.key;
-  };
-
   generateTagUrl = (tag: EventTag) => {
     const {eventView, organization} = this.props;
     const {event} = this.state;
@@ -121,7 +105,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     if (eventReference.id) {
       delete (eventReference as any).id;
     }
-    const tagKey = this.generateTagKey(tag);
+    const tagKey = formatTagKey(tag.key);
     const nextView = getExpandedResults(eventView, {[tagKey]: tag.value}, eventReference);
     return nextView.getResultsViewUrlTarget(organization.slug);
   };

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -30,7 +30,7 @@ import {GlobalSelection, Organization, SavedQuery} from 'app/types';
 import {defined, generateQueryWithTag} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
-import {generateAggregateFields} from 'app/utils/discover/fields';
+import {formatTagKey, generateAggregateFields} from 'app/utils/discover/fields';
 import {
   DisplayModes,
   MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
@@ -422,7 +422,7 @@ class Results extends React.Component<Props, State> {
 
     const url = eventView.getResultsViewUrlTarget(organization.slug);
     url.query = generateQueryWithTag(url.query, {
-      key,
+      key: formatTagKey(key),
       value,
     });
     return url;

--- a/static/app/views/eventsV2/table/tableActions.tsx
+++ b/static/app/views/eventsV2/table/tableActions.tsx
@@ -105,7 +105,12 @@ function renderEditButton(canEdit: boolean, props: Props) {
 
 function renderSummaryButton({onChangeShowTags, showTags}: Props) {
   return (
-    <Button size="small" onClick={onChangeShowTags} icon={<IconTag size="xs" />}>
+    <Button
+      data-test-id="toggle-show-tags"
+      size="small"
+      onClick={onChangeShowTags}
+      icon={<IconTag size="xs" />}
+    >
       {showTags ? t('Hide Tags') : t('Show Tags')}
     </Button>
   );

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -20,6 +20,7 @@ import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {Event, EventTag} from 'app/types/event';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {formatTagKey} from 'app/utils/discover/fields';
 import * as QuickTraceContext from 'app/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'app/utils/performance/quickTrace/quickTraceQuery';
 import TraceMetaQuery from 'app/utils/performance/quickTrace/traceMetaQuery';
@@ -85,7 +86,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const query = decodeScalar(location.query.query, '');
     const newQuery = {
       ...location.query,
-      query: appendTagCondition(query, tag.key, tag.value),
+      query: appendTagCondition(query, formatTagKey(tag.key), tag.value),
     };
     return transactionSummaryRouteWithQuery({
       orgSlug: organization.slug,

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -18,6 +18,7 @@ import {generateQueryWithTag} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {
+  formatTagKey,
   getAggregateAlias,
   isRelativeSpanOperationBreakdownField,
   SPAN_OP_BREAKDOWN_FIELDS,
@@ -88,7 +89,7 @@ class SummaryContent extends React.Component<Props> {
 
   generateTagUrl = (key: string, value: string) => {
     const {location} = this.props;
-    const query = generateQueryWithTag(location.query, {key, value});
+    const query = generateQueryWithTag(location.query, {key: formatTagKey(key), value});
 
     return {
       ...location,

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -115,11 +115,15 @@ describe('EventsV2 > Results', function () {
       body: [
         {
           key: 'release',
-          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+          topValues: [{count: 3, value: 'abcd123', name: 'abcd123'}],
         },
         {
           key: 'environment',
-          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+          topValues: [{count: 2, value: 'dev', name: 'dev'}],
+        },
+        {
+          key: 'foo',
+          topValues: [{count: 1, value: 'bar', name: 'bar'}],
         },
       ],
     });
@@ -801,5 +805,46 @@ describe('EventsV2 > Results', function () {
       })
     );
     wrapper.unmount();
+  });
+
+  it('appends tag value to existing query when clicked', async function () {
+    const organization = TestStubs.Organization({
+      features,
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {...generateFields(), display: 'default', yAxis: 'count'}},
+      },
+    });
+
+    const wrapper = mountWithTheme(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      initialData.routerContext
+    );
+
+    act(() => ProjectsStore.loadInitialData([TestStubs.Project()]));
+    await tick();
+    wrapper.update();
+
+    wrapper.find('[data-test-id="toggle-show-tags"]').first().simulate('click');
+    await tick();
+    wrapper.update();
+
+    // since environment collides with the environment field, it is wrapped with `tags[...]`
+    const envSegment = wrapper.find(
+      '[data-test-id="tag-environment-segment-dev"] Segment'
+    );
+    const envTarget = envSegment.props().to;
+    expect(envTarget.query.query).toEqual('tags[environment]:dev');
+
+    const fooSegment = wrapper.find('[data-test-id="tag-foo-segment-bar"] Segment');
+    const fooTarget = fooSegment.props().to;
+    expect(fooTarget.query.query).toEqual('foo:bar');
   });
 });

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -184,11 +184,15 @@ describe('Performance > TransactionSummary', function () {
       body: [
         {
           key: 'release',
-          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+          topValues: [{count: 3, value: 'abcd123', name: 'abcd123'}],
         },
         {
           key: 'environment',
-          topValues: [{count: 2, value: 'abcd123', name: 'abcd123'}],
+          topValues: [{count: 2, value: 'dev', name: 'dev'}],
+        },
+        {
+          key: 'foo',
+          topValues: [{count: 1, value: 'bar', name: 'bar'}],
         },
       ],
     });
@@ -575,5 +579,29 @@ describe('Performance > TransactionSummary', function () {
         }),
       })
     );
+  });
+
+  it('appends tag value to existing query when clicked', async function () {
+    const initialData = initializeData();
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    // since environment collides with the environment field, it is wrapped with `tags[...]`
+    const envSegment = wrapper.find(
+      '[data-test-id="tag-environment-segment-dev"] Segment'
+    );
+    const envTarget = envSegment.props().to;
+    expect(envTarget.query.query).toEqual('tags[environment]:dev');
+
+    const fooSegment = wrapper.find('[data-test-id="tag-foo-segment-bar"] Segment');
+    const fooTarget = fooSegment.props().to;
+    expect(fooTarget.query.query).toEqual('foo:bar');
   });
 });


### PR DESCRIPTION
Tag names can collide with field names, in these cases, we need to use the
explicit `tags[...]` syntax in the search to ensure that it's a tag.