### PR TITLE
fix(ui): Add rule name to the document title in alert rule details page

### DIFF
--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -7,6 +7,7 @@ import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {Client, ResponseMeta} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import DateTime from 'sentry/components/dateTime';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
@@ -216,6 +217,8 @@ class AlertRuleDetails extends Component<Props, State> {
 
     return (
       <Fragment>
+        <SentryDocumentTitle title={rule?.name ?? ''} />
+
         <DetailsHeader
           hasIncidentRuleDetailsError={hasError}
           params={params}


### PR DESCRIPTION
This adds the alert rule name to the document title in the alert rule details page, before it only had `Sentry`

Example:
<img width="252" alt="Screen Shot 2021-11-29 at 6 14 34 PM" src="https://user-images.githubusercontent.com/15015880/143973674-22012c55-c4bd-4718-9571-99b01d7fb9c5.png">