### PR TITLE
fix(metrics): Allow more date ranges [INGEST-542] [INGEST-700]

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -337,6 +337,9 @@ def get_constrained_date_range(
     if interval > ONE_DAY:
         raise InvalidParams("The interval has to be less than one day.")
 
+    if ONE_DAY % interval != 0:
+        raise InvalidParams("The interval should divide one day without a remainder.")
+
     using_minute_resolution = interval % ONE_HOUR != 0
 
     start, end = get_date_range_from_params(params)

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -337,9 +337,6 @@ def get_constrained_date_range(
     if interval > ONE_DAY:
         raise InvalidParams("The interval has to be less than one day.")
 
-    if ONE_DAY % interval != 0:
-        raise InvalidParams("The interval should divide one day without a remainder.")
-
     using_minute_resolution = interval % ONE_HOUR != 0
 
     start, end = get_date_range_from_params(params)


### PR DESCRIPTION
The Metrics API used the date range validation logic from `sessions_v2` up until this PR, which does a lot of sessions-specific validation. Remove these constraints by creating a simplified version of the same function for metrics. This might later be extended when constraints metrics-specific constraints pop up.