### PR TITLE
fix(performance): Duration chart in transaction overview should refle…

### DIFF
--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -27,11 +27,9 @@ export enum SpanOperationBreakdownFilter {
   Resource = 'resource',
 }
 
-export const SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD: Record<
-  SpanOperationBreakdownFilter,
-  string
+export const SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD: Partial<
+  Record<SpanOperationBreakdownFilter, string>
 > = {
-  [SpanOperationBreakdownFilter.None]: 'transaction.duration',
   [SpanOperationBreakdownFilter.Http]: 'spans.http',
   [SpanOperationBreakdownFilter.Db]: 'spans.db',
   [SpanOperationBreakdownFilter.Browser]: 'spans.browser',

--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -27,6 +27,17 @@ export enum SpanOperationBreakdownFilter {
   Resource = 'resource',
 }
 
+export const SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD: Record<
+  SpanOperationBreakdownFilter,
+  string
+> = {
+  [SpanOperationBreakdownFilter.None]: 'transaction.duration',
+  [SpanOperationBreakdownFilter.Http]: 'spans.http',
+  [SpanOperationBreakdownFilter.Db]: 'spans.db',
+  [SpanOperationBreakdownFilter.Browser]: 'spans.browser',
+  [SpanOperationBreakdownFilter.Resource]: 'spans.resource',
+};
+
 const OPTIONS: SpanOperationBreakdownFilter[] = [
   SpanOperationBreakdownFilter.Http,
   SpanOperationBreakdownFilter.Db,

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
@@ -24,7 +24,10 @@ import EventView from 'sentry/utils/discover/eventView';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
 
-import {SpanOperationBreakdownFilter} from '../filter';
+import {
+  SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD,
+  SpanOperationBreakdownFilter,
+} from '../filter';
 
 const QUERY_KEYS = [
   'environment',
@@ -46,8 +49,15 @@ type Props = WithRouterProps &
     withoutZerofill: boolean;
   };
 
-function generateYAxisValues() {
-  return ['p50()', 'p75()', 'p95()', 'p99()', 'p100()'];
+function generateYAxisValues(currentFilter: SpanOperationBreakdownFilter) {
+  const field = SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter];
+  return [
+    `p50(${field})`,
+    `p75(${field})`,
+    `p95(${field})`,
+    `p99(${field})`,
+    `p100(${field})`,
+  ];
 }
 
 /**
@@ -140,7 +150,7 @@ function DurationChart({
             showLoading={false}
             query={query}
             includePrevious={false}
-            yAxis={generateYAxisValues()}
+            yAxis={generateYAxisValues(currentFilter)}
             partial
             withoutZerofill={withoutZerofill}
             referrer="api.performance.transaction-summary.duration-chart"

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
@@ -50,7 +50,8 @@ type Props = WithRouterProps &
   };
 
 function generateYAxisValues(currentFilter: SpanOperationBreakdownFilter) {
-  const field = SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter];
+  const field =
+    SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter] ?? 'transaction.duration';
   return [
     `p50(${field})`,
     `p75(${field})`,

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -35,7 +35,10 @@ import {
   platformAndConditionsToPerformanceType,
   PROJECT_PERFORMANCE_TYPE,
 } from '../../utils';
-import {SpanOperationBreakdownFilter} from '../filter';
+import {
+  SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD,
+  SpanOperationBreakdownFilter,
+} from '../filter';
 import {tagsRouteWithQuery} from '../transactionTags/utils';
 
 const TAGS_CURSOR_NAME = 'tags_cursor';
@@ -115,19 +118,12 @@ const COLUMN_ORDER: TagColumn[] = [
   },
 ];
 
-const filterToField = {
-  [SpanOperationBreakdownFilter.Browser]: 'spans.browser',
-  [SpanOperationBreakdownFilter.Http]: 'spans.http',
-  [SpanOperationBreakdownFilter.Db]: 'spans.db',
-  [SpanOperationBreakdownFilter.Resource]: 'spans.resource',
-};
-
 export const getTransactionField = (
   currentFilter: SpanOperationBreakdownFilter,
   projects: Project[],
   eventView: EventView
 ) => {
-  const fieldFromFilter = filterToField[currentFilter];
+  const fieldFromFilter = SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter];
   if (fieldFromFilter) {
     return fieldFromFilter;
   }
@@ -152,7 +148,7 @@ const getColumnsWithReplacedDuration = (
     return columns;
   }
 
-  const fieldFromFilter = filterToField[currentFilter];
+  const fieldFromFilter = SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter];
   if (fieldFromFilter) {
     durationColumn.name = 'Avg Span Duration';
     return columns;


### PR DESCRIPTION
…ct current filter

The duration chart in transaction overview is always showing the transaction
duration regardless of the current filter. This change ensures that when a span
op filter is selected, the duration chart is updated to reflect the selection.