### PR TITLE
feat(ratelimit): Ratelimit keys for authtokens & apikeys

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -125,6 +125,8 @@ class RelayAuthentication(BasicAuthentication):
 
 
 class ApiKeyAuthentication(QuietBasicAuthentication):
+    token_name = b"basic"
+
     def authenticate_credentials(self, userid, password, request=None):
         # We don't use request, but it needs to be passed through to DRF 3.7+.
         if password:

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -2,7 +2,9 @@ from django.contrib.auth import get_user as auth_get_user
 from django.contrib.auth.models import AnonymousUser
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.functional import SimpleLazyObject
+from rest_framework.authentication import get_authorization_header
 
+from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
 from sentry.models import UserIP
 from sentry.utils.auth import AuthUserPasswordExpired, logger
 from sentry.utils.linksign import process_signature
@@ -43,9 +45,29 @@ class AuthenticationMiddleware(MiddlewareMixin):
         # If there is a valid signature on the request we override the
         # user with the user contained within the signature.
         user = process_signature(request)
+        auth = get_authorization_header(request).split()
+
         if user is not None:
             request.user = user
             request.user_from_signed_request = True
+        elif auth and auth[0].lower() == TokenAuthentication.token_name:
+            try:
+                result = TokenAuthentication().authenticate(request=request)
+                if result:
+                    request.user = result[0]
+                    request.auth = result[1]
+            except Exception:
+                # default to anonymous user and use IP ratelimit
+                request.user = AnonymousUser()
+        elif auth and auth[0].lower() == ApiKeyAuthentication.token_name:
+            try:
+                result = ApiKeyAuthentication().authenticate(request=request)
+                if result:
+                    request.user = result[0]
+                    request.auth = result[1]
+            except Exception:
+                # default to anonymous user and use IP ratelimit
+                request.user = AnonymousUser()
         else:
             request.user = SimpleLazyObject(lambda: get_user(request))
 

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -56,18 +56,22 @@ class AuthenticationMiddleware(MiddlewareMixin):
                 if result:
                     request.user = result[0]
                     request.auth = result[1]
+                else:
+                    raise Exception
             except Exception:
                 # default to anonymous user and use IP ratelimit
-                request.user = AnonymousUser()
+                request.user = SimpleLazyObject(lambda: get_user(request))
         elif auth and auth[0].lower() == ApiKeyAuthentication.token_name:
             try:
                 result = ApiKeyAuthentication().authenticate(request=request)
                 if result:
                     request.user = result[0]
                     request.auth = result[1]
+                else:
+                    raise Exception
             except Exception:
                 # default to anonymous user and use IP ratelimit
-                request.user = AnonymousUser()
+                request.user = SimpleLazyObject(lambda: get_user(request))
         else:
             request.user = SimpleLazyObject(lambda: get_user(request))
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-from django.conf import settings
 from django.http.response import HttpResponse
 from django.utils.deprecation import MiddlewareMixin
-from rest_framework.request import Request
 
-from sentry.api.helpers.group_index.index import EndpointFunction
-from sentry.models import SentryAppInstallationToken
 from sentry.ratelimits import (
     above_rate_limit_check,
     can_be_ratelimited,
@@ -14,59 +10,6 @@ from sentry.ratelimits import (
     get_rate_limit_value,
 )
 from sentry.types.ratelimit import RateLimitCategory
-
-
-def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | None:
-    """Construct a consistent global rate limit key using the arguments provided"""
-
-    view = view_func.__qualname__
-    http_method = request.method
-
-    # This avoids touching user session, which means we avoid
-    # setting `Vary: Cookie` as a response header which will
-    # break HTTP caching entirely.
-    if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
-        return None
-
-    request_user = getattr(request, "user", None)
-    user_id = getattr(request_user, "id", None)
-    is_sentry_app = getattr(request_user, "is_sentry_app", None)
-
-    ip_address = request.META.get("REMOTE_ADDR")
-
-    request_auth = getattr(request, "auth", None)
-    token_class = getattr(request_auth, "__class__", None)
-    token_name = token_class.__name__ if token_class else None
-
-    if token_name == "ApiToken" and is_sentry_app:
-        category = "org"
-        token = (
-            SentryAppInstallationToken.objects.filter(api_token_id=request_auth.id)
-            .select_related("sentry_app_installation")
-            .first()
-        )
-        installation = getattr(token, "sentry_app_installation", None)
-        id = getattr(installation, "organization_id", None)
-
-    elif token_name == "ApiToken" and not is_sentry_app:
-        category = "user"
-        id = getattr(request_auth, "user_id", None)
-
-    elif token_name == "ApiKey" and ip_address is not None:
-        category = "ip"
-        id = ip_address
-
-    elif user_id is not None:
-        category = "user"
-        id = user_id
-
-    elif ip_address is not None:
-        category = "ip"
-        id = ip_address
-    # If IP address doesn't exist, skip ratelimiting for now
-    else:
-        return None
-    return f"{category}:{view}:{http_method}:{id}"
 
 
 class RatelimitMiddleware(MiddlewareMixin):

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -26,7 +26,7 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
         )
 
     def get_by_api_token(self, token_id: str) -> QuerySet:
-        return self.filter(sentryappinstallationtoken__api_token_id=token_id)
+        return self.filter(status=SentryAppInstallationStatus.INSTALLED, api_token_id=token_id)
 
 
 class SentryAppInstallation(ParanoidModel):

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -25,6 +25,9 @@ class SentryAppInstallationForProviderManager(ParanoidManager):
             date_deleted=None,
         )
 
+    def get_by_api_token(self, token_id: str) -> QuerySet:
+        return self.filter(sentryappinstallationtoken__api_token_id=token_id)
+
 
 class SentryAppInstallation(ParanoidModel):
     __include_in_export__ = True

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -49,6 +49,8 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
     request_auth = getattr(request, "auth", None)
     request_user = getattr(request, "user", None)
 
+    from django.contrib.auth.models import AnonymousUser
+
     from sentry.models import ApiKey, ApiToken
 
     if isinstance(request_auth, ApiToken):
@@ -60,7 +62,7 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
             category = "user"
             id = request_auth.user_id
 
-    elif not isinstance(request_auth, ApiKey) and request_user:
+    elif not isinstance(request_auth, ApiKey) and not isinstance(request_user, AnonymousUser):
         category = "user"
         id = request_user.id
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -47,19 +47,22 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
 
     ip_address = request.META.get("REMOTE_ADDR")
     request_auth = getattr(request, "auth", None)
+    request_user = getattr(request, "user", None)
+
     from sentry.models import ApiKey, ApiToken
 
     if isinstance(request_auth, ApiToken):
-        if request.user.is_sentry_app:
+
+        if request_user.is_sentry_app:
             category = "org"
             id = get_organization_id_from_token(request_auth.id)
         else:
             category = "user"
             id = request_auth.user_id
 
-    elif not isinstance(request_auth, ApiKey) and request.user:
+    elif not isinstance(request_auth, ApiKey) and request_user:
         category = "user"
-        id = request.user.id
+        id = request_user.id
 
     # ApiKeys will be treated with IP ratelimits
     elif ip_address is not None:

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -46,18 +46,18 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
         return None
 
     ip_address = request.META.get("REMOTE_ADDR")
-
+    request_auth = getattr(request, "auth", None)
     from sentry.models import ApiKey, ApiToken
 
-    if isinstance(request.auth, ApiToken):
+    if isinstance(request_auth, ApiToken):
         if request.user.is_sentry_app:
             category = "org"
-            id = get_organization_id_from_token(request.auth.id)
+            id = get_organization_id_from_token(request_auth.id)
         else:
             category = "user"
-            id = request.auth.user_id
+            id = request_auth.user_id
 
-    elif not isinstance(request.auth, ApiKey) and request.user:
+    elif not isinstance(request_auth, ApiKey) and request.user:
         category = "user"
         id = request.user.id
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -7,14 +7,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.models import ApiKey, ApiToken, SentryAppInstallation
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils.hashlib import md5_text
 
 from . import backend as ratelimiter
 
 if TYPE_CHECKING:
-    from sentry.models import Organization, User
+    from sentry.models import ApiToken, Organization, User
 # TODO(mgaeta): It's not currently possible to type a Callable's args with kwargs.
 EndpointFunction = Callable[..., Response]
 
@@ -48,6 +47,8 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
 
     ip_address = request.META.get("REMOTE_ADDR")
 
+    from sentry.models import ApiKey, ApiToken
+
     if isinstance(request.auth, ApiToken):
         if request.user.is_sentry_app:
             category = "org"
@@ -72,6 +73,8 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
 
 
 def get_organization_id_from_token(token_id: str) -> int | None:
+    from sentry.models import SentryAppInstallation
+
     installation = SentryAppInstallation.objects.get_by_api_token(token_id).first()
     return installation.organization_id if installation else None
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -62,7 +62,11 @@ def get_rate_limit_key(view_func: EndpointFunction, request: Request) -> str | N
             category = "user"
             id = request_auth.user_id
 
-    elif not isinstance(request_auth, ApiKey) and not isinstance(request_user, AnonymousUser):
+    elif (
+        not isinstance(request_auth, ApiKey)
+        and request_user
+        and not isinstance(request_user, AnonymousUser)
+    ):
         category = "user"
         id = request_user.id
 

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -1,14 +1,23 @@
 from unittest.mock import patch
 
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from exam import fixture
 from freezegun import freeze_time
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
-from sentry.middleware.ratelimit import RatelimitMiddleware
+from sentry.api.endpoints.organization_group_index import OrganizationGroupIndexEndpoint
+from sentry.middleware.ratelimit import (
+    RatelimitMiddleware,
+    above_rate_limit_check,
+    get_rate_limit_key,
+    get_rate_limit_value,
+)
+from sentry.models import ApiKey, ApiToken, User
 from sentry.testutils import TestCase
-from sentry.types.ratelimit import RateLimit
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class RatelimitMiddlewareTest(TestCase):
@@ -54,3 +63,126 @@ class RatelimitMiddlewareTest(TestCase):
             frozen_time.tick(1)
             self.middleware.process_view(request, self._test_endpoint, [], {})
             assert not request.will_be_rate_limited
+
+    def test_above_rate_limit_check(self):
+
+        return_val = above_rate_limit_check("foo", RateLimit(10, 100))
+        assert return_val == dict(is_limited=False, current=1, limit=10, window=100)
+
+    def test_get_rate_limit_key(self):
+        # Import an endpoint
+
+        view = OrganizationGroupIndexEndpoint
+
+        # Test for default IP
+        request = self.factory.get("/")
+        assert (
+            get_rate_limit_key(view, request) == "ip:OrganizationGroupIndexEndpoint:GET:127.0.0.1"
+        )
+        # Test when IP address is missing
+        request.META["REMOTE_ADDR"] = None
+        assert get_rate_limit_key(view, request) is None
+
+        # Test when IP addess is IPv6
+        request.META["REMOTE_ADDR"] = "684D:1111:222:3333:4444:5555:6:77"
+        assert (
+            get_rate_limit_key(view, request)
+            == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+        )
+
+        # Test for users
+        request.session = {}
+        request.user = self.user
+        assert (
+            get_rate_limit_key(view, request)
+            == f"user:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+        )
+
+        # Test for user auth tokens
+        token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
+        request.auth = token
+        request.user = self.user
+        assert (
+            get_rate_limit_key(view, request)
+            == f"user:OrganizationGroupIndexEndpoint:GET:{self.user.id}"
+        )
+
+        # Test for sentryapp auth tokens:
+        sentry_app = self.create_sentry_app(
+            name="Bubbly Webhook",
+            organization=self.organization,
+            webhook_url="https://example.com",
+            scopes=["event:write"],
+        )
+
+        install = self.create_sentry_app_installation(
+            organization=self.organization, slug=sentry_app.slug, user=self.user
+        )
+        token = self.create_internal_integration_token(install=install, user=self.user)
+
+        request.user = User.objects.get(id=sentry_app.proxy_user_id)
+        request.auth = token
+        assert (
+            get_rate_limit_key(view, request)
+            == f"org:OrganizationGroupIndexEndpoint:GET:{self.organization.id}"
+        )
+
+        # Test for apikey
+        api_key = ApiKey.objects.create(
+            organization=self.organization, scope_list=["project:write"]
+        )
+        request.user = AnonymousUser()
+        request.auth = api_key
+        assert (
+            get_rate_limit_key(view, request)
+            == "ip:OrganizationGroupIndexEndpoint:GET:684D:1111:222:3333:4444:5555:6:77"
+        )
+
+
+class TestGetRateLimitValue(TestCase):
+    def test_default_rate_limit_values(self):
+        """Ensure that the default rate limits are called for endpoints without overrides"""
+
+        class TestEndpoint(Endpoint):
+            pass
+
+        assert (
+            get_rate_limit_value("GET", TestEndpoint, "ip")
+            == settings.SENTRY_RATELIMITER_DEFAULTS["ip"]
+        )
+        assert (
+            get_rate_limit_value("POST", TestEndpoint, "org")
+            == settings.SENTRY_RATELIMITER_DEFAULTS["org"]
+        )
+        assert (
+            get_rate_limit_value("DELETE", TestEndpoint, "user")
+            == settings.SENTRY_RATELIMITER_DEFAULTS["user"]
+        )
+
+    def test_override_rate_limit(self):
+        """Override one or more of the default rate limits"""
+
+        class TestEndpoint(Endpoint):
+            rate_limits = {
+                "GET": {RateLimitCategory.IP: RateLimit(100, 5)},
+                "POST": {RateLimitCategory.USER: RateLimit(20, 4)},
+            }
+
+        assert get_rate_limit_value("GET", TestEndpoint, "ip") == RateLimit(100, 5)
+        assert (
+            get_rate_limit_value("GET", TestEndpoint, "user")
+            == settings.SENTRY_RATELIMITER_DEFAULTS["user"]
+        )
+        assert (
+            get_rate_limit_value("POST", TestEndpoint, "ip")
+            == settings.SENTRY_RATELIMITER_DEFAULTS["ip"]
+        )
+        assert get_rate_limit_value("POST", TestEndpoint, "user") == RateLimit(20, 4)
+
+    def test_non_endpoint(self):
+        """views that don't inherit Endpoint shouldn not return a value"""
+
+        class TestEndpoint:
+            pass
+
+        assert get_rate_limit_value("GET", TestEndpoint, "ip") is None


### PR DESCRIPTION
## Objective:
We want to able to observe ratelimits for requests made using authtokens (sentryapps and user) and apikeys
Currently we handle AuthToken/ApiKey authentication during an Endpoint's dispatch(), which is after our ratelimit middleware. This PR brings the authentication logic up to the auth middleware. 

However, we will not reject requests here. This is outside the scope of this PR. Rejection will still occur during the dispatch(). The auth middleware will swallow all the errors and let the request continue on.