### PR TITLE
feat(metrics): Run metrics consumer in snuba when indexer is enabled [INGEST-768]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1844,6 +1844,7 @@ SENTRY_DEVSERVICES = {
                 "REDIS_HOST": "{containers[redis][name]}",
                 "REDIS_PORT": "6379",
                 "REDIS_DB": "1",
+                "ENABLE_SENTRY_METRICS_DEV": "1" if settings.SENTRY_USE_METRICS_DEV else "",
             },
             "only_if": "snuba" in settings.SENTRY_EVENTSTREAM
             or "kafka" in settings.SENTRY_EVENTSTREAM,

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -234,6 +234,13 @@ def devserver(
                 daemons += [_get_daemon("subscription-consumer", "--topic", topic, suffix=name)]
 
         if settings.SENTRY_USE_METRICS_DEV and settings.SENTRY_USE_RELAY:
+            if not settings.SENTRY_EVENTSTREAM == "sentry.eventstream.kafka.KafkaEventStream":
+                # The metrics indexer produces directly to kafka, so it makes
+                # no sense to run it with SnubaEventStream.
+                raise click.ClickException(
+                    "`SENTRY_USE_METRICS_DEV` can only be used when "
+                    "`SENTRY_EVENTSTREAM=sentry.eventstream.kafka.KafkaEventStream`."
+                )
             daemons += [_get_daemon("metrics")]
 
     if settings.SENTRY_USE_RELAY:


### PR DESCRIPTION
Configure the snuba devservice to start with metrics consumer when the metrics config flag is enabled in sentry. This should make it easy for any developer to enable the entire metrics pipeline in their dev environment.