### PR TITLE
fix(lint): use screen query in addDashboardIssueWidgetModal test

### DIFF
--- a/tests/js/spec/components/modals/addDashboardIssueWidgetModal.spec.tsx
+++ b/tests/js/spec/components/modals/addDashboardIssueWidgetModal.spec.tsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {mountWithTheme, userEvent} from 'sentry-test/reactTestingLibrary';
+import {mountWithTheme, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import AddDashboardIssueWidgetModal from 'sentry/components/modals/addDashboardIssueWidgetModal';
 
@@ -25,9 +25,9 @@ function mountModal({initialData, onAddWidget, onUpdateWidget, widget}) {
   );
 }
 
-async function clickSubmit(wrapper) {
+async function clickSubmit() {
   // Click on submit.
-  userEvent.click(wrapper.getByText('Add Widget'));
+  userEvent.click(screen.getByText('Add Widget'));
 }
 
 describe('Modals -> AddDashboardIssueWidgetModal', function () {
@@ -64,7 +64,7 @@ describe('Modals -> AddDashboardIssueWidgetModal', function () {
       onUpdateWidget: () => undefined,
       widget: undefined,
     });
-    await clickSubmit(wrapper);
+    await clickSubmit();
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({widgetType: 'issue'}));
     wrapper.unmount();


### PR DESCRIPTION
When upgrading `eslint-config-sentry-react` to `v1.68.0+`, there is an eslint error in the `AddDashboardIssueWidgetModal` test. 

<img width="819" alt="Screen Shot 2021-12-06 at 12 32 10 PM" src="https://user-images.githubusercontent.com/44172267/144918097-bb31451f-5e2e-4549-92ee-1cf6dd97dcd9.png">

This is due to a change in `v1.68.0` (see: https://github.com/getsentry/eslint-config-sentry/commit/8bf5ec4f013310fbc6f4d8fd06a465367dbe900e). Replacing `wrapper.getByText` with `screen.getByText` in the test file fixes this issue.