### PR TITLE
fix(ui): Use Input component in Issue Index sidebar

### DIFF
--- a/static/app/views/issueList/sidebar.tsx
+++ b/static/app/views/issueList/sidebar.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Tag, TagCollection} from 'sentry/types';
 import {objToQuery, QueryObj, queryToObj} from 'sentry/utils/stream';
+import Input from 'sentry/views/settings/components/forms/controls/input';
 
 import IssueListTagFilter from './tagFilter';
 import {TagValueLoader} from './types';
@@ -116,8 +117,7 @@ class IssueListSidebar extends React.Component<Props, State> {
             <StreamTagFilter>
               <StyledHeader>{t('Text')}</StyledHeader>
               <form onSubmit={this.onTextFilterSubmit}>
-                <input
-                  className="form-control"
+                <Input
                   placeholder={t('Search title and culprit text body')}
                   onChange={this.onTextChange}
                   value={this.state.textFilter}

--- a/static/app/views/issueList/sidebar.tsx
+++ b/static/app/views/issueList/sidebar.tsx
@@ -176,4 +176,5 @@ const StreamTagFilter = styled('div')`
 
 const StyledHr = styled('hr')`
   margin: ${space(2)} 0 0;
+  border-top: solid 1px ${p => p.theme.innerBorder};
 `;

--- a/static/app/views/issueList/tagFilter.tsx
+++ b/static/app/views/issueList/tagFilter.tsx
@@ -8,6 +8,7 @@ import SelectControl from 'sentry/components/forms/selectControl';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Tag, TagValue} from 'sentry/types';
+import Input from 'sentry/views/settings/components/forms/controls/input';
 
 import {TagValueLoader} from './types';
 
@@ -160,12 +161,7 @@ class IssueListTagFilter extends React.Component<Props, State> {
         <StyledHeader>{tag.key}</StyledHeader>
 
         {!!tag.isInput && (
-          <input
-            className="form-control"
-            type="text"
-            value={this.state.textValue}
-            onChange={this.handleChangeInput}
-          />
+          <Input value={this.state.textValue} onChange={this.handleChangeInput} />
         )}
 
         {!tag.isInput && (


### PR DESCRIPTION
In the Issue Index sidebar, we should use the updated Input component. The current version does not adapt to dark mode.

Before:
<img width="314" alt="Screen Shot 2021-12-01 at 3 55 09 PM" src="https://user-images.githubusercontent.com/44172267/144333256-494ae47b-024a-4c52-83e8-29bdca36e4fe.png">

After:
<img width="314" alt="Screen Shot 2021-12-01 at 3 55 20 PM" src="https://user-images.githubusercontent.com/44172267/144333262-96cc0725-327d-4d09-8289-f381f170e275.png">

