### PR TITLE
ref(ui): Give slightly more x padding to tooltips

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -326,7 +326,7 @@ const TooltipContent = styled(motion.div)<Pick<Props, 'popperStyle'>>`
   will-change: transform, opacity;
   position: relative;
   background: ${p => p.theme.backgroundElevated};
-  padding: ${space(1)};
+  padding: ${space(1)} ${space(1.5)};
   border-radius: ${p => p.theme.borderRadius};
   border: solid 1px ${p => p.theme.border};
   box-shadow: ${p => p.theme.dropShadowHeavy};


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/144148962-a2f1bced-47fb-4421-8467-c30637436a09.png)

After
![image](https://user-images.githubusercontent.com/1421724/144148970-d4d7d42a-0b3b-437b-877f-c25b69d28bcf.png)
