### PR TITLE
ref(ui): Change storybook imports to use `sentry` import alias

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -36,6 +36,7 @@
     "outDir": "../src/sentry/static/sentry/dist",
     "paths": {
       "app/*": ["static/app/*"],
+      "sentry/*": ["static/app/*"],
       "sentry-test/*": ["tests/js/sentry-test/*"],
       "sentry-images/*": ["static/images/*"],
       "sentry-locale/*": ["src/sentry/locale/*"],

--- a/docs-ui/components/code.tsx
+++ b/docs-ui/components/code.tsx
@@ -6,9 +6,9 @@ import styled from '@emotion/styled';
 import copy from 'copy-text-to-clipboard';
 import Prism from 'prismjs';
 
-import {IconCode} from 'app/icons';
-import space from 'app/styles/space';
-import {Theme} from 'app/utils/theme';
+import {IconCode} from 'sentry/icons';
+import space from 'sentry/styles/space';
+import {Theme} from 'sentry/utils/theme';
 
 type Props = {
   theme: Theme;

--- a/docs-ui/components/colorChip.tsx
+++ b/docs-ui/components/colorChip.tsx
@@ -2,8 +2,8 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import Color from 'color';
 
-import space from 'app/styles/space';
-import {Theme} from 'app/utils/theme';
+import space from 'sentry/styles/space';
+import {Theme} from 'sentry/utils/theme';
 
 type SizeProp = {
   size: 'md' | 'lg';

--- a/docs-ui/components/doDont.tsx
+++ b/docs-ui/components/doDont.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import {IconCheckmark, IconClose} from 'app/icons';
-import space from 'app/styles/space';
+import {IconCheckmark, IconClose} from 'sentry/icons';
+import space from 'sentry/styles/space';
 
 type BoxContent = {
   text: string;

--- a/docs-ui/components/docsLinks.tsx
+++ b/docs-ui/components/docsLinks.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 /* eslint-disable-next-line import/default */
 import LinkTo from '@storybook/addon-links/react';
 
-import {IconArrow} from 'app/icons';
-import space from 'app/styles/space';
-import {Theme} from 'app/utils/theme';
+import {IconArrow} from 'sentry/icons';
+import space from 'sentry/styles/space';
+import {Theme} from 'sentry/utils/theme';
 
 type Link = {
   img?: {

--- a/docs-ui/components/sample.tsx
+++ b/docs-ui/components/sample.tsx
@@ -2,9 +2,9 @@ import {createContext, ReactChild, useState} from 'react';
 import {ThemeProvider, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {IconMoon} from 'app/icons';
-import space from 'app/styles/space';
-import {darkTheme, lightTheme, Theme} from 'app/utils/theme';
+import {IconMoon} from 'sentry/icons';
+import space from 'sentry/styles/space';
+import {darkTheme, lightTheme, Theme} from 'sentry/utils/theme';
 
 type ThemeName = 'dark' | 'light';
 

--- a/docs-ui/components/table.tsx
+++ b/docs-ui/components/table.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import space from 'app/styles/space';
+import space from 'sentry/styles/space';
 
 type TableCellProps = {
   align: 'left' | 'right' | 'center';

--- a/docs-ui/components/tableOfContents.tsx
+++ b/docs-ui/components/tableOfContents.tsx
@@ -2,7 +2,7 @@ import {useEffect} from 'react';
 import styled from '@emotion/styled';
 import tocbot from 'tocbot';
 
-import space from 'app/styles/space';
+import space from 'sentry/styles/space';
 
 const Container = styled('div')`
   height: 100%;

--- a/docs-ui/stories/assets/fileIcon.stories.js
+++ b/docs-ui/stories/assets/fileIcon.stories.js
@@ -1,4 +1,4 @@
-import FileIcon from 'app/components/fileIcon';
+import FileIcon from 'sentry/components/fileIcon';
 
 export default {
   title: 'Assets/Icons/File Icon',

--- a/docs-ui/stories/assets/iconProps.stories.js
+++ b/docs-ui/stories/assets/iconProps.stories.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {IconAdd, IconArrow, IconBookmark, IconGroup, IconPin} from 'app/icons';
+import {IconAdd, IconArrow, IconBookmark, IconGroup, IconPin} from 'sentry/icons';
 
 export default {
   title: 'Assets/Icons',

--- a/docs-ui/stories/assets/iconSet.stories.js
+++ b/docs-ui/stories/assets/iconSet.stories.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import * as newIconset from 'app/icons';
+import * as newIconset from 'sentry/icons';
 
 export default {
   title: 'Assets/Icons/Icon Set',

--- a/docs-ui/stories/assets/logoSentry.stories.js
+++ b/docs-ui/stories/assets/logoSentry.stories.js
@@ -1,4 +1,4 @@
-import LogoSentry from 'app/components/logoSentry';
+import LogoSentry from 'sentry/components/logoSentry';
 
 export default {
   title: 'Assets/Logo',

--- a/docs-ui/stories/assets/platformList.stories.js
+++ b/docs-ui/stories/assets/platformList.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import PlatformList from 'app/components/platformList';
-import space from 'app/styles/space';
+import PlatformList from 'sentry/components/platformList';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Assets/Platforms/Platform List',

--- a/docs-ui/stories/components/alert.stories.js
+++ b/docs-ui/stories/components/alert.stories.js
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import Alert from 'app/components/alert';
-import ExternalLink from 'app/components/links/externalLink';
-import {IconCheckmark, IconInfo, IconLightning, IconNot, IconWarning} from 'app/icons';
-import space from 'app/styles/space';
+import Alert from 'sentry/components/alert';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {IconCheckmark, IconInfo, IconLightning, IconNot, IconWarning} from 'sentry/icons';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Components/Alerts/Alert',

--- a/docs-ui/stories/components/alertBadge.stories.js
+++ b/docs-ui/stories/components/alertBadge.stories.js
@@ -1,5 +1,5 @@
-import AlertBadge from 'app/views/alerts/alertBadge';
-import {IncidentStatus} from 'app/views/alerts/types';
+import AlertBadge from 'sentry/views/alerts/alertBadge';
+import {IncidentStatus} from 'sentry/views/alerts/types';
 
 export default {
   title: 'Components/Alerts/Alert Badge',

--- a/docs-ui/stories/components/alertBar.stories.js
+++ b/docs-ui/stories/components/alertBar.stories.js
@@ -1,4 +1,4 @@
-import PageAlertBar from 'app/components/pageAlertBar';
+import PageAlertBar from 'sentry/components/pageAlertBar';
 
 export default {
   title: 'Components/Alerts/Alert Bar',

--- a/docs-ui/stories/components/alertLink.stories.js
+++ b/docs-ui/stories/components/alertLink.stories.js
@@ -1,5 +1,5 @@
-import AlertLink from 'app/components/alertLink';
-import {IconDocs, IconGeneric, IconMail, IconStack, IconStar} from 'app/icons';
+import AlertLink from 'sentry/components/alertLink';
+import {IconDocs, IconGeneric, IconMail, IconStack, IconStar} from 'sentry/icons';
 
 export default {
   title: 'Components/Alerts/Alert Links',

--- a/docs-ui/stories/components/areaChart.stories.js
+++ b/docs-ui/stories/components/areaChart.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import AreaChart from 'app/components/charts/areaChart';
-import space from 'app/styles/space';
+import AreaChart from 'sentry/components/charts/areaChart';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Components/Data Visualization/Charts/Area Chart',

--- a/docs-ui/stories/components/autoComplete.stories.js
+++ b/docs-ui/stories/components/autoComplete.stories.js
@@ -1,4 +1,4 @@
-import AutoComplete from 'app/components/autoComplete';
+import AutoComplete from 'sentry/components/autoComplete';
 
 const items = [
   {

--- a/docs-ui/stories/components/avatar.stories.js
+++ b/docs-ui/stories/components/avatar.stories.js
@@ -1,4 +1,4 @@
-import Avatar from 'app/components/avatar';
+import Avatar from 'sentry/components/avatar';
 
 const USER = {
   id: 1,

--- a/docs-ui/stories/components/badge.stories.js
+++ b/docs-ui/stories/components/badge.stories.js
@@ -1,4 +1,4 @@
-import Badge from 'app/components/badge';
+import Badge from 'sentry/components/badge';
 
 export default {
   title: 'Components/Badges/Badge',

--- a/docs-ui/stories/components/barChart.stories.js
+++ b/docs-ui/stories/components/barChart.stories.js
@@ -1,4 +1,4 @@
-import BarChart from 'app/components/charts/barChart';
+import BarChart from 'sentry/components/charts/barChart';
 
 export default {
   title: 'Components/Data Visualization/Charts/Bar Chart',

--- a/docs-ui/stories/components/bulkController.stories.js
+++ b/docs-ui/stories/components/bulkController.stories.js
@@ -1,9 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import BulkController from 'app/components/bulkController';
-import Checkbox from 'app/components/checkbox';
-import {PanelTable} from 'app/components/panels';
+import BulkController from 'sentry/components/bulkController';
+import Checkbox from 'sentry/components/checkbox';
+import {PanelTable} from 'sentry/components/panels';
 
 const dummy = [
   {

--- a/docs-ui/stories/components/button.stories.js
+++ b/docs-ui/stories/components/button.stories.js
@@ -3,12 +3,12 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {action} from '@storybook/addon-actions';
 
-import Button from 'app/components/button';
-import ButtonBar from 'app/components/buttonBar';
-import DropdownButton from 'app/components/dropdownButton';
-import DropdownLink from 'app/components/dropdownLink';
-import NavigationButtonGroup from 'app/components/navigationButtonGroup';
-import {IconDelete} from 'app/icons/iconDelete';
+import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import DropdownButton from 'sentry/components/dropdownButton';
+import DropdownLink from 'sentry/components/dropdownLink';
+import NavigationButtonGroup from 'sentry/components/navigationButtonGroup';
+import {IconDelete} from 'sentry/icons/iconDelete';
 
 const Item = styled('span')`
   padding: 12px;

--- a/docs-ui/stories/components/chart-utilities.stories.js
+++ b/docs-ui/stories/components/chart-utilities.stories.js
@@ -1,7 +1,7 @@
 import {action} from '@storybook/addon-actions';
 
-import ChartZoom from 'app/components/charts/chartZoom';
-import LineChart from 'app/components/charts/lineChart';
+import ChartZoom from 'sentry/components/charts/chartZoom';
+import LineChart from 'sentry/components/charts/lineChart';
 
 export default {
   title: 'Components/Data Visualization/Charts/Utilities/Chart Zoom',

--- a/docs-ui/stories/components/charts-breakdownBars.stories.js
+++ b/docs-ui/stories/components/charts-breakdownBars.stories.js
@@ -1,4 +1,4 @@
-import BreakdownBars from 'app/components/charts/breakdownBars';
+import BreakdownBars from 'sentry/components/charts/breakdownBars';
 
 export default {
   title: 'Components/Data Visualization/Charts/Breakdown Bars',

--- a/docs-ui/stories/components/charts-chartcuterie.stories.js
+++ b/docs-ui/stories/components/charts-chartcuterie.stories.js
@@ -2,10 +2,10 @@ import styled from '@emotion/styled';
 import echarts from 'echarts/lib/echarts';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
 
-import config from 'app/chartcuterie/config';
-import {ChartType} from 'app/chartcuterie/types';
-import {getDimensionValue} from 'app/components/charts/utils';
-import space from 'app/styles/space';
+import config from 'sentry/chartcuterie/config';
+import {ChartType} from 'sentry/chartcuterie/types';
+import {getDimensionValue} from 'sentry/components/charts/utils';
+import space from 'sentry/styles/space';
 
 const {renderConfig} = config;
 

--- a/docs-ui/stories/components/charts-optionselector.stories.js
+++ b/docs-ui/stories/components/charts-optionselector.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import OptionSelector from 'app/components/charts/optionSelector';
-import space from 'app/styles/space';
+import OptionSelector from 'sentry/components/charts/optionSelector';
+import space from 'sentry/styles/space';
 
 const options = [
   {value: 'all', label: 'All things'},

--- a/docs-ui/stories/components/charts.stories.js
+++ b/docs-ui/stories/components/charts.stories.js
@@ -1,5 +1,5 @@
-import BarChart from 'app/components/charts/barChart';
-import LineChart from 'app/components/charts/lineChart';
+import BarChart from 'sentry/components/charts/barChart';
+import LineChart from 'sentry/components/charts/lineChart';
 
 export default {
   title: 'Components/Data Visualization/Charts/Playground',

--- a/docs-ui/stories/components/checkboxFancy.stories.js
+++ b/docs-ui/stories/components/checkboxFancy.stories.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
+import CheckboxFancy from 'sentry/components/checkboxFancy/checkboxFancy';
 
 export default {
   title: 'Components/Forms/Misc/Checkbox Fancy',

--- a/docs-ui/stories/components/circleIndicator.stories.js
+++ b/docs-ui/stories/components/circleIndicator.stories.js
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import CircleIndicator from 'app/components/circleIndicator';
+import CircleIndicator from 'sentry/components/circleIndicator';
 
 export default {
   title: 'Components/Data Visualization/Misc/Circle Indicator',

--- a/docs-ui/stories/components/clipboardTooltip.stories.js
+++ b/docs-ui/stories/components/clipboardTooltip.stories.js
@@ -1,4 +1,4 @@
-import ClipboardTooltip from 'app/components/clipboardTooltip';
+import ClipboardTooltip from 'sentry/components/clipboardTooltip';
 
 export default {
   title: 'Components/Tooltips/Clipboard Tooltip',

--- a/docs-ui/stories/components/colorBar.stories.js
+++ b/docs-ui/stories/components/colorBar.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import theme from 'app/utils/theme';
-import ColorBar from 'app/views/performance/vitalDetail/colorBar.tsx';
+import theme from 'sentry/utils/theme';
+import ColorBar from 'sentry/views/performance/vitalDetail/colorBar.tsx';
 
 export default {
   title: 'Components/Data Visualization/Charts/Color Bar',

--- a/docs-ui/stories/components/columnEditor.stories.js
+++ b/docs-ui/stories/components/columnEditor.stories.js
@@ -1,7 +1,7 @@
-import {openModal} from 'app/actionCreators/modal';
-import Button from 'app/components/button';
-import GlobalModal from 'app/components/globalModal';
-import ColumnEditModal, {modalCss} from 'app/views/eventsV2/table/columnEditModal';
+import {openModal} from 'sentry/actionCreators/modal';
+import Button from 'sentry/components/button';
+import GlobalModal from 'sentry/components/globalModal';
+import ColumnEditModal, {modalCss} from 'sentry/views/eventsV2/table/columnEditModal';
 
 const columns = [
   {

--- a/docs-ui/stories/components/commitRow.stories.js
+++ b/docs-ui/stories/components/commitRow.stories.js
@@ -1,4 +1,4 @@
-import CommitRow from 'app/components/commitRow';
+import CommitRow from 'sentry/components/commitRow';
 
 export default {
   title: 'Components/Tables/CommitRow',

--- a/docs-ui/stories/components/confirm.stories.js
+++ b/docs-ui/stories/components/confirm.stories.js
@@ -1,5 +1,5 @@
-import Button from 'app/components/button';
-import Confirm from 'app/components/confirm';
+import Button from 'sentry/components/button';
+import Confirm from 'sentry/components/confirm';
 
 // TODO(scttcper): modal not working
 export default {

--- a/docs-ui/stories/components/confirmDelete.stories.js
+++ b/docs-ui/stories/components/confirmDelete.stories.js
@@ -1,5 +1,5 @@
-import Button from 'app/components/button';
-import ConfirmDelete from 'app/components/confirmDelete';
+import Button from 'sentry/components/button';
+import ConfirmDelete from 'sentry/components/confirmDelete';
 
 // TODO(scttcper): modal not working
 export default {

--- a/docs-ui/stories/components/contextData.stories.js
+++ b/docs-ui/stories/components/contextData.stories.js
@@ -1,4 +1,4 @@
-import ContextData from 'app/components/contextData';
+import ContextData from 'sentry/components/contextData';
 
 export default {
   title: 'Components/Context Data',

--- a/docs-ui/stories/components/deployBadge.stories.js
+++ b/docs-ui/stories/components/deployBadge.stories.js
@@ -1,4 +1,4 @@
-import DeployBadge from 'app/components/deployBadge';
+import DeployBadge from 'sentry/components/deployBadge';
 
 export default {
   title: 'Components/Badges/Deploy Badge',

--- a/docs-ui/stories/components/dropdownAutoComplete.stories.js
+++ b/docs-ui/stories/components/dropdownAutoComplete.stories.js
@@ -1,6 +1,6 @@
-import Button from 'app/components/button';
-import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
-import DropdownButton from 'app/components/dropdownButton';
+import Button from 'sentry/components/button';
+import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
+import DropdownButton from 'sentry/components/dropdownButton';
 
 const items = [
   {

--- a/docs-ui/stories/components/dropdownControl.stories.js
+++ b/docs-ui/stories/components/dropdownControl.stories.js
@@ -1,5 +1,5 @@
-import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
-import MenuItem from 'app/components/menuItem';
+import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import MenuItem from 'sentry/components/menuItem';
 
 export default {
   title: 'Components/Buttons/Dropdowns/Dropdown Control',

--- a/docs-ui/stories/components/dropdownLink.stories.js
+++ b/docs-ui/stories/components/dropdownLink.stories.js
@@ -1,5 +1,5 @@
-import DropdownLink from 'app/components/dropdownLink';
-import MenuItem from 'app/components/menuItem';
+import DropdownLink from 'sentry/components/dropdownLink';
+import MenuItem from 'sentry/components/menuItem';
 
 export default {
   title: 'Components/Buttons/Dropdowns/Dropdown Link',

--- a/docs-ui/stories/components/editableText.stories.js
+++ b/docs-ui/stories/components/editableText.stories.js
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 import {action} from '@storybook/addon-actions';
 
-import EditableText from 'app/components/editableText';
-import space from 'app/styles/space';
+import EditableText from 'sentry/components/editableText';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Components/Forms/Misc/Editable Text',

--- a/docs-ui/stories/components/featureBadge.stories.js
+++ b/docs-ui/stories/components/featureBadge.stories.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import FeatureBadge from 'app/components/featureBadge';
+import FeatureBadge from 'sentry/components/featureBadge';
 
 export default {
   title: 'Components/Badges/Feature Badge',

--- a/docs-ui/stories/components/featureDisabled.stories.js
+++ b/docs-ui/stories/components/featureDisabled.stories.js
@@ -1,4 +1,4 @@
-import FeatureDisabled from 'app/components/acl/featureDisabled';
+import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 
 export default {
   title: 'Components/Alerts/Feature Disabled',

--- a/docs-ui/stories/components/form-fields.stories.js
+++ b/docs-ui/stories/components/form-fields.stories.js
@@ -1,20 +1,20 @@
 import {action} from '@storybook/addon-actions';
 
-import {Panel} from 'app/components/panels';
-import Switch from 'app/components/switchButton';
-import NewBooleanField from 'app/views/settings/components/forms/booleanField';
-import CheckboxField from 'app/views/settings/components/forms/checkboxField';
-import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
-import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
-import DatePickerField from 'app/views/settings/components/forms/datePickerField';
-import Form from 'app/views/settings/components/forms/form';
-import FormField from 'app/views/settings/components/forms/formField';
-import RadioBooleanField from 'app/views/settings/components/forms/radioBooleanField';
-import RadioField from 'app/views/settings/components/forms/radioField';
-import SelectField from 'app/views/settings/components/forms/selectField';
-import TextareaField from 'app/views/settings/components/forms/textareaField';
-import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
-import TextField from 'app/views/settings/components/forms/textField';
+import {Panel} from 'sentry/components/panels';
+import Switch from 'sentry/components/switchButton';
+import NewBooleanField from 'sentry/views/settings/components/forms/booleanField';
+import CheckboxField from 'sentry/views/settings/components/forms/checkboxField';
+import RadioGroup from 'sentry/views/settings/components/forms/controls/radioGroup';
+import RangeSlider from 'sentry/views/settings/components/forms/controls/rangeSlider';
+import DatePickerField from 'sentry/views/settings/components/forms/datePickerField';
+import Form from 'sentry/views/settings/components/forms/form';
+import FormField from 'sentry/views/settings/components/forms/formField';
+import RadioBooleanField from 'sentry/views/settings/components/forms/radioBooleanField';
+import RadioField from 'sentry/views/settings/components/forms/radioField';
+import SelectField from 'sentry/views/settings/components/forms/selectField';
+import TextareaField from 'sentry/views/settings/components/forms/textareaField';
+import TextCopyInput from 'sentry/views/settings/components/forms/textCopyInput';
+import TextField from 'sentry/views/settings/components/forms/textField';
 
 export default {
   title: 'Components/Forms/Fields',

--- a/docs-ui/stories/components/form.stories.js
+++ b/docs-ui/stories/components/form.stories.js
@@ -1,9 +1,9 @@
-import NewBooleanField from 'app/views/settings/components/forms/booleanField';
-import Form from 'app/views/settings/components/forms/form';
-import RadioField from 'app/views/settings/components/forms/radioField';
-import RangeField from 'app/views/settings/components/forms/rangeField';
-import SelectField from 'app/views/settings/components/forms/selectField';
-import TextField from 'app/views/settings/components/forms/textField';
+import NewBooleanField from 'sentry/views/settings/components/forms/booleanField';
+import Form from 'sentry/views/settings/components/forms/form';
+import RadioField from 'sentry/views/settings/components/forms/radioField';
+import RangeField from 'sentry/views/settings/components/forms/rangeField';
+import SelectField from 'sentry/views/settings/components/forms/selectField';
+import TextField from 'sentry/views/settings/components/forms/textField';
 
 export default {
   title: 'Components/Forms/Form',

--- a/docs-ui/stories/components/gridEditable.stories.js
+++ b/docs-ui/stories/components/gridEditable.stories.js
@@ -1,8 +1,8 @@
 import {Component, Fragment} from 'react';
 import PropTypes from 'prop-types';
 
-import Button from 'app/components/button';
-import GridEditable from 'app/components/gridEditable';
+import Button from 'sentry/components/button';
+import GridEditable from 'sentry/components/gridEditable';
 
 const COLUMN_ORDER = [
   {

--- a/docs-ui/stories/components/hovercard.stories.js
+++ b/docs-ui/stories/components/hovercard.stories.js
@@ -1,4 +1,4 @@
-import Hovercard from 'app/components/hovercard';
+import Hovercard from 'sentry/components/hovercard';
 
 export default {
   title: 'Components/Tooltips/Hovercard',

--- a/docs-ui/stories/components/idBadge.stories.js
+++ b/docs-ui/stories/components/idBadge.stories.js
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import IdBadge from 'app/components/idBadge';
+import IdBadge from 'sentry/components/idBadge';
 
 // TODO(scttcper): Handle dark mode
 const Item = styled('div')`

--- a/docs-ui/stories/components/indicators.stories.js
+++ b/docs-ui/stories/components/indicators.stories.js
@@ -2,10 +2,10 @@ import {
   addErrorMessage,
   addMessage,
   addSuccessMessage,
-} from 'app/actionCreators/indicator';
-import Button from 'app/components/button';
-import IndicatorContainer, {Indicators} from 'app/components/indicators';
-import IndicatorStore from 'app/stores/indicatorStore';
+} from 'sentry/actionCreators/indicator';
+import Button from 'sentry/components/button';
+import IndicatorContainer, {Indicators} from 'sentry/components/indicators';
+import IndicatorStore from 'sentry/stores/indicatorStore';
 
 export default {
   title: 'Components/Toast Indicators',

--- a/docs-ui/stories/components/keyValueTable.stories.js
+++ b/docs-ui/stories/components/keyValueTable.stories.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import {KeyValueTable, KeyValueTableRow} from 'app/components/keyValueTable';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
 
 const Wrapper = styled('div')`
   width: 250px;

--- a/docs-ui/stories/components/lineChart.stories.js
+++ b/docs-ui/stories/components/lineChart.stories.js
@@ -1,4 +1,4 @@
-import LineChart from 'app/components/charts/lineChart';
+import LineChart from 'sentry/components/charts/lineChart';
 
 export default {
   title: 'Components/Data Visualization/Charts/Line Chart',

--- a/docs-ui/stories/components/loadingError.stories.js
+++ b/docs-ui/stories/components/loadingError.stories.js
@@ -1,7 +1,7 @@
 import {action} from '@storybook/addon-actions';
 
-import LoadingError from 'app/components/loadingError';
-import {Panel, PanelHeader} from 'app/components/panels';
+import LoadingError from 'sentry/components/loadingError';
+import {Panel, PanelHeader} from 'sentry/components/panels';
 
 export default {
   title: 'Components/Alerts/Loading Error',

--- a/docs-ui/stories/components/loadingIndicator.stories.js
+++ b/docs-ui/stories/components/loadingIndicator.stories.js
@@ -1,4 +1,4 @@
-import LoadingIndicator from 'app/components/loadingIndicator';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 
 export default {
   title: 'Components/Loading Indicators',

--- a/docs-ui/stories/components/miniBarChart.stories.js
+++ b/docs-ui/stories/components/miniBarChart.stories.js
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
-import MiniBarChart from 'app/components/charts/miniBarChart';
-import theme from 'app/utils/theme';
+import MiniBarChart from 'sentry/components/charts/miniBarChart';
+import theme from 'sentry/utils/theme';
 
 export default {
   title: 'Components/Data Visualization/Charts/MiniBarChart',

--- a/docs-ui/stories/components/multipleCheckbox.stories.js
+++ b/docs-ui/stories/components/multipleCheckbox.stories.js
@@ -1,6 +1,6 @@
 import {action} from '@storybook/addon-actions';
 
-import MultipleCheckbox from 'app/views/settings/components/forms/controls/multipleCheckbox';
+import MultipleCheckbox from 'sentry/views/settings/components/forms/controls/multipleCheckbox';
 
 export default {
   title: 'Components/Forms/Controls/Multiple Checkbox',

--- a/docs-ui/stories/components/numberDragControl.stories.js
+++ b/docs-ui/stories/components/numberDragControl.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import {action} from '@storybook/addon-actions';
 
-import NumberDragControl from 'app/components/numberDragControl';
+import NumberDragControl from 'sentry/components/numberDragControl';
 
 export default {
   title: 'Components/Forms/Controls/Number Drag Control',

--- a/docs-ui/stories/components/pageTimeRangeSelector.stories.js
+++ b/docs-ui/stories/components/pageTimeRangeSelector.stories.js
@@ -1,10 +1,10 @@
 import {Fragment} from 'react';
 import omit from 'lodash/omit';
 
-import DateTime from 'app/components/dateTime';
-import PageTimeRangeSelector from 'app/components/pageTimeRangeSelector';
-import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
-import {t} from 'app/locale';
+import DateTime from 'sentry/components/dateTime';
+import PageTimeRangeSelector from 'sentry/components/pageTimeRangeSelector';
+import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
+import {t} from 'sentry/locale';
 
 export default {
   title: 'Components/PageTimeRangeSelector',

--- a/docs-ui/stories/components/pagination.stories.js
+++ b/docs-ui/stories/components/pagination.stories.js
@@ -1,7 +1,7 @@
 import {Component} from 'react';
 import PropTypes from 'prop-types';
 
-import Pagination from 'app/components/pagination';
+import Pagination from 'sentry/components/pagination';
 
 export default {
   title: 'Components/Buttons/Pagination',

--- a/docs-ui/stories/components/panels.stories.js
+++ b/docs-ui/stories/components/panels.stories.js
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import Button from 'app/components/button';
+import Button from 'sentry/components/button';
 import {
   Panel,
   PanelAlert,
@@ -8,9 +8,9 @@ import {
   PanelHeader,
   PanelItem,
   PanelTable,
-} from 'app/components/panels';
-import {IconTelescope} from 'app/icons';
-import Field from 'app/views/settings/components/forms/field';
+} from 'sentry/components/panels';
+import {IconTelescope} from 'sentry/icons';
+import Field from 'sentry/views/settings/components/forms/field';
 
 import {_BulkController} from './bulkController.stories';
 

--- a/docs-ui/stories/components/percentageAreaChart.stories.js
+++ b/docs-ui/stories/components/percentageAreaChart.stories.js
@@ -1,4 +1,4 @@
-import PercentageAreaChart from 'app/components/charts/percentageAreaChart';
+import PercentageAreaChart from 'sentry/components/charts/percentageAreaChart';
 
 const TOTAL = 6;
 

--- a/docs-ui/stories/components/pieChart.stories.js
+++ b/docs-ui/stories/components/pieChart.stories.js
@@ -1,4 +1,4 @@
-import PieChart from 'app/components/charts/pieChart';
+import PieChart from 'sentry/components/charts/pieChart';
 
 export default {
   title: 'Components/Data Visualization/Charts/Pie Chart',

--- a/docs-ui/stories/components/pills.stories.js
+++ b/docs-ui/stories/components/pills.stories.js
@@ -1,5 +1,5 @@
-import Pill from 'app/components/pill';
-import Pills from 'app/components/pills';
+import Pill from 'sentry/components/pill';
+import Pills from 'sentry/components/pills';
 
 export default {
   title: 'Components/Pills',

--- a/docs-ui/stories/components/placeholder.stories.js
+++ b/docs-ui/stories/components/placeholder.stories.js
@@ -1,4 +1,4 @@
-import Placeholder from 'app/components/placeholder';
+import Placeholder from 'sentry/components/placeholder';
 
 export default {
   title: 'Components/Loading Indicators/Placeholder',

--- a/docs-ui/stories/components/progressBar.stories.js
+++ b/docs-ui/stories/components/progressBar.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import ProgressBar from 'app/components/progressBar';
-import space from 'app/styles/space';
+import ProgressBar from 'sentry/components/progressBar';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Components/Data Visualization/Charts/Progress Bar',

--- a/docs-ui/stories/components/progressRing.stories.js
+++ b/docs-ui/stories/components/progressRing.stories.js
@@ -2,7 +2,7 @@ import {Component} from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 
-import ProgressRing from 'app/components/progressRing';
+import ProgressRing from 'sentry/components/progressRing';
 
 class Ticker extends Component {
   state = {

--- a/docs-ui/stories/components/questionTooltip.stories.js
+++ b/docs-ui/stories/components/questionTooltip.stories.js
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
-import QuestionTooltip from 'app/components/questionTooltip';
-import theme from 'app/utils/theme';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import theme from 'sentry/utils/theme';
 
 export default {
   title: 'Components/Tooltips/Question Tooltip',

--- a/docs-ui/stories/components/rangeSlider.stories.js
+++ b/docs-ui/stories/components/rangeSlider.stories.js
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
+import RangeSlider from 'sentry/views/settings/components/forms/controls/rangeSlider';
 
 export default {
   title: 'Components/Forms/Controls/Range Slider',

--- a/docs-ui/stories/components/repoLabel.stories.js
+++ b/docs-ui/stories/components/repoLabel.stories.js
@@ -1,4 +1,4 @@
-import RepoLabel from 'app/components/repoLabel';
+import RepoLabel from 'sentry/components/repoLabel';
 
 export default {
   title: 'Components/Tags/Repo Label',

--- a/docs-ui/stories/components/scoreBar.stories.js
+++ b/docs-ui/stories/components/scoreBar.stories.js
@@ -1,4 +1,4 @@
-import ScoreBar from 'app/components/scoreBar';
+import ScoreBar from 'sentry/components/scoreBar';
 
 export default {
   title: 'Components/Data Visualization/Score Bar',

--- a/docs-ui/stories/components/scoreCard.stories.js
+++ b/docs-ui/stories/components/scoreCard.stories.js
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-import ScoreCard from 'app/components/scoreCard';
-import {t} from 'app/locale';
-import space from 'app/styles/space';
+import ScoreCard from 'sentry/components/scoreCard';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Components/Data Visualization/Score Card',

--- a/docs-ui/stories/components/seenByList.stories.js
+++ b/docs-ui/stories/components/seenByList.stories.js
@@ -1,4 +1,4 @@
-import SeenByList from 'app/components/seenByList';
+import SeenByList from 'sentry/components/seenByList';
 
 const USER = {
   id: 1,

--- a/docs-ui/stories/components/seenInfo.stories.js
+++ b/docs-ui/stories/components/seenInfo.stories.js
@@ -1,4 +1,4 @@
-import SeenInfo from 'app/components/group/seenInfo';
+import SeenInfo from 'sentry/components/group/seenInfo';
 
 export default {
   title: 'Features/Issues/Seen Info',

--- a/docs-ui/stories/components/selectFields.stories.js
+++ b/docs-ui/stories/components/selectFields.stories.js
@@ -1,8 +1,8 @@
 import {action} from '@storybook/addon-actions';
 
-import {Form as LegacyForm} from 'app/components/forms';
-import SelectCreatableField from 'app/components/forms/selectCreatableField';
-import SelectField from 'app/components/forms/selectField';
+import {Form as LegacyForm} from 'sentry/components/forms';
+import SelectCreatableField from 'sentry/components/forms/selectCreatableField';
+import SelectField from 'sentry/components/forms/selectField';
 
 export default {
   title: 'Deprecated/SelectFields',

--- a/docs-ui/stories/components/similarSpectrum.stories.js
+++ b/docs-ui/stories/components/similarSpectrum.stories.js
@@ -1,4 +1,4 @@
-import SimilarSpectrum from 'app/components/similarSpectrum';
+import SimilarSpectrum from 'sentry/components/similarSpectrum';
 
 export default {
   title: 'Components/Data Visualization/Misc/Similar Spectrum',

--- a/docs-ui/stories/components/simpleTableChart.stories.js
+++ b/docs-ui/stories/components/simpleTableChart.stories.js
@@ -1,4 +1,4 @@
-import SimpleTableChart from 'app/components/charts/simpleTableChart';
+import SimpleTableChart from 'sentry/components/charts/simpleTableChart';
 
 export default {
   title: 'Components/Data Visualization/Charts/Simple Table Chart',

--- a/docs-ui/stories/components/splitDiff.stories.js
+++ b/docs-ui/stories/components/splitDiff.stories.js
@@ -1,4 +1,4 @@
-import SplitDiff from 'app/components/splitDiff';
+import SplitDiff from 'sentry/components/splitDiff';
 
 const base = `RangeError: Invalid array length
   at Constructor.render(./app/components/scoreBar.jsx:73:0)

--- a/docs-ui/stories/components/suggestedAvatarStack.stories.js
+++ b/docs-ui/stories/components/suggestedAvatarStack.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import SuggestedAvatarStack from 'app/components/avatar/suggestedAvatarStack';
-import TeamStore from 'app/stores/teamStore';
+import SuggestedAvatarStack from 'sentry/components/avatar/suggestedAvatarStack';
+import TeamStore from 'sentry/stores/teamStore';
 
 const exampleUserActor = {
   type: 'user',

--- a/docs-ui/stories/components/tag.stories.js
+++ b/docs-ui/stories/components/tag.stories.js
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-import Tag from 'app/components/tag';
-import {IconClock, IconDelete, IconFire, IconIssues, IconWarning} from 'app/icons';
-import {toTitleCase} from 'app/utils';
-import theme from 'app/utils/theme';
+import Tag from 'sentry/components/tag';
+import {IconClock, IconDelete, IconFire, IconIssues, IconWarning} from 'sentry/icons';
+import {toTitleCase} from 'sentry/utils';
+import theme from 'sentry/utils/theme';
 
 export default {
   title: 'Components/Tags',

--- a/docs-ui/stories/components/tooltip.stories.js
+++ b/docs-ui/stories/components/tooltip.stories.js
@@ -1,7 +1,7 @@
 import {Component, Fragment} from 'react';
 
-import Button from 'app/components/button';
-import Tooltip from 'app/components/tooltip';
+import Button from 'sentry/components/button';
+import Tooltip from 'sentry/components/tooltip';
 
 class CustomThing extends Component {
   render() {

--- a/docs-ui/stories/components/u2fEnrolledDetails.stories.js
+++ b/docs-ui/stories/components/u2fEnrolledDetails.stories.js
@@ -1,6 +1,6 @@
 import {action} from '@storybook/addon-actions';
 
-import U2fEnrolledDetails from 'app/views/settings/account/accountSecurity/components/u2fEnrolledDetails';
+import U2fEnrolledDetails from 'sentry/views/settings/account/accountSecurity/components/u2fEnrolledDetails';
 
 export default {
   title: 'Components/Tables/U2fEnrolledDetails',

--- a/docs-ui/stories/components/userMisery.stories.js
+++ b/docs-ui/stories/components/userMisery.stories.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import UserMisery from 'app/components/userMisery';
+import UserMisery from 'sentry/components/userMisery';
 
 export default {
   title: 'Components/Data Visualization/Score Bar/User Misery',

--- a/docs-ui/stories/components/well.stories.js
+++ b/docs-ui/stories/components/well.stories.js
@@ -1,4 +1,4 @@
-import Well from 'app/components/well';
+import Well from 'sentry/components/well';
 
 export default {
   title: 'Components/Well',

--- a/docs-ui/stories/core/colors/colorSwatch.tsx
+++ b/docs-ui/stories/core/colors/colorSwatch.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import * as Color from 'color';
 
-import space from 'app/styles/space';
+import space from 'sentry/styles/space';
 
 type Props = {
   theme: 'light' | 'dark';

--- a/docs-ui/stories/core/colors/tables.tsx
+++ b/docs-ui/stories/core/colors/tables.tsx
@@ -2,7 +2,7 @@ import {useContext} from 'react';
 import styled from '@emotion/styled';
 import Sample, {SampleThemeContext} from 'docs-ui/components/sample';
 
-import space from 'app/styles/space';
+import space from 'sentry/styles/space';
 
 import ColorSwatch from './colorSwatch';
 

--- a/docs-ui/stories/deprecated/form-old-fields.stories.js
+++ b/docs-ui/stories/deprecated/form-old-fields.stories.js
@@ -1,4 +1,4 @@
-import {BooleanField, Form as LegacyForm, PasswordField} from 'app/components/forms';
+import {BooleanField, Form as LegacyForm, PasswordField} from 'sentry/components/forms';
 
 export default {
   title: 'Deprecated/Fields',

--- a/docs-ui/stories/deprecated/form-old.stories.js
+++ b/docs-ui/stories/deprecated/form-old.stories.js
@@ -2,7 +2,7 @@ import {Component} from 'react';
 import {action} from '@storybook/addon-actions';
 import PropTypes from 'prop-types';
 
-import {Form as LegacyForm, TextField as LegacyTextField} from 'app/components/forms';
+import {Form as LegacyForm, TextField as LegacyTextField} from 'sentry/components/forms';
 
 class UndoButton extends Component {
   handleClick(e) {

--- a/docs-ui/stories/deprecated/tagDeprecated.stories.js
+++ b/docs-ui/stories/deprecated/tagDeprecated.stories.js
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 
-import Tag from 'app/components/tagDeprecated';
-import Tooltip from 'app/components/tooltip';
+import Tag from 'sentry/components/tagDeprecated';
+import Tooltip from 'sentry/components/tooltip';
 
 export default {
   title: 'Deprecated/TagDeprecated',

--- a/docs-ui/stories/features/issueDebugMeta.stories.js
+++ b/docs-ui/stories/features/issueDebugMeta.stories.js
@@ -1,7 +1,7 @@
 import {Component} from 'react';
 
-import DebugMeta from 'app/components/events/interfaces/debugMeta';
-import SentryTypes from 'app/sentryTypes';
+import DebugMeta from 'sentry/components/events/interfaces/debugMeta';
+import SentryTypes from 'sentry/sentryTypes';
 
 const event = {
   id: 'deadbeef',

--- a/docs-ui/stories/features/issueDebugMetaV2.stories.js
+++ b/docs-ui/stories/features/issueDebugMetaV2.stories.js
@@ -1,4 +1,4 @@
-import DebugMeta from 'app/components/events/interfaces/debugMeta-v2';
+import DebugMeta from 'sentry/components/events/interfaces/debugMeta-v2';
 
 const event = {
   id: '5caac5c07a3c4244ac2c02c0c484fb27',

--- a/docs-ui/stories/features/issueResolution.stories.js
+++ b/docs-ui/stories/features/issueResolution.stories.js
@@ -1,5 +1,5 @@
-import MutedBox from 'app/components/mutedBox';
-import ResolutionBox from 'app/components/resolutionBox';
+import MutedBox from 'sentry/components/mutedBox';
+import ResolutionBox from 'sentry/components/resolutionBox';
 
 const actor = {
   email: 'uhoh@example.com',

--- a/docs-ui/stories/features/issueSyncListElement.stories.js
+++ b/docs-ui/stories/features/issueSyncListElement.stories.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import IssueSyncListElement from 'app/components/issueSyncListElement';
-import space from 'app/styles/space';
+import IssueSyncListElement from 'sentry/components/issueSyncListElement';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Features/Issues/Issue Sync List',

--- a/docs-ui/stories/features/mutedBox.stories.js
+++ b/docs-ui/stories/features/mutedBox.stories.js
@@ -1,4 +1,4 @@
-import MutedBox from 'app/components/mutedBox';
+import MutedBox from 'sentry/components/mutedBox';
 
 export default {
   title: 'Features/Issues/Muted Box',

--- a/docs-ui/stories/features/processingIssueHint.stories.js
+++ b/docs-ui/stories/features/processingIssueHint.stories.js
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import ProcessingIssueHint from 'app/components/stream/processingIssueHint';
+import ProcessingIssueHint from 'sentry/components/stream/processingIssueHint';
 
 export default {
   title: 'Features/Issues/Processing Issue Hint',

--- a/docs-ui/stories/features/shareIssue.stories.js
+++ b/docs-ui/stories/features/shareIssue.stories.js
@@ -1,7 +1,7 @@
 import {Component} from 'react';
 import {action} from '@storybook/addon-actions';
 
-import ShareIssue from 'app/views/organizationGroupDetails/actions/shareIssue';
+import ShareIssue from 'sentry/views/organizationGroupDetails/actions/shareIssue';
 
 export default {
   title: 'Features/Issues/Share Issue',

--- a/docs-ui/stories/features/streamGroup.stories.js
+++ b/docs-ui/stories/features/streamGroup.stories.js
@@ -2,8 +2,8 @@ import {Component} from 'react';
 import {browserHistory, Route, Router} from 'react-router';
 import PropTypes from 'prop-types';
 
-import StreamGroup from 'app/components/stream/group';
-import GroupStore from 'app/stores/groupStore';
+import StreamGroup from 'sentry/components/stream/group';
+import GroupStore from 'sentry/stores/groupStore';
 
 export default {
   title: 'Features/Issues/Stream Group',

--- a/docs-ui/stories/features/tagsTable.stories.js
+++ b/docs-ui/stories/features/tagsTable.stories.js
@@ -1,4 +1,4 @@
-import TagsTable from 'app/components/tagsTable';
+import TagsTable from 'sentry/components/tagsTable';
 
 const event = {
   id: 'deadbeef',

--- a/docs-ui/stories/utilities/autoSelectText.stories.js
+++ b/docs-ui/stories/utilities/autoSelectText.stories.js
@@ -1,4 +1,4 @@
-import AutoSelectText from 'app/components/autoSelectText';
+import AutoSelectText from 'sentry/components/autoSelectText';
 
 export default {
   title: 'Utilities/Text/Auto Select',

--- a/docs-ui/stories/utilities/clipboard.stories.js
+++ b/docs-ui/stories/utilities/clipboard.stories.js
@@ -1,5 +1,5 @@
-import Clipboard from 'app/components/clipboard';
-import Tooltip from 'app/components/tooltip';
+import Clipboard from 'sentry/components/clipboard';
+import Tooltip from 'sentry/components/tooltip';
 
 export default {
   title: 'Utilities/Clipboard',

--- a/docs-ui/stories/utilities/clippedBox.stories.js
+++ b/docs-ui/stories/utilities/clippedBox.stories.js
@@ -1,4 +1,4 @@
-import ClippedBox from 'app/components/clippedBox';
+import ClippedBox from 'sentry/components/clippedBox';
 
 export default {
   title: 'Utilities/Hidden Content/Clipped Box',

--- a/docs-ui/stories/utilities/collapsible.stories.js
+++ b/docs-ui/stories/utilities/collapsible.stories.js
@@ -1,6 +1,6 @@
-import Button from 'app/components/button';
-import Collapsible from 'app/components/collapsible';
-import {tn} from 'app/locale';
+import Button from 'sentry/components/button';
+import Collapsible from 'sentry/components/collapsible';
+import {tn} from 'sentry/locale';
 
 export default {
   title: 'Utilities/Hidden Content/Collapsible',

--- a/docs-ui/stories/utilities/commandLine.stories.js
+++ b/docs-ui/stories/utilities/commandLine.stories.js
@@ -1,4 +1,4 @@
-import CommandLine from 'app/components/commandLine';
+import CommandLine from 'sentry/components/commandLine';
 
 export default {
   title: 'Utilities/Command Line',

--- a/docs-ui/stories/utilities/formatters.stories.js
+++ b/docs-ui/stories/utilities/formatters.stories.js
@@ -1,8 +1,8 @@
-import Count from 'app/components/count';
-import DateTime from 'app/components/dateTime';
-import Duration from 'app/components/duration';
-import FileSize from 'app/components/fileSize';
-import Version from 'app/components/version';
+import Count from 'sentry/components/count';
+import DateTime from 'sentry/components/dateTime';
+import Duration from 'sentry/components/duration';
+import FileSize from 'sentry/components/fileSize';
+import Version from 'sentry/components/version';
 
 export default {
   title: 'Utilities/Text/Formatters',

--- a/docs-ui/stories/utilities/getDynamicText.stories.js
+++ b/docs-ui/stories/utilities/getDynamicText.stories.js
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import getDynamicText from 'app/utils/getDynamicText';
+import getDynamicText from 'sentry/utils/getDynamicText';
 
 export default {
   title: 'Utilities/Get Dynamic Text',

--- a/docs-ui/stories/utilities/highlight.stories.js
+++ b/docs-ui/stories/utilities/highlight.stories.js
@@ -1,4 +1,4 @@
-import Highlight, {HighlightComponent} from 'app/components/highlight';
+import Highlight, {HighlightComponent} from 'sentry/components/highlight';
 
 export default {
   title: 'Utilities/Highlight',

--- a/docs-ui/stories/utilities/lazyLoad.stories.js
+++ b/docs-ui/stories/utilities/lazyLoad.stories.js
@@ -1,4 +1,4 @@
-import LazyLoad from 'app/components/lazyLoad';
+import LazyLoad from 'sentry/components/lazyLoad';
 
 export default {
   title: 'Utilities/Lazy Load',

--- a/docs-ui/stories/utilities/textCopyInput.stories.js
+++ b/docs-ui/stories/utilities/textCopyInput.stories.js
@@ -1,6 +1,6 @@
 import {action} from '@storybook/addon-actions';
 
-import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
+import TextCopyInput from 'sentry/views/settings/components/forms/textCopyInput';
 
 export default {
   title: 'Utilities/Copy/Input',

--- a/docs-ui/stories/utilities/textOverflow.stories.js
+++ b/docs-ui/stories/utilities/textOverflow.stories.js
@@ -1,4 +1,4 @@
-import TextOverflow from 'app/components/textOverflow';
+import TextOverflow from 'sentry/components/textOverflow';
 
 export default {
   title: 'Utilities/Text/Overflow',

--- a/docs-ui/stories/utilities/truncate.stories.js
+++ b/docs-ui/stories/utilities/truncate.stories.js
@@ -1,7 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import Truncate from 'app/components/truncate';
+import Truncate from 'sentry/components/truncate';
 
 export default {
   title: 'Utilities/Text/Truncate',

--- a/docs-ui/stories/views/activity.stories.js
+++ b/docs-ui/stories/views/activity.stories.js
@@ -1,6 +1,6 @@
-import ActivityItem from 'app/components/activity/item';
-import ActivityAvatar from 'app/components/activity/item/avatar';
-import ActivityBubble from 'app/components/activity/item/bubble';
+import ActivityItem from 'sentry/components/activity/item';
+import ActivityAvatar from 'sentry/components/activity/item/avatar';
+import ActivityBubble from 'sentry/components/activity/item/bubble';
 
 const user = {
   username: 'billy@sentry.io',

--- a/docs-ui/stories/views/breadcrumbs.stories.js
+++ b/docs-ui/stories/views/breadcrumbs.stories.js
@@ -1,6 +1,6 @@
 import {action} from '@storybook/addon-actions';
 
-import Breadcrumbs from 'app/components/breadcrumbs';
+import Breadcrumbs from 'sentry/components/breadcrumbs';
 
 export default {
   title: 'Views/Breadcrumbs',

--- a/docs-ui/stories/views/detailedError.stories.js
+++ b/docs-ui/stories/views/detailedError.stories.js
@@ -1,6 +1,6 @@
 import {action} from '@storybook/addon-actions';
 
-import DetailedError from 'app/components/errors/detailedError';
+import DetailedError from 'sentry/components/errors/detailedError';
 
 export default {
   title: 'Views/Detailed Error',

--- a/docs-ui/stories/views/emptyMessage.stories.js
+++ b/docs-ui/stories/views/emptyMessage.stories.js
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 
-import Button from 'app/components/button';
-import {Panel, PanelHeader} from 'app/components/panels';
-import {IconTelescope, IconUser} from 'app/icons';
-import space from 'app/styles/space';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import Button from 'sentry/components/button';
+import {Panel, PanelHeader} from 'sentry/components/panels';
+import {IconTelescope, IconUser} from 'sentry/icons';
+import space from 'sentry/styles/space';
+import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
 
 export default {
   title: 'Views/Empty States/Empty Messages',

--- a/docs-ui/stories/views/emptyStateWarning.stories.js
+++ b/docs-ui/stories/views/emptyStateWarning.stories.js
@@ -1,4 +1,4 @@
-import EmptyStateWarning from 'app/components/emptyStateWarning';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 
 export default {
   title: 'Views/Empty States/Empty State Warning',

--- a/docs-ui/stories/views/featureTourModal.stories.js
+++ b/docs-ui/stories/views/featureTourModal.stories.js
@@ -1,9 +1,9 @@
 import {action} from '@storybook/addon-actions';
 
-import Button from 'app/components/button';
-import GlobalModal from 'app/components/globalModal';
-import FeatureTourModal from 'app/components/modals/featureTourModal';
-import {IconEdit} from 'app/icons';
+import Button from 'sentry/components/button';
+import GlobalModal from 'sentry/components/globalModal';
+import FeatureTourModal from 'sentry/components/modals/featureTourModal';
+import {IconEdit} from 'sentry/icons';
 
 export default {
   title: 'Views/Modals/Feature Tour Modal',

--- a/docs-ui/stories/views/globalModal.stories.js
+++ b/docs-ui/stories/views/globalModal.stories.js
@@ -1,6 +1,6 @@
-import {openModal} from 'app/actionCreators/modal';
-import Button from 'app/components/button';
-import GlobalModal from 'app/components/globalModal';
+import {openModal} from 'sentry/actionCreators/modal';
+import Button from 'sentry/components/button';
+import GlobalModal from 'sentry/components/globalModal';
 
 export default {
   title: 'Views/Modals/Global Modal',

--- a/docs-ui/stories/views/layout-thirds.stories.js
+++ b/docs-ui/stories/views/layout-thirds.stories.js
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 
-import Breadcrumbs from 'app/components/breadcrumbs';
-import Button from 'app/components/button';
-import ButtonBar from 'app/components/buttonBar';
-import * as Layout from 'app/components/layouts/thirds';
-import Link from 'app/components/links/link';
-import space from 'app/styles/space';
+import Breadcrumbs from 'sentry/components/breadcrumbs';
+import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import * as Layout from 'sentry/components/layouts/thirds';
+import Link from 'sentry/components/links/link';
+import space from 'sentry/styles/space';
 
 const crumbs = [
   {

--- a/docs-ui/stories/views/linkWithConfirmation.stories.js
+++ b/docs-ui/stories/views/linkWithConfirmation.stories.js
@@ -1,6 +1,6 @@
 import {action} from '@storybook/addon-actions';
 
-import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
+import LinkWithConfirmation from 'sentry/components/links/linkWithConfirmation';
 
 export default {
   title: 'Views/Modals/Link With Confirmation Modal',

--- a/docs-ui/stories/views/narrowLayout.stories.js
+++ b/docs-ui/stories/views/narrowLayout.stories.js
@@ -1,4 +1,4 @@
-import NarrowLayout from 'app/components/narrowLayout';
+import NarrowLayout from 'sentry/components/narrowLayout';
 
 export default {
   title: 'Views/Layout - Narrow',

--- a/docs-ui/stories/views/navTabs.stories.js
+++ b/docs-ui/stories/views/navTabs.stories.js
@@ -1,4 +1,4 @@
-import NavTabs from 'app/components/navTabs';
+import NavTabs from 'sentry/components/navTabs';
 
 export default {
   title: 'Views/Tabs',

--- a/docs-ui/stories/views/notAvailable.stories.js
+++ b/docs-ui/stories/views/notAvailable.stories.js
@@ -1,5 +1,5 @@
-import NotAvailable from 'app/components/notAvailable';
-import PanelTable from 'app/components/panels/panelTable';
+import NotAvailable from 'sentry/components/notAvailable';
+import PanelTable from 'sentry/components/panels/panelTable';
 
 export default {
   title: 'Views/Not Available',

--- a/docs-ui/stories/views/note.stories.js
+++ b/docs-ui/stories/views/note.stories.js
@@ -1,11 +1,11 @@
 import {Component, useState} from 'react';
 import {action} from '@storybook/addon-actions';
 
-import Note from 'app/components/activity/note';
-import SentryTypes from 'app/sentryTypes';
-import ConfigStore from 'app/stores/configStore';
-import MemberListStore from 'app/stores/memberListStore';
-import ProjectsStore from 'app/stores/projectsStore';
+import Note from 'sentry/components/activity/note';
+import SentryTypes from 'sentry/sentryTypes';
+import ConfigStore from 'sentry/stores/configStore';
+import MemberListStore from 'sentry/stores/memberListStore';
+import ProjectsStore from 'sentry/stores/projectsStore';
 
 const user = {
   username: 'billy@sentry.io',

--- a/docs-ui/stories/views/onboardingPanel.stories.js
+++ b/docs-ui/stories/views/onboardingPanel.stories.js
@@ -1,5 +1,5 @@
-import OnboardingPanel from 'app/components/onboardingPanel';
-import {IconFire} from 'app/icons';
+import OnboardingPanel from 'sentry/components/onboardingPanel';
+import {IconFire} from 'sentry/icons';
 
 export default {
   title: 'Views/Onboarding Panel',

--- a/docs-ui/stories/views/pageHeading.stories.js
+++ b/docs-ui/stories/views/pageHeading.stories.js
@@ -1,4 +1,4 @@
-import PageHeading from 'app/components/pageHeading';
+import PageHeading from 'sentry/components/pageHeading';
 
 export default {
   title: 'Views/Page Heading',

--- a/docs-ui/stories/views/sidebarSection.stories.js
+++ b/docs-ui/stories/views/sidebarSection.stories.js
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
 
-import {KeyValueTable, KeyValueTableRow} from 'app/components/keyValueTable';
-import QuestionTooltip from 'app/components/questionTooltip';
-import SidebarSection from 'app/components/sidebarSection';
-import Tag from 'app/components/tag';
-import TextOverflow from 'app/components/textOverflow';
-import Tooltip from 'app/components/tooltip';
-import space from 'app/styles/space';
+import {KeyValueTable, KeyValueTableRow} from 'sentry/components/keyValueTable';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import SidebarSection from 'sentry/components/sidebarSection';
+import Tag from 'sentry/components/tag';
+import TextOverflow from 'sentry/components/textOverflow';
+import Tooltip from 'sentry/components/tooltip';
+import space from 'sentry/styles/space';
 
 export default {
   title: 'Views/Sidebar Section',

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -50,6 +50,7 @@ const config: Config.InitialOptions = {
   coverageReporters: ['html', 'cobertura'],
   coverageDirectory: '.artifacts/coverage',
   moduleNameMapper: {
+    '^sentry/(.*)': '<rootDir>/static/app/$1',
     '^sentry-test/(.*)': '<rootDir>/tests/js/sentry-test/$1',
     '^sentry-locale/(.*)': '<rootDir>/src/sentry/locale/$1',
     '\\.(css|less|png|jpg|mp4)$': '<rootDir>/tests/js/sentry-test/importStyleMock.js',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -379,6 +379,7 @@ let appConfig: Configuration = {
   resolve: {
     alias: {
       app: path.join(staticPrefix, 'app'),
+      sentry: path.join(staticPrefix, 'app'),
       'sentry-images': path.join(staticPrefix, 'images'),
       'sentry-logos': path.join(sentryDjangoAppPath, 'images', 'logos'),
       'sentry-fonts': path.join(staticPrefix, 'fonts'),


### PR DESCRIPTION
Part of refactoring from `app` import alias to `sentry`.

See https://github.com/getsentry/sentry/pull/30178