### PR TITLE
fix(ui): team selector and table item alignment

### DIFF
--- a/static/app/components/events/errors.tsx
+++ b/static/app/components/events/errors.tsx
@@ -211,6 +211,7 @@ const linkStyle = ({theme}: {theme: Theme}) => css`
 
 const StyledButton = styled(Button)`
   ${linkStyle}
+  align-self: center;
 `;
 
 const StyledBanner = styled(BannerContainer)`

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -196,6 +196,8 @@ export const GridBodyCell = styled('td')`
 
   background-color: ${p => p.theme.background};
   border-top: 1px solid ${p => p.theme.innerBorder};
+  display: flex;
+  align-items: center;
 
   font-size: ${p => p.theme.fontSizeMedium};
 

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -80,17 +80,17 @@ const GroupReleaseStats = ({
           <SidebarSection
             secondary
             title={
-              <span>
+              <Fragment>
                 {t('Last seen')}
                 <TooltipWrapper>
                   <Tooltip
                     title={t('When the most recent event in this issue was captured.')}
                     disableForVisualTest
                   >
-                    <StyledIconQuest size="xs" color="gray200" />
+                    <IconQuestion size="xs" color="gray200" />
                   </Tooltip>
                 </TooltipWrapper>
-              </span>
+              </Fragment>
             }
           >
             <SeenInfo
@@ -112,17 +112,17 @@ const GroupReleaseStats = ({
           <SidebarSection
             secondary
             title={
-              <span>
+              <Fragment>
                 {t('First seen')}
                 <TooltipWrapper>
                   <Tooltip
                     title={t('When the first event in this issue was captured.')}
                     disableForVisualTest
                   >
-                    <StyledIconQuest size="xs" color="gray200" />
+                    <IconQuestion size="xs" color="gray200" />
                   </Tooltip>
                 </TooltipWrapper>
-              </span>
+              </Fragment>
             }
           >
             <SeenInfo
@@ -156,9 +156,4 @@ export default memo(GroupReleaseStats);
 
 const TooltipWrapper = styled('span')`
   margin-left: ${space(0.5)};
-`;
-
-const StyledIconQuest = styled(IconQuestion)`
-  position: relative;
-  top: 2px;
 `;

--- a/static/app/components/group/sidebarSection.tsx
+++ b/static/app/components/group/sidebarSection.tsx
@@ -8,6 +8,7 @@ const Heading = styled('h5')`
   align-items: center;
   margin-bottom: ${space(2)};
   font-size: ${p => p.theme.fontSizeMedium};
+  line-height: 1;
 
   &:after {
     flex: 1;
@@ -23,7 +24,6 @@ const Subheading = styled('h6')`
   display: flex;
   font-size: ${p => p.theme.fontSizeExtraSmall};
   text-transform: uppercase;
-  justify-content: space-between;
   margin-bottom: ${space(1)};
 `;
 

--- a/static/app/components/group/suggestedOwners/ownershipRules.tsx
+++ b/static/app/components/group/suggestedOwners/ownershipRules.tsx
@@ -130,7 +130,7 @@ const OwnershipRules = ({
                   align-items: center;
                 `}
               >
-                <StyledIconQuestion size="xs" />
+                <StyledIconQuestion size="xs" color="gray200" />
               </Hovercard>
             )}
           </ClassNames>

--- a/static/app/components/idBadge/baseBadge.tsx
+++ b/static/app/components/idBadge/baseBadge.tsx
@@ -79,7 +79,7 @@ const DisplayNameAndDescription = styled('div')`
 const DisplayName = styled('span')`
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 1.2;
+  line-height: 1;
 `;
 
 const Description = styled('div')`

--- a/static/app/components/performance/teamKeyTransaction.tsx
+++ b/static/app/components/performance/teamKeyTransaction.tsx
@@ -298,6 +298,11 @@ function TeamKeyTransactionItem({team, isKeyed, disabled, onSelect}: ItemProps) 
 
 const StarWrapper = styled('div')`
   display: flex;
+
+  /* Fixes Star when it’s filled and is wrapped around Tooltip */
+  & > span {
+    display: flex;
+  }
 `;
 
 const DropdownWrapper = styled('div')`

--- a/static/app/components/performance/teamKeyTransaction.tsx
+++ b/static/app/components/performance/teamKeyTransaction.tsx
@@ -248,7 +248,7 @@ class TeamKeyTransaction extends Component<Props, State> {
       <Manager>
         <Reference>
           {({ref}) => (
-            <div ref={ref}>
+            <StarWrapper ref={ref}>
               <Title
                 isOpen={isOpen}
                 disabled={isLoading || Boolean(error)}
@@ -258,7 +258,7 @@ class TeamKeyTransaction extends Component<Props, State> {
                 initialValue={initialValue}
                 onClick={this.toggleOpen}
               />
-            </div>
+            </StarWrapper>
           )}
         </Reference>
         {menu}
@@ -295,6 +295,10 @@ function TeamKeyTransactionItem({team, isKeyed, disabled, onSelect}: ItemProps) 
     </DropdownMenuItem>
   );
 }
+
+const StarWrapper = styled('div')`
+  display: flex;
+`;
 
 const DropdownWrapper = styled('div')`
   /* Adapted from the dropdown-menu class */

--- a/static/app/components/performance/waterfall/row.tsx
+++ b/static/app/components/performance/waterfall/row.tsx
@@ -57,4 +57,6 @@ export const RowCell = styled('div')<RowCellProps>`
   background-color: ${p => getBackgroundColor(p)};
   transition: background-color 125ms ease-in-out;
   color: ${p => (p.showDetail ? p.theme.background : 'inherit')};
+  display: flex;
+  align-items: center;
 `;

--- a/static/app/components/performance/waterfall/rowBar.tsx
+++ b/static/app/components/performance/waterfall/rowBar.tsx
@@ -10,7 +10,6 @@ import {
 export const RowRectangle = styled('div')<{spanBarHatch: boolean}>`
   position: absolute;
   height: ${ROW_HEIGHT - 2 * ROW_PADDING}px;
-  top: ${ROW_PADDING}px;
   left: 0;
   min-width: 1px;
   user-select: none;

--- a/static/app/components/performance/waterfall/rowBar.tsx
+++ b/static/app/components/performance/waterfall/rowBar.tsx
@@ -31,6 +31,7 @@ export const DurationPill = styled('div')<{
   font-size: ${p => p.theme.fontSizeExtraSmall};
   color: ${p => (p.showDetail === true ? p.theme.gray200 : p.theme.gray300)};
   font-variant-numeric: tabular-nums;
+  line-height: 1;
 
   ${getDurationPillAlignment}
 

--- a/static/app/components/seenByList.tsx
+++ b/static/app/components/seenByList.tsx
@@ -79,11 +79,12 @@ const SeenByWrapper = styled('div')<{iconPosition: Props['iconPosition']}>`
 `;
 
 const IconWrapper = styled('div')<{iconPosition: Props['iconPosition']}>`
+  display: flex;
+  align-items: center;
   background-color: transparent;
   color: ${p => p.theme.textColor};
   height: 28px;
   width: 24px;
-  line-height: 26px;
   text-align: center;
   padding-top: ${space(0.5)};
   ${p => (p.iconPosition === 'left' ? 'margin-right: 10px' : '')};

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -316,6 +316,7 @@ const Container = styled('span')<{
 }>`
   ${p => p.containerDisplayMode && `display: ${p.containerDisplayMode}`};
   max-width: 100%;
+  width: 100%;
   display: flex;
 `;
 

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -316,8 +316,6 @@ const Container = styled('span')<{
 }>`
   ${p => p.containerDisplayMode && `display: ${p.containerDisplayMode}`};
   max-width: 100%;
-  width: 100%;
-  display: flex;
 `;
 
 const PositionWrapper = styled('div')`

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -316,6 +316,7 @@ const Container = styled('span')<{
 }>`
   ${p => p.containerDisplayMode && `display: ${p.containerDisplayMode}`};
   max-width: 100%;
+  display: flex;
 `;
 
 const PositionWrapper = styled('div')`

--- a/static/app/utils/discover/styles.tsx
+++ b/static/app/utils/discover/styles.tsx
@@ -46,6 +46,8 @@ export const BarContainer = styled('div')`
 export const FlexContainer = styled('div')`
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  width: 100%;
 `;
 
 export const UserIcon = styled(IconUser)`

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -448,6 +448,8 @@ const Container = styled('div')`
   position: relative;
   width: 100%;
   height: 100%;
+  display: flex;
+  align-items: center;
 `;
 
 const MenuRoot = styled('div')`

--- a/static/app/views/organizationStats/teamInsights/overview.tsx
+++ b/static/app/views/organizationStats/teamInsights/overview.tsx
@@ -350,7 +350,7 @@ const Body = styled(Layout.Body)`
 const ControlsWrapper = styled('div')`
   display: grid;
   align-items: center;
-  gap: ${space(1)};
+  gap: ${space(2)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {

--- a/static/app/views/performance/styles.tsx
+++ b/static/app/views/performance/styles.tsx
@@ -9,6 +9,7 @@ export const GridCell = styled('div')`
 export const GridCellNumber = styled(GridCell)`
   text-align: right;
   font-variant-numeric: tabular-nums;
+  flex-grow: 1;
 `;
 
 export const DoubleHeaderContainer = styled('div')`

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -193,7 +193,11 @@ class _Table extends React.Component<Props, State> {
           handleCellAction={this.handleCellAction(column, dataRow)}
           allowActions={allowActions}
         >
-          <Link to={target} onClick={this.handleSummaryClick}>
+          <Link
+            to={target}
+            onClick={this.handleSummaryClick}
+            style={{display: `block`, width: `100%`}}
+          >
             {rendered}
           </Link>
         </CellAction>

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -542,6 +542,7 @@ function TagsHeader(props: HeaderProps) {
 const AlignRight = styled('div')`
   text-align: right;
   font-variant-numeric: tabular-nums;
+  width: 100%;
 `;
 
 const Header = styled('div')`

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -185,19 +185,21 @@ export class TagValueTable extends Component<Props, State> {
       const searchConditions = new MutableSearch(eventView.query);
       const disabled = searchConditions.hasFilter(dataRow.tags_key);
       return (
-        <Link
-          disabled={disabled}
-          to=""
-          onClick={() => {
-            trackTagPageInteraction(organization);
-            this.handleTagValueClick(location, dataRow.tags_key, dataRow.tags_value);
-          }}
-        >
-          <LinkContainer>
-            <IconAdd isCircled />
-            {t('Add to filter')}
-          </LinkContainer>
-        </Link>
+        <AlignRight>
+          <Link
+            disabled={disabled}
+            to=""
+            onClick={() => {
+              trackTagPageInteraction(organization);
+              this.handleTagValueClick(location, dataRow.tags_key, dataRow.tags_value);
+            }}
+          >
+            <LinkContainer>
+              <IconAdd isCircled />
+              {t('Add to filter')}
+            </LinkContainer>
+          </Link>
+        </AlignRight>
       );
     }
 
@@ -304,6 +306,7 @@ const StyledPanelTable = styled('div')`
 
 const AlignRight = styled('div')`
   text-align: right;
+  flex: 1;
 `;
 
 const LinkContainer = styled('div')`

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -413,6 +413,8 @@ class Table extends React.Component<Props, State> {
 
 const UniqueTagCell = styled('div')`
   text-align: right;
+  justify-self: flex-end;
+  flex-grow: 1;
 `;
 
 const GoodTag = styled(Tag)`


### PR DESCRIPTION
1. Fixed wacky text alignment/padding of Team Selector on Team Stats page
2. Made spacing between Team Selector + Date Range input more consistent with other pages
3. Fixing the Team selector alignment revealed a bug on the Discover table where items were misaligned. This PR also fixes that.

## Before 

<img width="983" alt="CleanShot 2021-12-07 at 17 27 35@2x" src="https://user-images.githubusercontent.com/1900676/145132170-8b85a506-18e3-434d-9e9d-4ef0c2b0db44.png">


## After
<img width="988" alt="CleanShot 2021-12-07 at 17 27 04@2x" src="https://user-images.githubusercontent.com/1900676/145132176-7375ead5-4cec-4826-9040-d1773bc46153.png">


## Before
![Group 1849](https://user-images.githubusercontent.com/1900676/145270521-269efca2-c7bd-49ac-959f-fc7ca9724178.png)

## After
![after29486](https://user-images.githubusercontent.com/1900676/145270558-cc422dcb-9d28-4f19-9674-16d17dce6b1e.png)

