### PR TITLE
pickle: accept explicit protocols greater than 2

### DIFF
--- a/src/sentry/monkey/pickle.py
+++ b/src/sentry/monkey/pickle.py
@@ -117,11 +117,13 @@ def patch_pickle_loaders():
 
     class CompatPickler:
         def __init__(self, *args, **kwargs):
+            # If we don't explicitly pass in a protocol, use DEFAULT_PROTOCOL
             # Enforce protocol kwarg as DEFAULT_PROTOCOL. See the comment above
             # DEFAULT_PROTOCOL above to understand why we must pass the kwarg due
             # to _pickle.
             if len(args) == 1:
-                kwargs["protocol"] = pickle.DEFAULT_PROTOCOL
+                if not kwargs.get("protocol"):
+                    kwargs["protocol"] = pickle.DEFAULT_PROTOCOL
             else:
                 largs = list(args)
                 largs[1] = pickle.DEFAULT_PROTOCOL
@@ -167,11 +169,13 @@ def patch_pickle_loaders():
     # Patched dump and dumps
 
     def py3_compat_pickle_dump(*args, **kwargs):
+        # If we don't explicitly pass in a protocol, use DEFAULT_PROTOCOL
         # Enforce protocol kwarg as DEFAULT_PROTOCOL. See the comment above
         # DEFAULT_PROTOCOL above to understand why we must pass the kwarg due
         # to _pickle.
         if len(args) == 1:
-            kwargs["protocol"] = pickle.DEFAULT_PROTOCOL
+            if not kwargs.get("protocol"):
+                kwargs["protocol"] = pickle.DEFAULT_PROTOCOL
         else:
             largs = list(args)
             largs[1] = pickle.DEFAULT_PROTOCOL
@@ -180,11 +184,13 @@ def patch_pickle_loaders():
         return original_pickle_dump(*args, **kwargs)
 
     def py3_compat_pickle_dumps(*args, **kwargs):
+        # If we don't explicitly pass in a protocol, use DEFAULT_PROTOCOL
         # Enforce protocol kwarg as DEFAULT_PROTOCOL. See the comment above
         # DEFAULT_PROTOCOL above to understand why we must pass the kwarg due
         # to _pickle.
         if len(args) == 1:
-            kwargs["protocol"] = pickle.DEFAULT_PROTOCOL
+            if not kwargs.get("protocol"):
+                kwargs["protocol"] = pickle.DEFAULT_PROTOCOL
         else:
             largs = list(args)
             largs[1] = pickle.DEFAULT_PROTOCOL

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -26,7 +26,7 @@ class EventTest(TestCase):
 
         # When we pickle an event we need to make sure our canonical code
         # does not appear here or it breaks old workers.
-        data = pickle.dumps(event, protocol=2)
+        data = pickle.dumps(event, protocol=5)
         assert b"canonical" not in data
 
         # For testing we remove the backwards compat support in the

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -26,7 +26,7 @@ class EventTest(TestCase):
 
         # When we pickle an event we need to make sure our canonical code
         # does not appear here or it breaks old workers.
-        data = pickle.dumps(event, protocol=5)
+        data = pickle.dumps(event, protocol=2)
         assert b"canonical" not in data
 
         # For testing we remove the backwards compat support in the

--- a/tests/sentry/utils/test_pickle_protocol.py
+++ b/tests/sentry/utils/test_pickle_protocol.py
@@ -1,0 +1,27 @@
+import pickle
+from pickle import PickleBuffer, PickleError
+
+from sentry.testutils import TestCase
+
+
+class PickleProtocolTestCase(TestCase):
+    """
+    At the time of adding this test we still monkey patch `pickle` and hardcode the protocol to be 2.
+    For legacy reasons see `src/sentry/monkey/pickle.py`.
+
+    This test is for a change that's being made to allow explicitly passing a newer protocol to
+    pickle. If we remove the monkey patching to pickle there is no longer a need for this test.
+
+    """
+
+    def test_pickle_protocol(self):
+        data = b"iamsomedata"
+
+        pickled_data = PickleBuffer(data)
+        with self.assertRaises(PickleError) as context:
+            result = pickle.dumps(pickled_data)
+
+        assert "PickleBuffer can only pickled with protocol >= 5" == str(context.exception)
+
+        result = pickle.dumps(pickled_data, protocol=5)
+        assert result


### PR DESCRIPTION
**context**
I've been working on a piece of the metrics infrastructure, part of which included adding a new batching consumer (more context in https://github.com/getsentry/sentry/pull/28431). At the time, sentry was not on python 3.8, so we used the existing `BatchingKafkaConsumer`. 

Now that we are on 3.8 we'd like to use [arroyo](https://github.com/getsentry/arroyo) instead. The functionality we want to use from arroyo explicitly uses pickle protocol 5 (found [here](https://github.com/getsentry/arroyo/blob/1dbc30cbe842d4ca6aa8e46893805c50a6946f2d/arroyo/processing/strategies/streaming/transform.py#L186))

**problem**
we currently monkey patch pickle to always default to protocol 2, even if we provide the protocol in the `kwargs`. This makes arroyo in sentry unusable (for the streaming functionality I need). 

Until we can fully rip this old compat stuff out completely (still tbd because doing so many break things for data pipelines), this PR just allows respecting when someone explicitly passes in a pickle protocol. Which is something that I don't think we do in any of the sentry codebase as of right now