### PR TITLE
Rename onpremise to self-hosted in configs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1921,7 +1921,11 @@ SENTRY_RAW_EVENT_MAX_AGE_DAYS = 10
 STATUS_PAGE_ID = None
 STATUS_PAGE_API_HOST = "statuspage.io"
 
-SENTRY_ONPREMISE = True
+# Downstream (i.e., getsentry) sets SENTRY_ONPREMISE, so keep reading from that
+# for now, but in the rest of _this_ codebase we should reference
+# SENTRY_SELF_HOSTED.
+SENTRY_ONPREMISE = True  # deprecated, use ...
+SENTRY_SELF_HOSTED = SENTRY_ONPREMISE  # ... this instead
 
 # Whether we should look at X-Forwarded-For header or not
 # when checking REMOTE_ADDR ip addresses
@@ -2181,7 +2185,7 @@ JS_SDK_LOADER_SDK_VERSION = ""
 # This should be the url pointing to the JS SDK
 JS_SDK_LOADER_DEFAULT_SDK_URL = ""
 
-# block domains which are generally used by spammers -- keep this configurable in case an onpremise
+# block domains which are generally used by spammers -- keep this configurable in case a self-hosted
 # install wants to allow it
 INVALID_EMAIL_ADDRESS_PATTERN = re.compile(r"\@qq\.com$", re.I)
 

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -153,7 +153,8 @@ def get_client_config(request=None):
         "statuspage": _get_statuspage(),
         "messages": [{"message": msg.message, "level": msg.tags} for msg in messages],
         "apmSampling": float(settings.SENTRY_FRONTEND_APM_SAMPLING or 0),
-        "isOnPremise": settings.SENTRY_ONPREMISE,
+        "isOnPremise": settings.SENTRY_SELF_HOSTED,  # deprecated, use ...
+        "isSelfHosted": settings.SENTRY_SELF_HOSTED,  # ... this instead
         "invitesEnabled": settings.SENTRY_ENABLE_INVITES,
         "gravatarBaseUrl": settings.SENTRY_GRAVATAR_BASE_URL,
         "termsUrl": settings.TERMS_URL,

--- a/src/sentry/web/frontend/out.py
+++ b/src/sentry/web/frontend/out.py
@@ -7,7 +7,7 @@ from sentry import options
 
 class OutView(View):
     def get(self, request):
-        if not settings.SENTRY_ONPREMISE:
+        if not settings.SENTRY_SELF_HOSTED:
             raise Http404
 
         install_id = options.get("sentry:install-id")

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -20,7 +20,8 @@ def get_default_context(request, existing_context=None, team=None):
         "URL_PREFIX": options.get("system.url-prefix"),
         "SINGLE_ORGANIZATION": settings.SENTRY_SINGLE_ORGANIZATION,
         "PLUGINS": plugins,
-        "ONPREMISE": settings.SENTRY_ONPREMISE,
+        "ONPREMISE": settings.SENTRY_SELF_HOSTED,  # deprecated, use ...
+        "SELF_HOSTED": settings.SENTRY_SELF_HOSTED,  # ... this instead
     }
 
     if existing_context:

--- a/src/sentry_plugins/sessionstack/plugin.py
+++ b/src/sentry_plugins/sessionstack/plugin.py
@@ -123,7 +123,7 @@ class SessionStackPlugin(CorePluginMixin, Plugin2):
             },
         ]
 
-        if settings.SENTRY_ONPREMISE:
+        if settings.SENTRY_SELF_HOSTED:
             configurations.extend(
                 [
                     {

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -18,7 +18,7 @@ function BaseFooter({className}: Props) {
   return (
     <footer className={className}>
       <LeftLinks>
-        {config.isOnPremise && (
+        {config.isSelfHosted && (
           <Fragment>
             {'Sentry '}
             {getDynamicText({
@@ -47,7 +47,7 @@ function BaseFooter({className}: Props) {
         <FooterLink href="https://github.com/getsentry/sentry">
           {t('Contribute')}
         </FooterLink>
-        {config.isOnPremise && !config.demoMode && (
+        {config.isSelfHosted && !config.demoMode && (
           <FooterLink href="/out/">{t('Migrate to SaaS')}</FooterLink>
         )}
       </RightLinks>

--- a/static/app/plugins/sessionstack/components/settings.tsx
+++ b/static/app/plugins/sessionstack/components/settings.tsx
@@ -7,12 +7,12 @@ import DefaultSettings from 'sentry/plugins/components/settings';
 type Props = DefaultSettings['props'];
 
 type State = DefaultSettings['state'] & {
-  showOnPremisesConfiguration?: boolean;
+  showSelfHostedConfiguration?: boolean;
 };
 
 class Settings extends DefaultSettings<Props, State> {
   REQUIRED_FIELDS = ['account_email', 'api_token', 'website_id'];
-  ON_PREMISES_FIELDS = ['api_url', 'player_url'];
+  SELF_HOSTED_FIELDS = ['api_url', 'player_url'];
 
   renderFields(fields: State['fieldList']) {
     return fields?.map(f =>
@@ -29,9 +29,9 @@ class Settings extends DefaultSettings<Props, State> {
     return fields?.filter(field => fieldNames.includes(field.name)) ?? [];
   }
 
-  toggleOnPremisesConfiguration = () => {
+  toggleSelfHostedConfiguration = () => {
     this.setState({
-      showOnPremisesConfiguration: !this.state.showOnPremisesConfiguration,
+      showSelfHostedConfiguration: !this.state.showSelfHostedConfiguration,
     });
   };
 
@@ -53,9 +53,9 @@ class Settings extends DefaultSettings<Props, State> {
     const hasChanges = !isEqual(this.state.initialData, this.state.formData);
 
     const requiredFields = this.filterFields(this.state.fieldList, this.REQUIRED_FIELDS);
-    const onPremisesFields = this.filterFields(
+    const selfHostedFields = this.filterFields(
       this.state.fieldList,
-      this.ON_PREMISES_FIELDS
+      this.SELF_HOSTED_FIELDS
     );
 
     return (
@@ -68,19 +68,19 @@ class Settings extends DefaultSettings<Props, State> {
           </div>
         )}
         {this.renderFields(requiredFields)}
-        {onPremisesFields.length > 0 ? (
+        {selfHostedFields.length > 0 ? (
           <div className="control-group">
             <button
               className="btn btn-default"
               type="button"
-              onClick={this.toggleOnPremisesConfiguration}
+              onClick={this.toggleSelfHostedConfiguration}
             >
-              Configure on-premises
+              Configure self-hosted
             </button>
           </div>
         ) : null}
-        {this.state.showOnPremisesConfiguration
-          ? this.renderFields(onPremisesFields)
+        {this.state.showSelfHostedConfiguration
+          ? this.renderFields(selfHostedFields)
           : null}
       </Form>
     );

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -121,7 +121,8 @@ export interface Config {
   invitesEnabled: boolean;
   privacyUrl: string | null;
   termsUrl: string | null;
-  isOnPremise: boolean;
+  isOnPremise: boolean; // deprecated, use ...
+  isSelfHosted: boolean; // ... this instead
   lastOrganization: string | null;
   gravatarBaseUrl: string;
 

--- a/static/app/views/alerts/issueRuleEditor/setupAlertIntegrationButton.tsx
+++ b/static/app/views/alerts/issueRuleEditor/setupAlertIntegrationButton.tsx
@@ -55,7 +55,7 @@ export default class SetupAlertIntegrationButton extends AsyncComponent<Props, S
     const config = ConfigStore.getConfig();
     // link to docs to set up Slack for on-prem folks
     const referrerQuery = '?referrer=issue-alert-builder';
-    const buttonProps = config.isOnPremise
+    const buttonProps = config.isSelfHosted
       ? {
           href: `https://develop.sentry.dev/integrations/slack/${referrerQuery}`,
         }

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -67,17 +67,17 @@ class SettingsIndex extends React.Component<Props> {
   render() {
     const {organization} = this.props;
     const user = ConfigStore.get('user');
-    const isOnPremise = ConfigStore.get('isOnPremise');
+    const isSelfHosted = ConfigStore.get('isSelfHosted');
 
     const organizationSettingsUrl =
       (organization && `/settings/${organization.slug}/`) || '';
 
     const supportLinkProps = {
-      isOnPremise,
+      isSelfHosted,
       href: LINKS.FORUM,
       to: `${organizationSettingsUrl}support`,
     };
-    const supportText = isOnPremise ? t('Community Forums') : t('Contact Support');
+    const supportText = isSelfHosted ? t('Community Forums') : t('Contact Support');
 
     return (
       <SentryDocumentTitle
@@ -340,7 +340,7 @@ const ExternalHomeLink = styled(
 `;
 
 type SupportLinkProps<T extends boolean> = {
-  isOnPremise: T;
+  isSelfHosted: T;
   href: string;
   to: string;
   isCentered?: boolean;
@@ -350,12 +350,12 @@ type SupportLinkProps<T extends boolean> = {
 
 const SupportLinkComponent = <T extends boolean>({
   isCentered,
-  isOnPremise,
+  isSelfHosted,
   href,
   to,
   ...props
 }: SupportLinkProps<T>) =>
-  isOnPremise ? (
+  isSelfHosted ? (
     <ExternalHomeLink isCentered={isCentered} href={href} {...props} />
   ) : (
     <HomeLink to={to} {...props} />

--- a/tests/fixtures/js-stubs/config.js
+++ b/tests/fixtures/js-stubs/config.js
@@ -15,7 +15,8 @@ export function Config(params = {}) {
     invitesEnabled: false,
     privacyUrl: null,
     termsUrl: null,
-    isOnPremise: false,
+    isOnPremise: false, // deprecated, use ...
+    isSelfHosted: false, // ... this instead
     lastOrganization: null,
     gravatarBaseUrl: 'https://gravatar.com',
     dsn: 'test-dsn',

--- a/tests/js/spec/views/settings/settingsIndex.spec.jsx
+++ b/tests/js/spec/views/settings/settingsIndex.spec.jsx
@@ -25,8 +25,8 @@ describe('SettingsIndex', function () {
     expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
   });
 
-  it('has different links for on premise users', function () {
-    ConfigStore.set('isOnPremise', true);
+  it('has different links for self-hosted users', function () {
+    ConfigStore.set('isSelfHosted', true);
 
     wrapper = mountWithTheme(
       <SettingsIndex
@@ -62,7 +62,7 @@ describe('SettingsIndex', function () {
       api = MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/`,
       });
-      ConfigStore.config.isOnPremise = false;
+      ConfigStore.config.isSelfHosted = false;
       wrapper = mountWithTheme(
         <SettingsIndex router={TestStubs.router()} params={{}} />,
         TestStubs.routerContext()


### PR DESCRIPTION
Big things to think about here are backcompat for both getsentry and self-hosted users. Customizations? Plugins? FE? BE?