### PR TITLE
fix(dashboards): fixed issue widget search bar not updating correctly after selecting from autocomplete

### DIFF
--- a/static/app/components/dashboards/issueWidgetQueriesForm.tsx
+++ b/static/app/components/dashboards/issueWidgetQueriesForm.tsx
@@ -18,11 +18,21 @@ type Props = {
   tags: TagCollection;
 };
 
+type State = {
+  blurTimeout?: ReturnType<typeof setTimeout>;
+};
+
 /**
  * Contain widget queries interactions and signal changes via the onChange
  * callback. This component's state should live in the parent.
  */
-class IssueWidgetQueriesForm extends React.Component<Props> {
+class IssueWidgetQueriesForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      blurTimeout: undefined,
+    };
+  }
   // Handle scalar field values changing.
   handleFieldChange = (field: string) => {
     const {query, onChange} = this.props;
@@ -46,6 +56,7 @@ class IssueWidgetQueriesForm extends React.Component<Props> {
 
   render() {
     const {organization, error, query, tags} = this.props;
+    const {blurTimeout} = this.state;
 
     return (
       <QueryWrapper>
@@ -62,8 +73,25 @@ class IssueWidgetQueriesForm extends React.Component<Props> {
               organization={organization}
               query={query.conditions || ''}
               sort=""
-              onSearch={this.handleFieldChange('conditions')}
-              onBlur={this.handleFieldChange('conditions')}
+              onSearch={field => {
+                // IssueListSearchBar will call handlers for both onSearch and onBlur
+                // when selecting a value from the autocomplete dropdown. This can
+                // cause state issues for the search bar in our use case. To prevent
+                // this, we set a timer in our onSearch handler to block our onBlur
+                // handler from firing if it is within 200ms, ie from clicking an
+                // autocomplete value.
+                this.setState({
+                  blurTimeout: setTimeout(() => {
+                    this.setState({blurTimeout: undefined});
+                  }, 200),
+                });
+                return this.handleFieldChange('conditions')(field);
+              }}
+              onBlur={field => {
+                if (!blurTimeout) {
+                  this.handleFieldChange('conditions')(field);
+                }
+              }}
               excludeEnvironment
               supportedTags={tags}
               tagValueLoader={() => new Promise(() => [])}

--- a/static/app/components/modals/addDashboardIssueWidgetModal.tsx
+++ b/static/app/components/modals/addDashboardIssueWidgetModal.tsx
@@ -220,7 +220,7 @@ class AddDashboardIssueWidgetModal extends React.Component<Props, State> {
             selection={querySelection}
             query={state.queries[0]}
             error={errors?.queries?.[0]}
-            onChange={(widgetQuery: WidgetQuery) => this.handleQueryChange(widgetQuery)}
+            onChange={this.handleQueryChange}
           />
           <IssueWidgetCard
             api={api}

--- a/tests/js/spec/components/dashboards/issueWidgetQueriesForm.spec.tsx
+++ b/tests/js/spec/components/dashboards/issueWidgetQueriesForm.spec.tsx
@@ -1,0 +1,65 @@
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import IssueWidgetQueriesForm from 'sentry/components/dashboards/issueWidgetQueriesForm';
+
+describe('IssueWidgetQueriesForm', function () {
+  const organization = TestStubs.Organization();
+  let onChangeHandler;
+
+  beforeEach(() => {
+    onChangeHandler = jest.fn();
+    MockApiClient.clearMockResponses();
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [
+        {
+          id: '5718466',
+          organizationId: '1',
+          type: 0,
+          query: 'assigned:#visibility level:error',
+          lastSeen: '2021-12-01T20:46:36.972966Z',
+          dateCreated: '2021-12-01T20:46:36.975384Z',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'POST',
+    });
+
+    mountWithTheme(
+      <IssueWidgetQueriesForm
+        organization={organization}
+        selection={{
+          projects: [1],
+          environments: ['prod'],
+          datetime: {
+            period: '14d',
+            start: null,
+            end: null,
+            utc: false,
+          },
+        }}
+        query={{
+          conditions: 'assigned:',
+          fields: [],
+          name: '',
+          orderby: '',
+        }}
+        onChange={onChangeHandler}
+      />
+    );
+  });
+
+  it('only calls onChange once when selecting a value from the autocomplete dropdown', async function () {
+    userEvent.click(screen.getAllByText('assigned:')[1]);
+    await tick();
+    expect(screen.getByText('Recent Searches')).toBeInTheDocument();
+    expect(screen.getByText(':#visibility level:error')).toBeInTheDocument();
+    userEvent.click(screen.getByText(':#visibility level:error'));
+    await tick();
+    expect(onChangeHandler).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes a bug where selecting an autocomplete value from the Issue Widget Modal search bar doesn't update the widget correctly.

IssueListSearchBar will call handlers for both `onSearch` and `onBlur` when selecting a value from the autocomplete dropdown. This can cause state issues for the search bar in our use case. To prevent this, we set a timer in our `onSearch` handler to block our onBlur handler from firing if it is within 200ms, ie from clicking an autocomplete value.