### PR TITLE
feat(perf): Add error bar for landing instead of just toast

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -167,9 +167,13 @@ type EventsRequestPartialProps = {
    */
   partial: boolean;
   /**
-   * Hide error toast (used for pages which also query eventsV2)
+   * Hide error toast (used for pages which also query eventsV2). Stops error appearing as a toast.
    */
   hideError?: boolean;
+  /**
+   * A way to control error if error handling is not owned by the toast.
+   */
+  onError?: (error: string) => void;
   /**
    * Whether or not to zerofill results
    */
@@ -242,7 +246,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   private unmounting: boolean = false;
 
   fetchData = async () => {
-    const {api, confirmedQuery, expired, name, hideError, ...props} = this.props;
+    const {api, confirmedQuery, expired, name, hideError, onError, ...props} = this.props;
     let timeseriesData: EventsStats | MultiSeriesEventsStats | null = null;
 
     if (confirmedQuery === false) {
@@ -261,6 +265,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
         '%s has an invalid date range. Please try a more recent date range.',
         name
       );
+
       addErrorMessage(errorMessage, {append: true});
 
       this.setState({
@@ -279,6 +284,9 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
         }
         if (!hideError) {
           addErrorMessage(errorMessage);
+        }
+        if (onError) {
+          onError(errorMessage);
         }
         this.setState({
           errored: true,

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -18,6 +18,10 @@ import {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {generateAggregateFields} from 'sentry/utils/discover/fields';
 import {GenericQueryBatcher} from 'sentry/utils/performance/contexts/genericQueryBatcher';
+import {
+  PageErrorAlert,
+  PageErrorProvider,
+} from 'sentry/utils/performance/contexts/pageError';
 import useTeams from 'sentry/utils/useTeams';
 
 import MetricsSearchBar from '../metricsSearchBar';
@@ -83,94 +87,97 @@ export function PerformanceLanding(props: Props) {
 
   return (
     <div data-test-id="performance-landing-v3">
-      <Layout.Header>
-        <Layout.HeaderContent>
-          <StyledHeading>{t('Performance')}</StyledHeading>
-        </Layout.HeaderContent>
-        <Layout.HeaderActions>
-          {!showOnboarding && (
-            <ButtonBar gap={3}>
-              <MetricsSwitch />
-              <Button
-                priority="primary"
-                data-test-id="landing-header-trends"
-                onClick={() => handleTrendsClick()}
-              >
-                {t('View Trends')}
-              </Button>
-            </ButtonBar>
-          )}
-        </Layout.HeaderActions>
-
-        <StyledNavTabs>
-          {shownLandingDisplays.map(({label, field}) => (
-            <li
-              key={label}
-              className={currentLandingDisplay.field === field ? 'active' : ''}
-            >
-              <a
-                href="#"
-                onClick={() =>
-                  handleLandingDisplayChange(
-                    field,
-                    location,
-                    projects,
-                    organization,
-                    eventView
-                  )
-                }
-              >
-                {t(label)}
-              </a>
-            </li>
-          ))}
-        </StyledNavTabs>
-      </Layout.Header>
-      <Layout.Body>
-        <Layout.Main fullWidth>
-          <GlobalSdkUpdateAlert />
-          <SearchContainerWithFilter>
-            {isMetricsData ? (
-              <MetricsSearchBar
-                searchSource="performance_landing_metrics"
-                orgSlug={organization.slug}
-                query={filterString}
-                onSearch={handleSearch}
-                maxQueryLength={MAX_QUERY_LENGTH}
-                projectIds={eventView.project}
-              />
-            ) : (
-              <SearchBar
-                searchSource="performance_landing"
-                organization={organization}
-                projectIds={eventView.project}
-                query={filterString}
-                fields={generateAggregateFields(
-                  organization,
-                  [...eventView.fields, {field: 'tps()'}],
-                  ['epm()', 'eps()']
-                )}
-                onSearch={handleSearch}
-                maxQueryLength={MAX_QUERY_LENGTH}
-              />
+      <PageErrorProvider>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <StyledHeading>{t('Performance')}</StyledHeading>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
+            {!showOnboarding && (
+              <ButtonBar gap={3}>
+                <MetricsSwitch />
+                <Button
+                  priority="primary"
+                  data-test-id="landing-header-trends"
+                  onClick={() => handleTrendsClick()}
+                >
+                  {t('View Trends')}
+                </Button>
+              </ButtonBar>
             )}
-          </SearchContainerWithFilter>
-          {initiallyLoaded ? (
-            <TeamKeyTransactionManager.Provider
-              organization={organization}
-              teams={teams}
-              selectedTeams={['myteams']}
-              selectedProjects={eventView.project.map(String)}
-            >
-              <GenericQueryBatcher>
-                <ViewComponent {...props} />
-              </GenericQueryBatcher>
-            </TeamKeyTransactionManager.Provider>
-          ) : (
-            <LoadingIndicator />
-          )}
-        </Layout.Main>
-      </Layout.Body>
+          </Layout.HeaderActions>
+
+          <StyledNavTabs>
+            {shownLandingDisplays.map(({label, field}) => (
+              <li
+                key={label}
+                className={currentLandingDisplay.field === field ? 'active' : ''}
+              >
+                <a
+                  href="#"
+                  onClick={() =>
+                    handleLandingDisplayChange(
+                      field,
+                      location,
+                      projects,
+                      organization,
+                      eventView
+                    )
+                  }
+                >
+                  {t(label)}
+                </a>
+              </li>
+            ))}
+          </StyledNavTabs>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <GlobalSdkUpdateAlert />
+            <PageErrorAlert />
+            <SearchContainerWithFilter>
+              {isMetricsData ? (
+                <MetricsSearchBar
+                  searchSource="performance_landing_metrics"
+                  orgSlug={organization.slug}
+                  query={filterString}
+                  onSearch={handleSearch}
+                  maxQueryLength={MAX_QUERY_LENGTH}
+                  projectIds={eventView.project}
+                />
+              ) : (
+                <SearchBar
+                  searchSource="performance_landing"
+                  organization={organization}
+                  projectIds={eventView.project}
+                  query={filterString}
+                  fields={generateAggregateFields(
+                    organization,
+                    [...eventView.fields, {field: 'tps()'}],
+                    ['epm()', 'eps()']
+                  )}
+                  onSearch={handleSearch}
+                  maxQueryLength={MAX_QUERY_LENGTH}
+                />
+              )}
+            </SearchContainerWithFilter>
+            {initiallyLoaded ? (
+              <TeamKeyTransactionManager.Provider
+                organization={organization}
+                teams={teams}
+                selectedTeams={['myteams']}
+                selectedProjects={eventView.project.map(String)}
+              >
+                <GenericQueryBatcher>
+                  <ViewComponent {...props} />
+                </GenericQueryBatcher>
+              </TeamKeyTransactionManager.Provider>
+            ) : (
+              <LoadingIndicator />
+            )}
+          </Layout.Main>
+        </Layout.Body>
+      </PageErrorProvider>
     </div>
   );
 }

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -7,6 +7,7 @@ import _EventsRequest from 'sentry/components/charts/eventsRequest';
 import {getInterval} from 'sentry/components/charts/utils';
 import {t} from 'sentry/locale';
 import {QueryBatchNode} from 'sentry/utils/performance/contexts/genericQueryBatcher';
+import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
 
@@ -22,6 +23,7 @@ type DataType = {
 export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
   const {ContainerActions} = props;
   const globalSelection = props.eventView.getGlobalSelection();
+  const pageError = usePageError();
 
   if (props.fields.length !== 1) {
     throw new Error(`Single field area can only accept a single field (${props.fields})`);
@@ -44,6 +46,8 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
               currentSeriesNames={[field]}
               previousSeriesNames={[`previous ${field}`]}
               query={provided.eventView.getQueryWithAdditionalConditions()}
+              hideError
+              onError={pageError.setPageError}
               interval={getInterval(
                 {
                   start: provided.start,


### PR DESCRIPTION
### Summary
This will add the error bar back for the landing page. Uses the new `PageError` context, the toast will still show up but it is ephemeral, in a future PR  we can modify EventsRequest so it will provide the error to the context.

### Screenshot
![Screen Shot 2021-12-03 at 4 48 25 PM](https://user-images.githubusercontent.com/6111995/144677980-bf5ab0e9-c8c2-4fbd-9e71-bd72f59d7eb7.png)
