### PR TITLE
fix(echarts): Fix tooltip formatter for stacked charts

### DIFF
--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -186,7 +186,7 @@ function getFormatter({
     // The data attribute is usually a list of [name, value] but can also be an object of {name, value} when
     // there is item specific formatting being used.
     const timestamp = Array.isArray(seriesParamsOrParam)
-      ? seriesParams[0].data[0]
+      ? seriesParams[0].value[0]
       : getSeriesValue(seriesParams[0], 0);
 
     const date =


### PR DESCRIPTION
Yesterday i switched us from `seriesParams[0].axisValue` to `seriesParams[0].data[0]` because axisValue is always a string in echarts v5 even if we expected a number. Turns out this is an array in stacked charts. I think we want `seriesParams[0].value[0]`