### PR TITLE
ref(js): Improve functionality of SentryDocumentTitle

### DIFF
--- a/static/app/components/sentryDocumentTitle.tsx
+++ b/static/app/components/sentryDocumentTitle.tsx
@@ -2,15 +2,14 @@ import * as React from 'react';
 import DocumentTitle from 'react-document-title';
 
 type Props = {
-  // Main page title
-  title: string;
+  title?: string;
   orgSlug?: string;
   projectSlug?: string;
-  children?: React.ReactNode;
+  children?: React.ReactChild;
 };
 
 function SentryDocumentTitle({title, orgSlug, projectSlug, children}: Props) {
-  function getDocTitle() {
+  function getPageTitle() {
     if (!orgSlug && !projectSlug) {
       return title;
     }
@@ -26,13 +25,10 @@ function SentryDocumentTitle({title, orgSlug, projectSlug, children}: Props) {
     return `${title} - ${projectSlug}`;
   }
 
-  const docTitle = getDocTitle();
+  const pageTitle = getPageTitle();
+  const documentTitle = pageTitle ? `${pageTitle} - Sentry` : 'Sentry';
 
-  return (
-    <DocumentTitle title={`${docTitle} - Sentry`}>
-      {children as React.ReactChild}
-    </DocumentTitle>
-  );
+  return <DocumentTitle title={documentTitle}>{children}</DocumentTitle>;
 }
 
 export default SentryDocumentTitle;

--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -154,7 +154,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
 
     return (
       <SentryDocumentTitle title={t('Dashboards')} orgSlug={organization.slug}>
-        {super.renderComponent()}
+        {super.renderComponent() as React.ReactChild}
       </SentryDocumentTitle>
     );
   }

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -328,7 +328,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
         orgSlug={organization.slug}
         projectSlug={projectSlug}
       >
-        {super.renderComponent()}
+        {super.renderComponent() as React.ReactChild}
       </SentryDocumentTitle>
     );
   }

--- a/static/app/views/organizationStats/teamInsights/index.tsx
+++ b/static/app/views/organizationStats/teamInsights/index.tsx
@@ -21,7 +21,7 @@ function TeamInsightsContainer({children, organization}: Props) {
             ? cloneElement(children, {
                 organization,
               })
-            : children}
+            : (children as React.ReactChild)}
         </SentryDocumentTitle>
       </NoProjectMessage>
     </Feature>

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -268,7 +268,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
         title={t('Performance - Event Details')}
         orgSlug={organization.slug}
       >
-        {super.renderComponent()}
+        {super.renderComponent() as React.ReactChild}
       </SentryDocumentTitle>
     );
   }


### PR DESCRIPTION
- If no `title` is passed set it to just `Sentry`.

 - Fixes the child type. The DocumentTitle should only accept React.ReactChild, we push up this type checking to callers of the SentryDocumentTitle (which we should fix in the future)