### PR TITLE
fix(ui): Fix janky tooltips due to bigger hitbox

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -348,6 +348,7 @@ const TooltipArrow = styled('span')`
   width: 6px;
   height: 6px;
   border: solid 6px transparent;
+  pointer-events: none;
 
   &[data-placement*='bottom'] {
     top: 0;


### PR DESCRIPTION
The hitbox became slightly larger because of the pseudo element