### PR TITLE
fix(weekly_reports): Fix OOM when running `prepare_reports`

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -44,6 +44,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.iterators import chunked
 from sentry.utils.math import mean
 from sentry.utils.outcomes import Outcome
+from sentry.utils.query import RangeQuerySetWrapper
 from sentry.utils.snuba import raw_snql_query
 
 date_format = partial(dateformat.format, format_string="F jS, Y")
@@ -576,7 +577,7 @@ def prepare_reports(dry_run=False, *args, **kwargs):
     logger.info("reports.begin_prepare_report")
 
     organizations = _get_organization_queryset()
-    for organization in organizations:
+    for organization in RangeQuerySetWrapper(organizations, step=10000):
         if features.has("organizations:weekly-report-debugging", organization):
             logger.info(
                 "reports.org.begin_prepare_report",


### PR DESCRIPTION
We suspect that the reason no reports are firing is that the `prepare_reports` task is OOMing. Since
this task works correctly in S4S it's likely not a code issue. The problem is likely due to us
hitting a tipping point, and bringing nearly 1mm org models into is causing us to OOM and kill the
task.

We'll test this theory by allowing the worker to run on a task and see that the log we've added
appears, which proves the task is running. Then we'll deploy this and see whether it fixes the
issue.