### PR TITLE
feat(workflow): Use yAxis w/ create from discover transactions

### DIFF
--- a/static/app/views/alerts/incidentRules/constants.tsx
+++ b/static/app/views/alerts/incidentRules/constants.tsx
@@ -150,11 +150,12 @@ export function createRuleFromEventView(eventView: EventView): UnsavedIncidentRu
     : DATA_SOURCE_TO_SET_AND_EVENT_TYPES.error;
 
   let aggregate = eventView.getYAxis();
-  if (datasetAndEventtypes.dataset === 'transactions') {
+  if (
+    datasetAndEventtypes.dataset === 'transactions' &&
+    /^p\d{2}\(\)/.test(eventView.getYAxis())
+  ) {
     // p95() -> p95(transaction.duration)
-    if (/^p\d{2}\(\)/.test(eventView.getYAxis())) {
-      aggregate = eventView.getYAxis().slice(0, 3) + '(transaction.duration)';
-    }
+    aggregate = eventView.getYAxis().slice(0, 3) + '(transaction.duration)';
   }
 
   return {

--- a/static/app/views/alerts/incidentRules/constants.tsx
+++ b/static/app/views/alerts/incidentRules/constants.tsx
@@ -148,15 +148,20 @@ export function createRuleFromEventView(eventView: EventView): UnsavedIncidentRu
   const datasetAndEventtypes = parsedQuery
     ? DATA_SOURCE_TO_SET_AND_EVENT_TYPES[parsedQuery.source]
     : DATA_SOURCE_TO_SET_AND_EVENT_TYPES.error;
+
+  let aggregate = eventView.getYAxis();
+  if (datasetAndEventtypes.dataset === 'transactions') {
+    // p95() -> p95(transaction.duration)
+    if (/^p\d{2}\(\)/.test(eventView.getYAxis())) {
+      aggregate = eventView.getYAxis().slice(0, 3) + '(transaction.duration)';
+    }
+  }
+
   return {
     ...createDefaultRule(),
     ...datasetAndEventtypes,
     query: parsedQuery?.query ?? eventView.query,
-    // If creating a metric alert for transactions, default to the p95 metric
-    aggregate:
-      datasetAndEventtypes.dataset === 'transactions'
-        ? 'p95(transaction.duration)'
-        : eventView.getYAxis(),
+    aggregate,
     environment: eventView.environment.length ? eventView.environment[0] : null,
   };
 }

--- a/static/app/views/alerts/incidentRules/constants.tsx
+++ b/static/app/views/alerts/incidentRules/constants.tsx
@@ -152,7 +152,7 @@ export function createRuleFromEventView(eventView: EventView): UnsavedIncidentRu
   let aggregate = eventView.getYAxis();
   if (
     datasetAndEventtypes.dataset === 'transactions' &&
-    /^p\d{2}\(\)/.test(eventView.getYAxis())
+    /^p\d{2,3}\(\)/.test(eventView.getYAxis())
   ) {
     // p95() -> p95(transaction.duration)
     aggregate = eventView.getYAxis().slice(0, 3) + '(transaction.duration)';

--- a/tests/js/spec/views/alerts/incidentRules/constants.spec.jsx
+++ b/tests/js/spec/views/alerts/incidentRules/constants.spec.jsx
@@ -53,4 +53,15 @@ describe('createRuleFromEventView()', () => {
     expect(rule.dataset).toBe(Dataset.ERRORS);
     expect(rule.eventTypes).toEqual([EventTypes.ERROR, EventTypes.DEFAULT]);
   });
+  it('allows pXX transaction querys', () => {
+    const eventView = EventView.fromSavedQuery({
+      id: undefined,
+      query: 'event.type:transaction',
+      yAxis: 'p95()',
+      fields: ['p95()'],
+    });
+
+    const rule = createRuleFromEventView(eventView);
+    expect(rule.aggregate).toBe('p95(transaction.duration)');
+  });
 });


### PR DESCRIPTION
Uses the yAxis passed from create from discover instead of the hardcoded p95

fixes https://getsentry.atlassian.net/browse/WOR-1507

Open discover and use count() -> create alert should now use count
same with p95