### PR TITLE
style(readme): Fix readme images width

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ in realtime. The server is in Python, but it contains a full API for
 sending events from any language, in any application.
 
 <p align="center">
-  <img src="https://github.com/getsentry/sentry/raw/master/docs/screenshots/thumb-1.png" width="290">
-  <img src="https://github.com/getsentry/sentry/raw/master/docs/screenshots/thumb-2.png" width="290">
-  <img src="https://github.com/getsentry/sentry/raw/master/docs/screenshots/thumb-3.png" width="290">
+  <img src="https://github.com/getsentry/sentry/raw/master/docs/screenshots/thumb-1.png" width="270">
+  <img src="https://github.com/getsentry/sentry/raw/master/docs/screenshots/thumb-2.png" width="270">
+  <img src="https://github.com/getsentry/sentry/raw/master/docs/screenshots/thumb-3.png" width="270">
 </p>
 
 ## Official Sentry SDKs


### PR DESCRIPTION
So they don't wrap to a 2nd line

![image](https://user-images.githubusercontent.com/1421724/143939101-aee2bb74-e457-49fe-b00b-e6c03c904d37.png)
