### PR TITLE
feat(ui): Ability to hide TOC in Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -47,6 +47,8 @@ const withThemeDocs: DecoratorFn = ({children, context}) => {
     context.globals.backgrounds = {value: currentTheme.bodyBackground};
   }
 
+  const {hideToc} = context.parameters;
+
   return (
     <Fragment>
       <DocsContainer context={context}>
@@ -55,7 +57,7 @@ const withThemeDocs: DecoratorFn = ({children, context}) => {
         <ThemeProvider theme={currentTheme}>{children}</ThemeProvider>
       </DocsContainer>
       <ThemeProvider theme={currentTheme}>
-        <TableOfContents />
+        <TableOfContents hidden={!!hideToc} />
       </ThemeProvider>
     </Fragment>
   );

--- a/docs-ui/components/tableOfContents.tsx
+++ b/docs-ui/components/tableOfContents.tsx
@@ -91,7 +91,7 @@ const TableOfContents = ({hidden}: Props) => {
          */
         onClick: () => false,
       });
-  });
+  }, [hidden]);
 
   return (
     <Container>

--- a/docs-ui/components/tableOfContents.tsx
+++ b/docs-ui/components/tableOfContents.tsx
@@ -57,35 +57,50 @@ const Heading = styled('p')`
   margin-bottom: ${space(1)};
 `;
 
-const TableOfContents = () => {
+type Props = {
+  /**
+   * When true, show empty container. We still want the container
+   * (as opposed to showing nothing at all) because it affects the
+   * page layout and we want to preserve the layout across pages.
+   */
+  hidden: boolean;
+};
+
+const TableOfContents = ({hidden}: Props) => {
   useEffect(() => {
-    /** Initialize Tocbot
+    /**
+     * Initialize Tocbot if it's not hidden
      * https://tscanlin.github.io/tocbot/
-     * */
-    tocbot.init({
-      tocSelector: '.toc-wrapper',
-      contentSelector: '.sbdocs-content',
-      headingSelector: 'h2',
-      headingsOffset: 40,
-      scrollSmoothOffset: -40,
-      /** Ignore headings that did not
-       * come from the main markdown code.
-       * */
-      ignoreSelector: ':not(.sbdocs), .hide-from-toc',
-      orderedList: false,
-      /** Prevent default linking behavior,
-       * leaving only the smooth scrolling.
-       *  */
-      onClick: () => false,
-    });
+     */
+    !hidden &&
+      tocbot.init({
+        tocSelector: '.toc-wrapper',
+        contentSelector: '.sbdocs-content',
+        headingSelector: 'h2',
+        headingsOffset: 40,
+        scrollSmoothOffset: -40,
+        /**
+         * Ignore headings that did not
+         * come from the main markdown code.
+         */
+        ignoreSelector: ':not(.sbdocs), .hide-from-toc',
+        orderedList: false,
+        /**
+         * Prevent default linking behavior,
+         * leaving only the smooth scrolling.
+         */
+        onClick: () => false,
+      });
   });
 
   return (
     <Container>
-      <Content>
-        <Heading>Contents</Heading>
-        <div className="toc-wrapper" />
-      </Content>
+      {!hidden && (
+        <Content hidden={hidden}>
+          <Heading>Contents</Heading>
+          <div className="toc-wrapper" />
+        </Content>
+      )}
     </Container>
   );
 };

--- a/docs-ui/components/tableOfContents.tsx
+++ b/docs-ui/components/tableOfContents.tsx
@@ -96,7 +96,7 @@ const TableOfContents = ({hidden}: Props) => {
   return (
     <Container>
       {!hidden && (
-        <Content hidden={hidden}>
+        <Content>
           <Heading>Contents</Heading>
           <div className="toc-wrapper" />
         </Content>


### PR DESCRIPTION
Adding a Storybook parameter called `hideToc` (toc = Table of Contents) that can be specified in the `<Meta />` tag, like so:

```jsx
<Meta title="xxx" parameters={{hideToc: true}} />
```

This will hide the TOC content:
<img width="1288" alt="Screen Shot 2021-11-29 at 11 43 01 AM" src="https://user-images.githubusercontent.com/44172267/143932603-394423a9-968d-4167-99ce-b43a1808508f.png">
