### PR TITLE
ref(perf): Track landing display changes

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -31,6 +31,12 @@ export type PerformanceEventParameters = {
     num_sent: number;
     num_saved: number;
   };
+  'performance_views.landingv3.display_change': {
+    change_to_display: string;
+    default_display: string;
+    current_display: string;
+    is_default: boolean;
+  };
   'performance_views.overview.navigate.summary': {};
   'performance_views.overview.cellaction': {action?: string};
 };
@@ -53,4 +59,5 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Landing Widget Switched',
   'performance_views.landingv3.batch_queries':
     'Performance Views: Landing Query Batching',
+  'performance_views.landingv3.display_change': 'Performance Views: Switch Landing Tabs',
 };

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -108,7 +108,13 @@ export function PerformanceLanding(props: Props) {
               <a
                 href="#"
                 onClick={() =>
-                  handleLandingDisplayChange(field, location, projects, eventView)
+                  handleLandingDisplayChange(
+                    field,
+                    location,
+                    projects,
+                    organization,
+                    eventView
+                  )
                 }
               >
                 {t(label)}


### PR DESCRIPTION
### Summary
This will check if landing tabs are being chosen aren't the default platform auto-selected views so we might be able to offer clearer defaults.