### PR TITLE
fix(performance): Use short name for overview duration chart

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart.tsx
@@ -50,8 +50,7 @@ type Props = WithRouterProps &
   };
 
 function generateYAxisValues(currentFilter: SpanOperationBreakdownFilter) {
-  const field =
-    SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter] ?? 'transaction.duration';
+  const field = SPAN_OPERATION_BREAKDOWN_FILTER_TO_FIELD[currentFilter] ?? '';
   return [
     `p50(${field})`,
     `p75(${field})`,


### PR DESCRIPTION
This was changed to use `p99(transaction.duration)` explicitly in #30243 which
had the unintended side effect of changing the series names, thus the `p100()`
series was not being disabled by default anymore. Change this back to use
`p99()` again for the shorter series name and automatic disabling of the
`p100()` series.