### PR TITLE
fix(dashboard-layout): Table overflow

### DIFF
--- a/static/app/views/dashboardsV2/gridLayout/dashboard.tsx
+++ b/static/app/views/dashboardsV2/gridLayout/dashboard.tsx
@@ -4,6 +4,7 @@ import 'react-resizable/css/styles.css';
 import {Component} from 'react';
 import RGL, {WidthProvider} from 'react-grid-layout';
 import {InjectedRouter} from 'react-router';
+import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
@@ -217,7 +218,7 @@ class Dashboard extends Component<Props> {
     const dragId = key;
 
     return (
-      <div key={key} data-grid={getDefaultPosition(index, widget.displayType)}>
+      <GridItem key={key} data-grid={getDefaultPosition(index, widget.displayType)}>
         <SortableWidget
           widget={widget}
           dragId={dragId}
@@ -225,7 +226,7 @@ class Dashboard extends Component<Props> {
           onDelete={this.handleDeleteWidget(index)}
           onEdit={this.handleEditWidget(widget, index)}
         />
-      </div>
+      </GridItem>
     );
   }
 
@@ -262,6 +263,12 @@ class Dashboard extends Component<Props> {
 }
 
 export default withApi(withGlobalSelection(Dashboard));
+
+const GridItem = styled('div')`
+  .react-resizable-handle {
+    z-index: 1;
+  }
+`;
 
 function generateWidgetId(widget: Widget, index: number) {
   return widget.id ? `${widget.id}-index-${index}` : `index-${index}`;

--- a/static/app/views/dashboardsV2/issueWidgetCard.tsx
+++ b/static/app/views/dashboardsV2/issueWidgetCard.tsx
@@ -229,6 +229,8 @@ const StyledPanel = styled(Panel, {
   /* If a panel overflows due to a long title stretch its grid sibling */
   height: 100%;
   min-height: 96px;
+  display: flex;
+  flex-direction: column;
 `;
 
 const WidgetTitle = styled(HeaderTitle)`

--- a/static/app/views/dashboardsV2/widgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard.tsx
@@ -278,6 +278,8 @@ const StyledPanel = styled(Panel, {
   /* If a panel overflows due to a long title stretch its grid sibling */
   height: 100%;
   min-height: 96px;
+  display: flex;
+  flex-direction: column;
 `;
 
 const ToolbarPanel = styled('div')`


### PR DESCRIPTION
Use flex to constrain table to parent and allow for scrolling until
dynamic table rows is addressed.

Before:
![Screen Shot 2021-11-25 at 1 53 02 PM](https://user-images.githubusercontent.com/22846452/143490371-8a1763c6-008a-43ac-99bd-e71851f07ce6.png)


After:
![Screen Shot 2021-11-25 at 1 54 16 PM](https://user-images.githubusercontent.com/22846452/143490425-87b37f2a-787d-4a6e-986d-223aaad4fb05.png)


