### PR TITLE
fix(async-csv): Smaller and slower export batches

### DIFF
--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from enum import Enum
 
 MAX_BATCH_SIZE = 8 * 1024 * 1024
+MAX_FRAGMENTS_PER_BATCH = 10
 EXPORTED_ROWS_LIMIT = 10000000
 SNUBA_MAX_RESULTS = 10000
 DEFAULT_EXPIRATION = timedelta(weeks=4)


### PR DESCRIPTION
Currently, a batch is limited by the number of bytes it writes. This meant that
for an export that writes a small of bytes per row, it can query snuba many
times consecutively. This change introduces a limit of 10 snuba queries per
batch and a short delay to not use too many snuba queries too quickly.