### PR TITLE
fix(alerts): Disable hover color on alert edit chart

### DIFF
--- a/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -9,6 +9,7 @@ import Graphic from 'sentry/components/charts/components/graphic';
 import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
 import {LineChartSeries} from 'sentry/components/charts/lineChart';
 import LineSeries from 'sentry/components/charts/series/lineSeries';
+import CHART_PALETTE from 'sentry/constants/chartPalette';
 import space from 'sentry/styles/space';
 import {GlobalSelection} from 'sentry/types';
 import {ReactEchartsRef, Series} from 'sentry/types/echarts';
@@ -440,6 +441,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
             ])
           ),
         })}
+        colors={CHART_PALETTE[0]}
         series={[...dataWithoutRecentBucket, ...comparisonMarkLines]}
         additionalSeries={comparisonDataWithoutRecentBucket.map(
           ({data: _data, ...otherSeriesProps}) =>


### PR DESCRIPTION
Currently, the chart on alert editor will highlight on hover