### PR TITLE
ref: Fix very minor typo

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -90,7 +90,7 @@ class OrganizationPluginsTest(APITestCase):
             }
         ]
 
-    def test_disabled_proejct(self):
+    def test_disabled_project(self):
         plugins.get("trello").enable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         self.projectA.status = 1


### PR DESCRIPTION
See title. I typo'd "project" while searching through the repository and found this.