### PR TITLE
ref(perf): Remove flags for tag explorer backend

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -62,9 +62,8 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
         all_tag_keys = None
         tag_key = None
 
-        if self.has_tag_page_feature(organization, request):
-            all_tag_keys = request.GET.get("allTagKeys")
-            tag_key = request.GET.get("tagKey")
+        all_tag_keys = request.GET.get("allTagKeys")
+        tag_key = request.GET.get("tagKey")
 
         if tag_key in TAG_ALIASES:
             tag_key = TAG_ALIASES.get(tag_key)

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -29,21 +29,13 @@ DEFAULT_TAG_KEY_LIMIT = 5
 
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
     def has_feature(self, organization, request):
-        return features.has(
-            "organizations:performance-tag-explorer", organization, actor=request.user
-        )
-
-    def has_tag_page_feature(self, organization, request):
-        return features.has("organizations:performance-tag-page", organization, actor=request.user)
+        return features.has("organizations:performance-view", organization, actor=request.user)
 
     # NOTE: This used to be called setup, but since Django 2.2 it's a View method.
     #       We don't fit its semantics, but I couldn't think of a better name, and
     #       it's only used in child classes.
     def _setup(self, request, organization):
-        if not (
-            self.has_feature(organization, request)
-            or self.has_tag_page_feature(organization, request)
-        ):
+        if not (self.has_feature(organization, request)):
             raise Http404
 
         params = self.get_snuba_params(request, organization)
@@ -132,9 +124,6 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsFacetsPerfor
 class OrganizationEventsFacetsPerformanceHistogramEndpoint(
     OrganizationEventsFacetsPerformanceEndpointBase
 ):
-    def has_feature(self, organization, request):
-        return self.has_tag_page_feature(organization, request)
-
     def get(self, request, organization):
         try:
             params, aggregate_column, filter_query = self._setup(request, organization)

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -35,7 +35,7 @@ class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2Endpoi
     #       We don't fit its semantics, but I couldn't think of a better name, and
     #       it's only used in child classes.
     def _setup(self, request, organization):
-        if not (self.has_feature(organization, request)):
+        if not self.has_feature(organization, request):
             raise Http404
 
         params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -28,6 +28,11 @@ DEFAULT_TAG_KEY_LIMIT = 5
 
 
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:performance-view", organization, actor=request.user
+        )
+
     # NOTE: This used to be called setup, but since Django 2.2 it's a View method.
     #       We don't fit its semantics, but I couldn't think of a better name, and
     #       it's only used in child classes.

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -28,9 +28,6 @@ DEFAULT_TAG_KEY_LIMIT = 5
 
 
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
-    def has_feature(self, organization, request):
-        return features.has("organizations:performance-view", organization, actor=request.user)
-
     # NOTE: This used to be called setup, but since Django 2.2 it's a View method.
     #       We don't fit its semantics, but I couldn't think of a better name, and
     #       it's only used in child classes.

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -29,9 +29,7 @@ DEFAULT_TAG_KEY_LIMIT = 5
 
 class OrganizationEventsFacetsPerformanceEndpointBase(OrganizationEventsV2EndpointBase):
     def has_feature(self, organization, request):
-        return features.has(
-            "organizations:performance-view", organization, actor=request.user
-        )
+        return features.has("organizations:performance-view", organization, actor=request.user)
 
     # NOTE: This used to be called setup, but since Django 2.2 it's a View method.
     #       We don't fit its semantics, but I couldn't think of a better name, and

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1029,10 +1029,6 @@ SENTRY_FEATURES = {
     "organizations:prompt-dashboards": False,
     # Enable views for ops breakdown
     "organizations:performance-ops-breakdown": False,
-    # Enable views for tag explorer
-    "organizations:performance-tag-explorer": True,
-    # Enable views for tag page
-    "organizations:performance-tag-page": True,
     # Enable landing improvements for performance
     "organizations:performance-landing-widgets": False,
     # Enable views for transaction events page in performance

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -128,8 +128,6 @@ default_manager.add("organizations:performance-landing-widgets", OrganizationFea
 default_manager.add("organizations:performance-mobile-vitals", OrganizationFeature, True)
 default_manager.add("organizations:performance-ops-breakdown", OrganizationFeature)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
-default_manager.add("organizations:performance-tag-explorer", OrganizationFeature, True)
-default_manager.add("organizations:performance-tag-page", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-snql", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -43,8 +43,6 @@ class OrganizationSerializerTest(TestCase):
             "issue-percent-filters",
             "minute-resolution-sessions",
             "open-membership",
-            "performance-tag-page",
-            "performance-tag-explorer",
             "relay",
             "release-adoption-chart",
             "release-adoption-stage",

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -11,7 +11,6 @@ class BaseOrganizationEventsFacetsPerformanceEndpointTest(SnubaTestCase, APITest
     feature_list = (
         "organizations:discover-basic",
         "organizations:global-views",
-        "organizations:performance-tag-explorer",
     )
 
     def setUp(self):
@@ -194,16 +193,9 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
             "query": "(color:red or color:blue)",
             "allTagKeys": True,
         }
-        # No feature access
-        response = self.do_request(request, {"organizations:performance-tag-page": False})
-        data = response.data["data"]
-        assert len(data) == 1
-        assert data[0]["count"] == 5
-        assert data[0]["tags_key"] == "color"
-        assert data[0]["tags_value"] == "blue"
 
         # With feature access
-        response = self.do_request(request, {"organizations:performance-tag-page": True})
+        response = self.do_request(request)
         data = response.data["data"]
         assert len(data) == 5
         assert data[0]["count"] == 19
@@ -223,7 +215,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
             "allTagKeys": True,
         }
 
-        response = self.do_request(request, {"organizations:performance-tag-page": True})
+        response = self.do_request(request)
 
         data = response.data["data"]
         assert len(data) == 5
@@ -242,16 +234,8 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
             "statsPeriod": "14d",
             "tagKey": "color",
         }
-        # No feature access
-        response = self.do_request(request, {"organizations:performance-tag-page": False})
-        data = response.data["data"]
-        assert len(data) == 2
-        assert data[0]["count"] == 5
-        assert data[0]["tags_key"] == "color"
-        assert data[0]["tags_value"] == "blue"
-
         # With feature access
-        response = self.do_request(request, {"organizations:performance-tag-page": True})
+        response = self.do_request(request)
         data = response.data["data"]
         assert len(data) == 3
         assert data[0]["count"] == 14
@@ -271,7 +255,7 @@ class OrganizationEventsFacetsPerformanceEndpointTest(
             "query": "(color:purple)",
         }
 
-        response = self.do_request(request, {"organizations:performance-tag-page": True})
+        response = self.do_request(request)
         data = response.data["data"]
         assert len(data) == 1
         assert data[0]["count"] == 1

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -11,6 +11,7 @@ class BaseOrganizationEventsFacetsPerformanceEndpointTest(SnubaTestCase, APITest
     feature_list = (
         "organizations:discover-basic",
         "organizations:global-views",
+        "organizations:performance-view",
     )
 
     def setUp(self):

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
@@ -16,7 +16,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
     feature_list = (
         "organizations:discover-basic",
         "organizations:global-views",
-        "organizations:performance-tag-page",
+        "organizations:performance-view",
     )
 
     def setUp(self):
@@ -117,7 +117,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             {
                 "organizations:discover-basic": True,
                 "organizations:global-views": True,
-                "organizations:performance-tag-page": False,
+                "organizations:performance-view": False,
             },
         )
         assert error_response.status_code == 404
@@ -132,7 +132,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "per_page": 5,
         }
         # With feature access, no tag key
-        error_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        error_response = self.do_request(request, {"organizations:performance-view": True})
 
         assert error_response.status_code == 400, error_response.content
         assert error_response.data == {
@@ -150,14 +150,14 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:red or color:blue)",
         }
         # With feature access, no tag key
-        error_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        error_response = self.do_request(request, {"organizations:performance-view": True})
 
         assert error_response.status_code == 400, error_response.content
         assert error_response.data == {"detail": "'tagKey' must be provided when using histograms."}
 
         # With feature access and tag key
         request["tagKey"] = "color"
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 2
@@ -188,7 +188,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:teal or color:oak)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         histogram_data = data_response.data["histogram"]["data"]
         assert histogram_data == []
@@ -208,7 +208,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:red or color:blue or color:green)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 1
@@ -218,7 +218,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
         assert histogram_data[0]["tags_key"] == "color"
 
         request["per_page"] = 3
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 3
@@ -250,13 +250,13 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:red or color:blue or color:green or color:orange)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         assert data_response.data["tags"]["data"][2]["tags_value"] == "green"
 
         request["aggregateColumn"] = "measurements.lcp"
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         tags_data = data_response.data["tags"]["data"]
         assert len(tags_data) == 3
@@ -293,7 +293,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(user.id:555)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         histogram_data = data_response.data["histogram"]["data"]
         assert histogram_data[0]["count"] == 1
@@ -313,14 +313,14 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "tagKey": "color",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 3
 
         request["cursor"] = Cursor(0, 3)
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 1
@@ -335,7 +335,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "tagKey": "color",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 1
@@ -344,7 +344,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
 
         request["sort"] = "-aggregate"
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 1
@@ -364,7 +364,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "tagKey": "fruit",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-tag-page": True})
+        data_response = self.do_request(request, {"organizations:performance-view": True})
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 20

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance_histogram.py
@@ -115,8 +115,6 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
         error_response = self.do_request(
             request,
             {
-                "organizations:discover-basic": True,
-                "organizations:global-views": True,
                 "organizations:performance-view": False,
             },
         )
@@ -132,7 +130,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "per_page": 5,
         }
         # With feature access, no tag key
-        error_response = self.do_request(request, {"organizations:performance-view": True})
+        error_response = self.do_request(request)
 
         assert error_response.status_code == 400, error_response.content
         assert error_response.data == {
@@ -150,14 +148,14 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:red or color:blue)",
         }
         # With feature access, no tag key
-        error_response = self.do_request(request, {"organizations:performance-view": True})
+        error_response = self.do_request(request)
 
         assert error_response.status_code == 400, error_response.content
         assert error_response.data == {"detail": "'tagKey' must be provided when using histograms."}
 
         # With feature access and tag key
         request["tagKey"] = "color"
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 2
@@ -188,7 +186,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:teal or color:oak)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         histogram_data = data_response.data["histogram"]["data"]
         assert histogram_data == []
@@ -208,7 +206,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:red or color:blue or color:green)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 1
@@ -218,7 +216,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
         assert histogram_data[0]["tags_key"] == "color"
 
         request["per_page"] = 3
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 3
@@ -250,13 +248,13 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(color:red or color:blue or color:green or color:orange)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         assert data_response.data["tags"]["data"][2]["tags_value"] == "green"
 
         request["aggregateColumn"] = "measurements.lcp"
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         tags_data = data_response.data["tags"]["data"]
         assert len(tags_data) == 3
@@ -293,7 +291,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "query": "(user.id:555)",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         histogram_data = data_response.data["histogram"]["data"]
         assert histogram_data[0]["count"] == 1
@@ -313,14 +311,14 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "tagKey": "color",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 3
 
         request["cursor"] = Cursor(0, 3)
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 1
@@ -335,7 +333,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "tagKey": "color",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 1
@@ -344,7 +342,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
 
         request["sort"] = "-aggregate"
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         tag_data = data_response.data["tags"]["data"]
         assert len(tag_data) == 1
@@ -364,7 +362,7 @@ class OrganizationEventsFacetsPerformanceHistogramEndpointTest(
             "tagKey": "fruit",
         }
 
-        data_response = self.do_request(request, {"organizations:performance-view": True})
+        data_response = self.do_request(request)
 
         histogram_data = data_response.data["histogram"]["data"]
         assert len(histogram_data) == 20


### PR DESCRIPTION
### Summary
This is the second part of removing tag explorer tags, the frontend has already been merged in. After this gets merged, it should work for non SaaS installs of Sentry.