### PR TITLE
fix(metrics): Make metrics API more resilient to missing strings [INGEST-542]

### DIFF
--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -5,7 +5,6 @@ from typing import DefaultDict, Dict, Optional
 from .base import StringIndexer
 
 _STRINGS = (
-    "abnormal",
     "crashed",
     "environment",
     "errored",
@@ -19,6 +18,7 @@ _STRINGS = (
     "user",
     "init",
     "session.error",
+    "abnormal",
 )
 
 
@@ -27,7 +27,7 @@ class SimpleIndexer(StringIndexer):
     """Simple indexer with in-memory store. Do not use in production."""
 
     def __init__(self) -> None:
-        self._counter = itertools.count()
+        self._counter = itertools.count(start=1)
         self._strings: DefaultDict[str, int] = defaultdict(self._counter.__next__)
         self._reverse: Dict[int, str] = {}
 

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -460,6 +460,38 @@ class OrganizationMetricIntegrationTest(SessionMetricsTestCase, APITestCase):
             totals = group["totals"]
             assert totals == {"count(measurements.lcp)": expected_count}
 
+    @with_feature(FEATURE_FLAG)
+    def test_unknown_groupby(self):
+        """Use a tag name in groupby that does not exist in the indexer"""
+        # Insert session metrics:
+        self.store_session(self.build_session(project_id=self.project.id))
+
+        # "foo" is known by indexer, "bar" is not
+        indexer.record("foo")
+
+        response = self.get_success_response(
+            self.organization.slug,
+            field="sum(session)",
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["session.status", "foo"],
+        )
+
+        groups = response.data["groups"]
+        assert len(groups) == 1
+        assert groups[0]["by"] == {"session.status": "init", "foo": None}
+
+        response = self.get_response(
+            self.organization.slug,
+            field="sum(session)",
+            statsPeriod="1h",
+            interval="1h",
+            datasource="snuba",
+            groupBy=["session.status", "bar"],
+        )
+        assert response.status_code == 400
+
 
 class OrganizationMetricMetaIntegrationTest(SessionMetricsTestCase, APITestCase):
     def setUp(self):

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -48,14 +48,14 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
 @pytest.mark.parametrize(
     "query_string,expected",
     [
-        ('release:""', [Condition(Column(name="tags[6]"), Op.IN, rhs=[14])]),
-        ("release:myapp@2.0.0", [Condition(Column(name="tags[6]"), Op.IN, rhs=[15])]),
+        ('release:""', [Condition(Column(name="tags[6]"), Op.IN, rhs=[15])]),
+        ("release:myapp@2.0.0", [Condition(Column(name="tags[6]"), Op.IN, rhs=[16])]),
         (
             "release:myapp@2.0.0 and environment:production",
             [
                 And(
                     [
-                        Condition(Column(name="tags[6]"), Op.IN, rhs=[15]),
+                        Condition(Column(name="tags[6]"), Op.IN, rhs=[16]),
                         Condition(Column(name="tags[2]"), Op.EQ, rhs=5),
                     ]
                 )
@@ -64,7 +64,7 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
         (
             "release:myapp@2.0.0 environment:production",
             [
-                Condition(Column(name="tags[6]"), Op.IN, rhs=[15]),
+                Condition(Column(name="tags[6]"), Op.IN, rhs=[16]),
                 Condition(Column(name="tags[2]"), Op.EQ, rhs=5),
             ],
         ),
@@ -75,7 +75,7 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
                     [
                         And(
                             [
-                                Condition(Column(name="tags[6]"), Op.IN, rhs=[15]),
+                                Condition(Column(name="tags[6]"), Op.IN, rhs=[16]),
                                 Condition(Column(name="tags[2]"), Op.EQ, rhs=5),
                             ]
                         ),
@@ -88,7 +88,7 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
                 ),
             ],
         ),
-        ('transaction:"/bar/:orgId/"', [Condition(Column(name="tags[16]"), Op.EQ, rhs=17)]),
+        ('transaction:"/bar/:orgId/"', [Condition(Column(name="tags[17]"), Op.EQ, rhs=18)]),
     ],
 )
 @mock.patch("sentry.snuba.metrics.indexer")
@@ -321,7 +321,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 9,  # session
-                        "tags[8]": 0,  # session.status:abnormal
+                        "tags[8]": 14,  # session.status:abnormal
                         "value": 330,
                     },
                 ],
@@ -336,7 +336,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 9,  # session
-                        "tags[8]": 0,
+                        "tags[8]": 14,
                         "bucketed_time": "2021-08-24T00:00Z",
                         "value": 110,
                     },
@@ -348,7 +348,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 9,  # session
-                        "tags[8]": 0,
+                        "tags[8]": 14,
                         "bucketed_time": "2021-08-25T00:00Z",
                         "value": 220,
                     },
@@ -366,7 +366,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 7,  # session.duration
-                        "tags[8]": 0,
+                        "tags[8]": 14,
                         "max": 456.7,
                         "percentiles": [1.5, 2.5, 3.5, 4.5, 5.5],
                     },
@@ -383,7 +383,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 7,  # session.duration
-                        "tags[8]": 1,
+                        "tags[8]": 14,
                         "bucketed_time": "2021-08-24T00:00Z",
                         "max": 20.2,
                         "percentiles": [1.2, 2.2, 3.2, 4.2, 5.2],
@@ -397,7 +397,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 7,  # session.duration
-                        "tags[8]": 1,
+                        "tags[8]": 14,
                         "bucketed_time": "2021-08-25T00:00Z",
                         "max": 40.4,
                         "percentiles": [1.4, 2.4, 3.4, 4.4, 5.4],
@@ -424,7 +424,7 @@ def test_translate_results(_1, _2, mock_indexer):
             },
         },
         {
-            "by": {"session.status": "crashed"},
+            "by": {"session.status": "abnormal"},
             "totals": {
                 "sum(session)": 330,
                 "max(session.duration)": 456.7,

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -29,6 +29,7 @@ from sentry.snuba.metrics import (
     QueryDefinition,
     SnubaQueryBuilder,
     SnubaResultConverter,
+    _resolve_tags,
     get_date_range,
     get_intervals,
     parse_query,
@@ -79,7 +80,7 @@ MOCK_NOW = datetime(2021, 8, 25, 23, 59, tzinfo=pytz.utc)
                             ]
                         ),
                         Condition(
-                            Function(function="ifNull", parameters=[Column(name="tags[8]"), 14]),
+                            Column(name="tags[8]"),
                             Op.EQ,
                             rhs=4,
                         ),
@@ -96,7 +97,7 @@ def test_parse_query(mock_indexer, query_string, expected):
     for s in ("", "myapp@2.0.0", "transaction", "/bar/:orgId/"):
         local_indexer.record(s)
     mock_indexer.resolve = local_indexer.resolve
-    parsed = parse_query(query_string)
+    parsed = _resolve_tags(parse_query(query_string))
     assert parsed == expected
 
 

--- a/tests/sentry/snuba/test_metrics.py
+++ b/tests/sentry/snuba/test_metrics.py
@@ -383,7 +383,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 7,  # session.duration
-                        "tags[8]": 0,
+                        "tags[8]": 1,
                         "bucketed_time": "2021-08-24T00:00Z",
                         "max": 20.2,
                         "percentiles": [1.2, 2.2, 3.2, 4.2, 5.2],
@@ -397,7 +397,7 @@ def test_translate_results(_1, _2, mock_indexer):
                     },
                     {
                         "metric_id": 7,  # session.duration
-                        "tags[8]": 0,
+                        "tags[8]": 1,
                         "bucketed_time": "2021-08-25T00:00Z",
                         "max": 40.4,
                         "percentiles": [1.4, 2.4, 3.4, 4.4, 5.4],
@@ -424,7 +424,7 @@ def test_translate_results(_1, _2, mock_indexer):
             },
         },
         {
-            "by": {"session.status": "abnormal"},
+            "by": {"session.status": "crashed"},
             "totals": {
                 "sum(session)": 330,
                 "max(session.duration)": 456.7,


### PR DESCRIPTION
Respond with 400 when a requested metric ID or tag key does not exist in the indexer.

This is not ideal behavior, because it will cause many 400 responses when no data has not been written yet - especially if we go back to scoping indexer entries to orgs. Worst case we'll have to pre-fill the indexer when an org is created.

The alternative would be to work under the [closed-world assumption](https://en.wikipedia.org/wiki/Open-world_assumption) that every metric and tag exists and just return empty data when they are missing from the indexer. This is non-trivial though, because we would have to either
1. let snuba handle missing entries by passing 0 as values. This leads to problematic cases, e.g. the query `unknown_tag:unknown_value` would translate to `arrayElement(tags.value, indexOf(0)) == 0` in clickhouse, which evaluates to `true`.
2. Specify correct behavior for missing indexer entries in all combinations of AND and OR, and IN clauses on the sentry side.