### PR TITLE
fix(workflow): Ignore alert owners that have been deleted

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -72,7 +72,10 @@ class AlertRuleSerializer(Serializer):
         for alert_rule in alert_rules.values():
             if alert_rule.owner_id:
                 type = actor_type_to_string(alert_rule.owner.type)
-                result[alert_rule]["owner"] = f"{type}:{resolved_actors[type][alert_rule.owner_id]}"
+                if alert_rule.owner_id in resolved_actors[type]:
+                    result[alert_rule][
+                        "owner"
+                    ] = f"{type}:{resolved_actors[type][alert_rule.owner_id]}"
 
         if "original_alert_rule" in self.expand:
             snapshot_activities = AlertRuleActivity.objects.filter(

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -68,7 +68,8 @@ class RuleSerializer(Serializer):
         for rule in rules.values():
             if rule.owner_id:
                 type = actor_type_to_string(rule.owner.type)
-                result[rule]["owner"] = f"{type}:{resolved_actors[type][rule.owner_id]}"
+                if rule.owner_id in resolved_actors[type]:
+                    result[rule]["owner"] = f"{type}:{resolved_actors[type][rule.owner_id]}"
 
         return result
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -1076,3 +1076,34 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         result = json.loads(response.content)
         assert len(result) == 4
         assert result[0]["latestIncident"]["id"] == str(crit_incident.id)
+
+    def test_non_existing_owner(self):
+        self.setup_project_and_rules()
+        team = self.create_team(organization=self.organization, members=[self.user])
+        alert_rule = self.create_alert_rule(
+            name="the best rule",
+            organization=self.org,
+            projects=[self.project],
+            date_added=before_now(minutes=1).replace(tzinfo=pytz.UTC),
+            owner=team.actor.get_actor_tuple(),
+        )
+        self.create_issue_alert_rule(
+            data={
+                "project": self.project,
+                "name": "Issue Rule Test",
+                "conditions": [],
+                "actions": [],
+                "actionMatch": "all",
+                "date_added": before_now(minutes=2).replace(tzinfo=pytz.UTC),
+                "owner": team.actor,
+            }
+        )
+        team.delete()
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            request_data = {"per_page": "10"}
+            response = self.client.get(
+                path=self.combined_rules_url, data=request_data, content_type="application/json"
+            )
+        assert response.status_code == 200
+        assert response.data[0]["id"] == str(alert_rule.id)
+        assert response.data[0]["owner"] is None


### PR DESCRIPTION
In #29979 we started removing alert rule owners that needed to be removed when transferring a project. However, anyone that transferred a project before this change would be stuck with alerts that don't load.

https://getsentry.atlassian.net/browse/ISSUE-1358