### PR TITLE
fix(releasehealth): Sort data such that it can be compared [INGEST-253]

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1836,10 +1836,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             Column("project_id"),
             Column(release_column_name),
         ]
-        group_by = [
-            Column("project_id"),
-            Column(release_column_name),
-        ]
 
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
@@ -1937,6 +1933,9 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             entity = Entity(EntityKey.MetricsSets.value)
             having_clause = [Condition(users_column, Op.GT, 0)]
 
+        # Tiebreaker
+        order_by_clause.extend([OrderBy(col, Direction.DESC) for col in query_cols])
+
         query = Query(
             dataset=Dataset.Metrics.value,
             match=entity,
@@ -1944,7 +1943,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             where=where_clause,
             having=having_clause,
             orderby=order_by_clause,
-            groupby=group_by,
+            groupby=query_cols,
             offset=Offset(offset) if offset is not None else None,
             limit=Limit(limit) if limit is not None else None,
             granularity=Granularity(granularity),

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1197,7 +1197,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         release_column_name = tag_key(org_id, "release")
 
         query_cols = [Column("project_id"), Column(release_column_name)]
-        group_by = query_cols
 
         where_clause = [
             Condition(Column("org_id"), Op.EQ, org_id),
@@ -1212,7 +1211,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             match=Entity(EntityKey.MetricsCounters.value),
             select=query_cols,
             where=where_clause,
-            groupby=group_by,
+            groupby=query_cols,
+            orderby=query_cols,
         )
         result = raw_snql_query(
             query,

--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -1212,7 +1212,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             select=query_cols,
             where=where_clause,
             groupby=query_cols,
-            orderby=query_cols,
+            orderby=[OrderBy(col, Direction.DESC) for col in query_cols],
         )
         result = raw_snql_query(
             query,

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -173,6 +173,9 @@ def _get_project_releases_by_stability(
         "users": ["-users"],
     }[scope]
 
+    # Tiebreaker
+    orderby.extend(["project_id", "release"])
+
     conditions = []
     if environments is not None:
         conditions.append(["environment", "IN", environments])

--- a/src/sentry/snuba/sessions.py
+++ b/src/sentry/snuba/sessions.py
@@ -39,11 +39,12 @@ def _get_changed_project_release_model_adoptions(project_ids):
     # Find all releases with adoption in the last 48 hours
     for x in raw_query(
         dataset=Dataset.Sessions,
-        selected_columns=["project_id", "release", "users"],
+        selected_columns=["project_id", "release"],
         groupby=["release", "project_id"],
         start=start,
         referrer="sessions.get-adoption",
         filter_keys={"project_id": list(project_ids)},
+        orderby=["project_id", "release"],
     )["data"]:
         rv.append((x["project_id"], x["release"]))
 


### PR DESCRIPTION
Sort data such that it can be compared effectively in duplex backend,
also remove an unnecessarily selected column from the sessions backend.