### PR TITLE
fix(onboarding): adjust second project task

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -157,8 +157,8 @@ def record_first_event(project, event, **kwargs):
     except IndexError:
         return
 
-    # Only counts if it's a new project and platform
-    if oot.project_id != project.id and oot.data.get("platform", event.platform) != event.platform:
+    # Only counts if it's a new project
+    if oot.project_id != project.id:
         rows_affected, created = OrganizationOnboardingTask.objects.create_or_update(
             organization_id=project.organization_id,
             task=OnboardingTask.SECOND_PLATFORM,

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -98,7 +98,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.SECOND_PLATFORM,
       title: t('Create another project'),
       description: t(
-        'Easy, right? Don’t stop at one. Set up another project to keep things running smoothly in both the frontend and backend.'
+        'Easy, right? Don’t stop at one. Set up another project and send it events to keep things running smoothly in both the frontend and backend.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],


### PR DESCRIPTION
This PR fixes some confusion with the second onboarding task and removes the requirement that the second project is a different platform.