### PR TITLE
fix(perf): Remove landing errors

### DIFF
--- a/static/app/views/performance/landing/views/allTransactionsView.tsx
+++ b/static/app/views/performance/landing/views/allTransactionsView.tsx
@@ -28,7 +28,6 @@ export function AllTransactionsView(props: BasePerformanceViewProps) {
         <DoubleChartRow
           {...props}
           allowedCharts={[
-            PerformanceWidgetSetting.MOST_RELATED_ERRORS,
             PerformanceWidgetSetting.MOST_RELATED_ISSUES,
             PerformanceWidgetSetting.MOST_IMPROVED,
             PerformanceWidgetSetting.MOST_REGRESSED,

--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -29,7 +29,6 @@ export function FrontendOtherView(props: BasePerformanceViewProps) {
         <DoubleChartRow
           {...props}
           allowedCharts={[
-            PerformanceWidgetSetting.MOST_RELATED_ERRORS,
             PerformanceWidgetSetting.MOST_RELATED_ISSUES,
             PerformanceWidgetSetting.SLOW_HTTP_OPS,
             PerformanceWidgetSetting.SLOW_RESOURCE_OPS,

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -31,7 +31,6 @@ export function FrontendPageloadView(props: BasePerformanceViewProps) {
             PerformanceWidgetSetting.WORST_LCP_VITALS,
             PerformanceWidgetSetting.WORST_FCP_VITALS,
             PerformanceWidgetSetting.WORST_FID_VITALS,
-            PerformanceWidgetSetting.MOST_RELATED_ERRORS,
             PerformanceWidgetSetting.MOST_RELATED_ISSUES,
             PerformanceWidgetSetting.SLOW_HTTP_OPS,
             PerformanceWidgetSetting.SLOW_BROWSER_OPS,

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -182,7 +182,7 @@ describe('Performance > Landing > Index', function () {
       })
     );
 
-    expect(eventsV2Mock).toHaveBeenCalledTimes(2);
+    expect(eventsV2Mock).toHaveBeenCalledTimes(1);
 
     const titles = wrapper.find('div[data-test-id="performance-widget-title"]');
     expect(titles).toHaveLength(5);
@@ -190,8 +190,8 @@ describe('Performance > Landing > Index', function () {
     expect(titles.at(0).text()).toEqual('User Misery');
     expect(titles.at(1).text()).toEqual('Transactions Per Minute');
     expect(titles.at(2).text()).toEqual('Failure Rate');
-    expect(titles.at(3).text()).toEqual('Most Related Errors');
-    expect(titles.at(4).text()).toEqual('Most Related Issues');
+    expect(titles.at(3).text()).toEqual('Most Related Issues');
+    expect(titles.at(4).text()).toEqual('Most Improved');
   });
 
   it('Can switch between landing displays', async function () {


### PR DESCRIPTION
### Summary
This removes the most errors widget for now since it's use case isn't as clear.