### PR TITLE
Relax jest test timeout

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -62,7 +62,7 @@ jobs:
           CI_NODE_TOTAL: 2
           CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
-          JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
+          JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit --testTimeout=10000
 
       - name: Save HTML artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This is a bandaid to get `master` back to green ASAP (https://github.com/getsentry/sentry/issues/30500). Really [these tests](https://github.com/getsentry/sentry/issues/30500#issuecomment-988931886) should not be taking this long. Here are local runs for comparison:

```
 PASS  tests/js/spec/views/dashboardsV2/detail.spec.jsx (7.255 s)
  Dashboards > Detail
    prebuilt dashboards
      ✓ can delete (334 ms)
      ✓ can rename and save (132 ms)
      ✓ disables buttons based on features (45 ms)
    custom dashboards
      ✓ can remove widgets (278 ms)
      ✓ can enter edit mode for widgets (660 ms) <------------------------------------- vs. 5000+
      ✓ does not update if api update fails (252 ms)
      ✓ shows add wiget option (426 ms)
      ✓ hides add widget option (227 ms)
      ✓ hides and shows breadcrumbs based on feature (271 ms)
      ✓ enters edit mode when given a new widget in location query (113 ms)
      ✓ enters view mode when not given a new widget in location query (107 ms)
      ✓ can add library widgets (309 ms)
      ✓ disables add library widgets when max widgets reached (73 ms)
      ✓ adds an Issue widget to the dashboard (416 ms)

```

```
 PASS  tests/js/spec/views/alerts/create.spec.jsx (9.255 s)
  ProjectAlertsCreate
    ✓ redirects to wizard (439 ms)
    Issue Alert
      ✓ loads default values (111 ms)
      ✓ can remove filters, conditions and actions (1615 ms) <------------------------- vs. 5000+
      ✓ updates values and saves (1403 ms)
```