### PR TITLE
fix(echarts): Repair echarts pie chart

### DIFF
--- a/docs-ui/stories/components/pieChart.stories.js
+++ b/docs-ui/stories/components/pieChart.stories.js
@@ -7,7 +7,7 @@ export default {
 
 export const _PieChart = () => (
   <PieChart
-    startDate={new Date()}
+    selectOnRender
     series={[
       {
         seriesName: 'Browsers',

--- a/static/app/components/charts/pieChart.tsx
+++ b/static/app/components/charts/pieChart.tsx
@@ -1,17 +1,21 @@
 import * as React from 'react';
+import {withTheme} from '@emotion/react';
 import type {PieSeriesOption} from 'echarts';
 
 import {ReactEchartsRef, Series} from 'sentry/types/echarts';
-import theme from 'sentry/utils/theme';
+import type {Theme} from 'sentry/utils/theme';
 
+import Legend from './components/legend';
 import PieSeries from './series/pieSeries';
 import BaseChart from './baseChart';
+import {getTooltipArrow} from './utils';
 
 type ChartProps = Omit<React.ComponentProps<typeof BaseChart>, 'css'>;
 
 export type PieChartSeries = Series & Omit<PieSeriesOption, 'data' | 'name'>;
 
 type Props = Omit<ChartProps, 'series'> & {
+  theme: Theme;
   selectOnRender?: boolean;
   series: PieChartSeries[];
 };
@@ -61,7 +65,7 @@ class PieChart extends React.Component<Props> {
   };
 
   // echarts Legend does not have access to percentages (but tooltip does :/)
-  getSeriesPercentages = series => {
+  getSeriesPercentages = (series: PieChartSeries) => {
     const total = series.data.reduce((acc, {value}) => acc + value, 0);
     return series.data
       .map(({name, value}) => [name, Math.round((value / total) * 10000) / 100])
@@ -75,7 +79,7 @@ class PieChart extends React.Component<Props> {
   };
 
   render() {
-    const {series, ...props} = this.props;
+    const {series, theme, ...props} = this.props;
     if (!series || !series.length) {
       return null;
     }
@@ -122,20 +126,31 @@ class PieChart extends React.Component<Props> {
           this.isInitialSelected = false;
         }}
         {...props}
-        options={{
-          legend: {
-            orient: 'vertical',
-            align: 'left',
-            show: true,
-            left: 10,
-            top: 10,
-            bottom: 10,
-            formatter: name =>
-              `${name} ${
-                typeof seriesPercentages[name] !== 'undefined'
-                  ? `(${seriesPercentages[name]}%)`
-                  : ''
-              }`,
+        legend={Legend({
+          theme,
+          orient: 'vertical',
+          align: 'left',
+          show: true,
+          left: 10,
+          top: 10,
+          bottom: 10,
+          formatter: name =>
+            `${name} ${
+              typeof seriesPercentages[name] !== 'undefined'
+                ? `(${seriesPercentages[name]}%)`
+                : ''
+            }`,
+        })}
+        tooltip={{
+          formatter: data => {
+            return [
+              '<div class="tooltip-series">',
+              `<div><span class="tooltip-label">${data.marker}<strong>${data.name}</strong></span> ${data.percent}%</div>`,
+              '</div>',
+              `<div class="tooltip-date">${data.value}</div>`,
+              '</div>',
+              getTooltipArrow(),
+            ].join('');
           },
         }}
         series={[
@@ -144,28 +159,14 @@ class PieChart extends React.Component<Props> {
             data: firstSeries.data,
             avoidLabelOverlap: false,
             label: {
-              normal: {
-                formatter: ({name, percent}) => `${name}\n${percent}%`,
-                show: false,
-                position: 'center',
-              },
-              emphasis: {
-                show: true,
-                textStyle: {
-                  fontSize: '18',
-                },
-              },
-            } as any,
-            itemStyle: {
-              normal: {
-                label: {
-                  show: false,
-                },
-                labelLine: {
-                  show: false,
-                },
-              },
-            } as any,
+              formatter: ({name, percent}) => `${name}\n${percent}%`,
+              show: false,
+              position: 'center',
+              fontSize: '18',
+            },
+            labelLine: {
+              show: false,
+            },
           }),
         ]}
         xAxis={null}
@@ -175,4 +176,4 @@ class PieChart extends React.Component<Props> {
   }
 }
 
-export default PieChart;
+export default withTheme(PieChart);

--- a/static/app/components/charts/pieChart.tsx
+++ b/static/app/components/charts/pieChart.tsx
@@ -164,6 +164,11 @@ class PieChart extends React.Component<Props> {
               position: 'center',
               fontSize: '18',
             },
+            emphasis: {
+              label: {
+                show: true,
+              },
+            },
             labelLine: {
               show: false,
             },


### PR DESCRIPTION
fixes the legend and the tooltips and stuff

it is not currently used anywhere except [storybook](https://storybook.sentry.dev/?path=/story/components-data-visualization-charts-pie-chart--pie-chart)

![image](https://user-images.githubusercontent.com/1400464/144170821-89efe124-fa07-4eb8-b5d9-b08576b6a39e.png)
