### PR TITLE
fix(auth): fix login loop issue for superusers

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -296,9 +296,10 @@ def login(request, user, passed_2fa=None, after_2fa=None, organization_id=None, 
     # reasonable place.
     if not hasattr(user, "backend"):
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
-    _login(request, user)
     if organization_id:
         mark_sso_complete(request, organization_id)
+    _login(request, user)
+
     log_auth_success(request, user.username, organization_id, source)
     return True
 


### PR DESCRIPTION
### Problem:
Because we trigger `_login` before we set the SSO session, in many cases superusers will have to log in twice, since they weren't considered active superuser on the first attempt, leading to confusion. 

### Solution
Simply move the `_login` call to after the SSO session completion. Since sessions are not modified by login, there should be no other behavior differences.

### Details:
An extra test is added to `test_auth_organization_login` to confirm this behavior. (fails on master)