### PR TITLE
ref(sentry-apps): Refactor pluginIcon and integrationRow to be type agnostic

### DIFF
--- a/static/app/components/avatar/index.tsx
+++ b/static/app/components/avatar/index.tsx
@@ -7,7 +7,7 @@ import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {AvatarProject, AvatarSentryApp, OrganizationSummary, Team} from 'sentry/types';
 
-export type AvatarProps = {
+type Props = {
   team?: Team;
   organization?: OrganizationSummary;
   project?: AvatarProject;
@@ -33,7 +33,7 @@ const Avatar = React.forwardRef(function Avatar(
     isColor = true,
     isDefault = false,
     ...props
-  }: AvatarProps,
+  }: Props,
   ref: React.Ref<HTMLSpanElement>
 ) {
   const commonProps = {hasTooltip, forwardedRef: ref, ...props};

--- a/static/app/components/avatar/index.tsx
+++ b/static/app/components/avatar/index.tsx
@@ -7,7 +7,7 @@ import TeamAvatar from 'sentry/components/avatar/teamAvatar';
 import UserAvatar from 'sentry/components/avatar/userAvatar';
 import {AvatarProject, AvatarSentryApp, OrganizationSummary, Team} from 'sentry/types';
 
-type Props = {
+export type AvatarProps = {
   team?: Team;
   organization?: OrganizationSummary;
   project?: AvatarProject;
@@ -33,7 +33,7 @@ const Avatar = React.forwardRef(function Avatar(
     isColor = true,
     isDefault = false,
     ...props
-  }: Props,
+  }: AvatarProps,
   ref: React.Ref<HTMLSpanElement>
 ) {
   const commonProps = {hasTooltip, forwardedRef: ref, ...props};

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import ExternalLink from 'sentry/components/links/externalLink';
-import SentryAppIcon from 'sentry/components/sentryAppIcon';
+import SentryAppComponentIcon from 'sentry/components/sentryAppComponentIcon';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {SentryAppComponent} from 'sentry/types';
@@ -42,7 +42,7 @@ const OpenInContextLine = ({lineNo, filename, components}: Props) => {
             onContextMenu={onClickRecordInteraction}
             openInNewTab
           >
-            <SentryAppIcon sentryAppComponent={component} />
+            <SentryAppComponentIcon sentryAppComponent={component} />
             <OpenInName>{t(`${component.sentryApp.name}`)}</OpenInName>
           </OpenInLink>
         );

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -6,7 +6,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {deleteExternalIssue} from 'sentry/actionCreators/platformExternalIssues';
 import {Client} from 'sentry/api';
 import {IntegrationLink} from 'sentry/components/issueSyncListElement';
-import SentryAppIcon from 'sentry/components/sentryAppIcon';
+import SentryAppComponentIcon from 'sentry/components/sentryAppComponentIcon';
 import {IconAdd, IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -126,7 +126,7 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
     return (
       <IssueLinkContainer>
         <IssueLink>
-          <StyledSentryAppIcon sentryAppComponent={sentryAppComponent} />
+          <StyledSentryAppComponentIcon sentryAppComponent={sentryAppComponent} />
           <IntegrationLink onClick={this.doOpenModal} href={url}>
             {displayName}
           </IntegrationLink>
@@ -139,7 +139,7 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
   }
 }
 
-const StyledSentryAppIcon = styled(SentryAppIcon)`
+const StyledSentryAppComponentIcon = styled(SentryAppComponentIcon)`
   color: ${p => p.theme.textColor};
   width: ${space(3)};
   height: ${space(3)};

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -3,13 +3,12 @@ import styled from '@emotion/styled';
 
 import Access from 'sentry/components/acl/access';
 import AsyncComponent from 'sentry/components/asyncComponent';
-import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import Button from 'sentry/components/button';
 import CircleIndicator from 'sentry/components/circleIndicator';
+import SentryAppIcon from 'sentry/components/sentryAppIcon';
 import Tag from 'sentry/components/tag';
 import {IconFlag} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import {IntegrationFeature, Organization, SentryApp} from 'sentry/types';
 import {toPermissions} from 'sentry/utils/consolidatedScopes';
@@ -155,16 +154,10 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
     const overview = sentryApp.overview || '';
     const featureProps = {organization, features};
 
-    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
-
     return (
       <React.Fragment>
         <Heading>
-          {isAvatar ? (
-            <SentryAppAvatar sentryApp={sentryApp} isColor />
-          ) : (
-            <PluginIcon pluginId={sentryApp.slug} size={50} />
-          )}
+          <SentryAppIcon sentryApp={sentryApp} size={50} />
           <HeadingInfo>
             <Name>{sentryApp.name}</Name>
             {!!features.length && <Features>{this.featureTags(features)}</Features>}

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -154,10 +154,17 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
     const overview = sentryApp.overview || '';
     const featureProps = {organization, features};
 
+    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
+
     return (
       <React.Fragment>
         <Heading>
-          <PluginIcon sentryApp={sentryApp} isColor pluginId={sentryApp.slug} size={50} />
+          <PluginIcon
+            pluginId={sentryApp.slug}
+            size={50}
+            isAvatar={isAvatar}
+            avatarProps={{sentryApp, isColor: true}}
+          />
           <HeadingInfo>
             <Name>{sentryApp.name}</Name>
             {!!features.length && <Features>{this.featureTags(features)}</Features>}

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Access from 'sentry/components/acl/access';
 import AsyncComponent from 'sentry/components/asyncComponent';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import Button from 'sentry/components/button';
 import CircleIndicator from 'sentry/components/circleIndicator';
 import Tag from 'sentry/components/tag';
@@ -159,12 +160,11 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
     return (
       <React.Fragment>
         <Heading>
-          <PluginIcon
-            pluginId={sentryApp.slug}
-            size={50}
-            isAvatar={isAvatar}
-            avatarProps={{sentryApp, isColor: true}}
-          />
+          {isAvatar ? (
+            <SentryAppAvatar sentryApp={sentryApp} isColor />
+          ) : (
+            <PluginIcon pluginId={sentryApp.slug} size={50} />
+          )}
           <HeadingInfo>
             <Name>{sentryApp.name}</Name>
             {!!features.length && <Features>{this.featureTags(features)}</Features>}

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -73,6 +73,6 @@ export default SentryAppComponentIcon;
 
 const SentryAppAvatarWrapper = styled('span')<{isDark: boolean; isDefault: boolean}>`
   color: ${({isDark}) => (isDark ? 'white' : 'black')};
-  filter: ${({isDark, isDefault}) => (isDark && !isDefault ? 'invert(1)' : 'invert(0)')};
+  filter: ${p => (p.isDark && !p.isDefault ? 'invert(1)' : 'invert(0)')};
   line-height: 0;
 `;

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -46,28 +46,27 @@ const getFallbackIcon = (slug: string) => {
   }
 };
 
-const SentryAppIcon = ({sentryAppComponent: {sentryApp}}: Props) => {
-  return (
-    <Feature features={['organizations:sentry-app-logo-upload']}>
-      {({hasFeature}) => {
-        const selectedAvatar = sentryApp?.avatars?.find(({color}) => color === false);
-        const isDefault = !(selectedAvatar && selectedAvatar?.avatarType === 'upload');
-        return hasFeature ? (
-          <AvatarWrapper
-            isDark={ConfigStore.get('theme') === 'dark'}
-            isDefault={isDefault}
-          >
-            <Avatar size={20} sentryApp={sentryApp} isColor={false} />
-          </AvatarWrapper>
-        ) : (
-          getFallbackIcon(sentryApp.slug)
-        );
-      }}
-    </Feature>
-  );
-};
+/**
+ * Icon Renderer for SentryAppComponents with UI
+ * (e.g. Issue Linking, Stacktrace Linking)
+ */
+const SentryAppComponentIcon = ({sentryAppComponent: {sentryApp}}: Props) => (
+  <Feature features={['organizations:sentry-app-logo-upload']}>
+    {({hasFeature}) => {
+      const selectedAvatar = sentryApp?.avatars?.find(({color}) => color === false);
+      const isDefault = !(selectedAvatar && selectedAvatar?.avatarType === 'upload');
+      return hasFeature ? (
+        <AvatarWrapper isDark={ConfigStore.get('theme') === 'dark'} isDefault={isDefault}>
+          <Avatar size={20} sentryApp={sentryApp} isColor={false} />
+        </AvatarWrapper>
+      ) : (
+        getFallbackIcon(sentryApp.slug)
+      );
+    }}
+  </Feature>
+);
 
-export default SentryAppIcon;
+export default SentryAppComponentIcon;
 
 const AvatarWrapper = styled('span')<{isDark: boolean; isDefault: boolean}>`
   color: ${({isDark}) => (isDark ? 'white' : 'black')};

--- a/static/app/components/sentryAppComponentIcon.tsx
+++ b/static/app/components/sentryAppComponentIcon.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
-import Avatar from 'sentry/components/avatar';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import {
   IconCalixa,
   IconClickup,
@@ -54,11 +54,14 @@ const SentryAppComponentIcon = ({sentryAppComponent: {sentryApp}}: Props) => (
   <Feature features={['organizations:sentry-app-logo-upload']}>
     {({hasFeature}) => {
       const selectedAvatar = sentryApp?.avatars?.find(({color}) => color === false);
-      const isDefault = !(selectedAvatar && selectedAvatar?.avatarType === 'upload');
+      const isDefault = selectedAvatar?.avatarType !== 'upload';
       return hasFeature ? (
-        <AvatarWrapper isDark={ConfigStore.get('theme') === 'dark'} isDefault={isDefault}>
-          <Avatar size={20} sentryApp={sentryApp} isColor={false} />
-        </AvatarWrapper>
+        <SentryAppAvatarWrapper
+          isDark={ConfigStore.get('theme') === 'dark'}
+          isDefault={isDefault}
+        >
+          <SentryAppAvatar sentryApp={sentryApp} size={20} isColor={false} />
+        </SentryAppAvatarWrapper>
       ) : (
         getFallbackIcon(sentryApp.slug)
       );
@@ -68,7 +71,7 @@ const SentryAppComponentIcon = ({sentryAppComponent: {sentryApp}}: Props) => (
 
 export default SentryAppComponentIcon;
 
-const AvatarWrapper = styled('span')<{isDark: boolean; isDefault: boolean}>`
+const SentryAppAvatarWrapper = styled('span')<{isDark: boolean; isDefault: boolean}>`
   color: ${({isDark}) => (isDark ? 'white' : 'black')};
   filter: ${({isDark, isDefault}) => (isDark && !isDefault ? 'invert(1)' : 'invert(0)')};
   line-height: 0;

--- a/static/app/components/sentryAppIcon.tsx
+++ b/static/app/components/sentryAppIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import Feature from 'sentry/components/acl/feature';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
+import PluginIcon from 'sentry/plugins/components/pluginIcon';
+import {AvatarSentryApp} from 'sentry/types';
+
+type Props = {
+  size: number;
+  sentryApp: AvatarSentryApp;
+};
+
+const SentryAppIcon = ({sentryApp, size}: Props) => (
+  <Feature features={['organizations:sentry-app-logo-upload']}>
+    {({hasFeature}) =>
+      hasFeature ? (
+        <SentryAppAvatar sentryApp={sentryApp} size={size} isColor />
+      ) : (
+        <PluginIcon pluginId={sentryApp.slug} size={size} />
+      )
+    }
+  </Feature>
+);
+
+export default SentryAppIcon;

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -54,8 +54,6 @@ import visualstudio from 'sentry-logos/logo-visualstudio.svg';
 import youtrack from 'sentry-logos/logo-youtrack.svg';
 import zulip from 'sentry-logos/logo-zulip.svg';
 
-import Avatar, {AvatarProps} from 'sentry/components/avatar';
-
 // Map of plugin id -> logo filename
 export const DEFAULT_ICON = placeholder;
 export const ICON_PATHS = {
@@ -127,13 +125,9 @@ export const ICON_PATHS = {
 type Props = {
   pluginId?: string;
   size?: number;
-  className?: string;
-  isAvatar?: boolean;
-  avatarProps?: AvatarProps;
 };
 
-// The following component uses hardcoded frontend resources
-const FallbackPluginIcon = styled('div')<Props>`
+const PluginIcon = styled('div')<Props>`
   position: relative;
   height: ${p => p.size}px;
   width: ${p => p.size}px;
@@ -147,17 +141,9 @@ const FallbackPluginIcon = styled('div')<Props>`
     (pluginId !== undefined && ICON_PATHS[pluginId]) || DEFAULT_ICON});
 `;
 
-const PluginIcon = ({pluginId, size, isAvatar = false, avatarProps, className}: Props) =>
-  isAvatar && avatarProps ? (
-    <Avatar size={size} className={className} {...avatarProps} />
-  ) : (
-    <FallbackPluginIcon pluginId={pluginId} size={size} className={className} />
-  );
-
 PluginIcon.defaultProps = {
   pluginId: '_default',
   size: 20,
-  isColor: true,
 };
 
 export default PluginIcon;

--- a/static/app/plugins/components/pluginIcon.tsx
+++ b/static/app/plugins/components/pluginIcon.tsx
@@ -54,9 +54,7 @@ import visualstudio from 'sentry-logos/logo-visualstudio.svg';
 import youtrack from 'sentry-logos/logo-youtrack.svg';
 import zulip from 'sentry-logos/logo-zulip.svg';
 
-import Feature from 'sentry/components/acl/feature';
-import Avatar from 'sentry/components/avatar';
-import {SentryApp} from 'sentry/types';
+import Avatar, {AvatarProps} from 'sentry/components/avatar';
 
 // Map of plugin id -> logo filename
 export const DEFAULT_ICON = placeholder;
@@ -129,9 +127,9 @@ export const ICON_PATHS = {
 type Props = {
   pluginId?: string;
   size?: number;
-  isColor?: boolean;
-  sentryApp?: SentryApp;
   className?: string;
+  isAvatar?: boolean;
+  avatarProps?: AvatarProps;
 };
 
 // The following component uses hardcoded frontend resources
@@ -149,23 +147,12 @@ const FallbackPluginIcon = styled('div')<Props>`
     (pluginId !== undefined && ICON_PATHS[pluginId]) || DEFAULT_ICON});
 `;
 
-const PluginIcon = ({pluginId, size, sentryApp, isColor, className}: Props) => (
-  <Feature features={['organizations:sentry-app-logo-upload']}>
-    {({hasFeature}) => {
-      if (hasFeature && sentryApp) {
-        return (
-          <Avatar
-            size={size}
-            sentryApp={sentryApp}
-            isColor={isColor}
-            className={className}
-          />
-        );
-      }
-      return <FallbackPluginIcon pluginId={pluginId} size={size} className={className} />;
-    }}
-  </Feature>
-);
+const PluginIcon = ({pluginId, size, isAvatar = false, avatarProps, className}: Props) =>
+  isAvatar && avatarProps ? (
+    <Avatar size={size} className={className} {...avatarProps} />
+  ) : (
+    <FallbackPluginIcon pluginId={pluginId} size={size} className={className} />
+  );
 
 PluginIcon.defaultProps = {
   pluginId: '_default',

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -9,13 +9,13 @@ import uniq from 'lodash/uniq';
 import * as queryString from 'query-string';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import SelectControl from 'sentry/components/forms/selectControl';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
-import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import {
   AppOrProviderOrPlugin,
@@ -418,7 +418,9 @@ export class IntegrationListDirectory extends AsyncComponent<
     const {organization} = this.props;
     const status = getSentryAppInstallStatus(this.getAppInstall(app));
     const categories = getCategoriesForIntegration(app);
-    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
+    const customIcon = organization.features?.includes('sentry-app-logo-upload') ? (
+      <SentryAppAvatar sentryApp={app} isColor size={36} />
+    ) : undefined;
 
     return (
       <IntegrationRow
@@ -432,14 +434,7 @@ export class IntegrationListDirectory extends AsyncComponent<
         publishStatus={app.status}
         configurations={0}
         categories={categories}
-        customIcon={
-          <PluginIcon
-            pluginId={app.slug}
-            size={36}
-            isAvatar={isAvatar}
-            avatarProps={{sentryApp: app, isColor: true}}
-          />
-        }
+        customIcon={customIcon}
       />
     );
   };

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -15,6 +15,7 @@ import {Panel, PanelBody} from 'sentry/components/panels';
 import SearchBar from 'sentry/components/searchBar';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import {
   AppOrProviderOrPlugin,
@@ -417,10 +418,10 @@ export class IntegrationListDirectory extends AsyncComponent<
     const {organization} = this.props;
     const status = getSentryAppInstallStatus(this.getAppInstall(app));
     const categories = getCategoriesForIntegration(app);
+    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
 
     return (
       <IntegrationRow
-        sentryApp={app}
         key={`sentry-app-row-${app.slug}`}
         data-test-id="integration-row"
         organization={organization}
@@ -431,6 +432,14 @@ export class IntegrationListDirectory extends AsyncComponent<
         publishStatus={app.status}
         configurations={0}
         categories={categories}
+        customIcon={
+          <PluginIcon
+            pluginId={app.slug}
+            size={36}
+            isAvatar={isAvatar}
+            avatarProps={{sentryApp: app, isColor: true}}
+          />
+        }
       />
     );
   };

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -9,11 +9,11 @@ import uniq from 'lodash/uniq';
 import * as queryString from 'query-string';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
-import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import SelectControl from 'sentry/components/forms/selectControl';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import SearchBar from 'sentry/components/searchBar';
+import SentryAppIcon from 'sentry/components/sentryAppIcon';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -418,9 +418,6 @@ export class IntegrationListDirectory extends AsyncComponent<
     const {organization} = this.props;
     const status = getSentryAppInstallStatus(this.getAppInstall(app));
     const categories = getCategoriesForIntegration(app);
-    const customIcon = organization.features?.includes('sentry-app-logo-upload') ? (
-      <SentryAppAvatar sentryApp={app} isColor size={36} />
-    ) : undefined;
 
     return (
       <IntegrationRow
@@ -434,7 +431,7 @@ export class IntegrationListDirectory extends AsyncComponent<
         publishStatus={app.status}
         configurations={0}
         categories={categories}
-        customIcon={customIcon}
+        customIcon={<SentryAppIcon sentryApp={app} size={36} />}
       />
     );
   };

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -96,7 +96,7 @@ const IntegrationRow = (props: Props) => {
   return (
     <PanelRow noPadding data-test-id={slug}>
       <FlexContainer>
-        {customIcon ? customIcon : <PluginIcon size={36} pluginId={slug} />}
+        {customIcon ?? <PluginIcon size={36} pluginId={slug} />}
         <Container>
           <IntegrationName to={baseUrl}>{displayName}</IntegrationName>
           <IntegrationDetails>

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -41,8 +41,8 @@ type Props = {
    * in the alert.
    */
   resolveText?: string;
-  sentryApp?: SentryApp;
   plugin?: PluginWithProjectList;
+  customIcon?: React.ReactNode;
 };
 
 const urlMap = {
@@ -65,7 +65,7 @@ const IntegrationRow = (props: Props) => {
     alertText,
     resolveText,
     plugin,
-    sentryApp,
+    customIcon,
   } = props;
 
   const baseUrl =
@@ -96,7 +96,7 @@ const IntegrationRow = (props: Props) => {
   return (
     <PanelRow noPadding data-test-id={slug}>
       <FlexContainer>
-        <PluginIcon sentryApp={sentryApp} isColor size={36} pluginId={slug} />
+        {customIcon ? customIcon : <PluginIcon size={36} pluginId={slug} />}
         <Container>
           <IntegrationName to={baseUrl}>{displayName}</IntegrationName>
           <IntegrationDetails>

--- a/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -7,13 +7,12 @@ import {
   uninstallSentryApp,
 } from 'sentry/actionCreators/sentryAppInstallations';
 import AsyncComponent from 'sentry/components/asyncComponent';
-import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import Button from 'sentry/components/button';
 import CircleIndicator from 'sentry/components/circleIndicator';
 import Confirm from 'sentry/components/confirm';
+import SentryAppIcon from 'sentry/components/sentryAppIcon';
 import {IconSubtract} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import {IntegrationFeature, SentryApp, SentryAppInstallation} from 'sentry/types';
 import {toPermissions} from 'sentry/utils/consolidatedScopes';
@@ -281,13 +280,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   renderIntegrationIcon() {
-    const {organization} = this.props;
-    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
-    return isAvatar ? (
-      <SentryAppAvatar sentryApp={this.sentryApp} isColor size={50} />
-    ) : (
-      <PluginIcon pluginId={this.integrationSlug} size={50} />
-    );
+    return <SentryAppIcon sentryApp={this.sentryApp} size={50} />;
   }
 }
 

--- a/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -7,6 +7,7 @@ import {
   uninstallSentryApp,
 } from 'sentry/actionCreators/sentryAppInstallations';
 import AsyncComponent from 'sentry/components/asyncComponent';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import Button from 'sentry/components/button';
 import CircleIndicator from 'sentry/components/circleIndicator';
 import Confirm from 'sentry/components/confirm';
@@ -282,16 +283,10 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   renderIntegrationIcon() {
     const {organization} = this.props;
     const isAvatar = organization.features?.includes('sentry-app-logo-upload');
-    return (
-      <PluginIcon
-        pluginId={this.integrationSlug}
-        size={50}
-        isAvatar={isAvatar}
-        avatarProps={{
-          sentryApp: this.sentryApp,
-          isColor: true,
-        }}
-      />
+    return isAvatar ? (
+      <SentryAppAvatar sentryApp={this.sentryApp} isColor size={50} />
+    ) : (
+      <PluginIcon pluginId={this.integrationSlug} size={50} />
     );
   }
 }

--- a/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -280,12 +280,17 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
   }
 
   renderIntegrationIcon() {
+    const {organization} = this.props;
+    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
     return (
       <PluginIcon
-        sentryApp={this.sentryApp}
-        isColor
         pluginId={this.integrationSlug}
         size={50}
+        isAvatar={isAvatar}
+        avatarProps={{
+          sentryApp: this.sentryApp,
+          isColor: true,
+        }}
       />
     );
   }

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -2,12 +2,11 @@ import {PureComponent} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import Link from 'sentry/components/links/link';
 import SentryAppPublishRequestModal from 'sentry/components/modals/sentryAppPublishRequestModal';
 import {PanelItem} from 'sentry/components/panels';
+import SentryAppIcon from 'sentry/components/sentryAppIcon';
 import {t} from 'sentry/locale';
-import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import {Organization, SentryApp} from 'sentry/types';
 
@@ -45,15 +44,10 @@ export default class SentryApplicationRow extends PureComponent<Props> {
 
   render() {
     const {app, organization, onRemoveApp} = this.props;
-    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
     return (
       <SentryAppItem data-test-id={app.slug}>
         <StyledFlex>
-          {isAvatar ? (
-            <SentryAppAvatar sentryApp={app} isColor size={36} />
-          ) : (
-            <PluginIcon pluginId={app.slug} size={36} />
-          )}
+          <SentryAppIcon sentryApp={app} size={36} />
           <SentryAppBox>
             <SentryAppName hideStatus={this.hideStatus()}>
               <Link to={`/settings/${organization.slug}/developer-settings/${app.slug}/`}>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -2,6 +2,7 @@ import {PureComponent} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
+import SentryAppAvatar from 'sentry/components/avatar/sentryAppAvatar';
 import Link from 'sentry/components/links/link';
 import SentryAppPublishRequestModal from 'sentry/components/modals/sentryAppPublishRequestModal';
 import {PanelItem} from 'sentry/components/panels';
@@ -48,12 +49,11 @@ export default class SentryApplicationRow extends PureComponent<Props> {
     return (
       <SentryAppItem data-test-id={app.slug}>
         <StyledFlex>
-          <PluginIcon
-            pluginId={app.slug}
-            size={36}
-            isAvatar={isAvatar}
-            avatarProps={{sentryApp: app, isColor: true}}
-          />
+          {isAvatar ? (
+            <SentryAppAvatar sentryApp={app} isColor size={36} />
+          ) : (
+            <PluginIcon pluginId={app.slug} size={36} />
+          )}
           <SentryAppBox>
             <SentryAppName hideStatus={this.hideStatus()}>
               <Link to={`/settings/${organization.slug}/developer-settings/${app.slug}/`}>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -44,10 +44,16 @@ export default class SentryApplicationRow extends PureComponent<Props> {
 
   render() {
     const {app, organization, onRemoveApp} = this.props;
+    const isAvatar = organization.features?.includes('sentry-app-logo-upload');
     return (
       <SentryAppItem data-test-id={app.slug}>
         <StyledFlex>
-          <PluginIcon sentryApp={app} isColor size={36} pluginId={app.slug} />
+          <PluginIcon
+            pluginId={app.slug}
+            size={36}
+            isAvatar={isAvatar}
+            avatarProps={{sentryApp: app, isColor: true}}
+          />
           <SentryAppBox>
             <SentryAppName hideStatus={this.hideStatus()}>
               <Link to={`/settings/${organization.slug}/developer-settings/${app.slug}/`}>


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/30342

Update:  

This PR aims to refactor the previous PR (linked above) by reverting some of the design decisions. Certain components were set up to receive specific props when they were originally madeto be agnostic. Hopefully this addresses those concerns by using `SentryAppIcon` (full-color SentryApp logos) to decide whether to render `PluginIcon` or `SentryAppAvatar`. The diff is large because the existing `SentryAppicon` component was renamed to `SentryAppComponentIcon` (B&W logos on Issue Details page) to be detailed and precise.

#### Still works as intended when flagged in

<img width="511" alt="image" src="https://user-images.githubusercontent.com/35509934/144657928-db96bd2b-751f-40d3-85eb-b63a5a77cd96.png">
