### PR TITLE
fix(sentryapps): Properly check if the current session is a superuser

### DIFF
--- a/src/sentry/api/endpoints/sentry_apps.py
+++ b/src/sentry/api/endpoints/sentry_apps.py
@@ -63,7 +63,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
             "overview": request.json_body.get("overview"),
             "allowedOrigins": request.json_body.get("allowedOrigins", []),
             "popularity": request.json_body.get("popularity")
-            if request.user.is_superuser
+            if is_active_superuser(request)
             else None,
         }
 


### PR DESCRIPTION
I mistakenly checked if the user has the `is_superuser` attribute instead of whether or not their session was that of a superuser.