### PR TITLE
style: Onboarding progress bar color

### DIFF
--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -251,7 +251,7 @@ const ProgressBar = styled('div')`
     display: block;
     content: '';
     height: 4px;
-    background: ${p => p.theme.inactive};
+    background: ${p => p.theme.border};
     left: 2px;
     right: 2px;
     top: 50%;
@@ -264,7 +264,7 @@ const ProgressStep = styled('div')<{active: boolean}>`
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 4px solid ${p => (p.active ? p.theme.active : p.theme.inactive)};
+  border: 4px solid ${p => (p.active ? p.theme.active : p.theme.border)};
   background: ${p => p.theme.background};
 `;
 


### PR DESCRIPTION
We should use a lighter color for the inactive state.

Before:
![image](https://user-images.githubusercontent.com/44172267/144334151-f92aa34e-cda6-408d-873a-4ff3d78d0d9b.png)

After:
<img width="317" alt="Screen Shot 2021-12-01 at 4 04 32 PM" src="https://user-images.githubusercontent.com/44172267/144334167-0e994850-c26e-4503-bc3a-e209231aee89.png">
<img width="317" alt="Screen Shot 2021-12-01 at 4 04 06 PM" src="https://user-images.githubusercontent.com/44172267/144334184-77792327-687a-4357-a1db-b9418603592d.png">


