### PR TITLE
ref(alerts): Disable Threshold Type when form disabled

### DIFF
--- a/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/incidentRules/ruleConditionsForm.tsx
@@ -354,6 +354,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
             <FormRow>
               <RadioGroup
                 style={{flex: 1}}
+                disabled={disabled}
                 choices={[
                   [AlertRuleComparisonType.COUNT, 'Count'],
                   [AlertRuleComparisonType.CHANGE, 'Percent Change'],


### PR DESCRIPTION
Was just missing the prop :shrug: