### PR TITLE
fix(ui): Show a horizontal line for a single data point in line chart

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -359,7 +359,7 @@ function BaseChartUnwrapped({
       ? (series as LineSeriesOption[] | undefined)?.map(s => ({
           ...s,
           type: 'line',
-          itemStyle: {},
+          itemStyle: {...(s.lineStyle ?? {})},
           markLine: MarkLine({
             silent: true,
             lineStyle: {

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -23,6 +23,7 @@ import type {
 import * as echarts from 'echarts/core';
 import ReactEchartsCore from 'echarts-for-react/lib/core';
 
+import MarkLine from 'sentry/components/charts/components/markLine';
 import {IS_ACCEPTANCE_TEST} from 'sentry/constants';
 import space from 'sentry/styles/space';
 import {
@@ -270,6 +271,11 @@ type Props = {
    */
   transformSinglePointToBar?: boolean;
   /**
+   * If true and there's only one datapoint in series.data, we show a horizontal line to increase the visibility
+   * Similarly to single point bar in area charts a flat line for line charts makes it easy to spot the single data point.
+   */
+  transformSinglePointToLine?: boolean;
+  /**
    * Inline styles
    */
   style?: React.CSSProperties;
@@ -323,6 +329,7 @@ function BaseChartUnwrapped({
   lazyUpdate = false,
   isGroupedByDate = false,
   transformSinglePointToBar = false,
+  transformSinglePointToLine = false,
   onChartReady = () => {},
 }: Props) {
   const theme = useTheme();
@@ -347,6 +354,23 @@ function BaseChartUnwrapped({
           barWidth: 40,
           barGap: 0,
           itemStyle: {...(s.areaStyle ?? {})},
+        }))
+      : hasSinglePoints && transformSinglePointToLine
+      ? (series as LineSeriesOption[] | undefined)?.map(s => ({
+          ...s,
+          type: 'line',
+          itemStyle: {},
+          markLine: MarkLine({
+            silent: true,
+            lineStyle: {
+              type: 'solid',
+              width: 1.5,
+            },
+            data: [{yAxis: s?.data?.[0][1]}],
+            label: {
+              show: false,
+            },
+          }),
         }))
       : series) ?? [];
 

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -312,7 +312,12 @@ function ReleaseAdoption({
               xAxisIndex={[sessionsAxisIndex, usersAxisIndex]}
             >
               {zoomRenderProps => (
-                <LineChart {...chartOptions} {...zoomRenderProps} series={getSeries()} />
+                <LineChart
+                  {...chartOptions}
+                  {...zoomRenderProps}
+                  series={getSeries()}
+                  transformSinglePointToLine
+                />
               )}
             </ChartZoom>
           </TransitionChart>


### PR DESCRIPTION
This adds an option to base chart to show single data points as lines similarly to bars, useful for linecharts when there's a single data point.

Single data point before:
![Screen Shot 2021-12-03 at 8 30 11 AM](https://user-images.githubusercontent.com/15015880/144639107-b119ad72-5a93-4b6f-85a1-923048a6b1cb.png)


Single data point after:
![Screen Shot 2021-12-03 at 8 34 26 AM](https://user-images.githubusercontent.com/15015880/144639125-425b1742-d9bf-47de-8a12-943b8067be55.png)


