### PR TITLE
ref(ui): Add render instrumentation around GridEditable

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -5,6 +5,7 @@ import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {onRenderCallback} from 'sentry/utils/performanceForSentry';
 
 import {
   Body,
@@ -413,20 +414,22 @@ class GridEditable<
     const showHeader = title || headerButtons;
     return (
       <React.Fragment>
-        {showHeader && (
-          <Header>
-            {title && <HeaderTitle>{title}</HeaderTitle>}
-            {headerButtons && (
-              <HeaderButtonContainer>{headerButtons()}</HeaderButtonContainer>
-            )}
-          </Header>
-        )}
-        <Body>
-          <Grid data-test-id="grid-editable" ref={this.refGrid}>
-            <GridHead>{this.renderGridHead()}</GridHead>
-            <GridBody>{this.renderGridBody()}</GridBody>
-          </Grid>
-        </Body>
+        <React.Profiler id="GridEditable" onRender={onRenderCallback}>
+          {showHeader && (
+            <Header>
+              {title && <HeaderTitle>{title}</HeaderTitle>}
+              {headerButtons && (
+                <HeaderButtonContainer>{headerButtons()}</HeaderButtonContainer>
+              )}
+            </Header>
+          )}
+          <Body>
+            <Grid data-test-id="grid-editable" ref={this.refGrid}>
+              <GridHead>{this.renderGridHead()}</GridHead>
+              <GridBody>{this.renderGridBody()}</GridBody>
+            </Grid>
+          </Body>
+        </React.Profiler>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
### Summary
This is an example of wrapping a specific render to gain more insight into why App renders are slow. From passive devtools observation, our grids have a lot to render, and can sometimes take a bit to render. This wraps GridEditable in a profiler (now that profiling it out and stable), so we can catch specific GridEditable render times.

#### Screenshot
![Screen Shot 2021-12-03 at 2 03 29 PM](https://user-images.githubusercontent.com/6111995/144658611-3c067ce3-a904-4509-b2c7-1e683f5353ff.png)

