### PR TITLE
feat(team_stats): Link to releases list for the projects in the number of releases

### DIFF
--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -318,9 +318,7 @@ function TeamInsightsOverview({location, router}: Props) {
             </DescriptionCard>
             <DescriptionCard
               title={t('Number of Releases')}
-              description={t(
-                'A breakdown showing how your team shipped releases over time.'
-              )}
+              description={t("The releases that were created in your team's projects.")}
             >
               <TeamReleases
                 projects={projects}

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -245,7 +245,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
         <StyledPanelTable
           isEmpty={projects.length === 0}
           headers={[
-            t('Project'),
+            t('Releases Per Project'),
             <RightAligned key="last">
               {tct('Last [period] Average', {period})}
             </RightAligned>,
@@ -256,7 +256,14 @@ class TeamReleases extends AsyncComponent<Props, State> {
           {groupedProjects.map(({project}) => (
             <Fragment key={project.id}>
               <ProjectBadgeContainer>
-                <ProjectBadge avatarSize={18} project={project} />
+                <ProjectBadge
+                  avatarSize={18}
+                  project={project}
+                  to={{
+                    pathname: `/organizations/${organization.slug}/releases/`,
+                    query: {project: project.id},
+                  }}
+                />
               </ProjectBadgeContainer>
 
               <ScoreWrapper>{this.renderReleaseCount(project.id, 'period')}</ScoreWrapper>


### PR DESCRIPTION
This links project badges in the `Number of Releases` table in the `Team Stats` page to the release list filtered by project. Also updated the table title and description based on design.

Before:
<img width="820" alt="Screen Shot 2021-12-07 at 2 14 10 PM" src="https://user-images.githubusercontent.com/15015880/145114355-b9994d10-6b4e-4990-941e-60cda4dba106.png">

After:
<img width="820" alt="Screen Shot 2021-12-07 at 2 13 22 PM" src="https://user-images.githubusercontent.com/15015880/145114371-b2a640af-d224-4f4a-95c4-9d70bad474f2.png">

