### PR TITLE
ref(ui): Add profiler to jest tests

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -15,7 +15,10 @@ export function onRenderCallback(
   try {
     const transaction = getCurrentSentryReactTransaction();
     if (transaction && actualDuration > MIN_UPDATE_SPAN_TIME) {
-      const now = timestampWithMs();
+      // Switch now if code is being run with a mocked date (eg. test environment)
+      const now = (Date as any)._realDate
+        ? (Date as any)._realDate.now()
+        : timestampWithMs();
       transaction.startChild({
         description: `<${id}>`,
         op: `ui.react.${phase}`,

--- a/tests/js/sentry-test/enzyme.js
+++ b/tests/js/sentry-test/enzyme.js
@@ -1,9 +1,11 @@
+import {Profiler} from 'react';
 import {cache} from '@emotion/css'; // eslint-disable-line emotion/no-vanilla
 import {CacheProvider, ThemeProvider} from '@emotion/react';
 import {mount, shallow as enzymeShallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 
 import {act} from 'sentry-test/reactTestingLibrary';
 
+import {onRenderCallback} from 'sentry/utils/performanceForSentry';
 import {lightTheme} from 'sentry/utils/theme';
 
 /**
@@ -13,9 +15,11 @@ import {lightTheme} from 'sentry/utils/theme';
  */
 export function mountWithTheme(tree, opts) {
   const WrappingThemeProvider = props => (
-    <CacheProvider value={cache}>
-      <ThemeProvider theme={lightTheme}>{props.children}</ThemeProvider>
-    </CacheProvider>
+    <Profiler id="enzyme-root" onRender={onRenderCallback}>
+      <CacheProvider value={cache}>
+        <ThemeProvider theme={lightTheme}>{props.children}</ThemeProvider>
+      </CacheProvider>
+    </Profiler>
   );
 
   return mount(tree, {wrappingComponent: WrappingThemeProvider, ...opts});

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Component, Fragment, Profiler} from 'react';
 import {cache} from '@emotion/css';
 import {CacheProvider, ThemeProvider} from '@emotion/react';
 import {
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 
 import GlobalModal from 'sentry/components/globalModal';
 import {Organization} from 'sentry/types';
+import {onRenderCallback} from 'sentry/utils/performanceForSentry';
 import {lightTheme} from 'sentry/utils/theme';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
@@ -37,19 +38,21 @@ function makeAllTheProviders({context, organization}: ProviderOptions) {
     const ContextProvider = context ? createProvider(context) : Fragment;
 
     return (
-      <ContextProvider>
-        <CacheProvider value={cache}>
-          <ThemeProvider theme={lightTheme}>
-            {organization ? (
-              <OrganizationContext.Provider value={organization}>
-                {children}
-              </OrganizationContext.Provider>
-            ) : (
-              children
-            )}
-          </ThemeProvider>
-        </CacheProvider>
-      </ContextProvider>
+      <Profiler id="rtl-root" onRender={onRenderCallback}>
+        <ContextProvider>
+          <CacheProvider value={cache}>
+            <ThemeProvider theme={lightTheme}>
+              {organization ? (
+                <OrganizationContext.Provider value={organization}>
+                  {children}
+                </OrganizationContext.Provider>
+              ) : (
+                children
+              )}
+            </ThemeProvider>
+          </CacheProvider>
+        </ContextProvider>
+      </Profiler>
     );
   };
 }

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -44,7 +44,9 @@ Enzyme.configure({adapter: new Adapter()});
  * 2017-10-17T02:41:20.000Z
  */
 const constantDate = new Date(1508208080000);
+const RealDate = Date;
 MockDate.set(constantDate);
+(MockDate as any)._realDate = RealDate; // Expose the real date object for external uses (eg. test performance)
 
 /**
  * Load all files in `tests/js/fixtures/*` as a module.


### PR DESCRIPTION
### Summary
This adds a profiler wrapper around our jest tests (both RTL and enzyme) to potentially capture long renders inside our tests. This might help when debugging idleTimeout problems, or just generally understanding test performance.

This is mostly an RFC since I haven't confirmed the created span makes it into our test transactions, but it should be low friction to just try it.