### PR TITLE
fix(breadcrumbs): Link transactions in breadcrumbs to performance

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.tsx
@@ -5,7 +5,8 @@ import Link from 'sentry/components/links/link';
 import {Organization, Project} from 'sentry/types';
 import {BreadcrumbTypeDefault, BreadcrumbTypeNavigation} from 'sentry/types/breadcrumbs';
 import {Event} from 'sentry/types/event';
-import {eventDetailsRoute, generateEventSlug} from 'sentry/utils/discover/urls';
+import {generateEventSlug} from 'sentry/utils/discover/urls';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import withProjects from 'sentry/utils/withProjects';
 
 import Summary from './summary';
@@ -82,7 +83,7 @@ const FormatMessage = withProjects(function FormatMessageInner({
     const projectSlug = maybeProject.slug;
     const eventSlug = generateEventSlug({project: projectSlug, id: message});
 
-    return <Link to={eventDetailsRoute({orgSlug, eventSlug})}>{content}</Link>;
+    return <Link to={getTransactionDetailsUrl(orgSlug, eventSlug)}>{content}</Link>;
   }
 
   return content;

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -16,9 +16,9 @@ import {
   TraceError,
 } from 'sentry/utils/performance/quickTrace/types';
 import {getTraceTimeRangeFromEvent} from 'sentry/utils/performance/quickTrace/utils';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
-import {getTransactionDetailsUrl} from 'sentry/views/performance/utils';
 
 export function isQuickTraceEvent(
   event: QuickTraceEvent | TraceError
@@ -50,7 +50,7 @@ function generatePerformanceEventTarget(
     ...location.query,
     project: String(event.project_id),
   };
-  return getTransactionDetailsUrl(organization, eventSlug, event.transaction, query);
+  return getTransactionDetailsUrl(organization.slug, eventSlug, event.transaction, query);
 }
 
 function generateDiscoverEventTarget(

--- a/static/app/utils/performance/urls.ts
+++ b/static/app/utils/performance/urls.ts
@@ -15,7 +15,7 @@ export function getTransactionDetailsUrl(
     ...(query || {}),
     transaction,
   };
-  if (defined(locationQuery.transaction)) {
+  if (!defined(locationQuery.transaction)) {
     delete locationQuery.transaction;
   }
 

--- a/static/app/utils/performance/urls.ts
+++ b/static/app/utils/performance/urls.ts
@@ -1,0 +1,32 @@
+import {LocationDescriptor, Query} from 'history';
+
+import {spanTargetHash} from 'sentry/components/events/interfaces/spans/utils';
+import {Organization} from 'sentry/types';
+import {defined} from 'sentry/utils';
+
+export function getTransactionDetailsUrl(
+  orgSlug: Organization['slug'],
+  eventSlug: string,
+  transaction?: string,
+  query?: Query,
+  spanId?: string
+): LocationDescriptor {
+  const locationQuery = {
+    ...(query || {}),
+    transaction,
+  };
+  if (defined(locationQuery.transaction)) {
+    delete locationQuery.transaction;
+  }
+
+  const target = {
+    pathname: `/organizations/${orgSlug}/performance/${eventSlug}/`,
+    query: locationQuery,
+    hash: defined(spanId) ? spanTargetHash(spanId) : undefined,
+  };
+  if (!defined(target.hash)) {
+    delete target.hash;
+  }
+
+  return target;
+}

--- a/static/app/views/performance/compare/transactionSummary.tsx
+++ b/static/app/views/performance/compare/transactionSummary.tsx
@@ -9,8 +9,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-
-import {getTransactionDetailsUrl} from '../utils';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 
 import {isTransactionEvent} from './utils';
 
@@ -53,7 +52,7 @@ class TransactionSummary extends Component<Props> {
                 <span>{t('ID')}: </span>
                 <StyledLink
                   to={getTransactionDetailsUrl(
-                    organization,
+                    organization.slug,
                     baselineEventSlug.trim(),
                     baselineEvent.title,
                     location.query
@@ -77,7 +76,7 @@ class TransactionSummary extends Component<Props> {
                 <span>{t('ID')}: </span>
                 <StyledLink
                   to={getTransactionDetailsUrl(
-                    organization,
+                    organization.slug,
                     regressionEventSlug.trim(),
                     regressionEvent.title,
                     location.query

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -24,9 +24,9 @@ import {Organization} from 'sentry/types';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {TraceFullDetailed} from 'sentry/utils/performance/quickTrace/types';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
-import {getTransactionDetailsUrl} from 'sentry/views/performance/utils';
 
 import {Row, Tags, TransactionDetails, TransactionDetailsContainer} from './styles';
 
@@ -83,7 +83,7 @@ class TransactionDetail extends Component<Props> {
     });
 
     const target = getTransactionDetailsUrl(
-      organization,
+      organization.slug,
       eventSlug,
       transaction.transaction,
       omit(location.query, Object.values(PAGE_URL_PARAM))

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -25,12 +25,12 @@ import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTra
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import TraceMetaQuery from 'sentry/utils/performance/quickTrace/traceMetaQuery';
 import {getTraceTimeRangeFromEvent} from 'sentry/utils/performance/quickTrace/utils';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import Projects from 'sentry/utils/projects';
 import {appendTagCondition, decodeScalar} from 'sentry/utils/queryString';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
-import {getTransactionDetailsUrl} from '../utils';
 
 import EventMetas from './eventMetas';
 
@@ -185,7 +185,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                           value={{
                             getViewChildTransactionTarget: childTransactionProps => {
                               return getTransactionDetailsUrl(
-                                organization,
+                                organization.slug,
                                 childTransactionProps.eventSlug,
                                 childTransactionProps.transaction,
                                 location.query

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -5,10 +5,9 @@ import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
+import {getTransactionDetailsUrl} from 'sentry/utils/performance/urls';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
-
-import {getTransactionDetailsUrl} from '../utils';
 
 import {DisplayModes} from './transactionOverview/charts';
 
@@ -107,7 +106,7 @@ export function generateTransactionLink(transactionName: string) {
   ): LocationDescriptor => {
     const eventSlug = generateEventSlug(tableRow);
     return getTransactionDetailsUrl(
-      organization,
+      organization.slug,
       eventSlug,
       transactionName,
       query,

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -2,7 +2,6 @@ import {browserHistory} from 'react-router';
 import {Location, LocationDescriptor, Query} from 'history';
 
 import Duration from 'sentry/components/duration';
-import {spanTargetHash} from 'sentry/components/events/interfaces/spans/utils';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/globalSelectionHeader';
 import {backend, frontend, mobile} from 'sentry/data/platformCategories';
 import {
@@ -219,28 +218,6 @@ export function removeTracingKeysFromSearch(
   });
 
   return currentFilter;
-}
-
-export function getTransactionDetailsUrl(
-  organization: OrganizationSummary,
-  eventSlug: string,
-  transaction: string,
-  query: Query,
-  spanId?: string
-): LocationDescriptor {
-  const hash = defined(spanId) ? spanTargetHash(spanId) : undefined;
-  const target = {
-    pathname: `/organizations/${organization.slug}/performance/${eventSlug}/`,
-    query: {
-      ...query,
-      transaction,
-    },
-    hash,
-  };
-  if (!defined(hash)) {
-    delete target.hash;
-  }
-  return target;
 }
 
 export function getTransactionComparisonUrl({


### PR DESCRIPTION
Not all users have access to discover, so link transactions in breadcrumbs to
performance where more users have access to it.