### PR TITLE
ref(event-entries): Remove sentry capture Proguard message

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -230,6 +230,7 @@ const EventEntries = memo(
         setIsLoading(false);
         return;
       }
+
       if (proGuardImage) {
         Sentry.withScope(function (s) {
           s.setLevel(Sentry.Severity.Warning);
@@ -263,20 +264,6 @@ const EventEntries = memo(
               ),
             }
           ),
-        });
-
-        // This capture will be removed once we're confident with the level of effectiveness
-        Sentry.withScope(function (s) {
-          s.setLevel(Sentry.Severity.Warning);
-          if (event.sdk) {
-            s.setTag('offending.event.sdk.name', event.sdk.name);
-            s.setTag('offending.event.sdk.version', event.sdk.version);
-          }
-          Sentry.captureMessage(
-            !proGuardImage
-              ? 'No Proguard is used at all, but a frame did match the regex'
-              : "Displaying ProGuard warning 'proguard_potentially_misconfigured_plugin' for suspected event"
-          );
         });
       }
 


### PR DESCRIPTION
Remove sentry capture that contains the message "No Proguard is used at all, but a frame did match the regex" as we're confident with the level of effectiveness!

