### PR TITLE
ref(sentryapps): Read popularity weight from database

### DIFF
--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -1343,6 +1343,7 @@ export type SentryApp = {
     elements?: SentryAppSchemaElement[];
   };
   // possible null params
+  popularity: number | null;
   webhookUrl: string | null;
   redirectUrl: string | null;
   overview: string | null;

--- a/static/app/views/organizationIntegrations/constants.tsx
+++ b/static/app/views/organizationIntegrations/constants.tsx
@@ -13,7 +13,9 @@ export const COLORS = {
 } as const;
 
 /**
- * Integrations in the integration directory should be sorted by their popularity (weight). The weights should reflect the relative popularity of each integration are hardcoded.
+ * Integrations in the integration directory should be sorted by their popularity (weight).
+ * The weights should reflect the relative popularity of each integration are hardcoded, except for
+ * Sentry-apps which read popularity from the db.
  */
 
 export const POPULARITY_WEIGHT: {
@@ -33,20 +35,6 @@ export const POPULARITY_WEIGHT: {
   vercel: 10,
   msteams: 10,
   aws_lambda: 10,
-
-  // Sentry-apps
-  amixr: 9,
-  calixa: 9,
-  clickup: 9,
-  clubhouse: 9,
-  komodor: 9,
-  linear: 9,
-  quill: 9,
-  rookout: 9,
-  spikesh: 9,
-  split: 9,
-  taskcall: 9,
-  teamwork: 9,
 
   // Plugins
   webhooks: 10,

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -224,8 +224,15 @@ export class IntegrationListDirectory extends AsyncComponent<
     return integrations?.find(i => i.provider.key === integration.key) ? 2 : 0;
   }
 
-  getPopularityWeight = (integration: AppOrProviderOrPlugin) =>
-    POPULARITY_WEIGHT[integration.slug] ?? 1;
+  getPopularityWeight = (integration: AppOrProviderOrPlugin) => {
+    for (const sentryapp of this.state.publishedApps || []) {
+      if (sentryapp === integration) {
+        return integration.popularity ?? 1;
+      }
+    }
+
+    return POPULARITY_WEIGHT[integration.slug] ?? 1;
+  };
 
   sortByName = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) =>
     a.slug.localeCompare(b.slug);

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -225,13 +225,11 @@ export class IntegrationListDirectory extends AsyncComponent<
   }
 
   getPopularityWeight = (integration: AppOrProviderOrPlugin) => {
-    for (const sentryapp of this.state.publishedApps || []) {
-      if (sentryapp === integration) {
-        return integration.popularity ?? 1;
-      }
-    }
-
-    return POPULARITY_WEIGHT[integration.slug] ?? 1;
+    return (
+      (this.state.publishedApps || []).find(i => i === integration)?.popularity ||
+      POPULARITY_WEIGHT[integration.slug] ||
+      1
+    );
   };
 
   sortByName = (a: AppOrProviderOrPlugin, b: AppOrProviderOrPlugin) =>

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -226,8 +226,8 @@ export class IntegrationListDirectory extends AsyncComponent<
 
   getPopularityWeight = (integration: AppOrProviderOrPlugin) => {
     return (
-      (this.state.publishedApps || []).find(i => i === integration)?.popularity ||
-      POPULARITY_WEIGHT[integration.slug] ||
+      this.state.publishedApps?.find(i => i === integration)?.popularity ??
+      POPULARITY_WEIGHT[integration.slug] ??
       1
     );
   };

--- a/tests/fixtures/js-stubs/integrationListDirectory.js
+++ b/tests/fixtures/js-stubs/integrationListDirectory.js
@@ -173,6 +173,7 @@ export function PublishedApps() {
       scopes: [],
       slug: 'clickup',
       status: 'published',
+      popularity: 9,
       uuid: '5d547ecb-7eb8-4ed2-853b-40256177d526',
       verifyInstall: false,
       webhookUrl: 'http://localhost:7000',

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -54,7 +54,6 @@ describe('IntegrationListDirectory', function () {
         'bitbucket',
         'pagerduty',
         'my-headband-washer-289499',
-        'clickup',
         'asayer',
         'bitbucket_pipelines',
         'datadog',
@@ -64,6 +63,7 @@ describe('IntegrationListDirectory', function () {
         'octohook',
         'rocketchat',
         'amazon-sqs',
+        'clickup',
         'la-croix-monitor',
       ].map((name, index) =>
         expect(wrapper.find('IntegrationRow').at(index).props().slug).toEqual(name)

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -54,6 +54,7 @@ describe('IntegrationListDirectory', function () {
         'bitbucket',
         'pagerduty',
         'my-headband-washer-289499',
+        'clickup',
         'asayer',
         'bitbucket_pipelines',
         'datadog',
@@ -63,7 +64,6 @@ describe('IntegrationListDirectory', function () {
         'octohook',
         'rocketchat',
         'amazon-sqs',
-        'clickup',
         'la-croix-monitor',
       ].map((name, index) =>
         expect(wrapper.find('IntegrationRow').at(index).props().slug).toEqual(name)


### PR DESCRIPTION
Since we now have a `popularity` column in the `SentryApp` table, we don't need to hardcode the value anymore to sort by popularity on the integration directory page. We can just read that value for sentry apps and avoid the manual step of having to add in a hard coded value. 