### PR TITLE
fix(echarts): AxisValue is a string in v5 breaking timestamps

### DIFF
--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -186,7 +186,7 @@ function getFormatter({
     // The data attribute is usually a list of [name, value] but can also be an object of {name, value} when
     // there is item specific formatting being used.
     const timestamp = Array.isArray(seriesParamsOrParam)
-      ? seriesParams[0].axisValue
+      ? seriesParams[0].data[0]
       : getSeriesValue(seriesParams[0], 0);
 
     const date =

--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -76,7 +76,7 @@ export default class PercentageAreaChart extends React.Component<Props> {
             // Filter series that have 0 counts
             const date =
               `${
-                series.length && moment(series[0].axisValue).format('MMM D, YYYY')
+                series.length && moment(series[0].data[0]).format('MMM D, YYYY')
               }<br />` || '';
 
             return [

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -228,10 +228,8 @@ class TeamReleases extends AsyncComponent<Props, State> {
                   : [seriesParams];
 
                 const dateFormat = 'MMM D';
-                const startDate = moment(series.axisValue).format(dateFormat);
-                const endDate = moment(series.axisValue)
-                  .add(7, 'days')
-                  .format(dateFormat);
+                const startDate = moment(series.data[0]).format(dateFormat);
+                const endDate = moment(series.data[0]).add(7, 'days').format(dateFormat);
                 return [
                   '<div class="tooltip-series">',
                   `<div><span class="tooltip-label">${series.marker} <strong>${series.seriesName}</strong></span> ${series.data[1]}</div>`,

--- a/static/app/views/organizationStats/teamInsights/utils.tsx
+++ b/static/app/views/organizationStats/teamInsights/utils.tsx
@@ -51,8 +51,8 @@ export const barAxisLabel = (
     axisLabel: {
       showMaxLabel: true,
       showMinLabel: true,
-      formatter: (date: number) => {
-        return moment(new Date(date)).format('MMM D');
+      formatter: (date: string) => {
+        return moment(new Date(Number(date))).format('MMM D');
       },
     },
   };


### PR DESCRIPTION
https://storybook.sentry.dev/?path=/story/components-data-visualization-charts-percentage-area-chart--percentage-area-chart

Can see this in the tooltip on some charts that use timestamps, need to use data or value which both are still numbers.