### PR TITLE
fix(echarts): Emphasis project card chart types

### DIFF
--- a/static/app/views/projectsDashboard/chart.tsx
+++ b/static/app/views/projectsDashboard/chart.tsx
@@ -39,11 +39,13 @@ const Chart = ({firstEvent, stats, transactionStats}: Props) => {
       itemStyle: {
         color: theme.gray200,
         opacity: 0.8,
-        emphasis: {
+      },
+      emphasis: {
+        itemStyle: {
           color: theme.gray200,
           opacity: 1.0,
         },
-      } as any,
+      },
     });
   }
 
@@ -59,11 +61,13 @@ const Chart = ({firstEvent, stats, transactionStats}: Props) => {
       itemStyle: {
         color: theme.purple300,
         opacity: 0.6,
-        emphasis: {
+      },
+      emphasis: {
+        itemStyle: {
           color: theme.purple300,
           opacity: 0.8,
         },
-      } as any,
+      },
     });
   }
   const grid = hasTransactions


### PR DESCRIPTION
remove as any type

I can't really tell the difference
<img width="421" alt="Screen Shot 2021-11-30 at 9 00 02 PM" src="https://user-images.githubusercontent.com/1400464/144175601-ffc3f6b6-c6d9-40ae-b367-75045fbdafbb.png">
<img width="419" alt="Screen Shot 2021-11-30 at 8 59 48 PM" src="https://user-images.githubusercontent.com/1400464/144175604-1c7ea6a3-9828-4b7d-9db3-0fb91ee0ba9f.png">

