### PR TITLE
fix(ui): prevent onboarding back button from receiving events when it's "hidden"

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -301,9 +301,13 @@ const Back = styled(({className, animate, ...props}: BackProps) => (
     animate={animate}
     transition={testableTransition()}
     variants={{
-      initial: {opacity: 0},
-      visible: {opacity: 1, transition: testableTransition({delay: 1})},
-      hidden: {opacity: 0},
+      initial: {opacity: 0, visibility: 'hidden'},
+      visible: {
+        opacity: 1,
+        visibility: 'visible',
+        transition: testableTransition({delay: 1}),
+      },
+      hidden: {opacity: 0, visibility: 'hidden'},
     }}
   >
     <Button {...props} icon={<IconChevron direction="left" size="sm" />} priority="link">

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -307,7 +307,12 @@ const Back = styled(({className, animate, ...props}: BackProps) => (
         visibility: 'visible',
         transition: testableTransition({delay: 1}),
       },
-      hidden: {opacity: 0, visibility: 'hidden'},
+      hidden: {
+        opacity: 0,
+        transitionEnd: {
+          visibility: 'hidden',
+        },
+      },
     }}
   >
     <Button {...props} icon={<IconChevron direction="left" size="sm" />} priority="link">


### PR DESCRIPTION

I noticed that the back button could still receive pointer and navigation (tab navigation) while seemingly invisible. 
![CleanShot 2021-11-30 at 09 29 06](https://user-images.githubusercontent.com/9317857/144050006-4e327677-0c29-4997-a2ac-99707c656d6a.gif)

By adding visibility hidden, we remove it from the accessibility tree with the tradeoff that we lose the animation from visible back to hidden (which is instant as visibility: hidden rule kicks in immediately as the animation starts). I'd argue the tradeoff is ok, as it favours correctness and accessibility over design, + we only lose the animation if someone goes back from step 2 to the initial step which is unlikely because the 1st step is just the get started screen.

The proper solution (which may be a bit of an overkill) would be to add a keyframes animation or the equivalent motion [keyframes](https://www.framer.com/docs/animation/##keyframes) prop that toggles the visibility property at the end of the animation
```css
@keyframes hide {
0% { opacity: 1, visibility: visible }
99% { opacity: 0, visibility: visible}
100% { opacity: 0, visibility: hidden} // toggle visibility at the end
}
```
 