### PR TITLE
fix(linting): Fix some unbound local errors

### DIFF
--- a/src/sentry/utils/query.py
+++ b/src/sentry/utils/query.py
@@ -131,7 +131,7 @@ class RangeQuerySetWrapper:
                 results = queryset
             elif self.desc:
                 results = queryset.filter(**{"%s__lte" % self.order_by: cur_value})
-            elif not self.desc:
+            else:
                 results = queryset.filter(**{"%s__gte" % self.order_by: cur_value})
 
             results = list(results[0 : self.step])

--- a/src/sentry_plugins/redmine/forms.py
+++ b/src/sentry_plugins/redmine/forms.py
@@ -30,6 +30,7 @@ class RedmineOptionsForm(forms.Form):
             initial[key.lstrip(self.prefix or "")] = value
 
         has_credentials = all(initial.get(k) for k in ("host", "key"))
+        client = None
         if has_credentials:
             client = RedmineClient(initial["host"], initial["key"])
             try:
@@ -43,7 +44,7 @@ class RedmineOptionsForm(forms.Form):
                 ]
                 self.fields["project_id"].choices = project_choices
 
-        if has_credentials:
+        if client is not None and has_credentials:
             try:
                 trackers = client.get_trackers()
             except Exception:

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -186,6 +186,7 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
         initial = self.build_initial(initial_args, project)
 
         has_credentials = all(initial.get(k) for k in ("host", "key"))
+        client = None
         if has_credentials:
             client = RedmineClient(initial["host"], initial["key"])
             try:
@@ -202,7 +203,7 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
                 ]
                 self.add_choices("project_id", project_choices, choices_value)
 
-        if has_credentials:
+        if client is not None and has_credentials:
             try:
                 trackers = client.get_trackers()
             except Exception:

--- a/src/social_auth/backends/bitbucket.py
+++ b/src/social_auth/backends/bitbucket.py
@@ -85,6 +85,8 @@ class BitbucketAuth(BaseOAuth1):
         request = self.oauth_request(access_token, url)
         response = self.fetch_response(request)
         try:
+            email = None
+
             # Then retrieve the user's primary email address or the top email
             email_addresses = json.loads(response)
             for email_address in reversed(email_addresses):
@@ -92,6 +94,10 @@ class BitbucketAuth(BaseOAuth1):
                     email = email_address["email"]
                     if email_address["primary"]:
                         break
+
+            if email is None:
+                return None
+
             # Then return the user data using a normal GET with the
             # BITBUCKET_USER_DATA_URL and the user's email
             response = dsa_urlopen(BITBUCKET_USER_DATA_URL + email)


### PR DESCRIPTION
A recently added commithook flags this code as potentially referencing undefined variables. So far this appears to be true. See https://sentry.slack.com/archives/CTJL7358X/p1638785818427600, message:

----

hello folks, @ahmedetefy recently added a precommit hook to sentry that lints against unbound local errors. that was a direct action item from an incident we had, and the hook appears to be working now after some initial conflict with people's pyright setups.

however, unfortunately it appears that the hook actually fails for a lot of files that we currently have checked in.

to see for yourself:

```pyright --project pyrightconfig-commithook.json src/ |& rg error```

this gives 56 errors across 24 files. see thread for exact stats. most files only have 1 error.

in combination with sentry CI, this forces people to fix all potential unbound local errors within the file they're touching as part of some unrelated PR

the problem is: this hook is actually useful. I have looked into some of those errors, and they seem like legitimate bugs most of the time.

I would suggest that, instead of reverting the hook once again, we "roll forward" and take the time to fix the linting bugs. alternatively I can open a PR to add `# type: ignore` on all of those lines to silence the linter temporarily

this went unnoticed for quite a while now, so it seems that this mostly affects old code