### PR TITLE
fix(sentryapps): Address wonky behavior on logo upload

### DIFF
--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -140,7 +140,12 @@ class AvatarChooser extends React.Component<Props, State> {
         this.setState({savedDataUrl: this.state.dataUrl});
         this.handleSuccess(this.getModelFromResponse(resp));
       },
-      error: this.handleError.bind(this, 'There was an error saving your preferences.'),
+      error: resp => {
+        const avatarPhotoErrors = resp?.responseJSON?.avatar_photo || [];
+        avatarPhotoErrors.length
+          ? avatarPhotoErrors.map(this.handleError)
+          : this.handleError.bind(this, t('There was an error saving your preferences.'));
+      },
     });
   };
 

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -114,22 +114,22 @@ class AvatarChooser extends React.Component<Props, State> {
   handleSaveSettings = (ev: React.MouseEvent) => {
     const {endpoint, api, type} = this.props;
     const {model, dataUrl} = this.state;
-    const isSentryApp = type?.startsWith('sentryApp');
 
     ev.preventDefault();
-    const avatarType = model && model.avatar ? model.avatar.avatarType : undefined;
-    const avatarPhoto = dataUrl ? dataUrl.split(',')[1] : undefined;
+    const avatarType = model?.avatar?.avatarType;
+    const avatarPhoto = dataUrl?.split(',')[1];
 
     const data: {
       avatar_photo: string | undefined;
       avatar_type: string | undefined;
       color?: boolean;
     } = {
-      avatar_photo: avatarPhoto,
+      // If an image has been uploaded, then another option is selected, we should not submit the image
+      avatar_photo: avatarType === 'upload' ? avatarPhoto : undefined,
       avatar_type: avatarType,
     };
 
-    if (isSentryApp) {
+    if (type?.startsWith('sentryApp')) {
       data.color = type === 'sentryAppColor';
     }
 

--- a/static/app/components/avatarChooser.tsx
+++ b/static/app/components/avatarChooser.tsx
@@ -120,14 +120,15 @@ class AvatarChooser extends React.Component<Props, State> {
     const avatarPhoto = dataUrl?.split(',')[1];
 
     const data: {
-      avatar_photo: string | undefined;
-      avatar_type: string | undefined;
+      avatar_photo?: string;
+      avatar_type?: string;
       color?: boolean;
-    } = {
-      // If an image has been uploaded, then another option is selected, we should not submit the image
-      avatar_photo: avatarType === 'upload' ? avatarPhoto : undefined,
-      avatar_type: avatarType,
-    };
+    } = {avatar_type: avatarType};
+
+    // If an image has been uploaded, then another option is selected, we should not submit the uploaded image
+    if (avatarType === 'upload') {
+      data.avatar_photo = avatarPhoto;
+    }
 
     if (type?.startsWith('sentryApp')) {
       data.color = type === 'sentryAppColor';


### PR DESCRIPTION
This PR fixes buggy behavior behind logo uploading:

* If the user uploads a logo into the logo field, then selects "Letter Avatar" or "Gravatar", when they submit, we still send and save their uploaded image. This should not be the case, we should only send and save their image when 'upload' is selected
* For SentryApps, the errors thrown by the API were being swallowed. Now, they're being surfaced as a toast, not just a generic message.

https://user-images.githubusercontent.com/35509934/144690272-94e562a4-f5f4-487e-8a52-439898851f07.mov

