### PR TITLE
fix(auth): redirect superuser correctly on org with 2fa requirement

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -7,7 +7,7 @@ from sentry.api.exceptions import (
     TwoFactorRequired,
 )
 from sentry.auth import access
-from sentry.auth.superuser import is_active_superuser
+from sentry.auth.superuser import Superuser, is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.utils import auth
 
@@ -111,6 +111,9 @@ class SentryPermission(ScopedPermission):
                         "access.not-2fa-compliant",
                         extra=extra,
                     )
+                    if request.user.is_superuser and organization.id != Superuser.org_id:
+                        raise SuperuserRequired()
+
                     raise TwoFactorRequired()
 
                 if self.is_member_disabled_from_limit(request, organization):


### PR DESCRIPTION
### Problem
If a superuser tried to access an org that had a 2fa requirement and they weren't currently superuser-active, we'd send them a "require 2fa" error, which would cause the page to fail to load.

### Solution
If the superuser isn't active and they get this error while trying to access an org that isn't the superuser org, raise a Superuser required error instead of a twofactor required error. This will correctly pull up the superuser modal. (There is still one more fix needed on the frontend for the superuser modal to reload the page correctly)
