### PR TITLE
feat(stacktrace-link): Enable link if no context present

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -110,6 +110,20 @@ const Context = ({
           );
         })}
 
+      {organization?.features.includes('integrations-stacktrace-link') &&
+        !frame.context &&
+        frame.lineNo &&
+        frame.filename && (
+          <ErrorBoundary customComponent={null}>
+            <StacktraceLink
+              key={0}
+              lineNo={frame.lineNo}
+              frame={frame}
+              event={event}
+            />
+          </ErrorBoundary>
+      )}
+
       {(hasContextRegisters || hasContextVars) && (
         <StyledClippedBox clipHeight={100}>
           {hasContextRegisters && (


### PR DESCRIPTION
(I haven't tested this but wanted to get some feedback before going further)

Right now, the stack trace linking feature only shows if the frame itself has some context (the surrounding lines of code, plus the offending line).

This is great for languages that have access to the context, but some don't. I'm specifically interested in web assembly here, but I imagine this may apply elsewhere.

In this case, we have a frame, and the frame has the line number and file path, and I believe this is all we need to craft a github link. Here is an example of such a frame, with some details removed:
```
    {
       "filename":"<path_relative_to_repo_root>",
       "absPath":"<absolute_path_to_cpp_file>",
       "module":null,
       "package":"<url_to_wasm_binary>",
       "platform":"native",
       "instructionAddr":"0x114876",
       "symbolAddr":null,
       "function":"<some_function_symbol_name>",
       "rawFunction":"<raw_function_symbol_name>",
       "symbol":"<raw_symbol>",
       "context":[
       ],
       "lineNo":16,
       "colNo":null,
       "inApp":true,
       "trust":null,
       "errors":null,
       "vars":null,
       "addrMode":"rel:0",
       "symbolicatorStatus":"symbolicated"
    },
```

The place where I added the code likely isn't correct, but in general, can we support a stacktrace link when a frame has the line number and filename but no context?

Thoughts @MeredithAnya @mgaeta @scefali?