### PR TITLE
Revert "Add more logging"

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -574,8 +574,6 @@ backend = RedisReportBackend(redis.clusters.get("default"), 60 * 60 * 3)
 def prepare_reports(dry_run=False, *args, **kwargs):
     timestamp, duration = _fill_default_parameters(*args, **kwargs)
 
-    logger.info("reports.begin_prepare_report")
-
     organizations = _get_organization_queryset()
     for organization in RangeQuerySetWrapper(organizations, step=10000):
         if features.has("organizations:weekly-report-debugging", organization):
@@ -585,8 +583,7 @@ def prepare_reports(dry_run=False, *args, **kwargs):
                     "organization_id": organization.id,
                 },
             )
-
-            prepare_organization_report.delay(timestamp, duration, organization.id, dry_run=dry_run)
+        prepare_organization_report.delay(timestamp, duration, organization.id, dry_run=dry_run)
 
 
 @instrumented_task(
@@ -596,10 +593,6 @@ def prepare_reports(dry_run=False, *args, **kwargs):
     acks_late=True,
 )
 def prepare_organization_report(timestamp, duration, organization_id, dry_run=False):
-    logger.info(
-        "reports.begin_prepare_organization_report", extra={"organization_id": organization_id}
-    )
-
     try:
         organization = _get_organization_queryset().get(id=organization_id)
     except Organization.DoesNotExist:

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -574,6 +574,8 @@ backend = RedisReportBackend(redis.clusters.get("default"), 60 * 60 * 3)
 def prepare_reports(dry_run=False, *args, **kwargs):
     timestamp, duration = _fill_default_parameters(*args, **kwargs)
 
+    logger.info("reports.begin_prepare_report")
+
     organizations = _get_organization_queryset()
     for organization in RangeQuerySetWrapper(organizations, step=10000):
         if features.has("organizations:weekly-report-debugging", organization):

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -237,9 +237,8 @@ class ReportTestCase(TestCase, SnubaTestCase):
             # timestamp.
             get_earliest_timestamp.return_value = to_timestamp(now - timedelta(days=60))
 
-            with self.feature("organizations:weekly-report-debugging"):
-                prepare_reports(timestamp=to_timestamp(now))
-                assert len(mail.outbox) == len(member_set) == 1
+            prepare_reports(timestamp=to_timestamp(now))
+            assert len(mail.outbox) == len(member_set) == 1
 
             message = mail.outbox[0]
             assert self.organization.name in message.subject


### PR DESCRIPTION
Reverts getsentry/sentry#30355

DO NOT MERGE UNTIL SCHEDULE CHANGE IS MERGED. https://github.com/getsentry/getsentry/pull/6734/files

Kept the log message at the top of the task which shows that it began running.