### PR TITLE
ref(ratelimits): Move utils to module

### DIFF
--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -1,89 +1,21 @@
-"""Middleware that applies a rate limit to every endpoint."""
-
-
 from __future__ import annotations
 
-from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
-from rest_framework.request import Request
 
-from sentry.api.base import Endpoint
-from sentry.api.helpers.group_index.index import EndpointFunction
-from sentry.app import ratelimiter
-from sentry.types.ratelimit import RateLimit
-
-
-def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | None:
-    """Construct a consistent global rate limit key using the arguments provided"""
-
-    view = view_func.__qualname__
-    http_method = request.method
-
-    # This avoids touching user session, which means we avoid
-    # setting `Vary: Cookie` as a response header which will
-    # break HTTP caching entirely.
-    if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
-        return None
-
-    request_user = getattr(request, "user", None)
-    user_id = getattr(request_user, "id", None)
-    is_sentry_app = getattr(request_user, "is_sentry_app", None)
-
-    request_access = getattr(request, "access", None)
-    org_id = getattr(request_access, "organization_id", None)
-
-    ip_address = request.META.get("REMOTE_ADDR")
-
-    if is_sentry_app and org_id is not None:
-        category = "org"
-        id = org_id
-    elif user_id is not None:
-        category = "user"
-        id = user_id
-    elif ip_address is not None:
-        category = "ip"
-        id = ip_address
-    # If IP address doesn't exist, skip ratelimiting for now
-    else:
-        return None
-    return f"{category}:{view}:{http_method}:{id}"
-
-
-def get_rate_limit_value(http_method: str, endpoint: Endpoint, category: str) -> RateLimit | None:
-    """
-    Read the rate limit from the view function to be used for the rate limit check
-    """
-    rate_limit_lookup_dict = getattr(endpoint, "rate_limits", None)
-
-    # if the endpoint doesn't have a rate limit property, then it isn't a subclass to our Endpoint
-    # it should not be rate limited
-    if rate_limit_lookup_dict is None:
-        return None
-    rate_limits = rate_limit_lookup_dict.get(http_method, settings.SENTRY_RATELIMITER_DEFAULTS)
-    return rate_limits.get(category, settings.SENTRY_RATELIMITER_DEFAULTS[category])
-
-
-def above_rate_limit_check(key: str, rate_limit: RateLimit):
-    is_limited, current = ratelimiter.is_limited_with_value(
-        key, limit=rate_limit.limit, window=rate_limit.window
-    )
-    return {
-        "is_limited": is_limited,
-        "current": current,
-        "limit": rate_limit.limit,
-        "window": rate_limit.window,
-    }
+from sentry.ratelimits import (
+    above_rate_limit_check,
+    can_be_ratelimited,
+    get_rate_limit_key,
+    get_rate_limit_value,
+)
 
 
 class RatelimitMiddleware(MiddlewareMixin):
-    def _can_be_ratelimited(self, request: Request, view_func: EndpointFunction):
-        return hasattr(view_func, "view_class") and not request.path_info.startswith(
-            settings.ANONYMOUS_STATIC_PREFIXES
-        )
+    """Middleware that applies a rate limit to every endpoint."""
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         """Check if the endpoint call will violate"""
-        if not self._can_be_ratelimited(request, view_func):
+        if not can_be_ratelimited(request, view_func):
             request.will_be_rate_limited = False
             return
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -8,6 +8,7 @@ from sentry.ratelimits import (
     get_rate_limit_key,
     get_rate_limit_value,
 )
+from sentry.types.ratelimit import RateLimitCategory
 
 
 class RatelimitMiddleware(MiddlewareMixin):
@@ -27,7 +28,7 @@ class RatelimitMiddleware(MiddlewareMixin):
         rate_limit = get_rate_limit_value(
             http_method=request.method,
             endpoint=view_func.view_class,
-            category=key.split(":", 1)[0],
+            category=RateLimitCategory(key.split(":", 1)[0]),
         )
         if rate_limit is None:
             return

--- a/src/sentry/ratelimits/__init__.py
+++ b/src/sentry/ratelimits/__init__.py
@@ -2,7 +2,14 @@ from django.conf import settings
 
 from sentry.utils.services import LazyServiceWrapper
 
-__all__ = ("for_organization_member_invite", "RateLimiter")
+__all__ = (
+    "for_organization_member_invite",
+    "above_rate_limit_check",
+    "can_be_ratelimited",
+    "get_rate_limit_key",
+    "get_rate_limit_value",
+    "RateLimiter",
+)
 
 from .base import RateLimiter  # NOQA
 
@@ -11,4 +18,10 @@ backend = LazyServiceWrapper(
 )
 backend.expose(locals())
 
-from .utils import for_organization_member_invite
+from .utils import (
+    above_rate_limit_check,
+    can_be_ratelimited,
+    for_organization_member_invite,
+    get_rate_limit_key,
+    get_rate_limit_value,
+)

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Type
 
 from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.api.base import Endpoint
-from sentry.types.ratelimit import RateLimit
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.hashlib import md5_text
 
 from . import backend as ratelimiter
 
 if TYPE_CHECKING:
+    from sentry.api.base import Endpoint
     from sentry.models import ApiToken, Organization, User
 
 # TODO(mgaeta): It's not currently possible to type a Callable's args with kwargs.
@@ -71,7 +71,9 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
     return f"{category}:{view}:{http_method}:{id}"
 
 
-def get_rate_limit_value(http_method: str, endpoint: Endpoint, category: str) -> RateLimit | None:
+def get_rate_limit_value(
+    http_method: str, endpoint: Type[Endpoint], category: RateLimitCategory
+) -> RateLimit | None:
     """
     Read the rate limit from the view function to be used for the rate limit check
     """

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
+
+from django.conf import settings
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from sentry import features
+from sentry.api.base import Endpoint
+from sentry.types.ratelimit import RateLimit
 from sentry.utils.hashlib import md5_text
 
 from . import backend as ratelimiter
 
 if TYPE_CHECKING:
     from sentry.models import ApiToken, Organization, User
+
+# TODO(mgaeta): It's not currently possible to type a Callable's args with kwargs.
+EndpointFunction = Callable[..., Response]
 
 DEFAULT_CONFIG = {
     # 100 invites from a user per day
@@ -18,6 +27,74 @@ DEFAULT_CONFIG = {
     # 10 invites per email per org per day
     "members:org-invite-to-email": {"limit": 10, "window": 3600 * 24},
 }
+
+
+def can_be_ratelimited(request: Request, view_func: EndpointFunction) -> bool:
+    return hasattr(view_func, "view_class") and not request.path_info.startswith(
+        settings.ANONYMOUS_STATIC_PREFIXES
+    )
+
+
+def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | None:
+    """Construct a consistent global rate limit key using the arguments provided"""
+
+    view = view_func.__qualname__
+    http_method = request.method
+
+    # This avoids touching user session, which means we avoid
+    # setting `Vary: Cookie` as a response header which will
+    # break HTTP caching entirely.
+    if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
+        return None
+
+    request_user = getattr(request, "user", None)
+    user_id = getattr(request_user, "id", None)
+    is_sentry_app = getattr(request_user, "is_sentry_app", None)
+
+    request_access = getattr(request, "access", None)
+    org_id = getattr(request_access, "organization_id", None)
+
+    ip_address = request.META.get("REMOTE_ADDR")
+
+    if is_sentry_app and org_id is not None:
+        category = "org"
+        id = org_id
+    elif user_id is not None:
+        category = "user"
+        id = user_id
+    elif ip_address is not None:
+        category = "ip"
+        id = ip_address
+    # If IP address doesn't exist, skip ratelimiting for now
+    else:
+        return None
+    return f"{category}:{view}:{http_method}:{id}"
+
+
+def get_rate_limit_value(http_method: str, endpoint: Endpoint, category: str) -> RateLimit | None:
+    """
+    Read the rate limit from the view function to be used for the rate limit check
+    """
+    rate_limit_lookup_dict = getattr(endpoint, "rate_limits", None)
+
+    # If the endpoint doesn't have a rate limit property, then it isn't a
+    # subclass to our Endpoint it should not be rate limited.
+    if rate_limit_lookup_dict is None:
+        return None
+    rate_limits = rate_limit_lookup_dict.get(http_method, settings.SENTRY_RATELIMITER_DEFAULTS)
+    return rate_limits.get(category, settings.SENTRY_RATELIMITER_DEFAULTS[category])
+
+
+def above_rate_limit_check(key: str, rate_limit: RateLimit) -> Mapping[str, bool | int]:
+    is_limited, current = ratelimiter.is_limited_with_value(
+        key, limit=rate_limit.limit, window=rate_limit.window
+    )
+    return {
+        "is_limited": is_limited,
+        "current": current,
+        "limit": rate_limit.limit,
+        "window": rate_limit.window,
+    }
 
 
 def for_organization_member_invite(

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -9,12 +9,8 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from sentry.auth.access import from_request
-from sentry.middleware.ratelimit import (
-    RatelimitMiddleware,
-    above_rate_limit_check,
-    get_rate_limit_key,
-    get_rate_limit_value,
-)
+from sentry.middleware.ratelimit import RatelimitMiddleware
+from sentry.ratelimits import above_rate_limit_check, get_rate_limit_key, get_rate_limit_value
 from sentry.testutils import TestCase
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 

--- a/tests/sentry/ratelimits/test_redis.py
+++ b/tests/sentry/ratelimits/test_redis.py
@@ -14,7 +14,6 @@ class RedisRateLimiterTest(TestCase):
             assert self.backend.is_limited("foo", 1, self.project)
 
     def test_simple_key(self):
-
         with freeze_time("2000-01-01"):
             assert not self.backend.is_limited("foo", 1)
             assert self.backend.is_limited("foo", 1)

--- a/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
+++ b/tests/sentry/ratelimits/utils/test_above_rate_limit_check.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from sentry.ratelimits import above_rate_limit_check
+from sentry.types.ratelimit import RateLimit
+
+
+class RatelimitMiddlewareTest(TestCase):
+    def test_above_rate_limit_check(self):
+        return_val = above_rate_limit_check("foo", RateLimit(10, 100))
+        assert return_val == dict(is_limited=False, current=1, limit=10, window=100)

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+
+from django.conf import settings
+
+from sentry.api.base import Endpoint
+from sentry.ratelimits import get_rate_limit_value
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+class TestGetRateLimitValue(TestCase):
+    def test_default_rate_limit_values(self):
+        """Ensure that the default rate limits are called for endpoints without overrides."""
+
+        class TestEndpoint(Endpoint):
+            pass
+
+        assert (
+            get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.IP]
+        )
+        assert (
+            get_rate_limit_value("POST", TestEndpoint, RateLimitCategory.ORGANIZATION)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.ORGANIZATION]
+        )
+        assert (
+            get_rate_limit_value("DELETE", TestEndpoint, RateLimitCategory.USER)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.USER]
+        )
+
+    def test_override_rate_limit(self):
+        """Override one or more of the default rate limits."""
+
+        class TestEndpoint(Endpoint):
+            rate_limits = {
+                "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
+                "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
+            }
+
+        assert get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP) == RateLimit(100, 5)
+        assert (
+            get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.USER)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.USER]
+        )
+        assert (
+            get_rate_limit_value("POST", TestEndpoint, RateLimitCategory.IP)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.IP]
+        )
+        assert get_rate_limit_value("POST", TestEndpoint, RateLimitCategory.USER) == RateLimit(
+            20, 4
+        )
+
+    def test_non_endpoint(self):
+        """Views that don't inherit Endpoint should not return a value."""
+
+        class TestEndpoint:
+            pass
+
+        assert get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP) is None

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -1,7 +1,6 @@
 from unittest import TestCase
 
 from django.test import RequestFactory
-from exam import fixture
 
 from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from sentry.auth.access import Access
@@ -10,11 +9,9 @@ from sentry.ratelimits import get_rate_limit_key
 
 
 class GetRateLimitKeyTest(TestCase):
-    factory = fixture(RequestFactory)
-
     def setUp(self) -> None:
         self.view = OrganizationGroupIndexEndpoint
-        self.request = self.factory.get("/")
+        self.request = RequestFactory().get("/")
 
     def test_default_ip(self):
         assert (

--- a/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
+++ b/tests/sentry/ratelimits/utils/test_get_ratelimit_key.py
@@ -1,0 +1,62 @@
+from unittest import TestCase
+
+from django.test import RequestFactory
+from exam import fixture
+
+from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
+from sentry.auth.access import Access
+from sentry.models import Organization, User
+from sentry.ratelimits import get_rate_limit_key
+
+
+class GetRateLimitKeyTest(TestCase):
+    factory = fixture(RequestFactory)
+
+    def setUp(self) -> None:
+        self.view = OrganizationGroupIndexEndpoint
+        self.request = self.factory.get("/")
+
+    def test_default_ip(self):
+        assert (
+            get_rate_limit_key(self.view, self.request)
+            == "ip:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+        )
+
+    def test_ip_address_missing(self):
+        self.request.META["REMOTE_ADDR"] = None
+        assert get_rate_limit_key(self.view, self.request) is None
+
+    def test_ipv6(self):
+        self.request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
+        assert (
+            get_rate_limit_key(self.view, self.request)
+            == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+        )
+
+    def test_users(self):
+        user = User(id=1)
+        self.request.session = {}
+        self.request.user = user
+        assert (
+            get_rate_limit_key(self.view, self.request)
+            == f"user:OrganizationGroupIndexEndpoint:GET:{user.id}"
+        )
+
+    def test_organization(self):
+        organization = Organization(id=1)
+        self.request.session = {}
+        self.request.user = User(id=1, is_sentry_app=True)
+        self.request.access = Access(
+            scopes=[],
+            is_active=True,
+            organization_id=organization.id,
+            teams=[],
+            projects=[],
+            has_global_access=False,
+            sso_is_valid=True,
+            requires_sso=False,
+        )
+        assert (
+            get_rate_limit_key(self.view, self.request)
+            == f"org:OrganizationGroupIndexEndpoint:GET:{organization.id}"
+        )


### PR DESCRIPTION
This PR refactors ratelimits by moving util functions to a module. 
In order to speed up unit test I removed the dependency on `sentry.testutils.TestCase`.
