### PR TITLE
fix(dashboards): Removed success toast for dashboard title update

### DIFF
--- a/static/app/views/dashboardsV2/title.tsx
+++ b/static/app/views/dashboardsV2/title.tsx
@@ -28,7 +28,6 @@ function DashboardTitle({dashboard, isEditing, organization, onUpdate}: Props) {
           }
           onChange={newTitle => onUpdate({...dashboard, title: newTitle})}
           errorMessage={t('Please set a title for this dashboard')}
-          successMessage={t('Dashboard title updated successfully')}
         />
       )}
     </div>


### PR DESCRIPTION
Removed success toast when updating a Dashboard title. Toast message was misleading since the Dashboard title doesn't update until the user clicks `Save and Finish`, which has its own toast message.