### PR TITLE
fix(snuba): Fix cache key for SnQL queries

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -672,7 +672,7 @@ def raw_snql_query(
     # other functions do here. It does not add any automatic conditions, format
     # results, nothing. Use at your own risk.
     metrics.incr("snql.sdk.api", tags={"referrer": referrer or "unknown"})
-    params: SnubaQuery = (query, lambda x: x, lambda x: x)
+    params: SnubaQueryBody = (query, lambda x: x, lambda x: x)
     return _apply_cache_and_build_results([params], referrer=referrer, use_cache=use_cache)[0]
 
 
@@ -723,7 +723,7 @@ def _apply_cache_and_build_results(
     results = []
 
     if use_cache:
-        cache_keys = [get_cache_key(query_params) for _, query_params in query_param_list]
+        cache_keys = [get_cache_key(query_params[0]) for _, query_params in query_param_list]
         cache_data = cache.get_many(cache_keys)
         to_query: List[Tuple[int, SnubaQueryBody, Optional[str]]] = []
         for (query_pos, query_params), cache_key in zip(query_param_list, cache_keys):

--- a/tests/snuba/test_snql_snuba.py
+++ b/tests/snuba/test_snql_snuba.py
@@ -3,9 +3,11 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 
+from django.utils import timezone
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import Limit
 from snuba_sdk.function import Function
 from snuba_sdk.query import Query
 
@@ -56,3 +58,22 @@ class SnQLTest(TestCase, SnubaTestCase):
         result = snuba.raw_snql_query(query)
         assert len(result["data"]) == 1
         assert result["data"][0] == {"count": 1, "project_id": self.project.id}
+
+    def test_cache(self):
+        """Minimal test to verify if use_cache works"""
+        results = snuba.raw_snql_query(
+            Query(
+                "events",
+                Entity("events"),
+                select=[Column("event_id")],
+                where=[
+                    Condition(Column("project_id"), Op.EQ, self.project.id),
+                    Condition(Column("timestamp"), Op.GTE, timezone.now() - timedelta(days=1)),
+                    Condition(Column("timestamp"), Op.LT, timezone.now()),
+                ],
+                limit=Limit(1),
+            ),
+            use_cache=True,
+        )
+
+        assert results["data"] == []


### PR DESCRIPTION
`get_cache_key` had `SnubaQuery` in its signature, but actually received a tuple of `SnubaQuery` and two callables. This worked for non-SnQL queries, because it resulted in JSON `[{...}, "<function>", "<function>"]`, but crashes for actual `Query` objects.

The question to answer here is: Should the translator functions be encoded into the cache key or not?