### PR TITLE
ref(sentryapps): Require black icon for stacktrace link integrations

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -15,6 +15,8 @@ from sentry.models import Organization, SentryApp, SentryAppInstallation
 from sentry.utils.sdk import configure_scope
 from sentry.utils.strings import to_single_line_str
 
+COMPONENT_TYPES = ["stacktrace-link", "issue-link"]
+
 
 def catch_raised_errors(func):
     @wraps(func)

--- a/src/sentry/api/endpoints/sentry_app_interaction.py
+++ b/src/sentry/api/endpoints/sentry_app_interaction.py
@@ -5,11 +5,11 @@ from rest_framework.response import Response
 from sentry import tsdb
 from sentry.api.base import StatsMixin
 from sentry.api.bases import SentryAppBaseEndpoint, SentryAppStatsPermission
+from sentry.api.bases.sentryapps import COMPONENT_TYPES
 
 logger = logging.getLogger(__name__)
 
 TSDB_MODELS = [tsdb.models.sentry_app_viewed, tsdb.models.sentry_app_component_interacted]
-COMPONENT_TYPES = ["stacktrace-link", "issue-link"]
 
 
 def get_component_interaction_key(sentry_app, component_type):

--- a/src/sentry/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/api/endpoints/sentry_app_publish_request.py
@@ -8,10 +8,11 @@ from sentry.models import SentryAppAvatar, SentryAppAvatarTypes
 from sentry.utils import email
 
 
-def is_issue_link_integration(sentry_app):
-    """Determine if the sentry app supports issue linking"""
+def has_ui_component(sentry_app):
+    """Determine if the sentry app supports issue linking or stack trace linking."""
+    ui_components = ["issue-link", "stacktrace-link"]
     elements = (sentry_app.schema or {}).get("elements", [])
-    return any(element.get("type") == "issue-link" for element in elements)
+    return any(element.get("type") in ui_components for element in elements)
 
 
 class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
@@ -34,7 +35,7 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
                 return Response({"detail": "Must upload a logo for the integration."}, status=400)
 
             if (
-                is_issue_link_integration(sentry_app)
+                has_ui_component(sentry_app)
                 and not SentryAppAvatar.objects.filter(
                     sentry_app=sentry_app,
                     color=False,
@@ -43,7 +44,7 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
             ):
                 return Response(
                     {
-                        "detail": "Must upload a black and white logo for issue linking integrations."
+                        "detail": "Must upload a black icon for issue and stack trace linking integrations."
                     },
                     status=400,
                 )

--- a/src/sentry/api/endpoints/sentry_app_publish_request.py
+++ b/src/sentry/api/endpoints/sentry_app_publish_request.py
@@ -1,23 +1,20 @@
 from rest_framework.response import Response
 
 from sentry import features, options
-from sentry.api.bases.sentryapps import SentryAppBaseEndpoint
+from sentry.api.bases.sentryapps import COMPONENT_TYPES, SentryAppBaseEndpoint
 from sentry.constants import SentryAppStatus
 from sentry.mediators.sentry_apps import Updater
 from sentry.models import SentryAppAvatar, SentryAppAvatarTypes
 from sentry.utils import email
 
 
-def has_ui_component(sentry_app):
-    """Determine if the sentry app supports issue linking or stack trace linking."""
-    ui_components = ["issue-link", "stacktrace-link"]
-    elements = (sentry_app.schema or {}).get("elements", [])
-    return any(element.get("type") in ui_components for element in elements)
-
-
 class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
-    def post(self, request, sentry_app):
+    def has_ui_component(self, sentry_app):
+        """Determine if the sentry app supports issue linking or stack trace linking."""
+        elements = (sentry_app.schema or {}).get("elements", [])
+        return any(element.get("type") in COMPONENT_TYPES for element in elements)
 
+    def post(self, request, sentry_app):
         # check status of app to make sure it is unpublished
         if sentry_app.is_published:
             return Response({"detail": "Cannot publish already published integration."}, status=400)
@@ -35,7 +32,7 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
                 return Response({"detail": "Must upload a logo for the integration."}, status=400)
 
             if (
-                has_ui_component(sentry_app)
+                self.has_ui_component(sentry_app)
                 and not SentryAppAvatar.objects.filter(
                     sentry_app=sentry_app,
                     color=False,
@@ -44,7 +41,7 @@ class SentryAppPublishRequestEndpoint(SentryAppBaseEndpoint):
             ):
                 return Response(
                     {
-                        "detail": "Must upload a black icon for issue and stack trace linking integrations."
+                        "detail": "Must upload an icon for issue and stack trace linking integrations."
                     },
                     status=400,
                 )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -761,6 +761,10 @@ class Factories:
         return install
 
     @staticmethod
+    def create_stacktrace_link_schema():
+        return {"type": "stacktrace-link", "uri": "/redirect/"}
+
+    @staticmethod
     def create_issue_link_schema():
         return {
             "type": "issue-link",

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -250,6 +250,9 @@ class Fixtures:
     def create_sentry_app_installation(self, *args, **kwargs):
         return Factories.create_sentry_app_installation(*args, **kwargs)
 
+    def create_stacktrace_link_schema(self, *args, **kwargs):
+        return Factories.create_stacktrace_link_schema(*args, **kwargs)
+
     def create_issue_link_schema(self, *args, **kwargs):
         return Factories.create_issue_link_schema(*args, **kwargs)
 

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -25,12 +25,12 @@ class SentryAppPublishRequestTest(APITestCase):
             schema={"elements": [self.create_issue_link_schema()]},
         )
         self.url = reverse("sentry-api-0-sentry-app-publish-request", args=[self.sentry_app.slug])
+        self.login_as(user=self.user)
 
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_request(self, send_mail):
         self.upload_logo()
         self.upload_issue_link_logo()
-        self.login_as(user=self.user)
         response = self.client.post(
             self.url,
             format="json",
@@ -59,7 +59,6 @@ class SentryAppPublishRequestTest(APITestCase):
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_already_published(self, send_mail):
         self.sentry_app.update(status=SentryAppStatus.PUBLISHED)
-        self.login_as(user=self.user)
         response = self.client.post(self.url, format="json")
         assert response.status_code == 400
         assert response.data["detail"] == "Cannot publish already published integration."
@@ -68,7 +67,6 @@ class SentryAppPublishRequestTest(APITestCase):
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_internal(self, send_mail):
         self.sentry_app.update(status=SentryAppStatus.INTERNAL)
-        self.login_as(user=self.user)
         response = self.client.post(self.url, format="json")
         assert response.status_code == 400
         assert response.data["detail"] == "Cannot publish internal integration."
@@ -76,7 +74,6 @@ class SentryAppPublishRequestTest(APITestCase):
 
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_no_logo(self, send_mail):
-        self.login_as(user=self.user)
         with self.feature("organizations:sentry-app-logo-upload"):
             response = self.client.post(self.url, format="json")
         assert response.status_code == 400
@@ -85,13 +82,38 @@ class SentryAppPublishRequestTest(APITestCase):
 
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_no_issue_link_logo(self, send_mail):
+        """Test that you cannot submit a pulication request for an issue link
+        integration without having uploaded a black icon."""
         self.upload_logo()
-        self.login_as(user=self.user)
         with self.feature("organizations:sentry-app-logo-upload"):
             response = self.client.post(self.url, format="json")
         assert response.status_code == 400
         assert (
             response.data["detail"]
-            == "Must upload a black and white logo for issue linking integrations."
+            == "Must upload a black icon for issue and stack trace linking integrations."
+        )
+        send_mail.asssert_not_called()
+
+    @mock.patch("sentry.utils.email.send_mail")
+    def test_publish_no_stacktrace_link_logo(self, send_mail):
+        """Test that you cannot submit a pulication request for a stacktrace link
+        integration without having uploaded a black icon."""
+        stacktrace_link_sentry_app = self.create_sentry_app(
+            name="Meowin",
+            organization=self.org,
+            schema={"elements": [self.create_stacktrace_link_schema()]},
+        )
+        SentryAppAvatar.objects.create(
+            sentry_app=stacktrace_link_sentry_app, avatar_type=1, color=True
+        )
+        url = reverse(
+            "sentry-api-0-sentry-app-publish-request", args=[stacktrace_link_sentry_app.slug]
+        )
+        with self.feature("organizations:sentry-app-logo-upload"):
+            response = self.client.post(url, format="json")
+        assert response.status_code == 400
+        assert (
+            response.data["detail"]
+            == "Must upload a black icon for issue and stack trace linking integrations."
         )
         send_mail.asssert_not_called()

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -90,7 +90,7 @@ class SentryAppPublishRequestTest(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"]
-            == "Must upload a black icon for issue and stack trace linking integrations."
+            == "Must upload an icon for issue and stack trace linking integrations."
         )
         send_mail.asssert_not_called()
 
@@ -114,6 +114,6 @@ class SentryAppPublishRequestTest(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"]
-            == "Must upload a black icon for issue and stack trace linking integrations."
+            == "Must upload an icon for issue and stack trace linking integrations."
         )
         send_mail.asssert_not_called()

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -82,7 +82,7 @@ class SentryAppPublishRequestTest(APITestCase):
 
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_no_issue_link_logo(self, send_mail):
-        """Test that you cannot submit a pulication request for an issue link
+        """Test that you cannot submit a publication request for an issue link
         integration without having uploaded a black icon."""
         self.upload_logo()
         with self.feature("organizations:sentry-app-logo-upload"):
@@ -96,7 +96,7 @@ class SentryAppPublishRequestTest(APITestCase):
 
     @mock.patch("sentry.utils.email.send_mail")
     def test_publish_no_stacktrace_link_logo(self, send_mail):
-        """Test that you cannot submit a pulication request for a stacktrace link
+        """Test that you cannot submit a publication request for a stacktrace link
         integration without having uploaded a black icon."""
         stacktrace_link_sentry_app = self.create_sentry_app(
             name="Meowin",


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/30104 because I forgot stack trace linking integrations need an icon too - now they are required to upload one before submitting a publication request as well. 