### PR TITLE
Refactor user and identity into AuthIdentityHandler instance variables

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -432,7 +432,7 @@ class AuthIdentityHandler:
             verification_key = self.request.session.get("confirm_account_verification_key")
             verification_value = get_verification_value_from_key(verification_key)
             if verification_value:
-                is_account_verified = self.has_verified_account(self.identity, verification_value)
+                is_account_verified = self.has_verified_account(verification_value)
 
         is_new_account = not self.user.is_authenticated  # stateful
         if self.identity.get("email_verified") or is_account_verified:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -476,7 +476,7 @@ class AuthIdentityHandler:
             auth_identity = self.handle_attach_identity()
         elif op == "newuser":
             auth_identity = self.handle_new_user()
-        elif op == "login" and not self.user.is_authenticated:
+        elif op == "login" and not self.request.user.is_authenticated:
             # confirm authentication, login
             op = None
             if login_form.is_valid():

--- a/src/sentry/web/frontend/idp_email_verification.py
+++ b/src/sentry/web/frontend/idp_email_verification.py
@@ -2,7 +2,7 @@ from django.http.response import HttpResponse
 from rest_framework.request import Request
 
 from sentry.auth.idpmigration import SSO_VERIFICATION_KEY, get_verification_value_from_key
-from sentry.models import Organization, OrganizationMember
+from sentry.models import Organization
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
@@ -28,25 +28,12 @@ class AccountConfirmationView(BaseView):
         return render_to_response("sentry/idp_account_not_verified.html", request=request)
 
     @staticmethod
-    def _recover_org_member(verification_value):
-        member_id = verification_value.get("member_id")
-        if member_id is None:
-            return None  # the user was not an org member when the record was written
-        try:
-            return OrganizationMember.objects.get(id=member_id)
-        except OrganizationMember.DoesNotExist:
-            return None  # the user has left the org since the record was written
-
-    @staticmethod
     def _recover_org_slug(verification_value):
-        om = AccountConfirmationView._recover_org_member(verification_value)
-        if om is not None:
-            return om.organization.slug
-
         organization_id = verification_value.get("organization_id")
+        if organization_id is None:
+            return None
         try:
             org = Organization.objects.get(id=organization_id)
         except Organization.DoesNotExist:
             return None
-        else:
-            return org.slug
+        return org.slug

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -407,14 +407,14 @@ class HasVerifiedAccountTest(AuthIdentityHandlerTest):
             "identity_id": self.identity_id,
         }
 
-    @mock.patch("sentry.auth.helper.AuthIdentityHandler._get_user")
-    def test_has_verified_account_success(self, mock_get_user):
-        mock_get_user.return_value = self.user
+    @mock.patch("sentry.auth.helper.AuthIdentityHandler.initialize_user")
+    def test_has_verified_account_success(self, mock_init_user):
+        mock_init_user.return_value = self.user
         assert self.handler.has_verified_account(self.verification_value) is True
 
-    @mock.patch("sentry.auth.helper.AuthIdentityHandler._get_user")
-    def test_has_verified_account_fail_email(self, mock_get_user):
-        mock_get_user.return_value = self.user
+    @mock.patch("sentry.auth.helper.AuthIdentityHandler.initialize_user")
+    def test_has_verified_account_fail_email(self, mock_init_user):
+        mock_init_user.return_value = self.user
         identity = {
             "id": "1234",
             "email": "b@test.com",
@@ -423,8 +423,8 @@ class HasVerifiedAccountTest(AuthIdentityHandlerTest):
         }
         assert self._handler_with(identity).has_verified_account(self.verification_value) is False
 
-    @mock.patch("sentry.auth.helper.AuthIdentityHandler._get_user")
-    def test_has_verified_account_fail_user_id(self, mock_get_user):
-        mock_get_user.return_value = self.create_user()
+    @mock.patch("sentry.auth.helper.AuthIdentityHandler.initialize_user")
+    def test_has_verified_account_fail_user_id(self, mock_init_user):
+        mock_init_user.return_value = self.create_user()
         self.wrong_user_flag = True
         assert self.handler.has_verified_account(self.verification_value) is False

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -20,6 +20,7 @@ from sentry.models import (
     InviteStatus,
     OrganizationMember,
     OrganizationMemberTeam,
+    UserEmail,
 )
 from sentry.testutils import TestCase
 from sentry.utils import json
@@ -407,14 +408,12 @@ class HasVerifiedAccountTest(AuthIdentityHandlerTest):
             "identity_id": self.identity_id,
         }
 
-    @mock.patch("sentry.auth.helper.AuthIdentityHandler.initialize_user")
-    def test_has_verified_account_success(self, mock_init_user):
-        mock_init_user.return_value = self.user
+    def test_has_verified_account_success(self):
+        UserEmail.objects.create(email=self.email, user=self.user)
         assert self.handler.has_verified_account(self.verification_value) is True
 
-    @mock.patch("sentry.auth.helper.AuthIdentityHandler.initialize_user")
-    def test_has_verified_account_fail_email(self, mock_init_user):
-        mock_init_user.return_value = self.user
+    def test_has_verified_account_fail_email(self):
+        UserEmail.objects.create(email=self.email, user=self.user)
         identity = {
             "id": "1234",
             "email": "b@test.com",
@@ -423,8 +422,7 @@ class HasVerifiedAccountTest(AuthIdentityHandlerTest):
         }
         assert self._handler_with(identity).has_verified_account(self.verification_value) is False
 
-    @mock.patch("sentry.auth.helper.AuthIdentityHandler.initialize_user")
-    def test_has_verified_account_fail_user_id(self, mock_init_user):
-        mock_init_user.return_value = self.create_user()
-        self.wrong_user_flag = True
+    def test_has_verified_account_fail_user_id(self):
+        wrong_user = self.create_user()
+        UserEmail.objects.create(email=self.email, user=wrong_user)
         assert self.handler.has_verified_account(self.verification_value) is False

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -50,11 +50,20 @@ class AuthIdentityHandlerTest(TestCase):
             "data": {"foo": "bar"},
         }
 
-        self.handler = AuthIdentityHandler(
-            self.auth_provider, Provider(self.provider), self.organization, self.request
-        )
-
         self.state = AuthHelperSessionStore(self.request, "pipeline")
+
+    @property
+    def handler(self):
+        return self._handler_with(self.identity)
+
+    def _handler_with(self, identity):
+        return AuthIdentityHandler(
+            self.auth_provider,
+            Provider(self.provider),
+            self.organization,
+            self.request,
+            identity,
+        )
 
     def set_up_user(self):
         """Set up a persistent user and associate it to the request.
@@ -80,7 +89,7 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
     @mock.patch("sentry.analytics.record")
     def test_simple(self, mock_record):
 
-        auth_identity = self.handler.handle_new_user(self.identity)
+        auth_identity = self.handler.handle_new_user()
         user = auth_identity.user
 
         assert user.email == self.email
@@ -100,7 +109,7 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
     def test_associated_existing_member_invite_by_email(self):
         member = OrganizationMember.objects.create(organization=self.organization, email=self.email)
 
-        auth_identity = self.handler.handle_new_user(self.identity)
+        auth_identity = self.handler.handle_new_user()
 
         assigned_member = OrganizationMember.objects.get(
             organization=self.organization, user=auth_identity.user
@@ -115,7 +124,7 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
             invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
         )
 
-        auth_identity = self.handler.handle_new_user(self.identity)
+        auth_identity = self.handler.handle_new_user()
 
         assert OrganizationMember.objects.filter(
             organization=self.organization,
@@ -136,7 +145,7 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
             {"memberId": member.id, "token": member.token, "url": ""}
         )
 
-        auth_identity = self.handler.handle_new_user(self.identity)
+        auth_identity = self.handler.handle_new_user()
 
         assigned_member = OrganizationMember.objects.get(
             organization=self.organization, user=auth_identity.user
@@ -151,7 +160,7 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest):
         mock_auth.get_login_redirect.return_value = "test_login_url"
         user, auth_identity = self.set_up_user_identity()
 
-        redirect = self.handler.handle_existing_identity(self.state, auth_identity, self.identity)
+        redirect = self.handler.handle_existing_identity(self.state, auth_identity)
 
         assert redirect.url == mock_auth.get_login_redirect.return_value
         assert mock_auth.get_login_redirect.called_with(self.request)
@@ -174,9 +183,7 @@ class HandleExistingIdentityTest(AuthIdentityHandlerTest):
             mock_auth.get_login_redirect.return_value = "test_login_url"
             user, auth_identity = self.set_up_user_identity()
 
-            redirect = self.handler.handle_existing_identity(
-                self.state, auth_identity, self.identity
-            )
+            redirect = self.handler.handle_existing_identity(self.state, auth_identity)
 
             assert redirect.url == mock_auth.get_login_redirect.return_value
             assert mock_auth.get_login_redirect.called_with(self.request)
@@ -196,7 +203,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
     def test_new_identity(self, mock_messages):
         self.set_up_user()
 
-        auth_identity = self.handler.handle_attach_identity(self.identity)
+        auth_identity = self.handler.handle_attach_identity()
         assert auth_identity.ident == self.identity["id"]
         assert auth_identity.data == self.identity["data"]
 
@@ -226,7 +233,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
         user = self.set_up_user()
         existing_om = OrganizationMember.objects.create(user=user, organization=self.organization)
 
-        auth_identity = self.handler.handle_attach_identity(self.identity)
+        auth_identity = self.handler.handle_attach_identity()
         assert auth_identity.ident == self.identity["id"]
         assert auth_identity.data == self.identity["data"]
 
@@ -242,7 +249,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
     def test_existing_identity(self, mock_messages):
         user, existing_identity = self.set_up_user_identity()
 
-        returned_identity = self.handler.handle_attach_identity(self.identity)
+        returned_identity = self.handler.handle_attach_identity()
         assert returned_identity == existing_identity
         assert not mock_messages.add_message.called
 
@@ -255,7 +262,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
         )
         OrganizationMember.objects.create(user=other_user, organization=self.organization)
 
-        returned_identity = self.handler.handle_attach_identity(self.identity)
+        returned_identity = self.handler.handle_attach_identity()
         assert returned_identity.user == request_user
         assert returned_identity.ident == self.identity["id"]
         assert returned_identity.data == self.identity["data"]
@@ -278,7 +285,7 @@ class HandleAttachIdentityTest(AuthIdentityHandlerTest):
 
 class HandleUnknownIdentityTest(AuthIdentityHandlerTest):
     def _test_simple(self, mock_render, expected_template):
-        redirect = self.handler.handle_unknown_identity(self.state, self.identity)
+        redirect = self.handler.handle_unknown_identity(self.state)
 
         assert redirect is mock_render.return_value
         template, context, request = mock_render.call_args.args
@@ -403,7 +410,7 @@ class HasVerifiedAccountTest(AuthIdentityHandlerTest):
     @mock.patch("sentry.auth.helper.AuthIdentityHandler._get_user")
     def test_has_verified_account_success(self, mock_get_user):
         mock_get_user.return_value = self.user
-        assert self.handler.has_verified_account(self.identity, self.verification_value) is True
+        assert self.handler.has_verified_account(self.verification_value) is True
 
     @mock.patch("sentry.auth.helper.AuthIdentityHandler._get_user")
     def test_has_verified_account_fail_email(self, mock_get_user):
@@ -414,10 +421,10 @@ class HasVerifiedAccountTest(AuthIdentityHandlerTest):
             "name": "Morty",
             "data": {"foo": "bar"},
         }
-        assert self.handler.has_verified_account(identity, self.verification_value) is False
+        assert self._handler_with(identity).has_verified_account(self.verification_value) is False
 
     @mock.patch("sentry.auth.helper.AuthIdentityHandler._get_user")
     def test_has_verified_account_fail_user_id(self, mock_get_user):
         mock_get_user.return_value = self.create_user()
         self.wrong_user_flag = True
-        assert self.handler.has_verified_account(self.identity, self.verification_value) is False
+        assert self.handler.has_verified_account(self.verification_value) is False


### PR DESCRIPTION
Broken out from https://github.com/getsentry/sentry/pull/30356. See [this comment](https://github.com/getsentry/sentry/pull/30356#issuecomment-985086072) for context.

Move the operation of looking up an existing user from the email address in the identity up front to the creation of the `AuthIdentityHandler` object. This prevents the need to pass around the "acting user" among methods, as newly required for the fix in #30356.

Business logic within `handle_unknown_identity` around "blanking" the acting user to None, thereby triggering a new account provisioning (sometimes), is now represented with a more meaningful boolean variable.

The signature change to `AuthIdentityHandler` requires changes in `getsentry`.