### PR TITLE
feat(metric_alerts): Add subscription handler to log evaluated values for alerts.

### DIFF
--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 from urllib.parse import urlencode
 
 from django.urls import reverse
@@ -6,6 +7,7 @@ from django.urls import reverse
 from sentry.auth.access import from_user
 from sentry.incidents.models import (
     INCIDENT_STATUS,
+    AlertRule,
     AlertRuleStatus,
     AlertRuleTriggerAction,
     Incident,
@@ -25,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 INCIDENTS_SNUBA_SUBSCRIPTION_TYPE = "incidents"
 INCIDENT_SNAPSHOT_BATCH_SIZE = 50
+SUBSCRIPTION_METRICS_LOGGER = "subscription_metrics_logger"
 
 
 @instrumented_task(name="sentry.incidents.tasks.send_subscriber_notifications", queue="incidents")
@@ -97,6 +100,32 @@ def build_activity_context(activity, user):
         + urlencode({"referrer": "incident_activity_email"}),
         "comment": activity.comment,
     }
+
+
+@register_subscriber(SUBSCRIPTION_METRICS_LOGGER)
+def handle_subscription_metrics_logger(subscription_update, subscription):
+    """
+    Logs results from a `QuerySubscription`.
+    :param subscription_update: dict formatted according to schemas in
+    sentry.snuba.json_schemas.SUBSCRIPTION_PAYLOAD_VERSIONS
+    :param subscription: The `QuerySubscription` that this update is for
+    """
+    from sentry.incidents.subscription_processor import SubscriptionProcessor
+
+    try:
+        processor = SubscriptionProcessor(subscription)
+        processor.alert_rule = AlertRule()
+        aggregation_value = int(processor.get_aggregation_value(subscription_update))
+        processor.alert_rule.comparison_delta = int(timedelta(days=7).total_seconds())
+        comparison_value = processor.get_aggregation_value(subscription_update)
+        tags = {"project_id": subscription.project_id, "subscription_id": subscription.id}
+        metrics.incr("subscriptions.result.value", aggregation_value, tags=tags, sample_rate=1.0)
+        if comparison_value is not None:
+            metrics.incr(
+                "subscriptions.result.comparison", int(comparison_value), tags=tags, sample_rate=1.0
+            )
+    except Exception:
+        logger.exception("Failed to log subscription results")
 
 
 @register_subscriber(INCIDENTS_SNUBA_SUBSCRIPTION_TYPE)

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, mock, patch
+from unittest.mock import Mock, call, patch
 
 import pytz
 from django.urls import reverse
@@ -215,10 +215,10 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
         }
 
     def test(self):
-        with mock.patch("sentry.incidents.tasks.metrics") as metrics:
+        with patch("sentry.incidents.tasks.metrics") as metrics:
             handle_subscription_metrics_logger(self.build_subscription_update(), self.subscription)
             assert metrics.incr.call_args_list == [
-                mock.call(
+                call(
                     "subscriptions.result.value",
                     100,
                     tags={"project_id": self.project.id, "subscription_id": self.subscription.id},

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,6 +1,8 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock, patch
 
+import pytz
 from django.urls import reverse
+from django.utils import timezone
 from exam import fixture, patcher
 from freezegun import freeze_time
 
@@ -20,6 +22,7 @@ from sentry.incidents.models import (
 from sentry.incidents.tasks import (
     build_activity_context,
     generate_incident_activity_email,
+    handle_subscription_metrics_logger,
     handle_trigger_action,
     send_subscriber_notifications,
 )
@@ -187,3 +190,38 @@ class HandleTriggerActionTest(TestCase):
                 )
             mock_handler.assert_called_once_with(self.action, incident, self.project)
             mock_handler.return_value.fire.assert_called_once_with(metric_value)
+
+
+class TestHandleSubscriptionMetricsLogger(TestCase):
+    @fixture
+    def rule(self):
+        return self.create_alert_rule()
+
+    @fixture
+    def subscription(self):
+        return self.rule.snuba_query.subscriptions.get()
+
+    def build_subscription_update(self):
+        timestamp = timezone.now().replace(tzinfo=pytz.utc, microsecond=0)
+        data = {"count": 100}
+        values = {"data": [data]}
+        return {
+            "subscription_id": self.subscription.subscription_id,
+            "values": values,
+            "timestamp": timestamp,
+            "interval": 1,
+            "partition": 1,
+            "offset": 1,
+        }
+
+    def test(self):
+        with mock.patch("sentry.incidents.tasks.metrics") as metrics:
+            handle_subscription_metrics_logger(self.build_subscription_update(), self.subscription)
+            assert metrics.incr.call_args_list == [
+                mock.call(
+                    "subscriptions.result.value",
+                    100,
+                    tags={"project_id": self.project.id, "subscription_id": self.subscription.id},
+                    sample_rate=1.0,
+                )
+            ]


### PR DESCRIPTION
We want to evaluate a small number of alerts and track their values for both comparison and normal
alerts. This is to evaluate a project in Q4.

We'll use this with maybe 50 unique projects, so we won't have a large number of tags here.