### PR TITLE
feat(suspect-spans): Add show more button for more examples

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/content.tsx
@@ -129,6 +129,7 @@ function SpansContent(props: Props) {
               location={location}
               orgSlug={organization.slug}
               eventView={eventView}
+              perSuspect={10}
               spanOps={defined(spanOp) ? [spanOp] : []}
               spanGroups={defined(spanGroup) ? [spanGroup] : []}
             >
@@ -164,6 +165,7 @@ function SpansContent(props: Props) {
                         generateTransactionLink={generateTransactionLink(transactionName)}
                         eventView={eventView}
                         totals={totals}
+                        preview={2}
                       />
                     ))}
                     <Pagination pageLinks={pageLinks} />

--- a/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/styles.tsx
@@ -40,11 +40,27 @@ export const UpperPanel = styled(Panel)`
   }
 `;
 
-export const LowerPanel = styled('div')`
+export const LowerPanel = styled('div')<{expandable: boolean}>`
   > div {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
+
+    ${p =>
+      p.expandable &&
+      `
+      margin-bottom: 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      `}
   }
+`;
+
+export const FooterPanel = styled(Panel)`
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding: ${space(1)} ${space(0)} ${space(1)} ${space(3)};
+  border-top: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 `;
 
 type HeaderItemProps = {

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpanCard.tsx
@@ -1,5 +1,7 @@
+import {useReducer} from 'react';
 import {Location, LocationDescriptor, Query} from 'history';
 
+import Button from 'sentry/components/button';
 import GridEditable, {COL_WIDTH_UNDEFINED} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 import Link from 'sentry/components/links/link';
@@ -18,6 +20,7 @@ import {PerformanceDuration} from '../../utils';
 
 import {
   emptyValue,
+  FooterPanel,
   HeaderItem,
   LowerPanel,
   SpanDurationBar,
@@ -86,6 +89,7 @@ type Props = {
   ) => LocationDescriptor;
   eventView: EventView;
   totals: SpansTotalValues | null;
+  preview: number;
 };
 
 export default function SuspectSpanEntry(props: Props) {
@@ -96,9 +100,18 @@ export default function SuspectSpanEntry(props: Props) {
     generateTransactionLink,
     eventView,
     totals,
+    preview,
   } = props;
 
-  const examples = suspectSpan.examples.map(example => ({
+  const expandable = suspectSpan.examples.length > preview;
+
+  const [collapsed, toggleCollapsed] = useReducer(state => !state, true);
+
+  const visibileExamples = collapsed
+    ? suspectSpan.examples.slice(0, preview)
+    : suspectSpan.examples;
+
+  const examples = visibileExamples.map(example => ({
     id: example.id,
     project: suspectSpan.project,
     // timestamps are in seconds but want them in milliseconds
@@ -127,7 +140,7 @@ export default function SuspectSpanEntry(props: Props) {
         <SpanCount sort={sort} suspectSpan={suspectSpan} totals={totals} />
         <TotalCumulativeDuration sort={sort} suspectSpan={suspectSpan} totals={totals} />
       </UpperPanel>
-      <LowerPanel data-test-id="suspect-card-lower">
+      <LowerPanel expandable={expandable} data-test-id="suspect-card-lower">
         <GridEditable
           data={examples}
           columnOrder={SPANS_TABLE_COLUMN_ORDER}
@@ -144,6 +157,15 @@ export default function SuspectSpanEntry(props: Props) {
           location={location}
         />
       </LowerPanel>
+      {expandable && (
+        <FooterPanel>
+          <Button priority="link" onClick={toggleCollapsed}>
+            {collapsed
+              ? t('Show More Transaction Examples')
+              : t('Hide Transaction Examples')}
+          </Button>
+        </FooterPanel>
+      )}
     </div>
   );
 }

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -61,6 +61,11 @@ export const SAMPLE_SPANS = [
         description: 'span-2',
         spans: [{id: 'acacac11'}, {id: 'acacac22'}],
       },
+      {
+        id: 'adadadadadadadad',
+        description: 'span-3',
+        spans: [{id: 'adadad11'}, {id: 'adadad22'}],
+      },
     ],
   },
   {
@@ -69,13 +74,18 @@ export const SAMPLE_SPANS = [
     examples: [
       {
         id: 'bcbcbcbcbcbcbcbc',
-        description: 'span-3',
+        description: 'span-4',
         spans: [{id: 'bcbcbc11'}, {id: 'bcbcbc11'}],
       },
       {
         id: 'bdbdbdbdbdbdbdbd',
-        description: 'span-4',
+        description: 'span-5',
         spans: [{id: 'bdbdbd11'}, {id: 'bdbdbd22'}],
+      },
+      {
+        id: 'bebebebebebebebe',
+        description: 'span-6',
+        spans: [{id: 'bebebe11'}, {id: 'bebebe22'}],
       },
     ],
   },


### PR DESCRIPTION
In order to compact the information on the span view, only 2 examples per span
will be visible by default with up to 10 once the user clicks show more
transactions examples.