### PR TITLE
fix(reprocessing2): Batch tombstone creation [NATIVE-416]

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1294,7 +1294,6 @@ def _handle_regression(group, event, release):
     group.status = GroupStatus.UNRESOLVED
 
     if is_regression and release:
-        # TODO: pyright is complaining about resolution being unbound
         resolution = None
 
         # resolutions are only valid if the state of the group is still
@@ -1309,7 +1308,6 @@ def _handle_regression(group, event, release):
             cursor.execute("DELETE FROM sentry_groupresolution WHERE id = %s", [resolution.id])
             affected = cursor.rowcount > 0
 
-        # TODO: pyright is complaining about resolution being unbound
         if affected and resolution:
             # if we had to remove the GroupResolution (i.e. we beat the
             # the queue to handling this) then we need to also record

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -14,7 +14,7 @@ from django.db.models import Func
 from django.utils.encoding import force_text
 from pytz import UTC
 
-from sentry import (  # reprocessing2,
+from sentry import (
     buffer,
     eventstore,
     eventstream,
@@ -22,6 +22,7 @@ from sentry import (  # reprocessing2,
     features,
     options,
     quotas,
+    reprocessing2,
     tsdb,
 )
 from sentry.attachments import MissingAttachmentChunks, attachment_cache
@@ -519,17 +520,17 @@ class EventManager:
                     project=project, event=job["event"], sender=Project
                 )
 
-        # if is_reprocessed:
-        # safe_execute(
-        #     reprocessing2.buffered_delete_old_primary_hash,
-        #     project_id=job["event"].project_id,
-        #     group_id=job["event"].group_id,
-        #     event_id=job["event"].event_id,
-        #     datetime=job["event"].datetime,
-        #     old_primary_hash=reprocessing2.get_original_primary_hash(job["event"]),
-        #     current_primary_hash=job["event"].get_primary_hash(),
-        #     _with_transaction=False,
-        # )
+        if is_reprocessed:
+            safe_execute(
+                reprocessing2.buffered_delete_old_primary_hash,
+                project_id=job["event"].project_id,
+                group_id=job["event"].group_id,
+                event_id=job["event"].event_id,
+                datetime=job["event"].datetime,
+                old_primary_hash=reprocessing2.get_original_primary_hash(job["event"]),
+                current_primary_hash=job["event"].get_primary_hash(),
+                _with_transaction=False,
+            )
 
         _eventstream_insert_many(jobs)
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -524,7 +524,7 @@ class EventManager:
             safe_execute(
                 reprocessing2.buffered_delete_old_primary_hash,
                 project_id=job["event"].project_id,
-                group_id=job["event"].group_id,
+                group_id=reprocessing2.get_original_group_id(job["event"]),
                 event_id=job["event"].event_id,
                 datetime=job["event"].datetime,
                 old_primary_hash=reprocessing2.get_original_primary_hash(job["event"]),

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -14,7 +14,7 @@ from django.db.models import Func
 from django.utils.encoding import force_text
 from pytz import UTC
 
-from sentry import (
+from sentry import (  # reprocessing2,
     buffer,
     eventstore,
     eventstream,
@@ -22,7 +22,6 @@ from sentry import (
     features,
     options,
     quotas,
-    reprocessing2,
     tsdb,
 )
 from sentry.attachments import MissingAttachmentChunks, attachment_cache
@@ -520,17 +519,17 @@ class EventManager:
                     project=project, event=job["event"], sender=Project
                 )
 
-        if is_reprocessed:
-            safe_execute(
-                reprocessing2.buffered_delete_old_primary_hash,
-                project_id=job["event"].project_id,
-                group_id=job["event"].group_id,
-                event_id=job["event"].event_id,
-                datetime=job["event"].datetime,
-                old_primary_hash=reprocessing2.get_original_primary_hash(job["event"]),
-                current_primary_hash=job["event"].get_primary_hash(),
-                _with_transaction=False,
-            )
+        # if is_reprocessed:
+        # safe_execute(
+        #     reprocessing2.buffered_delete_old_primary_hash,
+        #     project_id=job["event"].project_id,
+        #     group_id=job["event"].group_id,
+        #     event_id=job["event"].event_id,
+        #     datetime=job["event"].datetime,
+        #     old_primary_hash=reprocessing2.get_original_primary_hash(job["event"]),
+        #     current_primary_hash=job["event"].get_primary_hash(),
+        #     _with_transaction=False,
+        # )
 
         _eventstream_insert_many(jobs)
 

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -312,14 +312,14 @@ def buffered_delete_old_primary_hash(event, force_flush_batch: bool = False):
             # otherwise.
             return
 
-        delete_old_primary_hash(
+        _delete_old_primary_hash(
             project_id=event.project_id,
             old_primary_hash=old_primary_hash,
             event_ids_redis_key=new_key,
         )
 
 
-def delete_old_primary_hash(
+def _delete_old_primary_hash(
     project_id,
     old_primary_hash,
     event_ids_redis_key,

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -323,8 +323,6 @@ def _delete_old_primary_hash(
     project_id,
     old_primary_hash,
     event_ids_redis_key,
-    # TODO: Deprecated argument, can remove in next version.
-    event=None,
 ):
     """In case the primary hash changed during reprocessing, we need to tell
     Snuba before reinserting the event. Snuba may then insert a tombstone row

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -264,6 +264,10 @@ def reprocess_event(project_id, event_id, start_time):
     )
 
 
+def get_original_group_id(event):
+    return get_path(event.data, "contexts", "reprocessing", "original_issue_id")
+
+
 def get_original_primary_hash(event):
     return get_path(event.data, "contexts", "reprocessing", "original_primary_hash")
 

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -299,9 +299,10 @@ def buffered_delete_old_primary_hash(
 
     client = _get_sync_redis_client()
 
-    # This is a meta key that contains old primary hashes. These hashes are then combined with
-    # other values to construct a key that points to a list of tombstonable events.
-    primary_hash_set_key = f"re2:tombstone-primary-hashes:{{{project_id}:{group_id}}}"
+    # This is a meta key that contains old primary hashes. These hashes are then
+    # combined with other values to construct a key that points to a list of
+    # tombstonable events.
+    primary_hash_set_key = f"re2:tombstone-primary-hashes:{project_id}:{group_id}"
     old_primary_hashes = client.smembers(primary_hash_set_key)
 
     def build_event_key(primary_hash):

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -295,7 +295,6 @@ def buffered_delete_old_primary_hash(
     # This is a meta key that contains old primary hashes. These hashes are then combined with
     # other values to construct a key that points to a list of tombstonable events.
     primary_hash_set_key = f"re2:tombstone-primary-hashes:{{{project_id}:{group_id}}}"
-    # todo: is this an empty list or none if the key doesn't exist?
     old_primary_hashes = client.smembers(primary_hash_set_key)
 
     def build_event_key(primary_hash):

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -350,25 +350,21 @@ def buffered_delete_old_primary_hash(
                 event_ids_redis_key=new_key,
             )
 
-        # Try to track counts so if it turns out that tombstoned events trend towards a ratio of 1
-        # event per hash, a different solution may need to be considered.
-        ratio = 0 if len(old_primary_hashes) == 0 else event_count / len(old_primary_hashes)
-        metrics.gauge(
-            "reprocessing2.buffered_delete_old_primary_hash.event_count",
-            event_count,
-            {
-                "project_id": project_id,
-                "group_id": group_id,
-            },
-        )
-        metrics.gauge(
-            "reprocessing2.buffered_delete_old_primary_hash.primary_hash_to_event_ratio",
-            ratio,
-            {
-                "project_id": project_id,
-                "group_id": group_id,
-            },
-        )
+    # Try to track counts so if it turns out that tombstoned events trend towards a ratio of 1
+    # event per hash, a different solution may need to be considered.
+    ratio = 0 if len(old_primary_hashes) == 0 else event_count / len(old_primary_hashes)
+    metrics.timing(
+        key="reprocessing2.buffered_delete_old_primary_hash.event_count",
+        value=event_count,
+    )
+    metrics.timing(
+        key="reprocessing2.buffered_delete_old_primary_hash.primary_hash_count",
+        value=len(old_primary_hashes),
+    )
+    metrics.timing(
+        key="reprocessing2.buffered_delete_old_primary_hash.primary_hash_to_event_ratio",
+        value=ratio,
+    )
 
 
 def _delete_old_primary_hash(

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -312,6 +312,9 @@ def buffered_delete_old_primary_hash(
             client.sadd(primary_hash_set_key, old_primary_hash)
             client.expire(primary_hash_set_key, settings.SENTRY_REPROCESSING_SYNC_TTL)
 
+    # Events for a group are split and bucketed by their primary hashes. If flushing is to be
+    # performed on a per-group basis, the event count needs to be summed up across all buckets
+    # belonging to a single group.
     event_count = 0
     for primary_hash in old_primary_hashes:
         key = build_event_key(primary_hash)

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -281,6 +281,9 @@ def buffered_delete_old_primary_hash(
     Like `buffered_handle_remaining_events`, is a quick and dirty way to batch
     event IDs so requests to tombstone rows are not being individually sent
     over to Snuba.
+
+    See `_delete_old_primary_hash` for an explanation of the purpose and
+    intent of this routine.
     """
 
     from sentry import killswitches

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -314,6 +314,7 @@ def buffered_delete_old_primary_hash(
         client.expire(event_key, settings.SENTRY_REPROCESSING_SYNC_TTL)
 
         if old_primary_hash not in old_primary_hashes:
+            old_primary_hashes.add(old_primary_hash)
             client.sadd(primary_hash_set_key, old_primary_hash)
             client.expire(primary_hash_set_key, settings.SENTRY_REPROCESSING_SYNC_TTL)
 

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -330,15 +330,9 @@ def buffered_delete_old_primary_hash(
             old_key = build_event_key(primary_hash)
             new_key = f"{old_key}:{uuid.uuid4().hex}"
 
-            try:
-                # Rename the event key to a new temp key that is passed to celery task. We
-                # use `renamenx` instead of `rename` only to detect UUID collisions.
-                assert client.renamenx(old_key, new_key), "UUID collision for new_key?"
-            except redis.exceptions.ResponseError:
-                # `key` does not exist in Redis. `ResponseError` is a bit too broad
-                # but it seems we'd have to do string matching on error message
-                # otherwise.
-                continue
+            assert client.renamenx(old_key, new_key), "UUID collision for new_key?"
+
+            # TODO: inline the below bit
 
             # In the worst case scenario, a group will have a 1:1 mapping of primary hashes to
             # events, which means 1 insert per event.

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -27,7 +27,7 @@ How reprocessing works
    A group redirect is installed. The old group is deleted, while the new group
    is unresolved. This effectively unsets the REPROCESSING status.
 
-   A user looking at the progressbar on the old group's URL is supposed to be
+   A user looking at the progress bar on the old group's URL is supposed to be
    redirected at this point. The new group can either:
 
    a. Have events by itself, but also show a success message based on the data in activity.

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -521,8 +521,8 @@ def pop_batched_events_from_redis(key):
     min_datetime = None
     max_datetime = None
 
-    for item in client.lrange(key, 0, -1):
-        datetime_raw, event_id = item.split(";")
+    for row in client.lrange(key, 0, -1):
+        datetime_raw, event_id = row.split(";")
         datetime = to_datetime(float(datetime_raw))
 
         assert datetime is not None

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -362,7 +362,7 @@ def buffered_delete_old_primary_hash(
                         scope.set_tag("old_group_id", group_id)
                         scope.set_tag("old_primary_hash", old_primary_hash)
 
-                    logger.error("events_batch.not_found")
+                    logger.error("reprocessing2.buffered_delete_old_primary_hash.empty_batch")
                     return
 
                 from sentry import eventstream

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -296,6 +296,18 @@ def buffered_delete_old_primary_hash(
     Like `buffered_handle_remaining_events` this is a quick and dirty way to
     batch event IDs so requests to tombstone rows are not being individually
     sent over to Snuba.
+
+    This also includes the same constraints for optimal performance as
+    `buffered_handle_remaining_events` in that events being fed to this
+    should have datetimes as close to each other as possible. The assumption
+    is that since this goes through the same pipeline as
+    `buffered_handle_remaining_events`, this requirement continues to be
+    fulfilled.
+
+    This does not batch events which have different old primary hashes
+    together into one operation. This means that if the data being fed in
+    tends to have a 1:1 ratio of event:old primary hashes, then the
+    buffering in this effectively does nothing.
     """
 
     from sentry import killswitches

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -357,9 +357,9 @@ def buffered_delete_old_primary_hash(
 
                 if len(event_ids) == 0:
                     with sentry_sdk.push_scope() as scope:
-                        scope.set_tag("old_primary_hash", old_primary_hash)
                         scope.set_tag("project_id", project_id)
                         scope.set_tag("old_group_id", group_id)
+                        scope.set_tag("old_primary_hash", old_primary_hash)
                         raise CannotReprocess("events_batch.not_found")
 
                 from sentry import eventstream

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -293,21 +293,21 @@ def buffered_delete_old_primary_hash(
     did not change, nothing needs to be done as ClickHouse's table merge will
     merge the two rows together.
 
-    Like `buffered_handle_remaining_events` this is a quick and dirty way to
+    Like `buffered_handle_remaining_events`, this is a quick and dirty way to
     batch event IDs so requests to tombstone rows are not being individually
     sent over to Snuba.
 
     This also includes the same constraints for optimal performance as
-    `buffered_handle_remaining_events` in that events being fed to this
-    should have datetimes as close to each other as possible. The assumption
-    is that since this goes through the same pipeline as
-    `buffered_handle_remaining_events`, this requirement continues to be
-    fulfilled.
+    `buffered_handle_remaining_events` in that events being fed to this should
+    have datetimes as close to each other as possible. Unfortunately, this
+    function is invoked by tasks that are run asynchronously and therefore the
+    guarantee from `buffered_handle_remaining_events` regarding events being
+    sorted by timestamps is not applicable here.
 
-    This does not batch events which have different old primary hashes
-    together into one operation. This means that if the data being fed in
-    tends to have a 1:1 ratio of event:old primary hashes, then the
-    buffering in this effectively does nothing.
+    This function also does not batch events which have different old primary
+    hashes together into one operation. This means that if the data being fed
+    in tends to have a 1:1 ratio of event:old primary hashes, then the buffering
+    in this effectively does nothing.
     """
 
     from sentry import killswitches

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -74,13 +74,6 @@ def reprocess_group(
             remaining_events=remaining_events,
             force_flush_batch=True,
         )
-        # Tombstone unwanted events that should be dropped after new group
-        # is generated after reprocessing
-        buffered_delete_old_primary_hash(
-            project_id=project_id,
-            group_id=group_id,
-            force_flush_batch=True,
-        )
 
         return
 
@@ -248,6 +241,14 @@ def finish_reprocessing(project_id, group_id):
         # All the associated models (groupassignee and eventattachments) should
         # have moved to a successor group that may be deleted independently.
         group.delete()
+
+    # Tombstone unwanted events that should be dropped after new group
+    # is generated after reprocessing
+    buffered_delete_old_primary_hash(
+        project_id=project_id,
+        group_id=group_id,
+        force_flush_batch=True,
+    )
 
     eventstream.exclude_groups(project_id, [group_id])
 

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -76,11 +76,8 @@ def reprocess_group(
         # Tombstone unwanted events that should be dropped after new group
         # is generated after reprocessing
         buffered_delete_old_primary_hash(
-            event={
-                "project_id": project_id,
-                "group_id": group_id,
-                "data": None,
-            },
+            project_id=project_id,
+            group_id=group_id,
             force_flush_batch=True,
         )
 

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -41,6 +41,7 @@ def reprocess_group(
 
     sentry_sdk.set_tag("is_start", "false")
 
+    # Only executed once during reprocessing
     if start_time is None:
         assert new_group_id is None
         start_time = time.time()
@@ -75,11 +76,11 @@ def reprocess_group(
         )
         # Tombstone unwanted events that should be dropped after new group
         # is generated after reprocessing
-        buffered_delete_old_primary_hash(
-            project_id=project_id,
-            group_id=group_id,
-            force_flush_batch=True,
-        )
+        # buffered_delete_old_primary_hash(
+        #     project_id=project_id,
+        #     group_id=group_id,
+        #     force_flush_batch=True,
+        # )
 
         return
 

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -76,11 +76,11 @@ def reprocess_group(
         )
         # Tombstone unwanted events that should be dropped after new group
         # is generated after reprocessing
-        # buffered_delete_old_primary_hash(
-        #     project_id=project_id,
-        #     group_id=group_id,
-        #     force_flush_batch=True,
-        # )
+        buffered_delete_old_primary_hash(
+            project_id=project_id,
+            group_id=group_id,
+            force_flush_batch=True,
+        )
 
         return
 

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -157,12 +157,10 @@ def handle_remaining_events(
 
     from sentry import buffer
     from sentry.models.group import Group
-    from sentry.reprocessing2 import EVENT_MODELS_TO_MIGRATE, pop_remaining_event_ids_from_redis
+    from sentry.reprocessing2 import EVENT_MODELS_TO_MIGRATE, pop_batched_events_from_redis
 
     if event_ids_redis_key is not None:
-        event_ids, from_timestamp, to_timestamp = pop_remaining_event_ids_from_redis(
-            event_ids_redis_key
-        )
+        event_ids, from_timestamp, to_timestamp = pop_batched_events_from_redis(event_ids_redis_key)
 
     metrics.timing(
         "events.reprocessing.handle_remaining_events.batch_size",

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -110,7 +110,6 @@ def test_basic(
 ):
     from sentry import eventstream
 
-
     tombstone_calls = 0
     old_tombstone_fn = eventstream.tombstone_events_unsafe
 

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -18,7 +18,7 @@ from sentry.models import (
     UserReport,
 )
 from sentry.plugins.base.v2 import Plugin2
-from sentry.reprocessing2 import _get_sync_redis_client, is_group_finished
+from sentry.reprocessing2 import is_group_finished
 from sentry.tasks.reprocessing2 import reprocess_group
 from sentry.tasks.store import preprocess_event
 from sentry.testutils.helpers import Feature
@@ -297,6 +297,7 @@ def test_max_events(
 
     burst(max_jobs=100)
 
+    event = None
     for i, event_id in enumerate(event_ids):
         event = eventstore.get_event_by_id(default_project.id, event_id)
         if max_events is not None and i < (len(event_ids) - max_events):


### PR DESCRIPTION
During reprocessing, an event may have two properties (among many others) changed: its group ID, also known as the issue ID in the UI and its primary hash, an internal identifier. When this happens, a row in snuba needs to be moved. This is composed of two actions: Marking the existing row as soft-deleted (tombstoning) and then inserting a new entry with the event's new values. Without going into the details of how snuba works, tombstoning counts as an insert operation.

This PR concerns itself with tombstoning. Prior to this change, every event that needed to be tombstoned would translate to a single insert on snuba. This eventually ended up overwhelming snuba as a single issue or group on sentry typically contains several events, and reprocessing is triggered on a single issue instead of an individual event.

This PR adds in batching for the tombstoning operation to the best of its ability by borrowing the same mechanism used to buffer events in another part of reprocessing: Lists of events are stored in redis, and when the size of those lists reach a large enough size (or a forced flush is triggered via the end of reprocessing) those events are batched up and sent over to snuba.   

This is noted several times in the code itself, but the batching logic here has one major flaw: If tombstonable events trend towards a 1:1 ratio of event:old primary hashes, then the batching is effectively doing nothing as it cannot batch tombstoning requests across multiple primary hashes. To fix this would require a change to snuba's API.