### PR TITLE
ref(js): Move `::before` to the top of tooltip styles

### DIFF
--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -349,6 +349,16 @@ const TooltipArrow = styled('span')`
   border: solid 6px transparent;
   pointer-events: none;
 
+  &::before {
+    content: '';
+    display: block;
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: solid 7px transparent;
+    z-index: -1;
+  }
+
   &[data-placement*='bottom'] {
     top: 0;
     margin-top: -12px;
@@ -391,16 +401,6 @@ const TooltipArrow = styled('span')`
       left: -6px;
       border-left-color: ${p => p.theme.border};
     }
-  }
-
-  &::before {
-    content: '';
-    display: block;
-    position: absolute;
-    width: 0;
-    height: 0;
-    border: solid 7px transparent;
-    z-index: -1;
   }
 `;
 


### PR DESCRIPTION
It was harder to find farther down before