### PR TITLE
fix(trace-navigator): No overflow hidden on meta data headers

### DIFF
--- a/static/app/views/performance/transactionDetails/styles.tsx
+++ b/static/app/views/performance/transactionDetails/styles.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import FeatureBadge from 'sentry/components/featureBadge';
 import QuestionTooltip from 'sentry/components/questionTooltip';
-import overflowEllipsis from 'sentry/styles/overflowEllipsis';
 import space from 'sentry/styles/space';
 
 type MetaDataProps = {
@@ -52,7 +51,6 @@ const SectionBody = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
   padding: ${space(0.5)} 0;
   max-height: 32px;
-  ${overflowEllipsis};
 `;
 
 const StyledFeatureBadge = styled(FeatureBadge)`


### PR DESCRIPTION
The `overflowEllipsis` style introduced `overflow: hidden` which caused the
dropdown in the trace navigator to be hidden.