### PR TITLE
feat(ui): Load more teams on organization teams page

### DIFF
--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -184,7 +184,7 @@ export async function fetchOrganizationDetails(
   }
 
   if (loadTeam) {
-    TeamStore.loadInitialData(data.teams);
+    TeamStore.loadInitialData(data.teams, false, null);
   }
 
   if (loadProjects) {

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -72,7 +72,7 @@ function OrganizationTeams({
 
   const [teamQuery, setTeamQuery] = useState('');
   const {initiallyLoaded} = useTeams({provideUserTeams: true});
-  const {teams, onSearch} = useTeams();
+  const {teams, onSearch, loadMore, hasMore, fetching} = useTeams();
 
   const debouncedSearch = debounce(onSearch, DEFAULT_DEBOUNCE_DURATION);
   function handleSearch(query: string) {
@@ -130,12 +130,26 @@ function OrganizationTeams({
           />
         </PanelBody>
       </Panel>
+      {hasMore && (
+        <LoadMoreWrapper>
+          {fetching && <LoadingIndicator mini />}
+          <Button onClick={() => loadMore(teamQuery)}>{t('Load more')}</Button>
+        </LoadMoreWrapper>
+      )}
     </div>
   );
 }
 
 const StyledSearchBar = styled(SearchBar)`
   margin-bottom: ${space(2)};
+`;
+
+const LoadMoreWrapper = styled('div')`
+  display: grid;
+  grid-gap: ${space(2)};
+  align-items: center;
+  justify-content: end;
+  grid-auto-flow: column;
 `;
 
 export default OrganizationTeams;

--- a/static/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -133,7 +133,7 @@ function OrganizationTeams({
       {hasMore && (
         <LoadMoreWrapper>
           {fetching && <LoadingIndicator mini />}
-          <Button onClick={() => loadMore(teamQuery)}>{t('Load more')}</Button>
+          <Button onClick={() => loadMore(teamQuery)}>{t('Show more')}</Button>
         </LoadMoreWrapper>
       )}
     </div>


### PR DESCRIPTION
Utilizes the new `loadMore` function from the `useTeams` hook https://github.com/getsentry/sentry/pull/30307 to render additional teams when clicked.

![Kapture 2021-12-02 at 18 39 13](https://user-images.githubusercontent.com/9372512/144535702-f43757db-afe7-4ef2-bd59-7b3fe467d19f.gif)