### PR TITLE
feat(integrations): adds organizationIntegrationStatus and updates types

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -141,6 +141,7 @@ class OrganizationIntegrationSerializer(Serializer):  # type: ignore
                 "externalId": obj.integration.external_id,
                 "organizationId": obj.organization.id,
                 "organizationIntegrationStatus": obj.get_status_display(),
+                "gracePeriodEnd": obj.grace_period_end,
             }
         )
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -140,6 +140,7 @@ class OrganizationIntegrationSerializer(Serializer):  # type: ignore
                 "configData": config_data,
                 "externalId": obj.integration.external_id,
                 "organizationId": obj.organization.id,
+                "organizationIntegrationStatus": obj.get_status_display(),
             }
         )
 

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -288,6 +288,7 @@ export type Integration = {
   scopes?: string[];
   status: ObjectStatus;
   organizationIntegrationStatus: ObjectStatus;
+  gracePeriodEnd: string;
   provider: OrganizationIntegrationProvider;
   dynamicDisplayInformation?: {
     configure_integration?: {
@@ -308,6 +309,7 @@ export type OrganizationIntegration = {
   name: string;
   status: ObjectStatus;
   organizationIntegrationStatus: ObjectStatus;
+  gracePeriodEnd: string;
   provider: OrganizationIntegrationProvider;
   configOrganization: Field[];
   configData: ConfigData | null;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -275,6 +275,10 @@ export type IntegrationProvider = BaseIntegrationProvider & {
   };
 };
 
+type OrganizationIntegrationProvider = BaseIntegrationProvider & {
+  aspects: IntegrationAspects;
+};
+
 export type Integration = {
   id: string;
   name: string;
@@ -283,7 +287,7 @@ export type Integration = {
   accountType: string;
   scopes?: string[];
   status: ObjectStatus;
-  provider: BaseIntegrationProvider & {aspects: IntegrationAspects};
+  provider: OrganizationIntegrationProvider;
   dynamicDisplayInformation?: {
     configure_integration?: {
       instructions: string[];
@@ -294,10 +298,29 @@ export type Integration = {
   };
 };
 
+type ConfigData = {
+  installationType?: string;
+};
+
+export type OrganizationIntegration = {
+  id: string;
+  name: string;
+  status: ObjectStatus;
+  organizationIntegrationStatus: ObjectStatus;
+  provider: OrganizationIntegrationProvider;
+  configOrganization: Field[];
+  configData: ConfigData | null;
+  organizationId: string;
+  externalId: string;
+  icon: string | null;
+  domainName: string | null;
+  accountType: string | null;
+};
+
 // we include the configOrganization when we need it
 export type IntegrationWithConfig = Integration & {
   configOrganization: Field[];
-  configData: object | null;
+  configData: ConfigData;
 };
 
 /**

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -287,6 +287,7 @@ export type Integration = {
   accountType: string;
   scopes?: string[];
   status: ObjectStatus;
+  organizationIntegrationStatus: ObjectStatus;
   provider: OrganizationIntegrationProvider;
   dynamicDisplayInformation?: {
     configure_integration?: {

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {t} from 'sentry/locale';
 import {Organization, OrganizationSummary} from 'sentry/types';
+import {OrganizationIntegration} from 'sentry/types/integrations';
 import withOrganizations from 'sentry/utils/withOrganizations';
 import {
   CONFIRMATION_MESSAGE,
@@ -14,10 +15,7 @@ import {ACCOUNT_NOTIFICATION_FIELDS} from 'sentry/views/settings/account/notific
 import {NOTIFICATION_SETTING_FIELDS} from 'sentry/views/settings/account/notifications/fields2';
 import NotificationSettingsByOrganization from 'sentry/views/settings/account/notifications/notificationSettingsByOrganization';
 import NotificationSettingsByProjects from 'sentry/views/settings/account/notifications/notificationSettingsByProjects';
-import {
-  Identity,
-  OrganizationIntegration,
-} from 'sentry/views/settings/account/notifications/types';
+import {Identity} from 'sentry/views/settings/account/notifications/types';
 import UnlinkedAlert from 'sentry/views/settings/account/notifications/unlinkedAlert';
 import {
   getCurrentDefault,

--- a/static/app/views/settings/account/notifications/types.tsx
+++ b/static/app/views/settings/account/notifications/types.tsx
@@ -1,47 +1,14 @@
-type ProviderAlert = {
-  type?: string;
-  text?: string;
-};
-
-type Provider = {
-  key?: string;
-  slug?: string;
-  name?: string;
-  canAdd?: boolean;
-  canDisable?: boolean;
-  features?: string[];
-  aspects?: {
-    alerts?: ProviderAlert[];
-  };
-};
-
-type ConfigOrganization = any; // this is very complicated and unimportant
-
-export type OrganizationIntegration = {
-  id?: string;
-  name?: string;
-  icon?: string;
-  domainName?: string;
-  accountType?: string;
-  status?: string;
-  provider?: Provider;
-  configOrganization?: ConfigOrganization[];
-  configData: {
-    installationType?: string;
-  };
-  organizationId?: number;
-  externalId?: string;
-};
+import {ObjectStatus} from 'sentry/types/core';
 
 type IdentityProvider = {
-  id?: string;
-  type?: string;
-  externalId?: string;
+  id: string;
+  type: string;
+  externalId: string;
 };
 
 export type Identity = {
-  id?: string;
-  identityProvider?: IdentityProvider;
-  externalId?: string;
-  status?: string;
+  id: string;
+  identityProvider: IdentityProvider;
+  externalId: string;
+  status: ObjectStatus;
 };

--- a/tests/js/spec/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/tests/js/spec/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -1,12 +1,10 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {OrganizationIntegration} from 'sentry/types/integrations';
 import {NotificationSettingsObject} from 'sentry/views/settings/account/notifications/constants';
 import NotificationSettingsByType from 'sentry/views/settings/account/notifications/notificationSettingsByType';
-import {
-  Identity,
-  OrganizationIntegration,
-} from 'sentry/views/settings/account/notifications/types';
+import {Identity} from 'sentry/views/settings/account/notifications/types';
 
 const addMockResponses = (
   notificationSettings: NotificationSettingsObject,


### PR DESCRIPTION
This PR adds the `organizationIntegrationStatus` and `gracePeriodEnd` fields to the `Integration` and `OrganizationIntegration` serializers and improves the typing of `OrganizationIntegration`. We are going to use the new field to show an alert if the `OrganizationIntegration` is disabled.