### PR TITLE
ref(releasehealth): Refactor metrics comparison, fix some bugs [INGEST-253]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, Mapping, Optional, Sequence, Set, Tuple,
 
 import pytz
 from dateutil import parser
-from sentry_sdk import capture_exception, capture_message, push_scope
+from sentry_sdk import capture_exception, capture_message, push_scope, set_context, set_tag
 from typing_extensions import Literal
 
 from sentry import features
@@ -457,36 +457,11 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
     def _org_from_id(org_id: OrganizationId) -> Organization:
         return Organization.objects.get_from_cache(id=org_id)
 
-    def log_exception(
-        self, ex: Exception, fn_name: str, sessions: ReleaseHealthResult = None
-    ) -> None:
-        with push_scope() as scope:
-            scope.set_tag("func-name", fn_name)
-            scope.fingerprint = ["release-health-exception", fn_name]
-            scope.set_context(
-                "release-health",
-                {
-                    "sessions": sessions,
-                },
-            )
-            capture_exception(ex)
+    def _dispatch_call(self, *args, **kwargs):
+        with push_scope():
+            return self._dispatch_call_inner(*args, **kwargs)
 
-    def log_errors(
-        self,
-        errors: List[str],
-        fn_name: str,
-        sessions: ReleaseHealthResult,
-        metrics: ReleaseHealthResult,
-    ) -> None:
-        with push_scope() as scope:
-            scope.set_tag("func-name", fn_name)
-            scope.fingerprint = ["release-health-errors", fn_name]
-            scope.set_context(
-                "release-health", {"errors": errors, "sessions": sessions, "metrics": metrics}
-            )
-            capture_message(f"{fn_name} - Release health metrics missmatch")
-
-    def _dispatch_call(
+    def _dispatch_call_inner(
         self,
         fn_name: str,
         should_compare: Union[bool, Callable[[Any], bool]],
@@ -499,7 +474,11 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
             rollup = 0  # force exact date comparison if not specified
 
         sessions_fn = getattr(self.sessions, fn_name)
-        tags = {"method": fn_name}
+        set_tag("releasehealth.duplex.rollup", str(rollup))
+        set_tag("releasehealth.duplex.method", fn_name)
+        set_tag("releasehealth.duplex.organization", str(getattr(organization, "id")))
+
+        tags = {"method": fn_name, "rollup": str(rollup)}
         with timer("releasehealth.sessions.duration", tags=tags, sample_rate=1.0):
             ret_val = sessions_fn(*args)
 
@@ -508,49 +487,60 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
         ):
             return ret_val  # cannot check feature without organization
 
+        set_context(
+            "release-health-duplex-sessions",
+            {
+                "sessions": ret_val,
+            },
+        )
+
         try:
             if not isinstance(should_compare, bool):
                 # should compare depends on the session result
                 # evaluate it now
                 should_compare = should_compare(ret_val)
-        except Exception as ex:
-            should_compare = False
-            self.log_exception(ex, fn_name)
-            incr(
-                "releasehealth.metrics.check_should_compare",
-                tags={"should_compare": "crashed", **tags},
-                sample_rate=1.0,
-            )
-        else:
+
             incr(
                 "releasehealth.metrics.check_should_compare",
                 tags={"should_compare": str(should_compare), **tags},
                 sample_rate=1.0,
             )
 
-        if should_compare:
+            if not should_compare:
+                return ret_val
+
             copy = deepcopy(ret_val)
-            try:
-                metrics_fn = getattr(self.metrics, fn_name)
-                with timer("releasehealth.metrics.duration", tags=tags, sample_rate=1.0):
-                    metrics_val = metrics_fn(*args)
-                with timer("releasehealth.results-diff.duration", tags=tags, sample_rate=1.0):
-                    errors = compare_results(copy, metrics_val, rollup, None, schema)
 
-                incr(
-                    "releasehealth.metrics.compare",
-                    tags={"has_errors": str(bool(errors)), **tags},
-                    sample_rate=1.0,
-                )
+            metrics_fn = getattr(self.metrics, fn_name)
+            with timer("releasehealth.metrics.duration", tags=tags, sample_rate=1.0):
+                metrics_val = metrics_fn(*args)
 
-                self.log_errors(errors, fn_name, copy, metrics_val)
-            except Exception as ex:
-                incr(
-                    "releasehealth.metrics.compare",
-                    tags={"has_errors": "crashed", **tags},
-                    sample_rate=1.0,
-                )
-                self.log_exception(ex, fn_name, copy)
+            set_context("release-health-duplex-metrics", {"metrics": metrics_val})
+
+            with timer("releasehealth.results-diff.duration", tags=tags, sample_rate=1.0):
+                errors = compare_results(copy, metrics_val, rollup, None, schema)
+
+            set_context("release-health-duplex-errors", {"errors": errors})
+
+            incr(
+                "releasehealth.metrics.compare",
+                tags={"has_errors": str(bool(errors)), **tags},
+                sample_rate=1.0,
+            )
+
+            if errors:
+                with push_scope() as scope:
+                    scope.fingerprint = ["release-health-errors", fn_name]
+                    capture_message(f"{fn_name} - Release health metrics mismatch")
+        except Exception:
+            capture_exception()
+            should_compare = False
+            incr(
+                "releasehealth.metrics.crashed",
+                tags=tags,
+                sample_rate=1.0,
+            )
+
         return ret_val
 
     def get_current_and_previous_crash_free_rates(


### PR DESCRIPTION
* Fix a bug where the duplex backend would send a sentry event unconditionally, not only for errors
* Split up releasehealth context into two to bypass truncation logic in Relay
* Put everything into one pushed scope, and only have one try-except block. This simplifies error handling in general
* Add rollup tag to metrics and events
* Add organization tag to events