### PR TITLE
build(js): Add `sentry` import alias

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -36,6 +36,7 @@
     "outDir": "../src/sentry/static/sentry/dist",
     "paths": {
       "app/*": ["static/app/*"],
+      "sentry/*": ["static/app/*"],
       "sentry-test/*": ["tests/js/sentry-test/*"],
       "sentry-images/*": ["static/images/*"],
       "sentry-locale/*": ["src/sentry/locale/*"],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -50,6 +50,7 @@ const config: Config.InitialOptions = {
   coverageReporters: ['html', 'cobertura'],
   coverageDirectory: '.artifacts/coverage',
   moduleNameMapper: {
+    '^sentry/(.*)': '<rootDir>/static/app/$1',
     '^sentry-test/(.*)': '<rootDir>/tests/js/sentry-test/$1',
     '^sentry-locale/(.*)': '<rootDir>/src/sentry/locale/$1',
     '\\.(css|less|png|jpg|mp4)$': '<rootDir>/tests/js/sentry-test/importStyleMock.js',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -379,6 +379,7 @@ let appConfig: Configuration = {
   resolve: {
     alias: {
       app: path.join(staticPrefix, 'app'),
+      sentry: path.join(staticPrefix, 'app'),
       'sentry-images': path.join(staticPrefix, 'images'),
       'sentry-logos': path.join(sentryDjangoAppPath, 'images', 'logos'),
       'sentry-fonts': path.join(staticPrefix, 'fonts'),


### PR DESCRIPTION
Instead of using `app` alias, we want to migrate to using  `sentry`
alias so that it is consistent across this repo and `getsentry`. This PR
only adds the `sentry` alias, there will be follow-ups to refactor our
codebase.