### PR TITLE
ref(performance-metrics): Not fire metrics request with transaction.duration [INGEST-759]

### DIFF
--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -19,7 +19,6 @@ import {t} from 'sentry/locale';
 import {PageContent, PageHeader} from 'sentry/styles/organization';
 import {GlobalSelection} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
-import EventView from 'sentry/utils/discover/eventView';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -42,7 +41,6 @@ type Props = {
 };
 
 type State = {
-  eventView: EventView;
   error?: string;
 };
 
@@ -53,12 +51,7 @@ function PerformanceContent({selection, location, demoMode}: Props) {
   const {isMetricsData} = useMetricsSwitch();
   const previousDateTime = usePrevious(selection.datetime);
 
-  const [state, setState] = useState<State>({
-    eventView: generatePerformanceEventView(location, organization, projects, {
-      isMetricsData,
-    }),
-    error: undefined,
-  });
+  const [state, setState] = useState<State>({error: undefined});
 
   useEffect(() => {
     loadOrganizationTags(api, organization.slug, selection);
@@ -72,15 +65,6 @@ function PerformanceContent({selection, location, demoMode}: Props) {
   }, []);
 
   useEffect(() => {
-    setState({
-      ...state,
-      eventView: generatePerformanceEventView(location, organization, projects, {
-        isMetricsData,
-      }),
-    });
-  }, [organization, location, projects]);
-
-  useEffect(() => {
     loadOrganizationTags(api, organization.slug, selection);
     addRoutePerformanceContext(selection);
   }, [selection.projects]);
@@ -92,34 +76,7 @@ function PerformanceContent({selection, location, demoMode}: Props) {
     }
   }, [selection.datetime]);
 
-  const {eventView, error} = state;
-
-  function shouldShowOnboarding() {
-    // XXX used by getsentry to bypass onboarding for the upsell demo state.
-    if (demoMode) {
-      return false;
-    }
-
-    if (projects.length === 0) {
-      return false;
-    }
-
-    // Current selection is 'my projects' or 'all projects'
-    if (eventView.project.length === 0 || eventView.project === [ALL_ACCESS_PROJECTS]) {
-      return (
-        projects.filter(p => p.firstTransactionEvent === false).length === projects.length
-      );
-    }
-
-    // Any other subset of projects.
-    return (
-      projects.filter(
-        p =>
-          eventView.project.includes(parseInt(p.id, 10)) &&
-          p.firstTransactionEvent === false
-      ).length === eventView.project.length
-    );
-  }
+  const {error} = state;
 
   function setError(newError?: string) {
     if (
@@ -161,6 +118,37 @@ function PerformanceContent({selection, location, demoMode}: Props) {
       <Alert type="error" icon={<IconFlag size="md" />}>
         {error}
       </Alert>
+    );
+  }
+
+  const eventView = generatePerformanceEventView(location, organization, projects, {
+    isMetricsData,
+  });
+
+  function shouldShowOnboarding() {
+    // XXX used by getsentry to bypass onboarding for the upsell demo state.
+    if (demoMode) {
+      return false;
+    }
+
+    if (projects.length === 0) {
+      return false;
+    }
+
+    // Current selection is 'my projects' or 'all projects'
+    if (eventView.project.length === 0 || eventView.project === [ALL_ACCESS_PROJECTS]) {
+      return (
+        projects.filter(p => p.firstTransactionEvent === false).length === projects.length
+      );
+    }
+
+    // Any other subset of projects.
+    return (
+      projects.filter(
+        p =>
+          eventView.project.includes(parseInt(p.id, 10)) &&
+          p.firstTransactionEvent === false
+      ).length === eventView.project.length
     );
   }
 

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -114,7 +114,7 @@ export function PerformanceLanding(props: Props) {
         <Layout.HeaderActions>
           {!showOnboarding && (
             <ButtonBar gap={3}>
-              <MetricsSwitch />
+              <MetricsSwitch onSwitch={() => handleSearch('')} />
               <Button
                 priority="primary"
                 data-test-id="landing-header-trends"

--- a/static/app/views/performance/metricsSwitch.tsx
+++ b/static/app/views/performance/metricsSwitch.tsx
@@ -14,19 +14,20 @@ const FEATURE_FLAG = 'metrics-performance-ui';
  * This is a temporary component used for debugging metrics data on performance pages.
  * Visible only to small amount of internal users.
  */
-function MetricsSwitch() {
+function MetricsSwitch({onSwitch}: {onSwitch: () => void}) {
   const organization = useOrganization();
   const {isMetricsData, setIsMetricsData} = useMetricsSwitch();
+
+  function handleToggle() {
+    onSwitch();
+    setIsMetricsData(!isMetricsData);
+  }
 
   return (
     <Feature features={[FEATURE_FLAG]} organization={organization}>
       <Label>
         {t('Metrics Data')}
-        <Switch
-          isActive={isMetricsData}
-          toggle={() => setIsMetricsData(!isMetricsData)}
-          size="lg"
-        />
+        <Switch isActive={isMetricsData} toggle={handleToggle} size="lg" />
       </Label>
     </Feature>
   );

--- a/tests/js/spec/views/performance/metricsSwitch.spec.tsx
+++ b/tests/js/spec/views/performance/metricsSwitch.spec.tsx
@@ -8,11 +8,13 @@ import {
   useMetricsSwitch,
 } from 'sentry/views/performance/metricsSwitch';
 
+const handleSwitch = jest.fn();
+
 function TestComponent() {
   const {isMetricsData} = useMetricsSwitch();
   return (
     <Fragment>
-      <MetricsSwitch />
+      <MetricsSwitch onSwitch={handleSwitch} />
       {isMetricsData ? 'using metrics' : 'using transactions'}
     </Fragment>
   );
@@ -27,7 +29,7 @@ describe('MetricsSwitch', () => {
   });
 
   it('MetricsSwitch is not visible to users without feature flag', () => {
-    const {container} = mountWithTheme(<MetricsSwitch />, {
+    const {container} = mountWithTheme(<MetricsSwitch onSwitch={handleSwitch} />, {
       organization: TestStubs.Organization(),
     });
     expect(container).toBeEmptyDOMElement();

--- a/tests/js/spec/views/performance/metricsSwitch.spec.tsx
+++ b/tests/js/spec/views/performance/metricsSwitch.spec.tsx
@@ -49,6 +49,8 @@ describe('MetricsSwitch', () => {
 
     userEvent.click(screen.getByRole('checkbox'));
 
+    expect(handleSwitch).toHaveBeenCalled();
+
     expect(screen.getByText('using metrics')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- [x] Add new prop `onSwitch` to the `MetricsSwitch` component
- [x] Clear URL query when switching from transaction x metrics
- [x] Move `eventView` out of the state