### PR TITLE
fix(ui): use inverted colors for ToastIndicator

### DIFF
--- a/static/app/components/alerts/toastIndicator.tsx
+++ b/static/app/components/alerts/toastIndicator.tsx
@@ -62,10 +62,10 @@ const Toast = styled(motion.div)`
   height: 40px;
   padding: 0 15px 0 10px;
   margin-top: 15px;
-  background: ${p => p.theme.gray500};
-  color: #fff;
+  background: ${p => p.theme.inverted.background};
+  color: ${p => p.theme.inverted.textColor};
   border-radius: 44px 7px 7px 44px;
-  box-shadow: 0 4px 12px 0 rgba(47, 40, 55, 0.16);
+  box-shadow: ${p => p.theme.dropShadowHeavy};
   position: relative;
 `;
 
@@ -104,21 +104,21 @@ const Message = styled('div')`
 
 const Undo = styled('div')`
   display: inline-block;
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.inverted.subText};
   padding-left: ${space(2)};
   margin-left: ${space(2)};
-  border-left: 1px solid ${p => p.theme.gray200};
+  border-left: 1px solid ${p => p.theme.inverted.innerBorder};
   cursor: pointer;
 
   &:hover {
-    color: ${p => p.theme.gray200};
+    color: ${p => p.theme.inverted.textColor};
   }
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   .loading-indicator {
-    border-color: ${p => p.theme.gray500};
-    border-left-color: ${p => p.theme.purple300};
+    border-color: ${p => p.theme.inverted.border};
+    border-left-color: ${p => p.theme.inverted.purple300};
   }
 `;
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -677,12 +677,17 @@ const commonTheme = {
 };
 
 const lightAliases = generateAliases(lightColors);
+const darkAliases = generateAliases(darkColors);
 
 export const lightTheme = {
   ...commonTheme,
   ...lightColors,
   ...lightAliases,
   ...lightShadows,
+  inverted: {
+    ...darkColors,
+    ...darkAliases,
+  },
   alert: generateAlertTheme(lightColors, lightAliases),
   badge: generateBadgeTheme(lightColors),
   button: generateButtonTheme(lightColors, lightAliases),
@@ -692,13 +697,15 @@ export const lightTheme = {
     'linear-gradient(294.17deg,#2f1937 35.57%,#452650 92.42%,#452650 92.42%)',
 };
 
-const darkAliases = generateAliases(darkColors);
-
 export const darkTheme: Theme = {
   ...commonTheme,
   ...darkColors,
   ...darkAliases,
   ...darkShadows,
+  inverted: {
+    ...lightColors,
+    ...lightAliases,
+  },
   alert: generateAlertTheme(darkColors, darkAliases),
   badge: generateBadgeTheme(darkColors),
   button: generateButtonTheme(darkColors, darkAliases),


### PR DESCRIPTION
ToastIndicator should use color aliases (textColor, subtext,…) instead of base colors (gray500, gray300,…). Also, we want toasts to have inverted colors (i.e. a dark background in light theme and vice versa), so we should have an inverted color scheme inside the theme object.

**Before:**
<img width="160" alt="b3" src="https://user-images.githubusercontent.com/44172267/143309561-1055e61c-8973-416f-a7ed-b8a631541c3a.png">
<img width="160" alt="b2" src="https://user-images.githubusercontent.com/44172267/143309565-a6fad16c-a649-421c-973a-125f9dc21288.png">

**After:**
<img width="160" alt="Screen Shot 2021-11-24 at 12 05 55 PM" src="https://user-images.githubusercontent.com/44172267/143309653-44375548-aed7-4f73-a4d8-0c32aa8a19f7.png">
<img width="160" alt="Screen Shot 2021-11-24 at 12 05 58 PM" src="https://user-images.githubusercontent.com/44172267/143309657-7879ddfd-82cc-4a36-a91c-066d4e3293e3.png">
<img width="240" alt="Screen Shot 2021-11-24 at 12 12 44 PM" src="https://user-images.githubusercontent.com/44172267/143309668-3d42c2ca-f070-4fcd-bb04-c7d8ffac3df1.png">
<img width="160" alt="Screen Shot 2021-11-24 at 12 06 06 PM" src="https://user-images.githubusercontent.com/44172267/143309659-d122256b-5a58-4567-b7b3-01e66b06384e.png">
<img width="160" alt="Screen Shot 2021-11-24 at 12 06 09 PM" src="https://user-images.githubusercontent.com/44172267/143309661-2177230c-3bbc-4c01-964b-49244a554339.png">
<img width="240" alt="Screen Shot 2021-11-24 at 12 12 18 PM" src="https://user-images.githubusercontent.com/44172267/143309665-6e8bbee5-74ec-4710-b365-6879858832e9.png">



