### PR TITLE
fix(ui): Add resolve threshold to metric alert chart

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -519,6 +519,15 @@ class MetricChart extends React.PureComponent<Props, State> {
       maxThresholdValue = Math.max(maxThresholdValue, alertThreshold);
     }
 
+    if (!rule.comparisonDelta && rule.resolveThreshold) {
+      const resolveThresholdLine = createThresholdSeries(
+        theme.green300,
+        rule.resolveThreshold
+      );
+      series.push(resolveThresholdLine);
+      maxThresholdValue = Math.max(maxThresholdValue, rule.resolveThreshold);
+    }
+
     const comparisonSeriesName = capitalize(
       COMPARISON_DELTA_OPTIONS.find(({value}) => value === rule.comparisonDelta)?.label ||
         ''


### PR DESCRIPTION
This adds the resolve threshold line alongside critical and warning threshold line to the alert details chart

Old chart:
<img width="1307" alt="Screen Shot 2021-11-29 at 5 55 57 PM" src="https://user-images.githubusercontent.com/15015880/143971678-8c805476-4b17-4a74-b7e9-bd44e501c49d.png">

New chart:
<img width="1310" alt="Screen Shot 2021-11-29 at 5 55 32 PM" src="https://user-images.githubusercontent.com/15015880/143971736-810ea8eb-9287-492c-81cd-fbda2559c43f.png">

