### PR TITLE
fix(perf): Fix visual bug with double truncation

### DIFF
--- a/static/app/views/performance/landing/widgets/components/selectableList.tsx
+++ b/static/app/views/performance/landing/widgets/components/selectableList.tsx
@@ -67,6 +67,7 @@ export const Subtitle = styled('span')`
 `;
 export const GrowLink = styled(Link)`
   flex-grow: 1;
+  margin-right: ${space(2)};
 `;
 
 export const WidgetEmptyStateWarning = () => {

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -7,7 +7,6 @@ import {getInterval} from 'sentry/components/charts/utils';
 import Count from 'sentry/components/count';
 import Link from 'sentry/components/links/link';
 import Tooltip from 'sentry/components/tooltip';
-import Truncate from 'sentry/components/truncate';
 import {t, tct} from 'sentry/locale';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import {getAggregateAlias} from 'sentry/utils/discover/fields';
@@ -258,12 +257,13 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                     return (
                       <Fragment>
                         <GrowLink to={transactionTarget} className="truncate">
-                          <Truncate value={transaction} maxLength={40} />
+                          {transaction}
                         </GrowLink>
                         <RightAlignedCell>
                           <Tooltip title={listItem.title}>
                             <Link
                               to={`/organizations/${props.organization.slug}/issues/${listItem['issue.id']}/`}
+                              className="truncate"
                             >
                               {rightValue}
                             </Link>
@@ -279,7 +279,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                     return (
                       <Fragment>
                         <GrowLink to={transactionTarget} className="truncate">
-                          <Truncate value={transaction} maxLength={40} />
+                          {transaction}
                         </GrowLink>
                         <RightAlignedCell>
                           {tct('[count] errors', {
@@ -297,7 +297,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                       return (
                         <Fragment>
                           <GrowLink to={transactionTarget} className="truncate">
-                            <Truncate value={transaction} maxLength={40} />
+                            {transaction}
                           </GrowLink>
                           <RightAlignedCell>
                             <Count value={rightValue} />
@@ -314,7 +314,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                     return (
                       <Fragment>
                         <GrowLink to={transactionTarget} className="truncate">
-                          <Truncate value={transaction} maxLength={40} />
+                          {transaction}
                         </GrowLink>
                         <RightAlignedCell>{rightValue}</RightAlignedCell>
                         <ListClose

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -2,7 +2,6 @@ import {Fragment, useMemo, useState} from 'react';
 import {withRouter} from 'react-router';
 
 import Button from 'sentry/components/button';
-import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -144,9 +143,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
                 });
                 return (
                   <Fragment>
-                    <GrowLink to={trendsTarget}>
-                      <Truncate value={listItem.transaction} maxLength={40} />
-                    </GrowLink>
+                    <GrowLink to={trendsTarget}>{listItem.transaction}</GrowLink>
                     <RightAlignedCell>
                       <CompareDurations transaction={listItem} />
                     </RightAlignedCell>

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -5,7 +5,6 @@ import pick from 'lodash/pick';
 import Button from 'sentry/components/button';
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
-import Truncate from 'sentry/components/truncate';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -281,9 +280,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
 
                 return (
                   <Fragment>
-                    <GrowLink to={target}>
-                      <Truncate value={transaction} maxLength={40} />
-                    </GrowLink>
+                    <GrowLink to={target}>{transaction}</GrowLink>
                     <VitalBarCell>
                       <VitalBar
                         isLoading={provided.widgetData.list?.isLoading}


### PR DESCRIPTION
### Summary
We are already using the truncation class, and have a fair amount of horizontal space. This will truncate the transaction names with just text-overflow instead of the truncation class (which also fixes the visual bug where the truncation wrapper was moving around on hover). We can improve this later or perhaps just wrap every transaction name with a tooltip.