### PR TITLE
feat(ratelimits): Use BFS to find ratelimits

### DIFF
--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -85,7 +85,7 @@ def get_rate_limit_value(
             return ratelimit_option
 
         # Everything will eventually hit `object`, which has no __bases__.
-        for klass in endpoint.__bases__:
+        for klass in next_class.__bases__:
             classes_queue.append(klass)
 
     return settings.SENTRY_RATELIMITER_DEFAULTS[category]

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -13,7 +13,6 @@ from sentry.utils.hashlib import md5_text
 from . import backend as ratelimiter
 
 if TYPE_CHECKING:
-    from sentry.api.base import Endpoint
     from sentry.models import ApiToken, Organization, User
 
 # TODO(mgaeta): It's not currently possible to type a Callable's args with kwargs.
@@ -72,13 +71,18 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
 
 
 def get_rate_limit_value(
-    http_method: str, endpoint: Type[Endpoint], category: RateLimitCategory
+    http_method: str, endpoint: Type[object], category: RateLimitCategory
 ) -> RateLimit | None:
     """Read the rate limit from the view function to be used for the rate limit check."""
+    found_endpoint_class = False
     classes_queue = [endpoint]
     while len(classes_queue) > 0:
         next_class = classes_queue.pop(0)
-        rate_limit_lookup_dict = getattr(next_class, "rate_limits", {})
+        rate_limit_lookup_dict = getattr(next_class, "rate_limits", None)
+        if rate_limit_lookup_dict is not None:
+            found_endpoint_class = True
+        else:
+            rate_limit_lookup_dict = {}
         ratelimits_by_category = rate_limit_lookup_dict.get(http_method, {})
         ratelimit_option = ratelimits_by_category.get(category)
         if ratelimit_option:
@@ -88,6 +92,8 @@ def get_rate_limit_value(
         for klass in next_class.__bases__:
             classes_queue.append(klass)
 
+    if not found_endpoint_class:
+        return None
     return settings.SENTRY_RATELIMITER_DEFAULTS[category]
 
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -75,6 +75,7 @@ def get_rate_limit_value(
 ) -> RateLimit | None:
     """Read the rate limit from the view function to be used for the rate limit check."""
     found_endpoint_class = False
+    seen_classes = {endpoint}
     classes_queue = [endpoint]
     while len(classes_queue) > 0:
         next_class = classes_queue.pop(0)
@@ -90,7 +91,10 @@ def get_rate_limit_value(
 
         # Everything will eventually hit `object`, which has no __bases__.
         for klass in next_class.__bases__:
-            classes_queue.append(klass)
+            # Short-circuit for diamond inheritance.
+            if klass not in seen_classes:
+                classes_queue.append(klass)
+                seen_classes.add(klass)
 
     if not found_endpoint_class:
         return None

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -55,4 +55,15 @@ class TestGetRateLimitValue(TestCase):
         class TestEndpoint:
             pass
 
-        assert get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP) is None
+        assert (
+            get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.IP]
+        )
+        assert (
+            get_rate_limit_value("POST", TestEndpoint, RateLimitCategory.ORGANIZATION)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.ORGANIZATION]
+        )
+        assert (
+            get_rate_limit_value("DELETE", TestEndpoint, RateLimitCategory.USER)
+            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.USER]
+        )

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -49,6 +49,27 @@ class TestGetRateLimitValue(TestCase):
             20, 4
         )
 
+    def test_inherit(self):
+        class ParentEndpoint(Endpoint):
+            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(100, 5)}}
+
+        class ChildEndpoint(ParentEndpoint):
+            rate_limits = {"GET": {}}
+
+        assert get_rate_limit_value("GET", ChildEndpoint, RateLimitCategory.IP) == RateLimit(100, 5)
+
+    def test_multiple_inheritance(self):
+        class ParentEndpoint(Endpoint):
+            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(100, 5)}}
+
+        class Mixin:
+            rate_limits = {"GET": {RateLimitCategory.IP: RateLimit(2, 4)}}
+
+        class ChildEndpoint(ParentEndpoint, Mixin):
+            rate_limits = {"GET": {}}
+
+        assert get_rate_limit_value("GET", ChildEndpoint, RateLimitCategory.IP) == RateLimit(100, 5)
+
     def test_non_endpoint(self):
         """Views that don't inherit Endpoint should not return a value."""
 

--- a/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
+++ b/tests/sentry/ratelimits/utils/test_get_rate_limit_value.py
@@ -68,7 +68,13 @@ class TestGetRateLimitValue(TestCase):
         class ChildEndpoint(ParentEndpoint, Mixin):
             rate_limits = {"GET": {}}
 
+        class ChildEndpointReverse(Mixin, ParentEndpoint):
+            rate_limits = {"GET": {}}
+
         assert get_rate_limit_value("GET", ChildEndpoint, RateLimitCategory.IP) == RateLimit(100, 5)
+        assert get_rate_limit_value("GET", ChildEndpointReverse, RateLimitCategory.IP) == RateLimit(
+            2, 4
+        )
 
     def test_non_endpoint(self):
         """Views that don't inherit Endpoint should not return a value."""
@@ -76,15 +82,6 @@ class TestGetRateLimitValue(TestCase):
         class TestEndpoint:
             pass
 
-        assert (
-            get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP)
-            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.IP]
-        )
-        assert (
-            get_rate_limit_value("POST", TestEndpoint, RateLimitCategory.ORGANIZATION)
-            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.ORGANIZATION]
-        )
-        assert (
-            get_rate_limit_value("DELETE", TestEndpoint, RateLimitCategory.USER)
-            == settings.SENTRY_RATELIMITER_DEFAULTS[RateLimitCategory.USER]
-        )
+        assert get_rate_limit_value("GET", TestEndpoint, RateLimitCategory.IP) is None
+        assert get_rate_limit_value("POST", TestEndpoint, RateLimitCategory.ORGANIZATION) is None
+        assert get_rate_limit_value("DELETE", TestEndpoint, RateLimitCategory.USER) is None


### PR DESCRIPTION
When an Endpoint extends a BaseEndpoint that defines `rate_limits`, the rate limit dictionaries should be merged starting with at the root.