### PR TITLE
ref(perf): Fix memoized queries refiring

### DIFF
--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -66,6 +66,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
   return (
     <Fragment>
       <QueryHandler
+        eventView={props.eventView}
         widgetData={widgetData}
         setWidgetDataForKey={setWidgetDataForKey}
         removeWidgetDataForKey={removeWidgetDataForKey}

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -60,6 +60,7 @@ function SingleQueryHandler<T extends WidgetDataConstraint>(
       environment={globalSelection.environments}
       organization={props.queryProps.organization}
       orgSlug={props.queryProps.organization.slug}
+      eventView={props.queryProps.eventView}
       query={props.queryProps.eventView.getQueryWithAdditionalConditions()}
       widgetData={props.widgetData}
     >

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -6,6 +6,7 @@ import MenuItem from 'app/components/menuItem';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import trackAdvancedAnalyticsEvent from 'app/utils/analytics/trackAdvancedAnalyticsEvent';
+import EventView from 'app/utils/discover/eventView';
 import {usePerformanceDisplayType} from 'app/utils/performance/contexts/performanceDisplayContext';
 import useOrganization from 'app/utils/useOrganization';
 import withOrganization from 'app/utils/withOrganization';
@@ -30,6 +31,7 @@ type Props = {
   allowedCharts: PerformanceWidgetSetting[];
   chartHeight: number;
   chartColor?: string;
+  eventView: EventView;
   forceDefaultChartSetting?: boolean;
   rowChartSettings: PerformanceWidgetSetting[];
   setRowChartSettings: (settings: PerformanceWidgetSetting[]) => void;

--- a/static/app/views/performance/landing/widgets/transforms/transformEventsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformEventsToArea.tsx
@@ -29,7 +29,7 @@ export function transformEventsRequestToArea<T extends WidgetDataConstraint>(
 
   const childData = {
     ...results,
-    isLoading: results.loading,
+    isLoading: results.loading || results.reloading,
     isErrored: results.errored,
     hasData: defined(data) && !!data.length && !!data[0].data.length,
     data,

--- a/static/app/views/performance/landing/widgets/transforms/transformEventsToVitals.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformEventsToVitals.tsx
@@ -15,7 +15,7 @@ export function transformEventsRequestToVitals<T extends WidgetDataConstraint>(
 
   const childData = {
     ...results,
-    isLoading: results.loading,
+    isLoading: results.loading || results.reloading,
     isErrored: results.errored,
     hasData: defined(data) && !!data.length && !!data[0].data.length,
     data,

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -49,6 +49,7 @@ export type QueryFC<T extends WidgetDataConstraint> = FunctionComponent<
     team?: Readonly<string | string[]>;
     query?: string;
     orgSlug: string;
+    eventView: EventView;
     organization: OrganizationSummary;
     widgetData: T;
   }
@@ -142,6 +143,7 @@ export type QueryHandlerProps<T extends WidgetDataConstraint> = {
   api: Client;
   queries: QueryDefinitionWithKey<T>[];
   children?: ReactNode;
+  eventView: EventView;
   queryProps: WidgetPropUnion<T>;
 } & WidgetDataProps<T>;
 

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -44,7 +44,7 @@ export function HistogramWidget(props: Props) {
         component: provided => (
           <HistogramQuery
             {...provided}
-            eventView={props.eventView}
+            eventView={provided.eventView}
             location={props.location}
             numBuckets={20}
             dataFilter="exclude_outliers"
@@ -53,7 +53,7 @@ export function HistogramWidget(props: Props) {
         transform: transformHistogramQuery,
       },
     };
-  }, [props.eventView, props.fields[0], props.organization.slug]);
+  }, [props.chartSetting]);
 
   const onFilterChange = () => {};
 

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -81,7 +81,7 @@ export function LineChartListWidget(props: Props) {
     () => ({
       fields: field,
       component: provided => {
-        const eventView = props.eventView.clone();
+        const eventView = provided.eventView.clone();
         eventView.sorts = [{kind: 'desc', field}];
         if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
           eventView.fields = [
@@ -125,7 +125,7 @@ export function LineChartListWidget(props: Props) {
       },
       transform: transformDiscoverToList,
     }),
-    [props.eventView, field, props.organization.slug]
+    [props.chartSetting]
   );
 
   const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(() => {
@@ -187,7 +187,7 @@ export function LineChartListWidget(props: Props) {
       },
       transform: transformEventsRequestToArea,
     };
-  }, [props.eventView, field, props.organization.slug, selectedListIndex]);
+  }, [props.chartSetting, selectedListIndex]);
 
   const Queries = {
     list: listQuery,

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -58,7 +58,7 @@ export function SingleFieldAreaWidget(props: Props) {
           includeTransformedData
           partial
           currentSeriesNames={[field]}
-          query={props.eventView.getQueryWithAdditionalConditions()}
+          query={provided.eventView.getQueryWithAdditionalConditions()}
           interval={getInterval(
             {
               start: provided.start,
@@ -71,7 +71,7 @@ export function SingleFieldAreaWidget(props: Props) {
       ),
       transform: transformEventsRequestToArea,
     }),
-    [props.eventView, field, props.organization.slug]
+    [props.chartSetting]
   );
 
   const Queries = {

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -79,7 +79,7 @@ export function TrendsWidget(props: Props) {
       component: provided => (
         <TrendsDiscoverQuery
           {...provided}
-          eventView={eventView}
+          eventView={provided.eventView}
           location={props.location}
           trendChangeType={trendChangeType}
           trendFunctionField={trendFunctionField}
@@ -90,7 +90,7 @@ export function TrendsWidget(props: Props) {
       ),
       transform: transformTrendsDiscover,
     }),
-    [eventView, trendChangeType]
+    [props.chartSetting, trendChangeType]
   );
 
   const Queries = {

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -118,7 +118,7 @@ export function VitalWidget(props: Props) {
       () => ({
         fields: sortField,
         component: provided => {
-          const _eventView = props.eventView.clone();
+          const _eventView = provided.eventView.clone();
 
           const fieldFromProps = fieldsList.map(propField => ({
             field: propField,
@@ -156,7 +156,7 @@ export function VitalWidget(props: Props) {
         },
         fields: fieldsList,
         component: provided => {
-          const _eventView = props.eventView.clone();
+          const _eventView = provided.eventView.clone();
 
           _eventView.additionalConditions.setFilterValues('transaction', [
             provided.widgetData.list.data[selectedListIndex].transaction as string,
@@ -184,7 +184,7 @@ export function VitalWidget(props: Props) {
         },
         transform: transformEventsRequestToVitals,
       }),
-      [props.eventView, selectedListIndex, props.chartSetting, props.organization.slug]
+      [props.chartSetting, selectedListIndex]
     ),
   };
 

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.jsx
@@ -7,9 +7,9 @@ import WidgetContainer from 'app/views/performance/landing/widgets/components/wi
 import {PerformanceWidgetSetting} from 'app/views/performance/landing/widgets/widgetDefinitions';
 import {PROJECT_PERFORMANCE_TYPE} from 'app/views/performance/utils';
 
-const initializeData = () => {
+const initializeData = (query = {}) => {
   const data = _initializeData({
-    query: {statsPeriod: '7d', environment: ['prod'], project: [-42]},
+    query: {statsPeriod: '7d', environment: ['prod'], project: [-42], ...query},
   });
 
   data.eventView.additionalConditions.addFilterValues('transaction.op', ['pageload']);
@@ -26,6 +26,7 @@ const WrappedComponent = ({data, ...rest}) => {
             PerformanceWidgetSetting.TPM_AREA,
             PerformanceWidgetSetting.FAILURE_RATE_AREA,
             PerformanceWidgetSetting.USER_MISERY_AREA,
+            PerformanceWidgetSetting.DURATION_HISTOGRAM,
           ]}
           rowChartSettings={[]}
           forceDefaultChartSetting
@@ -82,6 +83,123 @@ describe('Performance > Widgets > WidgetContainer', function () {
       url: '/organizations/org-slug/events-trends-stats/',
       body: [],
     });
+  });
+
+  it('Check requests when changing widget props', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.TPM_AREA}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(eventStatsMock).toHaveBeenCalledTimes(1);
+
+    // Change eventView reference
+    wrapper.setProps({
+      eventView: data.eventView.clone(),
+    });
+
+    await tick();
+    wrapper.update();
+
+    expect(eventStatsMock).toHaveBeenCalledTimes(1);
+
+    const modifiedData = initializeData({
+      statsPeriod: '14d',
+    });
+
+    // Change eventView statsperiod
+    wrapper.setProps({
+      eventView: modifiedData.eventView,
+    });
+
+    await tick();
+    wrapper.update();
+
+    expect(eventStatsMock).toHaveBeenCalledTimes(2);
+
+    expect(eventStatsMock).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          interval: '1h',
+          partial: '1',
+          query: 'transaction.op:pageload',
+          statsPeriod: '28d',
+          yAxis: 'tpm()',
+        }),
+      })
+    );
+  });
+
+  it('Check requests when changing widget props for GenericDiscoverQuery based widget', async function () {
+    const data = initializeData();
+
+    const wrapper = mountWithTheme(
+      <WrappedComponent
+        data={data}
+        defaultChartSetting={PerformanceWidgetSetting.MOST_IMPROVED}
+      />,
+      data.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+
+    // Change eventView reference
+    wrapper.setProps({
+      eventView: data.eventView.clone(),
+    });
+
+    await tick();
+    wrapper.update();
+
+    expect(eventsTrendsStats).toHaveBeenCalledTimes(1);
+
+    const modifiedData = initializeData({
+      statsPeriod: '14d',
+    });
+
+    // Change eventView statsperiod
+    wrapper.setProps({
+      eventView: modifiedData.eventView,
+    });
+
+    await tick();
+    wrapper.update();
+
+    expect(eventsTrendsStats).toHaveBeenCalledTimes(2);
+
+    expect(eventsTrendsStats).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({
+          cursor: '0:0:1',
+          environment: ['prod'],
+          field: ['transaction', 'project'],
+          interval: undefined,
+          middle: undefined,
+          noPagination: true,
+          per_page: 3,
+          project: ['-42'],
+          query:
+            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
+          sort: 'trend_percentage()',
+          statsPeriod: '14d',
+          trendFunction: 'avg(transaction.duration)',
+          trendType: 'improved',
+        }),
+      })
+    );
   });
 
   it('TPM Widget', async function () {


### PR DESCRIPTION
### Summary
This removes conditions that would cause the queries to be re-instantiated and instead fixes them to not refire on prop changes (eg. eventView). This should stop the queries from firing, cancelling and firing again like they were previously.