### PR TITLE
perf(api): Add rate limits to group mutation endpoints

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -106,9 +106,10 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :pparam string issue_id: the ID of the issue to retrieve.
         :auth: required
         """
+        from sentry.utils import snuba
+
         try:
             # TODO(dcramer): handle unauthenticated/public response
-            from sentry.utils import snuba
 
             organization = group.project.organization
             environments = get_environments(request, organization)
@@ -276,7 +277,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         except Exception:
             raise
 
-    @rate_limit_endpoint(limit=5, window=1)
+    @rate_limit_endpoint(limit=5, window=5)
     def delete(self, request, group):
         """
         Remove an Issue

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -328,7 +328,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         return response
 
     @track_slo_response("workflow")
-    @rate_limit_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=5, window=5)
     def put(self, request, organization):
         """
         Bulk Mutate a List of Issues
@@ -411,7 +411,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         )
 
     @track_slo_response("workflow")
-    @rate_limit_endpoint(limit=10, window=1)
+    @rate_limit_endpoint(limit=5, window=5)
     def delete(self, request, organization):
         """
         Bulk Remove a List of Issues


### PR DESCRIPTION
Since these can cause replacements they create a potential DDOS vector. Adding more stringent rate
limiting in place here.