### PR TITLE
feat(team): Add cursor to team store

### DIFF
--- a/static/app/stores/teamStore.tsx
+++ b/static/app/stores/teamStore.tsx
@@ -2,15 +2,15 @@ import Reflux from 'reflux';
 
 import TeamActions from 'sentry/actions/teamActions';
 import {Team} from 'sentry/types';
+import {defined} from 'sentry/utils';
 
 import {CommonStoreInterface} from './types';
-
-const MAX_TEAMS = 100;
 
 type State = {
   teams: Team[];
   loading: boolean;
   hasMore: boolean | null;
+  cursor: string | null;
   loadedUserTeams: boolean;
 };
 
@@ -18,7 +18,7 @@ type TeamStoreInterface = CommonStoreInterface<State> & {
   initialized: boolean;
   state: State;
   reset(): void;
-  loadInitialData(items: Team[], hasMore?: boolean | null): void;
+  loadInitialData(items: Team[], hasMore?: boolean | null, cursor?: string | null): void;
   onUpdateSuccess(itemId: string, response: Team): void;
   onRemoveSuccess(slug: string): void;
   onCreateSuccess(team: Team): void;
@@ -34,6 +34,7 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
     loadedUserTeams: false,
     loading: true,
     hasMore: null,
+    cursor: null,
   },
 
   init() {
@@ -48,17 +49,23 @@ const teamStoreConfig: Reflux.StoreDefinition & TeamStoreInterface = {
   },
 
   reset() {
-    this.state = {teams: [], loadedUserTeams: false, loading: true, hasMore: null};
+    this.state = {
+      teams: [],
+      loadedUserTeams: false,
+      loading: true,
+      hasMore: null,
+      cursor: null,
+    };
   },
 
-  loadInitialData(items, hasMore = null) {
+  loadInitialData(items, hasMore, cursor) {
     this.initialized = true;
     this.state = {
       teams: items.sort((a, b) => a.slug.localeCompare(b.slug)),
-      // TODO(davidenwang): Replace with a more reliable way of knowing when we have loaded all teams
-      loadedUserTeams: items.length < MAX_TEAMS,
+      loadedUserTeams: defined(hasMore) ? !hasMore : this.state.loadedUserTeams,
       loading: false,
-      hasMore,
+      hasMore: hasMore ?? this.state.hasMore,
+      cursor: cursor ?? this.state.cursor,
     };
     this.trigger(new Set(items.map(item => item.id)));
   },

--- a/tests/js/spec/stores/teamStore.spec.jsx
+++ b/tests/js/spec/stores/teamStore.spec.jsx
@@ -19,6 +19,7 @@ describe('TeamStore', function () {
         teams: [],
         loading: true,
         hasMore: null,
+        cursor: null,
         loadedUserTeams: false,
       });
 
@@ -28,7 +29,8 @@ describe('TeamStore', function () {
         teams: [teamBar, teamFoo],
         loading: false,
         hasMore: null,
-        loadedUserTeams: true,
+        cursor: null,
+        loadedUserTeams: false,
       });
     });
 
@@ -42,6 +44,24 @@ describe('TeamStore', function () {
       await tick();
       expect(TeamStore.getState()).toMatchObject({
         teams: [teamFoo],
+        loadedUserTeams: true,
+      });
+    });
+
+    it('stores cursor and hasMore correctly', async function () {
+      expect(TeamStore.getState()).toMatchObject({
+        teams: [],
+        hasMore: null,
+        cursor: null,
+        loadedUserTeams: false,
+      });
+
+      TeamActions.loadTeams([teamFoo], false, null);
+      await tick();
+      expect(TeamStore.getState()).toMatchObject({
+        teams: [teamFoo],
+        hasMore: false,
+        cursor: null,
         loadedUserTeams: true,
       });
     });

--- a/tests/js/spec/utils/useTeams.spec.tsx
+++ b/tests/js/spec/utils/useTeams.spec.tsx
@@ -58,7 +58,7 @@ describe('useTeams', function () {
   it('provides only the users teams', async function () {
     const userTeams = [TestStubs.Team({isMember: true})];
     const nonUserTeams = [TestStubs.Team({isMember: false})];
-    TeamStore.loadInitialData([...userTeams, ...nonUserTeams]);
+    TeamStore.loadInitialData([...userTeams, ...nonUserTeams], false, null);
 
     const {result} = renderHook(props => useTeams(props), {
       initialProps: {provideUserTeams: true},

--- a/tests/js/spec/views/alerts/create.spec.jsx
+++ b/tests/js/spec/views/alerts/create.spec.jsx
@@ -34,7 +34,7 @@ jest.mock('sentry/utils/analytics', () => ({
 }));
 
 describe('ProjectAlertsCreate', function () {
-  TeamStore.loadInitialData([]);
+  TeamStore.loadInitialData([], false, null);
   const projectAlertRuleDetailsRoutes = [
     {
       path: '/organizations/:orgId/alerts/',

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -12,7 +12,7 @@ jest.mock('sentry/utils/analytics');
 
 describe('OrganizationRuleList', () => {
   const {routerContext, organization, router} = initializeOrg();
-  TeamStore.loadInitialData([]);
+  TeamStore.loadInitialData([], false, null);
   let rulesMock;
   let projectMock;
   const pageLinks =

--- a/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
+++ b/tests/js/spec/views/organizationStats/teamInsights/overview.spec.jsx
@@ -130,7 +130,7 @@ describe('TeamInsightsOverview', () => {
     const projects = [project1, project2];
     const organization = TestStubs.Organization({teams, projects});
     const context = TestStubs.routerContext([{organization}]);
-    TeamStore.loadInitialData(teams);
+    TeamStore.loadInitialData(teams, false, null);
 
     return mountWithTheme(
       <OrganizationContext.Provider value={organization}>
@@ -181,7 +181,7 @@ describe('TeamInsightsOverview', () => {
   it('shows users with no teams the join team button', () => {
     createWrapper();
     ProjectsStore.loadInitialData([{...project1, isMember: false}]);
-    TeamStore.loadInitialData([]);
+    TeamStore.loadInitialData([], false, null);
 
     expect(screen.getByText('Join a Team')).toBeInTheDocument();
   });

--- a/tests/js/spec/views/performance/content.spec.jsx
+++ b/tests/js/spec/views/performance/content.spec.jsx
@@ -76,7 +76,7 @@ describe('Performance > Content', function () {
   enforceActOnUseLegacyStoreHook();
 
   beforeEach(function () {
-    act(() => void TeamStore.loadInitialData([]));
+    act(() => void TeamStore.loadInitialData([], false, null));
     browserHistory.push = jest.fn();
     jest.spyOn(globalSelection, 'updateDateTime');
 

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -34,7 +34,7 @@ describe('Performance > Landing > Index', function () {
   let eventsV2Mock: any;
   let wrapper: any;
 
-  act(() => void TeamStore.loadInitialData([]));
+  act(() => void TeamStore.loadInitialData([], false, null));
   beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -35,7 +35,7 @@ function initializeData({features: additionalFeatures = [], query = {}} = {}) {
     },
   });
   act(() => ProjectsStore.loadInitialData(initialData.organization.projects));
-  act(() => TeamStore.loadInitialData(teams));
+  act(() => TeamStore.loadInitialData(teams, false, null));
 
   return initialData;
 }

--- a/tests/js/spec/views/performance/transactionSummary/teamKeyTransactionButton.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary/teamKeyTransactionButton.spec.jsx
@@ -36,7 +36,7 @@ describe('TeamKeyTransactionButton', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
     act(() => ProjectsStore.loadInitialData([project]));
-    act(() => void TeamStore.loadInitialData(teams));
+    act(() => void TeamStore.loadInitialData(teams, false, null));
   });
 
   it('fetches key transactions with project param', async function () {

--- a/tests/js/spec/views/performance/vitalDetail/index.spec.jsx
+++ b/tests/js/spec/views/performance/vitalDetail/index.spec.jsx
@@ -42,7 +42,7 @@ describe('Performance > VitalDetail', function () {
   enforceActOnUseLegacyStoreHook();
 
   beforeEach(function () {
-    act(() => void TeamStore.loadInitialData([]));
+    act(() => void TeamStore.loadInitialData([], false, null));
     browserHistory.push = jest.fn();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/tests/js/spec/views/settings/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/settings/organizationTeams.spec.jsx
@@ -59,7 +59,7 @@ describe('OrganizationTeams', function () {
 
     it('can join team and have link to details', function () {
       const mockTeams = [TestStubs.Team({hasAccess: true, isMember: false})];
-      act(() => void TeamStore.loadInitialData(mockTeams));
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       const wrapper = createWrapper({
         access: new Set([]),
       });
@@ -93,7 +93,7 @@ describe('OrganizationTeams', function () {
 
     it('can request access to team and does not have link to details', function () {
       const mockTeams = [TestStubs.Team({hasAccess: false, isMember: false})];
-      act(() => void TeamStore.loadInitialData(mockTeams));
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       const wrapper = createWrapper({
         access: new Set([]),
       });
@@ -105,7 +105,7 @@ describe('OrganizationTeams', function () {
 
     it('can leave team when you are a member', function () {
       const mockTeams = [TestStubs.Team({hasAccess: true, isMember: true})];
-      act(() => void TeamStore.loadInitialData(mockTeams));
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       const wrapper = createWrapper({
         access: new Set([]),
       });


### PR DESCRIPTION
Because we only have 100 teams initially fetched and stored in reflux we need to be able to paginate and retrieve additional pages of teams. By storing a cursor in the team store we can keep track of our progress on fetching additional pages of teams and reduce the need for individual components to paginate teams separately with redundant requests.

Also added a `loadMore` function to the `useTeams` hook to leverage the cursor in requesting additional pages of teams.