### PR TITLE
fix(auth): improve sso signed out superuser auth flow

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -135,7 +135,7 @@ class AuthIndexEndpoint(Endpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        if request.user.is_superuser and not is_active_superuser(request):
+        if request.user.is_superuser and not is_active_superuser(request) and Superuser.org_id:
             # if a superuser hitting this endpoint is not active, they are most likely
             # trying to become active, and likely need to re-identify with SSO to do so.
             redirect = request.META.get("HTTP_REFERER", "")

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -1,15 +1,19 @@
 from django.contrib.auth import logout
 from django.contrib.auth.models import AnonymousUser
+from django.utils.http import is_safe_url
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from sentry.api.authentication import QuietBasicAuthentication
 from sentry.api.base import Endpoint
+from sentry.api.exceptions import SsoRequired
 from sentry.api.serializers import DetailedUserSerializer, serialize
 from sentry.api.validators import AuthVerifyValidator
-from sentry.models import Authenticator
+from sentry.auth.superuser import Superuser, is_active_superuser
+from sentry.models import Authenticator, Organization
 from sentry.utils import auth, json
+from sentry.utils.auth import initiate_login
 from sentry.utils.functional import extract_lazy_object
 
 
@@ -130,6 +134,16 @@ class AuthIndexEndpoint(Endpoint):
                 },
                 status=status.HTTP_403_FORBIDDEN,
             )
+
+        if request.user.is_superuser and not is_active_superuser(request):
+            # if a superuser hitting this endpoint is not active, they are most likely
+            # trying to become active, and likely need to re-identify with SSO to do so.
+            redirect = request.META.get("HTTP_REFERER", "")
+            if not is_safe_url(redirect, allowed_hosts=(request.get_host(),)):
+                redirect = None
+
+            initiate_login(request, redirect)
+            raise SsoRequired(Organization.objects.get_from_cache(id=Superuser.org_id))
 
         request.user = request._request.user
 


### PR DESCRIPTION
### Problem
Since our default SSO expiry window has moved down to 20 hours in #29422, superusers are now faced with the situation of being logged out of the superuser org SSO, while still logged into their account. The verify auth endpoint did not know how to handle this, and would simply return a 200, putting the superuser into an infinite sudo modal flow since they were not made superuser from this request.

### Solution
In the verify auth endpoint, if it's a superuser and they are not currently active, we raise an `SsoRequired` exception which will redirect them to log into the superuser org, and then send them back to the page they were trying to access via the `_next` session variable and the http referer. (the sudo auth modal makes an API call to this endpoint so referer should be the page they were trying to access).

related: #30466, as users would have to verify twice in the above flow without this mentioned change.