### PR TITLE
fix(ui): Sidebar Onboarding progress text color

### DIFF
--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -154,7 +154,7 @@ const hoverCss = (p: {theme: Theme}) => css`
     color: ${p.theme.white};
   }
   ${Remaining} {
-    color: ${p.theme.gray200};
+    color: ${p.theme.textColor};
   }
 `;
 

--- a/static/app/components/sidebar/onboardingStatus.tsx
+++ b/static/app/components/sidebar/onboardingStatus.tsx
@@ -154,7 +154,7 @@ const hoverCss = (p: {theme: Theme}) => css`
     color: ${p.theme.white};
   }
   ${Remaining} {
-    color: ${p.theme.textColor};
+    color: ${p.theme.white};
   }
 `;
 


### PR DESCRIPTION
Gray200 is not an accessible text color (see below). Instead, we should use `textColor` for the hover state.

Before:
<img width="505" alt="Screen Shot 2021-11-30 at 4 49 49 PM" src="https://user-images.githubusercontent.com/44172267/144151581-3a486315-ffde-40e3-b6ed-a9e661a81959.png">

After:
<img width="216" alt="Screen Shot 2021-11-30 at 5 02 58 PM" src="https://user-images.githubusercontent.com/44172267/144164216-ec840e93-6dff-4880-a1dc-fbce21d558a6.png">


