### PR TITLE
ref(sentry-apps): Use SentryAppAvatars from the DB instead of SVGs

### DIFF
--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -25,8 +25,6 @@ const StyledBaseAvatar = styled('span')<{
   flex-shrink: 0;
   border-radius: ${p => (p.round ? '50%' : '3px')};
   border: ${p => (p.suggested ? `1px dashed ${p.theme.gray400}` : 'none')};
-  background-color: ${p =>
-    p.loaded ? p.theme.background : 'background-color: rgba(200, 200, 200, 0.1);'};
 `;
 
 const defaultProps: DefaultProps = {

--- a/static/app/components/avatar/index.tsx
+++ b/static/app/components/avatar/index.tsx
@@ -5,13 +5,13 @@ import ProjectAvatar from 'sentry/components/avatar/projectAvatar';
 import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
-import {AvatarProject, OrganizationSummary, SentryApp, Team} from 'sentry/types';
+import {AvatarProject, AvatarSentryApp, OrganizationSummary, Team} from 'sentry/types';
 
 type Props = {
   team?: Team;
   organization?: OrganizationSummary;
   project?: AvatarProject;
-  sentryApp?: SentryApp;
+  sentryApp?: AvatarSentryApp;
   /**
    * True if the Avatar is full color, rather than B&W (Used for SentryAppAvatar)
    */

--- a/static/app/components/avatar/sentryAppAvatar.tsx
+++ b/static/app/components/avatar/sentryAppAvatar.tsx
@@ -1,9 +1,9 @@
 import BaseAvatar from 'sentry/components/avatar/baseAvatar';
 import {IconGeneric} from 'sentry/icons';
-import {SentryApp} from 'sentry/types';
+import {AvatarSentryApp} from 'sentry/types';
 
 type Props = {
-  sentryApp?: SentryApp;
+  sentryApp?: AvatarSentryApp;
   isColor?: boolean;
   isDefault?: boolean;
 } & BaseAvatar['props'];

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import ExternalLink from 'sentry/components/links/externalLink';
-import {SentryAppIcon} from 'sentry/components/sentryAppIcon';
+import SentryAppIcon from 'sentry/components/sentryAppIcon';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {SentryAppComponent} from 'sentry/types';
@@ -42,7 +42,7 @@ const OpenInContextLine = ({lineNo, filename, components}: Props) => {
             onContextMenu={onClickRecordInteraction}
             openInNewTab
           >
-            <SentryAppIcon slug={slug} />
+            <SentryAppIcon sentryAppComponent={component} />
             <OpenInName>{t(`${component.sentryApp.name}`)}</OpenInName>
           </OpenInLink>
         );

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/react';
 import {openModal} from 'sentry/actionCreators/modal';
 import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
 import Access from 'sentry/components/acl/access';
+import Feature from 'sentry/components/acl/feature';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {Body, Header, Hovercard} from 'sentry/components/hovercard';
 import {IconInfo} from 'sentry/icons';
@@ -329,9 +330,17 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       <OpenInContainer columnQuantity={2}>
         <div>{t('Open this line in')}</div>
         <OpenInLink onClick={() => this.onOpenLink()} href={url} openInNewTab>
-          <StyledIconWrapper isDark={ConfigStore.get('theme') === 'dark'}>
-            {getIntegrationIcon(config.provider.key)}
-          </StyledIconWrapper>
+          <Feature features={['organizations:sentry-app-logo-upload']}>
+            {({hasFeature}) => (
+              <StyledIconWrapper
+                isDark={ConfigStore.get('theme') === 'dark'}
+                hasFeature={hasFeature}
+              >
+                {getIntegrationIcon(config.provider.key)}
+              </StyledIconWrapper>
+            )}
+          </Feature>
+
           <OpenInName>{config.provider.name}</OpenInName>
         </OpenInLink>
       </OpenInContainer>
@@ -364,8 +373,9 @@ export const CodeMappingButtonContainer = styled(OpenInContainer)`
   justify-content: space-between;
 `;
 
-const StyledIconWrapper = styled('span')<{isDark: boolean}>`
-  color: ${({isDark}) => (isDark ? 'white' : 'black')};
+const StyledIconWrapper = styled('span')<{isDark: boolean; hasFeature: boolean}>`
+  color: ${({isDark, hasFeature}) =>
+    !hasFeature ? 'inherit' : isDark ? 'white' : 'black'};
   line-height: 0;
 `;
 

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -10,6 +10,7 @@ import {Body, Header, Hovercard} from 'sentry/components/hovercard';
 import {IconInfo} from 'sentry/icons';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tct} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import {
   Frame,
@@ -328,7 +329,9 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       <OpenInContainer columnQuantity={2}>
         <div>{t('Open this line in')}</div>
         <OpenInLink onClick={() => this.onOpenLink()} href={url} openInNewTab>
-          {getIntegrationIcon(config.provider.key)}
+          <StyledIconWrapper isDark={ConfigStore.get('theme') === 'dark'}>
+            {getIntegrationIcon(config.provider.key)}
+          </StyledIconWrapper>
           <OpenInName>{config.provider.name}</OpenInName>
         </OpenInLink>
       </OpenInContainer>
@@ -359,6 +362,11 @@ export {StacktraceLink};
 
 export const CodeMappingButtonContainer = styled(OpenInContainer)`
   justify-content: space-between;
+`;
+
+const StyledIconWrapper = styled('span')<{isDark: boolean}>`
+  color: ${({isDark}) => (isDark ? 'white' : 'black')};
+  line-height: 0;
 `;
 
 const StyledIconClose = styled(IconClose)`

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -6,7 +6,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {deleteExternalIssue} from 'sentry/actionCreators/platformExternalIssues';
 import {Client} from 'sentry/api';
 import {IntegrationLink} from 'sentry/components/issueSyncListElement';
-import {SentryAppIcon} from 'sentry/components/sentryAppIcon';
+import SentryAppIcon from 'sentry/components/sentryAppIcon';
 import {IconAdd, IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -126,7 +126,7 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
     return (
       <IssueLinkContainer>
         <IssueLink>
-          <StyledSentryAppIcon slug={sentryAppComponent.sentryApp.slug} />
+          <StyledSentryAppIcon sentryAppComponent={sentryAppComponent} />
           <IntegrationLink onClick={this.doOpenModal} href={url}>
             {displayName}
           </IntegrationLink>

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -157,17 +157,14 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
     return (
       <React.Fragment>
         <Heading>
-          <PluginIcon pluginId={sentryApp.slug} size={50} />
-
+          <PluginIcon sentryApp={sentryApp} isColor pluginId={sentryApp.slug} size={50} />
           <HeadingInfo>
             <Name>{sentryApp.name}</Name>
             {!!features.length && <Features>{this.featureTags(features)}</Features>}
           </HeadingInfo>
         </Heading>
-
         <Description dangerouslySetInnerHTML={{__html: marked(overview)}} />
         <FeatureList {...featureProps} provider={{...sentryApp, key: sentryApp.slug}} />
-
         <IntegrationFeatures {...featureProps}>
           {({disabled, disabledReason}) => (
             <React.Fragment>

--- a/static/app/components/sentryAppIcon.tsx
+++ b/static/app/components/sentryAppIcon.tsx
@@ -51,8 +51,10 @@ const SentryAppIcon = ({sentryAppComponent: {sentryApp}}: Props) => {
   return (
     <Feature features={['organizations:sentry-app-logo-upload']}>
       {({hasFeature}) => {
+        const selectedAvatar = sentryApp?.avatars?.find(({color}) => color === false);
+        const isDefault = !(selectedAvatar && selectedAvatar?.avatarType === 'upload');
         return hasFeature ? (
-          <AvatarWrapper isDark={ConfigStore.get('theme') === 'dark'}>
+          <AvatarWrapper shouldInvert={ConfigStore.get('theme') === 'dark' && !isDefault}>
             <Avatar size={20} sentryApp={sentryApp} isColor={false} />
           </AvatarWrapper>
         ) : (
@@ -65,9 +67,9 @@ const SentryAppIcon = ({sentryAppComponent: {sentryApp}}: Props) => {
 
 export default SentryAppIcon;
 
-const AvatarWrapper = styled('span')<{isDark: boolean}>`
-  ${({isDark}) =>
-    isDark &&
+const AvatarWrapper = styled('span')<{shouldInvert: boolean}>`
+  ${({shouldInvert}) =>
+    shouldInvert &&
     css`
       filter: invert(1);
     `}

--- a/static/app/components/sentryAppIcon.tsx
+++ b/static/app/components/sentryAppIcon.tsx
@@ -1,4 +1,3 @@
-import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -54,7 +53,10 @@ const SentryAppIcon = ({sentryAppComponent: {sentryApp}}: Props) => {
         const selectedAvatar = sentryApp?.avatars?.find(({color}) => color === false);
         const isDefault = !(selectedAvatar && selectedAvatar?.avatarType === 'upload');
         return hasFeature ? (
-          <AvatarWrapper shouldInvert={ConfigStore.get('theme') === 'dark' && !isDefault}>
+          <AvatarWrapper
+            isDark={ConfigStore.get('theme') === 'dark'}
+            isDefault={isDefault}
+          >
             <Avatar size={20} sentryApp={sentryApp} isColor={false} />
           </AvatarWrapper>
         ) : (
@@ -67,11 +69,8 @@ const SentryAppIcon = ({sentryAppComponent: {sentryApp}}: Props) => {
 
 export default SentryAppIcon;
 
-const AvatarWrapper = styled('span')<{shouldInvert: boolean}>`
-  ${({shouldInvert}) =>
-    shouldInvert &&
-    css`
-      filter: invert(1);
-    `}
+const AvatarWrapper = styled('span')<{isDark: boolean; isDefault: boolean}>`
+  color: ${({isDark}) => (isDark ? 'white' : 'black')};
+  filter: ${({isDark, isDefault}) => (isDark && !isDefault ? 'invert(1)' : 'invert(0)')};
   line-height: 0;
 `;

--- a/static/app/components/sentryAppIcon.tsx
+++ b/static/app/components/sentryAppIcon.tsx
@@ -1,3 +1,8 @@
+import {css} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Feature from 'sentry/components/acl/feature';
+import Avatar from 'sentry/components/avatar';
 import {
   IconCalixa,
   IconClickup,
@@ -10,13 +15,14 @@ import {
   IconTaskcall,
   IconTeamwork,
 } from 'sentry/icons';
+import ConfigStore from 'sentry/stores/configStore';
 import {SentryAppComponent} from 'sentry/types';
 
 type Props = {
-  slug: SentryAppComponent['sentryApp']['slug'];
+  sentryAppComponent: SentryAppComponent;
 };
 
-const SentryAppIcon = ({slug}: Props) => {
+const getFallbackIcon = (slug: string) => {
   switch (slug) {
     case 'calixa':
       return <IconCalixa size="md" />;
@@ -41,4 +47,29 @@ const SentryAppIcon = ({slug}: Props) => {
   }
 };
 
-export {SentryAppIcon};
+const SentryAppIcon = ({sentryAppComponent: {sentryApp}}: Props) => {
+  return (
+    <Feature features={['organizations:sentry-app-logo-upload']}>
+      {({hasFeature}) => {
+        return hasFeature ? (
+          <AvatarWrapper isDark={ConfigStore.get('theme') === 'dark'}>
+            <Avatar size={20} sentryApp={sentryApp} isColor={false} />
+          </AvatarWrapper>
+        ) : (
+          getFallbackIcon(sentryApp.slug)
+        );
+      }}
+    </Feature>
+  );
+};
+
+export default SentryAppIcon;
+
+const AvatarWrapper = styled('span')<{isDark: boolean}>`
+  ${({isDark}) =>
+    isDark &&
+    css`
+      filter: invert(1);
+    `}
+  line-height: 0;
+`;

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -52,6 +52,7 @@ import visualstudio from 'sentry-logos/logo-visualstudio.svg';
 import youtrack from 'sentry-logos/logo-youtrack.svg';
 import zulip from 'sentry-logos/logo-zulip.svg';
 
+import Feature from 'sentry/components/acl/feature';
 import Avatar from 'sentry/components/avatar';
 import {SentryApp} from 'sentry/types';
 
@@ -144,10 +145,15 @@ const FallbackPluginIcon = styled('div')<Props>`
 `;
 
 const PluginIcon = ({pluginId, size, sentryApp, isColor}: Props) => {
-  return sentryApp ? (
-    <Avatar size={size} sentryApp={sentryApp} isColor={isColor} />
-  ) : (
-    <FallbackPluginIcon pluginId={pluginId} size={size} />
+  return (
+    <Feature features={['organizations:sentry-app-logo-upload']}>
+      {({hasFeature}) => {
+        if (hasFeature && sentryApp) {
+          return <Avatar size={size} sentryApp={sentryApp} isColor={isColor} />;
+        }
+        return <FallbackPluginIcon pluginId={pluginId} size={size} />;
+      }}
+    </Feature>
   );
 };
 

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -127,6 +127,7 @@ type Props = {
   size?: number;
   isColor?: boolean;
   sentryApp?: SentryApp;
+  className?: string;
 };
 
 // The following component uses hardcoded frontend resources
@@ -144,18 +145,23 @@ const FallbackPluginIcon = styled('div')<Props>`
     (pluginId !== undefined && ICON_PATHS[pluginId]) || DEFAULT_ICON});
 `;
 
-const PluginIcon = ({pluginId, size, sentryApp, isColor}: Props) => {
-  return (
-    <Feature features={['organizations:sentry-app-logo-upload']}>
-      {({hasFeature}) => {
-        if (hasFeature && sentryApp) {
-          return <Avatar size={size} sentryApp={sentryApp} isColor={isColor} />;
-        }
-        return <FallbackPluginIcon pluginId={pluginId} size={size} />;
-      }}
-    </Feature>
-  );
-};
+const PluginIcon = ({pluginId, size, sentryApp, isColor, className}: Props) => (
+  <Feature features={['organizations:sentry-app-logo-upload']}>
+    {({hasFeature}) => {
+      if (hasFeature && sentryApp) {
+        return (
+          <Avatar
+            size={size}
+            sentryApp={sentryApp}
+            isColor={isColor}
+            className={className}
+          />
+        );
+      }
+      return <FallbackPluginIcon pluginId={pluginId} size={size} className={className} />;
+    }}
+  </Feature>
+);
 
 PluginIcon.defaultProps = {
   pluginId: '_default',

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -52,6 +52,9 @@ import visualstudio from 'sentry-logos/logo-visualstudio.svg';
 import youtrack from 'sentry-logos/logo-youtrack.svg';
 import zulip from 'sentry-logos/logo-zulip.svg';
 
+import Avatar from 'sentry/components/avatar';
+import {SentryApp} from 'sentry/types';
+
 // Map of plugin id -> logo filename
 export const DEFAULT_ICON = placeholder;
 export const ICON_PATHS = {
@@ -63,7 +66,6 @@ export const ICON_PATHS = {
   os: sentry,
   urls: sentry,
   webhooks: sentry,
-
   'amazon-sqs': aws,
   aws_lambda: aws,
   amixr,
@@ -122,9 +124,12 @@ export const ICON_PATHS = {
 type Props = {
   pluginId?: string;
   size?: number;
+  isColor?: boolean;
+  sentryApp?: SentryApp;
 };
 
-const PluginIcon = styled('div')<Props>`
+// The following component uses hardcoded frontend resources
+const FallbackPluginIcon = styled('div')<Props>`
   position: relative;
   height: ${p => p.size}px;
   width: ${p => p.size}px;
@@ -138,9 +143,18 @@ const PluginIcon = styled('div')<Props>`
     (pluginId !== undefined && ICON_PATHS[pluginId]) || DEFAULT_ICON});
 `;
 
+const PluginIcon = ({pluginId, size, sentryApp, isColor}: Props) => {
+  return sentryApp ? (
+    <Avatar size={size} sentryApp={sentryApp} isColor={isColor} />
+  ) : (
+    <FallbackPluginIcon pluginId={pluginId} size={size} />
+  );
+};
+
 PluginIcon.defaultProps = {
   pluginId: '_default',
   size: 20,
+  isColor: true,
 };
 
 export default PluginIcon;

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -164,6 +164,14 @@ export type SentryApp = {
   avatars?: Avatar[];
 };
 
+// Minimal Sentry App representation for use with avatars
+export type AvatarSentryApp = {
+  name: string;
+  slug: string;
+  uuid: string;
+  avatars?: Avatar[];
+};
+
 export type SentryAppInstallation = {
   app: {
     uuid: string;
@@ -183,17 +191,9 @@ export type SentryAppComponent = {
   schema: SentryAppSchemaStacktraceLink;
   sentryApp: {
     uuid: string;
-    slug:
-      | 'calixa'
-      | 'clickup'
-      | 'komodor'
-      | 'linear'
-      | 'rookout'
-      | 'shortcut'
-      | 'spikesh'
-      | 'taskcall'
-      | 'teamwork';
+    slug: string;
     name: string;
+    avatars: Avatar[];
   };
 };
 

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -228,6 +228,10 @@ class AbstractIntegrationDetailedView<
     return getCategories(this.featureData);
   }
 
+  renderIntegrationIcon() {
+    return <PluginIcon pluginId={this.integrationSlug} size={50} />;
+  }
+
   renderRequestIntegrationButton() {
     return (
       <RequestIntegrationButton
@@ -276,7 +280,7 @@ class AbstractIntegrationDetailedView<
 
     return (
       <Flex>
-        <PluginIcon pluginId={this.integrationSlug} size={50} />
+        {this.renderIntegrationIcon()}
         <NameContainer>
           <Flex>
             <Name>{this.integrationName}</Name>

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -420,6 +420,7 @@ export class IntegrationListDirectory extends AsyncComponent<
 
     return (
       <IntegrationRow
+        sentryApp={app}
         key={`sentry-app-row-${app.slug}`}
         data-test-id="integration-row"
         organization={organization}

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -41,7 +41,7 @@ type Props = {
    * in the alert.
    */
   resolveText?: string;
-
+  sentryApp?: SentryApp;
   plugin?: PluginWithProjectList;
 };
 
@@ -65,6 +65,7 @@ const IntegrationRow = (props: Props) => {
     alertText,
     resolveText,
     plugin,
+    sentryApp,
   } = props;
 
   const baseUrl =
@@ -95,7 +96,7 @@ const IntegrationRow = (props: Props) => {
   return (
     <PanelRow noPadding data-test-id={slug}>
       <FlexContainer>
-        <PluginIcon size={36} pluginId={slug} />
+        <PluginIcon sentryApp={sentryApp} isColor size={36} pluginId={slug} />
         <Container>
           <IntegrationName to={baseUrl}>{displayName}</IntegrationName>
           <IntegrationDetails>

--- a/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -12,6 +12,7 @@ import CircleIndicator from 'sentry/components/circleIndicator';
 import Confirm from 'sentry/components/confirm';
 import {IconSubtract} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import {IntegrationFeature, SentryApp, SentryAppInstallation} from 'sentry/types';
 import {toPermissions} from 'sentry/utils/consolidatedScopes';
@@ -276,6 +277,17 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   // no configurations for sentry apps
   renderConfigurations() {
     return null;
+  }
+
+  renderIntegrationIcon() {
+    return (
+      <PluginIcon
+        sentryApp={this.sentryApp}
+        isColor
+        pluginId={this.integrationSlug}
+        size={50}
+      />
+    );
   }
 }
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -47,7 +47,7 @@ export default class SentryApplicationRow extends PureComponent<Props> {
     return (
       <SentryAppItem data-test-id={app.slug}>
         <StyledFlex>
-          <PluginIcon size={36} pluginId={app.slug} />
+          <PluginIcon sentryApp={app} isColor size={36} pluginId={app.slug} />
           <SentryAppBox>
             <SentryAppName hideStatus={this.hideStatus()}>
               <Link to={`/settings/${organization.slug}/developer-settings/${app.slug}/`}>


### PR DESCRIPTION
See [API-2270](https://getsentry.atlassian.net/browse/API-2270)

This PR will use the Sentry App Avatars instead of the default logos that appear for unpublished/internal apps. To see the logos and new styles, the user must be flagged into the feature.

### Screenshots

#### Without Feature Flag

![image](https://user-images.githubusercontent.com/35509934/144488130-0009fb0f-d961-4929-b56a-6d659c4d31fd.png)

![image](https://user-images.githubusercontent.com/35509934/144487995-773dabc1-0403-4e4e-9037-3fe21b655597.png)

![image](https://user-images.githubusercontent.com/35509934/144488027-34740569-8034-43d7-ab39-78d2d6de68bc.png)


#### Light Mode Integration Directory

![directory](https://user-images.githubusercontent.com/35509934/144331464-1ec0ef98-6916-4a7c-8560-31f8239be620.png)

#### Dark Mode Integration Directory

![dm directory](https://user-images.githubusercontent.com/35509934/144331461-1c6a0cf7-6e2e-4a09-9f9a-785be7340aae.png)

#### Light Mode Detail View

![detailed](https://user-images.githubusercontent.com/35509934/144331462-76be84cb-1ff1-4d34-ae0c-3622b4ade6a8.png)

#### Dark Mode Detail View

![dm detailed](https://user-images.githubusercontent.com/35509934/144331463-76ecd6d7-30af-457b-acce-87c1c463ec74.png)

#### Developer Settings

![dev settings](https://user-images.githubusercontent.com/35509934/144331466-caa9610c-cfcf-468f-bb35-45350db91bb7.png)

####  Light Mode Stacktrace Linking

![image](https://user-images.githubusercontent.com/35509934/144486763-5f9ec663-5d2b-4861-b1f2-3e75214e86bb.png)

####  Dark Mode Stacktrace Linking

![image](https://user-images.githubusercontent.com/35509934/144486818-2bbce3f4-fbc5-4907-a120-e345f8b3f337.png)

#### Light Mode Issue Linking

![image](https://user-images.githubusercontent.com/35509934/144486900-992cb427-d2ed-4b40-9a0b-0fc0cbc8ffa7.png)

#### Dark Mode Issue Linking

![image](https://user-images.githubusercontent.com/35509934/144486860-0a2c81dd-4d92-4a95-9f21-d19b7f6bb448.png)

---


### TODO

- [x] Write a better PR description
- [ ] Write tests for altered logic (if applicable)
- [x] Ensure organization integrations have updated stacktrace link colors
- [x] Screenshots for UI component changes