### PR TITLE
fix(performance-metrics): Update transform metrics logic

### DIFF
--- a/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformMetricsToArea.tsx
@@ -35,7 +35,7 @@ export function transformMetricsToArea<T extends WidgetDataConstraint>(
     end: end ?? '',
   };
 
-  if (!response || !responsePrevious) {
+  if (!response) {
     return {
       ...commonChildData,
       hasData: false,
@@ -97,21 +97,21 @@ export function transformMetricsToArea<T extends WidgetDataConstraint>(
   });
 
   const previousGroups = isFailureRateWidget
-    ? responsePrevious.groups.filter(
+    ? responsePrevious?.groups.filter(
         group => !TRANSACTION_SUCCESS_STATUS.includes(group.by['transaction.status'])
       )
-    : responsePrevious.groups;
+    : responsePrevious?.groups;
 
   const previousTotalPerBucket = isFailureRateWidget
-    ? responsePrevious.intervals.map((_intervalValue, intervalIndex) =>
-        responsePrevious.groups.reduce(
+    ? responsePrevious?.intervals.map((_intervalValue, intervalIndex) =>
+        responsePrevious?.groups.reduce(
           (acc, group) => acc + group.series[metricsField][intervalIndex],
           0
         )
       )
     : undefined;
 
-  const previousData = previousGroups.map(group => ({
+  const previousData = previousGroups?.map(group => ({
     seriesName: `previous ${metricsField}`,
     data: response?.intervals.map((intervalValue, intervalIndex) => ({
       name: moment(intervalValue).valueOf(),


### PR DESCRIPTION
Remove the `responsePrevious` null check as it was not working when a second request (previous data) was not being made. Ex: with 90d

This will not affect charts with previous data request, because when the `response` is available, the `responsePrevious` will also be available as we are using `Promise.all`