### PR TITLE
ref(sentry-apps): Send SentryAppAvatar info along with components payload

### DIFF
--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -2,8 +2,9 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
-from sentry.models import IntegrationFeature, SentryApp, SentryAppAvatar
+from sentry.models import IntegrationFeature, SentryApp
 from sentry.models.sentryapp import MASKED_VALUE
+from sentry.models.sentryappavatar import get_sentry_app_avatars
 from sentry.utils.compat import map
 
 
@@ -53,16 +54,5 @@ class SentryAppSerializer(Serializer):
                 }
             )
 
-        data.update(
-            {
-                "avatars": [
-                    {
-                        "avatarType": img.get_avatar_type_display(),
-                        "avatarUuid": img.ident,
-                        "color": img.color,
-                    }
-                    for img in SentryAppAvatar.objects.filter(sentry_app=obj)
-                ]
-            }
-        )
+        data.update({"avatars": get_sentry_app_avatars(sentry_app=obj)})
         return data

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -53,6 +53,6 @@ class SentryAppSerializer(Serializer):
                 }
             )
 
-        data.update({"avatars": [serialize(avatar) for avatar in obj.sentry_app.avatars.all()]})
+        data.update({"avatars": [serialize(avatar) for avatar in obj.avatars.all()]})
 
         return data

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -53,6 +53,6 @@ class SentryAppSerializer(Serializer):
                 }
             )
 
-        data.update({"avatars": [serialize(avatar) for avatar in obj.avatars.all()]})
+        data.update({"avatars": [serialize(avatar) for avatar in obj.avatar.all()]})
 
         return data

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -4,7 +4,6 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.models import IntegrationFeature, SentryApp
 from sentry.models.sentryapp import MASKED_VALUE
-from sentry.models.sentryappavatar import get_sentry_app_avatars
 from sentry.utils.compat import map
 
 
@@ -54,5 +53,6 @@ class SentryAppSerializer(Serializer):
                 }
             )
 
-        data.update({"avatars": get_sentry_app_avatars(sentry_app=obj)})
+        data.update({"avatars": [serialize(avatar) for avatar in obj.sentry_app.avatars.all()]})
+
         return data

--- a/src/sentry/api/serializers/models/sentry_app_avatar.py
+++ b/src/sentry/api/serializers/models/sentry_app_avatar.py
@@ -1,0 +1,17 @@
+from typing import MutableMapping
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import SentryAppAvatar
+from sentry.utils.json import JSONData
+
+
+@register(SentryAppAvatar)
+class SentryAppAvatarSerializer(Serializer):
+    def serialize(
+        self, obj: SentryAppAvatar, attrs, user, **kwargs
+    ) -> MutableMapping[str, JSONData]:
+        return {
+            "avatarType": obj.get_avatar_type_display(),
+            "avatarUuid": obj.ident,
+            "color": obj.color,
+        }

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -1,5 +1,6 @@
 from sentry.api.serializers import Serializer, register
 from sentry.models import SentryAppComponent
+from sentry.models.sentryappavatar import get_sentry_app_avatars
 
 
 @register(SentryAppComponent)
@@ -13,7 +14,7 @@ class SentryAppComponentSerializer(Serializer):
                 "uuid": obj.sentry_app.uuid,
                 "slug": obj.sentry_app.slug,
                 "name": obj.sentry_app.name,
-                "avatars": obj.sentry_app.avatars,
+                "avatars": get_sentry_app_avatars(sentry_app=obj.sentry_app),
             },
         }
 

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -13,6 +13,7 @@ class SentryAppComponentSerializer(Serializer):
                 "uuid": obj.sentry_app.uuid,
                 "slug": obj.sentry_app.slug,
                 "name": obj.sentry_app.name,
+                "avatars": obj.sentry_app.avatars,
             },
         }
 

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -14,7 +14,7 @@ class SentryAppComponentSerializer(Serializer):
                 "uuid": obj.sentry_app.uuid,
                 "slug": obj.sentry_app.slug,
                 "name": obj.sentry_app.name,
-                "avatars": [serialize(avatar) for avatar in obj.sentry_app.avatars.all()],
+                "avatars": [serialize(avatar) for avatar in obj.sentry_app.avatar.all()],
             },
         }
 

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -1,6 +1,6 @@
 from sentry.api.serializers import Serializer, register
+from sentry.api.serializers.base import serialize
 from sentry.models import SentryAppComponent
-from sentry.models.sentryappavatar import get_sentry_app_avatars
 
 
 @register(SentryAppComponent)
@@ -14,7 +14,7 @@ class SentryAppComponentSerializer(Serializer):
                 "uuid": obj.sentry_app.uuid,
                 "slug": obj.sentry_app.slug,
                 "name": obj.sentry_app.name,
-                "avatars": get_sentry_app_avatars(sentry_app=obj.sentry_app),
+                "avatars": [serialize(avatar) for avatar in obj.sentry_app.avatars.all()],
             },
         }
 

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -26,7 +26,7 @@ class SentryAppAvatar(AvatarBase):
 
     FILE_TYPE = "avatar.file"
 
-    sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="avatars")
+    sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="avatar")
     avatar_type = models.PositiveSmallIntegerField(default=0, choices=AVATAR_TYPES)
     color = models.BooleanField(default=False)
     # e.g. issue linking logos will not have color

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -1,10 +1,25 @@
 from enum import Enum
+from typing import TYPE_CHECKING, Iterable, Mapping, Union
 
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey
 
 from . import AvatarBase
+
+if TYPE_CHECKING:
+    from sentry.models import SentryApp
+
+
+def get_sentry_app_avatars(sentry_app: "SentryApp") -> Iterable[Mapping[str, Union[str, bool]]]:
+    return [
+        {
+            "avatarType": img.get_avatar_type_display(),
+            "avatarUuid": img.ident,
+            "color": img.color,
+        }
+        for img in SentryAppAvatar.objects.filter(sentry_app=sentry_app)
+    ]
 
 
 class SentryAppAvatarTypes(Enum):

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -1,25 +1,10 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Mapping, Union
 
 from django.db import models
 
 from sentry.db.models import FlexibleForeignKey
 
 from . import AvatarBase
-
-if TYPE_CHECKING:
-    from sentry.models import SentryApp
-
-
-def get_sentry_app_avatars(sentry_app: "SentryApp") -> Iterable[Mapping[str, Union[str, bool]]]:
-    return [
-        {
-            "avatarType": img.get_avatar_type_display(),
-            "avatarUuid": img.ident,
-            "color": img.color,
-        }
-        for img in SentryAppAvatar.objects.filter(sentry_app=sentry_app)
-    ]
 
 
 class SentryAppAvatarTypes(Enum):
@@ -41,7 +26,7 @@ class SentryAppAvatar(AvatarBase):
 
     FILE_TYPE = "avatar.file"
 
-    sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="avatar")
+    sentry_app = FlexibleForeignKey("sentry.SentryApp", related_name="avatars")
     avatar_type = models.PositiveSmallIntegerField(default=0, choices=AVATAR_TYPES)
     color = models.BooleanField(default=False)
     # e.g. issue linking logos will not have color

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -41,7 +41,7 @@ class SentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app.uuid,
                 "slug": self.sentry_app.slug,
                 "name": self.sentry_app.name,
-                "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app),
+                "avatars": get_sentry_app_avatars(self.sentry_app),
             },
         }
 
@@ -101,7 +101,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app1.uuid,
                 "slug": self.sentry_app1.slug,
                 "name": self.sentry_app1.name,
-                "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app1),
+                "avatars": get_sentry_app_avatars(self.sentry_app1),
             },
         }
 
@@ -113,7 +113,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app2.uuid,
                 "slug": self.sentry_app2.slug,
                 "name": self.sentry_app2.name,
-                "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app2),
+                "avatars": get_sentry_app_avatars(self.sentry_app2),
             },
         }
 
@@ -155,7 +155,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                     "uuid": sentry_app.uuid,
                     "slug": sentry_app.slug,
                     "name": sentry_app.name,
-                    "avatars": get_sentry_app_avatars(sentry_app=sentry_app),
+                    "avatars": get_sentry_app_avatars(sentry_app),
                 },
             }
         ]

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -1,9 +1,14 @@
 from unittest.mock import call, patch
 
+from sentry.api.serializers.base import serialize
 from sentry.constants import SentryAppInstallationStatus
 from sentry.coreapi import APIError
-from sentry.models.sentryappavatar import get_sentry_app_avatars
+from sentry.models.sentryapp import SentryApp
 from sentry.testutils import APITestCase
+
+
+def get_sentry_app_avatars(sentry_app: SentryApp):
+    return [serialize(avatar) for avatar in sentry_app.avatars.all()]
 
 
 class SentryAppComponentsTest(APITestCase):
@@ -183,7 +188,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                     "uuid": self.sentry_app2.uuid,
                     "slug": self.sentry_app2.slug,
                     "name": self.sentry_app2.name,
-                    "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app2),
+                    "avatars": get_sentry_app_avatars(self.sentry_app2),
                 },
             }
         ]

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -35,6 +35,7 @@ class SentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app.uuid,
                 "slug": self.sentry_app.slug,
                 "name": self.sentry_app.name,
+                "avatars": self.sentry_app.avatars,
             },
         }
 
@@ -94,6 +95,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app1.uuid,
                 "slug": self.sentry_app1.slug,
                 "name": self.sentry_app1.name,
+                "avatars": self.sentry_app1.avatars,
             },
         }
 
@@ -105,6 +107,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app2.uuid,
                 "slug": self.sentry_app2.slug,
                 "name": self.sentry_app2.name,
+                "avatars": self.sentry_app2.avatars,
             },
         }
 
@@ -146,6 +149,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                     "uuid": sentry_app.uuid,
                     "slug": sentry_app.slug,
                     "name": sentry_app.name,
+                    "avatars": sentry_app.avatars,
                 },
             }
         ]
@@ -178,6 +182,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                     "uuid": self.sentry_app2.uuid,
                     "slug": self.sentry_app2.slug,
                     "name": self.sentry_app2.name,
+                    "avatars": self.sentry_app2.avatars,
                 },
             }
         ]

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -8,7 +8,7 @@ from sentry.testutils import APITestCase
 
 
 def get_sentry_app_avatars(sentry_app: SentryApp):
-    return [serialize(avatar) for avatar in sentry_app.avatars.all()]
+    return [serialize(avatar) for avatar in sentry_app.avatar.all()]
 
 
 class SentryAppComponentsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -2,6 +2,7 @@ from unittest.mock import call, patch
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.coreapi import APIError
+from sentry.models.sentryappavatar import get_sentry_app_avatars
 from sentry.testutils import APITestCase
 
 
@@ -35,7 +36,7 @@ class SentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app.uuid,
                 "slug": self.sentry_app.slug,
                 "name": self.sentry_app.name,
-                "avatars": self.sentry_app.avatars,
+                "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app),
             },
         }
 
@@ -95,7 +96,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app1.uuid,
                 "slug": self.sentry_app1.slug,
                 "name": self.sentry_app1.name,
-                "avatars": self.sentry_app1.avatars,
+                "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app1),
             },
         }
 
@@ -107,7 +108,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": self.sentry_app2.uuid,
                 "slug": self.sentry_app2.slug,
                 "name": self.sentry_app2.name,
-                "avatars": self.sentry_app2.avatars,
+                "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app2),
             },
         }
 
@@ -149,7 +150,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                     "uuid": sentry_app.uuid,
                     "slug": sentry_app.slug,
                     "name": sentry_app.name,
-                    "avatars": sentry_app.avatars,
+                    "avatars": get_sentry_app_avatars(sentry_app=sentry_app),
                 },
             }
         ]
@@ -182,7 +183,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                     "uuid": self.sentry_app2.uuid,
                     "slug": self.sentry_app2.slug,
                     "name": self.sentry_app2.name,
-                    "avatars": self.sentry_app2.avatars,
+                    "avatars": get_sentry_app_avatars(sentry_app=self.sentry_app2),
                 },
             }
         ]


### PR DESCRIPTION
Since we render icons along side certain UI components, it'd be helpful to also receive information about the avatars along with the basic app info.

This will help avoid an extra API call on the Issue Details page (which already has a lot going on).

_(This PR will also be used as evidence in my argument for GraphQL-ing our API)_

