### PR TITLE
feat(perf): Remove tab stickiness for landing

### DIFF
--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -1,8 +1,7 @@
-import {FC, useEffect, useRef, useState} from 'react';
+import {FC, useEffect, useRef} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import omit from 'lodash/omit';
 
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -78,17 +77,14 @@ export function PerformanceLanding(props: Props) {
     projects,
     eventView
   );
-  const [landingDisplay, setLocalLandingDisplay] = useState(
-    paramLandingDisplay || defaultLandingDisplayForProjects
-  );
+  const landingDisplay = paramLandingDisplay ?? defaultLandingDisplayForProjects;
 
   useEffect(() => {
     if (hasMounted.current) {
-      setLocalLandingDisplay(defaultLandingDisplayForProjects);
       browserHistory.replace({
         pathname: location.pathname,
         query: {
-          ...omit(location.query, ['landingDisplay']),
+          ...location.query,
           landingDisplay: undefined,
         },
       });
@@ -144,8 +140,7 @@ export function PerformanceLanding(props: Props) {
                       location,
                       projects,
                       organization,
-                      eventView,
-                      setLocalLandingDisplay
+                      eventView
                     )
                   }
                 >

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -1,6 +1,8 @@
-import {FC} from 'react';
+import {FC, useEffect, useRef, useState} from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
+import omit from 'lodash/omit';
 
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -31,7 +33,8 @@ import {FrontendOtherView} from './views/frontendOtherView';
 import {FrontendPageloadView} from './views/frontendPageloadView';
 import {MobileView} from './views/mobileView';
 import {
-  getCurrentLandingDisplay,
+  getDefaultDisplayForPlatform,
+  getLandingDisplayFromParam,
   handleLandingDisplayChange,
   LANDING_V3_DISPLAYS,
   LandingDisplayField,
@@ -69,7 +72,33 @@ export function PerformanceLanding(props: Props) {
 
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
 
-  const currentLandingDisplay = getCurrentLandingDisplay(location, projects, eventView);
+  const hasMounted = useRef(false);
+  const paramLandingDisplay = getLandingDisplayFromParam(location);
+  const defaultLandingDisplayForProjects = getDefaultDisplayForPlatform(
+    projects,
+    eventView
+  );
+  const [landingDisplay, setLocalLandingDisplay] = useState(
+    paramLandingDisplay || defaultLandingDisplayForProjects
+  );
+
+  useEffect(() => {
+    if (hasMounted.current) {
+      setLocalLandingDisplay(defaultLandingDisplayForProjects);
+      browserHistory.replace({
+        pathname: location.pathname,
+        query: {
+          ...omit(location.query, ['landingDisplay']),
+          landingDisplay: undefined,
+        },
+      });
+    }
+  }, [eventView.project.join('.')]);
+
+  useEffect(() => {
+    hasMounted.current = true;
+  }, []);
+
   const filterString = getTransactionSearchQuery(location, eventView.query);
   const {isMetricsData} = useMetricsSwitch();
 
@@ -79,7 +108,7 @@ export function PerformanceLanding(props: Props) {
     ({isShown}) => !isShown || isShown(organization)
   );
 
-  const ViewComponent = fieldToViewMap[currentLandingDisplay.field];
+  const ViewComponent = fieldToViewMap[landingDisplay.field];
 
   return (
     <StyledPageContent>
@@ -105,19 +134,18 @@ export function PerformanceLanding(props: Props) {
 
           <StyledNavTabs>
             {shownLandingDisplays.map(({label, field}) => (
-              <li
-                key={label}
-                className={currentLandingDisplay.field === field ? 'active' : ''}
-              >
+              <li key={label} className={landingDisplay.field === field ? 'active' : ''}>
                 <a
                   href="#"
+                  data-test-id={`landing-tab-${field}`}
                   onClick={() =>
                     handleLandingDisplayChange(
                       field,
                       location,
                       projects,
                       organization,
-                      eventView
+                      eventView,
+                      setLocalLandingDisplay
                     )
                   }
                 >

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -139,8 +139,7 @@ export function handleLandingDisplayChange(
   location: Location,
   projects: Project[],
   organization: Organization,
-  eventView?: EventView,
-  setLandingDisplay?: (field: LandingDisplay) => void
+  eventView?: EventView
 ) {
   // Transaction op can affect the display and show no results if it is explicitly set.
   const query = decodeScalar(location.query.query, '');
@@ -171,10 +170,6 @@ export function handleLandingDisplayChange(
     is_default: defaultDisplay === currentDisplay,
   });
 
-  const display = LANDING_DISPLAYS.find(({field: f}) => f === field);
-  if (setLandingDisplay && display) {
-    setLandingDisplay(display);
-  }
   browserHistory.push({
     pathname: location.pathname,
     query: newQuery,

--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -11,7 +11,7 @@ import {BasePerformanceViewProps} from './types';
 export function AllTransactionsView(props: BasePerformanceViewProps) {
   return (
     <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
-      <div>
+      <div data-test-id="all-transactions-view">
         <TripleChartRow
           {...props}
           allowedCharts={[

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -23,21 +23,22 @@ export function initializeData(settings?: {
     project: _defaultProject,
     ...settings,
   };
-  const {query, features} = _settings;
-
-  const projects = [TestStubs.Project()];
-  const [project] = projects;
+  const {query, features, projects, project} = _settings;
 
   const organization = TestStubs.Organization({
     features,
     projects,
   });
-  const router = {
-    location: {
-      query: {
-        ...query,
-      },
+  const routerLocation: {query: {project?: number}} = {
+    query: {
+      ...query,
     },
+  };
+  if (settings?.project) {
+    routerLocation.query.project = project;
+  }
+  const router = {
+    location: routerLocation,
   };
   const initialData = initializeOrg({organization, projects, project, router});
   const location = initialData.router.location;

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -191,4 +191,51 @@ describe('Performance > Landing > Index', function () {
     expect(titles.at(3).text()).toEqual('Most Related Errors');
     expect(titles.at(4).text()).toEqual('Most Related Issues');
   });
+
+  it('Can switch between landing displays', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.FRONTEND_PAGELOAD},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="frontend-pageload-view"]').exists()).toBe(
+      true
+    );
+
+    wrapper.find('a[data-test-id="landing-tab-all"]').simulate('click');
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="all-transactions-view"]').exists()).toBe(true);
+  });
+
+  it('Updating projects switches performance view', async function () {
+    const data = initializeData({
+      query: {landingDisplay: LandingDisplayField.FRONTEND_PAGELOAD},
+    });
+
+    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="frontend-pageload-view"]').exists()).toBe(
+      true
+    );
+
+    const updatedData = initializeData({
+      query: {landingDisplay: LandingDisplayField.FRONTEND_PAGELOAD},
+      project: -1 as any,
+    });
+
+    wrapper.setProps({
+      data: updatedData,
+    } as any);
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.find('div[data-test-id="all-transactions-view"]').exists()).toBe(true);
+  });
 });

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -197,7 +197,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.FRONTEND_PAGELOAD},
     });
 
-    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
     await tick();
     wrapper.update();
 
@@ -217,7 +217,7 @@ describe('Performance > Landing > Index', function () {
       query: {landingDisplay: LandingDisplayField.FRONTEND_PAGELOAD},
     });
 
-    const wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
+    wrapper = mountWithTheme(<WrappedComponent data={data} />, data.routerContext);
     await tick();
     wrapper.update();
 


### PR DESCRIPTION
### Summary
The 'stickiness' of specific views is confusing when switching projects. This change will cause switching projects to automatically go to the preferred performance view instead of retaining the previous one. We originally were going to keep 'All Transactions' sticky between project switches, but it would be an edge case that would likely be confusing for users.