### PR TITLE
fix(metrics): Flaky crash free rates test

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -163,7 +163,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             prj: {"currentCrashFreeRate": None, "previousCrashFreeRate": None}
             for prj in project_ids
         }
-
         previous = self._get_crash_free_rate_data(
             org_id,
             project_ids,

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -987,7 +987,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             )
 
     def test_get_current_and_previous_crash_free_rates(self):
-        now = timezone.now()
+        now = timezone.now().replace(minute=15, second=23)
         last_24h_start = now - 24 * timedelta(hours=1)
         last_48h_start = now - 2 * 24 * timedelta(hours=1)
 
@@ -998,7 +998,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             current_end=now,
             previous_start=last_48h_start,
             previous_end=last_24h_start,
-            rollup=86400,
+            rollup=3600,
         )
 
         assert data == {
@@ -1011,7 +1011,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
         }
 
     def test_get_current_and_previous_crash_free_rates_with_zero_sessions(self):
-        now = timezone.now()
+        now = timezone.now().replace(minute=15, second=23)
         last_48h_start = now - 2 * 24 * timedelta(hours=1)
         last_72h_start = now - 3 * 24 * timedelta(hours=1)
         last_96h_start = now - 4 * 24 * timedelta(hours=1)
@@ -1023,7 +1023,7 @@ class GetCrashFreeRateTestCase(TestCase, SnubaTestCase):
             current_end=last_48h_start,
             previous_start=last_96h_start,
             previous_end=last_72h_start,
-            rollup=86400,
+            rollup=3600,
         )
 
         assert data == {


### PR DESCRIPTION
These tests failed for certain invocations of `timezone.now()`, because the start and end times are not rounded to the query granularity.
This problem should actually be solved in the application logic and not the test. I will create a follow up for that in Jira.