### PR TITLE
ref(symbol-sources): Improve error message when an obfuscated secret is missing for a symbol source

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -373,9 +373,7 @@ def parse_backfill_sources(sources_json, original_sources):
                         sentry_sdk.capture_message(
                             "Obfuscated symbol source secret does not have a corresponding saved value in project options"
                         )
-                    raise InvalidSourcesError(
-                        "Obfuscated symbol source secret does not have a corresponding saved value in project options"
-                    )
+                    raise InvalidSourcesError("Hidden symbol source secret is missing a value")
                 else:
                     source[secret] = secret_value
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -849,9 +849,7 @@ class ProjectUpdateTest(APITestCase):
             )
             assert response.status_code == 400
             assert json.loads(response.content) == {
-                "symbolSources": [
-                    "Obfuscated symbol source secret does not have a corresponding saved value in project options"
-                ]
+                "symbolSources": ["Hidden symbol source secret is missing a value"]
             }
 
     def symbol_sources(self):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -849,7 +849,9 @@ class ProjectUpdateTest(APITestCase):
             )
             assert response.status_code == 400
             assert json.loads(response.content) == {
-                "symbolSources": ["Sources contain unknown hidden secret"]
+                "symbolSources": [
+                    "Obfuscated symbol source secret does not have a corresponding saved value in project options"
+                ]
             }
 
     def symbol_sources(self):


### PR DESCRIPTION
Whenever this occurs the issue looks vaguely like the following:

<img width="587" alt="Screenshot 2021-12-02 at 5 52 59 PM" src="https://user-images.githubusercontent.com/5597345/144516192-9bb96eb6-49b7-4521-bae3-7551543bb1b8.png">
<img width="969" alt="Screenshot 2021-12-02 at 5 55 35 PM" src="https://user-images.githubusercontent.com/5597345/144516193-7819d9a1-a7e5-4db9-9002-3d0ca62609e2.png">

This changes the error message and adds some contextual data so it's more clear what the problem is.