### PR TITLE
fix(dashboards): Fixed getWidgetInterval returning incorrect intervals

### DIFF
--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -47,8 +47,14 @@ function getWidgetInterval(
   const desiredPeriod = parsePeriodToHours(interval);
   const selectedRange = getDiffInMinutes(datetimeObj);
 
-  if (selectedRange / desiredPeriod > MAX_BIN_COUNT) {
-    return getInterval(datetimeObj, 'high');
+  // selectedRange is in minutes, desiredPeriod is in hours
+  // convert desiredPeriod to minutes
+  if (selectedRange / (desiredPeriod * 60) > MAX_BIN_COUNT) {
+    const highInterval = getInterval(datetimeObj, 'high');
+    // Only return high fidelity interval if desired interval is higher fidelity
+    if (desiredPeriod < parsePeriodToHours(highInterval)) {
+      return highInterval;
+    }
   }
   return interval;
 }

--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -30,8 +30,8 @@ import {TOP_N} from 'sentry/utils/discover/types';
 import {DisplayType, Widget, WidgetQuery} from './types';
 import {eventViewFromWidget} from './utils';
 
-// Don't fetch more than 4000 bins as we're plotting on a small area.
-const MAX_BIN_COUNT = 4000;
+// Don't fetch more than 66 bins as we're plotting on a small area.
+const MAX_BIN_COUNT = 66;
 
 function getWidgetInterval(
   widget: Widget,

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -561,16 +561,15 @@ describe('Dashboards > WidgetQueries', function () {
       url: '/organizations/org-slug/events-stats/',
       body: [],
     });
-    const barWidget = {
+    const areaWidget = {
       ...singleQueryWidget,
-      displayType: 'bar',
-      // Should be ignored for bars.
-      interval: '5m',
+      displayType: 'area',
+      interval: '1d',
     };
     const wrapper = mountWithTheme(
       <WidgetQueries
         api={api}
-        widget={barWidget}
+        widget={areaWidget}
         organization={initialData.organization}
         selection={{
           ...selection,

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -556,7 +556,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
   });
 
-  it('calls events-stats with 1d interval when interval buckets would exceed 66', async function () {
+  it('calls events-stats with desired 1d interval when interval buckets would exceed 66 and calculated interval is higher fidelity', async function () {
     const eventsStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: [],

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -555,4 +555,81 @@ describe('Dashboards > WidgetQueries', function () {
       })
     );
   });
+
+  it('calls events-stats with 1d interval when interval buckets would exceed 4000', async function () {
+    const eventsStatsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+    });
+    const barWidget = {
+      ...singleQueryWidget,
+      displayType: 'bar',
+      // Should be ignored for bars.
+      interval: '5m',
+    };
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={barWidget}
+        organization={initialData.organization}
+        selection={{
+          ...selection,
+          datetime: {
+            period: '90d',
+          },
+        }}
+      >
+        {() => <div data-test-id="child" />}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 1 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(eventsStatsMock).toHaveBeenCalledTimes(1);
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({query: expect.objectContaining({interval: '1d'})})
+    );
+  });
+
+  it('calls events-stats with 4h interval when interval buckets would exceed 4000', async function () {
+    const eventsStatsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: [],
+    });
+    const barWidget = {
+      ...singleQueryWidget,
+      displayType: 'area',
+      interval: '5m',
+    };
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={barWidget}
+        organization={initialData.organization}
+        selection={{
+          ...selection,
+          datetime: {
+            period: '90d',
+          },
+        }}
+      >
+        {() => <div data-test-id="child" />}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 1 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(eventsStatsMock).toHaveBeenCalledTimes(1);
+    expect(eventsStatsMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({query: expect.objectContaining({interval: '4h'})})
+    );
+  });
 });

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -556,7 +556,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
   });
 
-  it('calls events-stats with 1d interval when interval buckets would exceed 4000', async function () {
+  it('calls events-stats with 1d interval when interval buckets would exceed 66', async function () {
     const eventsStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: [],
@@ -595,12 +595,12 @@ describe('Dashboards > WidgetQueries', function () {
     );
   });
 
-  it('calls events-stats with 4h interval when interval buckets would exceed 4000', async function () {
+  it('calls events-stats with 4h interval when interval buckets would exceed 66', async function () {
     const eventsStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: [],
     });
-    const barWidget = {
+    const areaWidget = {
       ...singleQueryWidget,
       displayType: 'area',
       interval: '5m',
@@ -608,7 +608,7 @@ describe('Dashboards > WidgetQueries', function () {
     const wrapper = mountWithTheme(
       <WidgetQueries
         api={api}
-        widget={barWidget}
+        widget={areaWidget}
         organization={initialData.organization}
         selection={{
           ...selection,


### PR DESCRIPTION
Fixed getWidgetInterval not checking interval buckets against `MAX_BIN_COUNT` correctly. 
Fixed getWidgetInterval returning high fidelity interval if desired interval is lower fidelity.