### PR TITLE
fix(integrations): bug returning multiple results in query

### DIFF
--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -106,13 +106,14 @@ def get_channel_and_integration_by_team(
                 organization=organization,
                 integration__status=ObjectStatus.ACTIVE,
                 integration__organizationintegration__status=ObjectStatus.ACTIVE,
+                # limit to org here to prevent multiple query results
+                integration__organizationintegration__organization=organization,
             )
             .select_related("integration")
             .get()
         )
     except ExternalActor.DoesNotExist:
         return {}
-
     return {external_actor.external_id: external_actor.integration}
 
 

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -237,6 +237,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_disabled_org_integration_for_team(self, mock_func):
+
         # update the team's notification settings
         ExternalActor.objects.create(
             actor=self.team.actor,
@@ -403,6 +404,9 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_issue_alert_team(self, mock_func):
         """Test that issue alerts are sent to a team in Slack."""
+        # add a second organization
+        org = self.create_organization(owner=self.user)
+        OrganizationIntegration.objects.create(organization=org, integration=self.integration)
 
         # add a second user to the team so we can be sure it's only
         # sent once (to the team, and not to each individual user)


### PR DESCRIPTION
Need to scope the join on `integration_integrationorganization` to just the organization for the query so we don't get results for other organizations. Fixes SENTRY-SWT