### PR TITLE
fix(ui): Use black for modal backdrop color

### DIFF
--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -214,7 +214,7 @@ const fullPageCss = css`
 const Backdrop = styled('div')`
   ${fullPageCss};
   z-index: ${p => p.theme.zIndex.modal};
-  background: ${p => p.theme.gray500};
+  background: ${p => p.theme.black};
   will-change: opacity;
   transition: opacity 200ms;
   pointer-events: none;


### PR DESCRIPTION
In the new two-palette color system, `gray500` is a light color in dark mode (meant for headings). We should use black for modal backdrops instead.

Before:
<img width="1077" alt="Screen Shot 2021-12-01 at 9 37 58 AM" src="https://user-images.githubusercontent.com/44172267/144284990-08a77b1c-16df-4abe-ba48-1d428f6c9179.png">

After:
<img width="1077" alt="Screen Shot 2021-12-01 at 9 35 03 AM" src="https://user-images.githubusercontent.com/44172267/144285021-acad2b48-4198-412d-9192-668568e97015.png">
<img width="1077" alt="Screen Shot 2021-12-01 at 9 28 34 AM" src="https://user-images.githubusercontent.com/44172267/144285027-341d9444-6f28-435c-9377-ff871617118d.png">

(In dark mode, there doesn't seem to be sufficient contrast between the modal and the backdrop. This will be addressed in future work (by adding borders, drop shadows, etc.). For now, I think switching the backdrop color to `black` is enough.)
