### PR TITLE
style: Button drop shadow

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -167,13 +167,13 @@ const getFontWeight = ({priority, borderless}: StyledButtonProps) =>
   `font-weight: ${priority === 'link' || borderless ? 'inherit' : 600};`;
 
 const getBoxShadow =
-  (active: boolean) =>
+  (theme: Theme, active: boolean) =>
   ({priority, borderless, disabled}: StyledButtonProps) => {
     if (disabled || borderless || priority === 'link') {
       return 'box-shadow: none';
     }
 
-    return `box-shadow: ${active ? 'inset' : ''} 0 2px rgba(0, 0, 0, 0.05)`;
+    return `box-shadow: ${active ? 'inset' : ''} ${theme.dropShadowLight}`;
   };
 
 const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) => {
@@ -263,12 +263,12 @@ const StyledButton = styled(
   ${getFontWeight};
   font-size: ${getFontSize};
   ${getColors};
-  ${getBoxShadow(false)};
+  ${p => getBoxShadow(p.theme, false)};
   cursor: ${p => (p.disabled ? 'not-allowed' : 'pointer')};
   opacity: ${p => (p.busy || p.disabled) && '0.65'};
 
   &:active {
-    ${getBoxShadow(true)};
+    ${p => getBoxShadow(p.theme, true)};
   }
   &:focus {
     outline: none;


### PR DESCRIPTION
Using the drop shadow from theme, instead of a hard-coded value.

Before:
<img width="696" alt="Screen Shot 2021-12-01 at 4 55 11 PM" src="https://user-images.githubusercontent.com/44172267/144338197-75159ade-9d40-402a-b439-fc9d6db855be.png">
<img width="696" alt="Screen Shot 2021-12-01 at 4 56 49 PM" src="https://user-images.githubusercontent.com/44172267/144338324-a52ee898-254e-4578-9d66-657c38a2e559.png">

After:
<img width="696" alt="Screen Shot 2021-12-01 at 4 55 19 PM" src="https://user-images.githubusercontent.com/44172267/144338208-73628d37-0eec-45c2-a32d-56eab802c58d.png">
<img width="696" alt="Screen Shot 2021-12-01 at 4 57 09 PM" src="https://user-images.githubusercontent.com/44172267/144338353-d2302b5e-5e0c-495a-8bed-6b99def54078.png">


