### PR TITLE
feat(codeowners): Limit size of raw in ProjectCodeOwners

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -24,7 +24,8 @@ from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
-MAX_RAW_LENGTH = 100000
+# Max accepted string length of the CODEOWNERS file
+MAX_RAW_LENGTH = 100_000
 
 
 def validate_association(

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -24,6 +24,8 @@ from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
+MAX_RAW_LENGTH = 100000
+
 
 def validate_association(
     raw_items: Sequence[Union[UserEmail, ExternalActor]],
@@ -60,6 +62,16 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
 
         if not attrs.get("raw", "").strip():
             return attrs
+
+        # We want to limit `raw` to a reasonable length, so that people don't end up with values
+        # that are several megabytes large. To not break this functionality for existing customers
+        # we temporarily allow rows that already exceed this limit to still be updated.
+        # We do something similar with ProjectOwnership at the API level.
+        existing_raw = self.instance.raw or ""
+        if len(attrs["raw"]) > MAX_RAW_LENGTH and len(existing_raw) <= MAX_RAW_LENGTH:
+            raise serializers.ValidationError(
+                {"raw": f"Raw needs to be <= {MAX_RAW_LENGTH} characters in length"}
+            )
 
         # Ignore association errors and continue parsing CODEOWNERS for valid lines.
         # Allow users to incrementally fix association errors; for CODEOWNERS with many external mappings.

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -68,7 +68,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
         # that are several megabytes large. To not break this functionality for existing customers
         # we temporarily allow rows that already exceed this limit to still be updated.
         # We do something similar with ProjectOwnership at the API level.
-        existing_raw = self.instance.raw or ""
+        existing_raw = self.instance.raw if self.instance else ""
         if len(attrs["raw"]) > MAX_RAW_LENGTH and len(existing_raw) <= MAX_RAW_LENGTH:
             raise serializers.ValidationError(
                 {"raw": f"Raw needs to be <= {MAX_RAW_LENGTH} characters in length"}


### PR DESCRIPTION
This PR limits the number of characters in raw to 100k. We have a couple customers that cross that threshold: https://redash.getsentry.net/queries/2375/source

For now the older customers will be grandfathered in and so can still write larger rows. We'll work
with these customers to get the size down to something more reasonable.

This PR is a follow up to https://github.com/getsentry/sentry/pull/29628