### PR TITLE
fix(ui): Use onPointer{Enter,Leave} for tooltips

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -129,7 +129,7 @@ class BaseButton extends React.Component<ButtonProps, {}> {
     // Doing this instead of using `Tooltip`'s `disabled` prop so that we can minimize snapshot nesting
     if (title) {
       return (
-        <Tooltip skipWrapper={!disabled} {...tooltipProps} title={title}>
+        <Tooltip skipWrapper {...tooltipProps} title={title}>
           {button}
         </Tooltip>
       );

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -203,8 +203,8 @@ class Tooltip extends React.Component<Props, State> {
       'aria-describedby': this.tooltipId,
       onFocus: this.handleOpen,
       onBlur: this.handleClose,
-      onMouseEnter: this.handleOpen,
-      onMouseLeave: this.handleClose,
+      onPointerEnter: this.handleOpen,
+      onPointerLeave: this.handleClose,
     };
 
     // Use the `type` property of the react instance to detect whether we

--- a/tests/js/spec/components/tooltip.spec.jsx
+++ b/tests/js/spec/components/tooltip.spec.jsx
@@ -23,13 +23,13 @@ describe('Tooltip', function () {
     wrapper.setProps({title: 'bar'});
     wrapper.update();
     const trigger = wrapper.find('span');
-    trigger.simulate('mouseEnter');
+    trigger.simulate('pointerEnter');
 
     const tooltip = document.querySelector('#tooltip-portal .tooltip-content');
     // Check the text node.
     expect(tooltip.childNodes[0].nodeValue).toEqual('bar');
 
-    trigger.simulate('mouseLeave');
+    trigger.simulate('pointerLeave');
 
     // XXX(epurkhiser): AnimatePresence will remove the element, but for
     // testing it's easier to just remove it
@@ -44,12 +44,12 @@ describe('Tooltip', function () {
       TestStubs.routerContext()
     );
     const trigger = wrapper.find('span');
-    trigger.simulate('mouseEnter');
+    trigger.simulate('pointerEnter');
 
     const tooltip = document.querySelector('#tooltip-portal .tooltip-content');
     expect(tooltip).toBeFalsy();
 
-    trigger.simulate('mouseLeave');
+    trigger.simulate('pointerLeave');
   });
 
   it('does not render an empty tooltip', function () {
@@ -60,10 +60,10 @@ describe('Tooltip', function () {
       TestStubs.routerContext()
     );
     const trigger = wrapper.find('span');
-    trigger.simulate('mouseEnter');
+    trigger.simulate('pointerEnter');
 
     expect(wrapper.find('TooltipContent')).toHaveLength(0);
 
-    trigger.simulate('mouseLeave');
+    trigger.simulate('pointerLeave');
   });
 });


### PR DESCRIPTION
This allows us to receive pointer events when buttons are disabled,
which do not emit `onMouse*` events typically.

Support for this is pretty good.

https://caniuse.com/mdn-api_globaleventhandlers_onpointerenter