### PR TITLE
chore(py): Ignore tests in CodeCov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,11 +13,11 @@ coverage:
         - "static/app"
         target: 60%
   ignore:
-  - src/sentry/lint/.*
-  - src/sentry/runner/.*
-  - src/sentry/debug/.*
   - src/.*?/migrations/.*
   - src/bitfield/.*
+  - src/sentry/debug/.*
+  - src/sentry/lint/.*
+  - src/sentry/runner/.*
   - src/social_auth/.*
   - static/app/routes.tsx
   - tests/

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,4 +20,5 @@ coverage:
   - src/bitfield/.*
   - src/social_auth/.*
   - static/app/routes.tsx
+  - tests/
 comment: false


### PR DESCRIPTION
This is a somewhat drastic step to fix Codecov flakiness.