### PR TITLE
ref(ui): Use normal font weights for tooltips

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -335,7 +335,6 @@ const TooltipContent = styled(motion.div)<Pick<Props, 'popperStyle'>>`
 
   color: ${p => p.theme.textColor};
   font-size: ${p => p.theme.fontSizeSmall};
-  font-weight: bold;
   line-height: 1.2;
 
   margin: 6px;

--- a/static/less/shared/tooltip.less
+++ b/static/less/shared/tooltip.less
@@ -115,7 +115,6 @@
 
 .tooltip-content,
 .tooltip-inner {
-  font-weight: bold;
   padding: 5px 10px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
   overflow-wrap: break-word;


### PR DESCRIPTION
IMO looks better

old
![image](https://user-images.githubusercontent.com/1421724/144148334-96e9d86d-f764-4fce-87aa-0a3c54dae036.png)


new
![image](https://user-images.githubusercontent.com/1421724/144148323-1053422b-8a64-4405-bfdc-c7ee733c5075.png)
