### PR TITLE
ref(symbolicator): Disable everything related to the low priority queue take 2

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -787,11 +787,6 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=20),
         "options": {"expires": 20 * 60},
     },
-    "check-symbolicator-lpq-project-eligibility": {
-        "task": "sentry.tasks.low_priority_symbolication.scan_for_suspect_projects",
-        "schedule": timedelta(seconds=10),
-        "options": {"expires": 10},
-    },
 }
 
 BGTASKS = {
@@ -2396,7 +2391,7 @@ SENTRY_REPROCESSING_REMAINING_EVENTS_BUF_SIZE = 500
 #
 # Currently, only redis is supported.
 SENTRY_REALTIME_METRICS_BACKEND = (
-    "sentry.processing.realtime_metrics.redis.RedisRealtimeMetricsStore"
+    "sentry.processing.realtime_metrics.dummy.DummyRealtimeMetricsStore"
 )
 SENTRY_REALTIME_METRICS_OPTIONS = {
     # The redis cluster used for the realtime store redis backend.


### PR DESCRIPTION
I messed up my first attempt, and apparently tested the first set of changes incorrectly on my local env... I tested this change myself locally, but I wasn't able to test https://github.com/getsentry/getsentry/pull/6683 with this change. A sanity check by simply just running this locally would be much appreciated; I'm not sure I trust myself after seeing what happened to https://github.com/getsentry/sentry/pull/30210.

relates to getsentry/self-hosted#1131