### PR TITLE
fix(sentryapps): Properly save file to database

### DIFF
--- a/src/sentry/models/avatar.py
+++ b/src/sentry/models/avatar.py
@@ -90,7 +90,7 @@ class AvatarBase(Model):
                 if isinstance(avatar, str):
                     avatar = BytesIO(force_bytes(avatar))
 
-                # XXX: Avatar pre-processing may adjust file-position
+                # XXX: Avatar processing may adjust file position; reset before saving.
                 avatar.seek(0)
                 photo.putfile(avatar)
         else:

--- a/src/sentry/models/avatar.py
+++ b/src/sentry/models/avatar.py
@@ -89,6 +89,9 @@ class AvatarBase(Model):
                 # if it's not wrapped in BytesIO.
                 if isinstance(avatar, str):
                     avatar = BytesIO(force_bytes(avatar))
+
+                # XXX: Avatar pre-processing may adjust file-position
+                avatar.seek(0)
                 photo.putfile(avatar)
         else:
             photo = None

--- a/src/sentry/models/sentryappavatar.py
+++ b/src/sentry/models/sentryappavatar.py
@@ -36,4 +36,5 @@ class SentryAppAvatar(AvatarBase):
         db_table = "sentry_sentryappavatar"
 
     def get_cache_key(self, size):
-        return f"sentry_app_avatar:{self.sentry_app_id}:{size}"
+        color_identifier = "color" if self.color else "simple"
+        return f"sentry_app_avatar:{self.sentry_app_id}:{color_identifier}:{size}"

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -2,7 +2,7 @@
 Note: Also see letterAvatar.jsx. Anything changed in this file (how colors are
       selected, the svg, etc) will also need to be changed there.
 """
-from typing import MutableMapping, Optional, Union
+from typing import MutableMapping, Optional, TextIO, Union
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -128,7 +128,7 @@ def get_email_avatar(
     return get_letter_avatar(display_name, identifier, size, use_svg=False)
 
 
-def is_black_alpha_only(data: bytes) -> bool:
+def is_black_alpha_only(data: TextIO) -> bool:
     """Check if an image has only black pixels (with alpha)"""
     result = False
     with Image.open(data) as image:

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -130,8 +130,9 @@ def get_email_avatar(
 
 def is_black_alpha_only(data: bytes) -> bool:
     """Check if an image has only black pixels (with alpha)"""
-    image = Image.open(data)
-    if image.mode != "RGBA":
-        return False
-
-    return not any(p[:3] != (0, 0, 0) for p in list(image.getdata()))
+    result = False
+    with Image.open(data) as image:
+        if image.mode == "RGBA":
+            result = not any(p[:3] != (0, 0, 0) for p in list(image.getdata()))
+    data.seek(0)
+    return result


### PR DESCRIPTION
See [API-2308](https://getsentry.atlassian.net/browse/API-2308)

This PR addresses a bug in which python would pretty much just upload an EOF and assume it was a logo. This happened because we were checking every pixel value for whether or not it was fully black/transparent, but never reset the read position afterward. The function checking has been fixed as good practice but another `.seek(0)` has been added just before saving the File to prevent any future implementation from having similar issues during pre-processing or validation.

### Demos

#### Before: Broken file size on storage
https://user-images.githubusercontent.com/35509934/144690832-947a2f6d-80ac-44ca-b873-6e082242eac5.mov

#### Before: Broken logo on reload
<img width="1781" alt="after refresh on master" src="https://user-images.githubusercontent.com/35509934/144690831-185ff835-3277-47c7-a869-de6c63ec8b34.png">

#### After: Fixed file size on storage
https://user-images.githubusercontent.com/35509934/144690816-725ec5ec-1871-4c17-a101-2898e7ea590c.mov