### PR TITLE
feat(ui): Decouple MetricsRequest types from SeriesApi [INGEST-542]

### DIFF
--- a/static/app/types/metrics.tsx
+++ b/static/app/types/metrics.tsx
@@ -1,7 +1,12 @@
 import {DateString} from './core';
-import {SeriesApi} from '.';
 
-export type MetricsApiResponse = SeriesApi & {
+export type MetricsApiResponse = {
+  intervals: string[];
+  groups: {
+    by: Record<string, string>;
+    totals: Record<string, number>;
+    series: Record<string, number[]>;
+  }[];
   start: DateString;
   end: DateString;
   query: string;

--- a/static/app/utils/metrics/metricsRequest.tsx
+++ b/static/app/utils/metrics/metricsRequest.tsx
@@ -6,7 +6,7 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
-import {MetricsApiResponse, Organization} from 'sentry/types';
+import {DateString, MetricsApiResponse, Organization} from 'sentry/types';
 
 const propNamesToIgnore = ['api', 'children'];
 const omitIgnoredProps = (props: Props) =>
@@ -24,11 +24,11 @@ type Props = {
   organization: Organization;
   field: string[];
   children?: (renderProps: MetricsRequestRenderProps) => React.ReactNode;
-  project?: number[];
-  environment?: string[];
+  project?: Readonly<number[]>;
+  environment?: Readonly<string[]>;
   statsPeriod?: string;
-  start?: string;
-  end?: string;
+  start?: DateString;
+  end?: DateString;
   query?: string;
   groupBy?: string[];
   orderBy?: string;


### PR DESCRIPTION
- decoupling MetricsApiResponse type from generic SeriesApi as we want them typed slightly differently
- changing start/end to DateString to be more consistent with the rest of the app
- adding a couple of readonlys