### PR TITLE
fix(perf): Add p75 duration minichart to Frontend(other)

### DIFF
--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -21,6 +21,7 @@ export function FrontendOtherView(props: BasePerformanceViewProps) {
             PerformanceWidgetSetting.TPM_AREA,
             PerformanceWidgetSetting.DURATION_HISTOGRAM,
             PerformanceWidgetSetting.P50_DURATION_AREA,
+            PerformanceWidgetSetting.P75_DURATION_AREA,
             PerformanceWidgetSetting.P95_DURATION_AREA,
             PerformanceWidgetSetting.P99_DURATION_AREA,
           ]}


### PR DESCRIPTION
### Summary
It's been brought up that for consistency, since it also exists on All Transactions, we should have a p75 as well for Frontend (other). We'll likely want to have a p75 either duration or other for the upcoming 'Frontend' (all) tab change.