### PR TITLE
ref(subscriptions): Rename QueryDatasets to QueryEntity

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -11,7 +11,7 @@ from sentry.incidents.models import (
     IncidentSeen,
     IncidentSubscription,
 )
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.snuba.tasks import apply_dataset_query_conditions
 
 
@@ -125,7 +125,7 @@ class DetailedIncidentSerializer(IncidentSerializer):
 
     def _build_discover_query(self, incident):
         return apply_dataset_query_conditions(
-            QueryDatasets(incident.alert_rule.snuba_query.dataset),
+            QueryEntity(incident.alert_rule.snuba_query.dataset),
             incident.alert_rule.snuba_query.query,
             incident.alert_rule.snuba_query.event_types,
             discover=True,

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -43,7 +43,7 @@ from sentry.mediators import alert_rule_actions
 from sentry.models import OrganizationMember, SentryAppInstallation, Team, User
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, SnubaQueryEventType
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils.compat import zip
 from sentry.utils.snuba import raw_query
@@ -63,11 +63,11 @@ action_target_type_to_string = {
 }
 string_to_action_target_type = {v: k for (k, v) in action_target_type_to_string.items()}
 dataset_valid_event_types = {
-    QueryDatasets.EVENTS: {
+    QueryEntity.EVENTS: {
         SnubaQueryEventType.EventType.ERROR,
         SnubaQueryEventType.EventType.DEFAULT,
     },
-    QueryDatasets.TRANSACTIONS: {SnubaQueryEventType.EventType.TRANSACTION},
+    QueryEntity.TRANSACTIONS: {SnubaQueryEventType.EventType.TRANSACTION},
 }
 
 # TODO(davidenwang): eventually we should pass some form of these to the event_search parser to raise an error
@@ -436,10 +436,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
     def validate_dataset(self, dataset):
         try:
-            return QueryDatasets(dataset)
+            return QueryEntity(dataset)
         except ValueError:
             raise serializers.ValidationError(
-                "Invalid dataset, valid values are %s" % [item.value for item in QueryDatasets]
+                "Invalid dataset, valid values are %s" % [item.value for item in QueryEntity]
             )
 
     def validate_event_types(self, event_types):
@@ -470,7 +470,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         both alert and resolve 'after' the warning trigger (whether that means
         > or < the value depends on threshold type).
         """
-        data.setdefault("dataset", QueryDatasets.EVENTS)
+        data.setdefault("dataset", QueryEntity.EVENTS)
         project_id = data.get("projects")
         if not project_id:
             # We just need a valid project id from the org so that we can verify

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -35,7 +35,7 @@ from sentry.search.events.fields import resolve_field
 from sentry.search.events.filter import get_filter
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
     bulk_delete_snuba_subscriptions,
@@ -289,7 +289,7 @@ def build_incident_query_params(incident, start=None, end=None, windowed_stats=F
 
     snuba_query = incident.alert_rule.snuba_query
     snuba_filter = build_snuba_filter(
-        QueryDatasets(snuba_query.dataset),
+        QueryEntity(snuba_query.dataset),
         snuba_query.query,
         snuba_query.aggregate,
         snuba_query.environment,
@@ -350,7 +350,7 @@ def get_incident_aggregates(
     end: Optional[datetime] = None,
     windowed_stats: bool = False,
     use_alert_aggregate: bool = False,
-    dataset: QueryDatasets = QueryDatasets.EVENTS,
+    dataset: QueryEntity = QueryEntity.EVENTS,
 ) -> Dict[str, Union[float, int]]:
     """
     Calculates aggregate stats across the life of an incident, or the provided range.
@@ -361,7 +361,7 @@ def get_incident_aggregates(
     - unique_users: Total number of unique users
     """
     query_params = build_incident_query_params(incident, start, end, windowed_stats)
-    if dataset == QueryDatasets.SESSIONS:
+    if dataset == QueryEntity.SESSIONS:
         query_params["aggregations"][0][2] = "count"
         if not use_alert_aggregate:
             query_params["aggregations"][1] = ("identity", "users", "unique_users")
@@ -421,7 +421,7 @@ def create_alert_rule(
     environment=None,
     include_all_projects=False,
     excluded_projects=None,
-    dataset=QueryDatasets.EVENTS,
+    dataset=QueryEntity.EVENTS,
     user=None,
     event_types=None,
     comparison_delta: Optional[int] = None,
@@ -651,7 +651,7 @@ def update_alert_rule(
 
         if updated_query_fields or environment != alert_rule.snuba_query.environment:
             snuba_query = alert_rule.snuba_query
-            updated_query_fields.setdefault("dataset", QueryDatasets(snuba_query.dataset))
+            updated_query_fields.setdefault("dataset", QueryEntity(snuba_query.dataset))
             updated_query_fields.setdefault("query", snuba_query.query)
             updated_query_fields.setdefault("aggregate", snuba_query.aggregate)
             updated_query_fields.setdefault(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -30,7 +30,7 @@ from sentry.incidents.models import (
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.models import Project
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils import metrics, redis
 from sentry.utils.compat import zip
@@ -177,7 +177,7 @@ class SubscriptionProcessor:
 
         try:
             snuba_filter = build_snuba_filter(
-                QueryDatasets(snuba_query.dataset),
+                QueryEntity(snuba_query.dataset),
                 snuba_query.query,
                 snuba_query.aggregate,
                 snuba_query.environment,

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, get_incident_aggregates
 from sentry.incidents.models import INCIDENT_STATUS, IncidentStatus, IncidentTrigger
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 
@@ -45,7 +45,7 @@ def incident_attachment_info(incident, metric_value=None, action=None, method=No
 
     if CRASH_RATE_ALERT_AGGREGATE_ALIAS in alert_rule.snuba_query.aggregate:
         agg_display_key = agg_display_key.split(f"AS {CRASH_RATE_ALERT_AGGREGATE_ALIAS}")[0].strip()
-        dataset = QueryDatasets.SESSIONS
+        dataset = QueryEntity.SESSIONS
 
     agg_text = QUERY_AGGREGATION_DISPLAY.get(agg_display_key, alert_rule.snuba_query.aggregate)
 

--- a/src/sentry/migrations/0233_recreate_subscriptions_in_snuba.py
+++ b/src/sentry/migrations/0233_recreate_subscriptions_in_snuba.py
@@ -4,7 +4,7 @@ import logging
 
 from django.db import migrations
 
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, SnubaQueryEventType
 from sentry.snuba.tasks import _create_in_snuba, _delete_from_snuba
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
@@ -33,14 +33,14 @@ def migrate_subscriptions(apps, schema_editor):
 
             try:
                 _delete_from_snuba(
-                    QueryDatasets(subscription.snuba_query.dataset),
+                    QueryEntity(subscription.snuba_query.dataset),
                     subscription.subscription_id,
                 )
             except Exception as e:
                 try:
                     # Delete the subscription we just created to avoid orphans
                     _delete_from_snuba(
-                        QueryDatasets(subscription.snuba_query.dataset),
+                        QueryEntity(subscription.snuba_query.dataset),
                         subscription_id,
                     )
                 except Exception as oe:

--- a/src/sentry/migrations/0237_recreate_subscriptions_in_snuba.py
+++ b/src/sentry/migrations/0237_recreate_subscriptions_in_snuba.py
@@ -4,7 +4,7 @@ import logging
 
 from django.db import migrations
 
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, SnubaQueryEventType
 from sentry.snuba.tasks import _create_in_snuba, _delete_from_snuba
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
@@ -33,14 +33,14 @@ def migrate_subscriptions(apps, schema_editor):
 
             try:
                 _delete_from_snuba(
-                    QueryDatasets(subscription.snuba_query.dataset),
+                    QueryEntity(subscription.snuba_query.dataset),
                     subscription.subscription_id,
                 )
             except Exception as e:
                 try:
                     # Delete the subscription we just created to avoid orphans
                     _delete_from_snuba(
-                        QueryDatasets(subscription.snuba_query.dataset),
+                        QueryEntity(subscription.snuba_query.dataset),
                         subscription_id,
                     )
                 except Exception as oe:

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -20,7 +20,7 @@ query_aggregation_to_snuba = {
 }
 
 
-class QueryDatasets(Enum):
+class QueryEntity(Enum):
     EVENTS = "events"
     TRANSACTIONS = "transactions"
     SESSIONS = "sessions"

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -13,7 +13,7 @@ from django.conf import settings
 
 from sentry import options
 from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTION_WRAPPER_SCHEMA
-from sentry.snuba.models import QueryDatasets, QuerySubscription
+from sentry.snuba.models import QueryEntity, QuerySubscription
 from sentry.snuba.tasks import _delete_from_snuba
 from sentry.utils import json, kafka_config, metrics
 from sentry.utils.batching_kafka_consumer import wait_for_topics
@@ -52,10 +52,10 @@ class QuerySubscriptionConsumer:
     These values are passed along to a callback associated with the subscription.
     """
 
-    topic_to_dataset: Dict[str, QueryDatasets] = {
-        settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: QueryDatasets.EVENTS,
-        settings.KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: QueryDatasets.TRANSACTIONS,
-        settings.KAFKA_SESSIONS_SUBSCRIPTIONS_RESULTS: QueryDatasets.SESSIONS,
+    topic_to_dataset: Dict[str, QueryEntity] = {
+        settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: QueryEntity.EVENTS,
+        settings.KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: QueryEntity.TRANSACTIONS,
+        settings.KAFKA_SESSIONS_SUBSCRIPTIONS_RESULTS: QueryEntity.SESSIONS,
     }
 
     def __init__(

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -2,7 +2,7 @@ import logging
 
 from django.db import transaction
 
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -40,7 +40,7 @@ def create_snuba_query(
     if not event_types:
         event_types = [
             SnubaQueryEventType.EventType.ERROR
-            if dataset == QueryDatasets.EVENTS
+            if dataset == QueryEntity.EVENTS
             else SnubaQueryEventType.EventType.TRANSACTION
         ]
     sq_event_types = [
@@ -75,7 +75,7 @@ def update_snuba_query(
 
     new_event_types = set(event_types) - current_event_types
     removed_event_types = current_event_types - set(event_types)
-    old_dataset = QueryDatasets(snuba_query.dataset)
+    old_dataset = QueryEntity(snuba_query.dataset)
     with transaction.atomic():
         query_subscriptions = list(snuba_query.subscriptions.all())
         snuba_query.update(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -85,7 +85,7 @@ from sentry.models import (
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, loremipsum
 
@@ -973,7 +973,7 @@ class Factories:
         environment=None,
         excluded_projects=None,
         date_added=None,
-        dataset=QueryDatasets.EVENTS,
+        dataset=QueryEntity.EVENTS,
         threshold_type=AlertRuleThresholdType.ABOVE,
         resolve_threshold=None,
         user=None,

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import subscribe_to_incident
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.testutils import TestCase
 
 
@@ -60,7 +60,7 @@ class DetailedIncidentSerializerTest(TestCase):
 
     def test_transaction_alert_rule(self):
         query = "test query"
-        alert_rule = self.create_alert_rule(dataset=QueryDatasets.TRANSACTIONS, query=query)
+        alert_rule = self.create_alert_rule(dataset=QueryEntity.TRANSACTIONS, query=query)
         incident = self.create_incident(alert_rule=alert_rule)
 
         serializer = DetailedIncidentSerializer()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.models.organizationmember import OrganizationMember
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, SnubaQueryEventType
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
@@ -357,7 +357,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryEntity.TRANSACTIONS)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug)

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -6,7 +6,7 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import IncidentStatus
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.testutils import APITestCase
 
 
@@ -81,7 +81,7 @@ class IncidentListEndpointTest(APITestCase):
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         # alert_rule = self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryEntity.TRANSACTIONS)
 
         perf_incident = self.create_incident(alert_rule=perf_alert_rule)
         incident = self.create_incident()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
 from sentry.models import Integration
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
@@ -46,7 +46,7 @@ class AlertRuleListEndpointTest(APITestCase):
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryEntity.TRANSACTIONS)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug, self.project.slug)
@@ -346,7 +346,7 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryEntity.TRANSACTIONS)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(self.organization.slug, self.project.slug)

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -22,7 +22,7 @@ from sentry.incidents.logic import (
 )
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTriggerAction
 from sentry.models import ACTOR_TYPES, Environment, Integration
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, SnubaQueryEventType
 from sentry.testutils import TestCase
 from sentry.utils import json
 
@@ -34,7 +34,7 @@ class TestAlertRuleSerializer(TestCase):
             "name": "hello",
             "owner": self.user.id,
             "time_window": 10,
-            "dataset": QueryDatasets.EVENTS.value,
+            "dataset": QueryEntity.EVENTS.value,
             "query": "level:error",
             "threshold_type": 0,
             "resolve_threshold": 100,
@@ -64,7 +64,7 @@ class TestAlertRuleSerializer(TestCase):
     @fixture
     def valid_transaction_params(self):
         params = self.valid_params.copy()
-        params["dataset"] = QueryDatasets.TRANSACTIONS.value
+        params["dataset"] = QueryEntity.TRANSACTIONS.value
         params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
         return params
 
@@ -135,7 +135,7 @@ class TestAlertRuleSerializer(TestCase):
 
     def test_dataset(self):
         invalid_values = [
-            "Invalid dataset, valid values are %s" % [item.value for item in QueryDatasets]
+            "Invalid dataset, valid values are %s" % [item.value for item in QueryEntity]
         ]
         self.run_fail_validation_test({"dataset": "events_wrong"}, {"dataset": invalid_values})
 
@@ -199,7 +199,7 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=self.valid_transaction_params)
         assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
-        assert alert_rule.snuba_query.dataset == QueryDatasets.TRANSACTIONS.value
+        assert alert_rule.snuba_query.dataset == QueryEntity.TRANSACTIONS.value
         assert alert_rule.snuba_query.aggregate == "count()"
 
     def test_query_project(self):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -70,7 +70,7 @@ from sentry.incidents.models import (
 from sentry.models import ActorTuple, PagerDutyService
 from sentry.models.integration import Integration
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, QuerySubscription, SnubaQueryEventType
 from sentry.testutils import BaseIncidentsTest, SnubaTestCase, TestCase
 from sentry.utils import json
 
@@ -285,11 +285,11 @@ class GetCrashRateIncidentAggregatesTest(TestCase, SnubaTestCase):
             [self.project],
             query="",
             time_window=1,
-            dataset=QueryDatasets.SESSIONS,
+            dataset=QueryEntity.SESSIONS,
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
         )
         incident.update(alert_rule=alert_rule)
-        assert get_incident_aggregates(incident, dataset=QueryDatasets.SESSIONS) == {
+        assert get_incident_aggregates(incident, dataset=QueryEntity.SESSIONS) == {
             "count": 0.0,
             "unique_users": 2,
         }
@@ -428,7 +428,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.owner is None
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.snuba_query.subscriptions.all().count() == 1
-        assert alert_rule.snuba_query.dataset == QueryDatasets.EVENTS.value
+        assert alert_rule.snuba_query.dataset == QueryEntity.EVENTS.value
         assert alert_rule.snuba_query.query == query
         assert alert_rule.snuba_query.aggregate == aggregate
         assert alert_rule.snuba_query.time_window == time_window * 60

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -39,7 +39,7 @@ from sentry.incidents.subscription_processor import (
     update_alert_rule_stats,
 )
 from sentry.models import Integration
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, QuerySubscription, SnubaQueryEventType
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils import json
@@ -139,7 +139,7 @@ class ProcessUpdateTest(TestCase, SnubaTestCase):
     def crash_rate_alert_rule(self):
         rule = self.create_alert_rule(
             projects=[self.project],
-            dataset=QueryDatasets.SESSIONS,
+            dataset=QueryEntity.SESSIONS,
             name="JustAValidRule",
             query="",
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models import IncidentStatus, IncidentTrigger
 from sentry.integrations.metric_alerts import incident_attachment_info
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.testutils import BaseIncidentsTest, SnubaTestCase, TestCase
 from sentry.utils.dates import to_timestamp
 
@@ -123,7 +123,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         self.alert_rule = self.create_alert_rule(
             query="",
             aggregate=f"percentage({field}_crashed, {field}) AS _crash_rate_alert_aggregate",
-            dataset=QueryDatasets.SESSIONS,
+            dataset=QueryEntity.SESSIONS,
             time_window=60,
         )
         self.incident = self.create_incident(

--- a/tests/sentry/snuba/test_models.py
+++ b/tests/sentry/snuba/test_models.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query
 from sentry.testutils import TestCase
 
@@ -8,7 +8,7 @@ from sentry.testutils import TestCase
 class SnubaQueryEventTypesTest(TestCase):
     def test(self):
         snuba_query = create_snuba_query(
-            QueryDatasets.EVENTS,
+            QueryEntity.EVENTS,
             "release:123",
             "count()",
             timedelta(minutes=10),

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -8,7 +8,7 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 from exam import fixture, patcher
 
-from sentry.snuba.models import QueryDatasets, QuerySubscription
+from sentry.snuba.models import QueryEntity, QuerySubscription
 from sentry.snuba.query_subscription_consumer import (
     InvalidMessageError,
     InvalidSchemaError,
@@ -69,7 +69,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
             pool.urlopen.assert_called_once_with(
                 "DELETE",
                 "/{}/subscriptions/{}".format(
-                    QueryDatasets.EVENTS.value, self.valid_payload["subscription_id"]
+                    QueryEntity.EVENTS.value, self.valid_payload["subscription_id"]
                 ),
             )
         self.metrics.incr.assert_called_once_with(
@@ -93,7 +93,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         register_subscriber(registration_key)(mock_callback)
         with self.tasks():
             snuba_query = create_snuba_query(
-                QueryDatasets.EVENTS,
+                QueryEntity.EVENTS,
                 "hello",
                 "count()",
                 timedelta(minutes=10),

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
+from sentry.snuba.models import QueryEntity, QuerySubscription, SnubaQueryEventType
 from sentry.snuba.subscriptions import (
     bulk_delete_snuba_subscriptions,
     create_snuba_query,
@@ -14,7 +14,7 @@ from sentry.testutils import TestCase
 
 class CreateSnubaQueryTest(TestCase):
     def test(self):
-        dataset = QueryDatasets.EVENTS
+        dataset = QueryEntity.EVENTS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -29,7 +29,7 @@ class CreateSnubaQueryTest(TestCase):
         assert set(snuba_query.event_types) == {SnubaQueryEventType.EventType.ERROR}
 
     def test_environment(self):
-        dataset = QueryDatasets.EVENTS
+        dataset = QueryEntity.EVENTS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -46,7 +46,7 @@ class CreateSnubaQueryTest(TestCase):
         assert set(snuba_query.event_types) == {SnubaQueryEventType.EventType.ERROR}
 
     def test_event_types(self):
-        dataset = QueryDatasets.EVENTS
+        dataset = QueryEntity.EVENTS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -72,7 +72,7 @@ class CreateSnubaQueryTest(TestCase):
 class CreateSnubaSubscriptionTest(TestCase):
     def test(self):
         type = "something"
-        dataset = QueryDatasets.EVENTS
+        dataset = QueryEntity.EVENTS
         query = "level:error"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
@@ -89,7 +89,7 @@ class CreateSnubaSubscriptionTest(TestCase):
     def test_with_task(self):
         with self.tasks():
             type = "something"
-            dataset = QueryDatasets.EVENTS
+            dataset = QueryEntity.EVENTS
             query = "level:error"
             time_window = timedelta(minutes=10)
             resolution = timedelta(minutes=1)
@@ -105,7 +105,7 @@ class CreateSnubaSubscriptionTest(TestCase):
 
     def test_translated_query(self):
         type = "something"
-        dataset = QueryDatasets.EVENTS
+        dataset = QueryEntity.EVENTS
         query = "event.type:error"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
@@ -124,7 +124,7 @@ class CreateSnubaSubscriptionTest(TestCase):
 class UpdateSnubaQueryTest(TestCase):
     def test(self):
         snuba_query = create_snuba_query(
-            QueryDatasets.EVENTS,
+            QueryEntity.EVENTS,
             "hello",
             "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
@@ -132,7 +132,7 @@ class UpdateSnubaQueryTest(TestCase):
             self.environment,
             [SnubaQueryEventType.EventType.ERROR],
         )
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = QueryEntity.TRANSACTIONS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -171,7 +171,7 @@ class UpdateSnubaQueryTest(TestCase):
 
     def test_environment(self):
         snuba_query = create_snuba_query(
-            QueryDatasets.EVENTS,
+            QueryEntity.EVENTS,
             "hello",
             "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
@@ -180,7 +180,7 @@ class UpdateSnubaQueryTest(TestCase):
         )
 
         new_env = self.create_environment()
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = QueryEntity.TRANSACTIONS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -199,7 +199,7 @@ class UpdateSnubaQueryTest(TestCase):
 
     def test_subscriptions(self):
         snuba_query = create_snuba_query(
-            QueryDatasets.EVENTS,
+            QueryEntity.EVENTS,
             "hello",
             "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
@@ -209,7 +209,7 @@ class UpdateSnubaQueryTest(TestCase):
         sub = create_snuba_subscription(self.project, "hi", snuba_query)
 
         new_env = self.create_environment()
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = QueryEntity.TRANSACTIONS
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -224,7 +224,7 @@ class UpdateSnubaQueryTest(TestCase):
 
 class UpdateSnubaSubscriptionTest(TestCase):
     def test(self):
-        old_dataset = QueryDatasets.EVENTS
+        old_dataset = QueryEntity.EVENTS
         with self.tasks():
             snuba_query = create_snuba_query(
                 old_dataset,
@@ -236,7 +236,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             )
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
 
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = QueryEntity.TRANSACTIONS
         query = "level:warning"
         aggregate = "count_unique(tags[sentry:user])"
         time_window = timedelta(minutes=20)
@@ -263,7 +263,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
 
     def test_with_task(self):
         with self.tasks():
-            old_dataset = QueryDatasets.EVENTS
+            old_dataset = QueryEntity.EVENTS
             snuba_query = create_snuba_query(
                 old_dataset,
                 "level:error",
@@ -274,7 +274,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             )
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
 
-            dataset = QueryDatasets.TRANSACTIONS
+            dataset = QueryEntity.TRANSACTIONS
             query = "level:warning"
             aggregate = "count_unique(tags[sentry:user])"
             time_window = timedelta(minutes=20)
@@ -301,7 +301,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
     def test(self):
         with self.tasks():
             snuba_query = create_snuba_query(
-                QueryDatasets.EVENTS,
+                QueryEntity.EVENTS,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),
@@ -310,7 +310,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
             )
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
             snuba_query = create_snuba_query(
-                QueryDatasets.EVENTS,
+                QueryEntity.EVENTS,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),
@@ -336,7 +336,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
     def test(self):
         with self.tasks():
             snuba_query = create_snuba_query(
-                QueryDatasets.EVENTS,
+                QueryEntity.EVENTS,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),
@@ -355,7 +355,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
     def test_with_task(self):
         with self.tasks():
             snuba_query = create_snuba_query(
-                QueryDatasets.EVENTS,
+                QueryEntity.EVENTS,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from exam import fixture
 
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.models import QueryEntity
 from sentry.snuba.query_subscription_consumer import (
     QuerySubscriptionConsumer,
     register_subscriber,
@@ -89,7 +89,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
     def create_subscription(self):
         with self.tasks():
             snuba_query = create_snuba_query(
-                QueryDatasets.EVENTS,
+                QueryEntity.EVENTS,
                 "hello",
                 "count()",
                 timedelta(minutes=1),


### PR DESCRIPTION
Renames `QueryDatasets` to `QueryEntity` as the relationship in snuba from dataset to entity is one to many
and clearly `QueryDatasets` refers to `Entity` in snuba so renaming so that its easier to follow

Adding this change now for Crash Rate Alerts for metrics because in metrics the dataset name is `metrics` while the `QueryDatasets`, or after this PR the `QueryEntity` is `metrics_counters` which is why it makes sense to do the rename to be able to make the distinction