### PR TITLE
fix(perf): Fix values and date in widget tooltips

### DIFF
--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -170,7 +170,10 @@ function Chart({
     colors: [colors[0], colors[1]] as string[],
     tooltip: {
       valueFormatter: (value, seriesName) => {
-        return tooltipFormatter(value, seriesName);
+        return tooltipFormatter(
+          value,
+          data && data.length ? data[0].seriesName : seriesName
+        );
       },
       nameFormatter(value: string) {
         return value === 'epm()' ? 'tpm()' : value;

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -62,6 +62,7 @@ export function SingleFieldAreaWidget(props: Props) {
               includeTransformedData
               partial
               currentSeriesNames={[field]}
+              previousSeriesNames={[`previous ${field}`]}
               query={provided.eventView.getQueryWithAdditionalConditions()}
               interval={getInterval(
                 {

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -286,6 +286,7 @@ export type _VitalChartProps = Props & {
   reloading: boolean;
   field: string;
   height?: number;
+  utc?: boolean;
   grid: LineChart['props']['grid'];
   vitalFields?: {
     poorCountField: string;
@@ -319,6 +320,7 @@ function __VitalChart(props: _VitalChartProps) {
     reloading,
     height,
     grid,
+    utc,
     vitalFields,
   } = props;
   if (!_results || !vitalFields) {
@@ -333,7 +335,12 @@ function __VitalChart(props: _VitalChartProps) {
     },
     tooltip: {
       trigger: 'axis' as const,
-      valueFormatter: tooltipFormatter,
+      valueFormatter: (value: number, seriesName?: string) => {
+        return tooltipFormatter(
+          value,
+          vitalFields[0] === WebVital.CLS ? seriesName : yAxis
+        );
+      },
     },
     xAxis: {
       axisLine: {
@@ -353,6 +360,9 @@ function __VitalChart(props: _VitalChartProps) {
         formatter: (value: number) => axisLabelFormatter(value, yAxis),
       },
     },
+    utc,
+    isGroupedByDate: true,
+    showTimeInTooltip: true,
   };
 
   const results = _results.filter(s => !!fieldToVitalType(s.seriesName, vitalFields));
@@ -383,6 +393,7 @@ function __VitalChart(props: _VitalChartProps) {
               {...chartOptions}
               onLegendSelectChanged={() => {}}
               series={[...smoothedSeries]}
+              isGroupedByDate
             />
           ),
           fixed: 'Web Vitals Chart',


### PR DESCRIPTION
### Summary
The vitals widgets didn't have date formatted correctly since the option wasn't being passed. The previous period in the area chart (mini chart) tooltips was also not being formatted correctly since the series name was simply 'Previous'.