### PR TITLE
ref(symbolicator): All components of the low priority queue are disabled by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2396,7 +2396,7 @@ SENTRY_REPROCESSING_REMAINING_EVENTS_BUF_SIZE = 500
 #
 # Currently, only redis is supported.
 SENTRY_REALTIME_METRICS_BACKEND = (
-    "sentry.processing.realtime_metrics.redis.RedisRealtimeMetricsStore"
+    "sentry.processing.realtime_metrics.dummy.DummyRealtimeMetricsStore"
 )
 SENTRY_REALTIME_METRICS_OPTIONS = {
     # The redis cluster used for the realtime store redis backend.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -789,9 +789,9 @@ CELERYBEAT_SCHEDULE = {
     },
     "check-symbolicator-lpq-project-eligibility": {
         "task": "sentry.tasks.low_priority_symbolication.scan_for_suspect_projects",
-        # Set to Feb 32 so it never runs. Here's to hoping February doesn't somehow get
-        # 32 days in the foreseeable future.
-        "schedule": crontab(day_of_month=32, month_of_year=2),
+        # Set to Feb 31 so it never runs. Here's to hoping February doesn't somehow get
+        # 31 days in the foreseeable future.
+        "schedule": crontab(day_of_month=31, month_of_year=2),
         "options": {"expires": 10},
     },
 }

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -789,7 +789,9 @@ CELERYBEAT_SCHEDULE = {
     },
     "check-symbolicator-lpq-project-eligibility": {
         "task": "sentry.tasks.low_priority_symbolication.scan_for_suspect_projects",
-        "schedule": timedelta(seconds=10),
+        # Set to Feb 32 so it never runs. Here's to hoping February doesn't somehow get
+        # 32 days in the foreseeable future.
+        "schedule": crontab(day_of_month=32, month_of_year=2),
         "options": {"expires": 10},
     },
 }


### PR DESCRIPTION
This does two things: 
- Formally switch `sentry` over to using the dummy backend for the realtime metrics store
- Remove scheduled LPQ-related tasks from celery

Relies on https://github.com/getsentry/sentry/pull/30208.

Related to https://github.com/getsentry/self-hosted/issues/1131. This feature should be completely turned off for non-SaaS setups.