### PR TITLE
Continue self-hosted rename in build-related files

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -6,7 +6,7 @@ statusProvider:
   name: github
   config:
     contexts:
-      - 'onpremise-builder (sentryio)'
+      - 'self-hosted-builder (sentryio)'
 artifactProvider:
   name: gcs
   config:

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -33,23 +33,23 @@ steps:
       ]
     timeout: 300s
   - name: 'gcr.io/$PROJECT_ID/docker-compose'
-    id: get-onpremise-repo
+    id: get-self-hosted-repo
     waitFor: ['-']
     entrypoint: 'bash'
     args:
       - '-e'
       - '-c'
       - |
-        mkdir onpremise && cd onpremise
-        curl -L "https://github.com/getsentry/onpremise/archive/master.tar.gz" | tar xzf - --strip-components=1
+        mkdir self-hosted && cd self-hosted
+        curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
   - name: 'gcr.io/$PROJECT_ID/docker-compose'
     id: e2e-test
     waitFor:
       - runtime-image
-      - get-onpremise-repo
+      - get-self-hosted-repo
     entrypoint: 'bash'
-    dir: onpremise
+    dir: self-hosted
     args:
       - '-e'
       - '-c'


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/30482, part of https://github.com/getsentry/self-hosted/issues/796.

### Review

- [x] I need to look into the `.craft.yml` setting to make sure it's fine to change - [thread](https://github.com/getsentry/sentry/pull/30483#discussion_r764391302)
- [x] Pretty sure the `cloudbuild.yml` changes are fine.
- [x] What's up with the newsletter thing? Does anyone actually consume that? Bit of a sidecar here but didn't seem worth a separate PR and not really related better to anything else.—Dead code. Removing [separately](https://github.com/getsentry/sentry/pull/30486).

### Todo

- [x] Rename [GCB triggers](https://console.cloud.google.com/cloud-build/triggers?project=sentryio) when this lands (see [this thread](https://github.com/getsentry/sentry/pull/30483#discussion_r764391302))