### PR TITLE
fix(dashboards): Display default cursor when hovering dashboard title

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -155,6 +155,7 @@ function EditableText({
         <Label
           onClick={isDisabled ? undefined : handleEditClick}
           ref={labelRef}
+          isDisabled={isDisabled}
           data-test-id="editable-text-label"
         >
           <InnerLabel>{inputValue}</InnerLabel>
@@ -167,12 +168,12 @@ function EditableText({
 
 export default EditableText;
 
-const Label = styled('div')`
+const Label = styled('div')<{isDisabled: boolean}>`
   display: grid;
   grid-auto-flow: column;
   align-items: center;
   gap: ${space(1)};
-  cursor: pointer;
+  cursor: ${p => (p.isDisabled ? 'default' : 'pointer')};
 `;
 
 const InnerLabel = styled(TextOverflow)`


### PR DESCRIPTION
Displaying a pointer cursor is distracting to the user because it seems
like they can click the title when not in edit mode.

Before:

https://user-images.githubusercontent.com/22846452/143315676-3a6a9e4e-2a86-446e-9432-ddabe2c5b07f.mov


After:

https://user-images.githubusercontent.com/22846452/143315698-1049c380-1323-4bb9-a763-3555346749b0.mov


