### PR TITLE
feat(sentryapps): Fallback to the default SentryAppAvatar if needed

### DIFF
--- a/static/app/components/avatar/baseAvatar.tsx
+++ b/static/app/components/avatar/baseAvatar.tsx
@@ -89,6 +89,7 @@ type BaseProps = DefaultProps & {
   gravatarId?: string;
   letterId?: string;
   title?: string;
+  backupAvatar?: React.ReactNode;
   /**
    * The content for the tooltip. Requires hasTooltip to display
    */
@@ -213,6 +214,11 @@ class BaseAvatar extends React.Component<Props, State> {
     return <BackgroundAvatar round={round} suggested={suggested} />;
   }
 
+  renderBackupAvatar() {
+    const {backupAvatar} = this.props;
+    return backupAvatar ?? this.renderLetterAvatar();
+  }
+
   render() {
     const {
       className,
@@ -251,7 +257,7 @@ class BaseAvatar extends React.Component<Props, State> {
           }}
           {...props}
         >
-          {this.state.showBackupAvatar && this.renderLetterAvatar()}
+          {this.state.showBackupAvatar && this.renderBackupAvatar()}
           {this.renderImg()}
         </StyledBaseAvatar>
       </Tooltip>

--- a/static/app/components/avatar/sentryAppAvatar.tsx
+++ b/static/app/components/avatar/sentryAppAvatar.tsx
@@ -10,15 +10,16 @@ type Props = {
 
 const SentryAppAvatar = ({isColor = true, sentryApp, isDefault, ...props}: Props) => {
   const avatarDetails = sentryApp?.avatars?.find(({color}) => color === isColor);
+  const defaultSentryAppAvatar = (
+    <IconGeneric
+      size={`${props.size}`}
+      className={props.className}
+      data-test-id="default-sentry-app-avatar"
+    />
+  );
   // Render the default if the prop is provided, there is no existing avatar, or it has been reverted to 'default'
   if (isDefault || !avatarDetails || avatarDetails.avatarType === 'default') {
-    return (
-      <IconGeneric
-        size={`${props.size}`}
-        className={props.className}
-        data-test-id="default-sentry-app-avatar"
-      />
-    );
+    return defaultSentryAppAvatar;
   }
   return (
     <BaseAvatar
@@ -27,6 +28,7 @@ const SentryAppAvatar = ({isColor = true, sentryApp, isDefault, ...props}: Props
       uploadPath="sentry-app-avatar"
       uploadId={avatarDetails?.avatarUuid}
       title={sentryApp?.name}
+      backupAvatar={defaultSentryAppAvatar}
     />
   );
 };


### PR DESCRIPTION
This PR will address a niche, rare bug that only happens if the stored image for an avatar is inaccessible. The default behavior for BaseAvatar is to fallback to the LetterAvatars. Instead, BaseAvatar (which already has considerations for checking if there should be a backup) will accept a `backupAvatar` prop, and use that instead.

#### Before

<img width="503" alt="borked dir" src="https://user-images.githubusercontent.com/35509934/144942853-285a02c4-dcaa-4616-889a-507782fa44af.png">
<img width="326" alt="borked stack" src="https://user-images.githubusercontent.com/35509934/144942863-59d29a9a-450a-42b8-9ae1-5c88be9f8789.png">
<img width="326" alt="image" src="https://user-images.githubusercontent.com/35509934/144942832-aa08ea07-2eb1-4bd9-8474-858dc6e4e2c2.png">

#### After
<img width="976" alt="working dir" src="https://user-images.githubusercontent.com/35509934/144942930-dac72566-c856-4116-965f-dfec24db5dcd.png">
<img width="326" alt="working stack" src="https://user-images.githubusercontent.com/35509934/144942933-4d525103-6bd1-44c0-9a06-aec990beb992.png">
<img width="326" alt="working issue" src="https://user-images.githubusercontent.com/35509934/144942935-2718c727-dfb7-4de5-96cc-a944c41321d4.png">


