### PR TITLE
feat(suspect-spans): Add sort by avg occurrences in span tab

### DIFF
--- a/static/app/utils/performance/suspectSpans/types.tsx
+++ b/static/app/utils/performance/suspectSpans/types.tsx
@@ -22,6 +22,7 @@ export type SuspectSpan = {
   group: string;
   frequency: number;
   count: number;
+  avgOccurrences: number;
   sumExclusiveTime: number;
   p50ExclusiveTime: number;
   p75ExclusiveTime: number;

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -12,7 +12,7 @@ import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {ColumnType, fieldAlignment} from 'sentry/utils/discover/fields';
-import {formatPercentage} from 'sentry/utils/formatters';
+import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
 import {SuspectSpan} from 'sentry/utils/performance/suspectSpans/types';
 
 import {PerformanceDuration} from '../../utils';
@@ -187,6 +187,17 @@ function SpanCount(props: HeaderItemProps) {
       <HeaderItem
         label={t('Occurrences')}
         value={String(suspectSpan.count)}
+        align="right"
+        isSortKey
+      />
+    );
+  }
+
+  if (sort.field === SpanSortOthers.AVG_OCCURRENCE) {
+    return (
+      <HeaderItem
+        label={t('Avg Occurrences')}
+        value={formatFloat(suspectSpan.avgOccurrences, 2)}
         align="right"
         isSortKey
       />

--- a/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/types.tsx
@@ -9,6 +9,7 @@ export enum SpanSortPercentiles {
 
 export enum SpanSortOthers {
   COUNT = 'count',
+  AVG_OCCURRENCE = 'avgOccurrence',
   SUM_EXCLUSIVE_TIME = 'sumExclusiveTime',
 }
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -41,6 +41,21 @@ export function spansRouteWithQuery({
 
 export const SPAN_SORT_OPTIONS: SpanSortOption[] = [
   {
+    prefix: t('Total'),
+    label: t('Cumulative Duration'),
+    field: SpanSortOthers.SUM_EXCLUSIVE_TIME,
+  },
+  {
+    prefix: t('Average'),
+    label: t('Avg Occurrences'),
+    field: SpanSortOthers.AVG_OCCURRENCE,
+  },
+  {
+    prefix: t('Total'),
+    label: t('Occurrences'),
+    field: SpanSortOthers.COUNT,
+  },
+  {
     prefix: t('Percentile'),
     label: t('p50 Duration'),
     field: SpanSortPercentiles.P50_EXCLUSIVE_TIME,
@@ -59,16 +74,6 @@ export const SPAN_SORT_OPTIONS: SpanSortOption[] = [
     prefix: t('Percentile'),
     label: t('p99 Duration'),
     field: SpanSortPercentiles.P99_EXCLUSIVE_TIME,
-  },
-  {
-    prefix: t('Total'),
-    label: t('Cumulative Duration'),
-    field: SpanSortOthers.SUM_EXCLUSIVE_TIME,
-  },
-  {
-    prefix: t('Total'),
-    label: t('Occurrences'),
-    field: SpanSortOthers.COUNT,
   },
 ];
 

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -129,6 +129,7 @@ function makeSuspectSpan(opt: SuspectOpt): SuspectSpan {
     group,
     frequency: 1,
     count: 1,
+    avgOccurrences: 1,
     sumExclusiveTime: 1,
     p50ExclusiveTime: 1,
     p75ExclusiveTime: 1,

--- a/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSpans/index.spec.tsx
@@ -211,6 +211,37 @@ describe('Performance > Transaction Spans', function () {
       }
     });
 
+    it('renders the right avg occurrence header', async function () {
+      const initialData = initializeData({query: {sort: SpanSortOthers.AVG_OCCURRENCE}});
+      mountWithTheme(
+        <TransactionSpans
+          organization={initialData.organization}
+          location={initialData.router.location}
+        />,
+        {context: initialData.routerContext}
+      );
+
+      const cards = await screen.findAllByTestId('suspect-card');
+      expect(cards).toHaveLength(2);
+      for (let i = 0; i < cards.length; i++) {
+        const card = cards[i];
+
+        // these headers should be present by default
+        expect(await within(card).findByText('Span Operation')).toBeInTheDocument();
+        expect(await within(card).findByText('p75 Duration')).toBeInTheDocument();
+        expect(await within(card).findByText('Avg Occurrences')).toBeInTheDocument();
+        expect(
+          await within(card).findByText('Total Cumulative Duration')
+        ).toBeInTheDocument();
+
+        const arrow = await within(card).findByTestId('span-sort-arrow');
+        expect(arrow).toBeInTheDocument();
+        expect(
+          await within(arrow.closest('div')!).findByText('Avg Occurrences')
+        ).toBeInTheDocument();
+      }
+    });
+
     it('renders the right table headers', async function () {
       const initialData = initializeData();
       mountWithTheme(


### PR DESCRIPTION
This exposes the option to sort by avg occurrences in the span tab.