### PR TITLE
fix(perf): Cleanup heights and visualization axes for landing widgets

### DIFF
--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -193,6 +193,14 @@ function Chart({
     xAxisIndex: i,
   }));
 
+  const xAxis = disableXAxis
+    ? {
+        show: false,
+        axisLabel: {show: true, margin: 0},
+        axisLine: {show: false},
+      }
+    : undefined;
+
   return (
     <ChartZoom
       router={router}
@@ -210,8 +218,7 @@ function Chart({
               {...zoomRenderProps}
               series={series}
               previousPeriod={previousData}
-              xAxis={disableXAxis ? {show: false} : undefined}
-              {...areaChartProps}
+              xAxis={xAxis}
             />
           );
         }
@@ -222,7 +229,7 @@ function Chart({
             {...zoomRenderProps}
             series={series}
             previousPeriod={previousData}
-            xAxis={disableXAxis ? {show: false} : undefined}
+            xAxis={xAxis}
             {...areaChartProps}
           />
         );

--- a/static/app/views/performance/landing/chart/histogramChart.tsx
+++ b/static/app/views/performance/landing/chart/histogramChart.tsx
@@ -123,6 +123,7 @@ type ChartProps = {
   grid?: BarChart['props']['grid'];
   disableXAxis?: boolean;
   disableZoom?: boolean;
+  disableChartPadding?: boolean;
   colors?: string[];
 };
 
@@ -138,6 +139,7 @@ export function Chart(props: ChartProps) {
     grid,
     disableXAxis,
     disableZoom,
+    disableChartPadding,
     colors,
   } = props;
   if (!chartData) {
@@ -186,7 +188,7 @@ export function Chart(props: ChartProps) {
       >
         {zoomRenderProps => {
           return (
-            <BarChartContainer>
+            <BarChartContainer hasPadding={!disableChartPadding}>
               <MaskContainer>
                 <TransparentLoadingMask visible={isLoading} />
                 {getDynamicText({
@@ -220,8 +222,8 @@ export function Chart(props: ChartProps) {
   );
 }
 
-const BarChartContainer = styled('div')`
-  padding-top: ${space(1)};
+const BarChartContainer = styled('div')<{hasPadding?: boolean}>`
+  padding-top: ${p => (p.hasPadding ? space(1) : 0)};
   position: relative;
 `;
 

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -106,8 +106,6 @@ function _DataDisplay<T extends WidgetDataConstraint>(
   const isErrored =
     !missingDataKeys && Object.values(props.widgetData).some(d => d && d.isErrored);
 
-  const paddingOffset = 32; // space(2) * 2;
-
   return (
     <Container data-test-id="performance-widget-container">
       <ContentContainer>
@@ -117,7 +115,7 @@ function _DataDisplay<T extends WidgetDataConstraint>(
         isLoading={isLoading}
         isErrored={isErrored}
         hasData={hasData}
-        errorComponent={<DefaultErrorComponent height={totalHeight - paddingOffset} />}
+        errorComponent={<DefaultErrorComponent height={totalHeight} />}
         dataComponents={Visualizations.map((Visualization, index) => (
           <ContentContainer
             key={index}
@@ -136,12 +134,12 @@ function _DataDisplay<T extends WidgetDataConstraint>(
             />
           </ContentContainer>
         ))}
-        loadingComponent={<Placeholder height={`${totalHeight - paddingOffset}px`} />}
+        loadingComponent={<Placeholder height={`${totalHeight}px`} />}
         emptyComponent={
           EmptyComponent ? (
             <EmptyComponent />
           ) : (
-            <Placeholder height={`${totalHeight - paddingOffset}px`} />
+            <Placeholder height={`${totalHeight}px`} />
           )
         }
       />

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -63,6 +63,8 @@ export const RightAlignedCell = styled('div')`
 export const Subtitle = styled('span')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};
+  min-height: 24px;
+  display: inline-block;
 `;
 export const GrowLink = styled(Link)`
   flex-grow: 1;

--- a/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
@@ -71,14 +71,14 @@ export const TripleChartRow = (props: ChartRowProps) => <ChartRow {...props} />;
 
 TripleChartRow.defaultProps = {
   chartCount: 3,
-  chartHeight: 120,
+  chartHeight: 100,
 };
 
 export const DoubleChartRow = (props: ChartRowProps) => <ChartRow {...props} />;
 
 DoubleChartRow.defaultProps = {
   chartCount: 2,
-  chartHeight: 220,
+  chartHeight: 180,
 };
 
 const StyledRow = styled(PerformanceLayoutBodyRow)`

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -25,6 +25,23 @@ export enum GenericPerformanceWidgetDataType {
   trends = 'trends',
 }
 
+export type PerformanceWidgetProps = {
+  chartSetting: PerformanceWidgetSetting;
+  chartDefinition: ChartDefinition;
+  chartHeight: number;
+
+  title: string;
+  titleTooltip: string;
+  fields: string[];
+  chartColor?: string;
+
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+
+  ContainerActions: FunctionComponent<{isLoading: boolean}>;
+};
+
 export interface WidgetDataResult {
   isLoading: boolean;
   isErrored: boolean;

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -1,39 +1,19 @@
-import {Fragment, FunctionComponent, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
-import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
-import EventView from 'sentry/utils/discover/eventView';
 import HistogramQuery from 'sentry/utils/performance/histogram/histogramQuery';
 import {Chart as HistogramChart} from 'sentry/views/performance/landing/chart/histogramChart';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformHistogramQuery} from '../transforms/transformHistogramQuery';
-import {WidgetDataResult} from '../types';
-import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
-
-type Props = {
-  chartSetting: PerformanceWidgetSetting;
-  chartDefinition: ChartDefinition;
-  title: string;
-  titleTooltip: string;
-  fields: string[];
-  chartColor?: string;
-
-  eventView: EventView;
-  location: Location;
-  organization: Organization;
-
-  ContainerActions: FunctionComponent<{isLoading: boolean}>;
-};
+import {PerformanceWidgetProps, WidgetDataResult} from '../types';
 
 type AreaDataType = {
   chart: WidgetDataResult & ReturnType<typeof transformHistogramQuery>;
 };
 
-export function HistogramWidget(props: Props) {
+export function HistogramWidget(props: PerformanceWidgetProps) {
   const {ContainerActions, location} = props;
   const globalSelection = props.eventView.getGlobalSelection();
 
@@ -79,7 +59,6 @@ export function HistogramWidget(props: Props) {
             <HistogramChart
               {...provided}
               colors={props.chartColor ? [props.chartColor] : undefined}
-              height={100}
               location={location}
               isLoading={false}
               isErrored={false}
@@ -88,9 +67,10 @@ export function HistogramWidget(props: Props) {
               chartData={provided.widgetData.chart?.data?.[props.fields[0]]}
               disableXAxis
               disableZoom
+              disableChartPadding
             />
           ),
-          height: 160,
+          height: props.chartHeight,
         },
       ]}
     />

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -1,6 +1,5 @@
-import {Fragment, FunctionComponent, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {withRouter} from 'react-router';
-import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
@@ -10,9 +9,7 @@ import Link from 'sentry/components/links/link';
 import Tooltip from 'sentry/components/tooltip';
 import Truncate from 'sentry/components/truncate';
 import {t, tct} from 'sentry/locale';
-import {Organization} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
-import EventView from 'sentry/utils/discover/eventView';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withApi from 'sentry/utils/withApi';
@@ -31,24 +28,9 @@ import SelectableList, {
 } from '../components/selectableList';
 import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
-import {QueryDefinition, WidgetDataResult} from '../types';
+import {PerformanceWidgetProps, QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
-import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
-
-type Props = {
-  title: string;
-  titleTooltip: string;
-  fields: string[];
-  chartColor?: string;
-
-  eventView: EventView;
-  location: Location;
-  organization: Organization;
-  chartSetting: PerformanceWidgetSetting;
-  chartDefinition: ChartDefinition;
-
-  ContainerActions: FunctionComponent<{isLoading: boolean}>;
-};
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToArea>;
@@ -64,7 +46,7 @@ const slowList = [
   PerformanceWidgetSetting.MOST_FROZEN_FRAMES,
 ];
 
-export function LineChartListWidget(props: Props) {
+export function LineChartListWidget(props: PerformanceWidgetProps) {
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const {ContainerActions} = props;
 
@@ -215,7 +197,7 @@ export function LineChartListWidget(props: Props) {
               isLineChart
             />
           ),
-          height: 160,
+          height: props.chartHeight,
         },
         {
           component: provided => (
@@ -319,7 +301,7 @@ export function LineChartListWidget(props: Props) {
               })}
             />
           ),
-          height: 200,
+          height: 124,
           noPadding: true,
         },
       ]}

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -1,45 +1,25 @@
-import {Fragment, FunctionComponent, useMemo} from 'react';
+import {Fragment, useMemo} from 'react';
 import {withRouter} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
-import EventView from 'sentry/utils/discover/eventView';
 import {QueryBatchNode} from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformEventsRequestToArea} from '../transforms/transformEventsToArea';
-import {QueryDefinition, WidgetDataResult} from '../types';
+import {PerformanceWidgetProps, QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
-import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
-
-type Props = {
-  chartSetting: PerformanceWidgetSetting;
-  chartDefinition: ChartDefinition;
-
-  title: string;
-  titleTooltip: string;
-  fields: string[];
-  chartColor?: string;
-
-  eventView: EventView;
-  location: Location;
-  organization: Organization;
-
-  ContainerActions: FunctionComponent<{isLoading: boolean}>;
-};
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformEventsRequestToArea>;
 };
 
-export function SingleFieldAreaWidget(props: Props) {
+export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
   const {ContainerActions} = props;
   const globalSelection = props.eventView.getGlobalSelection();
 
@@ -117,7 +97,7 @@ export function SingleFieldAreaWidget(props: Props) {
               chartColors={props.chartColor ? [props.chartColor] : undefined}
             />
           ),
-          height: 160,
+          height: props.chartHeight,
         },
       ]}
     />

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -1,12 +1,9 @@
-import {Fragment, FunctionComponent, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {withRouter} from 'react-router';
-import {Location} from 'history';
 
 import Button from 'sentry/components/button';
 import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
-import EventView from 'sentry/utils/discover/eventView';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withProjects from 'sentry/utils/withProjects';
@@ -25,23 +22,8 @@ import SelectableList, {
   WidgetEmptyStateWarning,
 } from '../components/selectableList';
 import {transformTrendsDiscover} from '../transforms/transformTrendsDiscover';
-import {QueryDefinition, WidgetDataResult} from '../types';
-import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
-
-type Props = {
-  title: string;
-  titleTooltip: string;
-  fields: string[];
-  chartColor?: string;
-
-  eventView: EventView;
-  location: Location;
-  organization: Organization;
-  chartSetting: PerformanceWidgetSetting;
-  chartDefinition: ChartDefinition;
-
-  ContainerActions: FunctionComponent<{isLoading: boolean}>;
-};
+import {PerformanceWidgetProps, QueryDefinition, WidgetDataResult} from '../types';
+import {PerformanceWidgetSetting} from '../widgetDefinitions';
 
 type DataType = {
   chart: WidgetDataResult & ReturnType<typeof transformTrendsDiscover>;
@@ -49,7 +31,7 @@ type DataType = {
 
 const fields = [{field: 'transaction'}, {field: 'project'}];
 
-export function TrendsWidget(props: Props) {
+export function TrendsWidget(props: PerformanceWidgetProps) {
   const {eventView: _eventView, ContainerActions, location, organization} = props;
   const trendChangeType =
     props.chartSetting === PerformanceWidgetSetting.MOST_IMPROVED
@@ -141,7 +123,7 @@ export function TrendsWidget(props: Props) {
             />
           ),
           bottomPadding: false,
-          height: 160,
+          height: props.chartHeight,
         },
         {
           component: provided => (
@@ -177,7 +159,7 @@ export function TrendsWidget(props: Props) {
               })}
             />
           ),
-          height: 200,
+          height: 124,
           noPadding: true,
         },
       ]}

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -1,6 +1,5 @@
-import {Fragment, FunctionComponent, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import Button from 'sentry/components/button';
@@ -9,10 +8,8 @@ import {getInterval} from 'sentry/components/charts/utils';
 import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import DiscoverQuery, {TableDataRow} from 'sentry/utils/discover/discoverQuery';
-import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/discover/fields';
 import {VitalData} from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {decodeList} from 'sentry/utils/queryString';
@@ -33,24 +30,9 @@ import SelectableList, {
 } from '../components/selectableList';
 import {transformDiscoverToList} from '../transforms/transformDiscoverToList';
 import {transformEventsRequestToVitals} from '../transforms/transformEventsToVitals';
-import {QueryDefinition, WidgetDataResult} from '../types';
+import {PerformanceWidgetProps, QueryDefinition, WidgetDataResult} from '../types';
 import {eventsRequestQueryProps} from '../utils';
 import {ChartDefinition, PerformanceWidgetSetting} from '../widgetDefinitions';
-
-type Props = {
-  title: string;
-  titleTooltip: string;
-  fields: string[];
-  chartColor?: string;
-
-  eventView: EventView;
-  location: Location;
-  organization: Organization;
-  chartSetting: PerformanceWidgetSetting;
-  chartDefinition: ChartDefinition;
-
-  ContainerActions: FunctionComponent<{isLoading: boolean}>;
-};
 
 type DataType = {
   list: WidgetDataResult & ReturnType<typeof transformDiscoverToList>;
@@ -102,7 +84,7 @@ export function transformFieldsWithStops(props: {
   };
 }
 
-export function VitalWidget(props: Props) {
+export function VitalWidget(props: PerformanceWidgetProps) {
   const {ContainerActions, eventView, organization, location} = props;
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const field = props.fields[0];
@@ -206,7 +188,7 @@ export function VitalWidget(props: Props) {
         const listItem = provided.widgetData.list?.data[selectedListIndex];
 
         if (!listItem) {
-          return <Subtitle> </Subtitle>;
+          return <Subtitle />;
         }
 
         const data = {
@@ -265,15 +247,10 @@ export function VitalWidget(props: Props) {
               query={eventView.query}
               project={eventView.project}
               environment={eventView.environment}
-              grid={{
-                left: space(0),
-                right: space(0),
-                top: space(2),
-                bottom: space(2),
-              }}
+              grid={provided.grid}
             />
           ),
-          height: 160,
+          height: props.chartHeight,
         },
         {
           component: provided => (
@@ -328,7 +305,7 @@ export function VitalWidget(props: Props) {
               })}
             />
           ),
-          height: 200,
+          height: 124,
           noPadding: true,
         },
       ]}

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -343,16 +343,9 @@ function __VitalChart(props: _VitalChartProps) {
       },
     },
     xAxis: {
-      axisLine: {
-        show: false,
-      },
-      axisTick: {
-        show: false,
-      },
-      splitLine: {
-        show: false,
-      },
+      show: false,
     },
+    xAxes: undefined,
     yAxis: {
       axisLabel: {
         color: theme.chartLabel,


### PR DESCRIPTION
### Summary
This makes all the widgets slightly smaller, as well as fixing issues with hardcoded padding and height offsets that just happened to be working before. Now all xAxis lines should be lined up across the widgets, and placeholders shouldn't cause so much visual jank like they did before.

Other:
- Remove the xAxis label on vitals widget
- Refactored the specialized widget props into a single type

### Screenshots
#### Before
![Screen Shot 2021-11-25 at 1 44 43 PM](https://user-images.githubusercontent.com/6111995/143491076-124a75ee-986b-42dd-97ef-b06df652010e.png)
#### After
![Screen Shot 2021-11-25 at 1 44 31 PM](https://user-images.githubusercontent.com/6111995/143491073-bc3140be-3e39-4eef-a0b1-c500dae74633.png)
![Screen Shot 2021-11-25 at 2 00 32 PM](https://user-images.githubusercontent.com/6111995/143491159-1a6ef614-0ac8-4fe3-b146-2d648c091f8f.png)


