### PR TITLE
feat(cra-metrics): Updates subscription deletion

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -45,7 +45,7 @@ from sentry.mediators import alert_rule_actions
 from sentry.models import OrganizationMember, SentryAppInstallation, Team, User
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.entity_subscription import map_aggregate_to_entity_subscription
+from sentry.snuba.entity_subscription import get_entity_subscription_for_dataset
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils import json
@@ -484,7 +484,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             project_id = list(self.context["organization"].project_set.all()[:1])
 
         try:
-            entity_subscription = map_aggregate_to_entity_subscription(
+            entity_subscription = get_entity_subscription_for_dataset(
                 dataset=QueryDatasets(data["dataset"]),
                 aggregate=data["aggregate"],
                 extra_fields={

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -35,7 +35,7 @@ from sentry.search.events.fields import resolve_field
 from sentry.search.events.filter import get_filter
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
 from sentry.snuba.dataset import Dataset
-from sentry.snuba.entity_subscription import map_aggregate_to_entity_subscription
+from sentry.snuba.entity_subscription import get_entity_subscription_for_dataset
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
@@ -289,7 +289,7 @@ def build_incident_query_params(incident, start=None, end=None, windowed_stats=F
         params["project_id"] = project_ids
 
     snuba_query = incident.alert_rule.snuba_query
-    entity_subscription = map_aggregate_to_entity_subscription(
+    entity_subscription = get_entity_subscription_for_dataset(
         dataset=QueryDatasets(snuba_query.dataset),
         aggregate=snuba_query.aggregate,
         extra_fields={"org_id": incident.organization.id, "event_types": snuba_query.event_types},

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -32,7 +32,7 @@ from sentry.models import Project
 from sentry.release_health.metrics import reverse_tag_value, tag_key
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QueryDatasets
-from sentry.snuba.tasks import build_snuba_filter, map_aggregate_to_entity_subscription
+from sentry.snuba.tasks import build_snuba_filter, get_entity_subscription_for_dataset
 from sentry.utils import metrics, redis
 from sentry.utils.compat import zip
 from sentry.utils.dates import to_datetime, to_timestamp
@@ -176,7 +176,7 @@ class SubscriptionProcessor:
         snuba_query = self.subscription.snuba_query
         start = end - timedelta(seconds=snuba_query.time_window)
 
-        entity_subscription = map_aggregate_to_entity_subscription(
+        entity_subscription = get_entity_subscription_for_dataset(
             dataset=QueryDatasets(snuba_query.dataset),
             aggregate=snuba_query.aggregate,
             extra_fields={

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from random import random
 from typing import Any, Callable, Dict, Iterable, List, Optional, cast
@@ -12,6 +13,7 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 
 from sentry import options
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTION_WRAPPER_SCHEMA
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.snuba.tasks import _delete_from_snuba
@@ -280,9 +282,23 @@ class QuerySubscriptionConsumer:
                     },
                 )
                 try:
+                    # XXX(ahmed): Temporary hack to be able to extract entity key from query
+                    # which is now required by snuba because with the introduction of metrics
+                    # dataset, the relationship between dataset and entity is no longer 1-to-1
+                    # However, will deploy a fix in snuba to send the entity key in the payload
+                    # of the message
+                    entity_regex = r"^(MATCH|match)[ ]*\(([^)]+)\)"
+                    entity_match = re.match(entity_regex, contents["request"]["query"])
+                    if not entity_match:
+                        raise InvalidMessageError("Unable to fetch entity from query in message")
+                    entity_key = entity_match.group(2)
                     _delete_from_snuba(
-                        self.topic_to_dataset[message.topic()], contents["subscription_id"]
+                        self.topic_to_dataset[message.topic()],
+                        contents["subscription_id"],
+                        EntityKey(entity_key),
                     )
+                except InvalidMessageError as e:
+                    logger.exception(e)
                 except Exception:
                     logger.exception("Failed to delete unused subscription from snuba.")
                 return

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -7,9 +7,11 @@ from snuba_sdk.legacy import json_to_snql
 
 from sentry.eventstore import Filter
 from sentry.models import Any, Environment, Mapping, Optional
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
-    map_aggregate_to_entity_subscription,
+    get_entity_subscription_for_dataset,
+    map_aggregate_to_entity_key,
 )
 from sentry.snuba.models import QueryDatasets, QuerySubscription
 from sentry.tasks.base import instrumented_task
@@ -46,9 +48,15 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
         # This mostly shouldn't happen, but it's possible that a subscription can get
         # into this state. Just attempt to delete the existing subscription and then
         # create a new one.
+        query_dataset = QueryDatasets(subscription.snuba_query.dataset)
+        entity_key: EntityKey = map_aggregate_to_entity_key(
+            query_dataset, subscription.snuba_query.aggregate
+        )
         try:
             _delete_from_snuba(
-                QueryDatasets(subscription.snuba_query.dataset), subscription.subscription_id
+                query_dataset,
+                subscription.subscription_id,
+                entity_key,
             )
         except SnubaError:
             logger.exception("Failed to delete subscription")
@@ -83,7 +91,14 @@ def update_subscription_in_snuba(query_subscription_id, old_dataset=None, **kwar
 
     if subscription.subscription_id is not None:
         dataset = old_dataset if old_dataset is not None else subscription.snuba_query.dataset
-        _delete_from_snuba(QueryDatasets(dataset), subscription.subscription_id)
+        entity_key: EntityKey = map_aggregate_to_entity_key(
+            QueryDatasets(dataset), subscription.snuba_query.aggregate
+        )
+        _delete_from_snuba(
+            QueryDatasets(dataset),
+            subscription.subscription_id,
+            entity_key,
+        )
 
     subscription_id = _create_in_snuba(subscription)
     subscription.update(
@@ -118,8 +133,14 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
         return
 
     if subscription.subscription_id is not None:
+        query_dataset = QueryDatasets(subscription.snuba_query.dataset)
+        entity_key: EntityKey = map_aggregate_to_entity_key(
+            query_dataset, subscription.snuba_query.aggregate
+        )
         _delete_from_snuba(
-            QueryDatasets(subscription.snuba_query.dataset), subscription.subscription_id
+            query_dataset,
+            subscription.subscription_id,
+            entity_key,
         )
 
     if subscription.status == QuerySubscription.Status.DELETING.value:
@@ -139,7 +160,7 @@ def build_snuba_filter(
 
 def _create_in_snuba(subscription: QuerySubscription) -> str:
     snuba_query = subscription.snuba_query
-    entity_subscription = map_aggregate_to_entity_subscription(
+    entity_subscription = get_entity_subscription_for_dataset(
         dataset=QueryDatasets(snuba_query.dataset),
         aggregate=snuba_query.aggregate,
         extra_fields={
@@ -188,8 +209,10 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
     return json.loads(response.data)["subscription_id"]
 
 
-def _delete_from_snuba(dataset: QueryDatasets, subscription_id: str) -> None:
-    response = _snuba_pool.urlopen("DELETE", f"/{dataset.value}/subscriptions/{subscription_id}")
+def _delete_from_snuba(dataset: QueryDatasets, subscription_id: str, entity_key: EntityKey) -> None:
+    response = _snuba_pool.urlopen(
+        "DELETE", f"/{dataset.value}/{entity_key.value}/subscriptions/{subscription_id}"
+    )
     if response.status != 202:
         raise SnubaError("HTTP %s response from Snuba!" % response.status)
 


### PR DESCRIPTION
- Updates subscription deletion to use the new snuba endpoint that accepts an `entity_key` 

For context: https://github.com/getsentry/snuba/pull/2244