### PR TITLE
test(ui): Adjust echarts transform for performance

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -80,7 +80,7 @@ const config: Config.InitialOptions = {
     '^.+\\.tsx?$': ['babel-jest', babelConfig as any],
     '^.+\\.pegjs?$': '<rootDir>/tests/js/jest-pegjs-transform.js',
   },
-  transformIgnorePatterns: ['node_modules/(?!echarts/lib)/'],
+  transformIgnorePatterns: ['/node_modules/(?!echarts)'],
   moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx'],
   globals: {},
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -80,7 +80,7 @@ const config: Config.InitialOptions = {
     '^.+\\.tsx?$': ['babel-jest', babelConfig as any],
     '^.+\\.pegjs?$': '<rootDir>/tests/js/jest-pegjs-transform.js',
   },
-  transformIgnorePatterns: ['/node_modules/(?!echarts)'],
+  transformIgnorePatterns: ['/node_modules/(?!echarts|zrender)'],
   moduleFileExtensions: ['js', 'ts', 'jsx', 'tsx'],
   globals: {},
 


### PR DESCRIPTION
the speed of our slowest tests got worse around the time the echarts v5 was merged and i think it was the jest transform change. Testing locally using `overview.spec.jsx` our slowest test, transforming echarts vs transforming echarts/lib was 27 sec vs 46 sec. Hopefully this fixes it.

![image](https://user-images.githubusercontent.com/1400464/144553878-ce81e64c-2d4d-416c-8962-c48ce3dee8be.png)
