### PR TITLE
fix(ui): Fix releases tooltips text color

### DIFF
--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -117,7 +117,7 @@ const Version = ({
 
       <Clipboard value={version}>
         <TooltipClipboardIconWrapper>
-          <IconCopy size="xs" color="textColor" />
+          <IconCopy size="xs" />
         </TooltipClipboardIconWrapper>
       </Clipboard>
     </TooltipContent>

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -117,7 +117,7 @@ const Version = ({
 
       <Clipboard value={version}>
         <TooltipClipboardIconWrapper>
-          <IconCopy size="xs" color="white" />
+          <IconCopy size="xs" color="textColor" />
         </TooltipClipboardIconWrapper>
       </Clipboard>
     </TooltipContent>

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -197,7 +197,7 @@ function ReleaseAdoption({
         return label && Object.values(releaseMarkLinesLabels).includes(label)
           ? ''
           : `<span>${formatAbbreviatedNumber(absoluteCount)} <span style="color: ${
-              theme.white
+              theme.textColor
             };margin-left: ${space(0.5)}">${value}%</span></span>`;
       },
       filter: (_, seriesParam: any) => {


### PR DESCRIPTION
Changing the color of tooltip text on two releases tooltips now that they come in two different background colors.

## Before
![image](https://user-images.githubusercontent.com/9060071/144281916-d8b1cf2e-d068-441b-a772-c8d00918f581.png)
**and**
![image](https://user-images.githubusercontent.com/9060071/144281853-23f588f1-f6c3-43db-a9ee-f60e0673d876.png)

## After
![image](https://user-images.githubusercontent.com/9060071/144281682-c1854505-967e-4e06-9407-9f4e155ebe65.png)
**and**
![image](https://user-images.githubusercontent.com/9060071/144281759-8d36f327-c588-43cb-b601-4720d3376de8.png)
