### PR TITLE
fix(metrics): Rename measurements metrics

### DIFF
--- a/src/sentry/snuba/metrics.py
+++ b/src/sentry/snuba/metrics.py
@@ -401,7 +401,7 @@ _METRICS = {
 
 _METRICS.update(
     {
-        f"measurement.{web_vital}": {
+        f"measurements.{web_vital}": {
             "type": "distribution",
             "operations": _AVAILABLE_OPERATIONS["metrics_distributions"],
             "tags": _MEASUREMENT_TAGS,

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -411,7 +411,7 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
     @with_feature(FEATURE_FLAG)
     def test_orderby(self):
         # Record some strings
-        metric_id = indexer.record("measurement.lcp")
+        metric_id = indexer.record("measurements.lcp")
         k_transaction = indexer.record("transaction")
         v_foo = indexer.record("/foo")
         v_bar = indexer.record("/bar")
@@ -445,13 +445,13 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
 
         response = self.get_success_response(
             self.organization.slug,
-            field="count(measurement.lcp)",
+            field="count(measurements.lcp)",
             query="measurement_rating:poor",
             statsPeriod="1h",
             interval="1h",
             datasource="snuba",
             groupBy="transaction",
-            orderBy="-count(measurement.lcp)",
+            orderBy="-count(measurements.lcp)",
             limit=2,
         )
         groups = response.data["groups"]
@@ -466,7 +466,7 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
             assert "series" not in group
             assert group["by"] == {"transaction": expected_transaction}
             totals = group["totals"]
-            assert totals == {"count(measurement.lcp)": expected_count}
+            assert totals == {"count(measurements.lcp)": expected_count}
 
 
 class OrganizationMetricMetaIntegrationTest(SessionMetricsTestCase, APITestCase):


### PR DESCRIPTION
Rename metrics extracted from measurements (e.g. `measurements.lcp`) to plural in order to to be consistent with the rest of the product. This PR only fixes the mock data source of the Metrics API, the actual extraction is fixed as part of https://github.com/getsentry/relay/pull/1141.