### PR TITLE
ref: Update symbolicator snapshots in preparation for new SymCache

### DIFF
--- a/tests/fixtures/native/unreal_crash.sym
+++ b/tests/fixtures/native/unreal_crash.sym
@@ -3160,9 +3160,11 @@ FUNC 500c8 126 0 OAPIPELINE::GetOptimalMatrixMixFunction(OAPIPELINE::EAudioForma
 501e4 2 289 1582
 501e6 7 303 1582
 501ed 1 310 1582
+PUBLIC 501ee 0 <truncated> # Original file was truncated. The following record here fills the gap between 501ef-703390, as the new SymCache does not allow gaps in the middle of the file.
+PUBLIC 501ef 0 <truncated>
 PUBLIC 703390 0 AActor::IsPendingKillPending()
 PUBLIC 7036a0 0 AOnlineBeacon::IsRelevancyOwnerFor(AActor const *,AActor const *,AActor const *)
 PUBLIC 7036b0 0 FVoicePacketImpl::IsReliable()
 PUBLIC 7036c0 0 FOnlineVoiceImpl::IsRemotePlayerTalking(FUniqueNetId const &)
 PUBLIC 703700 0 FVoiceEngineImpl::IsRemotePlayerTalking(FUniqueNetId const &)
-FUNC 703800 1 0 <EOF>  # Original file was truncated. Added to prevent the last PUBLIC record covering the remainder of the file.
+FUNC 703800 1 0 <EOF> # Original file was truncated. Added to prevent the last PUBLIC record covering the remainder of the file.

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-12-02T13:46:44.534064Z'
+created: '2021-12-02T13:53:08.216475Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -128,10 +128,13 @@ exception:
       frames:
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: AActor::IsPendingKillPending
         in_app: false
         instruction_addr: '0x7ff754be3394'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: AActor::IsPendingKillPending()
+        symbol: AActor::IsPendingKillPending()
         trust: context
       registers:
         r10: '0x7ffef000'
@@ -166,59 +169,23 @@ threads:
       frames:
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff7548229e6'
+        instruction_addr: '0x7ff7548229e5'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75563d233'
+        instruction_addr: '0x7ff754814ea9'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589ca88b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a4831a8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754814eaa'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a4831a8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -236,17 +203,23 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff754814eaa'
+        instruction_addr: '0x7ff754814ea9'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff754814eaa'
+        instruction_addr: '0x7ff754814ea9'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -254,34 +227,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe03a9bf10'
         package: C:\Windows\System32\VCRUNTIME140.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589e69ae'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759a2f3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755181c71'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -464,127 +409,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a672d0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8f221'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -639,106 +465,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -793,106 +521,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -947,146 +577,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e426b5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b27e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3af02'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3ae3b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1136,69 +626,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1206,64 +633,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1318,113 +689,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3469f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1479,69 +745,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1549,64 +752,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553923b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8b7c9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1661,69 +808,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1731,64 +815,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553923b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8b7c9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1843,69 +871,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1913,57 +878,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8b7c9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2018,69 +934,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d959f5'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d290'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551659f9'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2088,57 +941,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754dbe522'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7589c665e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a672d0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a672d0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2179,36 +983,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2249,50 +1025,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2333,48 +1067,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2410,50 +1102,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2494,50 +1144,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754d8bdf1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a19ed98'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7553a0fdf'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2592,162 +1200,8 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75506e26d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d176'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3bba8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1ae0c0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3469f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3419b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3409c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e349d6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e01a18'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8ca09'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75504752f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d7a570'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8f221'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3aed7'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2802,104 +1256,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758bbfa00'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75503ff42'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a67100'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758c25f01'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2944,55 +1300,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -3045,73 +1352,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff75482017a'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75482017b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -3164,73 +1411,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff75482017a'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75482017b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -3283,73 +1470,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff75482017a'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75482017b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759452a10'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75797c3f0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -3404,62 +1531,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b27e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -3504,62 +1575,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b27e'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -3614,34 +1629,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754f680be'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75518c971'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0caa5e9a'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -3686,27 +1673,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff756780450'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -3759,80 +1725,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff754b6efc5'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754b6efc6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754efc17c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754f0021d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e19759'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758ae6d48'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -3887,62 +1786,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75517fbb1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -3987,62 +1830,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75517fbb1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -4097,55 +1884,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -4190,62 +1928,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e44d8d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e449af'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75517fbb1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -4335,62 +2017,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7559e6610'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754f70c36'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754f2efca'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7559ccee1'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7559e7c57'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -4435,41 +2061,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e4b37f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff756cba688'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -4788,52 +2379,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -4886,52 +2438,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -4984,52 +2497,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -5082,52 +2556,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -5180,52 +2615,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -5278,52 +2674,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -5376,52 +2733,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -5474,52 +2792,13 @@ threads:
         trust: scan
       - data:
           orig_in_app: -1
-          symbolicator_status: missing
+          symbolicator_status: symbolicated
+        function: truncated
         in_app: false
-        instruction_addr: '0x7ff75519224c'
+        instruction_addr: '0x7ff7549e3f3c'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7549e3f3d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        raw_function: <truncated>
+        symbol: <truncated>
         trust: scan
       - data:
           orig_in_app: -1
@@ -5556,48 +2835,6 @@ threads:
   - id: 10672
     stacktrace:
       frames:
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff757fb47f2'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758adc9f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
       - data:
           orig_in_app: -1
           symbolicator_status: missing
@@ -5646,62 +2883,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e4b37f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff757aaf081'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551976c3'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3b984'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -5882,41 +3063,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff754d8ca09'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d7a570'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -5966,146 +3112,6 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e4b37f'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7566cc3d7'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7566cbf67'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8d176'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75501f8fc'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75504b92d'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754da6f49'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754dc5267'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e349d6'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8ca09'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75a1e2338'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d89952'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff755199769'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8f221'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754e3419b'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -6150,104 +3156,6 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff75519224c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551971e8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7566cc508'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a671f8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759054684'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7566be97c'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff759054684'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7566ce2a3'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a670b0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754db0220'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff758a67a48'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d8f4e0'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff7551976c3'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        trust: scan
-      - data:
-          orig_in_app: -1
-          symbolicator_status: missing
-        in_app: false
-        instruction_addr: '0x7ff754d7feb8'
-        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-01-05T09:42:55.087777Z'
+created: '2021-12-02T13:46:44.534064Z'
 creator: sentry
 source: tests/symbolicator/test_unreal_full.py
 ---
@@ -128,13 +128,10 @@ exception:
       frames:
       - data:
           orig_in_app: -1
-          symbolicator_status: symbolicated
-        function: AActor::IsPendingKillPending
+          symbolicator_status: missing
         in_app: false
         instruction_addr: '0x7ff754be3394'
         package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
-        raw_function: AActor::IsPendingKillPending()
-        symbol: AActor::IsPendingKillPending()
         trust: context
       registers:
         r10: '0x7ffef000'
@@ -171,6 +168,62 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff7548229e6'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75563d233'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759a2f3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589ca88b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a4831a8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754814eaa'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759a2f3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a4831a8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe10066c86'
         package: C:\Windows\System32\ntdll.dll
         trust: scan
@@ -185,8 +238,50 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754814eaa'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754814eaa'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe03a9bf10'
         package: C:\Windows\System32\VCRUNTIME140.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589e69ae'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759a2f3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759a2f3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755181c71'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -369,8 +464,127 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a672d0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a671f8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8f221'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -425,8 +639,106 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -481,8 +793,106 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -537,6 +947,146 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e426b5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b27e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3af02'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3ae3b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a19ed98'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553a0fdf'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -586,6 +1136,69 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -593,8 +1206,64 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a19ed98'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553a0fdf'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -649,8 +1318,113 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3469f'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -705,6 +1479,69 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -712,8 +1549,64 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553923b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8b7c9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75504b92d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -768,6 +1661,69 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -775,8 +1731,64 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553923b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8b7c9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75504b92d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -831,6 +1843,69 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -838,8 +1913,57 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8b7c9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75504b92d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -894,6 +2018,69 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d959f5'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d290'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551659f9'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -901,8 +2088,57 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754dbe522'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7589c665e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a672d0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a672d0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -943,8 +2179,36 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75504b92d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -985,8 +2249,50 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a19ed98'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553a0fdf'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1027,6 +2333,48 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a19ed98'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553a0fdf'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1062,8 +2410,50 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a19ed98'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553a0fdf'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1104,8 +2494,50 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754d8bdf1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe100d1450'
         package: C:\Windows\System32\ntdll.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a19ed98'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7553a0fdf'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1160,8 +2592,162 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75506e26d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d176'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3bba8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1ae0c0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3469f'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0cab443b'
         package: C:\Windows\System32\KERNELBASE.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3419b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3409c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e349d6'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e01a18'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8ca09'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1e2338'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1e2338'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75504752f'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d7a570'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8f221'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3aed7'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1216,6 +2802,104 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758bbfa00'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a671f8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75503ff42'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a67100'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758c25f01'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759452a10'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75797c3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1260,6 +2944,55 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1314,6 +3047,76 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75482017b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759452a10'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75797c3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1358,6 +3161,76 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75482017b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759452a10'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75797c3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1412,6 +3285,76 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75482017b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759452a10'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75797c3f0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1456,6 +3399,62 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b27e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1510,6 +3509,62 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b27e'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1554,6 +3609,34 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754f680be'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75518c971'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1608,6 +3691,27 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff756780450'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0caa5e9a'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1652,6 +3756,83 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754b6efc6'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754efc17c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754f0021d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e19759'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758ae6d48'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a671f8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1706,6 +3887,62 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75517fbb1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1750,6 +3987,62 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75517fbb1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1804,6 +4097,55 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1848,6 +4190,62 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e44d8d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e449af'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75517fbb1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -1937,6 +4335,62 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7559e6610'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754f70c36'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754f2efca'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7559ccee1'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7559e7c57'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -1981,6 +4435,41 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e4b37f'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff756cba688'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2301,6 +4790,55 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2345,6 +4883,55 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2399,6 +4986,55 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2443,6 +5079,55 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2497,6 +5182,55 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2541,6 +5275,55 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2595,6 +5378,55 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2644,6 +5476,55 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7549e3f3d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2675,6 +5556,48 @@ threads:
   - id: 10672
     stacktrace:
       frames:
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff757fb47f2'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758adc9f8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
       - data:
           orig_in_app: -1
           symbolicator_status: missing
@@ -2723,6 +5646,62 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e4b37f'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff757aaf081'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551976c3'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3b984'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1
@@ -2903,6 +5882,41 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff754d8ca09'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d7a570'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2952,6 +5966,146 @@ threads:
           orig_in_app: -1
           symbolicator_status: missing
         in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e4b37f'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7566cc3d7'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7566cbf67'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8d176'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75501f8fc'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75504b92d'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754da6f49'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754dc5267'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e349d6'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8ca09'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1e2338'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75a1e2338'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d89952'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff755199769'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8f221'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754e3419b'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
         instruction_addr: '0x7ffe0ca99252'
         package: C:\Windows\System32\KERNELBASE.dll
         trust: scan
@@ -2996,6 +6150,104 @@ threads:
         in_app: false
         instruction_addr: '0x7ffe0fd53034'
         package: C:\Windows\System32\kernel32.dll
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff75519224c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551971e8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7566cc508'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a671f8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759054684'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7566be97c'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff759054684'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7566ce2a3'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a670b0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754db0220'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff758a67a48'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d8f4e0'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff7551976c3'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
+        trust: scan
+      - data:
+          orig_in_app: -1
+          symbolicator_status: missing
+        in_app: false
+        instruction_addr: '0x7ff754d7feb8'
+        package: \\Mac\Home\Desktop\WindowsNoEditor\YetAnother\Binaries\Win64\YetAnother.exe
         trust: scan
       - data:
           orig_in_app: -1

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -27,6 +27,8 @@ def get_unreal_crash_apple_file():
 class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
     # For these tests to run, write `symbolicator.enabled: true` into your
     # `~/.sentry/config.yml` and run `sentry devservices up`
+    # Also running locally, it might be necessary to set the
+    # `system.internal-url-prefix` option instead of `system.url-prefix`.
 
     @pytest.fixture(autouse=True)
     def initialize(self, live_server):


### PR DESCRIPTION
The new SymCache does not save explicit function ends *in the middle* of the executable range, but only at *the end* of it.
This changes the fixture/snapshot in such a way that we have a known but truncated function entry in that range, so the test should work with both the old and new SymCache format.