### PR TITLE
Revert "chore(js): Upgrade typescript (#30268)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "style-loader": "^3.0.0",
     "ts-node": "^10.1.0",
     "tslib": "^2.3.1",
-    "typescript": "^4.5.2",
+    "typescript": "^4.4.4",
     "u2f-api": "1.0.10",
     "webpack": "5.48.0",
     "webpack-cli": "4.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14488,10 +14488,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 u2f-api@1.0.10:
   version "1.0.10"


### PR DESCRIPTION
This reverts commit 22f41316ae0b15eb639322ec53005146e22ffbad.

We're seeing this regression https://github.com/microsoft/TypeScript/issues/46587