### PR TITLE
ref(ts): Don't import React types

### DIFF
--- a/docs-ui/components/sample.tsx
+++ b/docs-ui/components/sample.tsx
@@ -1,4 +1,4 @@
-import {createContext, ReactChild, useState} from 'react';
+import {createContext, useState} from 'react';
 import {ThemeProvider, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -9,7 +9,7 @@ import {darkTheme, lightTheme, Theme} from 'sentry/utils/theme';
 type ThemeName = 'dark' | 'light';
 
 type Props = {
-  children?: ReactChild;
+  children?: React.ReactChild;
   /**
    * Show the theme switcher, which allows for
    * switching the local theme context between

--- a/static/app/bootstrap/renderDom.tsx
+++ b/static/app/bootstrap/renderDom.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom';
 
 export function renderDom(

--- a/static/app/components/alert.tsx
+++ b/static/app/components/alert.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';

--- a/static/app/components/charts/optionCheckboxSelector.tsx
+++ b/static/app/components/charts/optionCheckboxSelector.tsx
@@ -1,4 +1,4 @@
-import {Component, createRef, Fragment, MouseEvent} from 'react';
+import {Component, createRef, Fragment} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
@@ -80,7 +80,7 @@ class OptionCheckboxSelector extends Component<Props, State> {
     return disabled || (selected.length > 2 && !selected.includes(value));
   }
 
-  handleCheckboxClick(event: MouseEvent, opt: SelectValue<string>) {
+  handleCheckboxClick(event: React.MouseEvent, opt: SelectValue<string>) {
     const {onChange} = this.props;
     event.stopPropagation();
     if (!this.shouldBeDisabled(opt)) {

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useEffect, useState} from 'react';
+import {memo, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import React, {memo} from 'react';
+import {memo} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, MouseEvent, useState} from 'react';
+import {cloneElement, Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
@@ -77,12 +77,12 @@ function Content({
     return minGroupingLevel <= groupingCurrentLevel;
   }
 
-  function handleToggleAddresses(mouseEvent: MouseEvent<SVGElement>) {
+  function handleToggleAddresses(mouseEvent: React.MouseEvent<SVGElement>) {
     mouseEvent.stopPropagation(); // to prevent collapsing if collapsible
     setShowingAbsoluteAddresses(!showingAbsoluteAddresses);
   }
 
-  function handleToggleFunctionName(mouseEvent: MouseEvent<SVGElement>) {
+  function handleToggleFunctionName(mouseEvent: React.MouseEvent<SVGElement>) {
     mouseEvent.stopPropagation(); // to prevent collapsing if collapsible
     setShowCompleteFunctionName(!showCompleteFunctionName);
   }

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -1,4 +1,4 @@
-import {cloneElement, Fragment, MouseEvent, useState} from 'react';
+import {cloneElement, Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import List from 'sentry/components/list';
@@ -86,12 +86,12 @@ function StackTraceContent({
     return minGroupingLevel <= groupingCurrentLevel;
   }
 
-  function handleToggleAddresses(mouseEvent: MouseEvent<SVGElement>) {
+  function handleToggleAddresses(mouseEvent: React.MouseEvent<SVGElement>) {
     mouseEvent.stopPropagation(); // to prevent collapsing if collapsible
     setShowingAbsoluteAddresses(!showingAbsoluteAddresses);
   }
 
-  function handleToggleFunctionName(mouseEvent: MouseEvent<SVGElement>) {
+  function handleToggleFunctionName(mouseEvent: React.MouseEvent<SVGElement>) {
     mouseEvent.stopPropagation(); // to prevent collapsing if collapsible
     setShowCompleteFunctionName(!showCompleteFunctionName);
   }

--- a/static/app/components/events/interfaces/frame/lineV2/default.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/default.tsx
@@ -1,4 +1,3 @@
-import {MouseEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -17,7 +16,7 @@ type Props = React.ComponentProps<typeof Expander> &
   React.ComponentProps<typeof LeadHint> & {
     frame: Frame;
     isUsedForGrouping: boolean;
-    onMouseDown?: MouseEventHandler<HTMLDivElement>;
+    onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
     onClick?: () => void;
     timesRepeated?: number;
   };

--- a/static/app/components/events/interfaces/frame/lineV2/expander.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/expander.tsx
@@ -1,4 +1,3 @@
-import {MouseEvent} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
@@ -13,7 +12,7 @@ import {isDotnet} from '../utils';
 type Props = {
   isExpandable: boolean;
   platform: PlatformType;
-  onToggleContext: (evt: MouseEvent) => void;
+  onToggleContext: (evt: React.MouseEvent) => void;
   isHoverPreviewed?: boolean;
   isExpanded?: boolean;
 };

--- a/static/app/components/events/interfaces/frame/lineV2/native.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/native.tsx
@@ -1,4 +1,3 @@
-import {MouseEvent, MouseEventHandler} from 'react';
 import styled from '@emotion/styled';
 import scrollToElement from 'scroll-to-element';
 
@@ -24,7 +23,7 @@ type Props = React.ComponentProps<typeof Expander> &
   React.ComponentProps<typeof LeadHint> & {
     frame: Frame;
     isUsedForGrouping: boolean;
-    onMouseDown?: MouseEventHandler<HTMLDivElement>;
+    onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
     onClick?: () => void;
     isFrameAfterLastNonApp?: boolean;
     includeSystemFrames?: boolean;
@@ -86,7 +85,7 @@ function Native({
     return addr;
   }
 
-  function scrollToImage(event: MouseEvent<HTMLAnchorElement>) {
+  function scrollToImage(event: React.MouseEvent<HTMLAnchorElement>) {
     event.stopPropagation(); // to prevent collapsing if collapsible
 
     if (instructionAddr) {

--- a/static/app/components/events/interfaces/frame/lineV2/nativeV2.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/nativeV2.tsx
@@ -1,4 +1,4 @@
-import {MouseEvent, MouseEventHandler, useContext} from 'react';
+import {useContext} from 'react';
 import styled from '@emotion/styled';
 import scrollToElement from 'scroll-to-element';
 
@@ -26,7 +26,7 @@ type Props = React.ComponentProps<typeof Expander> &
   React.ComponentProps<typeof LeadHint> & {
     frame: Frame;
     isUsedForGrouping: boolean;
-    onMouseDown?: MouseEventHandler<HTMLDivElement>;
+    onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
     onClick?: () => void;
     isFrameAfterLastNonApp?: boolean;
     includeSystemFrames?: boolean;
@@ -86,7 +86,7 @@ function Native({
     return addr;
   }
 
-  function scrollToImage(event: MouseEvent<HTMLAnchorElement>) {
+  function scrollToImage(event: React.MouseEvent<HTMLAnchorElement>) {
     event.stopPropagation(); // to prevent collapsing if collapsible
 
     if (instructionAddr) {

--- a/static/app/components/events/interfaces/spans/anchorLinkManager.tsx
+++ b/static/app/components/events/interfaces/spans/anchorLinkManager.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import {Component, createContext} from 'react';
 
 export type AnchorLinkManagerChildrenProps = {
   registerScrollFn: (id: string, fn: () => void) => void;
   scrollToHash: (hash: string) => void;
 };
 
-const AnchorLinkManagerContext = React.createContext<AnchorLinkManagerChildrenProps>({
+const AnchorLinkManagerContext = createContext<AnchorLinkManagerChildrenProps>({
   registerScrollFn: () => () => undefined,
   scrollToHash: () => undefined,
 });
@@ -14,7 +14,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-export class Provider extends React.Component<Props> {
+export class Provider extends Component<Props> {
   componentDidMount() {
     this.scrollToHash(location.hash);
   }

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -1,4 +1,3 @@
-import {MouseEvent} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 import isNumber from 'lodash/isNumber';
@@ -610,7 +609,7 @@ export function scrollToSpan(
   scrollToHash: (hash: string) => void,
   location: Location
 ) {
-  return (e: MouseEvent<Element>) => {
+  return (e: React.MouseEvent<Element>) => {
     // do not use the default anchor behaviour
     // because it will be hidden behind the minimap
     e.preventDefault();

--- a/static/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/static/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -53,7 +53,7 @@ const defaultProps = {
 };
 
 type Props = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   organization: Organization;
 
   memberProjects: Project[];

--- a/static/app/components/organizations/globalSelectionHeader/index.tsx
+++ b/static/app/components/organizations/globalSelectionHeader/index.tsx
@@ -1,4 +1,4 @@
-import {ComponentPropsWithoutRef, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
@@ -23,7 +23,7 @@ const getDateObjectFromQuery = (query: Record<string, any>) =>
   );
 
 type GlobalSelectionHeaderProps = Omit<
-  ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,
+  React.ComponentPropsWithoutRef<typeof GlobalSelectionHeader>,
   | 'router'
   | 'memberProjects'
   | 'nonMemberProjects'

--- a/static/app/components/pageTimeRangeSelector.tsx
+++ b/static/app/components/pageTimeRangeSelector.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, useState} from 'react';
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import TimeRangeSelector from 'sentry/components/organizations/timeRangeSelector';
@@ -7,7 +7,7 @@ import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
-type Props = ComponentProps<typeof TimeRangeSelector> & {
+type Props = React.ComponentProps<typeof TimeRangeSelector> & {
   className?: string;
 };
 

--- a/static/app/components/performance/teamKeyTransaction.tsx
+++ b/static/app/components/performance/teamKeyTransaction.tsx
@@ -1,4 +1,4 @@
-import {Component, ComponentClass, Fragment, ReactPortal} from 'react';
+import {Component, Fragment} from 'react';
 import ReactDOM from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
@@ -25,7 +25,7 @@ export type TitleProps = Partial<ReturnType<GetActorPropsFn>> & {
 type Props = {
   isLoading: boolean;
   error: string | null;
-  title: ComponentClass<TitleProps>;
+  title: React.ComponentClass<TitleProps>;
   handleToggleKeyTransaction: (selection: TeamSelection) => void;
   teams: Team[];
   project: Project;
@@ -201,7 +201,7 @@ class TeamKeyTransaction extends Component<Props, State> {
     );
   }
 
-  renderMenu(): ReactPortal | null {
+  renderMenu(): React.ReactPortal | null {
     const {isLoading, counts, keyedTeams} = this.props;
 
     if (isLoading || !defined(counts) || !defined(keyedTeams)) {
@@ -242,7 +242,7 @@ class TeamKeyTransaction extends Component<Props, State> {
     const {isLoading, error, title: Title, keyedTeams, initialValue, teams} = this.props;
     const {isOpen} = this.state;
 
-    const menu: ReactPortal | null = isOpen ? this.renderMenu() : null;
+    const menu: React.ReactPortal | null = isOpen ? this.renderMenu() : null;
 
     return (
       <Manager>

--- a/static/app/components/performance/teamKeyTransactionsManager.tsx
+++ b/static/app/components/performance/teamKeyTransactionsManager.tsx
@@ -1,4 +1,4 @@
-import {Component, createContext, ReactNode} from 'react';
+import {Component, createContext} from 'react';
 import isEqual from 'lodash/isEqual';
 
 import {
@@ -39,7 +39,7 @@ const TeamKeyTransactionsManagerContext =
 
 type Props = {
   api: Client;
-  children: ReactNode;
+  children: React.ReactNode;
   organization: Organization;
   teams: Team[];
   selectedTeams: string[];

--- a/static/app/components/repositoryEditForm.tsx
+++ b/static/app/components/repositoryEditForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Component} from 'react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
 import {IconWarning} from 'sentry/icons';
@@ -17,7 +17,7 @@ type Props = Pick<Form['props'], 'onSubmitSuccess' | 'onCancel'> & {
   closeModal: () => void;
 };
 
-export default class RepositoryEditForm extends React.Component<Props> {
+export default class RepositoryEditForm extends Component<Props> {
   get initialData() {
     const {repository} = this.props;
 

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Route, RouteComponentProps} from 'react-router';
 
 import {ChildrenRenderFn} from 'sentry/components/acl/feature';

--- a/static/app/utils/attachmentUrl.tsx
+++ b/static/app/utils/attachmentUrl.tsx
@@ -1,4 +1,4 @@
-import {memo, ReactNode} from 'react';
+import {memo} from 'react';
 
 import Role from 'sentry/components/acl/role';
 import {IssueAttachment, Organization} from 'sentry/types';
@@ -9,7 +9,7 @@ type Props = {
   projectId: string;
   eventId: string;
   attachment: IssueAttachment;
-  children: (downloadUrl: string | null) => ReactNode;
+  children: (downloadUrl: string | null) => React.ReactNode;
 };
 
 function AttachmentUrl({attachment, organization, eventId, projectId, children}: Props) {

--- a/static/app/utils/performance/contexts/utils.tsx
+++ b/static/app/utils/performance/contexts/utils.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 type CreateContextReturn<T> = [React.Provider<T>, () => T, React.Context<T>];
 /*

--- a/static/app/utils/performance/suspectSpans/spanOpsQuery.tsx
+++ b/static/app/utils/performance/suspectSpans/spanOpsQuery.tsx
@@ -1,4 +1,3 @@
-import {ReactNode} from 'react';
 import omit from 'lodash/omit';
 
 import GenericDiscoverQuery, {
@@ -18,7 +17,7 @@ type ChildrenProps = Omit<GenericChildrenProps<SpanOpsProps>, 'tableData'> & {
 };
 
 type Props = RequestProps & {
-  children: (props: ChildrenProps) => ReactNode;
+  children: (props: ChildrenProps) => React.ReactNode;
 };
 
 function SpanOpsQuery(props: Props) {

--- a/static/app/utils/performance/suspectSpans/suspectSpansQuery.tsx
+++ b/static/app/utils/performance/suspectSpans/suspectSpansQuery.tsx
@@ -1,4 +1,3 @@
-import {ReactNode} from 'react';
 import omit from 'lodash/omit';
 
 import {defined} from 'sentry/utils';
@@ -23,7 +22,7 @@ type ChildrenProps = Omit<GenericChildrenProps<SuspectSpansProps>, 'tableData'> 
 };
 
 type Props = RequestProps & {
-  children: (props: ChildrenProps) => ReactNode;
+  children: (props: ChildrenProps) => React.ReactNode;
 };
 
 function getSuspectSpanPayload(props: RequestProps) {

--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -1,4 +1,4 @@
-import {Fragment, MouseEvent} from 'react';
+import {Fragment} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {urlEncode} from '@sentry/utils';
@@ -48,7 +48,7 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
     return `${path}?${urlEncode({next: window.location.pathname})}`;
   }
 
-  handleLogout = async (e: MouseEvent) => {
+  handleLogout = async (e: React.MouseEvent) => {
     e.preventDefault();
     await logout(this.api);
     window.location.replace(this.makeNextUrl('/auth/login/'));

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -1,5 +1,3 @@
-import {ComponentProps} from 'react';
-
 import diagramApdex from 'sentry-images/spot/alerts-wizard-apdex.svg';
 import diagramCLS from 'sentry-images/spot/alerts-wizard-cls.svg';
 import diagramCrashFreeSessions from 'sentry-images/spot/alerts-wizard-crash-free-sessions.svg';
@@ -59,7 +57,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
 type AlertWizardCategory = {
   categoryHeading: string;
   options: AlertType[];
-  featureBadgeType?: ComponentProps<typeof FeatureBadge>['type'];
+  featureBadgeType?: React.ComponentProps<typeof FeatureBadge>['type'];
 };
 export const getAlertWizardCategories = (org: Organization): AlertWizardCategory[] => [
   {

--- a/static/app/views/dashboardsV2/contextMenu.tsx
+++ b/static/app/views/dashboardsV2/contextMenu.tsx
@@ -1,4 +1,3 @@
-import {MouseEvent} from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
@@ -21,7 +20,7 @@ const ContextMenu = ({children}) => (
         >
           <DropdownTarget
             {...getActorProps<HTMLDivElement>({
-              onClick: (event: MouseEvent) => {
+              onClick: (event: React.MouseEvent) => {
                 event.stopPropagation();
                 event.preventDefault();
               },

--- a/static/app/views/dashboardsV2/create.tsx
+++ b/static/app/views/dashboardsV2/create.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';

--- a/static/app/views/dashboardsV2/view.tsx
+++ b/static/app/views/dashboardsV2/view.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 
 import {updateDashboardVisit} from 'sentry/actionCreators/dashboards';

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -1,4 +1,3 @@
-import {MouseEvent} from 'react';
 import * as React from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
@@ -392,7 +391,7 @@ const ContextMenu = ({children}) => (
         >
           <DropdownTarget
             {...getActorProps<HTMLDivElement>({
-              onClick: (event: MouseEvent) => {
+              onClick: (event: React.MouseEvent) => {
                 event.stopPropagation();
                 event.preventDefault();
               },

--- a/static/app/views/issueList/container.tsx
+++ b/static/app/views/issueList/container.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import {Component, Fragment} from 'react';
 import DocumentTitle from 'react-document-title';
 
 import NoProjectMessage from 'sentry/components/noProjectMessage';
@@ -27,12 +27,12 @@ class IssueListContainer extends Component<Props, State> {
     const {organization, children} = this.props;
     return (
       <DocumentTitle title={this.getTitle()}>
-        <React.Fragment>
+        <Fragment>
           {this.state.showSampleEventBanner && <SampleEventAlert />}
           <GlobalSelectionHeader>
             <NoProjectMessage organization={organization}>{children}</NoProjectMessage>
           </GlobalSelectionHeader>
-        </React.Fragment>
+        </Fragment>
       </DocumentTitle>
     );
   }

--- a/static/app/views/issueList/displayOptions.tsx
+++ b/static/app/views/issueList/displayOptions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
@@ -81,10 +81,10 @@ const IssueListDisplayOptions = ({
             : getDisplayLabel(display)
         }
       >
-        <React.Fragment>
+        <Fragment>
           {getMenuItem(IssueDisplayOptions.EVENTS)}
           {getMenuItem(IssueDisplayOptions.SESSIONS)}
-        </React.Fragment>
+        </Fragment>
       </StyledDropdownControl>
     </GuideAnchor>
   );

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {browserHistory, InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -211,7 +211,7 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
 
   if (error) {
     return (
-      <React.Fragment>
+      <Fragment>
         <ErrorMessage
           onRetry={fetchGroupingLevels}
           groupId={groupId}
@@ -221,7 +221,7 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
           hasProjectWriteAccess={organization.access.includes('project:write')}
         />
         <LinkFooter />
-      </React.Fragment>
+      </Fragment>
     );
   }
 

--- a/static/app/views/organizationIntegrations/integrationMainSettings.tsx
+++ b/static/app/views/organizationIntegrations/integrationMainSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Component} from 'react';
 
 import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
@@ -17,7 +17,7 @@ type State = {
   integration: Integration;
 };
 
-class IntegrationMainSettings extends React.Component<Props, State> {
+class IntegrationMainSettings extends Component<Props, State> {
   state: State = {
     integration: this.props.integration,
   };

--- a/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
+++ b/static/app/views/organizationIntegrations/pluginDeprecationAlert.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
@@ -21,7 +21,7 @@ class PluginDeprecationAlert extends Component<Props, State> {
 
     // Short-circuit if not deprecated.
     if (!plugin.deprecationDate) {
-      return <React.Fragment />;
+      return <Fragment />;
     }
     const resource = plugin.altIsSentryApp ? 'sentry-apps' : 'integrations';
     const upgradeUrl = `/settings/${organization.slug}/${resource}/${plugin.firstPartyAlternative}/`;

--- a/static/app/views/organizationStats/teamInsights/descriptionCard.tsx
+++ b/static/app/views/organizationStats/teamInsights/descriptionCard.tsx
@@ -1,12 +1,11 @@
-import {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 
 type Props = {
   title: string;
-  description: ReactNode;
-  children: ReactNode;
+  description: React.ReactNode;
+  children: React.ReactNode;
 };
 
 function DescriptionCard({title, description, children}: Props) {

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -1,4 +1,3 @@
-import {ReactText} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 import omit from 'lodash/omit';
@@ -63,7 +62,7 @@ export const LANDING_DISPLAYS = [
 ];
 
 export function excludeTransaction(
-  transaction: string | ReactText,
+  transaction: string | React.ReactText,
   props: {eventView: EventView; location: Location}
 ) {
   const {eventView, location} = props;

--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -1,4 +1,3 @@
-import React, {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -13,7 +12,7 @@ import {RadioLineItem} from 'sentry/views/settings/components/forms/controls/rad
 type Props = {
   selectedIndex: number;
   setSelectedIndex: (index: number) => void;
-  items: (() => ReactNode)[];
+  items: (() => React.ReactNode)[];
   radioColor?: string;
 };
 

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -1,4 +1,3 @@
-import {FunctionComponent, ReactNode} from 'react';
 import {Location} from 'history';
 
 import {Client} from 'sentry/api';
@@ -39,7 +38,7 @@ export type PerformanceWidgetProps = {
   location: Location;
   organization: Organization;
 
-  ContainerActions: FunctionComponent<{isLoading: boolean}>;
+  ContainerActions: React.FC<{isLoading: boolean}>;
 };
 
 export interface WidgetDataResult {
@@ -52,9 +51,9 @@ export interface WidgetDataConstraint {
 }
 
 export type QueryChildren = {
-  children: (props: any) => ReactNode; // TODO(k-fish): Fix any type.
+  children: (props: any) => React.ReactNode; // TODO(k-fish): Fix any type.
 };
-export type QueryFC<T extends WidgetDataConstraint> = FunctionComponent<
+export type QueryFC<T extends WidgetDataConstraint> = React.FC<
   QueryChildren & {
     fields?: string | string[];
     yAxis?: string | string[];
@@ -91,7 +90,7 @@ export type Queries<T extends WidgetDataConstraint> = Record<
 >;
 
 type Visualization<T> = {
-  component: FunctionComponent<{
+  component: React.FC<{
     widgetData: T;
     queryFields?: string;
     grid?: React.ComponentProps<typeof BaseChart>['grid'];
@@ -107,11 +106,11 @@ type Visualization<T> = {
 
 type Visualizations<T extends WidgetDataConstraint> = Readonly<Visualization<T>[]>; // Readonly because of index being used for React key.
 
-type HeaderActions<T> = FunctionComponent<{
+type HeaderActions<T> = React.FC<{
   widgetData: T;
 }>;
 
-type Subtitle<T> = FunctionComponent<{
+type Subtitle<T> = React.FC<{
   widgetData: T;
 }>;
 
@@ -134,7 +133,7 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   // Components
   Subtitle?: Subtitle<T>;
   HeaderActions?: HeaderActions<T>;
-  EmptyComponent?: FunctionComponent<{height?: number}>;
+  EmptyComponent?: React.FC<{height?: number}>;
 
   Queries: Queries<T>;
   Visualizations: Visualizations<T>;
@@ -159,7 +158,7 @@ export type QueryDefinitionWithKey<T extends WidgetDataConstraint> = QueryDefini
 export type QueryHandlerProps<T extends WidgetDataConstraint> = {
   api: Client;
   queries: QueryDefinitionWithKey<T>[];
-  children?: ReactNode;
+  children?: React.ReactNode;
   eventView: EventView;
   queryProps: WidgetPropUnion<T>;
 } & WidgetDataProps<T>;

--- a/static/app/views/performance/metricsSwitch.tsx
+++ b/static/app/views/performance/metricsSwitch.tsx
@@ -1,4 +1,4 @@
-import {createContext, ReactNode, useContext, useState} from 'react';
+import {createContext, useContext, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -46,7 +46,7 @@ const MetricsSwitchContext = createContext({
   setIsMetricsData: (_isMetricsData: boolean) => {},
 });
 
-function MetricsSwitchContextContainer({children}: {children: ReactNode}) {
+function MetricsSwitchContextContainer({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
   const localStorageKey = `metrics-performance:${organization.slug}`;
   const [isMetricsData, setIsMetricsData] = useState(

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -1,4 +1,3 @@
-import {ComponentProps, ReactNode} from 'react';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
@@ -24,7 +23,10 @@ import useOrganization from 'sentry/utils/useOrganization';
 
 import {MetaData} from './styles';
 
-type Props = Pick<ComponentProps<typeof QuickTrace>, 'errorDest' | 'transactionDest'> & {
+type Props = Pick<
+  React.ComponentProps<typeof QuickTrace>,
+  'errorDest' | 'transactionDest'
+> & {
   event: Event;
   location: Location;
   quickTrace: QuickTraceQueryChildrenProps | null;
@@ -62,8 +64,8 @@ export default function QuickTraceMeta({
   const traceId = event.contexts?.trace?.trace_id ?? null;
   const traceTarget = generateTraceTarget(event, organization);
 
-  let body: ReactNode;
-  let footer: ReactNode;
+  let body: React.ReactNode;
+  let footer: React.ReactNode;
 
   if (!traceId || !quickTrace || quickTrace.trace === null) {
     // this platform doesn't support performance don't show anything here
@@ -138,7 +140,13 @@ export default function QuickTraceMeta({
   );
 }
 
-export function QuickTraceMetaBase({body, footer}: {body: ReactNode; footer: ReactNode}) {
+export function QuickTraceMetaBase({
+  body,
+  footer,
+}: {
+  body: React.ReactNode;
+  footer: React.ReactNode;
+}) {
   return (
     <MetaData
       headingText={t('Trace Navigator')}

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -1,4 +1,4 @@
-import {Dispatch, ReactNode, SetStateAction, useState} from 'react';
+import {useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -32,7 +32,7 @@ export type ChildProps = {
   eventView: EventView;
   projectId: string;
   transactionName: string;
-  setError: Dispatch<SetStateAction<string | undefined>>;
+  setError: React.Dispatch<React.SetStateAction<string | undefined>>;
   // These are used to trigger a reload when the threshold/metric changes.
   transactionThreshold?: number;
   transactionThresholdMetric?: TransactionThresholdMetric;
@@ -46,7 +46,7 @@ type Props = {
   getDocumentTitle: (name: string) => string;
   generateEventView: (location: Location, transactionName: string) => EventView;
   childComponent: (props: ChildProps) => JSX.Element;
-  relativeDateOptions?: Record<string, ReactNode>;
+  relativeDateOptions?: Record<string, React.ReactNode>;
   maxPickableDays?: number;
   features?: string[];
 };
@@ -83,7 +83,9 @@ function PageLayout(props: Props) {
 
   const [error, setError] = useState<string | undefined>();
 
-  const [incompatibleAlertNotice, setIncompatibleAlertNotice] = useState<ReactNode>(null);
+  const [incompatibleAlertNotice, setIncompatibleAlertNotice] =
+    useState<React.ReactNode>(null);
+
   const handleIncompatibleQuery = (incompatibleAlertNoticeFn, _errors) => {
     const notice = incompatibleAlertNoticeFn(() => setIncompatibleAlertNotice(null));
     setIncompatibleAlertNotice(notice);

--- a/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/operationSort.tsx
@@ -1,4 +1,4 @@
-import {Component, ComponentClass, ReactPortal} from 'react';
+import {Component} from 'react';
 import ReactDOM from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import {browserHistory} from 'react-router';
@@ -16,7 +16,7 @@ import EventView from 'sentry/utils/discover/eventView';
 export type TitleProps = Partial<ReturnType<GetActorPropsFn>>;
 
 type Props = {
-  title: ComponentClass<TitleProps>;
+  title: React.ComponentClass<TitleProps>;
   eventView: EventView;
   tableMeta: TableData['meta'];
   location: Location;
@@ -162,7 +162,7 @@ class OperationSort extends Component<Props, State> {
   render() {
     const {title: Title} = this.props;
     const {isOpen} = this.state;
-    const menu: ReactPortal | null = isOpen ? this.renderMenu() : null;
+    const menu: React.ReactPortal | null = isOpen ? this.renderMenu() : null;
 
     return (
       <Manager>

--- a/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/suspectSpans.tsx
@@ -1,4 +1,4 @@
-import {Fragment, ReactNode} from 'react';
+import {Fragment} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -175,7 +175,7 @@ function renderHeadCellWithMeta(
   location: Location,
   sortColumn: GridColumnSortBy<SuspectSpanTableColumnKeys>
 ) {
-  return (column: SuspectSpanTableColumn, _index: number): ReactNode => {
+  return (column: SuspectSpanTableColumn, _index: number): React.ReactNode => {
     const columnType = SUSPECT_SPANS_TABLE_COLUMN_TYPE[column.key];
     const align = fieldAlignment(column.key, columnType);
 
@@ -218,7 +218,7 @@ function renderBodyCellWithMeta({
   return (
     column: SuspectSpanTableColumn,
     dataRow: SuspectSpanTableDataRow
-  ): ReactNode => {
+  ): React.ReactNode => {
     const fieldRenderer = getFieldRenderer(column.key, SUSPECT_SPANS_TABLE_COLUMN_TYPE);
     const rendered = fieldRenderer(dataRow, {location, organization});
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
@@ -1,4 +1,3 @@
-import {ReactNode} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -50,7 +49,7 @@ export const LowerPanel = styled('div')`
 
 type HeaderItemProps = {
   label: string;
-  value: ReactNode;
+  value: React.ReactNode;
   align: 'left' | 'right';
   isSortKey?: boolean;
 };

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -1,4 +1,3 @@
-import {ReactNode} from 'react';
 import {Location, LocationDescriptor, Query} from 'history';
 
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
@@ -265,7 +264,7 @@ function TotalCumulativeDuration(props: HeaderItemProps) {
   );
 }
 
-function renderHeadCell(column: SuspectSpanTableColumn, _index: number): ReactNode {
+function renderHeadCell(column: SuspectSpanTableColumn, _index: number): React.ReactNode {
   const align = fieldAlignment(column.key, SPANS_TABLE_COLUMN_TYPE[column.key]);
   return (
     <SortLink
@@ -289,7 +288,10 @@ function renderBodyCellWithMeta(
   ) => LocationDescriptor,
   suspectSpan: SuspectSpan
 ) {
-  return (column: SuspectSpanTableColumn, dataRow: SuspectSpanDataRow): ReactNode => {
+  return (
+    column: SuspectSpanTableColumn,
+    dataRow: SuspectSpanDataRow
+  ): React.ReactNode => {
     // if the transaction duration is falsey, then just render the span duration on its own
     if (column.key === 'spanDuration' && dataRow.transactionDuration) {
       return (

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import {Component} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location, LocationDescriptorObject} from 'history';

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
 
@@ -134,9 +134,9 @@ const TagsDisplay = (props: Props) => {
   );
 
   return (
-    <React.Fragment>
+    <Fragment>
       {tagKey ? (
-        <React.Fragment>
+        <Fragment>
           <TagKeyHistogramQuery
             eventView={eventView}
             orgSlug={organization.slug}
@@ -186,9 +186,9 @@ const TagsDisplay = (props: Props) => {
               );
             }}
           </SegmentExplorerQuery>
-        </React.Fragment>
+        </Fragment>
       ) : (
-        <React.Fragment>
+        <Fragment>
           <TagsHeatMap
             {...props}
             aggregateColumn={aggregateColumn}
@@ -202,9 +202,9 @@ const TagsDisplay = (props: Props) => {
             tableData={null}
             isLoading={false}
           />
-        </React.Fragment>
+        </Fragment>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import {Fragment, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
 import {Popper} from 'react-popper';
 import styled from '@emotion/styled';
@@ -313,7 +313,7 @@ const TagsHeatMap = (
             };
 
             return (
-              <React.Fragment>
+              <Fragment>
                 {ReactDOM.createPortal(
                   <div>
                     {chartElement ? (
@@ -359,7 +359,7 @@ const TagsHeatMap = (
                                           },
                                         });
                                     return (
-                                      <React.Fragment>
+                                      <Fragment>
                                         {isTransactionsLoading ? (
                                           <LoadingContainer>
                                             <LoadingIndicator size={40} hideMessage />
@@ -412,7 +412,7 @@ const TagsHeatMap = (
                                             ) : null}
                                           </div>
                                         )}
-                                      </React.Fragment>
+                                      </Fragment>
                                     );
                                   }}
                                 </TagTransactionsQuery>
@@ -438,7 +438,7 @@ const TagsHeatMap = (
                   ),
                   fixed: <Placeholder height="290px" testId="skeleton-ui" />,
                 })}
-              </React.Fragment>
+              </Fragment>
             );
           }}
         </DropdownMenu>

--- a/static/app/views/performance/trends/index.tsx
+++ b/static/app/views/performance/trends/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -30,7 +30,7 @@ type State = {
   error?: string;
 };
 
-class TrendsSummary extends React.Component<Props, State> {
+class TrendsSummary extends Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -1,4 +1,3 @@
-import {ReactElement} from 'react';
 import * as React from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -128,7 +127,7 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
 
   getIssueAlertsChoices(
     hasProperlyLoadedConditions: boolean
-  ): [string, string | ReactElement][] {
+  ): [string, string | React.ReactElement][] {
     const options: [string, React.ReactNode][] = [
       [Actions.CREATE_ALERT_LATER.toString(), t("I'll create my own alerts later")],
       [Actions.ALERT_ON_EVERY_ISSUE.toString(), t('Alert me on every new issue')],

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx
@@ -1,4 +1,3 @@
-import {ReactNode} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -21,7 +20,7 @@ type Props = Omit<ReleaseComparisonRow, 'diffDirection' | 'diffColor'> & {
   showPlaceholders: boolean;
   activeChart: ReleaseComparisonChartType;
   onChartChange: (type: ReleaseComparisonChartType) => void;
-  chartDiff: ReactNode;
+  chartDiff: React.ReactNode;
   onExpanderToggle: (type: ReleaseComparisonChartType) => void;
   expanded: boolean;
   withExpanders: boolean;

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -1,4 +1,3 @@
-import {ComponentProps} from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -144,7 +143,7 @@ function ReleaseAdoption({
     },
   };
 
-  const chartOptions: Omit<ComponentProps<typeof LineChart>, 'series' | 'ref'> = {
+  const chartOptions: Omit<React.ComponentProps<typeof LineChart>, 'series' | 'ref'> = {
     height: hasUsers ? 280 : 140,
     grid: [
       {

--- a/static/app/views/releases/list/releasesDropdown.tsx
+++ b/static/app/views/releases/list/releasesDropdown.tsx
@@ -1,10 +1,8 @@
-import {ComponentProps} from 'react';
-
 import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import Tooltip from 'sentry/components/tooltip';
 
 type DropdownItemProps = Pick<
-  ComponentProps<typeof DropdownItem>,
+  React.ComponentProps<typeof DropdownItem>,
   'disabled' | 'title'
 > & {
   label: string;

--- a/static/app/views/releases/list/releasesSortOptions.tsx
+++ b/static/app/views/releases/list/releasesSortOptions.tsx
@@ -1,4 +1,3 @@
-import {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
@@ -46,7 +45,7 @@ function ReleasesSortOptions({
           [ReleasesSortOption.SESSIONS_24_HOURS]: {label: t('Active Sessions')},
           [ReleasesSortOption.CRASH_FREE_SESSIONS]: {label: t('Crash Free Sessions')},
         }),
-  } as ComponentProps<typeof ReleasesDropdown>['options'];
+  } as React.ComponentProps<typeof ReleasesDropdown>['options'];
 
   if (organization.features.includes('semver')) {
     sortOptions[ReleasesSortOption.BUILD] = {label: t('Build Number')};

--- a/static/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import AlertLink from 'sentry/components/alertLink';
 import AsyncComponent from 'sentry/components/asyncComponent';
@@ -112,7 +112,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
       const field = Object.assign({}, NOTIFICATION_SETTING_FIELDS[notificationType], {
         getData: data => this.getStateToPutForDefault(data, notificationType),
         help: (
-          <React.Fragment>
+          <Fragment>
             <p>
               {NOTIFICATION_SETTING_FIELDS[notificationType].help}
               &nbsp;
@@ -123,7 +123,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
                 Fine tune
               </Link>
             </p>
-          </React.Fragment>
+          </Fragment>
         ),
       }) as any;
 
@@ -143,7 +143,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
     const {legacyData} = this.state;
 
     return (
-      <React.Fragment>
+      <Fragment>
         <SettingsPageHeader title="Notifications" />
         <TextBlock>Personal notifications sent via email or an integration.</TextBlock>
         <FeedbackAlert />
@@ -171,7 +171,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
         <AlertLink to="/settings/account/emails" icon={<IconMail />}>
           {t('Looking to add or remove an email address? Use the emails panel.')}
         </AlertLink>
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/static/app/views/settings/account/notifications/notificationSettingsByOrganization.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByOrganization.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Component} from 'react';
 
 import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
@@ -26,7 +26,7 @@ type Props = {
 
 type State = {};
 
-class NotificationSettingsByOrganization extends React.Component<Props, State> {
+class NotificationSettingsByOrganization extends Component<Props, State> {
   render() {
     const {notificationType, notificationSettings, onChange, organizations} = this.props;
 

--- a/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByProjects.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
@@ -85,7 +85,7 @@ class NotificationSettingsByProjects extends AsyncComponent<Props, State> {
     );
 
     return (
-      <React.Fragment>
+      <Fragment>
         {canSearch &&
           this.renderSearchInput({
             stateKey: 'projects',
@@ -117,7 +117,7 @@ class NotificationSettingsByProjects extends AsyncComponent<Props, State> {
         {canSearch && shouldPaginate && (
           <Pagination pageLinks={projectsPageLinks} {...this.props} />
         )}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {t} from 'sentry/locale';
@@ -228,7 +228,7 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
     const unlinkedOrgs = this.getUnlinkedOrgs();
     const {title, description} = ACCOUNT_NOTIFICATION_FIELDS[notificationType];
     return (
-      <React.Fragment>
+      <Fragment>
         <SettingsPageHeader title={title} />
         {description && <TextBlock>{description}</TextBlock>}
         {hasSlack && unlinkedOrgs.length > 0 && (
@@ -264,7 +264,7 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
               onChange={this.getStateToPutForParent}
             />
           ))}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/static/app/views/settings/account/notifications/unlinkedAlert.tsx
+++ b/static/app/views/settings/account/notifications/unlinkedAlert.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import Alert from 'sentry/components/alert';
@@ -10,7 +10,7 @@ type Props = {
   organizations: OrganizationSummary[];
 };
 
-class UnlinkedAlert extends React.Component<Props> {
+class UnlinkedAlert extends Component<Props> {
   render = () => {
     const {organizations} = this.props;
     return (

--- a/static/app/views/settings/components/defaultSearchBar.tsx
+++ b/static/app/views/settings/components/defaultSearchBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';

--- a/static/app/views/settings/components/forms/controls/rangeSlider.tsx
+++ b/static/app/views/settings/components/forms/controls/rangeSlider.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, KeyboardEvent, MouseEvent, useEffect, useState} from 'react';
+import {forwardRef as reactFowardRef, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
@@ -63,9 +63,9 @@ type Props = {
    * be triggered quite frequently
    */
   onBlur?: (
-    event: MouseEvent<HTMLInputElement> | KeyboardEvent<HTMLInputElement>
+    event: React.MouseEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>
   ) => void;
-  onChange?: (value: Props['value'], event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (value: Props['value'], event: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
   forwardRef?: React.Ref<HTMLDivElement>;
 };
@@ -118,17 +118,19 @@ function RangeSlider({
     return allowedValues[newSliderValue];
   }
 
-  function handleInput(e: ChangeEvent<HTMLInputElement>) {
+  function handleInput(e: React.ChangeEvent<HTMLInputElement>) {
     const newSliderValue = parseInt(e.target.value, 10);
     setSliderValue(newSliderValue);
     onChange?.(getActualValue(newSliderValue), e);
   }
 
-  function handleCustomInputChange(e: ChangeEvent<HTMLInputElement>) {
+  function handleCustomInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     setSliderValue(parseInt(e.target.value, 10) || 0);
   }
 
-  function handleBlur(e: MouseEvent<HTMLInputElement> | KeyboardEvent<HTMLInputElement>) {
+  function handleBlur(
+    e: React.MouseEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>
+  ) {
     if (typeof onBlur !== 'function') {
       return;
     }
@@ -193,7 +195,7 @@ function RangeSlider({
   );
 }
 
-const RangeSliderContainer = React.forwardRef(function RangeSliderContainer(
+const RangeSliderContainer = reactFowardRef(function RangeSliderContainer(
   props: Props,
   ref: React.Ref<any>
 ) {

--- a/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/teamCrumb.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import debounce from 'lodash/debounce';
 

--- a/static/app/views/settings/projectPerformance/index.tsx
+++ b/static/app/views/settings/projectPerformance/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Component} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';
@@ -12,7 +12,7 @@ type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
   project: Project;
 };
 
-class ProjectPerformanceContainer extends React.Component<Props> {
+class ProjectPerformanceContainer extends Component<Props> {
   render() {
     return (
       <Feature features={['performance-view']}>

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -138,7 +138,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
     const {organization, project} = this.props;
     const endpoint = `/projects/${organization.slug}/${project.slug}/transaction-threshold/configure/`;
     return (
-      <React.Fragment>
+      <Fragment>
         <SettingsPageHeader title={t('Performance')} />
         <PermissionAlert />
         <Form
@@ -173,7 +173,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
             )}
           />
         </Form>
-      </React.Fragment>
+      </Fragment>
     );
   }
 }

--- a/tests/js/spec/views/performance/metricsSwitch.spec.tsx
+++ b/tests/js/spec/views/performance/metricsSwitch.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 
 import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -11,10 +11,10 @@ import {
 function TestComponent() {
   const {isMetricsData} = useMetricsSwitch();
   return (
-    <React.Fragment>
+    <Fragment>
       <MetricsSwitch />
       {isMetricsData ? 'using metrics' : 'using transactions'}
-    </React.Fragment>
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
You don't need to import React to access the `React.*` types. This
removes almost all imports that are type only for react.

Also removes `import React from 'react'` since this was often
incorrectly added.

It would be nice to lint this but I don't see any lints right now :/