### PR TITLE
feat(notifications): Nudge Notifications

### DIFF
--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -20,7 +20,14 @@ from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.integrations.slack.views.unlink_identity import build_unlinking_url
-from sentry.models import Group, Identity, IdentityProvider, InviteStatus, NotificationSetting, OrganizationMember
+from sentry.models import (
+    Group,
+    Identity,
+    IdentityProvider,
+    InviteStatus,
+    NotificationSetting,
+    OrganizationMember,
+)
 from sentry.notifications.utils.actions import MessageAction
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import ExternalProviders

--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -20,9 +20,10 @@ from sentry.integrations.slack.requests.action import SlackActionRequest
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.views.link_identity import build_linking_url
 from sentry.integrations.slack.views.unlink_identity import build_unlinking_url
-from sentry.models import Group, Identity, IdentityProvider, InviteStatus, OrganizationMember
+from sentry.models import Group, Identity, IdentityProvider, InviteStatus, NotificationSetting, OrganizationMember
 from sentry.notifications.utils.actions import MessageAction
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
@@ -42,6 +43,7 @@ UNLINK_IDENTITY_MESSAGE = (
 NO_ACCESS_MESSAGE = "You do not have access to the organization for the invitation."
 NO_PERMISSION_MESSAGE = "You do not have permission to approve member invitations."
 NO_IDENTITY_MESSAGE = "Identity not linked for user."
+ENABLE_SLACK_SUCCESS_MESSAGE = "Slack has been enabled."
 
 DEFAULT_ERROR_MESSAGE = "Sentry can't perform that action right now on your behalf!"
 SUCCESS_MESSAGE = (
@@ -383,7 +385,23 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         if action_option in ["approve_member", "reject_member"]:
             return self.handle_member_approval(slack_request, action_option)
 
+        if action_list and action_list[0].name == "enable_notifications":
+            self.handle_enable_notifications(slack_request)
+
         return self._handle_group_actions(slack_request, request, action_list)
+
+    def handle_enable_notifications(self, slack_request: SlackActionRequest) -> Response:
+        try:
+            identity = slack_request.get_identity()
+        except IdentityProvider.DoesNotExist:
+            identity = None
+        if not identity:
+            return self.respond(status=403)
+
+        NotificationSetting.objects.enable_settings_for_user(
+            recipient=identity.user, provider=ExternalProviders.SLACK
+        )
+        return self.respond(ENABLE_SLACK_SUCCESS_MESSAGE)
 
     def handle_member_approval(self, slack_request: SlackActionRequest, action: str) -> Response:
         try:

--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -393,7 +393,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
             return self.handle_member_approval(slack_request, action_option)
 
         if action_list and action_list[0].name == "enable_notifications":
-            self.handle_enable_notifications(slack_request)
+            return self.handle_enable_notifications(slack_request)
 
         return self._handle_group_actions(slack_request, request, action_list)
 
@@ -408,7 +408,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         NotificationSetting.objects.enable_settings_for_user(
             recipient=identity.user, provider=ExternalProviders.SLACK
         )
-        return self.respond(ENABLE_SLACK_SUCCESS_MESSAGE)
+        return self.respond_with_text(ENABLE_SLACK_SUCCESS_MESSAGE)
 
     def handle_member_approval(self, slack_request: SlackActionRequest, action: str) -> Response:
         try:

--- a/src/sentry/integrations/slack/endpoints/action.py
+++ b/src/sentry/integrations/slack/endpoints/action.py
@@ -50,7 +50,7 @@ UNLINK_IDENTITY_MESSAGE = (
 NO_ACCESS_MESSAGE = "You do not have access to the organization for the invitation."
 NO_PERMISSION_MESSAGE = "You do not have permission to approve member invitations."
 NO_IDENTITY_MESSAGE = "Identity not linked for user."
-ENABLE_SLACK_SUCCESS_MESSAGE = "Slack has been enabled."
+ENABLE_SLACK_SUCCESS_MESSAGE = "Slack notifications have been enabled."
 
 DEFAULT_ERROR_MESSAGE = "Sentry can't perform that action right now on your behalf!"
 SUCCESS_MESSAGE = (

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -389,3 +389,20 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
                     target_id=user.actor_id,
                     defaults={"value": NotificationSettingOptionValues.NEVER.value},
                 )
+
+    def has_any_provider_settings(
+        self, recipient: Team | User, provider: ExternalProviders
+    ) -> bool:
+        # Explicitly typing to satisfy mypy.
+        has_settings: bool = (
+            self._filter(provider=provider, target_ids={recipient.actor_id})
+            .filter(
+                value__in={
+                    NotificationSettingOptionValues.ALWAYS.value,
+                    NotificationSettingOptionValues.COMMITTED_ONLY.value,
+                    NotificationSettingOptionValues.SUBSCRIBE_ONLY.value,
+                }
+            )
+            .exists()
+        )
+        return has_settings

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -8,6 +8,7 @@ from django.db.models import Q, QuerySet
 
 from sentry import analytics
 from sentry.db.models.manager import BaseManager
+from sentry.notifications.defaults import NOTIFICATION_SETTINGS_ALL_SOMETIMES
 from sentry.notifications.helpers import (
     get_scope,
     get_scope_type,
@@ -406,3 +407,17 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
             .exists()
         )
         return has_settings
+
+    def enable_settings_for_user(
+        self,
+        recipient: User,
+        provider: ExternalProviders,
+        types: set[NotificationSettingTypes] | None = None,
+    ) -> None:
+        for type_ in types or NOTIFICATION_SETTINGS_ALL_SOMETIMES.keys():
+            self.update_settings(
+                provider=provider,
+                type=type_,
+                value=NOTIFICATION_SETTINGS_ALL_SOMETIMES[type_],
+                user=recipient,
+            )

--- a/src/sentry/notifications/notifications/base.py
+++ b/src/sentry/notifications/notifications/base.py
@@ -186,6 +186,7 @@ class BaseNotification(abc.ABC):
         }
 
     def send(self) -> None:
+        """The default way to send notifications that respects Notification Settings."""
         from sentry.notifications.notify import notify
 
         participants_by_provider = self.get_participants()

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -42,18 +42,6 @@ MESSAGE_LIBRARY = [
 
 
 class IntegrationNudgeNotification(BaseNotification):
-    def get_filename(self) -> str:
-        pass
-
-    def get_category(self) -> str:
-        pass
-
-    def get_type(self) -> str:
-        pass
-
-    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
-        pass
-
     category = "integration_nudge"
     filename = "integration-nudge"
     type = "integration.nudge"
@@ -87,7 +75,13 @@ class IntegrationNudgeNotification(BaseNotification):
         return MESSAGE_LIBRARY[self.seed].format(provider=self.provider.name.capitalize())
 
     def get_message_actions(self) -> Sequence[MessageAction]:
-        return [MessageAction(name="Turn on personal notifications", value="1")]
+        return [
+            MessageAction(
+                name="Turn on personal notifications",
+                action_id="enable_notifications",
+                value="all_slack",
+            )
+        ]
 
     def get_context(self) -> MutableMapping[str, Any]:
         return {}
@@ -100,3 +94,15 @@ class IntegrationNudgeNotification(BaseNotification):
 
     def build_attachment_title(self) -> str:
         return ""
+
+    def get_filename(self) -> str:
+        return ""
+
+    def get_category(self) -> str:
+        return ""
+
+    def get_type(self) -> str:
+        return ""
+
+    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
+        pass

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -27,9 +27,6 @@ MESSAGE_LIBRARY = [
     "Like getting notified in {provider}? Sentry can do that. Want to be left alone? Ignore this.",
     "Like this notification? There's more where that came from. Hear from Sentry right here in {provider}.",
     "Notifications aren't always bad. Hear from Sentry right here in {provider}.",
-    "Now, get Sentry notifications in {provider}. You choose the settings, so we'll"
-    " blow up your phone exactly as much as you want us to.",
-    "Push notifications suck. Get more of them.",
     "Remember when email was exciting? It's not 1998 anymore. Get notified in {provider} instead.",
     "Reminisce on the days before your email address was an obligational burden"
     " while signing up for {provider} notifications instead.",

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+import random
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, MutableMapping, Sequence
+
+from sentry.db.models import Model
+from sentry.notifications.notifications.base import BaseNotification
+from sentry.notifications.utils.actions import MessageAction
+from sentry.types.integrations import ExternalProviders
+
+if TYPE_CHECKING:
+    from sentry.models import Organization, Team, User
+
+logger = logging.getLogger(__name__)
+
+MESSAGE_LIBRARY = [
+    "Check your email lately? We didn't think so. Get Sentry notifications in {provider}.",
+    "Complicated relationship with email? We understand. We can notify you in {provider} instead.",
+    "Dread email? We get it. Hear from Sentry in {provider} instead.",
+    "Emails are so 2010s. Get Sentry notifications in {provider}.",
+    "Everyone has feelings about notifications. Whatever yours are, get your"
+    " needs met with Sentry for {provider}.",
+    "Get notifications where you'll actually see them. Hear from Sentry in {provider}.",
+    "Is this a dream come true? Or notifications out of control? Hear from"
+    " Sentry right here in {provider}. If you want.",
+    "Like getting notified in {provider}? Sentry can do that. Want to be left alone? Ignore this.",
+    "Like this notification? There's more where that came from. Hear from Sentry right here in {provider}.",
+    "Notifications aren't always bad. Hear from Sentry right here in {provider}.",
+    "Now, get Sentry notifications in {provider}. You choose the settings, so we'll"
+    " blow up your phone exactly as much as you want us to.",
+    "Push notifications suck. Get more of them.",
+    "Remember when email was exciting? It's not 1998 anymore. Get notified in {provider} instead.",
+    "Reminisce on the days before your email address was an obligational burden"
+    " while signing up for {provider} notifications instead.",
+    "This is a notification about notifications. Now you can hear from Sentry right here in {provider}.",
+    "This isn't 1998. Swap emails for Sentry notifications in {provider}.",
+    "We're doing something new. Get Sentry notifications right here in {provider}.",
+    "We're here to notify you about notifications. Meta, huh? Hear from Sentry right here in {provider}.",
+    "We've got something new for you. Get Sentry notifications right here in {provider}.",
+    "Who even checks their email anymore? Get Sentry notifications in {provider}.",
+    "You've got mail. So much mail. You're lost and confused as you cut through"
+    " a jungle of mail. Sentry can notify you in {provider} instead.",
+]
+
+
+class IntegrationNudgeNotification(BaseNotification):
+    def get_filename(self) -> str:
+        pass
+
+    def get_category(self) -> str:
+        pass
+
+    def get_type(self) -> str:
+        pass
+
+    def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
+        pass
+
+    category = "integration_nudge"
+    filename = "integration-nudge"
+    type = "integration.nudge"
+
+    def __init__(
+        self,
+        organization: Organization,
+        recipient: User,
+        provider: ExternalProviders,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(organization)
+        self.recipient = recipient
+        self.provider = provider
+        self.seed = (
+            (seed % len(MESSAGE_LIBRARY))
+            if seed is not None
+            else random.randint(0, len(MESSAGE_LIBRARY) - 1)
+        )
+
+    def get_reference(self) -> Model | None:
+        return None
+
+    def get_participants(self) -> Mapping[ExternalProviders, Iterable[Team | User]]:
+        return {self.provider: {self.recipient}}
+
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
+        return ""
+
+    def get_message_description(self) -> Any:
+        return MESSAGE_LIBRARY[self.seed].format(provider=self.provider.name.capitalize())
+
+    def get_message_actions(self) -> Sequence[MessageAction]:
+        return [MessageAction(name="Turn on personal notifications", value="1")]
+
+    def get_context(self) -> MutableMapping[str, Any]:
+        return {}
+
+    def get_notification_title(self) -> str:
+        return ""
+
+    def get_title_link(self) -> str | None:
+        return None
+
+    def build_attachment_title(self) -> str:
+        return ""

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -74,7 +74,7 @@ class IntegrationNudgeNotification(BaseNotification):
     def get_message_description(self) -> Any:
         return MESSAGE_LIBRARY[self.seed].format(provider=self.provider.name.capitalize())
 
-    def get_message_actions(self) -> Sequence[MessageAction]:
+    def get_message_actions(self, recipient: Team | User) -> Sequence[MessageAction]:
         return [
             MessageAction(
                 name="Turn on personal notifications",

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -104,5 +104,8 @@ class IntegrationNudgeNotification(BaseNotification):
     def get_type(self) -> str:
         return ""
 
+    def build_notification_footer(self, recipient: Team | User) -> str:
+        return ""
+
     def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         pass

--- a/src/sentry/notifications/notifications/integration_nudge.py
+++ b/src/sentry/notifications/notifications/integration_nudge.py
@@ -109,3 +109,6 @@ class IntegrationNudgeNotification(BaseNotification):
 
     def record_notification_sent(self, recipient: Team | User, provider: ExternalProviders) -> None:
         pass
+
+    def get_log_params(self, recipient: Team | User) -> Mapping[str, Any]:
+        return {"seed": self.seed, **super().get_log_params(recipient)}

--- a/tests/sentry/integrations/slack/endpoints/test_action.py
+++ b/tests/sentry/integrations/slack/endpoints/test_action.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from freezegun import freeze_time
 
 from sentry.integrations.slack.endpoints.action import (
+    ENABLE_SLACK_SUCCESS_MESSAGE,
     LINK_IDENTITY_MESSAGE,
     UNLINK_IDENTITY_MESSAGE,
 )
@@ -22,11 +23,14 @@ from sentry.models import (
     IdentityStatus,
     Integration,
     InviteStatus,
+    NotificationSetting,
     OrganizationIntegration,
     OrganizationMember,
 )
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import add_identity, install_slack
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
@@ -567,3 +571,53 @@ class StatusActionTest(BaseEventTest):
 
         assert resp.status_code == 200, resp.content
         assert resp.data["text"] == "You do not have permission to approve member invitations."
+
+
+class EnableNotificationsActionTest(BaseEventTest):
+    def setUp(self):
+        super().setUp()
+        self.slack_id = "UXXXXXXX1"
+        self.team_id = "TXXXXXXX1"
+
+    def test_enable_all_slack_no_identity(self):
+        Identity.objects.delete_identity(user=self.user, idp=self.idp, external_id=self.external_id)
+        response = self.post_webhook(
+            action_data=[{"name": "enable_notifications", "value": "all_slack"}]
+        )
+
+        assert response.status_code == 403, response.content
+
+    def test_enable_all_slack_already_enabled(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+        )
+
+        response = self.post_webhook(
+            action_data=[{"name": "enable_notifications", "value": "all_slack"}]
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["text"] == ENABLE_SLACK_SUCCESS_MESSAGE
+
+        assert NotificationSetting.objects.has_any_provider_settings(
+            self.user, ExternalProviders.SLACK
+        )
+
+    def test_enable_all_slack(self):
+        assert not NotificationSetting.objects.has_any_provider_settings(
+            self.user, ExternalProviders.SLACK
+        )
+
+        response = self.post_webhook(
+            action_data=[{"name": "enable_notifications", "value": "all_slack"}]
+        )
+
+        assert response.status_code == 200, response.content
+        assert response.data["text"] == ENABLE_SLACK_SUCCESS_MESSAGE
+
+        assert NotificationSetting.objects.has_any_provider_settings(
+            self.user, ExternalProviders.SLACK
+        )

--- a/tests/sentry/integrations/slack/notifications/test_nudge.py
+++ b/tests/sentry/integrations/slack/notifications/test_nudge.py
@@ -1,0 +1,35 @@
+from unittest import mock
+
+import responses
+
+from sentry.notifications.notifications.integration_nudge import (
+    MESSAGE_LIBRARY,
+    IntegrationNudgeNotification,
+)
+from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.helpers.slack import get_attachment_no_text, send_notification
+from sentry.types.integrations import ExternalProviders
+
+SEED = 0
+
+
+class SlackNudgeNotificationTest(SlackActivityNotificationTest):
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_nudge(self, mock_func):
+        notification = IntegrationNudgeNotification(
+            self.organization,
+            recipient=self.user,
+            provider=ExternalProviders.SLACK,
+            seed=SEED,
+        )
+
+        with self.tasks():
+            notification.send()
+
+        attachment = get_attachment_no_text()
+        assert attachment["text"] == MESSAGE_LIBRARY[SEED].format(provider="Slack")
+        assert len(attachment["actions"]) == 1
+        assert attachment["actions"][0]["action_id"] == "enable_notifications"
+        assert attachment["actions"][0]["name"] == "Turn on personal notifications"
+        assert attachment["actions"][0]["value"] == "all_slack"


### PR DESCRIPTION
When a user links their identity but doesn't have their notification settings "on" for Slack, send them a reminder message.
Here are some examples:
![Screen Shot 2021-12-09 at 10 56 29 AM](https://user-images.githubusercontent.com/31750075/145458423-f7346865-de4c-4efb-9470-e6ad3f2f75a8.png)