### PR TITLE
fix(ui): Chart tooltip shadows

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -509,17 +509,12 @@ function BaseChartUnwrapped({
 // elements directly
 const ChartContainer = styled('div')`
   /* Tooltip styling */
-  .tooltip-container {
-    box-shadow: ${p => p.theme.dropShadowHeavy};
-  }
   .tooltip-series,
   .tooltip-date {
     color: ${p => p.theme.subText};
     font-family: ${p => p.theme.text.family};
     font-variant-numeric: tabular-nums;
-    background: ${p => p.theme.backgroundElevated};
     padding: ${space(1)} ${space(2)};
-    border: solid 1px ${p => p.theme.border};
     border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   }
   .tooltip-series {
@@ -551,7 +546,7 @@ const ChartContainer = styled('div')`
     border-radius: ${p => p.theme.borderRadiusBottom};
   }
   .tooltip-arrow {
-    top: calc(100% - 1px);
+    top: 100%;
     left: 50%;
     position: absolute;
     pointer-events: none;

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -1,5 +1,6 @@
 import 'echarts/lib/component/tooltip';
 
+import {useTheme} from '@emotion/react';
 import type {TooltipComponentFormatterCallback, TooltipComponentOption} from 'echarts';
 import moment from 'moment';
 
@@ -201,7 +202,7 @@ function getFormatter({
         seriesParamsOrParam
       );
 
-    const tooltipContent = [
+    return [
       '<div class="tooltip-series">',
       seriesParams
         .filter(getFilter)
@@ -224,8 +225,6 @@ function getFormatter({
       `<div class="tooltip-date">${date}</div>`,
       getTooltipArrow(),
     ].join('');
-
-    return `<div class="tooltip-container">${tooltipContent}</div>`;
   };
 
   return formatter;
@@ -252,6 +251,8 @@ export default function Tooltip({
   indentLabels,
   ...props
 }: Props = {}): TooltipComponentOption {
+  const theme = useTheme();
+
   formatter =
     formatter ||
     getFormatter({
@@ -272,8 +273,10 @@ export default function Tooltip({
   return {
     show: true,
     trigger: 'item',
-    backgroundColor: 'unset',
-    borderWidth: 0,
+    borderWidth: 1,
+    borderColor: `${theme.border}`,
+    backgroundColor: `${theme.backgroundElevated}`,
+    extraCssText: `box-shadow: ${theme.dropShadowHeavy}`,
     transitionDuration: 0,
     padding: 0,
     className: 'tooltip-container',

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -6,7 +6,6 @@ import type {SeriesOption, TooltipComponentOption} from 'echarts';
 
 import BaseChart from 'sentry/components/charts/baseChart';
 import Legend from 'sentry/components/charts/components/legend';
-import Tooltip from 'sentry/components/charts/components/tooltip';
 import xAxis from 'sentry/components/charts/components/xAxis';
 import barSeries from 'sentry/components/charts/series/barSeries';
 import {ChartContainer, HeaderTitleLegend} from 'sentry/components/charts/styles';
@@ -24,6 +23,8 @@ import commonTheme, {Theme} from 'sentry/utils/theme';
 import {formatUsageWithUnits, GIGABYTE} from '../utils';
 
 import {getTooltipFormatter, getXAxisDates, getXAxisLabelInterval} from './utils';
+
+type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 const COLOR_ERRORS = Color(commonTheme.dataCategory.errors).lighten(0.25).string();
 const COLOR_TRANSACTIONS = Color(commonTheme.dataCategory.transactions)
@@ -373,7 +374,7 @@ export class UsageChart extends React.Component<Props, State> {
     return legend;
   }
 
-  get chartTooltip(): TooltipComponentOption {
+  get chartTooltip(): ChartProps['tooltip'] {
     const {chartTooltip} = this.props;
 
     if (chartTooltip) {
@@ -382,12 +383,12 @@ export class UsageChart extends React.Component<Props, State> {
 
     const {tooltipValueFormatter} = this.chartMetadata;
 
-    return Tooltip({
+    return {
       // Trigger to axis prevents tooltip from redrawing when hovering
       // over individual bars
       trigger: 'axis',
       valueFormatter: tooltipValueFormatter,
-    });
+    };
   }
 
   renderChart() {


### PR DESCRIPTION
Echarts V5 adds a dark shadow to its tooltip container, darkening the one we already have. This update fixes that.

Before:
<img width="260" alt="Screen Shot 2021-11-30 at 3 34 08 PM" src="https://user-images.githubusercontent.com/44172267/144144944-3fa919d1-45aa-4483-b650-8bd08827f918.png">

After:
<img width="260" alt="Screen Shot 2021-11-30 at 3 34 24 PM" src="https://user-images.githubusercontent.com/44172267/144144955-33bf5586-df27-4c79-a203-0d5f732259e6.png">
