### PR TITLE
fix(ui): Chart tooltip colors

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -486,14 +486,21 @@ function BaseChartUnwrapped({
 // elements directly
 const ChartContainer = styled('div')`
   /* Tooltip styling */
+  .tooltip-container {
+    box-shadow: ${p => p.theme.dropShadowHeavy};
+  }
   .tooltip-series,
   .tooltip-date {
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     font-family: ${p => p.theme.text.family};
     font-variant-numeric: tabular-nums;
-    background: ${p => p.theme.gray500};
+    background: ${p => p.theme.backgroundElevated};
     padding: ${space(1)} ${space(2)};
+    border: solid 1px ${p => p.theme.border};
     border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
+  }
+  .tooltip-series {
+    border-bottom: none;
   }
   .tooltip-series-solo {
     border-radius: ${p => p.theme.borderRadius};
@@ -503,7 +510,7 @@ const ChartContainer = styled('div')`
   }
   .tooltip-label strong {
     font-weight: normal;
-    color: ${p => p.theme.white};
+    color: ${p => p.theme.textColor};
   }
   .tooltip-label-indent {
     margin-left: ${space(3)};
@@ -514,24 +521,32 @@ const ChartContainer = styled('div')`
     align-items: baseline;
   }
   .tooltip-date {
-    border-top: 1px solid ${p => p.theme.gray400};
+    border-top: solid 1px ${p => p.theme.innerBorder};
     text-align: center;
     position: relative;
     width: auto;
     border-radius: ${p => p.theme.borderRadiusBottom};
   }
   .tooltip-arrow {
-    top: 100%;
+    top: calc(100% - 1px);
     left: 50%;
-    border: 0px solid transparent;
-    content: ' ';
-    height: 0;
-    width: 0;
     position: absolute;
     pointer-events: none;
-    border-top-color: ${p => p.theme.gray500};
-    border-width: 8px;
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 8px solid ${p => p.theme.backgroundElevated};
     margin-left: -8px;
+    &:before {
+      border-left: 9px solid transparent;
+      border-right: 9px solid transparent;
+      border-top: 9px solid ${p => p.theme.border};
+      content: '';
+      display: block;
+      position: absolute;
+      top: -8px;
+      left: -9px;
+      z-index: -1;
+    }
   }
 
   .echarts-for-react div:first-of-type {

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -201,7 +201,7 @@ function getFormatter({
         seriesParamsOrParam
       );
 
-    return [
+    const tooltipContent = [
       '<div class="tooltip-series">',
       seriesParams
         .filter(getFilter)
@@ -224,6 +224,8 @@ function getFormatter({
       `<div class="tooltip-date">${date}</div>`,
       `<div class="tooltip-arrow"></div>`,
     ].join('');
+
+    return `<div class="tooltip-container">${tooltipContent}</div>`;
   };
 
   return formatter;

--- a/static/app/components/events/interfaces/request.tsx
+++ b/static/app/components/events/interfaces/request.tsx
@@ -140,12 +140,12 @@ const Header = styled('h3')`
 const StyledIconOpen = styled(IconOpen)`
   transition: 0.1s linear color;
   margin: 0 ${space(0.5)};
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.gray200};
   position: relative;
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.textColor};
+    color: ${p => p.theme.subText};
   }
 `;
 

--- a/static/app/components/events/interfaces/request.tsx
+++ b/static/app/components/events/interfaces/request.tsx
@@ -140,12 +140,12 @@ const Header = styled('h3')`
 const StyledIconOpen = styled(IconOpen)`
   transition: 0.1s linear color;
   margin: 0 ${space(0.5)};
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   position: relative;
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.subText};
+    color: ${p => p.theme.textColor};
   }
 `;
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -56,7 +56,7 @@ const darkColors = {
 
   surface100: '#1A141F',
   surface200: '#241D2A',
-  surface300: '#2E2734',
+  surface300: '#2C2433',
 
   gray500: '#EBE6EF',
   gray400: '#D6D0DC',
@@ -95,6 +95,18 @@ const darkColors = {
   pink100: 'rgba(250, 51, 150, 0.13)',
 };
 
+const lightShadows = {
+  dropShadowLightest: '0 0 2px rgba(43, 34, 51, 0.04)',
+  dropShadowLight: '0 1px 4px rgba(43, 34, 51, 0.04)',
+  dropShadowHeavy: '0 4px 24px rgba(43, 34, 51, 0.12)',
+};
+
+const darkShadows = {
+  dropShadowLightest: '0 0 2px rgba(10, 8, 12, 0.2)',
+  dropShadowLight: '0 1px 4px rgba(10, 8, 12, 0.2)',
+  dropShadowHeavy: '0 4px 24px rgba(10, 8, 12, 0.36)',
+};
+
 type BaseColors = typeof lightColors;
 
 const generateAliases = (colors: BaseColors) => ({
@@ -117,6 +129,11 @@ const generateAliases = (colors: BaseColors) => ({
    * Primary background color
    */
   background: colors.surface200,
+
+  /**
+   * Elevated background color
+   */
+  backgroundElevated: colors.surface300,
 
   /**
    * Secondary background color used as a slight contrast against primary background
@@ -500,6 +517,8 @@ const commonTheme = {
 
   ...lightColors,
 
+  ...lightShadows,
+
   iconSizes,
 
   iconDirections: {
@@ -579,10 +598,6 @@ const commonTheme = {
   borderRadiusTop: '4px 4px 0 0',
   headerSelectorRowHeight: 44,
   headerSelectorLabelHeight: 28,
-
-  dropShadowLightest: '0 0 2px rgba(43, 34, 51, 0.04)',
-  dropShadowLight: '0 1px 4px rgba(43, 34, 51, 0.04)',
-  dropShadowHeavy: '0 4px 24px rgba(43, 34, 51, 0.08)',
 
   // Relative font sizes
   fontSizeRelativeSmall: '0.9em',
@@ -667,6 +682,7 @@ export const lightTheme = {
   ...commonTheme,
   ...lightColors,
   ...lightAliases,
+  ...lightShadows,
   alert: generateAlertTheme(lightColors, lightAliases),
   badge: generateBadgeTheme(lightColors),
   button: generateButtonTheme(lightColors, lightAliases),
@@ -682,6 +698,7 @@ export const darkTheme: Theme = {
   ...commonTheme,
   ...darkColors,
   ...darkAliases,
+  ...darkShadows,
   alert: generateAlertTheme(darkColors, darkAliases),
   badge: generateBadgeTheme(darkColors),
   button: generateButtonTheme(darkColors, darkAliases),


### PR DESCRIPTION
** This is a visual fix accompanying #29917

Chart tooltips currently use gray500 as their background color. This doesn't work in the new, two-palette color system (#29917). Instead, they should use `surface300` (`backgroundElevated`).

Before: 
<img width="313" alt="Screen Shot 2021-11-23 at 10 45 21 AM" src="https://user-images.githubusercontent.com/44172267/143085110-84bdd24a-87d3-4abd-a5e5-85a25f162563.png">

After:
<img width="313" alt="Screen Shot 2021-11-23 at 10 45 00 AM" src="https://user-images.githubusercontent.com/44172267/143085072-4e9620b3-e7d4-4dcf-b5da-145f64fe8003.png">
<img width="313" alt="Screen Shot 2021-11-23 at 10 45 45 AM" src="https://user-images.githubusercontent.com/44172267/143085166-d62acf10-50b4-438e-930a-dd72b78fa188.png">

(The design team has discussed and concluded that chart tooltips should use the current theme colors - light colors in light mode and dark colors in dark mode).