### PR TITLE
ref(symbolicator): Introduce a dummy backend for realtime metrics in case it needs to be disabled

### DIFF
--- a/src/sentry/processing/realtime_metrics/dummy.py
+++ b/src/sentry/processing/realtime_metrics/dummy.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterable, Set
+from typing import Any, Iterable, Set
 
 from . import base
 
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         pass
 
     def increment_project_event_counter(self, project_id: int, timestamp: int) -> None:
@@ -30,7 +30,7 @@ class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
         return base.BucketedDurationsHistograms(timestamp=-1, width=0, histograms=[])
 
     def get_lpq_projects(self) -> Set[int]:
-        return []
+        return set()
 
     def is_lpq_project(self, project_id: int) -> bool:
         return False

--- a/src/sentry/processing/realtime_metrics/dummy.py
+++ b/src/sentry/processing/realtime_metrics/dummy.py
@@ -33,10 +33,10 @@ class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
         return []
 
     def is_lpq_project(self, project_id: int) -> bool:
-        pass
+        return False
 
     def add_project_to_lpq(self, project_id: int) -> bool:
-        pass
+        return False
 
     def remove_projects_from_lpq(self, project_ids: Set[int]) -> int:
         return 0

--- a/src/sentry/processing/realtime_metrics/dummy.py
+++ b/src/sentry/processing/realtime_metrics/dummy.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Iterable, Set
+
+from . import base
+
+logger = logging.getLogger(__name__)
+
+
+class DummyRealtimeMetricsStore(base.RealtimeMetricsStore):
+    def __init__(self, **kwargs) -> None:
+        pass
+
+    def increment_project_event_counter(self, project_id: int, timestamp: int) -> None:
+        pass
+
+    def increment_project_duration_counter(
+        self, project_id: int, timestamp: int, duration: int
+    ) -> None:
+        pass
+
+    def projects(self) -> Iterable[int]:
+        yield from ()
+
+    def get_counts_for_project(self, project_id: int, timestamp: int) -> base.BucketedCounts:
+        return base.BucketedCounts(timestamp=-1, width=0, counts=[])
+
+    def get_durations_for_project(
+        self, project_id: int, timestamp: int
+    ) -> base.BucketedDurationsHistograms:
+        return base.BucketedDurationsHistograms(timestamp=-1, width=0, histograms=[])
+
+    def get_lpq_projects(self) -> Set[int]:
+        return []
+
+    def is_lpq_project(self, project_id: int) -> bool:
+        pass
+
+    def add_project_to_lpq(self, project_id: int) -> bool:
+        pass
+
+    def remove_projects_from_lpq(self, project_ids: Set[int]) -> int:
+        return 0


### PR DESCRIPTION
Does what it says on the tin. Tested this by setting 
```
SENTRY_REALTIME_METRICS_BACKEND = (
    "sentry.processing.realtime_metrics.dummy.DummyRealtimeMetricsStore"
)
```

in `sentry/conf/server.py`.

This is 1/(2?) steps needed to ensure that the metrics recording part of symbolicator's low priority queue is disabled for on-prem/self-hosted environments, and single tenant environments if it is unnecessary for small enough single tenant setups.

Related to https://github.com/getsentry/self-hosted/issues/1131