### PR TITLE
Revert "ref(symbolicator): All components of the low priority queue are disabled by default (#30210)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -789,9 +789,7 @@ CELERYBEAT_SCHEDULE = {
     },
     "check-symbolicator-lpq-project-eligibility": {
         "task": "sentry.tasks.low_priority_symbolication.scan_for_suspect_projects",
-        # Set to Feb 31 so it never runs. Here's to hoping February doesn't somehow get
-        # 31 days in the foreseeable future.
-        "schedule": crontab(day_of_month=31, month_of_year=2),
+        "schedule": timedelta(seconds=10),
         "options": {"expires": 10},
     },
 }
@@ -2398,7 +2396,7 @@ SENTRY_REPROCESSING_REMAINING_EVENTS_BUF_SIZE = 500
 #
 # Currently, only redis is supported.
 SENTRY_REALTIME_METRICS_BACKEND = (
-    "sentry.processing.realtime_metrics.dummy.DummyRealtimeMetricsStore"
+    "sentry.processing.realtime_metrics.redis.RedisRealtimeMetricsStore"
 )
 SENTRY_REALTIME_METRICS_OPTIONS = {
     # The redis cluster used for the realtime store redis backend.


### PR DESCRIPTION
This reverts commit fced8d0cd20d93238f27184c1f4e6a44c1c7ce2d.


Feb 31 does not work.