### PR TITLE
style: Tooltip colors

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -8,6 +8,7 @@ import memoize from 'lodash/memoize';
 import * as PopperJS from 'popper.js';
 
 import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
+import space from 'sentry/styles/space';
 import {domId} from 'sentry/utils/domId';
 import testableTransition from 'sentry/utils/testableTransition';
 
@@ -289,7 +290,6 @@ class Tooltip extends React.Component<Props, State> {
                 ref={arrowProps.ref}
                 data-placement={placement}
                 style={arrowProps.style}
-                background={(popperStyle as React.CSSProperties)?.background || '#000'}
               />
             </TooltipContent>
           </PositionWrapper>
@@ -325,73 +325,82 @@ const PositionWrapper = styled('div')`
 const TooltipContent = styled(motion.div)<Pick<Props, 'popperStyle'>>`
   will-change: transform, opacity;
   position: relative;
-  color: ${p => p.theme.white};
-  background: #000;
-  opacity: 0.9;
-  padding: 5px 10px;
+  background: ${p => p.theme.backgroundElevated};
+  padding: ${space(1)};
   border-radius: ${p => p.theme.borderRadius};
+  border: solid 1px ${p => p.theme.border};
+  box-shadow: ${p => p.theme.dropShadowHeavy};
   overflow-wrap: break-word;
   max-width: 225px;
 
-  font-weight: bold;
+  color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 1.4;
+  font-weight: bold;
+  line-height: 1.2;
 
   margin: 6px;
   text-align: center;
   ${p => p.popperStyle as any};
 `;
 
-const TooltipArrow = styled('span')<{background: string | number}>`
+const TooltipArrow = styled('span')`
   position: absolute;
-  width: 10px;
-  height: 5px;
+  width: 6px;
+  height: 6px;
+  border: solid 6px transparent;
 
   &[data-placement*='bottom'] {
     top: 0;
-    left: 0;
-    margin-top: -5px;
+    margin-top: -12px;
+    border-bottom-color: ${p => p.theme.backgroundElevated};
     &::before {
-      border-width: 0 5px 5px 5px;
-      border-color: transparent transparent ${p => p.background} transparent;
+      bottom: -6px;
+      left: -7px;
+      border-bottom-color: ${p => p.theme.border};
     }
   }
 
   &[data-placement*='top'] {
     bottom: 0;
-    left: 0;
-    margin-bottom: -5px;
+    margin-bottom: -12px;
+    border-top-color: ${p => p.theme.backgroundElevated};
     &::before {
-      border-width: 5px 5px 0 5px;
-      border-color: ${p => p.background} transparent transparent transparent;
+      top: -6px;
+      left: -7px;
+      border-top-color: ${p => p.theme.border};
     }
   }
 
   &[data-placement*='right'] {
     left: 0;
-    margin-left: -5px;
+    margin-left: -12px;
+    border-right-color: ${p => p.theme.backgroundElevated};
     &::before {
-      border-width: 5px 5px 5px 0;
-      border-color: transparent ${p => p.background} transparent transparent;
+      top: -7px;
+      right: -6px;
+      border-right-color: ${p => p.theme.border};
     }
   }
 
   &[data-placement*='left'] {
     right: 0;
-    margin-right: -5px;
+    margin-right: -12px;
+    border-left-color: ${p => p.theme.backgroundElevated};
     &::before {
-      border-width: 5px 0 5px 5px;
-      border-color: transparent transparent transparent ${p => p.background};
+      top: -7px;
+      left: -6px;
+      border-left-color: ${p => p.theme.border};
     }
   }
 
   &::before {
     content: '';
-    margin: auto;
     display: block;
+    position: absolute;
     width: 0;
     height: 0;
-    border-style: solid;
+    border: solid 7px transparent;
+    z-index: -1;
   }
 `;
 


### PR DESCRIPTION
Updating tooltips to make better use of the new two-palette color system, with the same design as chart tooltips (#30170).

Before:

<img width="154" alt="Screen Shot 2021-11-30 at 10 35 53 AM" src="https://user-images.githubusercontent.com/44172267/144107471-a7e722d8-1417-4ace-8b1c-5f713637a40a.png">
<img width="154" alt="Screen Shot 2021-11-30 at 10 36 35 AM" src="https://user-images.githubusercontent.com/44172267/144107474-f4e6dc80-d875-406a-ac5a-d022acec4298.png">

After:

<img width="154" alt="Screen Shot 2021-11-30 at 10 37 29 AM" src="https://user-images.githubusercontent.com/44172267/144107501-a8750ba1-a66b-4895-8286-cff70a6438d6.png">
<img width="154" alt="Screen Shot 2021-11-30 at 10 37 05 AM" src="https://user-images.githubusercontent.com/44172267/144107497-3ab2d6d8-2c94-405f-a03f-5a01e20eb410.png">
