### PR TITLE
fix(github): Use .get() on access_token

### DIFF
--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,3 +1,5 @@
+from rest_framework.response import Response
+
 from sentry import http, options
 from sentry.identity.oauth2 import OAuth2Provider
 
@@ -38,7 +40,10 @@ class GitHubIdentityProvider(OAuth2Provider):
 
     def build_identity(self, data):
         data = data["data"]
-        user = get_user_info(data.get("access_token"))
+        access_token = data.get("access_token")
+        if not access_token:
+            return Response(status=403)
+        user = get_user_info(access_token)
 
         return {
             "type": "github",

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -38,7 +38,7 @@ class GitHubIdentityProvider(OAuth2Provider):
 
     def build_identity(self, data):
         data = data["data"]
-        user = get_user_info(data["access_token"])
+        user = get_user_info(data.get("access_token"))
 
         return {
             "type": "github",

--- a/src/sentry/identity/github/provider.py
+++ b/src/sentry/identity/github/provider.py
@@ -1,4 +1,4 @@
-from rest_framework.response import Response
+from django.core.exceptions import PermissionDenied
 
 from sentry import http, options
 from sentry.identity.oauth2 import OAuth2Provider
@@ -42,7 +42,7 @@ class GitHubIdentityProvider(OAuth2Provider):
         data = data["data"]
         access_token = data.get("access_token")
         if not access_token:
-            return Response(status=403)
+            raise PermissionDenied()
         user = get_user_info(access_token)
 
         return {


### PR DESCRIPTION
Use `.get()` instead of directly accessing the access token key - if it's bad the data will not have that key and look like this instead:

```
{
error: 'bad_verification_code', 
error_description: 'The code passed is incorrect or expired.', 
error_uri: [Filtered]
}
```

Fixes [SENTRY-RPF](https://sentry.io/organizations/sentry/issues/2532105138/events/c635a910a434430ebdd2f33f5eaabe96/?project=1&referrer=slack)