### PR TITLE
fix(perf): Fix setError enhancement to only catch object types

### DIFF
--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -122,7 +122,10 @@ function PerformanceContent({selection, location, demoMode}: Props) {
   }
 
   function setError(newError?: string) {
-    if (typeof newError !== 'string') {
+    if (
+      typeof newError === 'object' ||
+      (Array.isArray(newError) && typeof newError[0] === 'object')
+    ) {
       Sentry.withScope(scope => {
         scope.setExtra('error', newError);
         Sentry.captureException(new Error('setError failed with error type.'));


### PR DESCRIPTION
### Summary
An array with undefined is making it in but that isn't the error data we wanted to catch with setError (and it seems to fire frequently). We can fix that separately but we should still catch the error object.

Refs JAVASCRIPT-2685
Refs JAVASCRIPT-2645