### PR TITLE
ref(relay): Add APM setting for relay config update task [ISSUE-1306]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1184,6 +1184,9 @@ SENTRY_PROCESS_EVENT_APM_SAMPLING = 0
 # sample rate for the relay projectconfig endpoint
 SENTRY_RELAY_ENDPOINT_APM_SAMPLING = 0
 
+# sample rate for relay's cache invalidation task
+SENTRY_RELAY_TASK_APM_SAMPLING = 0
+
 # sample rate for ingest consumer processing functions
 SENTRY_INGEST_CONSUMER_APM_SAMPLING = 0
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -4,6 +4,10 @@ import inspect
 import sentry_sdk
 from django.conf import settings
 from django.urls import resolve
+
+# Reexport sentry_sdk just in case we ever have to write another shim like we
+# did for raven
+from sentry_sdk import capture_exception, capture_message, configure_scope, push_scope  # NOQA
 from sentry_sdk.client import get_options
 from sentry_sdk.transport import make_transport
 from sentry_sdk.utils import logger as sdk_logger
@@ -93,14 +97,11 @@ SAMPLED_TASKS = {
     "sentry.tasks.reprocessing2.handle_remaining_events": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.reprocess_group": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.finish_reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
+    "sentry.taks.relay.update_config_cache": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
 }
 
 
 UNSAFE_TAG = "_unsafe"
-
-# Reexport sentry_sdk just in case we ever have to write another shim like we
-# did for raven
-from sentry_sdk import capture_exception, capture_message, configure_scope, push_scope  # NOQA
 
 
 def is_current_event_safe():

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -97,7 +97,7 @@ SAMPLED_TASKS = {
     "sentry.tasks.reprocessing2.handle_remaining_events": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.reprocess_group": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.reprocessing2.finish_reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
-    "sentry.taks.relay.update_config_cache": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
+    "sentry.tasks.relay.update_config_cache": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
 }
 
 


### PR DESCRIPTION
This task has become very slow and we need to figure out why, otherwise people will run into cache invalidation issues.

#sync-getsentry