### PR TITLE
fix(ui): fixed grid resizer missing 1 pixel

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -249,9 +249,9 @@ export const GridResizer = styled('div')<{dataRows: number}>`
     const numOfRows = p.dataRows;
     let height = GRID_HEAD_ROW_HEIGHT + numOfRows * GRID_BODY_ROW_HEIGHT;
 
-    if (numOfRows >= 2) {
+    if (numOfRows >= 1) {
       // account for border-bottom height
-      height += numOfRows - 1;
+      height += numOfRows;
     }
 
     return height;


### PR DESCRIPTION
We're missing 1 pixel when calculating the height of the grid resizer based on the number of rows. Updates so we always get the proper height for the resizer.

before
![image](https://user-images.githubusercontent.com/83961295/144130224-a71c4563-b3bb-4d8a-81a2-43562de635c7.png)

after
![image](https://user-images.githubusercontent.com/83961295/144130188-96887ca5-c8c8-4e98-85a9-afe8447985b6.png)

Not sure if there was a preexisting reason for `numOfRows >= 2` and `height += numOfRows - 1`