### PR TITLE
fix(slack): Use .first() and avoid indexerror

### DIFF
--- a/src/sentry/integrations/slack/endpoints/event.py
+++ b/src/sentry/integrations/slack/endpoints/event.py
@@ -130,9 +130,10 @@ class SlackEventEndpoint(SlackDMEndpoint):
             if link_type is None or args is None:
                 continue
 
-            organization = slack_request.integration.organizations.all()[0]
+            organization = slack_request.integration.organizations.first()
             if (
-                link_type == LinkType.DISCOVER
+                organization
+                and link_type == LinkType.DISCOVER
                 and not slack_request.has_identity
                 and features.has("organizations:chart-unfurls", organization, actor=request.user)
             ):


### PR DESCRIPTION
If a user in an organization who doesn't have the Slack integration installed shares a Discover link, we still try to grab the first organization and that results in an index error.

Fixes [SENTRY-STK](https://sentry.io/organizations/sentry/issues/2811185107/?project=1&referrer=slack)