### PR TITLE
fix(trace-navigator): Expanded text covering project icon

### DIFF
--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -137,7 +137,7 @@ export const DropdownItemSubContainer = styled('div')`
 `;
 
 export const QuickTraceValue = styled(Truncate)`
-  padding-left: ${space(1)};
+  margin-left: ${space(1)};
   white-space: nowrap;
 `;
 


### PR DESCRIPTION
When expanding the transaction/error message on the trace navigator in an issue,
the hover text covers the project icon slightly. This change makes sure it's
visible.

# Screenshots

## Before

![Screen Shot 2021-11-26 at 3 08 18 PM](https://user-images.githubusercontent.com/10239353/143626064-4a1eca4f-f722-4431-905f-a95946baf9a5.png)

## After

![Screen Shot 2021-11-26 at 3 08 38 PM](https://user-images.githubusercontent.com/10239353/143626080-af5f91dc-5c40-4443-b54a-0e24bbde75a5.png)


