### PR TITLE
ref(notifications): BaseNotification

### DIFF
--- a/src/sentry/integrations/slack/analytics.py
+++ b/src/sentry/integrations/slack/analytics.py
@@ -21,7 +21,7 @@ class SlackIntegrationNotificationSent(analytics.Event):  # type: ignore
     type = "integrations.slack.notification_sent"
 
     attributes = (
-        analytics.Attribute("organization_id"),
+        analytics.Attribute("organization_id", required=False),
         analytics.Attribute("project_id", required=False),
         analytics.Attribute("category"),
         analytics.Attribute("actor_id"),

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -20,7 +20,7 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
+from sentry.notifications.notifications.base import OrganizationNotification, ProjectNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.actions import MessageAction
 from sentry.utils import json
@@ -271,7 +271,7 @@ def get_title_link(
     event: Event | None,
     link_to_event: bool,
     issue_details: bool,
-    notification: BaseNotification | None,
+    notification: OrganizationNotification | None,
 ) -> str:
     if event and link_to_event:
         url = group.get_absolute_url(params={"referrer": "slack"}, event_id=event.event_id)
@@ -293,7 +293,7 @@ def get_timestamp(group: Group, event: Event | None) -> float:
     return to_timestamp(max(ts, event.datetime) if event else ts)
 
 
-def get_color(event_for_tags: Event | None, notification: BaseNotification | None) -> str:
+def get_color(event_for_tags: Event | None, notification: OrganizationNotification | None) -> str:
     if notification:
         if not isinstance(notification, AlertRuleNotification):
             return "info"

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -8,7 +8,7 @@ from sentry.integrations.slack.message_builder import SlackBody
 from sentry.integrations.slack.message_builder.base.base import SlackMessageBuilder
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.models import Team, User
-from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
+from sentry.notifications.notifications.base import OrganizationNotification, ProjectNotification
 from sentry.notifications.notifications.digest import DigestNotification
 from sentry.utils import json
 
@@ -25,7 +25,7 @@ def get_message_builder(klass: str) -> type[SlackNotificationsMessageBuilder]:
 class SlackNotificationsMessageBuilder(SlackMessageBuilder):
     def __init__(
         self,
-        notification: BaseNotification,
+        notification: OrganizationNotification,
         context: Mapping[str, Any],
         recipient: Team | User,
     ) -> None:

--- a/src/sentry/integrations/slack/utils/notifications.py
+++ b/src/sentry/integrations/slack/utils/notifications.py
@@ -10,7 +10,7 @@ from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
 from sentry.models import Environment, Integration, Team, User
 from sentry.notifications.notifications.activity.release import ReleaseActivityNotification
-from sentry.notifications.notifications.base import BaseNotification
+from sentry.notifications.notifications.base import OrganizationNotification
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -50,7 +50,7 @@ def send_incident_alert_notification(
         logger.info("rule.fail.slack_post", extra={"error": str(e)})
 
 
-def get_referrer_qstring(notification: BaseNotification, recipient: Team | User) -> str:
+def get_referrer_qstring(notification: OrganizationNotification, recipient: Team | User) -> str:
     # TODO: make a generic version that works for other notification types
     return (
         "?referrer="
@@ -59,14 +59,16 @@ def get_referrer_qstring(notification: BaseNotification, recipient: Team | User)
     )
 
 
-def get_settings_url(notification: BaseNotification, recipient: Team | User) -> str:
+def get_settings_url(notification: OrganizationNotification, recipient: Team | User) -> str:
     url_str = "/settings/account/notifications/"
     if notification.fine_tuning_key:
         url_str += f"{notification.fine_tuning_key}/"
     return str(urljoin(absolute_uri(url_str), get_referrer_qstring(notification, recipient)))
 
 
-def build_notification_footer(notification: BaseNotification, recipient: Team | User) -> str:
+def build_notification_footer(
+    notification: OrganizationNotification, recipient: Team | User
+) -> str:
     if isinstance(recipient, Team):
         team = Team.objects.get(id=recipient.id)
         url_str = f"/settings/{notification.organization.slug}/teams/{team.slug}/notifications/"

--- a/src/sentry/mail/analytics.py
+++ b/src/sentry/mail/analytics.py
@@ -5,7 +5,7 @@ class EmailNotificationSent(analytics.Event):  # type: ignore
     type = "integrations.email.notification_sent"
 
     attributes = (
-        analytics.Attribute("organization_id"),
+        analytics.Attribute("organization_id", required=False),
         analytics.Attribute("project_id", required=False),
         analytics.Attribute("category"),
         analytics.Attribute("actor_id"),

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -7,11 +7,7 @@ from django.utils.encoding import force_text
 
 from sentry import options
 from sentry.models import Project, ProjectOption, Team, User
-from sentry.notifications.notifications.base import (
-    BaseNotification,
-    OrganizationNotification,
-    ProjectNotification,
-)
+from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -7,7 +7,11 @@ from django.utils.encoding import force_text
 
 from sentry import options
 from sentry.models import Project, ProjectOption, Team, User
-from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
+from sentry.notifications.notifications.base import (
+    BaseNotification,
+    OrganizationNotification,
+    ProjectNotification,
+)
 from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -137,11 +137,13 @@ def get_builder_args(
     # TODO: move context logic to single notification class method
     extra_context = (extra_context_by_actor_id or {}).get(recipient.actor_id, {})
     context = get_context(notification, recipient, shared_context or {}, extra_context)
+
+    html_template, txt_template = notification.get_email_template_filenames()
     return {
         "subject": get_subject_with_prefix(notification, context),
         "context": context,
-        "template": notification.get_template(),
-        "html_template": notification.get_html_template(),
+        "template": txt_template,
+        "html_template": html_template,
         "headers": get_headers(notification),
         "reference": notification.get_reference(),
         "reply_reference": notification.get_reply_reference(),

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
     headers = {
-        "X-SMTPAPI": json.dumps({"category": notification.get_category()}),
+        "X-SMTPAPI": json.dumps({"category": notification.category}),
     }
     if isinstance(notification, ProjectNotification):
         headers["X-Sentry-Project"] = notification.project.slug
@@ -145,5 +145,5 @@ def get_builder_args(
         "headers": get_headers(notification),
         "reference": notification.get_reference(),
         "reply_reference": notification.get_reply_reference(),
-        "type": notification.get_type(),
+        "type": notification.type,
     }

--- a/src/sentry/management/commands/generate_reset_password_link.py
+++ b/src/sentry/management/commands/generate_reset_password_link.py
@@ -2,7 +2,6 @@ import sys
 
 from click import echo
 from django.core.management.base import BaseCommand
-from django.utils import timezone
 
 from sentry.models import LostPasswordHash
 from sentry.utils.auth import find_users
@@ -27,9 +26,5 @@ class Command(BaseCommand):
             return
 
         for user in users:
-            password_hash, created = LostPasswordHash.objects.get_or_create(user=user)
-            if not password_hash.is_valid():
-                password_hash.date_added = timezone.now()
-                password_hash.set_hash()
-                password_hash.save()
+            password_hash = LostPasswordHash.objects.for_user(user)
             echo(f"{user.username} ({user.email}) - {password_hash.get_absolute_url()}")

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.db import models
@@ -10,13 +10,15 @@ from django.urls import reverse
 from django.utils import timezone
 
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model, sane_repr
-from sentry.models import User
 from sentry.utils.http import absolute_uri
 from sentry.utils.security import get_secure_token
 
+if TYPE_CHECKING:
+    from sentry.models import User
+
 
 class LostPasswordHashType(enum.Enum):
-    RECOVER = "recover"
+    RECOVER = "recover_account"
     SET_PASSWORD = "set_password"
 
 

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -1,13 +1,48 @@
+from __future__ import annotations
+
+import enum
 from datetime import timedelta
+from typing import Any
 
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 
-from sentry.db.models import FlexibleForeignKey, Model, sane_repr
+from sentry.db.models import BaseManager, FlexibleForeignKey, Model, sane_repr
+from sentry.models import User
 from sentry.utils.http import absolute_uri
 from sentry.utils.security import get_secure_token
+
+
+class LostPasswordHashType(enum.Enum):
+    RECOVER = "recover"
+    SET_PASSWORD = "set_password"
+
+
+URL_KEYS = {
+    LostPasswordHashType.RECOVER: "sentry-account-recover-confirm",
+    LostPasswordHashType.SET_PASSWORD: "sentry-account-set-password-confirm",
+}
+
+
+class LostPasswordHashManager(BaseManager):
+    def for_user(self, user: User) -> LostPasswordHash:
+        """
+        NOTE(mattrobenolt): Some security people suggest we invalidate existing
+        password hashes, but this opens up the possibility of a DoS vector where
+        then password resets are continually requested, thus preventing someone
+        from actually resetting their password.
+
+        See: https://github.com/getsentry/sentry/pull/17299
+        """
+        password_hash, _ = self.get_or_create(user=user)
+        if not password_hash.is_valid():
+            password_hash.date_added = timezone.now()
+            password_hash.set_hash()
+            password_hash.save()
+
+        return password_hash
 
 
 class LostPasswordHash(Model):
@@ -17,13 +52,15 @@ class LostPasswordHash(Model):
     hash = models.CharField(max_length=32)
     date_added = models.DateTimeField(default=timezone.now)
 
+    objects = LostPasswordHashManager()
+
     class Meta:
         app_label = "sentry"
         db_table = "sentry_lostpasswordhash"
 
     __repr__ = sane_repr("user_id", "hash")
 
-    def save(self, *args, **kwargs):
+    def save(self, *args: Any, **kwargs: Any) -> None:
         if not self.hash:
             self.set_hash()
         super().save(*args, **kwargs)
@@ -31,52 +68,8 @@ class LostPasswordHash(Model):
     def set_hash(self) -> None:
         self.hash = get_secure_token()
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         return self.date_added > timezone.now() - timedelta(hours=48)
 
-    def get_absolute_url(self, mode="recover"):
-        url_key = "sentry-account-recover-confirm"
-        if mode == "set_password":
-            url_key = "sentry-account-set-password-confirm"
-
-        return absolute_uri(reverse(url_key, args=[self.user.id, self.hash]))
-
-    def send_email(self, request, mode="recover"):
-        from sentry import options
-        from sentry.http import get_server_hostname
-        from sentry.utils.email import MessageBuilder
-
-        context = {
-            "user": self.user,
-            "domain": get_server_hostname(),
-            "url": self.get_absolute_url(mode),
-            "datetime": timezone.now(),
-            "ip_address": request.META["REMOTE_ADDR"],
-        }
-
-        template = "set_password" if mode == "set_password" else "recover_account"
-
-        msg = MessageBuilder(
-            subject="{}Password Recovery".format(options.get("mail.subject-prefix")),
-            template=f"sentry/emails/{template}.txt",
-            html_template=f"sentry/emails/{template}.html",
-            type="user.password_recovery",
-            context=context,
-        )
-        msg.send_async([self.user.email])
-
-    @classmethod
-    def for_user(cls, user):
-        # NOTE(mattrobenolt): Some security people suggest we invalidate
-        # existing password hashes, but this opens up the possibility
-        # of a DoS vector where then password resets are continually
-        # requested, thus preventing someone from actually resetting
-        # their password.
-        # See: https://github.com/getsentry/sentry/pull/17299
-        password_hash, created = cls.objects.get_or_create(user=user)
-        if not password_hash.is_valid():
-            password_hash.date_added = timezone.now()
-            password_hash.set_hash()
-            password_hash.save()
-
-        return password_hash
+    def get_absolute_url(self, mode: LostPasswordHashType = LostPasswordHashType.RECOVER) -> str:
+        return absolute_uri(reverse(URL_KEYS[mode], args=[self.user.id, self.hash]))

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -20,6 +20,7 @@ from sentry.constants import ALERTS_MEMBER_WRITE_DEFAULT, EVENTS_MEMBER_ADMIN_DE
 from sentry.db.models import BoundedPositiveIntegerField, FlexibleForeignKey, Model, sane_repr
 from sentry.db.models.manager import BaseManager
 from sentry.exceptions import UnableToAcceptMemberInvitationException
+from sentry.models.lostpasswordhash import LostPasswordHashType
 from sentry.models.team import TeamStatus
 from sentry.signals import member_invited
 from sentry.utils.http import absolute_uri
@@ -296,8 +297,10 @@ class OrganizationMember(Model):
         }
 
         if not self.user.password:
-            password_hash = LostPasswordHash.for_user(self.user)
-            context["set_password_url"] = password_hash.get_absolute_url(mode="set_password")
+            password_hash = LostPasswordHash.objects.for_user(self.user)
+            context["set_password_url"] = password_hash.get_absolute_url(
+                mode=LostPasswordHashType.SET_PASSWORD
+            )
 
         msg = MessageBuilder(
             subject=f"Action Required for {self.organization.name}",

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -71,11 +71,11 @@ class AssignedActivityNotification(GroupActivityNotification):
             author = "themselves"
 
             try:
-                assignee = User.objects.get_from_cache(id=data["assignee"])
+                assignee_user = User.objects.get_from_cache(id=data["assignee"])
             except User.DoesNotExist:
                 assignee = data.get("assigneeEmail", "an unknown user")
             else:
-                assignee = assignee.get_display_name()
+                assignee = assignee_user.get_display_name()
             return author, assignee
 
         if data.get("assigneeType") == "team":

--- a/src/sentry/notifications/notifications/activity/assigned.py
+++ b/src/sentry/notifications/notifications/activity/assigned.py
@@ -8,8 +8,8 @@ from .base import GroupActivityNotification
 
 
 class AssignedActivityNotification(GroupActivityNotification):
-    def get_activity_name(self) -> str:
-        return "Assigned"
+    activity_name = "Assigned"
+    category = "assigned_activity_email"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         activity = self.activity
@@ -56,9 +56,6 @@ class AssignedActivityNotification(GroupActivityNotification):
 
         raise NotImplementedError("Unknown Assignee Type ")
 
-    def get_category(self) -> str:
-        return "assigned_activity_email"
-
     def build_notification_title(self) -> tuple[str, str]:
         activity = self.activity
         data = activity.data
@@ -67,6 +64,7 @@ class AssignedActivityNotification(GroupActivityNotification):
             author = user.name or user.email
         else:
             author = "Sentry"
+        assignee = "an unknown assignee"
 
         # legacy Activity objects from before assignable teams
         if "assigneeType" not in data or data["assigneeType"] == "user":

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse, urlunparse
 from django.utils.html import escape
 from django.utils.safestring import SafeString, mark_safe
 
+from sentry.db.models import Model
 from sentry.notifications.helpers import get_reason_context
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.utils import send_activity_notification
@@ -52,7 +53,7 @@ class ActivityNotification(ProjectNotification, ABC):
         context = super().get_recipient_context(recipient, extra_context)
         return {**context, **get_reason_context(context)}
 
-    def get_reference(self) -> Any:
+    def get_reference(self) -> Model | None:
         return self.activity
 
     def get_context(self) -> MutableMapping[str, Any]:

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -56,9 +56,6 @@ class ActivityNotification(ProjectNotification, ABC):
     def get_reference(self) -> Model | None:
         return self.activity
 
-    def get_context(self) -> MutableMapping[str, Any]:
-        raise NotImplementedError
-
     def get_participants_with_group_subscription_reason(
         self,
     ) -> Mapping[ExternalProviders, Mapping[Team | User, int]]:

--- a/src/sentry/notifications/notifications/activity/base.py
+++ b/src/sentry/notifications/notifications/activity/base.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 
 class ActivityNotification(ProjectNotification, ABC):
+    filename = "activity/generic"
     fine_tuning_key = "workflow"
     metrics_key = "activity"
 
@@ -27,11 +28,12 @@ class ActivityNotification(ProjectNotification, ABC):
         super().__init__(activity.project)
         self.activity = activity
 
+    @property
+    def type(self) -> str:
+        return f"notify.activity.{self.activity.get_type_display()}"
+
     def get_title(self) -> str:
         raise NotImplementedError
-
-    def get_filename(self) -> str:
-        return "activity/generic"
 
     def get_base_context(self) -> MutableMapping[str, Any]:
         """The most basic context shared by every notification type."""
@@ -52,9 +54,6 @@ class ActivityNotification(ProjectNotification, ABC):
 
     def get_reference(self) -> Any:
         return self.activity
-
-    def get_type(self) -> str:
-        return f"notify.activity.{self.activity.get_type_display()}"
 
     def get_context(self) -> MutableMapping[str, Any]:
         raise NotImplementedError
@@ -78,14 +77,15 @@ class GroupActivityNotification(ActivityNotification, ABC):
         super().__init__(activity)
         self.group = activity.group
 
-    def get_activity_name(self) -> str:
+    @property
+    def activity_name(self) -> str:
         raise NotImplementedError
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         raise NotImplementedError
 
     def get_title(self) -> str:
-        return self.get_activity_name()
+        return self.activity_name
 
     def get_group_link(self) -> str:
         referrer = re.sub("Notification$", "Email", self.__class__.__name__)
@@ -118,7 +118,7 @@ class GroupActivityNotification(ActivityNotification, ABC):
         description, params, html_params = self.get_description()
         return {
             **self.get_base_context(),
-            "activity_name": self.get_activity_name(),
+            "activity_name": self.activity_name,
             "text_description": self.description_as_text(description, params),
             "html_description": self.description_as_html(description, html_params or params),
         }

--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -12,6 +12,9 @@ from .base import ActivityNotification
 
 
 class NewProcessingIssuesActivityNotification(ActivityNotification):
+    category = "new_processing_issues_activity_email"
+    filename = "activity/new_processing_issues"
+
     def __init__(self, activity: Activity) -> None:
         super().__init__(activity)
         self.issues = summarize_issues(self.activity.data["issues"])
@@ -49,12 +52,6 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
 
     def get_title(self) -> str:
         return self.get_subject()
-
-    def get_filename(self) -> str:
-        return "activity/new_processing_issues"
-
-    def get_category(self) -> str:
-        return "new_processing_issues_activity_email"
 
     def get_notification_title(self) -> str:
         project_url = absolute_uri(

--- a/src/sentry/notifications/notifications/activity/note.py
+++ b/src/sentry/notifications/notifications/activity/note.py
@@ -6,19 +6,13 @@ from .base import GroupActivityNotification
 
 
 class NoteActivityNotification(GroupActivityNotification):
+    activity_name = "Note"
+    category = "note_activity_email"
+    filename = "activity/note"
     message_builder = "SlackNotificationsMessageBuilder"
-
-    def get_activity_name(self) -> str:
-        return "Note"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return str(self.activity.data["text"]), {}, {}
-
-    def get_filename(self) -> str:
-        return "activity/note"
-
-    def get_category(self) -> str:
-        return "note_activity_email"
 
     def get_title(self) -> str:
         author = self.activity.user.get_display_name()

--- a/src/sentry/notifications/notifications/activity/regression.py
+++ b/src/sentry/notifications/notifications/activity/regression.py
@@ -9,8 +9,8 @@ from .base import GroupActivityNotification
 
 
 class RegressionActivityNotification(GroupActivityNotification):
-    def get_activity_name(self) -> str:
-        return "Regression"
+    activity_name = "Regression"
+    category = "regression_activity_email"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         data = self.activity.data
@@ -31,9 +31,6 @@ class RegressionActivityNotification(GroupActivityNotification):
             )
 
         return "{author} marked {an issue} as a regression", {}, {}
-
-    def get_category(self) -> str:
-        return "regression_activity_email"
 
     def get_notification_title(self) -> str:
         data = self.activity.data

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -26,6 +26,8 @@ from .base import ActivityNotification
 
 
 class ReleaseActivityNotification(ActivityNotification):
+    category = "release_activity_email"
+    filename = "activity/release"
     fine_tuning_key = "deploy"
 
     def __init__(self, activity: Activity) -> None:
@@ -124,12 +126,6 @@ class ReleaseActivityNotification(ActivityNotification):
         elif len(self.projects) > 1:
             projects_text = " for these projects"
         return f"Release {self.version_parsed} was deployed to {self.environment}{projects_text}"
-
-    def get_filename(self) -> str:
-        return "activity/release"
-
-    def get_category(self) -> str:
-        return "release_activity_email"
 
     def get_message_actions(self) -> Sequence[MessageAction]:
         if self.release:

--- a/src/sentry/notifications/notifications/activity/resolved.py
+++ b/src/sentry/notifications/notifications/activity/resolved.py
@@ -6,11 +6,8 @@ from .base import GroupActivityNotification
 
 
 class ResolvedActivityNotification(GroupActivityNotification):
-    def get_activity_name(self) -> str:
-        return "Resolved Issue"
+    activity_name = "Resolved Issue"
+    category = "resolved_activity_email"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} marked {an issue} as resolved", {}, {}
-
-    def get_category(self) -> str:
-        return "resolved_activity_email"

--- a/src/sentry/notifications/notifications/activity/resolved_in_release.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_release.py
@@ -9,8 +9,8 @@ from .base import GroupActivityNotification
 
 
 class ResolvedInReleaseActivityNotification(GroupActivityNotification):
-    def get_activity_name(self) -> str:
-        return "Resolved Issue"
+    activity_name = "Resolved Issue"
+    category = "resolved_in_release_activity_email"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         data = self.activity.data
@@ -30,9 +30,6 @@ class ResolvedInReleaseActivityNotification(GroupActivityNotification):
                 },
             )
         return "{author} marked {an issue} as resolved in an upcoming release", {}, {}
-
-    def get_category(self) -> str:
-        return "resolved_in_release_activity_email"
 
     def get_notification_title(self) -> str:
         data = self.activity.data

--- a/src/sentry/notifications/notifications/activity/unassigned.py
+++ b/src/sentry/notifications/notifications/activity/unassigned.py
@@ -6,14 +6,11 @@ from .base import GroupActivityNotification
 
 
 class UnassignedActivityNotification(GroupActivityNotification):
-    def get_activity_name(self) -> str:
-        return "Unassigned"
+    activity_name = "Unassigned"
+    category = "unassigned_activity_email"
 
     def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
         return "{author} unassigned {an issue}", {}, {}
-
-    def get_category(self) -> str:
-        return "unassigned_activity_email"
 
     def get_notification_title(self) -> str:
         user = self.activity.user

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -13,6 +13,18 @@ if TYPE_CHECKING:
 
 
 class BaseNotification(abc.ABC):
+    @property
+    def category(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def filename(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def type(self) -> str:
+        raise NotImplementedError
+
     message_builder = "SlackNotificationsMessageBuilder"
     fine_tuning_key: str | None = None
     metrics_key: str = ""

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -66,7 +66,7 @@ class BaseNotification(abc.ABC):
         )
 
 
-class OrganizationNotification(BaseNotification):
+class OrganizationNotification(BaseNotification, abc.ABC):
     message_builder = "SlackNotificationsMessageBuilder"
     fine_tuning_key: str | None = None
     metrics_key: str = ""

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -25,6 +25,13 @@ class BaseNotification(abc.ABC):
     def type(self) -> str:
         raise NotImplementedError
 
+    def get_email_template_filenames(self) -> tuple[str, str]:
+        """
+        Override this method if the templates are in an exotic location.
+        Otherwise just set `filename` as a class variable.
+        """
+        return f"sentry/emails/{self.filename}.html", f"sentry/emails/{self.filename}.txt"
+
     def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         analytics.record(
             f"integrations.{provider.name}.notification_sent",
@@ -70,12 +77,6 @@ class BaseNotification(abc.ABC):
 
     def should_email(self) -> bool:
         return True
-
-    def get_template(self) -> str:
-        return f"sentry/emails/{self.get_filename()}.txt"
-
-    def get_html_template(self) -> str:
-        return f"sentry/emails/{self.get_filename()}.html"
 
     def get_recipient_context(
         self, recipient: Team | User, extra_context: Mapping[str, Any]

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -4,6 +4,7 @@ import abc
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Sequence
 
 from sentry import analytics
+from sentry.db.models import Model
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
@@ -24,6 +25,12 @@ class BaseNotification(abc.ABC):
     @property
     def type(self) -> str:
         raise NotImplementedError
+
+    def get_reference(self) -> Model | None:
+        raise NotImplementedError
+
+    def get_reply_reference(self) -> Any | None:
+        return None
 
     def get_email_template_filenames(self) -> tuple[str, str]:
         """
@@ -68,12 +75,6 @@ class BaseNotification(abc.ABC):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         """The subject line when sending this notifications as an email."""
         raise NotImplementedError
-
-    def get_reference(self) -> Any:
-        raise NotImplementedError
-
-    def get_reply_reference(self) -> Any | None:
-        return None
 
     def should_email(self) -> bool:
         return True
@@ -131,3 +132,6 @@ class ProjectNotification(BaseNotification, abc.ABC):
 
     def get_log_params(self, recipient: Team | User) -> Mapping[str, Any]:
         return {"project_id": self.project.id, **super().get_log_params(recipient)}
+
+    def get_reference(self) -> Model | None:
+        return self.project

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -31,7 +31,10 @@ logger = logging.getLogger(__name__)
 
 
 class DigestNotification(ProjectNotification):
+    category = "digest_email"
+    filename = "digests/body"
     message_builder = "DigestNotificationMessageBuilder"
+    type = "notify.digest"
 
     def __init__(
         self,
@@ -44,15 +47,6 @@ class DigestNotification(ProjectNotification):
         self.digest = digest
         self.target_type = target_type
         self.target_identifier = target_identifier
-
-    def get_filename(self) -> str:
-        return "digests/body"
-
-    def get_category(self) -> str:
-        return "digest_email"
-
-    def get_type(self) -> str:
-        return "notify.digest"
 
     def get_unsubscribe_key(self) -> tuple[str, int, str | None] | None:
         return "project", self.project.id, "alert_digest"

--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -67,9 +67,6 @@ class DigestNotification(ProjectNotification):
     def build_attachment_title(self) -> str:
         return ""
 
-    def get_reference(self) -> Any:
-        return self.project
-
     def get_context(self) -> MutableMapping[str, Any]:
         return {
             **get_digest_as_context(self.digest),

--- a/src/sentry/notifications/notifications/membership/lost_password.py
+++ b/src/sentry/notifications/notifications/membership/lost_password.py
@@ -7,16 +7,17 @@ from django.utils import timezone
 from sentry import options
 from sentry.db.models import Model
 from sentry.http import get_server_hostname
+from sentry.models import LostPasswordHashType
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.notifications.utils import send_base_notification
 from sentry.types.integrations import ExternalProviders
 
 if TYPE_CHECKING:
-    from sentry.models import LostPasswordHash, LostPasswordHashType, Team, User
+    from sentry.models import LostPasswordHash, Team, User
 
 
 class LostPasswordNotification(BaseNotification):
-    category = "integration_request"
+    category = "lost_password"
     type = "user.password_recovery"
 
     def __init__(
@@ -37,7 +38,6 @@ class LostPasswordNotification(BaseNotification):
 
     def get_context(self) -> MutableMapping[str, Any]:
         return {
-            **super().get_context(),
             "datetime": timezone.now(),
             "domain": get_server_hostname(),
             "ip_address": self.ip,
@@ -54,15 +54,6 @@ class LostPasswordNotification(BaseNotification):
 
     def get_reference(self) -> Model | None:
         return None
-
-    def get_notification_title(self) -> str:
-        return ""
-
-    def get_title_link(self) -> str | None:
-        return None
-
-    def build_attachment_title(self) -> str:
-        return ""
 
     def send(self) -> None:
         return send_base_notification(

--- a/src/sentry/notifications/notifications/membership/lost_password.py
+++ b/src/sentry/notifications/notifications/membership/lost_password.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping
+
+from django.utils import timezone
+
+from sentry import options
+from sentry.db.models import Model
+from sentry.http import get_server_hostname
+from sentry.notifications.notifications.base import BaseNotification
+from sentry.notifications.utils import send_base_notification
+from sentry.types.integrations import ExternalProviders
+
+if TYPE_CHECKING:
+    from sentry.models import LostPasswordHash, LostPasswordHashType, Team, User
+
+
+class LostPasswordNotification(BaseNotification):
+    category = "integration_request"
+    type = "user.password_recovery"
+
+    def __init__(
+        self,
+        password_hash: LostPasswordHash,
+        ip: str,
+        mode: LostPasswordHashType = LostPasswordHashType.RECOVER,
+    ) -> None:
+        super().__init__()
+        self.password_hash = password_hash
+        self.ip = ip
+        self.mode = mode
+
+    @property
+    def filename(self) -> str:
+        _filename: str = self.mode.value
+        return _filename
+
+    def get_context(self) -> MutableMapping[str, Any]:
+        return {
+            **super().get_context(),
+            "datetime": timezone.now(),
+            "domain": get_server_hostname(),
+            "ip_address": self.ip,
+            "url": self.password_hash.get_absolute_url(self.mode),
+            "user": self.password_hash.user,
+        }
+
+    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | User]]:
+        return {ExternalProviders.EMAIL: {self.password_hash.user}}
+
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
+        prefix = options.get("mail.subject-prefix")
+        return f"{prefix}Password Recovery"
+
+    def get_reference(self) -> Model | None:
+        return None
+
+    def get_notification_title(self) -> str:
+        return ""
+
+    def get_title_link(self) -> str | None:
+        return None
+
+    def build_attachment_title(self) -> str:
+        return ""
+
+    def send(self) -> None:
+        return send_base_notification(
+            notification=self, participants_by_provider=self.get_participants()
+        )

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -17,15 +17,12 @@ if TYPE_CHECKING:
 
 # Abstract class for invite and join requests to inherit from
 class AbstractInviteRequestNotification(OrganizationRequestNotification):
+    category = "organization_invite_request"
+    type = "organization.invite-request"
+
     def __init__(self, pending_member: OrganizationMember, requester: User):
         super().__init__(pending_member.organization, requester)
         self.pending_member = pending_member
-
-    def get_type(self) -> str:
-        return "organization.invite-request"
-
-    def get_category(self) -> str:
-        return "organization_invite_request"
 
     @property
     def members_url(self) -> str:

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -82,6 +82,7 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification):
         return {"member_id": self.pending_member.id, "member_email": self.pending_member.email}
 
     def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
+        super(OrganizationRequestNotification, self).record_notification_sent(recipient, provider)
         analytics.record(
             self.analytics_event,
             organization_id=self.organization.id,

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -28,9 +28,6 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
         super().__init__(organization)
         self.requester = requester
 
-    def get_reference(self) -> Any:
-        return self.organization
-
     def get_context(self) -> MutableMapping[str, Any]:
         return {}
 

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -9,6 +9,7 @@ from sentry.models import NotificationSetting, OrganizationMember, Team
 from sentry.notifications.notifications.base import OrganizationNotification
 from sentry.notifications.notify import notification_providers
 from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.utils import send_base_notification
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 
@@ -70,16 +71,9 @@ class OrganizationRequestNotification(OrganizationNotification, abc.ABC):
         }
 
     def send(self) -> None:
-        from sentry.notifications.notify import notify
-
-        participants_by_provider = self.get_participants()
-        if not participants_by_provider:
-            return
-
-        context = self.get_context()
-        for provider, recipients in participants_by_provider.items():
-            # TODO: use safe_execute
-            notify(provider, self, recipients, context)
+        return send_base_notification(
+            notification=self, participants_by_provider=self.get_participants()
+        )
 
     def get_member(self, user: User) -> OrganizationMember:
         # cache the result

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -132,6 +132,8 @@ class OrganizationRequestNotification(BaseNotification, abc.ABC):
         return None
 
     def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
+        super().record_notification_sent(recipient, provider)
+
         # this event is meant to work for multiple providers but architecture
         # limitations mean we will fire individual for each provider
         analytics.record(

--- a/src/sentry/notifications/notifications/organization_request/base.py
+++ b/src/sentry/notifications/notifications/organization_request/base.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequen
 
 from sentry import analytics, features, roles
 from sentry.models import NotificationSetting, OrganizationMember, Team
-from sentry.notifications.notifications.base import BaseNotification
+from sentry.notifications.notifications.base import OrganizationNotification
 from sentry.notifications.notify import notification_providers
 from sentry.notifications.types import NotificationSettingTypes
 from sentry.notifications.utils.actions import MessageAction
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class OrganizationRequestNotification(BaseNotification, abc.ABC):
+class OrganizationRequestNotification(OrganizationNotification, abc.ABC):
     analytics_event: str = ""
     referrer_base: str = ""
     member_by_user_id: MutableMapping[int, OrganizationMember] = {}

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence
 
-from sentry import analytics
 from sentry.notifications.notifications.organization_request import OrganizationRequestNotification
 from sentry.notifications.utils.actions import MessageAction
-from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 
 if TYPE_CHECKING:
@@ -88,14 +86,3 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
         # Explicitly typing to satisfy mypy.
         recipients: Iterable[Team | User] = self.organization.get_owners()
         return recipients
-
-    def record_notification_sent(
-        self, recipient: Team | User, provider: ExternalProviders, **kwargs: Any
-    ) -> None:
-        # TODO: refactor since this is identical to ProjectNotification.record_notification_sent
-        analytics.record(
-            f"integrations.{provider.name}.notification_sent",
-            category=self.get_category(),
-            **self.get_log_params(recipient),
-            **kwargs,
-        )

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -33,6 +33,10 @@ def get_url(organization: Organization, provider_type: str, provider_slug: str) 
 
 
 class IntegrationRequestNotification(OrganizationRequestNotification):
+    category = "integration_request"
+    filename = "requests/organization-integration"
+    type = "organization.integration.request"
+
     def __init__(
         self,
         organization: Organization,
@@ -61,20 +65,11 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
             "message": self.message,
         }
 
-    def get_filename(self) -> str:
-        return "requests/organization-integration"
-
-    def get_category(self) -> str:
-        return "integration_request"
-
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return f"Your team member requested the {self.provider_name} integration on Sentry"
 
     def get_notification_title(self) -> str:
         return self.get_subject()
-
-    def get_type(self) -> str:
-        return "organization.integration.request"
 
     def build_attachment_title(self) -> str:
         return "Request to Install"

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -3,10 +3,8 @@ from .abstract_invite_request import AbstractInviteRequestNotification
 
 class InviteRequestNotification(AbstractInviteRequestNotification):
     analytics_event = "invite_request.sent"
+    filename = "organization-invite-request"
     referrer_base = "invite_request"
-
-    def get_filename(self) -> str:
-        return "organization-invite-request"
 
     def build_attachment_title(self) -> str:
         return "Request to Invite"

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -3,10 +3,8 @@ from .abstract_invite_request import AbstractInviteRequestNotification
 
 class JoinRequestNotification(AbstractInviteRequestNotification):
     analytics_event = "join_request.sent"
+    filename = "organization-join-request"
     referrer_base = "join_request"
-
-    def get_filename(self) -> str:
-        return "organization-join-request"
 
     def build_attachment_title(self) -> str:
         return "Request to Join"

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -26,9 +26,12 @@ logger = logging.getLogger(__name__)
 
 
 class AlertRuleNotification(ProjectNotification):
-    message_builder = "IssueNotificationMessageBuilder"
+    category = "issue_alert_email"
+    filename = "error"
     fine_tuning_key = "alerts"
+    message_builder = "IssueNotificationMessageBuilder"
     metrics_key = "issue_alert"
+    type = "notify.error"
 
     def __init__(
         self,
@@ -53,12 +56,6 @@ class AlertRuleNotification(ProjectNotification):
             target_identifier=self.target_identifier,
             event=self.event,
         )
-
-    def get_filename(self) -> str:
-        return "error"
-
-    def get_category(self) -> str:
-        return "issue_alert_email"
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return str(self.event.get_email_subject())
@@ -119,9 +116,6 @@ class AlertRuleNotification(ProjectNotification):
                 title_str += f" (+{len(self.rules) - 1} other)"
 
         return title_str
-
-    def get_type(self) -> str:
-        return "notify.error"
 
     def send(self) -> None:
         from sentry.notifications.notify import notify

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
 
+from sentry.db.models import Model
 from sentry.models import Team, User, UserOption
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import ActionTargetType
@@ -60,7 +61,7 @@ class AlertRuleNotification(ProjectNotification):
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         return str(self.event.get_email_subject())
 
-    def get_reference(self) -> Any:
+    def get_reference(self) -> Model | None:
         return self.group
 
     def get_recipient_context(

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -19,6 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 class UserReportNotification(ProjectNotification):
+    category = "user_report_email"
+    filename = "activity/new-user-feedback"
+    type = "notify.user-report"
+
     def __init__(self, project: Project, report: Mapping[str, Any]) -> None:
         super().__init__(project)
         self.group = Group.objects.get(id=report["issue"]["id"])
@@ -33,15 +37,6 @@ class UserReportNotification(ProjectNotification):
             for provider, data in data_by_provider.items()
             if provider in [ExternalProviders.EMAIL]
         }
-
-    def get_filename(self) -> str:
-        return "activity/new-user-feedback"
-
-    def get_category(self) -> str:
-        return "user_report_email"
-
-    def get_type(self) -> str:
-        return "notify.user-report"
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
         # Explicitly typing to satisfy mypy.

--- a/src/sentry/notifications/notifications/user_report.py
+++ b/src/sentry/notifications/notifications/user_report.py
@@ -48,9 +48,6 @@ class UserReportNotification(ProjectNotification):
         # This shouldn't be possible but adding a message just in case.
         return self.get_subject()
 
-    def get_reference(self) -> Any:
-        return self.project
-
     def get_context(self) -> MutableMapping[str, Any]:
         return {
             "enhanced_privacy": self.organization.flags.enhanced_privacy,

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -43,7 +43,7 @@ def register_notification_provider(
 
 def notify(
     provider: ExternalProviders,
-    notification: Any,
+    notification: BaseNotification,
     recipients: Iterable[Team | User],
     shared_context: Mapping[str, Any],
     extra_context_by_actor_id: Mapping[int, Mapping[str, Any]] | None = None,

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -69,7 +69,7 @@ class AvatarChooser extends React.Component<Props, State> {
 
   updateState(model: Model) {
     this.setState({model});
-<<  }
+  }
 
   handleError(msg: string) {
     addErrorMessage(msg);

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -69,7 +69,7 @@ class AvatarChooser extends React.Component<Props, State> {
 
   updateState(model: Model) {
     this.setState({model});
-  }
+<<  }
 
   handleError(msg: string) {
     addErrorMessage(msg);

--- a/tests/sentry/models/test_lost_password.py
+++ b/tests/sentry/models/test_lost_password.py
@@ -11,7 +11,7 @@ class LostPasswordTest(TestCase):
         password_hash = LostPasswordHash.objects.create(user=self.user)
 
         with self.options({"system.url-prefix": "http://testserver"}), self.tasks():
-            LostPasswordNotification(password_hash, "1.1.1.1")
+            LostPasswordNotification(password_hash, "1.1.1.1").send()
 
         assert len(mail.outbox) == 1
         msg = mail.outbox[0]
@@ -19,6 +19,6 @@ class LostPasswordTest(TestCase):
         assert msg.subject == "[Sentry] Password Recovery"
         url = "http://testserver" + reverse(
             "sentry-account-recover-confirm",
-            args=[self.password_hash.user_id, self.password_hash.hash],
+            args=[password_hash.user_id, password_hash.hash],
         )
         assert url in msg.body

--- a/tests/sentry/models/test_lost_password.py
+++ b/tests/sentry/models/test_lost_password.py
@@ -1,0 +1,24 @@
+from django.core import mail
+from django.urls import reverse
+
+from sentry.models import LostPasswordHash
+from sentry.notifications.notifications.membership.lost_password import LostPasswordNotification
+from sentry.testutils import TestCase
+
+
+class LostPasswordTest(TestCase):
+    def test_send_recover_mail(self):
+        password_hash = LostPasswordHash.objects.create(user=self.user)
+
+        with self.options({"system.url-prefix": "http://testserver"}), self.tasks():
+            LostPasswordNotification(password_hash, "1.1.1.1")
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert msg.to == [self.user.email]
+        assert msg.subject == "[Sentry] Password Recovery"
+        url = "http://testserver" + reverse(
+            "sentry-account-recover-confirm",
+            args=[self.password_hash.user_id, self.password_hash.hash],
+        )
+        assert url in msg.body


### PR DESCRIPTION
While refactoring notifications I noticed that we'll want to be able to support sending notifications to users without specifying an organization. I've made a superclass above `BaseNotification` with no parameters in its constructor. 
As an example of what a notification like this would look like I implemented `LostPasswordNotification`:
- [ ] TODO screenshot

Finally, I simplified the interface for `BaseNotification` by using `@property` for static attributes. This cleans up a lot of code. For example `ResolvedActivityNotification` is incredibly small now that it inherits most of it's methods:
```py
class ResolvedActivityNotification(GroupActivityNotification):
    activity_name = "Resolved Issue"
    category = "resolved_activity_email"

    def get_description(self) -> tuple[str, Mapping[str, Any], Mapping[str, Any]]:
        return "{author} marked {an issue} as resolved", {}, {}
```