### PR TITLE
chore(sentry-apps): Add copy to explain logo upload field requirements

### DIFF
--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -48,7 +48,7 @@ type Props = {
   savedDataUrl?: string;
   isUser?: boolean;
   title?: string;
-  description?: React.ReactNode;
+  help?: React.ReactNode;
 } & DefaultProps;
 
 type State = {
@@ -159,7 +159,7 @@ class AvatarChooser extends React.Component<Props, State> {
       isUser,
       disabled,
       title,
-      description,
+      help,
       defaultChoice,
     } = this.props;
     const {hasError, model} = this.state;
@@ -220,7 +220,7 @@ class AvatarChooser extends React.Component<Props, State> {
               )}
               {isDefault && preview}
             </AvatarGroup>
-            {description && <AvatarDescription>{description}</AvatarDescription>}
+            {help && <AvatarHelp>{help}</AvatarHelp>}
             <AvatarUploadSection>
               {allowGravatar && avatarType === 'gravatar' && (
                 <Well>
@@ -255,7 +255,7 @@ class AvatarChooser extends React.Component<Props, State> {
   }
 }
 
-const AvatarDescription = styled('p')`
+const AvatarHelp = styled('p')`
   margin: ${space(1)} 0 ${space(2)};
   color: ${p => p.theme.gray300};
   font-size: 14px;

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -12,6 +12,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import Well from 'sentry/components/well';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import {AvatarUser, Organization, SentryApp, Team} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
 import RadioGroup from 'sentry/views/settings/components/forms/controls/radioGroup';
@@ -46,10 +47,8 @@ type Props = {
   disabled?: boolean;
   savedDataUrl?: string;
   isUser?: boolean;
-  /**
-   * Title in the PanelHeader component (default: 'Avatar')
-   */
   title?: string;
+  description?: React.ReactNode;
 } & DefaultProps;
 
 type State = {
@@ -160,6 +159,7 @@ class AvatarChooser extends React.Component<Props, State> {
       isUser,
       disabled,
       title,
+      description,
       defaultChoice,
     } = this.props;
     const {hasError, model} = this.state;
@@ -220,6 +220,7 @@ class AvatarChooser extends React.Component<Props, State> {
               )}
               {isDefault && preview}
             </AvatarGroup>
+            {description && <AvatarDescription>{description}</AvatarDescription>}
             <AvatarUploadSection>
               {allowGravatar && avatarType === 'gravatar' && (
                 <Well>
@@ -253,6 +254,13 @@ class AvatarChooser extends React.Component<Props, State> {
     );
   }
 }
+
+const AvatarDescription = styled('p')`
+  margin: ${space(1)} 0 ${space(2)};
+  color: ${p => p.theme.gray300};
+  font-size: 14px;
+  width: 50%;
+`;
 
 const AvatarGroup = styled('div')<{inline: boolean}>`
   display: flex;

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -45,20 +45,17 @@ const AVATAR_STYLES = {
     size: 50,
     title: t('Default Logo'),
     previewText: t('The default icon for integrations'),
-    description: t('Image must be between 255px by 255px and 1024px by 1024px.'),
+    help: t('Image must be between 255px by 255px and 1024px by 1024px.'),
   },
   simple: {
     size: 20,
     title: t('Default Icon'),
-    previewText: tct(
-      'This is an optional silhouette icon used for [uiDocs:UI Components]',
-      {
-        uiDocs: (
-          <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/ui-components/" />
-        ),
-      }
-    ),
-    description: t(
+    previewText: tct('This is a silhouette icon used only for [uiDocs:UI Components]', {
+      uiDocs: (
+        <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/ui-components/" />
+      ),
+    }),
+    help: t(
       'Image must be between 255px by 255px and 1024px by 1024px, and use only black and transparency.'
     ),
   },
@@ -368,7 +365,9 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
           model={this.getAvatarModel(isColor)}
           onSave={this.addAvatar}
           title={isColor ? t('Logo') : t('Small Icon')}
-          description={AVATAR_STYLES[avatarStyle].description}
+          help={AVATAR_STYLES[avatarStyle].help.concat(
+            this.isInternal ? '' : t(' Required for publishing.')
+          )}
           savedDataUrl={undefined}
           defaultChoice={{
             allowDefault: true,

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -59,7 +59,7 @@ const AVATAR_STYLES = {
       }
     ),
     description: t(
-      'Image must be between 255px by 255px and 1024px by 1024px, and completely black/transparent.'
+      'Image must be between 255px by 255px and 1024px by 1024px, and use only black and transparency.'
     ),
   },
 };

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -45,7 +45,7 @@ const AVATAR_STYLES = {
     size: 50,
     title: t('Default Logo'),
     previewText: t('The default icon for integrations'),
-    description: t('Image must be between 255px by 255px and 1024px by 1024px'),
+    description: t('Image must be between 255px by 255px and 1024px by 1024px.'),
   },
   simple: {
     size: 20,

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -15,6 +15,7 @@ import Avatar from 'sentry/components/avatar';
 import AvatarChooser, {Model} from 'sentry/components/avatarChooser';
 import Button from 'sentry/components/button';
 import DateTime from 'sentry/components/dateTime';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels';
 import Tooltip from 'sentry/components/tooltip';
 import {SENTRY_APP_PERMISSIONS} from 'sentry/constants';
@@ -43,12 +44,23 @@ const AVATAR_STYLES = {
   color: {
     size: 50,
     title: t('Default Logo'),
-    description: t('The default icon for integrations'),
+    previewText: t('The default icon for integrations'),
+    description: t('Image must be between 255px by 255px and 1024px by 1024px'),
   },
   simple: {
     size: 20,
     title: t('Default Icon'),
-    description: t('This is an optional icon used for Issue Linking'),
+    previewText: tct(
+      'This is an optional silhouette icon used for [uiDocs:UI Components]',
+      {
+        uiDocs: (
+          <ExternalLink href="https://docs.sentry.io/product/integrations/integration-platform/ui-components/" />
+        ),
+      }
+    ),
+    description: t(
+      'Image must be between 255px by 255px and 1024px by 1024px, and completely black/transparent.'
+    ),
   },
 };
 
@@ -335,7 +347,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
           isDefault
         />
         <AvatarPreviewTitle>{AVATAR_STYLES[avatarStyle].title}</AvatarPreviewTitle>
-        <AvatarPreviewText>{AVATAR_STYLES[avatarStyle].description}</AvatarPreviewText>
+        <AvatarPreviewText>{AVATAR_STYLES[avatarStyle].previewText}</AvatarPreviewText>
       </AvatarPreview>
     );
   };
@@ -345,6 +357,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
     if (!app) {
       return null;
     }
+    const avatarStyle = isColor ? 'color' : 'simple';
     return (
       <Feature features={['organizations:sentry-app-logo-upload']}>
         <AvatarChooser
@@ -355,6 +368,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
           model={this.getAvatarModel(isColor)}
           onSave={this.addAvatar}
           title={isColor ? t('Logo') : t('Small Icon')}
+          description={AVATAR_STYLES[avatarStyle].description}
           savedDataUrl={undefined}
           defaultChoice={{
             allowDefault: true,

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -45,7 +45,7 @@ const AVATAR_STYLES = {
     size: 50,
     title: t('Default Logo'),
     previewText: t('The default icon for integrations'),
-    help: t('Image must be between 255px by 255px and 1024px by 1024px.'),
+    help: t('Image must be between 256px by 256px and 1024px by 1024px.'),
   },
   simple: {
     size: 20,
@@ -56,7 +56,7 @@ const AVATAR_STYLES = {
       ),
     }),
     help: t(
-      'Image must be between 255px by 255px and 1024px by 1024px, and may only use black and transparent pixels.'
+      'Image must be between 256px by 256px and 1024px by 1024px, and may only use black and transparent pixels.'
     ),
   },
 };

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -56,7 +56,7 @@ const AVATAR_STYLES = {
       ),
     }),
     help: t(
-      'Image must be between 255px by 255px and 1024px by 1024px, and use only black and transparency.'
+      'Image must be between 255px by 255px and 1024px by 1024px, and may only use black and transparent pixels.'
     ),
   },
 };


### PR DESCRIPTION
This PR adds some copy to the logo upload fields to better set expectations for the requirements of any uploaded logos. It matters more for the 'icon' upload since the requirement for a completely black/transparent image is unexpected. I added the word 'silhouette' since that implies our requirements and also link out to the UI Components doc since it will be used for Issue linking AND Stacktrace linking.

#### Unaffected other Avatar upload fields
![image](https://user-images.githubusercontent.com/35509934/144512748-9166e017-4ad7-437f-869f-83fdc346d2ad.png)

#### Changes to logo upload fields (⭐️ Updated)

![image](https://user-images.githubusercontent.com/35509934/144516693-ad939840-a999-43f3-8801-0521027d4d46.png)

![image](https://user-images.githubusercontent.com/35509934/144516734-5bf95886-720e-4231-9a1b-e6b58cad88d2.png)
