### PR TITLE
feat(teamStats): Add team oldest groups endpoint (WOR-1524)

### DIFF
--- a/src/sentry/api/endpoints/team_groups_old.py
+++ b/src/sentry/api/endpoints/team_groups_old.py
@@ -1,0 +1,35 @@
+from rest_framework.response import Response
+
+from sentry.api.base import EnvironmentMixin
+from sentry.api.bases.team import TeamEndpoint
+from sentry.api.serializers import GroupSerializer, serialize
+from sentry.models import Group, GroupStatus, Project
+
+
+class TeamGroupsOldEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
+    def get(self, request, team) -> Response:
+        """
+        Return the oldest issues in a team's projects
+        """
+        project_list = Project.objects.get_for_team_ids([team.id])
+        limit = min(100, int(request.GET.get("limit", 10)))
+
+        group_list = list(
+            Group.objects.filter(
+                status=GroupStatus.UNRESOLVED,
+                project__in=project_list,
+            )
+            .extra(select={"sort_by": "sentry_groupedmessage.first_seen"})
+            .select_related("project")
+            .order_by("sort_by")[:limit]
+        )
+
+        return Response(
+            serialize(
+                group_list,
+                request.user,
+                GroupSerializer(
+                    environment_func=self._get_environment_func(request, team.organization_id)
+                ),
+            )
+        )

--- a/src/sentry/api/endpoints/team_groups_old.py
+++ b/src/sentry/api/endpoints/team_groups_old.py
@@ -9,7 +9,7 @@ from sentry.models import Group, GroupStatus
 class TeamGroupsOldEndpoint(TeamEndpoint, EnvironmentMixin):  # type: ignore
     def get(self, request, team) -> Response:
         """
-        Return the oldest issues in a team's projects
+        Return the oldest issues owned by a team
         """
         limit = min(100, int(request.GET.get("limit", 10)))
         group_list = list(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1520,7 +1520,7 @@ urlpatterns = [
                     name="sentry-api-0-team-details",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/(?:issues|groups)/old/$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/issues/old/$",
                     TeamGroupsOldEndpoint.as_view(),
                     name="sentry-api-0-team-oldest-issues",
                 ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -400,6 +400,7 @@ from .endpoints.system_options import SystemOptionsEndpoint
 from .endpoints.team_alerts_triggered import TeamAlertsTriggeredEndpoint
 from .endpoints.team_avatar import TeamAvatarEndpoint
 from .endpoints.team_details import TeamDetailsEndpoint
+from .endpoints.team_groups_old import TeamGroupsOldEndpoint
 from .endpoints.team_issue_breakdown import TeamIssueBreakdownEndpoint
 from .endpoints.team_members import TeamMembersEndpoint
 from .endpoints.team_notification_settings_details import TeamNotificationSettingsDetailsEndpoint
@@ -1517,6 +1518,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/$",
                     TeamDetailsEndpoint.as_view(),
                     name="sentry-api-0-team-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/(?:issues|groups)/old/$",
+                    TeamGroupsOldEndpoint.as_view(),
+                    name="sentry-api-0-team-oldest-issues",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/release-count/$",

--- a/tests/sentry/api/endpoints/test_team_groups_old.py
+++ b/tests/sentry/api/endpoints/test_team_groups_old.py
@@ -2,10 +2,13 @@ from datetime import datetime
 
 from django.utils import timezone
 
+from sentry.models import GroupAssignee, GroupStatus
 from sentry.testutils import APITestCase
 
 
 class TeamGroupsOldTest(APITestCase):
+    endpoint = "sentry-api-0-team-oldest-issues"
+
     def test_simple(self):
         project1 = self.create_project(teams=[self.team], slug="foo")
         project2 = self.create_project(teams=[self.team], slug="bar")
@@ -19,11 +22,24 @@ class TeamGroupsOldTest(APITestCase):
             project=project2,
             first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
         )
+        resolved_group = self.create_group(project=project2, status=GroupStatus.RESOLVED)
+        GroupAssignee.objects.assign(group1, self.user)
+        GroupAssignee.objects.assign(group2, self.user)
+        GroupAssignee.objects.assign(resolved_group, self.user)
+
+        other_user = self.create_user()
+        assigned_to_other = self.create_group(
+            checksum="b" * 32,
+            project=project2,
+            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+        )
+        GroupAssignee.objects.assign(assigned_to_other, other_user)
+        self.create_group(
+            checksum="b" * 32,
+            project=project2,
+            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+        )
 
         self.login_as(user=self.user)
-        url = f"/api/0/teams/{self.team.organization.slug}/{self.team.slug}/issues/old/"
-        response = self.client.get(url, format="json")
-        assert response.status_code == 200
-        assert len(response.data) == 2
-        assert response.data[0]["id"] == str(group2.id)
-        assert response.data[1]["id"] == str(group1.id)
+        response = self.get_success_response(self.organization.slug, self.team.slug)
+        assert [group["id"] for group in response.data] == [str(group2.id), str(group1.id)]

--- a/tests/sentry/api/endpoints/test_team_groups_old.py
+++ b/tests/sentry/api/endpoints/test_team_groups_old.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+
+from django.utils import timezone
+
+from sentry.testutils import APITestCase
+
+
+class TeamGroupsOldTest(APITestCase):
+    def test_simple(self):
+        project1 = self.create_project(teams=[self.team], slug="foo")
+        project2 = self.create_project(teams=[self.team], slug="bar")
+        group1 = self.create_group(
+            checksum="a" * 32,
+            project=project1,
+            first_seen=datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+        )
+        group2 = self.create_group(
+            checksum="b" * 32,
+            project=project2,
+            first_seen=datetime(2015, 1, 12, 3, 8, 25, tzinfo=timezone.utc),
+        )
+
+        self.login_as(user=self.user)
+        url = f"/api/0/teams/{self.team.organization.slug}/{self.team.slug}/issues/old/"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == str(group2.id)
+        assert response.data[1]["id"] == str(group1.id)


### PR DESCRIPTION
We'd like to be able to display the oldest groups underneath a histogram of issue ages. This adds an api to get the list of oldest issues