### PR TITLE
fix(eslint): webpack config path in docs-ui's eslintrc

### DIFF
--- a/docs-ui/.eslintrc.js
+++ b/docs-ui/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: path.join(__dirname, '../.storybook/webpack.config.js'),
+        config: path.join(__dirname, '../.storybook/webpack.config.ts'),
       },
     },
     'import/extensions': ['.js', '.jsx'],


### PR DESCRIPTION
The webpack config file in .storybook is now a typescript file. We need to update its path reference in docs-ui/.eslintrc.js. Otherwise, running eslint on docs-ui will cause an error.