### PR TITLE
fix(perf): Omit sort when switching between landing tabs

### DIFF
--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -110,7 +110,7 @@ export function handleLandingDisplayChange(
   searchConditions.removeFilter('transaction.op');
 
   const queryWithConditions = {
-    ...omit(location.query, 'landingDisplay'),
+    ...omit(location.query, ['landingDisplay', 'sort']),
     query: searchConditions.formatString(),
   };
 


### PR DESCRIPTION
### Summary
The tabs have their own default sort and any sort picked from the table might not be compatible with other tabs. This removes the sort when switching tabs.