### PR TITLE
ref(ui): Change `jest.mock()` to use `sentry` alias

### DIFF
--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -61,10 +61,10 @@ ConfigStore.loadInitialData(fixtures.Config());
  * Mocks
  */
 jest.mock('lodash/debounce', () => jest.fn(fn => fn));
-jest.mock('app/utils/recreateRoute');
-jest.mock('app/api');
-jest.mock('app/utils/domId');
-jest.mock('app/utils/withOrganization');
+jest.mock('sentry/utils/recreateRoute');
+jest.mock('sentry/api');
+jest.mock('sentry/utils/domId');
+jest.mock('sentry/utils/withOrganization');
 jest.mock('scroll-to-element', () => jest.fn());
 jest.mock('react-router', () => {
   const ReactRouter = jest.requireActual('react-router');
@@ -233,7 +233,7 @@ window.TestStubs = {...fixtures, ...routerFixtures};
 // This is so we can use async/await in tests instead of wrapping with `setTimeout`.
 window.tick = () => new Promise(resolve => setTimeout(resolve));
 
-window.MockApiClient = jest.requireMock('app/api').Client;
+window.MockApiClient = jest.requireMock('sentry/api').Client;
 
 window.scrollTo = jest.fn();
 

--- a/tests/js/spec/actionCreators/globalSelection.spec.jsx
+++ b/tests/js/spec/actionCreators/globalSelection.spec.jsx
@@ -9,7 +9,7 @@ import {
 import GlobalSelectionActions from 'sentry/actions/globalSelectionActions';
 import localStorage from 'sentry/utils/localStorage';
 
-jest.mock('app/utils/localStorage');
+jest.mock('sentry/utils/localStorage');
 
 describe('GlobalSelection ActionCreators', function () {
   const organization = TestStubs.Organization();

--- a/tests/js/spec/actionCreators/navigation.spec.jsx
+++ b/tests/js/spec/actionCreators/navigation.spec.jsx
@@ -4,7 +4,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {navigateTo} from 'sentry/actionCreators/navigation';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-jest.mock('app/actionCreators/modal');
+jest.mock('sentry/actionCreators/modal');
 
 describe('navigation ActionCreator', () => {
   let router;

--- a/tests/js/spec/api.spec.jsx
+++ b/tests/js/spec/api.spec.jsx
@@ -1,7 +1,7 @@
 import {Client, Request} from 'sentry/api';
 import {PROJECT_MOVED} from 'sentry/constants/apiErrorCodes';
 
-jest.unmock('app/api');
+jest.unmock('sentry/api');
 
 describe('api', function () {
   let api;

--- a/tests/js/spec/components/activity/note/inputWithStorage.spec.jsx
+++ b/tests/js/spec/components/activity/note/inputWithStorage.spec.jsx
@@ -4,7 +4,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import NoteInputWithStorage from 'sentry/components/activity/note/inputWithStorage';
 import localStorage from 'sentry/utils/localStorage';
 
-jest.mock('app/utils/localStorage');
+jest.mock('sentry/utils/localStorage');
 
 describe('NoteInputWithStorage', function () {
   const defaultProps = {

--- a/tests/js/spec/components/assigneeSelector.spec.jsx
+++ b/tests/js/spec/components/assigneeSelector.spec.jsx
@@ -11,7 +11,7 @@ import MemberListStore from 'sentry/stores/memberListStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/actionCreators/modal', () => ({
   openInviteMembersModal: jest.fn(),
 }));
 

--- a/tests/js/spec/components/charts/eventsChart.spec.jsx
+++ b/tests/js/spec/components/charts/eventsChart.spec.jsx
@@ -7,10 +7,10 @@ import EventsChart from 'sentry/components/charts/eventsChart';
 import WorldMapChart from 'sentry/components/charts/worldMapChart';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 
-jest.mock('app/components/charts/eventsRequest', () => jest.fn(() => null));
+jest.mock('sentry/components/charts/eventsRequest', () => jest.fn(() => null));
 jest.spyOn(globalSelection, 'updateDateTime');
 jest.mock(
-  'app/components/charts/eventsGeoRequest',
+  'sentry/components/charts/eventsGeoRequest',
   () =>
     ({children}) =>
       children({

--- a/tests/js/spec/components/charts/eventsRequest.spec.jsx
+++ b/tests/js/spec/components/charts/eventsRequest.spec.jsx
@@ -7,7 +7,7 @@ const COUNT_OBJ = {
   count: 123,
 };
 
-jest.mock('app/actionCreators/events', () => ({
+jest.mock('sentry/actionCreators/events', () => ({
   doEventsRequest: jest.fn(),
 }));
 

--- a/tests/js/spec/components/createSampleEventButton.spec.jsx
+++ b/tests/js/spec/components/createSampleEventButton.spec.jsx
@@ -8,7 +8,7 @@ import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import CreateSampleEventButton from 'sentry/views/onboarding/createSampleEventButton';
 
 jest.useFakeTimers();
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('CreateSampleEventButton', function () {
   const {org, project, routerContext} = initializeOrg();

--- a/tests/js/spec/components/dataExport.spec.jsx
+++ b/tests/js/spec/components/dataExport.spec.jsx
@@ -4,7 +4,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import Button from 'sentry/components/button';
 import WrappedDataExport from 'sentry/components/dataExport';
 
-jest.mock('app/actionCreators/indicator');
+jest.mock('sentry/actionCreators/indicator');
 
 describe('DataExport', function () {
   const mockUnauthorizedOrg = TestStubs.Organization({

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import EventCauseEmpty from 'sentry/components/events/eventCauseEmpty';
 import {trackAnalyticsEventV2} from 'sentry/utils/analytics';
 
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('EventCauseEmpty', function () {
   let putMock;

--- a/tests/js/spec/components/events/interfaces/threadsV2.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/threadsV2.spec.tsx
@@ -68,8 +68,8 @@ describe('ThreadsV2', function () {
                         vars: null,
                       },
                       {
-                        filename: 'app/controllers/welcome_controller.rb',
-                        absPath: 'app/controllers/welcome_controller.rb',
+                        filename: 'sentry/controllers/welcome_controller.rb',
+                        absPath: 'sentry/controllers/welcome_controller.rb',
                         module: null,
                         package: null,
                         platform: null,
@@ -96,8 +96,8 @@ describe('ThreadsV2', function () {
                         minGroupingLevel: 1,
                       },
                       {
-                        filename: 'app/controllers/welcome_controller.rb',
-                        absPath: 'app/controllers/welcome_controller.rb',
+                        filename: 'sentry/controllers/welcome_controller.rb',
+                        absPath: 'sentry/controllers/welcome_controller.rb',
                         module: null,
                         package: null,
                         platform: null,
@@ -156,7 +156,7 @@ describe('ThreadsV2', function () {
         dist: null,
         message: '',
         title: 'ZeroDivisionError: divided by 0',
-        location: 'app/controllers/welcome_controller.rb',
+        location: 'sentry/controllers/welcome_controller.rb',
         user: null,
         contexts: {},
         sdk: null,
@@ -165,7 +165,7 @@ describe('ThreadsV2', function () {
         type: EventOrGroupType.ERROR,
         metadata: {
           display_title_with_tree_label: false,
-          filename: 'app/controllers/welcome_controller.rb',
+          filename: 'sentry/controllers/welcome_controller.rb',
           finest_tree_label: [
             {filebase: 'welcome_controller.rb', function: '/'},
             {filebase: 'welcome_controller.rb', function: 'index'},
@@ -179,7 +179,7 @@ describe('ThreadsV2', function () {
         dateReceived: '2021-10-28T12:28:22.318469Z',
         errors: [],
         crashFile: null,
-        culprit: 'app/controllers/welcome_controller.rb in /',
+        culprit: 'sentry/controllers/welcome_controller.rb in /',
         dateCreated: '2021-10-28T12:28:22.318469Z',
         fingerprints: ['58f1f47bea5239ea25397888dc9253d1'],
         groupingConfig: {
@@ -258,7 +258,7 @@ describe('ThreadsV2', function () {
 
         expect(
           within(screen.queryAllByTestId('stack-trace-frame')[0]).getByText(
-            'app/controllers/welcome_controller.rb'
+            'sentry/controllers/welcome_controller.rb'
           )
         ).toBeInTheDocument();
 

--- a/tests/js/spec/components/forms/teamSelector.spec.jsx
+++ b/tests/js/spec/components/forms/teamSelector.spec.jsx
@@ -5,7 +5,7 @@ import {TeamSelector} from 'sentry/components/forms/teamSelector';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import TeamStore from 'sentry/stores/teamStore';
 
-jest.mock('app/actionCreators/projects', () => ({
+jest.mock('sentry/actionCreators/projects', () => ({
   addTeamToProject: jest.fn(),
 }));
 

--- a/tests/js/spec/components/issueDiff.spec.jsx
+++ b/tests/js/spec/components/issueDiff.spec.jsx
@@ -2,7 +2,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {IssueDiff} from 'sentry/components/issueDiff';
 
-jest.mock('app/api');
+jest.mock('sentry/api');
 
 describe('IssueDiff', function () {
   const entries = TestStubs.Entries();

--- a/tests/js/spec/components/modals/addDashboardIssueWidgetModal.spec.tsx
+++ b/tests/js/spec/components/modals/addDashboardIssueWidgetModal.spec.tsx
@@ -3,7 +3,7 @@ import {mountWithTheme, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import AddDashboardIssueWidgetModal from 'sentry/components/modals/addDashboardIssueWidgetModal';
 
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/actionCreators/modal', () => ({
   openDashboardWidgetLibraryModal: jest.fn(),
 }));
 

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -10,7 +10,7 @@ import {t} from 'sentry/locale';
 import TagStore from 'sentry/stores/tagStore';
 import * as types from 'sentry/views/dashboardsV2/types';
 
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/actionCreators/modal', () => ({
   openDashboardWidgetLibraryModal: jest.fn(),
 }));
 

--- a/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
+++ b/tests/js/spec/components/modals/commandPaletteModal.spec.jsx
@@ -5,8 +5,8 @@ import {navigateTo} from 'sentry/actionCreators/navigation';
 import FormSearchStore from 'sentry/stores/formSearchStore';
 import App from 'sentry/views/app';
 
-jest.mock('app/actionCreators/formSearch');
-jest.mock('app/actionCreators/navigation');
+jest.mock('sentry/actionCreators/formSearch');
+jest.mock('sentry/actionCreators/navigation');
 
 describe('Command Palette Modal', function () {
   let orgsMock;

--- a/tests/js/spec/components/modals/createTeamModal.spec.jsx
+++ b/tests/js/spec/components/modals/createTeamModal.spec.jsx
@@ -3,7 +3,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {createTeam} from 'sentry/actionCreators/teams';
 import CreateTeamModal from 'sentry/components/modals/createTeamModal';
 
-jest.mock('app/actionCreators/teams', () => ({
+jest.mock('sentry/actionCreators/teams', () => ({
   createTeam: jest.fn((...args) => new Promise(resolve => resolve(...args))),
 }));
 

--- a/tests/js/spec/components/modals/redirectToProject.spec.jsx
+++ b/tests/js/spec/components/modals/redirectToProject.spec.jsx
@@ -2,7 +2,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {RedirectToProjectModal} from 'sentry/components/modals/redirectToProject';
 
-jest.unmock('app/utils/recreateRoute');
+jest.unmock('sentry/utils/recreateRoute');
 describe('RedirectToProjectModal', function () {
   jest.useFakeTimers();
   const routes = [

--- a/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
+++ b/tests/js/spec/components/organizations/globalSelectionHeader.spec.jsx
@@ -24,7 +24,7 @@ const changeQuery = (routerContext, query) => ({
   },
 });
 
-jest.mock('app/utils/localStorage', () => ({
+jest.mock('sentry/utils/localStorage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
 }));

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -12,7 +12,7 @@ import * as incidentActions from 'sentry/actionCreators/serviceIncidents';
 import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
 
-jest.mock('app/actionCreators/serviceIncidents');
+jest.mock('sentry/actionCreators/serviceIncidents');
 
 describe('Sidebar', function () {
   const {organization, router} = initializeOrg();

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -5,7 +5,7 @@ import StreamGroup from 'sentry/components/stream/group';
 import GroupStore from 'sentry/stores/groupStore';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('StreamGroup', function () {
   let GROUP_1;

--- a/tests/js/spec/components/suggestProjectCTA.spec.jsx
+++ b/tests/js/spec/components/suggestProjectCTA.spec.jsx
@@ -4,7 +4,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import SuggestProjectCTA from 'sentry/components/suggestProjectCTA';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-jest.mock('app/actionCreators/modal');
+jest.mock('sentry/actionCreators/modal');
 
 function generateWrapperAndSetMocks(inputProps, mobileEventResp, promptResp) {
   const projects = inputProps?.projects ?? [TestStubs.Project({platform: 'javascript'})];

--- a/tests/js/spec/stores/alertStore.spec.jsx
+++ b/tests/js/spec/stores/alertStore.spec.jsx
@@ -1,6 +1,6 @@
 import AlertStore from 'sentry/stores/alertStore';
 
-jest.mock('app/utils/localStorage');
+jest.mock('sentry/utils/localStorage');
 
 describe('AlertStore', function () {
   beforeEach(function () {

--- a/tests/js/spec/stores/globalSelectionStore.spec.jsx
+++ b/tests/js/spec/stores/globalSelectionStore.spec.jsx
@@ -5,7 +5,7 @@ import {
 } from 'sentry/actionCreators/globalSelection';
 import GlobalSelectionStore from 'sentry/stores/globalSelectionStore';
 
-jest.mock('app/utils/localStorage', () => ({
+jest.mock('sentry/utils/localStorage', () => ({
   getItem: () => JSON.stringify({projects: [5], environments: ['staging']}),
   setItem: jest.fn(),
 }));

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -2,7 +2,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import GuideStore from 'sentry/stores/guideStore';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('GuideStore', function () {
   let data;

--- a/tests/js/spec/utils/getDynamicText.spec.jsx
+++ b/tests/js/spec/utils/getDynamicText.spec.jsx
@@ -4,10 +4,10 @@ describe('getDynamicText', function () {
   });
 
   it('renders actual value', function () {
-    jest.doMock('app/constants', () => ({
+    jest.doMock('sentry/constants', () => ({
       IS_ACCEPTANCE_TEST: false,
     }));
-    const getDynamicText = require('app/utils/getDynamicText').default;
+    const getDynamicText = require('sentry/utils/getDynamicText').default;
 
     expect(
       getDynamicText({
@@ -18,10 +18,10 @@ describe('getDynamicText', function () {
   });
 
   it('renders fixed content when `app/constants/IS_ACCEPTANCE_TEST` is true', function () {
-    jest.doMock('app/constants', () => ({
+    jest.doMock('sentry/constants', () => ({
       IS_ACCEPTANCE_TEST: true,
     }));
-    const getDynamicText = require('app/utils/getDynamicText').default;
+    const getDynamicText = require('sentry/utils/getDynamicText').default;
 
     expect(
       getDynamicText({

--- a/tests/js/spec/utils/recreateRoute.spec.jsx
+++ b/tests/js/spec/utils/recreateRoute.spec.jsx
@@ -1,6 +1,6 @@
 import recreateRoute from 'sentry/utils/recreateRoute';
 
-jest.unmock('app/utils/recreateRoute');
+jest.unmock('sentry/utils/recreateRoute');
 
 const routes = [
   {path: '/', childRoutes: []},

--- a/tests/js/spec/utils/withExperiment.spec.jsx
+++ b/tests/js/spec/utils/withExperiment.spec.jsx
@@ -4,11 +4,11 @@ import ConfigStore from 'sentry/stores/configStore';
 import {logExperiment} from 'sentry/utils/analytics';
 import withExperiment from 'sentry/utils/withExperiment';
 
-jest.mock('app/utils/analytics', () => ({
+jest.mock('sentry/utils/analytics', () => ({
   logExperiment: jest.fn(),
 }));
 
-jest.mock('app/data/experimentConfig', () => ({
+jest.mock('sentry/data/experimentConfig', () => ({
   experimentConfig: {
     orgExperiment: {
       key: 'orgExperiment',

--- a/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
+++ b/tests/js/spec/views/acceptOrganizationInvite.spec.jsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {logout} from 'sentry/actionCreators/account';
 import AcceptOrganizationInvite from 'sentry/views/acceptOrganizationInvite';
 
-jest.mock('app/actionCreators/account');
+jest.mock('sentry/actionCreators/account');
 
 const addMock = body =>
   MockApiClient.addMockResponse({

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -18,9 +18,9 @@ import AlertsContainer from 'sentry/views/alerts';
 import AlertBuilderProjectProvider from 'sentry/views/alerts/builder/projectProvider';
 import ProjectAlertsCreate from 'sentry/views/alerts/create';
 
-jest.unmock('app/utils/recreateRoute');
+jest.unmock('sentry/utils/recreateRoute');
 jest.mock('react-router');
-jest.mock('app/utils/analytics', () => ({
+jest.mock('sentry/utils/analytics', () => ({
   metric: {
     startTransaction: jest.fn(() => ({
       setTag: jest.fn(),

--- a/tests/js/spec/views/alerts/details/index.spec.jsx
+++ b/tests/js/spec/views/alerts/details/index.spec.jsx
@@ -6,7 +6,7 @@ import {mountWithTheme, waitFor} from 'sentry-test/reactTestingLibrary';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import IncidentDetails from 'sentry/views/alerts/details';
 
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('IncidentDetails', () => {
   const params = {orgId: 'org-slug', alertId: '123'};

--- a/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/details.spec.jsx
@@ -12,7 +12,7 @@ import GlobalModal from 'sentry/components/globalModal';
 import {metric} from 'sentry/utils/analytics';
 import IncidentRulesDetails from 'sentry/views/alerts/incidentRules/details';
 
-jest.mock('app/utils/analytics', () => ({
+jest.mock('sentry/utils/analytics', () => ({
   metric: {
     startTransaction: jest.fn(() => ({
       setTag: jest.fn(),

--- a/tests/js/spec/views/alerts/incidentRules/presets.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/presets.spec.jsx
@@ -6,11 +6,11 @@ import {Dataset} from 'sentry/views/alerts/incidentRules/types';
 import {getIncidentDiscoverUrl} from 'sentry/views/alerts/utils/getIncidentDiscoverUrl';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
-jest.mock('app/views/performance/transactionSummary/utils', () => ({
+jest.mock('sentry/views/performance/transactionSummary/utils', () => ({
   transactionSummaryRouteWithQuery: jest.fn(),
 }));
 
-jest.mock('app/views/alerts/utils/getIncidentDiscoverUrl', () => {
+jest.mock('sentry/views/alerts/utils/getIncidentDiscoverUrl', () => {
   return {
     getIncidentDiscoverUrl: jest.fn(),
   };

--- a/tests/js/spec/views/alerts/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/ruleForm.spec.jsx
@@ -11,8 +11,8 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {metric} from 'sentry/utils/analytics';
 import RuleFormContainer from 'sentry/views/alerts/incidentRules/ruleForm';
 
-jest.mock('app/actionCreators/indicator');
-jest.mock('app/utils/analytics', () => ({
+jest.mock('sentry/actionCreators/indicator');
+jest.mock('sentry/utils/analytics', () => ({
   metric: {
     startTransaction: jest.fn(() => ({
       setTag: jest.fn(),

--- a/tests/js/spec/views/alerts/incidentRules/triggersChart.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/triggersChart.spec.jsx
@@ -5,7 +5,7 @@ import {Client} from 'sentry/api';
 import AreaChart from 'sentry/components/charts/areaChart';
 import TriggersChart from 'sentry/views/alerts/incidentRules/triggers/chart';
 
-jest.mock('app/components/charts/areaChart');
+jest.mock('sentry/components/charts/areaChart');
 
 describe('Incident Rules Create', () => {
   let eventStatsMock;

--- a/tests/js/spec/views/alerts/issueRuleEditor/issueRuleEditor.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/issueRuleEditor.spec.jsx
@@ -10,9 +10,9 @@ import {metric} from 'sentry/utils/analytics';
 import IssueRuleEditor from 'sentry/views/alerts/issueRuleEditor';
 import ProjectAlerts from 'sentry/views/settings/projectAlerts';
 
-jest.unmock('app/utils/recreateRoute');
-jest.mock('app/actionCreators/onboardingTasks');
-jest.mock('app/utils/analytics', () => ({
+jest.unmock('sentry/utils/recreateRoute');
+jest.mock('sentry/actionCreators/onboardingTasks');
+jest.mock('sentry/utils/analytics', () => ({
   metric: {
     startTransaction: jest.fn(() => ({
       setTag: jest.fn(),

--- a/tests/js/spec/views/alerts/issueRuleEditor/ticketRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRuleEditor/ticketRuleModal.spec.jsx
@@ -6,8 +6,8 @@ import {selectByQuery, selectByValue} from 'sentry-test/select-new';
 
 import TicketRuleModal from 'sentry/views/alerts/issueRuleEditor/ticketRuleModal';
 
-jest.unmock('app/utils/recreateRoute');
-jest.mock('app/actionCreators/onboardingTasks');
+jest.unmock('sentry/utils/recreateRoute');
+jest.mock('sentry/actionCreators/onboardingTasks');
 
 describe('ProjectAlerts -> TicketRuleModal', function () {
   const closeModal = jest.fn();

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -8,7 +8,7 @@ import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import AlertRulesList from 'sentry/views/alerts/rules';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('OrganizationRuleList', () => {
   const {routerContext, organization, router} = initializeOrg();

--- a/tests/js/spec/views/eventsV2/miniGraph.spec.tsx
+++ b/tests/js/spec/views/eventsV2/miniGraph.spec.tsx
@@ -4,7 +4,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import EventView from 'sentry/utils/discover/eventView';
 import MiniGraph from 'sentry/views/eventsV2/miniGraph';
 
-jest.mock('app/components/charts/eventsGeoRequest', () =>
+jest.mock('sentry/components/charts/eventsGeoRequest', () =>
   jest.fn(({children}) =>
     children({
       errored: false,

--- a/tests/js/spec/views/integrationPipeline/pipelineView.spec.jsx
+++ b/tests/js/spec/views/integrationPipeline/pipelineView.spec.jsx
@@ -7,7 +7,7 @@ function MockAwsLambdaProjectSelect() {
 }
 
 jest.mock(
-  'app/views/integrationPipeline/awsLambdaProjectSelect',
+  'sentry/views/integrationPipeline/awsLambdaProjectSelect',
   () => MockAwsLambdaProjectSelect
 );
 

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -4,7 +4,7 @@ import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import IssueListHeader from 'sentry/views/issueList/header';
 import {Query} from 'sentry/views/issueList/utils';
 
-jest.mock('app/utils/analytics', () => ({
+jest.mock('sentry/utils/analytics', () => ({
   trackAnalyticsEvent: jest.fn(),
 }));
 

--- a/tests/js/spec/views/issueList/noGroupsHandler/noUnresolvedIssues.spec.jsx
+++ b/tests/js/spec/views/issueList/noGroupsHandler/noUnresolvedIssues.spec.jsx
@@ -4,7 +4,7 @@ import CongratsRobotsVideo from 'sentry/views/issueList/noGroupsHandler/congrats
 import NoUnresolvedIssues from 'sentry/views/issueList/noGroupsHandler/noUnresolvedIssues';
 
 // Mocking this because of https://github.com/airbnb/enzyme/issues/2326
-jest.mock('app/views/issueList/noGroupsHandler/congratsRobots', () =>
+jest.mock('sentry/views/issueList/noGroupsHandler/congratsRobots', () =>
   jest.fn(() => null)
 );
 

--- a/tests/js/spec/views/issueList/overview.polling.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.polling.spec.jsx
@@ -6,9 +6,9 @@ import TagStore from 'sentry/stores/tagStore';
 import IssueList from 'sentry/views/issueList/overview';
 
 // Mock <IssueListSidebar> (need <IssueListActions> to toggling real time polling)
-jest.mock('app/views/issueList/sidebar', () => jest.fn(() => null));
-jest.mock('app/views/issueList/filters', () => jest.fn(() => null));
-jest.mock('app/components/stream/group', () => jest.fn(() => null));
+jest.mock('sentry/views/issueList/sidebar', () => jest.fn(() => null));
+jest.mock('sentry/views/issueList/filters', () => jest.fn(() => null));
+jest.mock('sentry/components/stream/group', () => jest.fn(() => null));
 
 jest.mock('js-cookie', () => ({
   get: jest.fn(),

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -14,10 +14,10 @@ import * as parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import IssueListWithStores, {IssueListOverview} from 'sentry/views/issueList/overview';
 
 // Mock <IssueListSidebar> and <IssueListActions>
-jest.mock('app/views/issueList/sidebar', () => jest.fn(() => null));
-jest.mock('app/views/issueList/actions', () => jest.fn(() => null));
-jest.mock('app/components/stream/group', () => jest.fn(() => null));
-jest.mock('app/views/issueList/noGroupsHandler/congratsRobots', () =>
+jest.mock('sentry/views/issueList/sidebar', () => jest.fn(() => null));
+jest.mock('sentry/views/issueList/actions', () => jest.fn(() => null));
+jest.mock('sentry/components/stream/group', () => jest.fn(() => null));
+jest.mock('sentry/views/issueList/noGroupsHandler/congratsRobots', () =>
   jest.fn(() => null)
 );
 

--- a/tests/js/spec/views/onboarding/platform.spec.jsx
+++ b/tests/js/spec/views/onboarding/platform.spec.jsx
@@ -5,7 +5,7 @@ import {createProject} from 'sentry/actionCreators/projects';
 import TeamStore from 'sentry/stores/teamStore';
 import OnboardingPlatform from 'sentry/views/onboarding/platform';
 
-jest.mock('app/actionCreators/projects');
+jest.mock('sentry/actionCreators/projects');
 
 describe('OnboardingWelcome', function () {
   it('calls onUpdate when setting the platform', function () {

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -8,10 +8,10 @@ import ConfigStore from 'sentry/stores/configStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import {OrganizationLegacyContext} from 'sentry/views/organizationContext';
 
-jest.mock('app/stores/configStore', () => ({
+jest.mock('sentry/stores/configStore', () => ({
   get: jest.fn(),
 }));
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/actionCreators/modal', () => ({
   openSudo: jest.fn(),
 }));
 

--- a/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
+++ b/tests/js/spec/views/organizationDetails/organizationsDetails.spec.jsx
@@ -4,7 +4,7 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import OrganizationDetails from 'sentry/views/organizationDetails';
 
-jest.mock('app/components/sidebar', () => () => <div />);
+jest.mock('sentry/components/sidebar', () => () => <div />);
 
 describe('OrganizationDetails', function () {
   let getTeamsMock;

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -8,7 +8,7 @@ import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import GroupDetails from 'sentry/views/organizationGroupDetails';
 
-jest.unmock('app/utils/recreateRoute');
+jest.unmock('sentry/utils/recreateRoute');
 
 const SAMPLE_EVENT_ALERT_TEXT =
   'You are viewing a sample error. Configure Sentry to start viewing real errors.';

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetailsContainer.spec.jsx
@@ -4,7 +4,7 @@ import OrganizationEnvironmentsStore from 'sentry/stores/organizationEnvironment
 import GroupEventDetailsContainer from 'sentry/views/organizationGroupDetails/groupEventDetails';
 
 jest.mock(
-  'app/views/organizationGroupDetails/groupEventDetails/groupEventDetails',
+  'sentry/views/organizationGroupDetails/groupEventDetails/groupEventDetails',
   () => () => <div>GroupEventDetails</div>
 );
 

--- a/tests/js/spec/views/organizationGroupDetails/groupMergedView.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupMergedView.spec.jsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {Client} from 'sentry/api';
 import {GroupMergedView} from 'sentry/views/organizationGroupDetails/groupMerged';
 
-jest.mock('app/api');
+jest.mock('sentry/api');
 
 describe('Issues -> Merged View', function () {
   const events = TestStubs.DetailedEvents();

--- a/tests/js/spec/views/organizationGroupDetails/quickTrace.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/quickTrace.spec.jsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import ConfigureDistributedTracing from 'sentry/views/organizationGroupDetails/quickTrace/configureDistributedTracing';
 
-jest.mock('app/utils/analytics');
+jest.mock('sentry/utils/analytics');
 
 describe('ConfigureDistributedTracing', function () {
   let putMock;

--- a/tests/js/spec/views/organizationJoinRequest.spec.jsx
+++ b/tests/js/spec/views/organizationJoinRequest.spec.jsx
@@ -4,10 +4,10 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {trackAdhocEvent} from 'sentry/utils/analytics';
 import OrganizationJoinRequest from 'sentry/views/organizationJoinRequest';
 
-jest.mock('app/utils/analytics', () => ({
+jest.mock('sentry/utils/analytics', () => ({
   trackAdhocEvent: jest.fn(),
 }));
-jest.mock('app/actionCreators/indicator');
+jest.mock('sentry/actionCreators/indicator');
 
 describe('OrganizationJoinRequest', function () {
   const org = TestStubs.Organization({slug: 'test-org'});

--- a/tests/js/spec/views/organizationRoot.spec.jsx
+++ b/tests/js/spec/views/organizationRoot.spec.jsx
@@ -4,11 +4,11 @@ import {setLastRoute} from 'sentry/actionCreators/navigation';
 import {setActiveProject} from 'sentry/actionCreators/projects';
 import {OrganizationRoot} from 'sentry/views/organizationRoot';
 
-jest.mock('app/actionCreators/projects', () => ({
+jest.mock('sentry/actionCreators/projects', () => ({
   setActiveProject: jest.fn(),
 }));
 
-jest.mock('app/actionCreators/navigation', () => ({
+jest.mock('sentry/actionCreators/navigation', () => ({
   setLastRoute: jest.fn(),
 }));
 

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -12,8 +12,8 @@ import localStorage from 'sentry/utils/localStorage';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import TeamInsightsOverview from 'sentry/views/organizationStats/teamInsights/overview';
 
-jest.mock('app/utils/localStorage');
-jest.mock('app/utils/isActiveSuperuser', () => ({
+jest.mock('sentry/utils/localStorage');
+jest.mock('sentry/utils/isActiveSuperuser', () => ({
   isActiveSuperuser: jest.fn(),
 }));
 

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -3,7 +3,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {openCreateTeamModal} from 'sentry/actionCreators/modal';
 import {CreateProject} from 'sentry/views/projectInstall/createProject';
 
-jest.mock('app/actionCreators/modal');
+jest.mock('sentry/actionCreators/modal');
 
 describe('CreateProject', function () {
   const teamNoAccess = {slug: 'test', id: '1', name: 'test', hasAccess: false};

--- a/tests/js/spec/views/projectOwnership.spec.jsx
+++ b/tests/js/spec/views/projectOwnership.spec.jsx
@@ -4,7 +4,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
 import ProjectOwnership from 'sentry/views/settings/project/projectOwnership';
 
-jest.mock('app/actionCreators/modal');
+jest.mock('sentry/actionCreators/modal');
 
 describe('Project Ownership', function () {
   let org = TestStubs.Organization();

--- a/tests/js/spec/views/projectPlugins/index.spec.jsx
+++ b/tests/js/spec/views/projectPlugins/index.spec.jsx
@@ -3,7 +3,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {disablePlugin, enablePlugin, fetchPlugins} from 'sentry/actionCreators/plugins';
 import ProjectPlugins from 'sentry/views/settings/projectPlugins';
 
-jest.mock('app/actionCreators/plugins', () => ({
+jest.mock('sentry/actionCreators/plugins', () => ({
   fetchPlugins: jest.fn().mockResolvedValue([]),
   enablePlugin: jest.fn(),
   disablePlugin: jest.fn(),

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -7,7 +7,7 @@ import TeamStore from 'sentry/stores/teamStore';
 import App from 'sentry/views/app';
 import ProjectTeams from 'sentry/views/settings/project/projectTeams';
 
-jest.unmock('app/actionCreators/modal');
+jest.unmock('sentry/actionCreators/modal');
 
 describe('ProjectTeams', function () {
   let org;

--- a/tests/js/spec/views/projects/projectContext.spec.jsx
+++ b/tests/js/spec/views/projects/projectContext.spec.jsx
@@ -2,8 +2,8 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 
 import {ProjectContext} from 'sentry/views/projects/projectContext';
 
-jest.unmock('app/utils/recreateRoute');
-jest.mock('app/actionCreators/modal', () => ({
+jest.unmock('sentry/utils/recreateRoute');
+jest.mock('sentry/actionCreators/modal', () => ({
   redirectToProject: jest.fn(),
 }));
 

--- a/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
@@ -5,7 +5,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import DataScrubbing from 'sentry/views/settings/components/dataScrubbing';
 import {ProjectId} from 'sentry/views/settings/components/dataScrubbing/types';
 
-jest.mock('app/actionCreators/modal');
+jest.mock('sentry/actionCreators/modal');
 
 const relayPiiConfig = TestStubs.DataScrubbingRelayPiiConfig();
 const stringRelayPiiConfig = JSON.stringify(relayPiiConfig);
@@ -13,7 +13,7 @@ const organizationSlug = 'sentry';
 const handleUpdateOrganization = jest.fn();
 const additionalContext = 'These rules can be configured for each project.';
 
-jest.mock('app/actionCreators/indicator');
+jest.mock('sentry/actionCreators/indicator');
 
 function getOrganization(piiConfig?: string) {
   return TestStubs.Organization(

--- a/tests/js/spec/views/settings/components/dataScrubbing/editModal.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/editModal.spec.tsx
@@ -24,7 +24,7 @@ const projectId = 'foo';
 const endpoint = `/projects/${organizationSlug}/${projectId}/`;
 const api = new MockApiClient();
 
-jest.mock('app/views/settings/components/dataScrubbing/submitRules');
+jest.mock('sentry/views/settings/components/dataScrubbing/submitRules');
 
 async function renderComponent() {
   const modal = await mountGlobalModal();

--- a/tests/js/spec/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsBreadcrumb/organizationCrumb.spec.jsx
@@ -5,7 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import OrganizationCrumb from 'sentry/views/settings/components/settingsBreadcrumb/organizationCrumb';
 
-jest.unmock('app/utils/recreateRoute');
+jest.unmock('sentry/utils/recreateRoute');
 
 describe('OrganizationCrumb', function () {
   const {organization, project, routerContext} = initializeOrg();

--- a/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
+++ b/tests/js/spec/views/settings/components/settingsSearch/index.spec.jsx
@@ -4,8 +4,8 @@ import {navigateTo} from 'sentry/actionCreators/navigation';
 import FormSearchStore from 'sentry/stores/formSearchStore';
 import SettingsSearch from 'sentry/views/settings/components/settingsSearch';
 
-jest.mock('app/actionCreators/formSearch');
-jest.mock('app/actionCreators/navigation');
+jest.mock('sentry/actionCreators/formSearch');
+jest.mock('sentry/actionCreators/navigation');
 
 describe('SettingsSearch', function () {
   let orgsMock;

--- a/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
@@ -3,7 +3,7 @@ import {mountGlobalModal} from 'sentry-test/modal';
 
 import OrganizationApiKeysList from 'sentry/views/settings/organizationApiKeys/organizationApiKeysList';
 
-jest.unmock('app/utils/recreateRoute');
+jest.unmock('sentry/utils/recreateRoute');
 
 const routes = [
   {path: '/'},

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -5,7 +5,7 @@ import {updateMember} from 'sentry/actionCreators/members';
 import TeamStore from 'sentry/stores/teamStore';
 import OrganizationMemberDetail from 'sentry/views/settings/organizationMembers/organizationMemberDetail';
 
-jest.mock('app/actionCreators/members', () => ({
+jest.mock('sentry/actionCreators/members', () => ({
   updateMember: jest.fn().mockReturnValue(new Promise(() => {})),
 }));
 

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -11,10 +11,10 @@ import OrganizationsStore from 'sentry/stores/organizationsStore';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 
-jest.mock('app/utils/analytics/trackAdvancedAnalyticsEvent', () => jest.fn());
+jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent', () => jest.fn());
 
-jest.mock('app/api');
-jest.mock('app/actionCreators/indicator');
+jest.mock('sentry/api');
+jest.mock('sentry/actionCreators/indicator');
 
 const roles = [
   {

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersWrapper.spec.jsx
@@ -5,8 +5,8 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import OrganizationMembersList from 'sentry/views/settings/organizationMembers/organizationMembersList';
 import OrganizationMembersWrapper from 'sentry/views/settings/organizationMembers/organizationMembersWrapper';
 
-jest.mock('app/utils/analytics/trackAdvancedAnalyticsEvent', () => jest.fn());
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/utils/analytics/trackAdvancedAnalyticsEvent', () => jest.fn());
+jest.mock('sentry/actionCreators/modal', () => ({
   openInviteMembersModal: jest.fn(),
 }));
 

--- a/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSettingsForm.spec.jsx
@@ -3,7 +3,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {saveOnBlurUndoMessage} from 'sentry/actionCreators/indicator';
 import OrganizationSettingsForm from 'sentry/views/settings/organizationGeneralSettings/organizationSettingsForm';
 
-jest.mock('app/actionCreators/indicator');
+jest.mock('sentry/actionCreators/indicator');
 
 describe('OrganizationSettingsForm', function () {
   const organization = TestStubs.Organization();

--- a/tests/js/spec/views/settings/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/settings/organizationTeams.spec.jsx
@@ -9,7 +9,7 @@ import OrganizationTeams from 'sentry/views/settings/organizationTeams/organizat
 
 recreateRoute.mockReturnValue('');
 
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/actionCreators/modal', () => ({
   openCreateTeamModal: jest.fn(),
 }));
 

--- a/tests/js/spec/views/settings/projectEnvironments.spec.jsx
+++ b/tests/js/spec/views/settings/projectEnvironments.spec.jsx
@@ -4,7 +4,7 @@ import {ALL_ENVIRONMENTS_KEY} from 'sentry/constants';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import ProjectEnvironments from 'sentry/views/settings/project/projectEnvironments';
 
-jest.mock('app/utils/recreateRoute');
+jest.mock('sentry/utils/recreateRoute');
 recreateRoute.mockReturnValue('/org-slug/project-slug/settings/environments/');
 
 function mountComponent(isHidden) {

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -11,8 +11,8 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import ProjectContext from 'sentry/views/projects/projectContext';
 import ProjectGeneralSettings from 'sentry/views/settings/projectGeneralSettings';
 
-jest.mock('app/actionCreators/indicator');
-jest.mock('app/components/organizations/globalSelectionHeader/utils');
+jest.mock('sentry/actionCreators/indicator');
+jest.mock('sentry/components/organizations/globalSelectionHeader/utils');
 
 describe('projectGeneralSettings', function () {
   const org = TestStubs.Organization();

--- a/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
+++ b/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
@@ -6,7 +6,7 @@ import ProjectReleaseTrackingContainer, {
   ProjectReleaseTracking,
 } from 'sentry/views/settings/project/projectReleaseTracking';
 
-jest.mock('app/actionCreators/plugins', () => ({
+jest.mock('sentry/actionCreators/plugins', () => ({
   fetchPlugins: jest.fn().mockResolvedValue([]),
 }));
 

--- a/tests/js/spec/views/team/teamMembers.spec.jsx
+++ b/tests/js/spec/views/team/teamMembers.spec.jsx
@@ -7,7 +7,7 @@ import {
 import {Client} from 'sentry/api';
 import TeamMembers from 'sentry/views/settings/organizationTeams/teamMembers';
 
-jest.mock('app/actionCreators/modal', () => ({
+jest.mock('sentry/actionCreators/modal', () => ({
   openInviteMembersModal: jest.fn(),
   openTeamAccessRequestModal: jest.fn(),
 }));


### PR DESCRIPTION
Part of refactoring from `app` import alias to `sentry`.

See https://github.com/getsentry/sentry/pull/30178