### PR TITLE
ref(ui): Change `require()` to use `sentry` alias

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -2,7 +2,7 @@ import isEqual from 'lodash/isEqual';
 
 import * as ApiNamespace from 'app/api';
 
-const RealApi: typeof ApiNamespace = jest.requireActual('app/api');
+const RealApi: typeof ApiNamespace = jest.requireActual('sentry/api');
 
 export class Request {}
 

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -30,9 +30,9 @@ const globals = {
 // modules that are not compiled with the sentry bundle.
 const SentryApp = {
   // The following components are used in sentry-plugins.
-  Form: require('app/components/forms/form').default,
-  FormState: require('app/components/forms/index').FormState,
-  LoadingIndicator: require('app/components/loadingIndicator').default,
+  Form: require('sentry/components/forms/form').default,
+  FormState: require('sentry/components/forms/index').FormState,
+  LoadingIndicator: require('sentry/components/loadingIndicator').default,
   plugins: {
     add: plugins.add,
     addContext: plugins.addContext,
@@ -41,11 +41,11 @@ const SentryApp = {
   },
 
   // The following components are used in legacy django HTML views
-  ConfigStore: require('app/stores/configStore').default,
-  HookStore: require('app/stores/hookStore').default,
-  Modal: require('app/actionCreators/modal'),
-  getModalPortal: require('app/utils/getModalPortal').default,
-  Client: require('app/api').Client,
+  ConfigStore: require('sentry/stores/configStore').default,
+  HookStore: require('sentry/stores/hookStore').default,
+  Modal: require('sentry/actionCreators/modal'),
+  getModalPortal: require('sentry/utils/getModalPortal').default,
+  Client: require('sentry/api').Client,
 };
 
 globals.SentryApp = SentryApp;

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -9,18 +9,19 @@ import space from 'app/styles/space';
 import {defined} from 'app/utils';
 
 const CONTEXT_TYPES = {
-  default: require('app/components/events/contexts/default').default,
-  app: require('app/components/events/contexts/app/app').default,
-  device: require('app/components/events/contexts/device/device').default,
-  os: require('app/components/events/contexts/operatingSystem/operatingSystem').default,
-  runtime: require('app/components/events/contexts/runtime/runtime').default,
-  browser: require('app/components/events/contexts/browser/browser').default,
-  user: require('app/components/events/contexts/user/user').default,
-  gpu: require('app/components/events/contexts/gpu/gpu').default,
-  trace: require('app/components/events/contexts/trace/trace').default,
+  default: require('sentry/components/events/contexts/default').default,
+  app: require('sentry/components/events/contexts/app/app').default,
+  device: require('sentry/components/events/contexts/device/device').default,
+  os: require('sentry/components/events/contexts/operatingSystem/operatingSystem')
+    .default,
+  runtime: require('sentry/components/events/contexts/runtime/runtime').default,
+  browser: require('sentry/components/events/contexts/browser/browser').default,
+  user: require('sentry/components/events/contexts/user/user').default,
+  gpu: require('sentry/components/events/contexts/gpu/gpu').default,
+  trace: require('sentry/components/events/contexts/trace/trace').default,
   // 'redux.state' will be replaced with more generic context called 'state'
-  'redux.state': require('app/components/events/contexts/redux').default,
-  state: require('app/components/events/contexts/state').default,
+  'redux.state': require('sentry/components/events/contexts/redux').default,
+  state: require('sentry/components/events/contexts/state').default,
 };
 
 export function getContextComponent(type: string) {

--- a/static/app/components/events/interfaces/debugMeta-v2/utils.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/utils.tsx
@@ -44,7 +44,7 @@ export function normalizeId(id?: string) {
   return id?.trim().toLowerCase().replace(/[- ]/g, '') ?? '';
 }
 
-// TODO(ts): When replacing debugMeta with debugMetaV2, also replace {type: string} with the Image type defined in 'app/types/debugImage'
+// TODO(ts): When replacing debugMeta with debugMetaV2, also replace {type: string} with the Image type defined in 'sentry/types/debugImage'
 export function shouldSkipSection(
   filteredImages: Array<{type: string}>,
   images: Array<{type: string} | null>

--- a/static/app/views/organizationStats/utils.tsx
+++ b/static/app/views/organizationStats/utils.tsx
@@ -64,7 +64,7 @@ export function getFormatUsageOptions(dataCategory: DataCategory): FormatOptions
  * provide clarity on usage of errors/transactions/attachments to the user.
  *
  * If you are not displaying usage numbers, it might be better to use
- * `formatAbbreviatedNumber` in 'app/utils/formatters'
+ * `formatAbbreviatedNumber` in 'sentry/utils/formatters'
  */
 export function abbreviateUsageNumber(n: number) {
   if (n >= BILLION) {


### PR DESCRIPTION
Part of refactoring from `app` import alias to `sentry`.

See https://github.com/getsentry/sentry/pull/30178